### PR TITLE
perf: reduce memory consumption of paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4209,6 +4209,7 @@ dependencies = [
  "rspack_error",
  "rspack_hash",
  "rspack_hook",
+ "rspack_paths",
  "rspack_plugin_css",
  "rspack_plugin_javascript",
  "rspack_plugin_runtime",

--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -3,6 +3,7 @@ mod entries;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::path::Path;
 use std::ptr::NonNull;
 
 use dependencies::JsDependencies;
@@ -549,7 +550,7 @@ impl JsCompilation {
 
     compilation
       .file_dependencies
-      .extend(deps.into_iter().map(Into::into));
+      .extend(deps.into_iter().map(|s| Path::new(&s).into()));
     Ok(())
   }
 
@@ -559,7 +560,7 @@ impl JsCompilation {
 
     compilation
       .context_dependencies
-      .extend(deps.into_iter().map(Into::into));
+      .extend(deps.into_iter().map(|s| Path::new(&s).into()));
     Ok(())
   }
 
@@ -569,7 +570,7 @@ impl JsCompilation {
 
     compilation
       .missing_dependencies
-      .extend(deps.into_iter().map(Into::into));
+      .extend(deps.into_iter().map(|s| Path::new(&s).into()));
     Ok(())
   }
 
@@ -579,7 +580,7 @@ impl JsCompilation {
 
     compilation
       .build_dependencies
-      .extend(deps.into_iter().map(Into::into));
+      .extend(deps.into_iter().map(|s| Path::new(&s).into()));
     Ok(())
   }
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -2,7 +2,6 @@ use std::{
   collections::{hash_map, VecDeque},
   fmt::Debug,
   hash::{BuildHasherDefault, Hash},
-  path::PathBuf,
   sync::{atomic::AtomicU32, Arc},
 };
 
@@ -18,6 +17,7 @@ use rspack_fs::FileSystem;
 use rspack_futures::FuturesResults;
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_hook::define_hook;
+use rspack_paths::ArcPath;
 use rspack_sources::{BoxSource, CachedSource, SourceExt};
 use rspack_util::itoa;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
@@ -187,10 +187,10 @@ pub struct Compilation {
   pub hash: Option<RspackHashDigest>,
   pub used_chunk_ids: HashSet<String>,
 
-  pub file_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
-  pub context_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
-  pub missing_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
-  pub build_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
+  pub file_dependencies: IndexSet<ArcPath, BuildHasherDefault<FxHasher>>,
+  pub context_dependencies: IndexSet<ArcPath, BuildHasherDefault<FxHasher>>,
+  pub missing_dependencies: IndexSet<ArcPath, BuildHasherDefault<FxHasher>>,
+  pub build_dependencies: IndexSet<ArcPath, BuildHasherDefault<FxHasher>>,
 
   pub value_cache_versions: ValueCacheVersions,
 
@@ -198,8 +198,8 @@ pub struct Compilation {
 
   pub module_executor: Option<ModuleExecutor>,
 
-  pub modified_files: HashSet<PathBuf>,
-  pub removed_files: HashSet<PathBuf>,
+  pub modified_files: HashSet<ArcPath>,
+  pub removed_files: HashSet<ArcPath>,
   make_artifact: MakeArtifact,
   pub input_filesystem: Arc<dyn FileSystem>,
 }
@@ -236,8 +236,8 @@ impl Compilation {
     cache: Arc<dyn Cache>,
     old_cache: Arc<OldCache>,
     module_executor: Option<ModuleExecutor>,
-    modified_files: HashSet<PathBuf>,
-    removed_files: HashSet<PathBuf>,
+    modified_files: HashSet<ArcPath>,
+    removed_files: HashSet<ArcPath>,
     input_filesystem: Arc<dyn FileSystem>,
   ) -> Self {
     let incremental = Incremental::new(options.experiments.incremental);
@@ -368,9 +368,9 @@ impl Compilation {
   pub fn file_dependencies(
     &self,
   ) -> (
-    impl Iterator<Item = &PathBuf>,
-    impl Iterator<Item = &PathBuf>,
-    impl Iterator<Item = &PathBuf>,
+    impl Iterator<Item = &ArcPath>,
+    impl Iterator<Item = &ArcPath>,
+    impl Iterator<Item = &ArcPath>,
   ) {
     let all_files = self
       .make_artifact
@@ -390,9 +390,9 @@ impl Compilation {
   pub fn context_dependencies(
     &self,
   ) -> (
-    impl Iterator<Item = &PathBuf>,
-    impl Iterator<Item = &PathBuf>,
-    impl Iterator<Item = &PathBuf>,
+    impl Iterator<Item = &ArcPath>,
+    impl Iterator<Item = &ArcPath>,
+    impl Iterator<Item = &ArcPath>,
   ) {
     let all_files = self
       .make_artifact
@@ -416,9 +416,9 @@ impl Compilation {
   pub fn missing_dependencies(
     &self,
   ) -> (
-    impl Iterator<Item = &PathBuf>,
-    impl Iterator<Item = &PathBuf>,
-    impl Iterator<Item = &PathBuf>,
+    impl Iterator<Item = &ArcPath>,
+    impl Iterator<Item = &ArcPath>,
+    impl Iterator<Item = &ArcPath>,
   ) {
     let all_files = self
       .make_artifact
@@ -442,9 +442,9 @@ impl Compilation {
   pub fn build_dependencies(
     &self,
   ) -> (
-    impl Iterator<Item = &PathBuf>,
-    impl Iterator<Item = &PathBuf>,
-    impl Iterator<Item = &PathBuf>,
+    impl Iterator<Item = &ArcPath>,
+    impl Iterator<Item = &ArcPath>,
+    impl Iterator<Item = &ArcPath>,
   ) {
     let all_files = self
       .make_artifact

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -1,9 +1,10 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rspack_collections::{Identifier, IdentifierMap};
 use rspack_error::Result;
 use rspack_hash::RspackHashDigest;
+use rspack_paths::ArcPath;
 use rspack_sources::Source;
 use rustc_hash::FxHashSet as HashSet;
 
@@ -48,18 +49,18 @@ impl Compiler {
 
     // build without stats
     {
-      let mut modified_files = HashSet::default();
-      modified_files.extend(changed_files.iter().map(PathBuf::from));
-      let mut removed_files = HashSet::default();
-      removed_files.extend(deleted_files.iter().map(PathBuf::from));
+      let mut modified_files: HashSet<ArcPath> = HashSet::default();
+      modified_files.extend(changed_files.iter().map(|files| Path::new(files).into()));
+      let mut removed_files: HashSet<ArcPath> = HashSet::default();
+      removed_files.extend(deleted_files.iter().map(|files| Path::new(files).into()));
 
       let mut all_files = modified_files.clone();
       all_files.extend(removed_files.clone());
 
       self.old_cache.end_idle();
-      self
-        .old_cache
-        .set_modified_files(all_files.into_iter().collect());
+      // self
+      //   .old_cache
+      //   .set_modified_files(all_files.into_iter().collect());
 
       self.plugin_driver.clear_cache();
 

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -1,10 +1,9 @@
 mod cutout;
 pub mod repair;
 
-use std::path::PathBuf;
-
 use rspack_collections::IdentifierSet;
 use rspack_error::{Diagnostic, Result};
+use rspack_paths::ArcPath;
 use rustc_hash::FxHashSet as HashSet;
 
 use self::{cutout::Cutout, repair::repair};
@@ -97,8 +96,8 @@ pub enum MakeParam {
   BuildEntry(HashSet<DependencyId>),
   BuildEntryAndClean(HashSet<DependencyId>),
   CheckNeedBuild,
-  ModifiedFiles(HashSet<PathBuf>),
-  RemovedFiles(HashSet<PathBuf>),
+  ModifiedFiles(HashSet<ArcPath>),
+  RemovedFiles(HashSet<ArcPath>),
   ForceBuildDeps(HashSet<BuildDependency>),
   ForceBuildModules(IdentifierSet),
 }

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -1,6 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 use rspack_error::Diagnostic;
+use rspack_paths::ArcPath;
 use rspack_sources::BoxSource;
 use rustc_hash::FxHashSet as HashSet;
 
@@ -161,9 +162,9 @@ pub struct FactorizeResultTask {
   pub current_profile: Option<Box<ModuleProfile>>,
   pub exports_info_related: ExportsInfoRelated,
 
-  pub file_dependencies: HashSet<PathBuf>,
-  pub context_dependencies: HashSet<PathBuf>,
-  pub missing_dependencies: HashSet<PathBuf>,
+  pub file_dependencies: HashSet<ArcPath>,
+  pub context_dependencies: HashSet<ArcPath>,
+  pub missing_dependencies: HashSet<ArcPath>,
   pub diagnostics: Vec<Diagnostic>,
 }
 
@@ -183,17 +184,17 @@ impl FactorizeResultTask {
     self
   }
 
-  fn with_file_dependencies(mut self, files: impl IntoIterator<Item = PathBuf>) -> Self {
+  fn with_file_dependencies(mut self, files: impl IntoIterator<Item = ArcPath>) -> Self {
     self.file_dependencies = files.into_iter().collect();
     self
   }
 
-  fn with_context_dependencies(mut self, contexts: impl IntoIterator<Item = PathBuf>) -> Self {
+  fn with_context_dependencies(mut self, contexts: impl IntoIterator<Item = ArcPath>) -> Self {
     self.context_dependencies = contexts.into_iter().collect();
     self
   }
 
-  fn with_missing_dependencies(mut self, missing: impl IntoIterator<Item = PathBuf>) -> Self {
+  fn with_missing_dependencies(mut self, missing: impl IntoIterator<Item = ArcPath>) -> Self {
     self.missing_dependencies = missing.into_iter().collect();
     self
   }

--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
 use std::{iter::once, sync::atomic::AtomicU32};
 
 use itertools::Itertools;
 use rspack_collections::{DatabaseItem, Identifier, IdentifierSet, UkeySet};
+use rspack_paths::ArcPath;
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 use tokio::sync::oneshot::Sender;
@@ -32,10 +32,10 @@ pub type ExecuteModuleId = u32;
 pub struct ExecuteModuleResult {
   pub error: Option<String>,
   pub cacheable: bool,
-  pub file_dependencies: HashSet<PathBuf>,
-  pub context_dependencies: HashSet<PathBuf>,
-  pub missing_dependencies: HashSet<PathBuf>,
-  pub build_dependencies: HashSet<PathBuf>,
+  pub file_dependencies: HashSet<ArcPath>,
+  pub context_dependencies: HashSet<ArcPath>,
+  pub missing_dependencies: HashSet<ArcPath>,
+  pub build_dependencies: HashSet<ArcPath>,
   pub code_generated_modules: IdentifierSet,
   pub assets: HashSet<String>,
   pub id: ExecuteModuleId,

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::{borrow::Cow, hash::Hash};
 
@@ -9,7 +8,7 @@ use itertools::Itertools;
 use rspack_collections::{Identifiable, Identifier};
 use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
 use rspack_macros::impl_source_map_config;
-use rspack_paths::Utf8PathBuf;
+use rspack_paths::{ArcPath, Utf8PathBuf};
 use rspack_regex::RspackRegex;
 use rspack_sources::{BoxSource, ConcatSource, RawSource, SourceExt};
 use rspack_util::itoa;
@@ -959,8 +958,8 @@ impl Module for ContextModule {
         .collect();
     }
 
-    let mut context_dependencies: HashSet<PathBuf> = Default::default();
-    context_dependencies.insert(self.options.resource.clone().into_std_path_buf());
+    let mut context_dependencies: HashSet<ArcPath> = Default::default();
+    context_dependencies.insert(self.options.resource.as_std_path().into());
 
     let build_info = BuildInfo {
       context_dependencies,

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -1,6 +1,5 @@
 use std::fmt::Display;
 use std::hash::Hash;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::{any::Any, borrow::Cow, fmt::Debug};
 
@@ -10,6 +9,7 @@ use rspack_collections::{Identifiable, Identifier, IdentifierSet};
 use rspack_error::{Diagnosable, Diagnostic, Result};
 use rspack_fs::FileSystem;
 use rspack_hash::RspackHashDigest;
+use rspack_paths::ArcPath;
 use rspack_sources::Source;
 use rspack_util::atom::Atom;
 use rspack_util::ext::{AsAny, DynHash};
@@ -48,10 +48,10 @@ pub struct BuildInfo {
   pub cacheable: bool,
   pub hash: Option<RspackHashDigest>,
   pub strict: bool,
-  pub file_dependencies: HashSet<PathBuf>,
-  pub context_dependencies: HashSet<PathBuf>,
-  pub missing_dependencies: HashSet<PathBuf>,
-  pub build_dependencies: HashSet<PathBuf>,
+  pub file_dependencies: HashSet<ArcPath>,
+  pub context_dependencies: HashSet<ArcPath>,
+  pub missing_dependencies: HashSet<ArcPath>,
+  pub build_dependencies: HashSet<ArcPath>,
   pub esm_named_exports: HashSet<Atom>,
   pub all_star_exports: Vec<DependencyId>,
   pub need_create_require: bool,
@@ -362,7 +362,7 @@ pub trait Module:
     false
   }
 
-  fn depends_on(&self, modified_file: &HashSet<PathBuf>) -> bool {
+  fn depends_on(&self, modified_file: &HashSet<ArcPath>) -> bool {
     if let Some(build_info) = self.build_info() {
       for item in modified_file {
         if build_info.file_dependencies.contains(item)

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -1,6 +1,7 @@
-use std::{fmt::Debug, path::PathBuf, sync::Arc};
+use std::{fmt::Debug, sync::Arc};
 
 use rspack_error::{Diagnostic, Result};
+use rspack_paths::ArcPath;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
@@ -19,9 +20,9 @@ pub struct ModuleFactoryCreateData {
   pub issuer_identifier: Option<ModuleIdentifier>,
   pub issuer_layer: Option<ModuleLayer>,
 
-  pub file_dependencies: HashSet<PathBuf>,
-  pub context_dependencies: HashSet<PathBuf>,
-  pub missing_dependencies: HashSet<PathBuf>,
+  pub file_dependencies: HashSet<ArcPath>,
+  pub context_dependencies: HashSet<ArcPath>,
+  pub missing_dependencies: HashSet<ArcPath>,
   pub diagnostics: Vec<Diagnostic>,
 }
 
@@ -37,28 +38,40 @@ impl ModuleFactoryCreateData {
       })
   }
 
-  pub fn add_file_dependency(&mut self, file: PathBuf) {
-    self.file_dependencies.insert(file);
+  pub fn add_file_dependency<F: Into<ArcPath>>(&mut self, file: F) {
+    self.file_dependencies.insert(file.into());
   }
 
-  pub fn add_file_dependencies(&mut self, files: impl IntoIterator<Item = PathBuf>) {
-    self.file_dependencies.extend(files);
+  pub fn add_file_dependencies<F: Into<ArcPath>>(&mut self, files: impl IntoIterator<Item = F>) {
+    self
+      .file_dependencies
+      .extend(files.into_iter().map(Into::into));
   }
 
-  pub fn add_context_dependency(&mut self, context: PathBuf) {
-    self.context_dependencies.insert(context);
+  pub fn add_context_dependency<F: Into<ArcPath>>(&mut self, context: F) {
+    self.context_dependencies.insert(context.into());
   }
 
-  pub fn add_context_dependencies(&mut self, contexts: impl IntoIterator<Item = PathBuf>) {
-    self.context_dependencies.extend(contexts);
+  pub fn add_context_dependencies<F: Into<ArcPath>>(
+    &mut self,
+    contexts: impl IntoIterator<Item = F>,
+  ) {
+    self
+      .context_dependencies
+      .extend(contexts.into_iter().map(Into::into));
   }
 
-  pub fn add_missing_dependency(&mut self, missing: PathBuf) {
-    self.missing_dependencies.insert(missing);
+  pub fn add_missing_dependency<F: Into<ArcPath>>(&mut self, missing: F) {
+    self.missing_dependencies.insert(missing.into());
   }
 
-  pub fn add_missing_dependencies(&mut self, missing: impl IntoIterator<Item = PathBuf>) {
-    self.missing_dependencies.extend(missing);
+  pub fn add_missing_dependencies<F: Into<ArcPath>>(
+    &mut self,
+    missing: impl IntoIterator<Item = F>,
+  ) {
+    self
+      .missing_dependencies
+      .extend(missing.into_iter().map(Into::into));
   }
 }
 

--- a/crates/rspack_core/src/utils/file_counter/mod.rs
+++ b/crates/rspack_core/src/utils/file_counter/mod.rs
@@ -1,14 +1,13 @@
 mod incremental_info;
 
-use std::path::PathBuf;
-
 use incremental_info::IncrementalInfo;
+use rspack_paths::ArcPath;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 /// Used to count file usage
 #[derive(Debug, Default)]
 pub struct FileCounter {
-  inner: HashMap<PathBuf, usize>,
+  inner: HashMap<ArcPath, usize>,
   incremental_info: IncrementalInfo,
 }
 
@@ -16,12 +15,12 @@ impl FileCounter {
   /// Add a [`PathBuf``] to counter
   ///
   /// It will +1 to the PathBuf in inner hashmap
-  fn add_file(&mut self, path: &PathBuf) {
-    if let Some(value) = self.inner.get_mut(path) {
+  fn add_file(&mut self, path: ArcPath) {
+    if let Some(value) = self.inner.get_mut(&path) {
       *value += 1;
     } else {
-      self.incremental_info.add(path);
-      self.inner.insert(path.clone(), 1);
+      self.incremental_info.add(&path);
+      self.inner.insert(path, 1);
     }
   }
 
@@ -31,7 +30,7 @@ impl FileCounter {
   ///
   /// If the PathBuf usage is 0 after reduction, the record will be deleted
   /// If PathBuf does not exist, panic will occur.
-  fn remove_file(&mut self, path: &PathBuf) {
+  fn remove_file(&mut self, path: &ArcPath) {
     if let Some(value) = self.inner.get_mut(path) {
       *value -= 1;
       if value == &0 {
@@ -44,21 +43,21 @@ impl FileCounter {
   }
 
   /// Add batch [`PathBuf``] to counter
-  pub fn add_batch_file(&mut self, paths: &HashSet<PathBuf>) {
+  pub fn add_batch_file(&mut self, paths: &HashSet<ArcPath>) {
     for path in paths {
-      self.add_file(path);
+      self.add_file(path.clone());
     }
   }
 
   /// Remove batch [`PathBuf`] to counter
-  pub fn remove_batch_file(&mut self, paths: &HashSet<PathBuf>) {
+  pub fn remove_batch_file(&mut self, paths: &HashSet<ArcPath>) {
     for path in paths {
       self.remove_file(path);
     }
   }
 
   /// Get files with count more than 0
-  pub fn files(&self) -> impl Iterator<Item = &PathBuf> {
+  pub fn files(&self) -> impl Iterator<Item = &ArcPath> {
     self.inner.keys()
   }
 
@@ -68,18 +67,20 @@ impl FileCounter {
   }
 
   /// Added files compared to the `files()` when call reset_incremental_info
-  pub fn added_files(&self) -> &HashSet<PathBuf> {
+  pub fn added_files(&self) -> &HashSet<ArcPath> {
     self.incremental_info.added_files()
   }
 
   /// Removed files compared to the `files()` when call reset_incremental_info
-  pub fn removed_files(&self) -> &HashSet<PathBuf> {
+  pub fn removed_files(&self) -> &HashSet<ArcPath> {
     self.incremental_info.removed_files()
   }
 }
 
 #[cfg(test)]
 mod test {
+  use rspack_paths::ArcPath;
+
   use super::FileCounter;
   #[test]
   fn file_counter_is_available() {
@@ -87,9 +88,12 @@ mod test {
     let file_a = std::path::PathBuf::from("/a");
     let file_b = std::path::PathBuf::from("/b");
 
-    counter.add_file(&file_a);
-    counter.add_file(&file_a);
-    counter.add_file(&file_b);
+    let file_a = ArcPath::from(file_a);
+    let file_b = ArcPath::from(file_b);
+
+    counter.add_file(file_a.clone());
+    counter.add_file(file_a.clone());
+    counter.add_file(file_b.clone());
     assert_eq!(counter.files().collect::<Vec<_>>().len(), 2);
     assert_eq!(counter.added_files().len(), 2);
     assert_eq!(counter.removed_files().len(), 0);
@@ -114,12 +118,13 @@ mod test {
   fn file_counter_add_file() {
     let mut counter = FileCounter::default();
     let file_a = std::path::PathBuf::from("/a");
+    let file_a = ArcPath::from(file_a);
     assert_eq!(counter.inner.get(&file_a), None);
 
-    counter.add_file(&file_a);
+    counter.add_file(file_a.clone());
     assert_eq!(counter.inner.get(&file_a), Some(&1));
 
-    counter.add_file(&file_a);
+    counter.add_file(file_a.clone());
     assert_eq!(counter.inner.get(&file_a), Some(&2));
   }
 
@@ -127,7 +132,8 @@ mod test {
   fn file_counter_remove_file() {
     let mut counter = FileCounter::default();
     let file_a = std::path::PathBuf::from("/a");
-    counter.add_file(&file_a);
+    let file_a = ArcPath::from(file_a);
+    counter.add_file(file_a.clone());
     assert_eq!(counter.inner.get(&file_a), Some(&1));
 
     counter.remove_file(&file_a);
@@ -139,6 +145,7 @@ mod test {
   fn file_counter_remove_file_with_panic() {
     let mut counter = FileCounter::default();
     let file_a = std::path::PathBuf::from("/a");
+    let file_a = ArcPath::from(file_a);
     counter.remove_file(&file_a);
   }
 
@@ -146,8 +153,9 @@ mod test {
   fn file_counter_reset_incremental_info() {
     let mut counter = FileCounter::default();
     let file_a = std::path::PathBuf::from("/a");
+    let file_a = ArcPath::from(file_a);
 
-    counter.add_file(&file_a);
+    counter.add_file(file_a.clone());
     assert_eq!(counter.added_files().len(), 1);
     assert_eq!(counter.removed_files().len(), 0);
 
@@ -155,7 +163,7 @@ mod test {
     assert_eq!(counter.added_files().len(), 0);
     assert_eq!(counter.removed_files().len(), 0);
 
-    counter.add_file(&file_a);
+    counter.add_file(file_a.clone());
     assert_eq!(counter.added_files().len(), 0);
     assert_eq!(counter.removed_files().len(), 0);
 

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -1,4 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::{
+  borrow::Borrow,
+  ops::{Deref, DerefMut},
+  path::{Path, PathBuf},
+  sync::Arc,
+};
 
 pub use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf, Utf8Prefix};
 
@@ -35,4 +40,56 @@ impl<'a> AssertUtf8 for &'a Path {
       panic!("expected UTF-8 path, got: {}", self.display());
     })
   }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ArcPath(Arc<Path>);
+
+impl Deref for ArcPath {
+  type Target = Arc<Path>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for ArcPath {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
+
+impl From<PathBuf> for ArcPath {
+  fn from(value: PathBuf) -> Self {
+    ArcPath(value.into())
+  }
+}
+
+impl From<&Path> for ArcPath {
+  fn from(value: &Path) -> Self {
+    ArcPath(value.into())
+  }
+}
+
+impl From<&Utf8Path> for ArcPath {
+  fn from(value: &Utf8Path) -> Self {
+    ArcPath(value.as_std_path().into())
+  }
+}
+
+impl From<&ArcPath> for ArcPath {
+  fn from(value: &ArcPath) -> Self {
+    value.clone()
+  }
+}
+
+impl Borrow<Path> for ArcPath {
+  fn borrow(&self) -> &Path {
+    &self.0
+  }
+}
+
+fn _assert_size() {
+  use std::mem::size_of;
+  assert_eq!(size_of::<ArcPath>(), size_of::<[usize; 2]>());
 }

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -609,10 +609,12 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   logger.time_end(start);
 
   let start = logger.time("emit assets");
-  compilation.file_dependencies.extend(file_dependencies);
+  compilation
+    .file_dependencies
+    .extend(file_dependencies.into_iter().map(Into::into));
   compilation
     .context_dependencies
-    .extend(context_dependencies);
+    .extend(context_dependencies.into_iter().map(Into::into));
   compilation.extend_diagnostics(std::mem::take(
     diagnostics
       .lock()

--- a/crates/rspack_plugin_extract_css/Cargo.toml
+++ b/crates/rspack_plugin_extract_css/Cargo.toml
@@ -14,6 +14,7 @@ rspack_core              = { workspace = true }
 rspack_error             = { workspace = true }
 rspack_hash              = { workspace = true }
 rspack_hook              = { workspace = true }
+rspack_paths             = { workspace = true }
 rspack_plugin_css        = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
 rspack_plugin_runtime    = { workspace = true }

--- a/crates/rspack_plugin_extract_css/src/css_dependency.rs
+++ b/crates/rspack_plugin_extract_css/src/css_dependency.rs
@@ -1,10 +1,9 @@
-use std::path::PathBuf;
-
 use rspack_collections::IdentifierSet;
 use rspack_core::{
   AffectType, AsContextDependency, AsDependencyTemplate, ConnectionState, Dependency,
   DependencyCategory, DependencyId, DependencyRange, ModuleDependency, ModuleGraph,
 };
+use rspack_paths::ArcPath;
 use rustc_hash::FxHashSet;
 
 use crate::css_module::DEPENDENCY_TYPE;
@@ -29,10 +28,10 @@ pub struct CssDependency {
   range: DependencyRange,
   resource_identifier: String,
   pub(crate) cacheable: bool,
-  pub(crate) file_dependencies: FxHashSet<PathBuf>,
-  pub(crate) context_dependencies: FxHashSet<PathBuf>,
-  pub(crate) missing_dependencies: FxHashSet<PathBuf>,
-  pub(crate) build_dependencies: FxHashSet<PathBuf>,
+  pub(crate) file_dependencies: FxHashSet<ArcPath>,
+  pub(crate) context_dependencies: FxHashSet<ArcPath>,
+  pub(crate) missing_dependencies: FxHashSet<ArcPath>,
+  pub(crate) build_dependencies: FxHashSet<ArcPath>,
 }
 
 impl CssDependency {
@@ -48,10 +47,10 @@ impl CssDependency {
     identifier_index: u32,
     range: DependencyRange,
     cacheable: bool,
-    file_dependencies: FxHashSet<PathBuf>,
-    context_dependencies: FxHashSet<PathBuf>,
-    missing_dependencies: FxHashSet<PathBuf>,
-    build_dependencies: FxHashSet<PathBuf>,
+    file_dependencies: FxHashSet<ArcPath>,
+    context_dependencies: FxHashSet<ArcPath>,
+    missing_dependencies: FxHashSet<ArcPath>,
+    build_dependencies: FxHashSet<ArcPath>,
   ) -> Self {
     let resource_identifier = format!("css-module-{}-{}", &identifier, identifier_index);
     Self {

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -1,5 +1,4 @@
 use std::hash::Hash;
-use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use rspack_collections::{Identifiable, Identifier};
@@ -14,6 +13,7 @@ use rspack_core::{
 use rspack_error::Result;
 use rspack_error::{impl_empty_diagnosable_trait, Diagnostic};
 use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_paths::ArcPath;
 use rspack_util::ext::DynHash;
 use rspack_util::itoa;
 use rustc_hash::FxHashSet;
@@ -45,10 +45,10 @@ pub(crate) struct CssModule {
 
   identifier__: Identifier,
   cacheable: bool,
-  file_dependencies: FxHashSet<PathBuf>,
-  context_dependencies: FxHashSet<PathBuf>,
-  missing_dependencies: FxHashSet<PathBuf>,
-  build_dependencies: FxHashSet<PathBuf>,
+  file_dependencies: FxHashSet<ArcPath>,
+  context_dependencies: FxHashSet<ArcPath>,
+  missing_dependencies: FxHashSet<ArcPath>,
+  build_dependencies: FxHashSet<ArcPath>,
 }
 
 impl CssModule {

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -190,7 +190,9 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     let (template_file_name, html) =
       match generate_html(filename, &output_file_name, config, compilation, &hooks).await {
         Ok(content) => {
-          compilation.file_dependencies.extend(content.2);
+          compilation
+            .file_dependencies
+            .extend(content.2.into_iter().map(Into::into));
           (content.0, content.1)
         }
         Err(err) => {

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use cow_utils::CowUtils;
 use rspack_collections::Identifiable;
@@ -158,7 +158,7 @@ impl Module for LazyCompilationProxyModule {
 
     let mut files = FxHashSet::default();
     files.extend(self.create_data.file_dependencies.clone());
-    files.insert(self.resource.to_owned().into());
+    files.insert(Path::new(&self.resource).into());
 
     Ok(BuildResult {
       build_info: BuildInfo {

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -82,7 +82,7 @@ fn resolve_matched_configs(
       resolved.insert(resource.path.as_str().to_string(), config.clone());
       compilation
         .file_dependencies
-        .insert(resource.path.into_std_path_buf());
+        .insert(resource.path.as_path().into());
     } else if ABSOLUTE_REQUEST.is_match(request) {
       resolved.insert(request.to_owned(), config.clone());
     } else if request.ends_with('/') {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Reduced a big amount of memory of copying `PathBuf`s.

<img width="1683" alt="image" src="https://github.com/user-attachments/assets/f11553e7-909a-47e6-87c4-4fa4353493cf">



<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
