### PR TITLE
fix: chunk render cache panic on css extract diagnostics

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -208,7 +208,7 @@ impl Compiler {
       .await
       .err()
     {
-      self.compilation.extend_diagnostics(vec![e.into()]);
+      self.compilation.push_diagnostic(e.into());
     }
     logger.time_end(make_hook_start);
     self.compilation.make().await?;

--- a/crates/rspack_core/src/old_cache/occasion/chunk_render.rs
+++ b/crates/rspack_core/src/old_cache/occasion/chunk_render.rs
@@ -5,7 +5,7 @@ use rspack_sources::BoxSource;
 
 use crate::{old_cache::storage, Chunk, Compilation, SourceType};
 
-type Storage = dyn storage::Storage<(BoxSource, Vec<Diagnostic>)>;
+type Storage = dyn storage::Storage<BoxSource>;
 
 #[derive(Debug)]
 pub struct ChunkRenderOccasion {
@@ -41,10 +41,10 @@ impl ChunkRenderOccasion {
     };
     let cache_key = Identifier::from(content_hash.encoded());
     if let Some(value) = storage.get(&cache_key) {
-      Ok(value)
+      Ok((value, Vec::new()))
     } else {
       let res = generator().await?;
-      storage.set(cache_key, res.clone());
+      storage.set(cache_key, res.0.clone());
       Ok(res)
     }
   }

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -275,11 +275,10 @@ impl CopyRspackPlugin {
       }
       Err(e) => {
         let e: Error = DiagnosticError::from(e.boxed()).into();
-        let rspack_err: Vec<Diagnostic> = vec![e.into()];
         diagnostics
           .lock()
           .expect("failed to obtain lock of `diagnostics`")
-          .extend(rspack_err);
+          .push(e.into());
         return None;
       }
     };

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/a.css
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/a.css
@@ -1,0 +1,3 @@
+body {
+  content: "a";
+}

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/ab.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/ab.js
@@ -1,0 +1,2 @@
+import "./a.css"
+import "./b.css"

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/b.css
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/b.css
@@ -1,0 +1,3 @@
+body {
+  content: "b";
+}

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/ba.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/ba.js
@@ -1,0 +1,2 @@
+import "./b.css"
+import "./a.css"

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/warnings.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/0/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+  /Conflicting order\. Following module has been added/,
+]

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/1/ab.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/1/ab.js
@@ -1,0 +1,2 @@
+// import "./a.css"
+import "./b.css"

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/1/warnings.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/1/warnings.js
@@ -1,0 +1,1 @@
+module.exports = []

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/2/ab.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/2/ab.js
@@ -1,0 +1,2 @@
+import "./a.css"
+import "./b.css"

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/rspack.config.js
@@ -1,0 +1,42 @@
+const rspack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    ab: './ab.js',
+    ba: './ba.js',
+  },
+  output: {
+    filename: '[name].js'
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        styles: {
+          name: "styles",
+          chunks: "all",
+          test: /\.css$/,
+          enforce: true,
+        },
+      },
+    },
+  },
+  plugins: [
+    new rspack.CssExtractRspackPlugin({ ignoreOrder: false }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          rspack.CssExtractRspackPlugin.loader,
+          "css-loader",
+        ],
+        type: "javascript/auto",
+      },
+    ],
+  },
+  experiments: {
+    css: false,
+  },
+};

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle(i) {
+		return ["ab.js", "ba.js"];
+	},
+}

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/a.css
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/a.css
@@ -1,0 +1,3 @@
+body {
+  content: "a";
+}

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/ab.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/ab.js
@@ -1,0 +1,2 @@
+import "./a.css"
+import "./b.css"

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/b.css
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/b.css
@@ -1,0 +1,3 @@
+body {
+  content: "b";
+}

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/ba.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/ba.js
@@ -1,0 +1,2 @@
+import "./b.css"
+import "./a.css"

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/warnings.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/0/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+  /Conflicting order between/,
+]

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/1/ab.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/1/ab.js
@@ -1,0 +1,2 @@
+// import "./a.css"
+import "./b.css"

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/1/warnings.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/1/warnings.js
@@ -1,0 +1,1 @@
+module.exports = []

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/2/ab.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/2/ab.js
@@ -1,0 +1,2 @@
+import "./a.css"
+import "./b.css"

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/rspack.config.js
@@ -1,0 +1,28 @@
+const rspack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    ab: './ab.js',
+    ba: './ba.js',
+  },
+  output: {
+    filename: '[name].js'
+  },
+  target: "web",
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        styles: {
+          name: "styles",
+          chunks: "all",
+          test: /\.css$/,
+          enforce: true,
+        },
+      },
+    },
+  },
+  experiments: {
+    css: true,
+  },
+};

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle(i) {
+		return ["ab.js", "ba.js"];
+	},
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Don't cache diagnostics for chunk render cache

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
