### PR TITLE
docs: align `DefinePlugin` with #7108 in v0.x

### DIFF
--- a/website/docs/en/plugins/webpack/define-plugin.mdx
+++ b/website/docs/en/plugins/webpack/define-plugin.mdx
@@ -52,10 +52,6 @@ if (!BROWSER_SUPPORTS_HTML5) require('html5shiv');
 When defining values for `process` prefer `'process.env.NODE_ENV': JSON.stringify('production')` over `process: { env: { NODE_ENV: JSON.stringify('production') } }`. Using the latter will overwrite the `process` object which can break compatibility with some modules that expect other values on the process object to be defined.
 :::
 
-:::tip
-Note that because the plugin does a direct text replacement, the value given to it must include **actual quotes** inside of the string itself. Typically, this is done either with alternate quotes, such as `'"production"'`, or by using `JSON.stringify('production')`.
-:::
-
 ```js
 if (!PRODUCTION) {
   console.log('Debug info');

--- a/website/docs/zh/plugins/webpack/define-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/define-plugin.mdx
@@ -52,10 +52,6 @@ if (!BROWSER_SUPPORTS_HTML5) require('html5shiv');
 在为 `process` 定义值时，推荐使用 `'process.env.NODE_ENV': JSON.stringify('production')` 而不是 `process: { env: { NODE_ENV: JSON.stringify('production') } }`。使用后者会重写 `process` 对象，这可能会破坏对某些模块的兼容性，这些模块期望 process 对象上的其他值被定义。
 :::
 
-:::tip 提示
-请注意，由于插件直接执行文本替换，因此提供给它的值必须包含字符串内部的实际引号。通常，这是通过使用交替引号，如 `'"production"'`，或使用 `JSON.stringify('production')` 来完成。
-:::
-
 ```js
 if (!PRODUCTION) {
   console.log('Debug info');


### PR DESCRIPTION
## Summary

Before #7108 there was a [`JSON.stringify()` call](https://github.com/web-infra-dev/rspack/pull/7108/files#diff-5f4e45b52caf136609c5147f1223fae8f4bfaada72f088bab2e4487b0dbb8510R2) in `DefinePlugin`

The change landed in https://github.com/web-infra-dev/rspack/releases/tag/v1.0.0-alpha.3

A couple of alpha versions do not require `JSON.stringify()`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
