### PR TITLE
fix: should report errors if stats was being accessed after the compiler was closed

### DIFF
--- a/packages/rspack-test-tools/tests/compilerCases/compiler-stats-shutdown.js
+++ b/packages/rspack-test-tools/tests/compilerCases/compiler-stats-shutdown.js
@@ -1,0 +1,41 @@
+
+let resolveCompilerStats;
+let compilerStats = new Promise((resolve) => {
+	resolveCompilerStats = resolve
+});
+
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.done.tap("Plugin", stats => {
+			resolveCompilerStats(stats)
+		});
+	}
+}
+
+/** @type {import('../../dist').TCompilerCaseConfig} */
+module.exports = {
+	description: "should be called every compilation",
+	options(context) {
+		return {
+			context: context.getSource(),
+			entry: "./d",
+			plugins: [new MyPlugin()]
+		};
+	},
+	async build(_, compiler) {
+		await new Promise(resolve => {
+			compiler.run((err, stats) => {
+				compiler.close(() => {
+					// Should be able to access `Stats` within the same tick of closing.
+					expect(() => stats.compilation).not.toThrow();
+					resolve()
+				})
+			});
+		});
+	},
+	async check() {
+		let stats = await compilerStats;
+		// Should not be able to access `Stats` after the compiler was shutdown.
+		expect(() => stats.compilation).toThrow("Unable to access `Stats` after the compiler was shutdown")
+	}
+};

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -574,6 +574,9 @@ export class Compilation {
     __internal__pushRspackDiagnostic(diagnostic: binding.JsRspackDiagnostic): void;
     // @internal
     __internal__setAssetSource(filename: string, source: Source): void;
+    // (undocumented)
+    get __internal__shutdown(): boolean;
+    set __internal__shutdown(shutdown: boolean);
     // @internal
     __internal_getInner(): binding.JsCompilation;
     // (undocumented)
@@ -10022,7 +10025,7 @@ type StatOptions = {
 export class Stats {
     constructor(compilation: Compilation);
     // (undocumented)
-    compilation: Compilation;
+    get compilation(): Compilation;
     // (undocumented)
     get endTime(): number | undefined;
     // (undocumented)

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -186,6 +186,7 @@ export type NormalizedStatsOptions = KnownNormalizedStatsOptions &
 
 export class Compilation {
 	#inner: JsCompilation;
+	#shutdown: boolean;
 
 	hooks: Readonly<{
 		processAssets: liteTapable.AsyncSeriesHook<Assets>;
@@ -272,6 +273,7 @@ export class Compilation {
 
 	constructor(compiler: Compiler, inner: JsCompilation) {
 		this.#inner = inner;
+		this.#shutdown = false;
 		this.#customModules = {};
 
 		const processAssetsHook = new liteTapable.AsyncSeriesHook<Assets>([
@@ -1226,6 +1228,14 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	 */
 	__internal_getInner() {
 		return this.#inner;
+	}
+
+	get __internal__shutdown() {
+		return this.#shutdown;
+	}
+
+	set __internal__shutdown(shutdown) {
+		this.#shutdown = shutdown;
 	}
 
 	seal() {}

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -250,6 +250,8 @@ class Compiler {
 
 		this.hooks.shutdown.tap("rspack:cleanup", () => {
 			if (!this.running) {
+				// Delayed rspack cleanup to the next tick.
+				// This supports calls to `fn rspack` to do something with `Stats` within the same tick.
 				process.nextTick(() => {
 					this.#instance = undefined;
 					this.#compilation && (this.#compilation.__internal__shutdown = true);

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -250,7 +250,10 @@ class Compiler {
 
 		this.hooks.shutdown.tap("rspack:cleanup", () => {
 			if (!this.running) {
-				this.#instance = undefined;
+				process.nextTick(() => {
+					this.#instance = undefined;
+					this.#compilation && (this.#compilation.__internal__shutdown = true);
+				});
 			}
 		});
 	}

--- a/packages/rspack/src/Stats.ts
+++ b/packages/rspack/src/Stats.ts
@@ -23,12 +23,12 @@ export type {
 
 export class Stats {
 	#inner: binding.JsStats;
-	compilation: Compilation;
+	#compilation: Compilation;
 	#innerMap: WeakMap<Compilation, binding.JsStats>;
 
 	constructor(compilation: Compilation) {
 		this.#inner = compilation.__internal_getInner().getStats();
-		this.compilation = compilation;
+		this.#compilation = compilation;
 		this.#innerMap = new WeakMap([[this.compilation, this.#inner]]);
 	}
 
@@ -40,6 +40,15 @@ export class Stats {
 		const inner = compilation.__internal_getInner().getStats();
 		this.#innerMap.set(compilation, inner);
 		return inner;
+	}
+
+	get compilation() {
+		if (this.#compilation.__internal__shutdown) {
+			throw new Error(
+				"Unable to access `Stats` after the compiler was shutdown"
+			);
+		}
+		return this.#compilation;
 	}
 
 	get hash() {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fixed an issue where the compiler/compilation was accessed after it was closed. 

Otherwise, it might report segmentation faults.

EDIT: use `process.nextTick` to postpone cleanups to the next tick to support accessing stats within the same tick.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
