### PR TITLE
perf: move from `Buffer` to zero-copy `BufferSlice`

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -47,7 +47,7 @@ export declare class EntryOptionsDto {
 export type EntryOptionsDTO = EntryOptionsDto
 
 export declare class JsCompilation {
-  updateAsset(filename: string, newSourceOrFunction: JsCompatSource | ((source: JsCompatSource) => JsCompatSource), assetInfoUpdateOrFunction?: JsAssetInfo | ((assetInfo: JsAssetInfo) => JsAssetInfo)): void
+  updateAsset(filename: string, newSourceOrFunction: JsCompatSource | ((source: JsCompatSourceOwned) => JsCompatSourceOwned), assetInfoUpdateOrFunction?: JsAssetInfo | ((assetInfo: JsAssetInfo) => JsAssetInfo)): void
   getAssets(): Readonly<JsAsset>[]
   getAsset(name: string): JsAsset | null
   getAssetSource(name: string): JsCompatSource | null
@@ -526,7 +526,19 @@ export interface JsCodegenerationResults {
   map: Record<string, Record<string, JsCodegenerationResult>>
 }
 
+/**
+ * Zero copy `JsCompatSource` slice shared between Rust and Node.js if buffer is used.
+ *
+ * It can only be used in non-async context and the lifetime is bound to the fn closure.
+ *
+ * If you want to use Node.js Buffer in async context or want to extend the lifetime, use `JsCompatSourceOwned` instead.
+ */
 export interface JsCompatSource {
+  source: string | Buffer
+  map?: string
+}
+
+export interface JsCompatSourceOwned {
   source: string | Buffer
   map?: string
 }
@@ -781,7 +793,7 @@ export interface JsRuntimeGlobals {
 }
 
 export interface JsRuntimeModule {
-  source?: JsCompatSource
+  source?: JsCompatSourceOwned
   moduleIdentifier: string
   constructorName: string
   name: string

--- a/crates/node_binding/src/plugins/interceptor.rs
+++ b/crates/node_binding/src/plugins/interceptor.rs
@@ -20,7 +20,7 @@ use rspack_binding_values::{
   JsFactorizeOutput, JsModuleWrapper, JsNormalModuleFactoryCreateModuleArgs, JsResolveArgs,
   JsResolveForSchemeArgs, JsResolveForSchemeOutput, JsResolveOutput, JsRuntimeGlobals,
   JsRuntimeModule, JsRuntimeModuleArg, JsRuntimeRequirementInTreeArg,
-  JsRuntimeRequirementInTreeResult, ToJsCompatSource,
+  JsRuntimeRequirementInTreeResult, ToJsCompatSourceOwned,
 };
 use rspack_collections::IdentifierSet;
 use rspack_core::{
@@ -1256,7 +1256,7 @@ impl CompilationRuntimeModule for CompilationRuntimeModuleTap {
         source: Some(
           module
             .generate(compilation)?
-            .to_js_compat_source()
+            .to_js_compat_source_owned()
             .unwrap_or_else(|err| panic!("Failed to generate runtime module source: {err}")),
         ),
         module_identifier: module.identifier().to_string(),

--- a/crates/rspack_binding_values/src/source.rs
+++ b/crates/rspack_binding_values/src/source.rs
@@ -7,15 +7,49 @@ use rspack_core::rspack_sources::{
 };
 use rspack_napi::napi::bindgen_prelude::*;
 
+/// Zero copy `JsCompatSource` slice shared between Rust and Node.js if buffer is used.
+///
+/// It can only be used in non-async context and the lifetime is bound to the fn closure.
+///
+/// If you want to use Node.js Buffer in async context or want to extend the lifetime, use `JsCompatSourceOwned` instead.
+#[napi(object)]
+pub struct JsCompatSource<'s> {
+  pub source: Either<String, BufferSlice<'s>>,
+  pub map: Option<String>,
+}
+
+impl<'s> From<JsCompatSource<'s>> for BoxSource {
+  fn from(value: JsCompatSource<'s>) -> Self {
+    match value.source {
+      Either::A(string) => {
+        if let Some(map) = value.map {
+          match SourceMap::from_slice(map.as_ref()).ok() {
+            Some(source_map) => SourceMapSource::new(WithoutOriginalOptions {
+              value: string,
+              name: "inmemory://from js",
+              source_map,
+            })
+            .boxed(),
+            None => RawSource::from(string).boxed(),
+          }
+        } else {
+          RawSource::from(string).boxed()
+        }
+      }
+      Either::B(buffer) => RawSource::from(buffer.to_vec()).boxed(),
+    }
+  }
+}
+
 #[napi(object)]
 #[derive(Clone)]
-pub struct JsCompatSource {
+pub struct JsCompatSourceOwned {
   pub source: Either<String, Buffer>,
   pub map: Option<String>,
 }
 
-impl From<JsCompatSource> for BoxSource {
-  fn from(value: JsCompatSource) -> Self {
+impl From<JsCompatSourceOwned> for BoxSource {
+  fn from(value: JsCompatSourceOwned) -> Self {
     match value.source {
       Either::A(string) => {
         if let Some(map) = value.map {
@@ -38,14 +72,14 @@ impl From<JsCompatSource> for BoxSource {
 }
 
 pub trait ToJsCompatSource {
-  fn to_js_compat_source(&self) -> Result<JsCompatSource>;
+  fn to_js_compat_source(&self, env: &Env) -> Result<JsCompatSource>;
 }
 
 impl ToJsCompatSource for RawSource {
-  fn to_js_compat_source(&self) -> Result<JsCompatSource> {
+  fn to_js_compat_source(&self, env: &Env) -> Result<JsCompatSource> {
     Ok(JsCompatSource {
       source: if self.is_buffer() {
-        Either::B(self.buffer().to_vec().into())
+        Either::B(BufferSlice::from_data(env, self.buffer())?)
       } else {
         Either::A(self.source().to_string())
       },
@@ -55,36 +89,36 @@ impl ToJsCompatSource for RawSource {
 }
 
 impl<T: Source + Hash + PartialEq + Eq + 'static> ToJsCompatSource for ReplaceSource<T> {
-  fn to_js_compat_source(&self) -> Result<JsCompatSource> {
+  fn to_js_compat_source(&self, env: &Env) -> Result<JsCompatSource> {
     Ok(JsCompatSource {
-      source: Either::A(self.source().to_string()),
+      source: Either::B(BufferSlice::from_data(env, self.source().as_bytes())?),
       map: to_webpack_map(self)?,
     })
   }
 }
 
 impl<T: ToJsCompatSource> ToJsCompatSource for CachedSource<T> {
-  fn to_js_compat_source(&self) -> Result<JsCompatSource> {
-    self.original().to_js_compat_source()
+  fn to_js_compat_source(&self, env: &Env) -> Result<JsCompatSource> {
+    self.original().to_js_compat_source(env)
   }
 }
 
 impl ToJsCompatSource for Arc<dyn Source> {
-  fn to_js_compat_source(&self) -> Result<JsCompatSource> {
-    (**self).to_js_compat_source()
+  fn to_js_compat_source(&self, env: &Env) -> Result<JsCompatSource> {
+    (**self).to_js_compat_source(env)
   }
 }
 
 impl ToJsCompatSource for Box<dyn Source> {
-  fn to_js_compat_source(&self) -> Result<JsCompatSource> {
-    (**self).to_js_compat_source()
+  fn to_js_compat_source(&self, env: &Env) -> Result<JsCompatSource> {
+    (**self).to_js_compat_source(env)
   }
 }
 
 macro_rules! impl_default_to_compat_source {
   ($ident:ident) => {
     impl ToJsCompatSource for $ident {
-      fn to_js_compat_source(&self) -> Result<JsCompatSource> {
+      fn to_js_compat_source(&self, _env: &Env) -> Result<JsCompatSource> {
         Ok(JsCompatSource {
           source: Either::A(self.source().to_string()),
           map: to_webpack_map(self)?,
@@ -98,35 +132,26 @@ impl_default_to_compat_source!(SourceMapSource);
 impl_default_to_compat_source!(ConcatSource);
 impl_default_to_compat_source!(OriginalSource);
 
-fn to_webpack_map(source: &dyn Source) -> Result<Option<String>> {
-  let map = source.map(&MapOptions::default());
-
-  map
-    .map(|m| m.to_json())
-    .transpose()
-    .map_err(|err| napi::Error::from_reason(err.to_string()))
-}
-
 impl ToJsCompatSource for dyn Source + '_ {
-  fn to_js_compat_source(&self) -> Result<JsCompatSource> {
+  fn to_js_compat_source(&self, env: &Env) -> Result<JsCompatSource> {
     if let Some(raw_source) = self.as_any().downcast_ref::<RawSource>() {
-      raw_source.to_js_compat_source()
+      raw_source.to_js_compat_source(env)
     } else if let Some(cached_source) = self.as_any().downcast_ref::<CachedSource<RawSource>>() {
-      cached_source.to_js_compat_source()
+      cached_source.to_js_compat_source(env)
     } else if let Some(cached_source) = self
       .as_any()
       .downcast_ref::<CachedSource<Box<dyn Source>>>()
     {
-      cached_source.to_js_compat_source()
+      cached_source.to_js_compat_source(env)
     } else if let Some(cached_source) = self
       .as_any()
       .downcast_ref::<CachedSource<Arc<dyn Source>>>()
     {
-      cached_source.to_js_compat_source()
+      cached_source.to_js_compat_source(env)
     } else if let Some(source) = self.as_any().downcast_ref::<Box<dyn Source>>() {
-      source.to_js_compat_source()
+      source.to_js_compat_source(env)
     } else if let Some(source) = self.as_any().downcast_ref::<Arc<dyn Source>>() {
-      source.to_js_compat_source()
+      source.to_js_compat_source(env)
     } else {
       // If it's not a `RawSource` related type, then we regards it as a `Source` type.
       Ok(JsCompatSource {
@@ -135,4 +160,104 @@ impl ToJsCompatSource for dyn Source + '_ {
       })
     }
   }
+}
+
+pub trait ToJsCompatSourceOwned {
+  fn to_js_compat_source_owned(&self) -> Result<JsCompatSourceOwned>;
+}
+
+impl ToJsCompatSourceOwned for RawSource {
+  fn to_js_compat_source_owned(&self) -> Result<JsCompatSourceOwned> {
+    Ok(JsCompatSourceOwned {
+      source: if self.is_buffer() {
+        Either::B(self.buffer().to_vec().into())
+      } else {
+        Either::A(self.source().to_string())
+      },
+      map: to_webpack_map(self)?,
+    })
+  }
+}
+
+impl<T: Source + Hash + PartialEq + Eq + 'static> ToJsCompatSourceOwned for ReplaceSource<T> {
+  fn to_js_compat_source_owned(&self) -> Result<JsCompatSourceOwned> {
+    Ok(JsCompatSourceOwned {
+      source: Either::A(self.source().to_string()),
+      map: to_webpack_map(self)?,
+    })
+  }
+}
+
+impl<T: ToJsCompatSourceOwned> ToJsCompatSourceOwned for CachedSource<T> {
+  fn to_js_compat_source_owned(&self) -> Result<JsCompatSourceOwned> {
+    self.original().to_js_compat_source_owned()
+  }
+}
+
+impl ToJsCompatSourceOwned for Arc<dyn Source> {
+  fn to_js_compat_source_owned(&self) -> Result<JsCompatSourceOwned> {
+    (**self).to_js_compat_source_owned()
+  }
+}
+
+impl ToJsCompatSourceOwned for Box<dyn Source> {
+  fn to_js_compat_source_owned(&self) -> Result<JsCompatSourceOwned> {
+    (**self).to_js_compat_source_owned()
+  }
+}
+
+macro_rules! impl_default_to_compat_source {
+  ($ident:ident) => {
+    impl ToJsCompatSourceOwned for $ident {
+      fn to_js_compat_source_owned(&self) -> Result<JsCompatSourceOwned> {
+        Ok(JsCompatSourceOwned {
+          source: Either::A(self.source().to_string()),
+          map: to_webpack_map(self)?,
+        })
+      }
+    }
+  };
+}
+
+impl_default_to_compat_source!(SourceMapSource);
+impl_default_to_compat_source!(ConcatSource);
+impl_default_to_compat_source!(OriginalSource);
+
+impl ToJsCompatSourceOwned for dyn Source + '_ {
+  fn to_js_compat_source_owned(&self) -> Result<JsCompatSourceOwned> {
+    if let Some(raw_source) = self.as_any().downcast_ref::<RawSource>() {
+      raw_source.to_js_compat_source_owned()
+    } else if let Some(cached_source) = self.as_any().downcast_ref::<CachedSource<RawSource>>() {
+      cached_source.to_js_compat_source_owned()
+    } else if let Some(cached_source) = self
+      .as_any()
+      .downcast_ref::<CachedSource<Box<dyn Source>>>()
+    {
+      cached_source.to_js_compat_source_owned()
+    } else if let Some(cached_source) = self
+      .as_any()
+      .downcast_ref::<CachedSource<Arc<dyn Source>>>()
+    {
+      cached_source.to_js_compat_source_owned()
+    } else if let Some(source) = self.as_any().downcast_ref::<Box<dyn Source>>() {
+      source.to_js_compat_source_owned()
+    } else if let Some(source) = self.as_any().downcast_ref::<Arc<dyn Source>>() {
+      source.to_js_compat_source_owned()
+    } else {
+      // If it's not a `RawSource` related type, then we regards it as a `Source` type.
+      Ok(JsCompatSourceOwned {
+        source: Either::A(self.source().to_string()),
+        map: to_webpack_map(self)?,
+      })
+    }
+  }
+}
+
+fn to_webpack_map(source: &dyn Source) -> Result<Option<String>> {
+  let map = source.map(&MapOptions::default());
+
+  map
+    .map(|m| m.to_json())
+    .transpose()
+    .map_err(|err| napi::Error::from_reason(err.to_string()))
 }

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -10,7 +10,7 @@
 import type * as binding from "@rspack/binding";
 import {
 	type ExternalObject,
-	type JsCompatSource,
+	type JsCompatSourceOwned,
 	type JsCompilation,
 	type JsModule,
 	type JsPathData,
@@ -605,12 +605,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			| ((assetInfo: AssetInfo) => AssetInfo)
 	) {
 		let compatNewSourceOrFunction:
-			| JsCompatSource
-			| ((source: JsCompatSource) => JsCompatSource);
+			| JsCompatSourceOwned
+			| ((source: JsCompatSourceOwned) => JsCompatSourceOwned);
 
 		if (typeof newSourceOrFunction === "function") {
 			compatNewSourceOrFunction = function newSourceFunction(
-				source: JsCompatSource
+				source: JsCompatSourceOwned
 			) {
 				return JsSource.__to_binding(
 					newSourceOrFunction(JsSource.__from_binding(source))

--- a/packages/rspack/src/util/source.ts
+++ b/packages/rspack/src/util/source.ts
@@ -1,8 +1,8 @@
-import type { JsCompatSource } from "@rspack/binding";
+import type { JsCompatSourceOwned } from "@rspack/binding";
 import { RawSource, Source, SourceMapSource } from "webpack-sources";
 
 class JsSource extends Source {
-	static __from_binding(source: JsCompatSource): Source {
+	static __from_binding(source: JsCompatSourceOwned): Source {
 		if (source.source instanceof Buffer) {
 			// @ts-expect-error: webpack-sources can accept buffer as source,
 			// see: https://github.com/webpack/webpack-sources/blob/9f98066311d53a153fdc7c633422a1d086528027/lib/RawSource.js#L12
@@ -20,7 +20,7 @@ class JsSource extends Source {
 		);
 	}
 
-	static __to_binding(source: Source): JsCompatSource {
+	static __to_binding(source: Source): JsCompatSourceOwned {
 		if (source instanceof RawSource) {
 			// @ts-expect-error: The 'isBuffer' method exists on 'RawSource' in 'webpack-sources',
 			if (source.isBuffer()) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Use `BufferSlice`.

The main difference between `BufferSlice` and `Buffer` is the prior one is zero-copy if passing from JS runtimes to Rust.
However, the second one does not have this benefit. Under the hood, `Buffer` leverages thread-safe function to free when it's no longer needed. `BufferSlice`s are just collected by finalizers registered on the fly.

`BufferSlice` cannot be used between functions and `Buffer` can.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
