### PR TITLE
refactor: unify to filesystem in rspack_core

### DIFF
--- a/crates/node_binding/src/resolver_factory.rs
+++ b/crates/node_binding/src/resolver_factory.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use napi_derive::napi;
 use rspack_core::{Resolve, ResolverFactory};
-use rspack_fs::{NativeFileSystem, SyncReadableFileSystem};
+use rspack_fs::{FileSystem, NativeFileSystem};
 
 use crate::{
   raw_resolve::{
@@ -15,7 +15,7 @@ use crate::{
 pub struct JsResolverFactory {
   pub(crate) resolver_factory: Option<Arc<ResolverFactory>>,
   pub(crate) loader_resolver_factory: Option<Arc<ResolverFactory>>,
-  pub(crate) input_filesystem: Arc<dyn SyncReadableFileSystem>,
+  pub(crate) input_filesystem: Arc<dyn FileSystem>,
 }
 
 #[napi]

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -4,7 +4,7 @@ pub mod persistent;
 
 use std::{fmt::Debug, sync::Arc};
 
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 
 use self::{disable::DisableCache, memory::MemoryCache, persistent::PersistentCache};
 use crate::{Compilation, CompilerOptions, ExperimentCacheOptions};
@@ -26,10 +26,7 @@ pub trait Cache: Debug + Send + Sync {
   fn after_compile(&self, _compilation: &Compilation) {}
 }
 
-pub fn new_cache(
-  compiler_option: Arc<CompilerOptions>,
-  fs: Arc<dyn SyncReadableFileSystem>,
-) -> Arc<dyn Cache> {
+pub fn new_cache(compiler_option: Arc<CompilerOptions>, fs: Arc<dyn FileSystem>) -> Arc<dyn Cache> {
   match &compiler_option.experiments.cache {
     ExperimentCacheOptions::Disabled => Arc::new(DisableCache),
     ExperimentCacheOptions::Memory => Arc::new(MemoryCache),

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -3,7 +3,7 @@ pub mod storage;
 
 use std::sync::Arc;
 
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 use rspack_paths::{AssertUtf8, Utf8PathBuf};
 use rustc_hash::FxHashSet as HashSet;
 
@@ -28,7 +28,7 @@ pub struct PersistentCache {
 }
 
 impl PersistentCache {
-  pub fn new(option: &PersistentCacheOptions, fs: Arc<dyn SyncReadableFileSystem>) -> Self {
+  pub fn new(option: &PersistentCacheOptions, fs: Arc<dyn FileSystem>) -> Self {
     let storage = Arc::new(MemoryStorage::default());
     Self {
       snapshot: Snapshot::new(option.snapshot.clone(), fs, storage.clone()),

--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -4,7 +4,7 @@ mod strategy;
 use std::sync::Arc;
 
 use rspack_cacheable::{from_bytes, to_bytes};
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 use rspack_paths::Utf8PathBuf;
 use rustc_hash::FxHashSet as HashSet;
 
@@ -25,16 +25,12 @@ pub struct Snapshot {
   // 1. update compiler.input_file_system to async file system
   // 2. update this fs to AsyncReadableFileSystem
   // 3. update add/calc_modified_files to async fn
-  fs: Arc<dyn SyncReadableFileSystem>,
+  fs: Arc<dyn FileSystem>,
   storage: Arc<dyn Storage>,
 }
 
 impl Snapshot {
-  pub fn new(
-    options: SnapshotOptions,
-    fs: Arc<dyn SyncReadableFileSystem>,
-    storage: Arc<dyn Storage>,
-  ) -> Self {
+  pub fn new(options: SnapshotOptions, fs: Arc<dyn FileSystem>, storage: Arc<dyn Storage>) -> Self {
     Self {
       options,
       fs,

--- a/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use rspack_cacheable::cacheable;
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 use rspack_paths::Utf8PathBuf;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -36,12 +36,12 @@ pub enum ValidateResult {
 }
 
 pub struct StrategyHelper {
-  fs: Arc<dyn SyncReadableFileSystem>,
+  fs: Arc<dyn FileSystem>,
   package_version_cache: HashMap<Utf8PathBuf, Option<String>>,
 }
 
 impl StrategyHelper {
-  pub fn new(fs: Arc<dyn SyncReadableFileSystem>) -> Self {
+  pub fn new(fs: Arc<dyn FileSystem>) -> Self {
     Self {
       fs,
       package_version_cache: Default::default(),

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -14,7 +14,7 @@ use rspack_collections::{
   DatabaseItem, Identifiable, IdentifierDashMap, IdentifierMap, IdentifierSet, UkeyMap, UkeySet,
 };
 use rspack_error::{error, miette::diagnostic, Diagnostic, DiagnosticExt, Result, Severity};
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 use rspack_futures::FuturesResults;
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_hook::define_hook;
@@ -201,7 +201,7 @@ pub struct Compilation {
   pub modified_files: HashSet<PathBuf>,
   pub removed_files: HashSet<PathBuf>,
   make_artifact: MakeArtifact,
-  pub input_filesystem: Arc<dyn SyncReadableFileSystem>,
+  pub input_filesystem: Arc<dyn FileSystem>,
 }
 
 impl Compilation {
@@ -238,7 +238,7 @@ impl Compilation {
     module_executor: Option<ModuleExecutor>,
     modified_files: HashSet<PathBuf>,
     removed_files: HashSet<PathBuf>,
-    input_filesystem: Arc<dyn SyncReadableFileSystem>,
+    input_filesystem: Arc<dyn FileSystem>,
   ) -> Self {
     let incremental = Incremental::new(options.experiments.incremental);
     Self {

--- a/crates/rspack_core/src/compiler/make/repair/build.rs
+++ b/crates/rspack_core/src/compiler/make/repair/build.rs
@@ -1,7 +1,7 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray};
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 
 use super::{process_dependencies::ProcessDependenciesTask, MakeTaskContext};
 use crate::{
@@ -18,7 +18,7 @@ pub struct BuildTask {
   pub resolver_factory: Arc<ResolverFactory>,
   pub compiler_options: Arc<CompilerOptions>,
   pub plugin_driver: SharedPluginDriver,
-  pub fs: Arc<dyn SyncReadableFileSystem>,
+  pub fs: Arc<dyn FileSystem>,
 }
 
 #[async_trait::async_trait]

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -6,7 +6,7 @@ pub mod process_dependencies;
 use std::sync::Arc;
 
 use rspack_error::Result;
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::MakeArtifact;
@@ -24,7 +24,7 @@ pub struct MakeTaskContext {
   pub compilation_id: CompilationId,
   pub plugin_driver: SharedPluginDriver,
   pub buildtime_plugin_driver: SharedPluginDriver,
-  pub fs: Arc<dyn SyncReadableFileSystem>,
+  pub fs: Arc<dyn FileSystem>,
   pub compiler_options: Arc<CompilerOptions>,
   pub resolver_factory: Arc<ResolverFactory>,
   pub loader_resolver_factory: Arc<ResolverFactory>,

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -5,7 +5,7 @@ mod module_executor;
 use std::sync::Arc;
 
 use rspack_error::Result;
-use rspack_fs::{AsyncWritableFileSystem, NativeFileSystem, SyncReadableFileSystem};
+use rspack_fs::{AsyncWritableFileSystem, FileSystem, NativeFileSystem};
 use rspack_futures::FuturesResults;
 use rspack_hook::define_hook;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
@@ -54,7 +54,7 @@ pub struct CompilerHooks {
 pub struct Compiler {
   pub options: Arc<CompilerOptions>,
   pub output_filesystem: Box<dyn AsyncWritableFileSystem + Send + Sync>,
-  pub input_filesystem: Arc<dyn SyncReadableFileSystem>,
+  pub input_filesystem: Arc<dyn FileSystem>,
   pub compilation: Compilation,
   pub plugin_driver: SharedPluginDriver,
   pub buildtime_plugin_driver: SharedPluginDriver,
@@ -75,7 +75,7 @@ impl Compiler {
     buildtime_plugins: Vec<BoxPlugin>,
     output_filesystem: Option<Box<dyn AsyncWritableFileSystem + Send + Sync>>,
     // only supports passing input_filesystem in rust api, no support for js api
-    input_filesystem: Option<Arc<dyn SyncReadableFileSystem + Send + Sync>>,
+    input_filesystem: Option<Arc<dyn FileSystem + Send + Sync>>,
     // no need to pass resolve_factory in rust api
     resolver_factory: Option<Arc<ResolverFactory>>,
     loader_resolver_factory: Option<Arc<ResolverFactory>>,

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use json::JsonValue;
 use rspack_collections::{Identifiable, Identifier, IdentifierSet};
 use rspack_error::{Diagnosable, Diagnostic, Result};
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 use rspack_hash::RspackHashDigest;
 use rspack_sources::Source;
 use rspack_util::atom::Atom;
@@ -32,7 +32,7 @@ pub struct BuildContext {
   pub compiler_options: Arc<CompilerOptions>,
   pub resolver_factory: Arc<ResolverFactory>,
   pub plugin_driver: SharedPluginDriver,
-  pub fs: Arc<dyn SyncReadableFileSystem>,
+  pub fs: Arc<dyn FileSystem>,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/rspack_core/src/resolver/boxfs.rs
+++ b/crates/rspack_core/src/resolver/boxfs.rs
@@ -1,14 +1,14 @@
 use std::{io, sync::Arc};
 
-use rspack_fs::{Error, SyncReadableFileSystem};
+use rspack_fs::{Error, FileSystem};
 use rspack_paths::AssertUtf8;
 use rspack_resolver::{FileMetadata, FileSystem as ResolverFileSystem};
 
 #[derive(Clone)]
-pub struct BoxFS(Arc<dyn SyncReadableFileSystem>);
+pub struct BoxFS(Arc<dyn FileSystem>);
 
 impl BoxFS {
-  pub fn new(fs: Arc<dyn SyncReadableFileSystem>) -> Self {
+  pub fn new(fs: Arc<dyn FileSystem>) -> Self {
     Self(fs)
   }
 }

--- a/crates/rspack_core/src/resolver/factory.rs
+++ b/crates/rspack_core/src/resolver/factory.rs
@@ -1,7 +1,7 @@
 use std::{hash::BuildHasherDefault, sync::Arc};
 
 use dashmap::DashMap;
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 use rustc_hash::FxHasher;
 
 use super::resolver_impl::Resolver;
@@ -29,7 +29,7 @@ impl ResolverFactory {
     self.resolver.clear_cache();
   }
 
-  pub fn new(options: Resolve, fs: Arc<dyn SyncReadableFileSystem>) -> Self {
+  pub fn new(options: Resolve, fs: Arc<dyn FileSystem>) -> Self {
     Self {
       base_options: options.clone(),
       resolver: Resolver::new(options, fs),

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -8,7 +8,7 @@ use rspack_error::{
   miette::{diagnostic, Diagnostic},
   DiagnosticExt, Severity, TraceableError,
 };
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 use rspack_loader_runner::DescriptionData;
 use rspack_paths::AssertUtf8;
 use rustc_hash::FxHashSet as HashSet;
@@ -83,11 +83,11 @@ pub struct Resolver {
 }
 
 impl Resolver {
-  pub fn new(options: Resolve, fs: Arc<dyn SyncReadableFileSystem>) -> Self {
+  pub fn new(options: Resolve, fs: Arc<dyn FileSystem>) -> Self {
     Self::new_rspack_resolver(options, fs)
   }
 
-  fn new_rspack_resolver(options: Resolve, fs: Arc<dyn SyncReadableFileSystem>) -> Self {
+  fn new_rspack_resolver(options: Resolve, fs: Arc<dyn FileSystem>) -> Self {
     let options = to_rspack_resolver_options(options, false, DependencyCategory::Unknown);
     let boxfs = BoxFS::new(fs);
     let resolver = rspack_resolver::ResolverGeneric::new_with_file_system(boxfs, options);

--- a/crates/rspack_fs/src/async.rs
+++ b/crates/rspack_fs/src/async.rs
@@ -44,7 +44,7 @@ pub trait AsyncReadableFileSystem: Debug {
   /// Read the entire contents of a file into a bytes vector.
   ///
   /// Error: This function will return an error if path does not already exist.
-  fn read<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>>;
+  fn async_read<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>>;
 }
 
 /// Async readable and writable file system representation.

--- a/crates/rspack_fs/src/fs.rs
+++ b/crates/rspack_fs/src/fs.rs
@@ -1,0 +1,10 @@
+use crate::{
+  AsyncFileSystem, AsyncReadableFileSystem, AsyncWritableFileSystem, SyncFileSystem,
+  SyncReadableFileSystem, SyncWritableFileSystem,
+};
+
+pub trait FileSystem: AsyncFileSystem + SyncFileSystem {}
+
+pub trait ReadableFileSystem: AsyncReadableFileSystem + SyncReadableFileSystem {}
+
+pub trait WritableFileSystem: AsyncWritableFileSystem + SyncWritableFileSystem {}

--- a/crates/rspack_fs/src/lib.rs
+++ b/crates/rspack_fs/src/lib.rs
@@ -1,3 +1,5 @@
+mod fs;
+pub use fs::{FileSystem, ReadableFileSystem, WritableFileSystem};
 mod r#async;
 pub use r#async::{AsyncFileSystem, AsyncReadableFileSystem, AsyncWritableFileSystem};
 

--- a/crates/rspack_fs/src/native_fs.rs
+++ b/crates/rspack_fs/src/native_fs.rs
@@ -4,12 +4,14 @@ use futures::future::BoxFuture;
 use rspack_paths::{AssertUtf8, Utf8Path, Utf8PathBuf};
 
 use crate::{
-  AsyncReadableFileSystem, AsyncWritableFileSystem, Error, FileMetadata, Result,
-  SyncReadableFileSystem, SyncWritableFileSystem,
+  AsyncReadableFileSystem, AsyncWritableFileSystem, Error, FileMetadata, FileSystem, Result,
+  SyncReadableFileSystem, SyncWritableFileSystem, WritableFileSystem,
 };
 
 #[derive(Debug)]
 pub struct NativeFileSystem;
+impl FileSystem for NativeFileSystem {}
+impl WritableFileSystem for NativeFileSystem {}
 
 impl SyncWritableFileSystem for NativeFileSystem {
   fn create_dir(&self, dir: &Utf8Path) -> Result<()> {
@@ -102,7 +104,7 @@ impl AsyncWritableFileSystem for NativeFileSystem {
 }
 
 impl AsyncReadableFileSystem for NativeFileSystem {
-  fn read<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>> {
+  fn async_read<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>> {
     let fut = async move { tokio::fs::read(file).await.map_err(Error::from) };
     Box::pin(fut)
   }

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, path::PathBuf, sync::Arc};
 
 use rspack_error::{error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
-use rspack_fs::SyncReadableFileSystem;
+use rspack_fs::FileSystem;
 use rspack_sources::SourceMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use tokio::task::spawn_blocking;
@@ -27,7 +27,7 @@ impl<Context> LoaderContext<Context> {
 
 async fn process_resource<Context: Send>(
   loader_context: &mut LoaderContext<Context>,
-  fs: Arc<dyn SyncReadableFileSystem>,
+  fs: Arc<dyn FileSystem>,
 ) -> Result<()> {
   if let Some(plugin) = &loader_context.plugin
     && let Some(processed_resource) = plugin
@@ -108,7 +108,7 @@ pub async fn run_loaders<Context: Send>(
   resource_data: Arc<ResourceData>,
   plugins: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
   context: Context,
-  fs: Arc<dyn SyncReadableFileSystem>,
+  fs: Arc<dyn FileSystem>,
 ) -> Result<TWithDiagnosticArray<LoaderResult>> {
   let loaders = loaders
     .into_iter()

--- a/crates/rspack_plugin_schemes/src/http_cache.rs
+++ b/crates/rspack_plugin_schemes/src/http_cache.rs
@@ -227,10 +227,10 @@ impl HttpCache {
         let current_time = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
         let is_valid = entry.valid_until > current_time;
 
-        if is_valid && self.filesystem.read(cache_path).await.is_ok() {
+        if is_valid && self.filesystem.async_read(cache_path).await.is_ok() {
           let cached_content = self
             .filesystem
-            .read(cache_path)
+            .async_read(cache_path)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to read cached content: {:?}", e))?;
 

--- a/crates/rspack_plugin_schemes/src/lockfile.rs
+++ b/crates/rspack_plugin_schemes/src/lockfile.rs
@@ -123,7 +123,7 @@ impl LockfileAsync for Lockfile {
     let utf8_path = Utf8Path::from_path(path.as_ref())
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid UTF-8 path"))?;
     let content = filesystem
-      .read(utf8_path)
+      .async_read(utf8_path)
       .await
       .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("{:?}", e)))?;
     let content_str =


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
It's not necessary to distinguish different filesystem trait in rust side, which only cause maintenance burden, 
we just need to distinguish input & output & intermediate filesystem in ThreadsafeNodeFS
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
