### PR TITLE
fix: `WebWorkerTemplatePlugin` should generate import-scripts chunk loading runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "format-ci:toml": "npx @taplo/cli format --check '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'",
     "format:toml": "npx @taplo/cli format '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'",
     "lint:js": "pnpm run lint-ci:js --write",
-    "lint-ci:js": "biome check --diagnostic-level=warn --no-errors-on-unmatched",
+    "lint-ci:js": "biome check --diagnostic-level=warn --no-errors-on-unmatched --max-diagnostics=none",
     "lint:rs": "node ./scripts/check_rust_dependency.cjs",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",
     "build:binding:release": "pnpm --filter @rspack/binding run build:release",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -115,7 +115,8 @@
     "style-loader": "^4.0.0",
     "terser": "5.36.0",
     "typescript": "^5.6.3",
-    "wast-loader": "^1.12.1"
+    "wast-loader": "^1.12.1",
+    "worker-rspack-loader": "^3.1.2"
   },
   "peerDependencies": {
     "@rspack/core": ">=1.0.0"

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/index.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/index.js
@@ -1,0 +1,9 @@
+import fs from "fs"
+import Worker from "worker-rspack-loader!./worker.js"
+
+it("should contain import-scripts chunkLoading runtime", (done) => {
+	Worker;
+	let file = fs.readFileSync(__dirname + "/bundle0.worker.js", "utf-8")
+	expect(file).toContain("__webpack_require__.f.i")
+	done()
+})

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/rspack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "async-node"
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/worker-async.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/worker-async.js
@@ -1,0 +1,1 @@
+export const message = 'workerAsync';

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/worker.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/worker.js
@@ -1,0 +1,4 @@
+onmessage = async function() {
+	let fetch = await import("./worker-async")
+	postMessage(`Hello ${fetch.message}`)
+}

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -11266,15 +11266,12 @@ interface Webworker {
 export const webworker: Webworker;
 
 // @public (undocumented)
-const WebWorkerTemplatePlugin: {
-    new (): {
-        name: BuiltinPluginName;
-        _args: [];
-        affectedHooks: "done" | "make" | "compile" | "emit" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
-        raw(compiler: Compiler_2): BuiltinPlugin;
-        apply(compiler: Compiler_2): void;
-    };
-};
+class WebWorkerTemplatePlugin extends RspackBuiltinPlugin {
+    // (undocumented)
+    name: BuiltinPluginName;
+    // (undocumented)
+    raw(compiler: Compiler): BuiltinPlugin | undefined;
+}
 
 // @public
 export type WorkerPublicPath = string;

--- a/packages/rspack/src/builtin-plugin/WebWorkerTemplatePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/WebWorkerTemplatePlugin.ts
@@ -1,8 +1,13 @@
-import { BuiltinPluginName } from "@rspack/binding";
+import { type BuiltinPlugin, BuiltinPluginName } from "@rspack/binding";
 
-import { create } from "./base";
+import type { Compiler } from "../Compiler";
+import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 
-export const WebWorkerTemplatePlugin = create(
-	BuiltinPluginName.WebWorkerTemplatePlugin,
-	() => undefined
-);
+export class WebWorkerTemplatePlugin extends RspackBuiltinPlugin {
+	name = BuiltinPluginName.WebWorkerTemplatePlugin;
+
+	raw(compiler: Compiler): BuiltinPlugin | undefined {
+		compiler.options.output.chunkLoading = "import-scripts";
+		return createBuiltinPlugin(this.name, undefined);
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,6 +651,9 @@ importers:
       wast-loader:
         specifier: ^1.12.1
         version: 1.12.1
+      worker-rspack-loader:
+        specifier: ^3.1.2
+        version: 3.1.2(@rspack/core@packages+rspack)(webpack@5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
 
   packages/rspack-test-tools/tests/normalCases/resolve/pnpm-workspace/packages/app:
     dependencies:
@@ -9768,6 +9771,18 @@ packages:
     resolution: {integrity: sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==}
     engines: {node: '>=0.4.0'}
 
+  worker-rspack-loader@3.1.2:
+    resolution: {integrity: sha512-lz2CoI/xGUFtjGrfTfzU6193fRdqSPsYrwPppeVCyknnFjq384RQ8BTHYp/KVMsgrodIubZX/G/i7sxvwC9tSA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || 1.x
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -12840,19 +12855,19 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
       webpack-cli: 5.1.4(webpack@5.94.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
       webpack-cli: 5.1.4(webpack@5.94.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0)':
     dependencies:
-      webpack: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
       webpack-cli: 5.1.4(webpack@5.94.0)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -19847,9 +19862,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0)
       colorette: 2.0.19
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -19858,7 +19873,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
       webpack-merge: 5.9.0
 
   webpack-dev-middleware@7.4.2(webpack@5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(esbuild@0.23.1)(webpack-cli@5.1.4(webpack@5.94.0))):
@@ -20179,6 +20194,14 @@ snapshots:
       acorn-globals: 3.1.0
 
   wordwrap@0.0.2: {}
+
+  worker-rspack-loader@3.1.2(@rspack/core@packages+rspack)(webpack@5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+    optionalDependencies:
+      '@rspack/core': link:packages/rspack
+      webpack: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
 
   wrap-ansi@6.2.0:
     dependencies:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fixed an issue where dynamic chunk manually created by worker-loader is failed to load.

See: https://github.com/webpack/webpack/blob/89dfc9a5c575dc691e3ac6a965d39c854fca3986/lib/webworker/WebWorkerTemplatePlugin.js#L20

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
