### PR TITLE
feat(rspack_cacheable): `as` attr support use with dyn trait

### DIFF
--- a/crates/rspack_cacheable/src/context.rs
+++ b/crates/rspack_cacheable/src/context.rs
@@ -20,7 +20,7 @@ impl<'a> ContextGuard<'a> {
     Self { context }
   }
 
-  pub fn add_to_sharing<S: Sharing<SerializeError>>(
+  pub fn add_to_sharing<S: Sharing<SerializeError> + ?Sized>(
     &self,
     sharing: &mut S,
   ) -> Result<(), SerializeError> {
@@ -28,7 +28,7 @@ impl<'a> ContextGuard<'a> {
     sharing.finish_sharing(CONTEXT_ADDR, self as *const _ as usize)
   }
 
-  pub fn sharing_context<S: Sharing<SerializeError>>(
+  pub fn sharing_context<S: Sharing<SerializeError> + ?Sized>(
     sharing: &'a mut S,
   ) -> Result<&'a dyn Any, SerializeError> {
     match sharing.start_sharing(CONTEXT_ADDR) {
@@ -40,7 +40,7 @@ impl<'a> ContextGuard<'a> {
     }
   }
 
-  pub fn add_to_pooling<P: Pooling<DeserializeError>>(
+  pub fn add_to_pooling<P: Pooling<DeserializeError> + ?Sized>(
     &self,
     pooling: &mut P,
   ) -> Result<(), DeserializeError> {
@@ -51,7 +51,7 @@ impl<'a> ContextGuard<'a> {
     }
   }
 
-  pub fn pooling_context<P: Pooling<DeserializeError>>(
+  pub fn pooling_context<P: Pooling<DeserializeError> + ?Sized>(
     pooling: &'a mut P,
   ) -> Result<&'a dyn Any, DeserializeError> {
     match pooling.start_pooling(CONTEXT_ADDR) {

--- a/crates/rspack_cacheable/src/with/as.rs
+++ b/crates/rspack_cacheable/src/with/as.rs
@@ -43,7 +43,7 @@ where
 impl<T, A, S> SerializeWith<T, S> for As<A>
 where
   A: AsConverter<T> + Archive + Serialize<S>,
-  S: Fallible<Error = SerializeError> + Sharing,
+  S: Fallible<Error = SerializeError> + Sharing + ?Sized,
 {
   #[inline]
   fn serialize_with(field: &T, serializer: &mut S) -> Result<Self::Resolver, SerializeError> {
@@ -60,7 +60,7 @@ impl<T, A, D> DeserializeWith<Archived<A>, T, D> for As<A>
 where
   A: AsConverter<T> + Archive,
   A::Archived: Deserialize<A, D>,
-  D: Fallible<Error = DeserializeError> + Pooling,
+  D: Fallible<Error = DeserializeError> + Pooling + ?Sized,
 {
   #[inline]
   fn deserialize_with(field: &Archived<A>, de: &mut D) -> Result<T, DeserializeError> {

--- a/crates/rspack_cacheable/src/with/as_cacheable.rs
+++ b/crates/rspack_cacheable/src/with/as_cacheable.rs
@@ -20,7 +20,7 @@ impl<T: Archive> ArchiveWith<T> for AsCacheable {
 impl<T, S> SerializeWith<T, S> for AsCacheable
 where
   T: Archive + Serialize<S>,
-  S: ?Sized + Fallible,
+  S: Fallible + ?Sized,
 {
   #[inline]
   fn serialize_with(field: &T, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
@@ -32,7 +32,7 @@ impl<T, D> DeserializeWith<Archived<T>, T, D> for AsCacheable
 where
   T: Archive,
   T::Archived: Deserialize<T, D>,
-  D: ?Sized + Fallible,
+  D: Fallible + ?Sized,
 {
   #[inline]
   fn deserialize_with(field: &Archived<T>, de: &mut D) -> Result<T, D::Error> {

--- a/crates/rspack_cacheable/src/with/as_inner.rs
+++ b/crates/rspack_cacheable/src/with/as_inner.rs
@@ -48,7 +48,7 @@ impl<T, A, O, D> DeserializeWith<A::Archived, T, D> for AsInner<A>
 where
   T: AsInnerConverter<Inner = O>,
   A: ArchiveWith<O> + DeserializeWith<A::Archived, O, D>,
-  D: ?Sized + Fallible,
+  D: Fallible + ?Sized,
 {
   fn deserialize_with(field: &A::Archived, d: &mut D) -> Result<T, D::Error> {
     Ok(T::from_inner(A::deserialize_with(field, d)?))

--- a/crates/rspack_cacheable/src/with/as_map.rs
+++ b/crates/rspack_cacheable/src/with/as_map.rs
@@ -57,10 +57,11 @@ where
   }
 }
 
-impl<WK, WV, K, V, S: Fallible + ?Sized> Serialize<S> for Entry<&'_ K, &'_ V, WK, WV>
+impl<WK, WV, K, V, S> Serialize<S> for Entry<&'_ K, &'_ V, WK, WV>
 where
   WK: SerializeWith<K, S>,
   WV: SerializeWith<V, S>,
+  S: Fallible + ?Sized,
 {
   #[inline]
   fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
@@ -90,7 +91,7 @@ where
   T: AsMapConverter<Key = K, Value = V>,
   WK: ArchiveWith<K>,
   WV: ArchiveWith<V>,
-  S: Fallible + ?Sized + Allocator + Writer,
+  S: Fallible + Allocator + Writer + ?Sized,
   for<'a> Entry<&'a K, &'a V, WK, WV>: Serialize<S>,
 {
   fn serialize_with(field: &T, s: &mut S) -> Result<Self::Resolver, S::Error> {

--- a/crates/rspack_cacheable/src/with/as_ref_str.rs
+++ b/crates/rspack_cacheable/src/with/as_ref_str.rs
@@ -31,7 +31,7 @@ where
 impl<T, S> SerializeWith<T, S> for AsRefStr
 where
   T: AsRefStrConverter,
-  S: ?Sized + Fallible + Writer,
+  S: Fallible + Writer + ?Sized,
   S::Error: Source,
 {
   #[inline]
@@ -43,7 +43,7 @@ where
 impl<T, D> DeserializeWith<ArchivedString, T, D> for AsRefStr
 where
   T: AsRefStrConverter,
-  D: ?Sized + Fallible,
+  D: Fallible + ?Sized,
 {
   #[inline]
   fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<T, D::Error> {

--- a/crates/rspack_cacheable/src/with/as_string.rs
+++ b/crates/rspack_cacheable/src/with/as_string.rs
@@ -39,7 +39,7 @@ where
 impl<T, S> SerializeWith<T, S> for AsString
 where
   T: AsStringConverter,
-  S: Fallible<Error = SerializeError> + Writer,
+  S: Fallible<Error = SerializeError> + Writer + ?Sized,
 {
   #[inline]
   fn serialize_with(field: &T, serializer: &mut S) -> Result<Self::Resolver, SerializeError> {
@@ -52,7 +52,7 @@ where
 impl<T, D> DeserializeWith<ArchivedString, T, D> for AsString
 where
   T: AsStringConverter,
-  D: Fallible<Error = DeserializeError>,
+  D: Fallible<Error = DeserializeError> + ?Sized,
 {
   #[inline]
   fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<T, DeserializeError> {

--- a/crates/rspack_cacheable/src/with/as_tuple2.rs
+++ b/crates/rspack_cacheable/src/with/as_tuple2.rs
@@ -30,10 +30,11 @@ where
   }
 }
 
-impl<A, B, K, V, S: Fallible + ?Sized> SerializeWith<(K, V), S> for AsTuple2<A, B>
+impl<A, B, K, V, S> SerializeWith<(K, V), S> for AsTuple2<A, B>
 where
   A: SerializeWith<K, S>,
   B: SerializeWith<V, S>,
+  S: Fallible + ?Sized,
 {
   #[inline]
   fn serialize_with(field: &(K, V), serializer: &mut S) -> Result<Self::Resolver, S::Error> {
@@ -49,7 +50,7 @@ impl<A, B, K, V, D> DeserializeWith<ArchivedTuple2<A::Archived, B::Archived>, (K
 where
   A: ArchiveWith<K> + DeserializeWith<A::Archived, K, D>,
   B: ArchiveWith<V> + DeserializeWith<B::Archived, V, D>,
-  D: ?Sized + Fallible,
+  D: Fallible + ?Sized,
 {
   fn deserialize_with(
     field: &ArchivedTuple2<A::Archived, B::Archived>,

--- a/crates/rspack_cacheable/src/with/as_tuple3.rs
+++ b/crates/rspack_cacheable/src/with/as_tuple3.rs
@@ -34,11 +34,12 @@ where
   }
 }
 
-impl<A, B, C, K, V, H, S: Fallible + ?Sized> SerializeWith<(K, V, H), S> for AsTuple3<A, B, C>
+impl<A, B, C, K, V, H, S> SerializeWith<(K, V, H), S> for AsTuple3<A, B, C>
 where
   A: SerializeWith<K, S>,
   B: SerializeWith<V, S>,
   C: SerializeWith<H, S>,
+  S: Fallible + ?Sized,
 {
   #[inline]
   fn serialize_with(field: &(K, V, H), serializer: &mut S) -> Result<Self::Resolver, S::Error> {
@@ -57,7 +58,7 @@ where
   A: ArchiveWith<K> + DeserializeWith<A::Archived, K, D>,
   B: ArchiveWith<V> + DeserializeWith<B::Archived, V, D>,
   C: ArchiveWith<H> + DeserializeWith<C::Archived, H, D>,
-  D: ?Sized + Fallible,
+  D: Fallible + ?Sized,
 {
   fn deserialize_with(
     field: &ArchivedTuple3<A::Archived, B::Archived, C::Archived>,

--- a/crates/rspack_cacheable/src/with/as_vec.rs
+++ b/crates/rspack_cacheable/src/with/as_vec.rs
@@ -79,7 +79,7 @@ where
 impl<T, A, O, D> DeserializeWith<ArchivedVec<A::Archived>, T, D> for AsVec<A>
 where
   T: AsVecConverter<Item = O>,
-  D: Fallible<Error = DeserializeError>,
+  D: Fallible<Error = DeserializeError> + ?Sized,
   A: ArchiveWith<O> + DeserializeWith<A::Archived, O, D>,
 {
   fn deserialize_with(field: &ArchivedVec<A::Archived>, d: &mut D) -> Result<T, DeserializeError> {

--- a/crates/rspack_cacheable/src/with/inline.rs
+++ b/crates/rspack_cacheable/src/with/inline.rs
@@ -26,7 +26,7 @@ where
 impl<'a, T, F, S> SerializeWith<&'a F, S> for Inline<T>
 where
   T: SerializeWith<F, S>,
-  S: ?Sized + Fallible,
+  S: Fallible + ?Sized,
 {
   #[inline]
   fn serialize_with(field: &&F, serializer: &mut S) -> Result<Self::Resolver, S::Error> {

--- a/crates/rspack_cacheable/src/with/unsupported.rs
+++ b/crates/rspack_cacheable/src/with/unsupported.rs
@@ -17,7 +17,7 @@ impl<F> ArchiveWith<F> for Unsupported {
 
 impl<F, S> SerializeWith<F, S> for Unsupported
 where
-  S: Fallible<Error = SerializeError>,
+  S: Fallible<Error = SerializeError> + ?Sized,
 {
   fn serialize_with(_: &F, _: &mut S) -> Result<(), SerializeError> {
     Err(SerializeError::UnsupportedField)
@@ -26,7 +26,7 @@ where
 
 impl<F, D> DeserializeWith<(), F, D> for Unsupported
 where
-  D: Fallible<Error = DeserializeError>,
+  D: Fallible<Error = DeserializeError> + ?Sized,
 {
   fn deserialize_with(_: &(), _: &mut D) -> Result<F, DeserializeError> {
     Err(DeserializeError::UnsupportedField)

--- a/crates/rspack_cacheable_test/tests/macro/cacheable/as_attr.rs
+++ b/crates/rspack_cacheable_test/tests/macro/cacheable/as_attr.rs
@@ -33,6 +33,7 @@ struct DataRef<'a> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn as_attr() {
   let a = Data {
     block1: "abc".into(),

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable/as_attr.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable/as_attr.rs
@@ -1,7 +1,10 @@
 use rspack_cacheable::{
-  from_bytes, to_bytes,
-  with::{AsTuple2, Inline},
+  cacheable_dyn, from_bytes, to_bytes,
+  with::{AsOption, AsTuple2, AsVec, Inline},
 };
+
+#[cacheable_dyn]
+trait Module {}
 
 #[derive(
   rspack_cacheable::__private::rkyv::Archive,
@@ -9,40 +12,73 @@ use rspack_cacheable::{
   rspack_cacheable::__private::rkyv::Serialize,
 )]
 #[rkyv(crate=rspack_cacheable::__private::rkyv)]
-#[derive(Debug, PartialEq, Eq)]
-struct Person {
-  name: String,
-  content: (String, String),
+struct NormalModule {
+  inner: String,
+}
+
+#[cacheable_dyn]
+impl Module for NormalModule {}
+
+#[derive(
+  rspack_cacheable::__private::rkyv::Archive,
+  rspack_cacheable::__private::rkyv::Deserialize,
+  rspack_cacheable::__private::rkyv::Serialize,
+)]
+#[rkyv(crate=rspack_cacheable::__private::rkyv)]
+struct Data {
+  block1: String,
+  block2: Vec<(String, Option<String>)>,
+  block3: Box<dyn Module>,
 }
 
 #[derive(
   rspack_cacheable::__private::rkyv::Archive, rspack_cacheable::__private::rkyv::Serialize,
 )]
 #[rkyv(crate=rspack_cacheable::__private::rkyv,
-         as=rspack_cacheable::__private::rkyv::Archived<Person>)]
+         as=rspack_cacheable::__private::rkyv::Archived<Data>)]
 #[rkyv(serialize_bounds(
     __S: rspack_cacheable::__private::rkyv::ser::Writer + rspack_cacheable::__private::rkyv::ser::Allocator + rspack_cacheable::__private::rkyv::rancor::Fallible<Error = rspack_cacheable::SerializeError>,
+    Inline: rspack_cacheable::__private::rkyv::with::SerializeWith<&'a String, __S>,
+    AsVec<AsTuple2<Inline, AsOption<Inline>>>: rspack_cacheable::__private::rkyv::with::SerializeWith<Vec<(&'a String, Option<&'a String>)>, __S>,
+    Inline: rspack_cacheable::__private::rkyv::with::SerializeWith<&'a Box<dyn Module>, __S>
   ))]
-struct PersonRef<'a> {
+struct DataRef<'a> {
   #[rkyv(omit_bounds)]
   #[rkyv(with=Inline)]
-  name: &'a String,
+  block1: &'a String,
   #[rkyv(omit_bounds)]
-  #[rkyv(with=AsTuple2<Inline, Inline>)]
-  content: (&'a String, &'a String),
+  #[rkyv(with=AsVec<AsTuple2<Inline, AsOption<Inline>>>)]
+  block2: Vec<(&'a String, Option<&'a String>)>,
+  #[allow(clippy::borrowed_box)]
+  #[rkyv(omit_bounds)]
+  #[rkyv(with=Inline)]
+  block3: &'a Box<dyn Module>,
 }
 
 #[test]
 fn as_attr() {
-  let a = Person {
-    name: "abc".into(),
-    content: ("a".into(), "b".into()),
+  let a = Data {
+    block1: "abc".into(),
+    block2: vec![
+      ("key1".into(), None),
+      ("key2".into(), Some("value2".into())),
+      ("key3".into(), Some("value3".into())),
+    ],
+    block3: Box::new(NormalModule {
+      inner: "inner".into(),
+    }),
   };
-  let a_ref = PersonRef {
-    name: &a.name,
-    content: (&a.content.0, &a.content.1),
+  let a_ref = DataRef {
+    block1: &a.block1,
+    block2: a
+      .block2
+      .iter()
+      .map(|(key, value)| (key, value.as_ref()))
+      .collect(),
+    block3: &a.block3,
   };
-  let bytes = to_bytes(&a_ref, &()).unwrap();
-  let deserialize_a: Person = from_bytes(&bytes, &()).unwrap();
-  assert_eq!(a, deserialize_a);
+  let bytes = to_bytes(&a, &()).unwrap();
+  let bytes_ref = to_bytes(&a_ref, &()).unwrap();
+  assert_eq!(bytes, bytes_ref);
+  from_bytes::<Data, ()>(&bytes, &()).unwrap();
 }

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable/as_attr.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable/as_attr.rs
@@ -56,6 +56,7 @@ struct DataRef<'a> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn as_attr() {
   let a = Data {
     block1: "abc".into(),

--- a/crates/rspack_macros/src/cacheable/impl_as.rs
+++ b/crates/rspack_macros/src/cacheable/impl_as.rs
@@ -4,10 +4,26 @@ use syn::{parse_macro_input, parse_quote, visit_mut::VisitMut, Field, Item, Toke
 
 use super::CacheableArgs;
 
-/// A visitor to add #[cacheable(omit_bounds)] on field
-struct AddFieldAttrVisitor;
+/// A visitor to add #[cacheable(omit_bounds)] and collect #[cacheable(with=...)] info on field
+#[derive(Default)]
+struct FieldAttrVisitor {
+  /// with info collected
+  ///
+  /// # Example
+  ///
+  /// ```rust,ignore
+  /// #[cacheable]
+  /// struct Test {
+  ///   #[cacheable(with=AsMap<AsCacheable, AsPreset>)]
+  ///   test_field: HashMap<String, Atom>,
+  /// }
+  ///
+  /// // with_info is vec![(AsMap<AsCacheable, AsPreset>, HashMap<String, Atom>)]
+  /// ```
+  with_info: Vec<(Type, Type)>,
+}
 
-impl VisitMut for AddFieldAttrVisitor {
+impl VisitMut for FieldAttrVisitor {
   fn visit_field_mut(&mut self, f: &mut Field) {
     let mut with_info = None;
     f.attrs.retain(|item| {
@@ -32,6 +48,7 @@ impl VisitMut for AddFieldAttrVisitor {
     // add rkyv with
     if let Some(with_info) = with_info {
       f.attrs.push(parse_quote!(#[rkyv(with=#with_info)]));
+      self.with_info.push((with_info, f.ty.clone()));
     }
     // add rkyv omit_bounds
     f.attrs.push(parse_quote!(#[rkyv(omit_bounds)]));
@@ -42,11 +59,17 @@ impl VisitMut for AddFieldAttrVisitor {
 pub fn impl_cacheable_as(tokens: TokenStream, args: CacheableArgs) -> TokenStream {
   let mut input = parse_macro_input!(tokens as Item);
 
-  let mut visitor = AddFieldAttrVisitor;
+  let mut visitor = FieldAttrVisitor::default();
   visitor.visit_item_mut(&mut input);
 
   let crate_path = &args.crate_path;
   let r#as = &args.r#as;
+
+  let serialize_bounds = visitor
+    .with_info
+    .iter()
+    .map(|(with, ty)| quote!(#with: #crate_path::__private::rkyv::with::SerializeWith<#ty, __S>));
+  let serialize_bounds = quote! { #(#serialize_bounds),* };
 
   quote! {
       #[derive(
@@ -59,6 +82,7 @@ pub fn impl_cacheable_as(tokens: TokenStream, args: CacheableArgs) -> TokenStrea
       )]
       #[rkyv(serialize_bounds(
           __S: #crate_path::__private::rkyv::ser::Writer + #crate_path::__private::rkyv::ser::Allocator + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::SerializeError>,
+          #serialize_bounds
       ))]
       #input
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

1. Add `?Size` for all of `Serializer` and `Deserializer` in `rspack_cacheable`
2. `as` attr support use with `dyn Trait`

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
