### PR TITLE
refactor: remove compilation.built_module

### DIFF
--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -185,7 +185,7 @@ impl JsCompilation {
 
     Ok(
       compilation
-        .built_modules
+        .built_modules()
         .iter()
         .filter_map(|module_id| {
           compilation.module_by_identifier(module_id).map(|module| {

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -19,10 +19,10 @@ pub struct MakeArtifact {
   // should be reset when rebuild
   pub diagnostics: Vec<Diagnostic>,
   pub has_module_graph_change: bool,
-
-  // data
   pub built_modules: IdentifierSet,
   pub revoked_modules: IdentifierSet,
+
+  // data
   pub make_failed_dependencies: HashSet<BuildDependency>,
   pub make_failed_module: IdentifierSet,
   pub module_graph_partial: ModuleGraphPartial,
@@ -51,14 +51,6 @@ impl MakeArtifact {
 
   pub fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
     std::mem::take(&mut self.diagnostics)
-  }
-
-  pub fn take_built_modules(&mut self) -> IdentifierSet {
-    std::mem::take(&mut self.built_modules)
-  }
-
-  pub fn take_revoked_modules(&mut self) -> IdentifierSet {
-    std::mem::take(&mut self.revoked_modules)
   }
 
   fn revoke_module(&mut self, module_identifier: &ModuleIdentifier) -> Vec<BuildDependency> {

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -148,20 +148,15 @@ impl ModuleExecutor {
     let diagnostics = self.make_artifact.take_diagnostics();
     compilation.extend_diagnostics(diagnostics);
 
-    let built_modules = self.make_artifact.take_built_modules();
     if let Some(mutations) = compilation.incremental.mutations_write() {
-      for id in &built_modules {
+      for id in &self.make_artifact.built_modules {
         mutations.add(Mutation::ModuleRemove { module: *id });
       }
     }
-    for id in built_modules {
-      compilation.built_modules.insert(id);
-    }
 
-    let revoked_modules = self.make_artifact.take_revoked_modules();
     if let Some(mutations) = compilation.incremental.mutations_write() {
-      for id in revoked_modules {
-        mutations.add(Mutation::ModuleRemove { module: id });
+      for id in &self.make_artifact.revoked_modules {
+        mutations.add(Mutation::ModuleRemove { module: *id });
       }
     }
 

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -681,7 +681,7 @@ impl Stats<'_> {
       .module_graph_module_by_identifier(&identifier)
       .unwrap_or_else(|| panic!("Could not find ModuleGraphModule by identifier: {identifier:?}"));
 
-    let built = self.compilation.built_modules.contains(&identifier);
+    let built = self.compilation.built_modules().contains(&identifier);
     let code_generated = self
       .compilation
       .code_generated_modules

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -681,7 +681,17 @@ impl Stats<'_> {
       .module_graph_module_by_identifier(&identifier)
       .unwrap_or_else(|| panic!("Could not find ModuleGraphModule by identifier: {identifier:?}"));
 
-    let built = self.compilation.built_modules().contains(&identifier);
+    let built = if executed {
+      self
+        .compilation
+        .module_executor
+        .as_ref()
+        .map(|executor| executor.make_artifact.built_modules.contains(&identifier))
+        .unwrap_or_default()
+    } else {
+      self.compilation.built_modules().contains(&identifier)
+    };
+
     let code_generated = self
       .compilation
       .code_generated_modules


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR will remove `compilation.built_module` and use `built_module()` method to proxy it to `compilation.make_artifact.built_module`.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
