### PR TITLE
chore: fix crate publish problems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,89 @@ swc_node_comments   = { version = "=4.0.0" }
 
 
 rspack_dojang = { version = "0.1.9" }
+
+
+# all rspack workspace dependencies
+rspack_allocator                       = { version = "0.2.0", path = "crates/rspack_allocator" }
+rspack_ast                             = { version = "0.2.0", path = "crates/rspack_ast" }
+rspack_binding                         = { version = "0.2.0", path = "crates/rspack_binding" }
+rspack_binding_options                 = { version = "0.2.0", path = "crates/rspack_binding_options" }
+rspack_binding_values                  = { version = "0.2.0", path = "crates/rspack_binding_values" }
+rspack_builtin                         = { version = "0.2.0", path = "crates/rspack_builtin" }
+rspack_cacheable                       = { version = "0.2.0", path = "crates/rspack_cacheable" }
+rspack_collection                      = { version = "0.2.0", path = "crates/rspack_collection" }
+rspack_collections                     = { version = "0.2.0", path = "crates/rspack_collections" }
+rspack_core                            = { version = "0.2.0", path = "crates/rspack_core" }
+rspack_deps_graph                      = { version = "0.2.0", path = "crates/rspack_deps_graph" }
+rspack_error                           = { version = "0.2.0", path = "crates/rspack_error" }
+rspack_fs                              = { version = "0.2.0", path = "crates/rspack_fs" }
+rspack_fs_node                         = { version = "0.2.0", path = "crates/rspack_fs_node" }
+rspack_hash                            = { version = "0.2.0", path = "crates/rspack_hash" }
+rspack_hook                            = { version = "0.2.0", path = "crates/rspack_hook" }
+rspack_identifier                      = { version = "0.2.0", path = "crates/rspack_identifier" }
+rspack_loader                          = { version = "0.2.0", path = "crates/rspack_loader" }
+rspack_loader_runner                   = { version = "0.2.0", path = "crates/rspack_loader_runner" }
+rspack_loader_swc                      = { version = "0.2.0", path = "crates/rspack_loader_swc" }
+rspack_macros                          = { version = "0.2.0", path = "crates/rspack_macros" }
+rspack_plugin_                         = { version = "0.2.0", path = "crates/rspack_plugin_ensure_chunk_conditions" }
+rspack_plugin_banner                   = { version = "0.2.0", path = "crates/rspack_plugin_banner" }
+rspack_plugin_context_replacement      = { version = "0.2.0", path = "crates/rspack_plugin_context_replacement" }
+rspack_plugin_copy                     = { version = "0.2.0", path = "crates/rspack_plugin_copy" }
+rspack_plugin_css                      = { version = "0.2.0", path = "crates/rspack_plugin_css" }
+rspack_plugin_devtool                  = { version = "0.2.0", path = "crates/rspack_plugin_devtool" }
+rspack_plugin_dll                      = { version = "0.2.0", path = "crates/rspack_plugin_dll" }
+rspack_plugin_dynamic                  = { version = "0.2.0", path = "crates/rspack_plugin_dynamic" }
+rspack_plugin_dynamic_entry            = { version = "0.2.0", path = "crates/rspack_plugin_dynamic_entry" }
+rspack_plugin_emit                     = { version = "0.2.0", path = "crates/rspack_plugin_emit" }
+rspack_plugin_ensure_chunk_conditions  = { version = "0.2.0", path = "crates/rspack_plugin_ensure_chunk_conditions" }
+rspack_plugin_entry                    = { version = "0.2.0", path = "crates/rspack_plugin_entry" }
+rspack_plugin_externals                = { version = "0.2.0", path = "crates/rspack_plugin_externals" }
+rspack_plugin_extract_css              = { version = "0.2.0", path = "crates/rspack_plugin_extract_css" }
+rspack_plugin_hmr                      = { version = "0.2.0", path = "crates/rspack_plugin_hmr" }
+rspack_plugin_html                     = { version = "0.2.0", path = "crates/rspack_plugin_html" }
+rspack_plugin_ignore                   = { version = "0.2.0", path = "crates/rspack_plugin_ignore" }
+rspack_plugin_javascript               = { version = "0.2.0", path = "crates/rspack_plugin_javascript" }
+rspack_plugin_json                     = { version = "0.2.0", path = "crates/rspack_plugin_json" }
+rspack_plugin_lazy_compilation         = { version = "0.2.0", path = "crates/rspack_plugin_lazy_compilation" }
+rspack_plugin_li                       = { version = "0.2.0", path = "crates/rspack_plugin_dynamic_entry" }
+rspack_plugin_library                  = { version = "0.2.0", path = "crates/rspack_plugin_library" }
+rspack_plugin_lightning_css_minimizer  = { version = "0.2.0", path = "crates/rspack_plugin_lightning_css_minimizer" }
+rspack_plugin_limit_chunk_count        = { version = "0.2.0", path = "crates/rspack_plugin_limit_chunk_count" }
+rspack_plugin_merge                    = { version = "0.2.0", path = "crates/rspack_plugin_merge" }
+rspack_plugin_merge_duplicate_chunks   = { version = "0.2.0", path = "crates/rspack_plugin_merge_duplicate_chunks" }
+rspack_plugin_mf                       = { version = "0.2.0", path = "crates/rspack_plugin_mf" }
+rspack_plugin_mini_css_extract         = { version = "0.2.0", path = "crates/rspack_plugin_mini_css_extract" }
+rspack_plugin_no_emit_on_errors        = { version = "0.2.0", path = "crates/rspack_plugin_no_emit_on_errors" }
+rspack_plugin_progress                 = { version = "0.2.0", path = "crates/rspack_plugin_progress" }
+rspack_plugin_real_content_hash        = { version = "0.2.0", path = "crates/rspack_plugin_real_content_hash" }
+rspack_plugin_remove_duplicate_modules = { version = "0.2.0", path = "crates/rspack_plugin_remove_duplicate_modules" }
+rspack_plugin_remove_empty_chunks      = { version = "0.2.0", path = "crates/rspack_plugin_remove_empty_chunks" }
+rspack_plugin_runtime                  = { version = "0.2.0", path = "crates/rspack_plugin_runtime" }
+rspack_plugin_runtime_chunk            = { version = "0.2.0", path = "crates/rspack_plugin_runtime_chunk" }
+rspack_plugin_schemes                  = { version = "0.2.0", path = "crates/rspack_plugin_schemes" }
+rspack_plugin_size_limits              = { version = "0.2.0", path = "crates/rspack_plugin_size_limits" }
+rspack_plugin_split_chunks             = { version = "0.2.0", path = "crates/rspack_plugin_split_chunks" }
+rspack_plugin_swc_js_minimizer         = { version = "0.2.0", path = "crates/rspack_plugin_swc_js_minimizer" }
+rspack_plugin_warn_sensitive_module    = { version = "0.2.0", path = "crates/rspack_plugin_warn_sensitive_module" }
+rspack_plugin_wasm                     = { version = "0.2.0", path = "crates/rspack_plugin_wasm" }
+rspack_plugin_web_worker_template      = { version = "0.2.0", path = "crates/rspack_plugin_web_worker_template" }
+rspack_plugin_worker                   = { version = "0.2.0", path = "crates/rspack_plugin_worker" }
+rspack_regex                           = { version = "0.2.0", path = "crates/rspack_regex" }
+
+rspack_futures = { version = "0.2.0", path = "crates/rspack_futures" }
+
+rspack_ids                   = { version = "0.2.0", path = "crates/rspack_ids" }
+rspack_loader_lightningcss   = { version = "0.2.0", path = "crates/rspack_loader_lightningcss" }
+rspack_loader_preact_refresh = { version = "0.2.0", path = "crates/rspack_loader_preact_refresh" }
+rspack_loader_react_refresh  = { version = "0.2.0", path = "crates/rspack_loader_react_refresh" }
+rspack_loader_testing        = { version = "0.2.0", path = "crates/rspack_loader_testing" }
+rspack_napi                  = { version = "0.2.0", path = "crates/rspack_napi" }
+rspack_napi_macros           = { version = "0.2.0", path = "crates/rspack_napi_macros" }
+rspack_paths                 = { version = "0.2.0", path = "crates/rspack_paths" }
+rspack_plugin_asset          = { version = "0.2.0", path = "crates/rspack_plugin_asset" }
+rspack_testing               = { version = "0.2.0", path = "crates/rspack_testing" }
+rspack_tracing               = { version = "0.2.0", path = "crates/rspack_tracing" }
+rspack_util                  = { version = "0.2.0", path = "crates/rspack_util" }
 [workspace.metadata.release]
 rate-limit = { existing-packages = 70, new-packages = 70 }
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,20 @@ license       = "MIT"
 repository    = "https://github.com/web-infra-dev/rspack"
 
 [workspace.metadata.cargo-shear]
-ignored = ["swc"]
+ignored = [
+  "swc",
+  "rspack_plugin_dynamic",
+  "rspack_builtin",
+  "rspack_loader",
+  "rspack_identifier",
+  "rspack_testing",
+  "rspack_plugin_emit",
+  "rspack_collection",
+  "rspack_deps_graph",
+  "rspack_plugin_mini_css_extract",
+  "rspack_binding",
+  "rspack_plugin_merge",
+]
 [workspace.dependencies]
 anyhow             = { version = "1.0.81", features = ["backtrace"] }
 anymap             = { version = "=1.0.0-beta.2" }
@@ -96,6 +109,7 @@ rspack_dojang = { version = "0.1.9" }
 # all rspack workspace dependencies
 rspack_allocator                       = { version = "0.2.0", path = "crates/rspack_allocator" }
 rspack_ast                             = { version = "0.2.0", path = "crates/rspack_ast" }
+rspack_base64                          = { version = "0.2.0", path = "crates/rspack_base64" }
 rspack_binding                         = { version = "0.2.0", path = "crates/rspack_binding" }
 rspack_binding_options                 = { version = "0.2.0", path = "crates/rspack_binding_options" }
 rspack_binding_values                  = { version = "0.2.0", path = "crates/rspack_binding_values" }
@@ -108,14 +122,23 @@ rspack_deps_graph                      = { version = "0.2.0", path = "crates/rsp
 rspack_error                           = { version = "0.2.0", path = "crates/rspack_error" }
 rspack_fs                              = { version = "0.2.0", path = "crates/rspack_fs" }
 rspack_fs_node                         = { version = "0.2.0", path = "crates/rspack_fs_node" }
+rspack_futures                         = { version = "0.2.0", path = "crates/rspack_futures" }
 rspack_hash                            = { version = "0.2.0", path = "crates/rspack_hash" }
 rspack_hook                            = { version = "0.2.0", path = "crates/rspack_hook" }
 rspack_identifier                      = { version = "0.2.0", path = "crates/rspack_identifier" }
+rspack_ids                             = { version = "0.2.0", path = "crates/rspack_ids" }
 rspack_loader                          = { version = "0.2.0", path = "crates/rspack_loader" }
+rspack_loader_lightningcss             = { version = "0.2.0", path = "crates/rspack_loader_lightningcss" }
+rspack_loader_preact_refresh           = { version = "0.2.0", path = "crates/rspack_loader_preact_refresh" }
+rspack_loader_react_refresh            = { version = "0.2.0", path = "crates/rspack_loader_react_refresh" }
 rspack_loader_runner                   = { version = "0.2.0", path = "crates/rspack_loader_runner" }
 rspack_loader_swc                      = { version = "0.2.0", path = "crates/rspack_loader_swc" }
+rspack_loader_testing                  = { version = "0.2.0", path = "crates/rspack_loader_testing" }
 rspack_macros                          = { version = "0.2.0", path = "crates/rspack_macros" }
-rspack_plugin_                         = { version = "0.2.0", path = "crates/rspack_plugin_ensure_chunk_conditions" }
+rspack_napi                            = { version = "0.2.0", path = "crates/rspack_napi" }
+rspack_napi_macros                     = { version = "0.2.0", path = "crates/rspack_napi_macros" }
+rspack_paths                           = { version = "0.2.0", path = "crates/rspack_paths" }
+rspack_plugin_asset                    = { version = "0.2.0", path = "crates/rspack_plugin_asset" }
 rspack_plugin_banner                   = { version = "0.2.0", path = "crates/rspack_plugin_banner" }
 rspack_plugin_context_replacement      = { version = "0.2.0", path = "crates/rspack_plugin_context_replacement" }
 rspack_plugin_copy                     = { version = "0.2.0", path = "crates/rspack_plugin_copy" }
@@ -135,7 +158,6 @@ rspack_plugin_ignore                   = { version = "0.2.0", path = "crates/rsp
 rspack_plugin_javascript               = { version = "0.2.0", path = "crates/rspack_plugin_javascript" }
 rspack_plugin_json                     = { version = "0.2.0", path = "crates/rspack_plugin_json" }
 rspack_plugin_lazy_compilation         = { version = "0.2.0", path = "crates/rspack_plugin_lazy_compilation" }
-rspack_plugin_li                       = { version = "0.2.0", path = "crates/rspack_plugin_dynamic_entry" }
 rspack_plugin_library                  = { version = "0.2.0", path = "crates/rspack_plugin_library" }
 rspack_plugin_lightning_css_minimizer  = { version = "0.2.0", path = "crates/rspack_plugin_lightning_css_minimizer" }
 rspack_plugin_limit_chunk_count        = { version = "0.2.0", path = "crates/rspack_plugin_limit_chunk_count" }
@@ -159,21 +181,10 @@ rspack_plugin_wasm                     = { version = "0.2.0", path = "crates/rsp
 rspack_plugin_web_worker_template      = { version = "0.2.0", path = "crates/rspack_plugin_web_worker_template" }
 rspack_plugin_worker                   = { version = "0.2.0", path = "crates/rspack_plugin_worker" }
 rspack_regex                           = { version = "0.2.0", path = "crates/rspack_regex" }
-
-rspack_futures = { version = "0.2.0", path = "crates/rspack_futures" }
-
-rspack_ids                   = { version = "0.2.0", path = "crates/rspack_ids" }
-rspack_loader_lightningcss   = { version = "0.2.0", path = "crates/rspack_loader_lightningcss" }
-rspack_loader_preact_refresh = { version = "0.2.0", path = "crates/rspack_loader_preact_refresh" }
-rspack_loader_react_refresh  = { version = "0.2.0", path = "crates/rspack_loader_react_refresh" }
-rspack_loader_testing        = { version = "0.2.0", path = "crates/rspack_loader_testing" }
-rspack_napi                  = { version = "0.2.0", path = "crates/rspack_napi" }
-rspack_napi_macros           = { version = "0.2.0", path = "crates/rspack_napi_macros" }
-rspack_paths                 = { version = "0.2.0", path = "crates/rspack_paths" }
-rspack_plugin_asset          = { version = "0.2.0", path = "crates/rspack_plugin_asset" }
-rspack_testing               = { version = "0.2.0", path = "crates/rspack_testing" }
-rspack_tracing               = { version = "0.2.0", path = "crates/rspack_tracing" }
-rspack_util                  = { version = "0.2.0", path = "crates/rspack_util" }
+rspack_testing                         = { version = "0.2.0", path = "crates/rspack_testing" }
+rspack_tracing                         = { version = "0.2.0", path = "crates/rspack_tracing" }
+rspack_util                            = { version = "0.2.0", path = "crates/rspack_util" }
+swc_plugin_import                      = { version = "0.2.0", path = "crates/swc_plugin_import" }
 [workspace.metadata.release]
 rate-limit = { existing-packages = 70, new-packages = 70 }
 [profile.dev]

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -15,23 +15,23 @@ plugin  = ["rspack_binding_options/plugin"]
 
 [dependencies]
 ropey                    = { workspace = true }
-rspack_allocator         = { version = "0.2.0", path = "../rspack_allocator" }
-rspack_binding_options   = { version = "0.2.0", path = "../rspack_binding_options" }
-rspack_binding_values    = { version = "0.2.0", path = "../rspack_binding_values" }
-rspack_collections       = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core              = { version = "0.2.0", path = "../rspack_core" }
-rspack_error             = { version = "0.2.0", path = "../rspack_error" }
-rspack_fs                = { version = "0.2.0", path = "../rspack_fs" }
-rspack_fs_node           = { version = "0.2.0", path = "../rspack_fs_node" }
-rspack_hash              = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook              = { version = "0.2.0", path = "../rspack_hook" }
-rspack_napi              = { version = "0.2.0", path = "../rspack_napi" }
-rspack_paths             = { version = "0.2.0", path = "../rspack_paths" }
-rspack_plugin_html       = { version = "0.2.0", path = "../rspack_plugin_html" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_util              = { version = "0.2.0", path = "../rspack_util" }
+rspack_allocator         = { workspace = true }
+rspack_binding_options   = { workspace = true }
+rspack_binding_values    = { workspace = true }
+rspack_collections       = { workspace = true }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_fs                = { workspace = true }
+rspack_fs_node           = { workspace = true }
+rspack_hash              = { workspace = true }
+rspack_hook              = { workspace = true }
+rspack_napi              = { workspace = true }
+rspack_paths             = { workspace = true }
+rspack_plugin_html       = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_util              = { workspace = true }
 
-rspack_tracing = { version = "0.2.0", path = "../rspack_tracing" }
+rspack_tracing = { workspace = true }
 
 async-trait = { workspace = true }
 cow-utils   = { workspace = true }

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -20,60 +20,60 @@ glob                                   = { workspace = true }
 napi                                   = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
 napi-derive                            = { workspace = true }
 pollster                               = { workspace = true }
-rspack_binding_values                  = { version = "0.2.0", path = "../rspack_binding_values" }
-rspack_collections                     = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core                            = { version = "0.2.0", path = "../rspack_core" }
-rspack_error                           = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook                            = { version = "0.2.0", path = "../rspack_hook" }
-rspack_ids                             = { version = "0.2.0", path = "../rspack_ids" }
-rspack_loader_lightningcss             = { version = "0.2.0", path = "../rspack_loader_lightningcss" }
-rspack_loader_preact_refresh           = { version = "0.2.0", path = "../rspack_loader_preact_refresh" }
-rspack_loader_react_refresh            = { version = "0.2.0", path = "../rspack_loader_react_refresh" }
-rspack_loader_runner                   = { version = "0.2.0", path = "../rspack_loader_runner" }
-rspack_loader_swc                      = { version = "0.2.0", path = "../rspack_loader_swc" }
-rspack_loader_testing                  = { version = "0.2.0", path = "../rspack_loader_testing" }
-rspack_napi                            = { version = "0.2.0", path = "../rspack_napi" }
-rspack_napi_macros                     = { version = "0.2.0", path = "../rspack_napi_macros" }
-rspack_paths                           = { version = "0.2.0", path = "../rspack_paths" }
-rspack_plugin_asset                    = { version = "0.2.0", path = "../rspack_plugin_asset" }
-rspack_plugin_banner                   = { version = "0.2.0", path = "../rspack_plugin_banner" }
-rspack_plugin_context_replacement      = { version = "0.2.0", path = "../rspack_plugin_context_replacement" }
-rspack_plugin_copy                     = { version = "0.2.0", path = "../rspack_plugin_copy" }
-rspack_plugin_css                      = { version = "0.2.0", path = "../rspack_plugin_css" }
-rspack_plugin_devtool                  = { version = "0.2.0", path = "../rspack_plugin_devtool" }
-rspack_plugin_dll                      = { version = "0.2.0", path = "../rspack_plugin_dll" }
-rspack_plugin_dynamic_entry            = { version = "0.2.0", path = "../rspack_plugin_dynamic_entry" }
-rspack_plugin_ensure_chunk_conditions  = { version = "0.2.0", path = "../rspack_plugin_ensure_chunk_conditions" }
-rspack_plugin_entry                    = { version = "0.2.0", path = "../rspack_plugin_entry" }
-rspack_plugin_externals                = { version = "0.2.0", path = "../rspack_plugin_externals" }
-rspack_plugin_extract_css              = { version = "0.2.0", path = "../rspack_plugin_extract_css" }
-rspack_plugin_hmr                      = { version = "0.2.0", path = "../rspack_plugin_hmr" }
-rspack_plugin_html                     = { version = "0.2.0", path = "../rspack_plugin_html" }
-rspack_plugin_ignore                   = { version = "0.2.0", path = "../rspack_plugin_ignore" }
-rspack_plugin_javascript               = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_plugin_json                     = { version = "0.2.0", path = "../rspack_plugin_json" }
-rspack_plugin_lazy_compilation         = { version = "0.2.0", path = "../rspack_plugin_lazy_compilation" }
-rspack_plugin_library                  = { version = "0.2.0", path = "../rspack_plugin_library" }
-rspack_plugin_lightning_css_minimizer  = { version = "0.2.0", path = "../rspack_plugin_lightning_css_minimizer" }
-rspack_plugin_limit_chunk_count        = { version = "0.2.0", path = "../rspack_plugin_limit_chunk_count" }
-rspack_plugin_merge_duplicate_chunks   = { version = "0.2.0", path = "../rspack_plugin_merge_duplicate_chunks" }
-rspack_plugin_mf                       = { version = "0.2.0", path = "../rspack_plugin_mf" }
-rspack_plugin_no_emit_on_errors        = { version = "0.2.0", path = "../rspack_plugin_no_emit_on_errors" }
-rspack_plugin_progress                 = { version = "0.2.0", path = "../rspack_plugin_progress" }
-rspack_plugin_real_content_hash        = { version = "0.2.0", path = "../rspack_plugin_real_content_hash" }
-rspack_plugin_remove_duplicate_modules = { version = "0.2.0", path = "../rspack_plugin_remove_duplicate_modules" }
-rspack_plugin_remove_empty_chunks      = { version = "0.2.0", path = "../rspack_plugin_remove_empty_chunks" }
-rspack_plugin_runtime                  = { version = "0.2.0", path = "../rspack_plugin_runtime" }
-rspack_plugin_runtime_chunk            = { version = "0.2.0", path = "../rspack_plugin_runtime_chunk" }
-rspack_plugin_schemes                  = { version = "0.2.0", path = "../rspack_plugin_schemes" }
-rspack_plugin_size_limits              = { version = "0.2.0", path = "../rspack_plugin_size_limits" }
-rspack_plugin_split_chunks             = { version = "0.2.0", path = "../rspack_plugin_split_chunks" }
-rspack_plugin_swc_js_minimizer         = { version = "0.2.0", path = "../rspack_plugin_swc_js_minimizer" }
-rspack_plugin_warn_sensitive_module    = { version = "0.2.0", path = "../rspack_plugin_warn_sensitive_module" }
-rspack_plugin_wasm                     = { version = "0.2.0", path = "../rspack_plugin_wasm" }
-rspack_plugin_web_worker_template      = { version = "0.2.0", path = "../rspack_plugin_web_worker_template" }
-rspack_plugin_worker                   = { version = "0.2.0", path = "../rspack_plugin_worker" }
-rspack_regex                           = { version = "0.2.0", path = "../rspack_regex" }
+rspack_binding_values                  = { workspace = true }
+rspack_collections                     = { workspace = true }
+rspack_core                            = { workspace = true }
+rspack_error                           = { workspace = true }
+rspack_hook                            = { workspace = true }
+rspack_ids                             = { workspace = true }
+rspack_loader_lightningcss             = { workspace = true }
+rspack_loader_preact_refresh           = { workspace = true }
+rspack_loader_react_refresh            = { workspace = true }
+rspack_loader_runner                   = { workspace = true }
+rspack_loader_swc                      = { workspace = true }
+rspack_loader_testing                  = { workspace = true }
+rspack_napi                            = { workspace = true }
+rspack_napi_macros                     = { workspace = true }
+rspack_paths                           = { workspace = true }
+rspack_plugin_asset                    = { workspace = true }
+rspack_plugin_banner                   = { workspace = true }
+rspack_plugin_context_replacement      = { workspace = true }
+rspack_plugin_copy                     = { workspace = true }
+rspack_plugin_css                      = { workspace = true }
+rspack_plugin_devtool                  = { workspace = true }
+rspack_plugin_dll                      = { workspace = true }
+rspack_plugin_dynamic_entry            = { workspace = true }
+rspack_plugin_ensure_chunk_conditions  = { workspace = true }
+rspack_plugin_entry                    = { workspace = true }
+rspack_plugin_externals                = { workspace = true }
+rspack_plugin_extract_css              = { workspace = true }
+rspack_plugin_hmr                      = { workspace = true }
+rspack_plugin_html                     = { workspace = true }
+rspack_plugin_ignore                   = { workspace = true }
+rspack_plugin_javascript               = { workspace = true }
+rspack_plugin_json                     = { workspace = true }
+rspack_plugin_lazy_compilation         = { workspace = true }
+rspack_plugin_library                  = { workspace = true }
+rspack_plugin_lightning_css_minimizer  = { workspace = true }
+rspack_plugin_limit_chunk_count        = { workspace = true }
+rspack_plugin_merge_duplicate_chunks   = { workspace = true }
+rspack_plugin_mf                       = { workspace = true }
+rspack_plugin_no_emit_on_errors        = { workspace = true }
+rspack_plugin_progress                 = { workspace = true }
+rspack_plugin_real_content_hash        = { workspace = true }
+rspack_plugin_remove_duplicate_modules = { workspace = true }
+rspack_plugin_remove_empty_chunks      = { workspace = true }
+rspack_plugin_runtime                  = { workspace = true }
+rspack_plugin_runtime_chunk            = { workspace = true }
+rspack_plugin_schemes                  = { workspace = true }
+rspack_plugin_size_limits              = { workspace = true }
+rspack_plugin_split_chunks             = { workspace = true }
+rspack_plugin_swc_js_minimizer         = { workspace = true }
+rspack_plugin_warn_sensitive_module    = { workspace = true }
+rspack_plugin_wasm                     = { workspace = true }
+rspack_plugin_web_worker_template      = { workspace = true }
+rspack_plugin_worker                   = { workspace = true }
+rspack_regex                           = { workspace = true }
 rustc-hash                             = { workspace = true }
 serde                                  = { workspace = true, features = ["derive"] }
 serde_json                             = { workspace = true }

--- a/crates/rspack_binding_values/Cargo.toml
+++ b/crates/rspack_binding_values/Cargo.toml
@@ -11,14 +11,14 @@ futures               = { workspace = true }
 heck                  = { workspace = true }
 napi                  = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
 napi-derive           = { workspace = true }
-rspack_collections    = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core           = { version = "0.2.0", path = "../rspack_core" }
-rspack_error          = { version = "0.2.0", path = "../rspack_error" }
-rspack_napi           = { version = "0.2.0", path = "../rspack_napi" }
-rspack_plugin_html    = { version = "0.2.0", path = "../rspack_plugin_html" }
-rspack_plugin_runtime = { version = "0.2.0", path = "../rspack_plugin_runtime" }
-rspack_regex          = { version = "0.2.0", path = "../rspack_regex" }
-rspack_util           = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections    = { workspace = true }
+rspack_core           = { workspace = true }
+rspack_error          = { workspace = true }
+rspack_napi           = { workspace = true }
+rspack_plugin_html    = { workspace = true }
+rspack_plugin_runtime = { workspace = true }
+rspack_regex          = { workspace = true }
+rspack_util           = { workspace = true }
 rustc-hash            = { workspace = true }
 serde                 = { workspace = true }
 serde_json            = { workspace = true }

--- a/crates/rspack_cacheable/Cargo.toml
+++ b/crates/rspack_cacheable/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
-edition = "2021"
-license = "MIT"
-name    = "rspack_cacheable"
-version = "0.2.0"
+description = "rspack_cacheable"
+edition     = "2021"
+license     = "MIT"
+name        = "rspack_cacheable"
+repository  = "https://github.com/web-infra-dev/rspack"
+version     = "0.2.0"
 
 [features]
 noop = []
@@ -17,7 +19,7 @@ json            = { workspace = true }
 lightningcss    = { workspace = true }
 once_cell       = { workspace = true }
 rkyv            = { workspace = true }
-rspack_macros   = { path = "../rspack_macros" }
+rspack_macros   = { workspace = true }
 rspack_resolver = { workspace = true }
 rspack_sources  = { workspace = true }
 serde_json      = { workspace = true }

--- a/crates/rspack_cacheable_test/Cargo.toml
+++ b/crates/rspack_cacheable_test/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-edition    = "2021"
-license    = "MIT"
-name       = "rspack_cacheable_test"
-repository = "https://github.com/web-infra-dev/rspack"
-version    = "0.2.0"
+description = "rspack_cacheable_test"
+edition     = "2021"
+license     = "MIT"
+name        = "rspack_cacheable_test"
+repository  = "https://github.com/web-infra-dev/rspack"
+version     = "0.2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +14,7 @@ dashmap          = { workspace = true }
 json             = { workspace = true }
 lightningcss     = { workspace = true }
 once_cell        = { workspace = true }
-rspack_cacheable = { path = "../rspack_cacheable" }
+rspack_cacheable = { workspace = true }
 rspack_resolver  = { workspace = true }
 rspack_sources   = { workspace = true }
 rustc-hash       = { workspace = true }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -28,18 +28,18 @@ once_cell = { workspace = true }
 paste = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
-rspack_ast = { version = "0.2.0", path = "../rspack_ast" }
-rspack_cacheable = { path = "../rspack_cacheable" }
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_fs = { version = "0.2.0", path = "../rspack_fs" }
-rspack_futures = { version = "0.2.0", path = "../rspack_futures" }
-rspack_hash = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook = { version = "0.2.0", path = "../rspack_hook" }
-rspack_loader_runner = { version = "0.2.0", path = "../rspack_loader_runner" }
-rspack_macros = { version = "0.2.0", path = "../rspack_macros" }
-rspack_paths = { version = "0.2.0", path = "../rspack_paths" }
-rspack_regex = { version = "0.2.0", path = "../rspack_regex" }
+rspack_ast = { workspace = true }
+rspack_cacheable = { workspace = true }
+rspack_collections = { workspace = true }
+rspack_error = { workspace = true }
+rspack_fs = { workspace = true }
+rspack_futures = { workspace = true }
+rspack_hash = { workspace = true }
+rspack_hook = { workspace = true }
+rspack_loader_runner = { workspace = true }
+rspack_macros = { workspace = true }
+rspack_paths = { workspace = true }
+rspack_regex = { workspace = true }
 rspack_resolver = { workspace = true }
 rspack_sources = { workspace = true }
 rspack_util = { version = "0.2.0", path = "../rspack_util" }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -42,7 +42,7 @@ rspack_paths = { workspace = true }
 rspack_regex = { workspace = true }
 rspack_resolver = { workspace = true }
 rspack_sources = { workspace = true }
-rspack_util = { version = "0.2.0", path = "../rspack_util" }
+rspack_util = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -15,8 +15,8 @@ futures            = { workspace = true }
 miette             = { version = "5", features = ["fancy"] }
 once_cell          = { workspace = true }
 owo-colors         = "3.5.0"
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_paths       = { version = "0.2.0", path = "../rspack_paths" }
+rspack_collections = { workspace = true }
+rspack_paths       = { workspace = true }
 swc_core           = { workspace = true, features = ["common", "common_concurrent"] }
 termcolor          = "1"
 textwrap           = "0.15.2"

--- a/crates/rspack_fs_node/Cargo.toml
+++ b/crates/rspack_fs_node/Cargo.toml
@@ -14,9 +14,9 @@ async-trait  = { workspace = true }
 futures      = { workspace = true }
 napi         = { workspace = true, features = ["napi4", "tokio_rt"] }
 napi-derive  = { workspace = true }
-rspack_fs    = { version = "0.2.0", path = "../rspack_fs" }
-rspack_napi  = { version = "0.2.0", path = "../rspack_napi" }
-rspack_paths = { version = "0.2.0", path = "../rspack_paths" }
+rspack_fs    = { workspace = true }
+rspack_napi  = { workspace = true }
+rspack_paths = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/rspack_hook/Cargo.toml
+++ b/crates/rspack_hook/Cargo.toml
@@ -10,6 +10,6 @@ version     = "0.2.0"
 [dependencies]
 async-trait         = { workspace = true }
 futures-concurrency = "7.5.0"
-rspack_error        = { version = "0.2.0", path = "../rspack_error" }
-rspack_macros       = { version = "0.2.0", path = "../rspack_macros" }
+rspack_error        = { workspace = true }
+rspack_macros       = { workspace = true }
 rustc-hash          = { workspace = true }

--- a/crates/rspack_ids/Cargo.toml
+++ b/crates/rspack_ids/Cargo.toml
@@ -11,11 +11,11 @@ version     = "0.2.0"
 itertools          = { workspace = true }
 rayon              = { workspace = true }
 regex              = { workspace = true }
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.2.0", path = "../rspack_core" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook        = { version = "0.2.0", path = "../rspack_hook" }
-rspack_util        = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections = { workspace = true }
+rspack_core        = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_hook        = { workspace = true }
+rspack_util        = { workspace = true }
 tracing            = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_loader_lightningcss/Cargo.toml
+++ b/crates/rspack_loader_lightningcss/Cargo.toml
@@ -12,8 +12,8 @@ async-trait          = { workspace = true }
 derivative           = { workspace = true }
 lightningcss         = { workspace = true, features = ["sourcemap", "browserslist", "visitor", "into_owned"] }
 parcel_sourcemap     = { workspace = true }
-rspack_core          = { version = "0.2.0", path = "../rspack_core" }
-rspack_error         = { version = "0.2.0", path = "../rspack_error" }
-rspack_loader_runner = { version = "0.2.0", path = "../rspack_loader_runner" }
+rspack_core          = { workspace = true }
+rspack_error         = { workspace = true }
+rspack_loader_runner = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
 tokio                = { workspace = true }

--- a/crates/rspack_loader_preact_refresh/Cargo.toml
+++ b/crates/rspack_loader_preact_refresh/Cargo.toml
@@ -9,6 +9,6 @@ version     = "0.2.0"
 
 [dependencies]
 async-trait          = { workspace = true }
-rspack_core          = { version = "0.2.0", path = "../rspack_core" }
-rspack_error         = { version = "0.2.0", path = "../rspack_error" }
-rspack_loader_runner = { version = "0.2.0", path = "../rspack_loader_runner" }
+rspack_core          = { workspace = true }
+rspack_error         = { workspace = true }
+rspack_loader_runner = { workspace = true }

--- a/crates/rspack_loader_react_refresh/Cargo.toml
+++ b/crates/rspack_loader_react_refresh/Cargo.toml
@@ -9,6 +9,6 @@ version     = "0.2.0"
 
 [dependencies]
 async-trait          = { workspace = true }
-rspack_core          = { version = "0.2.0", path = "../rspack_core" }
-rspack_error         = { version = "0.2.0", path = "../rspack_error" }
-rspack_loader_runner = { version = "0.2.0", path = "../rspack_loader_runner" }
+rspack_core          = { workspace = true }
+rspack_error         = { workspace = true }
+rspack_loader_runner = { workspace = true }

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -14,10 +14,10 @@ tokio       = { workspace = true, features = ["rt", "rt-multi-thread", "macros",
 
 once_cell          = { workspace = true }
 regex              = { workspace = true }
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_fs          = { version = "0.2.0", path = "../rspack_fs" }
-rspack_paths       = { version = "0.2.0", path = "../rspack_paths" }
+rspack_collections = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_fs          = { workspace = true }
+rspack_paths       = { workspace = true }
 rspack_sources     = { workspace = true }
-rspack_util        = { version = "0.2.0", path = "../rspack_util" }
+rspack_util        = { workspace = true }
 serde_json         = { workspace = true }

--- a/crates/rspack_loader_swc/Cargo.toml
+++ b/crates/rspack_loader_swc/Cargo.toml
@@ -23,17 +23,17 @@ base64                   = { version = "0.22" }
 dashmap                  = { workspace = true }
 either                   = { workspace = true }
 jsonc-parser             = { version = "0.26.0", features = ["serde"] }
-rspack_ast               = { version = "0.2.0", path = "../rspack_ast" }
-rspack_core              = { version = "0.2.0", path = "../rspack_core" }
-rspack_error             = { version = "0.2.0", path = "../rspack_error" }
-rspack_loader_runner     = { version = "0.2.0", path = "../rspack_loader_runner" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_util              = { version = "0.2.0", path = "../rspack_util" }
+rspack_ast               = { workspace = true }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_loader_runner     = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_util              = { workspace = true }
 serde                    = { workspace = true, features = ["derive"] }
 serde_json               = { workspace = true }
 stacker                  = { workspace = true }
 swc                      = { workspace = true, features = ["manual-tokio-runtmie"] }
 swc_config               = { workspace = true }
 swc_core                 = { workspace = true, features = ["base", "ecma_ast", "common"] }
-swc_plugin_import        = { version = "0.2.0", path = "../swc_plugin_import" }
+swc_plugin_import        = { workspace = true }
 url                      = "2.5.0"

--- a/crates/rspack_loader_testing/Cargo.toml
+++ b/crates/rspack_loader_testing/Cargo.toml
@@ -9,7 +9,7 @@ version     = "0.2.0"
 
 [dependencies]
 async-trait          = { workspace = true }
-rspack_core          = { version = "0.2.0", path = "../rspack_core" }
-rspack_error         = { version = "0.2.0", path = "../rspack_error" }
-rspack_loader_runner = { version = "0.2.0", path = "../rspack_loader_runner" }
+rspack_core          = { workspace = true }
+rspack_error         = { workspace = true }
+rspack_loader_runner = { workspace = true }
 serde_json           = { workspace = true }

--- a/crates/rspack_macros_test/Cargo.toml
+++ b/crates/rspack_macros_test/Cargo.toml
@@ -7,12 +7,12 @@ name        = "rspack_macros_test"
 repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.2.0"
 [dev-dependencies]
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.2.0", path = "../rspack_core" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook        = { version = "0.2.0", path = "../rspack_hook" }
-rspack_macros      = { version = "0.2.0", path = "../rspack_macros" }
-rspack_util        = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections = { workspace = true }
+rspack_core        = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_hook        = { workspace = true }
+rspack_macros      = { workspace = true }
+rspack_util        = { workspace = true }
 tokio              = { workspace = true, features = ["macros"] }
 tracing            = { workspace = true }
 trybuild           = { version = "1.0.91", features = ["diff"] }

--- a/crates/rspack_napi/Cargo.toml
+++ b/crates/rspack_napi/Cargo.toml
@@ -10,5 +10,5 @@ version     = "0.2.0"
 [dependencies]
 napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json", "napi4", "anyhow"] }
 oneshot      = "0.1.6"
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
+rspack_error = { workspace = true }
 tokio        = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }

--- a/crates/rspack_plugin_asset/Cargo.toml
+++ b/crates/rspack_plugin_asset/Cargo.toml
@@ -11,12 +11,12 @@ version     = "0.2.0"
 async-trait   = { workspace = true }
 mime_guess    = { workspace = true }
 rayon         = { workspace = true }
-rspack_base64 = { version = "0.2.0", path = "../rspack_base64" }
-rspack_core   = { version = "0.2.0", path = "../rspack_core" }
-rspack_error  = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash   = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook   = { version = "0.2.0", path = "../rspack_hook" }
-rspack_util   = { version = "0.2.0", path = "../rspack_util" }
+rspack_base64 = { workspace = true }
+rspack_core   = { workspace = true }
+rspack_error  = { workspace = true }
+rspack_hash   = { workspace = true }
+rspack_hook   = { workspace = true }
+rspack_util   = { workspace = true }
 serde_json    = { workspace = true }
 tracing       = { workspace = true }
 urlencoding   = { workspace = true }

--- a/crates/rspack_plugin_banner/Cargo.toml
+++ b/crates/rspack_plugin_banner/Cargo.toml
@@ -11,10 +11,10 @@ version     = "0.2.0"
 cow-utils    = { workspace = true }
 futures      = { workspace = true }
 regex        = { workspace = true }
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
-rspack_util  = { version = "0.2.0", path = "../rspack_util" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
+rspack_util  = { workspace = true }
 tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_context_replacement/Cargo.toml
+++ b/crates/rspack_plugin_context_replacement/Cargo.toml
@@ -7,11 +7,11 @@ repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.2.0"
 
 [dependencies]
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
-rspack_paths = { version = "0.2.0", path = "../rspack_paths" }
-rspack_regex = { version = "0.2.0", path = "../rspack_regex" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
+rspack_paths = { workspace = true }
+rspack_regex = { workspace = true }
 rustc-hash   = { workspace = true }
 tracing      = { workspace = true }
 

--- a/crates/rspack_plugin_copy/Cargo.toml
+++ b/crates/rspack_plugin_copy/Cargo.toml
@@ -13,13 +13,13 @@ glob           = { workspace = true }
 lazy_static    = "1.4.0"
 pathdiff       = { workspace = true, features = ["camino"] }
 regex          = { workspace = true }
-rspack_core    = { version = "0.2.0", path = "../rspack_core" }
-rspack_error   = { version = "0.2.0", path = "../rspack_error" }
-rspack_futures = { version = "0.2.0", path = "../rspack_futures" }
-rspack_hash    = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook    = { version = "0.2.0", path = "../rspack_hook" }
-rspack_paths   = { version = "0.2.0", path = "../rspack_paths" }
-rspack_util    = { version = "0.2.0", path = "../rspack_util" }
+rspack_core    = { workspace = true }
+rspack_error   = { workspace = true }
+rspack_futures = { workspace = true }
+rspack_hash    = { workspace = true }
+rspack_hook    = { workspace = true }
+rspack_paths   = { workspace = true }
+rspack_util    = { workspace = true }
 rustc-hash     = { workspace = true }
 sugar_path     = { workspace = true }
 tokio          = { workspace = true, features = ["fs"] }

--- a/crates/rspack_plugin_css/Cargo.toml
+++ b/crates/rspack_plugin_css/Cargo.toml
@@ -14,13 +14,13 @@ indexmap              = { version = "=1.9.3", features = ["serde-1"] }
 once_cell             = { workspace = true }
 rayon                 = { workspace = true }
 regex                 = { workspace = true }
-rspack_collections    = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core           = { version = "0.2.0", path = "../rspack_core" }
-rspack_error          = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash           = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook           = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_runtime = { version = "0.2.0", path = "../rspack_plugin_runtime" }
-rspack_util           = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections    = { workspace = true }
+rspack_core           = { workspace = true }
+rspack_error          = { workspace = true }
+rspack_hash           = { workspace = true }
+rspack_hook           = { workspace = true }
+rspack_plugin_runtime = { workspace = true }
+rspack_util           = { workspace = true }
 rustc-hash            = { workspace = true }
 serde_json            = { workspace = true }
 tracing               = { workspace = true }

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -16,14 +16,14 @@ futures                  = { workspace = true }
 itertools                = { workspace = true }
 rayon                    = { workspace = true }
 regex                    = { workspace = true }
-rspack_base64            = { version = "0.2.0", path = "../rspack_base64" }
-rspack_collections       = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core              = { version = "0.2.0", path = "../rspack_core" }
-rspack_error             = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash              = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook              = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_util              = { version = "0.2.0", path = "../rspack_util" }
+rspack_base64            = { workspace = true }
+rspack_collections       = { workspace = true }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_hash              = { workspace = true }
+rspack_hook              = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_util              = { workspace = true }
 rustc-hash               = { workspace = true }
 simd-json                = { workspace = true }
 tracing                  = { workspace = true }

--- a/crates/rspack_plugin_dll/Cargo.toml
+++ b/crates/rspack_plugin_dll/Cargo.toml
@@ -8,12 +8,12 @@ repository         = "https://github.com/web-infra-dev/rspack"
 version            = "0.2.0"
 
 [dependencies]
-rspack_collections      = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core             = { version = "0.2.0", path = "../rspack_core" }
-rspack_error            = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook             = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_externals = { version = "0.2.0", path = "../rspack_plugin_externals" }
-rspack_util             = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections      = { workspace = true }
+rspack_core             = { workspace = true }
+rspack_error            = { workspace = true }
+rspack_hook             = { workspace = true }
+rspack_plugin_externals = { workspace = true }
+rspack_util             = { workspace = true }
 
 async-trait = { workspace = true }
 rustc-hash  = { workspace = true }

--- a/crates/rspack_plugin_dynamic_entry/Cargo.toml
+++ b/crates/rspack_plugin_dynamic_entry/Cargo.toml
@@ -11,9 +11,9 @@ version     = "0.2.0"
 async-trait  = { workspace = true }
 derivative   = { workspace = true }
 futures      = { workspace = true }
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
 tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_ensure_chunk_conditions/Cargo.toml
+++ b/crates/rspack_plugin_ensure_chunk_conditions/Cargo.toml
@@ -8,9 +8,9 @@ version     = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
 rustc-hash   = { workspace = true }
 tracing      = { workspace = true }
 

--- a/crates/rspack_plugin_entry/Cargo.toml
+++ b/crates/rspack_plugin_entry/Cargo.toml
@@ -9,9 +9,9 @@ version     = "0.2.0"
 
 [dependencies]
 async-trait  = { workspace = true }
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
 tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_externals/Cargo.toml
+++ b/crates/rspack_plugin_externals/Cargo.toml
@@ -9,11 +9,11 @@ version     = "0.2.0"
 
 [dependencies]
 regex                    = { workspace = true }
-rspack_core              = { version = "0.2.0", path = "../rspack_core" }
-rspack_error             = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook              = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_regex             = { version = "0.2.0", path = "../rspack_regex" }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_hook              = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_regex             = { workspace = true }
 tracing                  = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_extract_css/Cargo.toml
+++ b/crates/rspack_plugin_extract_css/Cargo.toml
@@ -9,15 +9,15 @@ version     = "0.2.0"
 async-trait              = { workspace = true }
 cow-utils                = { workspace = true }
 regex                    = { workspace = true }
-rspack_collections       = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core              = { version = "0.2.0", path = "../rspack_core" }
-rspack_error             = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash              = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook              = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_css        = { version = "0.2.0", path = "../rspack_plugin_css" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_plugin_runtime    = { version = "0.2.0", path = "../rspack_plugin_runtime" }
-rspack_util              = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections       = { workspace = true }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_hash              = { workspace = true }
+rspack_hook              = { workspace = true }
+rspack_plugin_css        = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_plugin_runtime    = { workspace = true }
+rspack_util              = { workspace = true }
 rustc-hash               = { workspace = true }
 serde                    = { workspace = true, features = ["derive"] }
 serde_json               = { workspace = true }

--- a/crates/rspack_plugin_hmr/Cargo.toml
+++ b/crates/rspack_plugin_hmr/Cargo.toml
@@ -7,13 +7,13 @@ repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.2.0"
 
 [dependencies]
-rspack_collections       = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core              = { version = "0.2.0", path = "../rspack_core" }
-rspack_error             = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook              = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_css        = { version = "0.2.0", path = "../rspack_plugin_css" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_util              = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections       = { workspace = true }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_hook              = { workspace = true }
+rspack_plugin_css        = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_util              = { workspace = true }
 
 async-trait = { workspace = true }
 cow-utils   = { workspace = true }

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -16,13 +16,13 @@ futures           = { workspace = true }
 itertools         = { workspace = true }
 path-clean        = { workspace = true }
 rayon             = { workspace = true }
-rspack_base64     = { version = "0.2.0", path = "../rspack_base64" }
-rspack_core       = { version = "0.2.0", path = "../rspack_core" }
+rspack_base64     = { workspace = true }
+rspack_core       = { workspace = true }
 rspack_dojang     = { workspace = true }
-rspack_error      = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook       = { version = "0.2.0", path = "../rspack_hook" }
-rspack_paths      = { version = "0.2.0", path = "../rspack_paths" }
-rspack_util       = { version = "0.2.0", path = "../rspack_util" }
+rspack_error      = { workspace = true }
+rspack_hook       = { workspace = true }
+rspack_paths      = { workspace = true }
+rspack_util       = { workspace = true }
 serde             = { workspace = true, features = ["derive"] }
 serde_json        = { workspace = true }
 sha2              = "0.10.8"

--- a/crates/rspack_plugin_ignore/Cargo.toml
+++ b/crates/rspack_plugin_ignore/Cargo.toml
@@ -10,10 +10,10 @@ version     = "0.2.0"
 [dependencies]
 derivative   = { workspace = true }
 futures      = { workspace = true }
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
-rspack_regex = { version = "0.2.0", path = "../rspack_regex" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
+rspack_regex = { workspace = true }
 tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -22,16 +22,16 @@ once_cell = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 ropey = { workspace = true }
-rspack_ast = { version = "0.2.0", path = "../rspack_ast" }
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook = { version = "0.2.0", path = "../rspack_hook" }
-rspack_ids = { version = "0.2.0", path = "../rspack_ids/" }
-rspack_paths = { version = "0.2.0", path = "../rspack_paths" }
-rspack_regex = { version = "0.2.0", path = "../rspack_regex" }
-rspack_util = { version = "0.2.0", path = "../rspack_util" }
+rspack_ast = { workspace = true }
+rspack_collections = { workspace = true }
+rspack_core = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hash = { workspace = true }
+rspack_hook = { workspace = true }
+rspack_ids = { workspace = true }
+rspack_paths = { workspace = true }
+rspack_regex = { workspace = true }
+rspack_util = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 stacker = { workspace = true }

--- a/crates/rspack_plugin_json/Cargo.toml
+++ b/crates/rspack_plugin_json/Cargo.toml
@@ -11,6 +11,6 @@ version     = "0.2.0"
 cow-utils    = { workspace = true }
 json         = { workspace = true }
 ropey        = "1.6.1"
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_util  = { version = "0.2.0", path = "../rspack_util" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_util  = { workspace = true }

--- a/crates/rspack_plugin_lazy_compilation/Cargo.toml
+++ b/crates/rspack_plugin_lazy_compilation/Cargo.toml
@@ -15,13 +15,13 @@ rustc-hash  = { workspace = true }
 tokio       = { workspace = true }
 tracing     = { workspace = true }
 
-rspack_collections       = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core              = { version = "0.2.0", path = "../rspack_core" }
-rspack_error             = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook              = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_regex             = { version = "0.2.0", path = "../rspack_regex" }
-rspack_util              = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections       = { workspace = true }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_hook              = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_regex             = { workspace = true }
+rspack_util              = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_library/Cargo.toml
+++ b/crates/rspack_plugin_library/Cargo.toml
@@ -12,13 +12,13 @@ version                 = "0.2.0"
 [dependencies]
 async-trait              = { workspace = true }
 regex                    = { workspace = true }
-rspack_collections       = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core              = { version = "0.2.0", path = "../rspack_core" }
-rspack_error             = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash              = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook              = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_util              = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections       = { workspace = true }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_hash              = { workspace = true }
+rspack_hook              = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_util              = { workspace = true }
 rustc-hash               = { workspace = true }
 serde_json               = { workspace = true }
 tracing                  = { workspace = true }

--- a/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
@@ -14,11 +14,11 @@ rayon            = { workspace = true }
 regex            = { workspace = true }
 tracing          = { workspace = true }
 
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash  = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
-rspack_util  = { version = "0.2.0", path = "../rspack_util" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hash  = { workspace = true }
+rspack_hook  = { workspace = true }
+rspack_util  = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_limit_chunk_count/Cargo.toml
+++ b/crates/rspack_plugin_limit_chunk_count/Cargo.toml
@@ -8,10 +8,10 @@ version     = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.2.0", path = "../rspack_core" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook        = { version = "0.2.0", path = "../rspack_hook" }
+rspack_collections = { workspace = true }
+rspack_core        = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_hook        = { workspace = true }
 tracing            = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_merge_duplicate_chunks/Cargo.toml
+++ b/crates/rspack_plugin_merge_duplicate_chunks/Cargo.toml
@@ -8,10 +8,10 @@ version     = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.2.0", path = "../rspack_core" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook        = { version = "0.2.0", path = "../rspack_hook" }
+rspack_collections = { workspace = true }
+rspack_core        = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_hook        = { workspace = true }
 rustc-hash         = { workspace = true }
 tracing            = { workspace = true }
 

--- a/crates/rspack_plugin_mf/Cargo.toml
+++ b/crates/rspack_plugin_mf/Cargo.toml
@@ -8,13 +8,13 @@ version     = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_collections    = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core           = { version = "0.2.0", path = "../rspack_core" }
-rspack_error          = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook           = { version = "0.2.0", path = "../rspack_hook" }
-rspack_loader_runner  = { version = "0.2.0", path = "../rspack_loader_runner" }
-rspack_plugin_runtime = { version = "0.2.0", path = "../rspack_plugin_runtime" }
-rspack_util           = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections    = { workspace = true }
+rspack_core           = { workspace = true }
+rspack_error          = { workspace = true }
+rspack_hook           = { workspace = true }
+rspack_loader_runner  = { workspace = true }
+rspack_plugin_runtime = { workspace = true }
+rspack_util           = { workspace = true }
 
 async-trait = { workspace = true }
 hashlink    = { workspace = true }

--- a/crates/rspack_plugin_no_emit_on_errors/Cargo.toml
+++ b/crates/rspack_plugin_no_emit_on_errors/Cargo.toml
@@ -8,9 +8,9 @@ version     = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
 tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_progress/Cargo.toml
+++ b/crates/rspack_plugin_progress/Cargo.toml
@@ -10,10 +10,10 @@ version     = "0.2.0"
 [dependencies]
 async-trait        = { workspace = true }
 indicatif          = "0.17.8"
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.2.0", path = "../rspack_core" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook        = { version = "0.2.0", path = "../rspack_hook" }
+rspack_collections = { workspace = true }
+rspack_core        = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_hook        = { workspace = true }
 tracing            = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -13,10 +13,10 @@ indexmap     = { workspace = true }
 once_cell    = { workspace = true }
 rayon        = { workspace = true }
 regex        = { workspace = true }
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash  = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hash  = { workspace = true }
+rspack_hook  = { workspace = true }
 rustc-hash   = { workspace = true }
 tracing      = { workspace = true }
 

--- a/crates/rspack_plugin_remove_duplicate_modules/Cargo.toml
+++ b/crates/rspack_plugin_remove_duplicate_modules/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
-edition = "2021"
-name    = "rspack_plugin_remove_duplicate_modules"
-version = "0.2.0"
+description = "remove duplicate modules"
+edition     = "2021"
+name        = "rspack_plugin_remove_duplicate_modules"
+repository  = "https://github.com/web-infra-dev/rspack"
+version     = "0.2.0"
 
 [lints]
 workspace = true
@@ -10,8 +12,8 @@ workspace = true
 ignored = ["tracing"]
 
 [dependencies]
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
 rustc-hash   = { workspace = true }
 tracing      = { workspace = true }

--- a/crates/rspack_plugin_remove_empty_chunks/Cargo.toml
+++ b/crates/rspack_plugin_remove_empty_chunks/Cargo.toml
@@ -8,10 +8,10 @@ version     = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.2.0", path = "../rspack_core" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook        = { version = "0.2.0", path = "../rspack_hook" }
+rspack_collections = { workspace = true }
+rspack_core        = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_hook        = { workspace = true }
 tracing            = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_runtime/Cargo.toml
+++ b/crates/rspack_plugin_runtime/Cargo.toml
@@ -13,13 +13,13 @@ cow-utils                = { workspace = true }
 derivative               = { workspace = true }
 indexmap                 = { workspace = true }
 itertools                = { workspace = true }
-rspack_collections       = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core              = { version = "0.2.0", path = "../rspack_core" }
-rspack_error             = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash              = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook              = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_util              = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections       = { workspace = true }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_hash              = { workspace = true }
+rspack_hook              = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_util              = { workspace = true }
 rustc-hash               = { workspace = true }
 serde_json               = { workspace = true }
 tracing                  = { workspace = true }

--- a/crates/rspack_plugin_runtime_chunk/Cargo.toml
+++ b/crates/rspack_plugin_runtime_chunk/Cargo.toml
@@ -9,9 +9,9 @@ version     = "0.2.0"
 
 [dependencies]
 futures      = { workspace = true }
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
 tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -14,12 +14,12 @@ async-trait   = { workspace = true }
 cow-utils     = { workspace = true }
 once_cell     = { workspace = true }
 regex         = { workspace = true }
-rspack_base64 = { version = "0.2.0", path = "../rspack_base64" }
-rspack_core   = { version = "0.2.0", path = "../rspack_core" }
-rspack_error  = { version = "0.2.0", path = "../rspack_error" }
-rspack_fs     = { version = "0.2.0", path = "../rspack_fs" }
-rspack_hook   = { version = "0.2.0", path = "../rspack_hook" }
-rspack_paths  = { version = "0.2.0", path = "../rspack_paths" }
+rspack_base64 = { workspace = true }
+rspack_core   = { workspace = true }
+rspack_error  = { workspace = true }
+rspack_fs     = { workspace = true }
+rspack_hook   = { workspace = true }
+rspack_paths  = { workspace = true }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
 sha2          = "0.10.8"

--- a/crates/rspack_plugin_size_limits/Cargo.toml
+++ b/crates/rspack_plugin_size_limits/Cargo.toml
@@ -10,10 +10,10 @@ version     = "0.2.0"
 [dependencies]
 derivative   = { workspace = true }
 futures      = { workspace = true }
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
-rspack_util  = { version = "0.2.0", path = "../rspack_util" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
+rspack_util  = { workspace = true }
 tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_split_chunks/Cargo.toml
+++ b/crates/rspack_plugin_split_chunks/Cargo.toml
@@ -13,12 +13,12 @@ dashmap            = { workspace = true }
 derivative         = { workspace = true }
 rayon              = { workspace = true }
 regex              = { workspace = true }
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.2.0", path = "../rspack_core" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash        = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook        = { version = "0.2.0", path = "../rspack_hook" }
-rspack_regex       = { version = "0.2.0", path = "../rspack_regex" }
-rspack_util        = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections = { workspace = true }
+rspack_core        = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_hash        = { workspace = true }
+rspack_hook        = { workspace = true }
+rspack_regex       = { workspace = true }
+rspack_util        = { workspace = true }
 rustc-hash         = { workspace = true }
 tracing            = { workspace = true }

--- a/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
@@ -13,12 +13,12 @@ cow-utils = { workspace = true }
 once_cell = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
-rspack_core = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hash = { version = "0.2.0", path = "../rspack_hash" }
-rspack_hook = { version = "0.2.0", path = "../rspack_hook" }
-rspack_plugin_javascript = { version = "0.2.0", path = "../rspack_plugin_javascript" }
-rspack_util = { version = "0.2.0", path = "../rspack_util" }
+rspack_core = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hash = { workspace = true }
+rspack_hook = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_util = { workspace = true }
 serde_json = { workspace = true }
 swc_config = { workspace = true }
 swc_core = { workspace = true, features = [

--- a/crates/rspack_plugin_warn_sensitive_module/Cargo.toml
+++ b/crates/rspack_plugin_warn_sensitive_module/Cargo.toml
@@ -8,10 +8,10 @@ version     = "0.2.0"
 
 [dependencies]
 cow-utils          = { workspace = true }
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.2.0", path = "../rspack_core" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook        = { version = "0.2.0", path = "../rspack_hook" }
+rspack_collections = { workspace = true }
+rspack_core        = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_hook        = { workspace = true }
 rustc-hash         = { workspace = true }
 tracing            = { workspace = true }
 

--- a/crates/rspack_plugin_wasm/Cargo.toml
+++ b/crates/rspack_plugin_wasm/Cargo.toml
@@ -14,11 +14,11 @@ cow-utils          = { workspace = true }
 dashmap            = { workspace = true }
 indexmap           = { workspace = true }
 rayon              = { workspace = true }
-rspack_collections = { version = "0.2.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.2.0", path = "../rspack_core" }
-rspack_error       = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook        = { version = "0.2.0", path = "../rspack_hook" }
-rspack_util        = { version = "0.2.0", path = "../rspack_util" }
+rspack_collections = { workspace = true }
+rspack_core        = { workspace = true }
+rspack_error       = { workspace = true }
+rspack_hook        = { workspace = true }
+rspack_util        = { workspace = true }
 serde_json         = { workspace = true }
 swc_core           = { workspace = true, features = ["__ecma"] }
 tracing            = { workspace = true }

--- a/crates/rspack_plugin_web_worker_template/Cargo.toml
+++ b/crates/rspack_plugin_web_worker_template/Cargo.toml
@@ -9,5 +9,5 @@ version     = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_core           = { version = "0.2.0", path = "../rspack_core" }
-rspack_plugin_runtime = { version = "0.2.0", path = "../rspack_plugin_runtime" }
+rspack_core           = { workspace = true }
+rspack_plugin_runtime = { workspace = true }

--- a/crates/rspack_plugin_worker/Cargo.toml
+++ b/crates/rspack_plugin_worker/Cargo.toml
@@ -9,9 +9,9 @@ version     = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_core  = { version = "0.2.0", path = "../rspack_core" }
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.2.0", path = "../rspack_hook" }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
 tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_regex/Cargo.toml
+++ b/crates/rspack_regex/Cargo.toml
@@ -13,7 +13,7 @@ cow-utils    = { workspace = true }
 napi         = { workspace = true }
 regex-syntax = { version = "0.8.3", default-features = false, features = ["std"] }
 regress      = "0.10.0"
-rspack_error = { version = "0.2.0", path = "../rspack_error" }
+rspack_error = { workspace = true }
 swc_core     = { workspace = true, features = ["ecma_ast"] }
 
 [dev-dependencies]

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -25,4 +25,4 @@ unicase       = { workspace = true }
 
 swc_core = { workspace = true, features = ["ecma_ast"] }
 
-rspack_regex = { version = "0.2.0", path = "../rspack_regex" }
+rspack_regex = { workspace = true }

--- a/crates/swc_plugin_import/Cargo.toml
+++ b/crates/swc_plugin_import/Cargo.toml
@@ -3,6 +3,7 @@ description = "babel-plugin-import rewritten in Rust"
 edition     = "2021"
 license     = "MIT"
 name        = "swc_plugin_import"
+repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.2.0"
 
 [dependencies]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
* unify cargo.toml version following biome strategy  https://github.com/biomejs/biome/blob/main/Cargo.toml#L100
* add all missing field which is required for publishing

we have too many plugin crate which is hard to publish & maintain in the future,we should limit the plugin crate number and maybe put small plugin in rspack_common_plugins crates
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
