### PR TITLE
refactor: css hmr

### DIFF
--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -508,30 +508,16 @@ impl ParserAndGenerator for CssParserAndGenerator {
             let exports =
               get_used_exports(exports, module.identifier(), generate_context.runtime, &mg);
 
-            if with_hmr {
-              format!(
-                "{}\nmodule.hot.accept();\n",
-                css_modules_exports_to_string(
-                  exports,
-                  module,
-                  generate_context.compilation,
-                  generate_context.runtime_requirements,
-                  ns_obj,
-                  left,
-                  right,
-                )?
-              )
-            } else {
-              css_modules_exports_to_string(
-                exports,
-                module,
-                generate_context.compilation,
-                generate_context.runtime_requirements,
-                ns_obj,
-                left,
-                right,
-              )?
-            }
+            css_modules_exports_to_string(
+              exports,
+              module,
+              generate_context.compilation,
+              generate_context.runtime_requirements,
+              ns_obj,
+              left,
+              right,
+              with_hmr,
+            )?
           } else {
             format!(
               "{}{}module.exports = {{}}{};\n{}",

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-css-modules/modules-composes/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-css-modules/modules-composes/__snapshots__/output.snap.txt
@@ -54,35 +54,43 @@ __webpack_require__.r(__webpack_exports__);
 
 }),
 "./b.module.css": (function (module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.r(module.exports = {
+var exports = {
   "b-1": "./_b.module_./_b-1--/__f794ca5c2<f79",
   "b": "./_b.module_./_b--/__f794ca5c2<f79" + " " + "./_b.module_./_b-1--/__f794ca5c2<f79",
-});
+};
+
+__webpack_require__.r(module.exports = exports);
 
 
 }),
 "./d.module.css": (function (module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.r(module.exports = {
+var exports = {
   "d-1": "./_d.module_./_d-1--/__c5e7cbb4cc9231c2<c5e",
   "d": "./_d.module_./_d--/__c5e7cbb4cc9231c2<c5e" + " " + "./_d.module_./_d-1--/__c5e7cbb4cc9231c2<c5e",
-});
+};
+
+__webpack_require__.r(module.exports = exports);
 
 
 }),
 "./f.module.css": (function (module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.r(module.exports = {
+var exports = {
   "f-1": "./_f.module_./_f-1--/__d1fc8b18ab0f5133<d1f",
   "f": "./_f.module_./_f--/__d1fc8b18ab0f5133<d1f" + " " + "./_f.module_./_f-1--/__d1fc8b18ab0f5133<d1f",
-});
+};
+
+__webpack_require__.r(module.exports = exports);
 
 
 }),
 "./style.module.css": (function (module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.r(module.exports = {
+var exports = {
   "chain2": "./_style.module_./_chain2--/__d8ad836b5119c8e8<d8a" + " " + "e" + " " + __webpack_require__("./f.module.css")["f"],
   "chain1": "./_style.module_./_chain1--/__d8ad836b5119c8e8<d8a" + " " + "./_style.module_./_chain2--/__d8ad836b5119c8e8<d8a" + " " + "e" + " " + __webpack_require__("./f.module.css")["f"] + " " + "c" + " " + __webpack_require__("./d.module.css")["d"],
   "root-class": "./_style.module_./_root-class--/__d8ad836b5119c8e8<d8a" + " " + "./_style.module_./_chain1--/__d8ad836b5119c8e8<d8a" + " " + "./_style.module_./_chain2--/__d8ad836b5119c8e8<d8a" + " " + "e" + " " + __webpack_require__("./f.module.css")["f"] + " " + "c" + " " + __webpack_require__("./d.module.css")["d"] + " " + "a" + " " + __webpack_require__("./b.module.css")["b"],
-});
+};
+
+__webpack_require__.r(module.exports = exports);
 
 
 }),

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-css-modules/modules-ident-name/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-css-modules/modules-ident-name/__snapshots__/output.snap.txt
@@ -18,9 +18,11 @@ console.log(_style_module_css__WEBPACK_IMPORTED_MODULE_0__);
 
 }),
 "./style.module.css": (function (module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.r(module.exports = {
+var exports = {
   "foo": "./_style.module_./_foo--/__d8ad836b5119c8e8<d8a",
-});
+};
+
+__webpack_require__.r(module.exports = exports);
 
 
 }),

--- a/packages/rspack-test-tools/tests/hotCases/css/css-modules/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-modules/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 397
+- Update: main.LAST_HASH.hot-update.js, size: 725
 
 ## Manifest
 
@@ -33,11 +33,18 @@
 "use strict";
 self["webpackHotUpdate"]('main', {
 "./index.module.css": (function (module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.r(module.exports = {
+var exports = {
   "a": "-_index_module_css-a",
-});
-
-module.hot.accept();
+};
+// only invalidate when locals change
+var stringified_exports = JSON.stringify(exports);
+if (module.hot.data && module.hot.data.exports && module.hot.data.exports != stringified_exports) {
+  module.hot.invalidate();
+} else {
+  module.hot.accept(); 
+}
+module.hot.dispose(function(data) { data.exports = stringified_exports; });
+__webpack_require__.r(module.exports = exports);
 
 
 }),

--- a/packages/rspack-test-tools/tests/hotCases/css/css-modules/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-modules/index.js
@@ -1,9 +1,10 @@
 import style from './index.module.css';
 
+module.hot.accept('./index.module.css')
+
 it("css modules hmr", (done) => {
 	expect(style.div).toBeDefined();
 	NEXT(require("../../update")(done, true, () => {
-		const style = require('./index.module.css')
 		expect(style.a).toBeDefined();
 		expect(style).not.toContain('div');
 		done();

--- a/packages/rspack-test-tools/tests/hotCases/css/parser-and-generator-states/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/css/parser-and-generator-states/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 499
+- Update: main.LAST_HASH.hot-update.js, size: 827
 
 ## Manifest
 
@@ -33,12 +33,19 @@
 "use strict";
 self["webpackHotUpdate"]('main', {
 "./index.module.css": (function (module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.r(module.exports = {
+var exports = {
   "btn-info_is-enabled": "./index.module.css__btn-info_is-enabled",
   "btnInfoIsEnabled": "./index.module.css__btn-info_is-enabled",
-});
-
-module.hot.accept();
+};
+// only invalidate when locals change
+var stringified_exports = JSON.stringify(exports);
+if (module.hot.data && module.hot.data.exports && module.hot.data.exports != stringified_exports) {
+  module.hot.invalidate();
+} else {
+  module.hot.accept(); 
+}
+module.hot.dispose(function(data) { data.exports = stringified_exports; });
+__webpack_require__.r(module.exports = exports);
 
 
 }),

--- a/packages/rspack-test-tools/tests/hotCases/css/parser-and-generator-states/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/parser-and-generator-states/index.js
@@ -1,9 +1,10 @@
 import style from './index.module.css';
 
+module.hot.accept('./index.module.css')
+
 it("should store and resume css parser and generator states", (done) => {
 	expect(style['btnInfoIsDisabled']).toBe('./index.module.css__btn-info_is-disabled');
 	NEXT(require("../../update")(done, true, () => {
-		const style = require('./index.module.css')
 		expect(style['btnInfoIsEnabled']).toBe('./index.module.css__btn-info_is-enabled');
 		done();
 	}));

--- a/packages/rspack-test-tools/tests/treeShakingCases/css/__snapshots__/treeshaking.snap.txt
+++ b/packages/rspack-test-tools/tests/treeShakingCases/css/__snapshots__/treeshaking.snap.txt
@@ -11,11 +11,13 @@ _index_module_css__WEBPACK_IMPORTED_MODULE_0__.compose;
 
 }),
 "./index.module.css": (function (module, __unused_webpack_exports, __webpack_require__) {
-module.exports = {
+var exports = {
   "foo": "__rspack_test__-ec1c834ac8cc99e-foo",
   "bar": "__rspack_test__-ec1c834ac8cc99e-bar",
   "compose": "__rspack_test__-ec1c834ac8cc99e-compose" + " " + "__rspack_test__-ec1c834ac8cc99e-bar",
 };
+
+module.exports = exports;
 
 
 }),


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

refactor css hmr, see https://github.com/webpack/webpack/pull/19021.

Previous:

All css modules are self-accepted, but once modifies its classNames, importers won't know the css modules have changes.

This PR:

css modules are self-accepted if they have no className changes or if the css type is not `css/modules`. This way the importers are easily informed that the css has updates

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
