### PR TITLE
fix: trusted type should add module runtime requirements

### DIFF
--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -10,7 +10,9 @@ use rspack_core::{
   ApplyContext, BoxModule, ChunkInitFragments, ChunkUkey, Compilation, CompilationParams,
   CompilerCompilation, CompilerOptions, Plugin, PluginContext,
 };
-use rspack_core::{CompilationAdditionalTreeRuntimeRequirements, RuntimeGlobals};
+use rspack_core::{
+  CompilationAdditionalModuleRuntimeRequirements, ModuleIdentifier, RuntimeGlobals,
+};
 use rspack_error::Result;
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
@@ -190,17 +192,17 @@ impl Plugin for EvalDevToolModulePlugin {
     ctx
       .context
       .compilation_hooks
-      .additional_tree_runtime_requirements
-      .tap(eval_devtool_plugin_additional_tree_runtime_requirements::new(self));
+      .additional_module_runtime_requirements
+      .tap(eval_devtool_plugin_additional_module_runtime_requirements::new(self));
     Ok(())
   }
 }
 
-#[plugin_hook(CompilationAdditionalTreeRuntimeRequirements for EvalDevToolModulePlugin)]
-async fn eval_devtool_plugin_additional_tree_runtime_requirements(
+#[plugin_hook(CompilationAdditionalModuleRuntimeRequirements for EvalDevToolModulePlugin)]
+fn eval_devtool_plugin_additional_module_runtime_requirements(
   &self,
-  compilation: &mut Compilation,
-  _chunk_ukey: &ChunkUkey,
+  compilation: &Compilation,
+  _module: &ModuleIdentifier,
   runtime_requirements: &mut RuntimeGlobals,
 ) -> Result<()> {
   if compilation.options.output.trusted_types.is_some() {

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -6,7 +6,7 @@ use futures::future::join_all;
 use rspack_core::{
   rspack_sources::{BoxSource, MapOptions, RawSource, Source, SourceExt},
   ApplyContext, BoxModule, ChunkInitFragments, ChunkUkey, Compilation,
-  CompilationAdditionalTreeRuntimeRequirements, CompilationParams, CompilerCompilation,
+  CompilationAdditionalModuleRuntimeRequirements, CompilationParams, CompilerCompilation,
   CompilerOptions, ModuleIdentifier, Plugin, PluginContext, RuntimeGlobals,
 };
 use rspack_error::Result;
@@ -212,11 +212,11 @@ fn eval_source_map_devtool_plugin_inline_in_runtime_bailout(
   Ok(Some("the eval-source-map devtool is used.".to_string()))
 }
 
-#[plugin_hook(CompilationAdditionalTreeRuntimeRequirements for EvalSourceMapDevToolPlugin)]
-async fn eval_source_map_devtool_plugin_additional_tree_runtime_requirements(
+#[plugin_hook(CompilationAdditionalModuleRuntimeRequirements for EvalSourceMapDevToolPlugin)]
+fn eval_source_map_devtool_plugin_additional_module_runtime_requirements(
   &self,
-  compilation: &mut Compilation,
-  _chunk_ukey: &ChunkUkey,
+  compilation: &Compilation,
+  _module: &ModuleIdentifier,
   runtime_requirements: &mut RuntimeGlobals,
 ) -> Result<()> {
   if compilation.options.output.trusted_types.is_some() {
@@ -241,8 +241,8 @@ impl Plugin for EvalSourceMapDevToolPlugin {
     ctx
       .context
       .compilation_hooks
-      .additional_tree_runtime_requirements
-      .tap(eval_source_map_devtool_plugin_additional_tree_runtime_requirements::new(self));
+      .additional_module_runtime_requirements
+      .tap(eval_source_map_devtool_plugin_additional_module_runtime_requirements::new(self));
     Ok(())
   }
 }

--- a/packages/rspack-test-tools/tests/configCases/trusted-types/module-runtime-requirement/index.js
+++ b/packages/rspack-test-tools/tests/configCases/trusted-types/module-runtime-requirement/index.js
@@ -1,0 +1,19 @@
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+
+function createWorker() {
+	new Worker(new URL("./worker.js", import.meta.url), {
+		type: "module",
+		name: "test-worker"
+	});
+}
+
+createWorker;
+
+it("should generate correct new Worker statement", async () => {
+	const content = fs.readFileSync(path.resolve(path.dirname(__filename), './test-worker.js'), "utf-8");
+	expect(content).toContain(`this is worker`);
+	expect(content).toContain(`(function (__unused_webpack_module, __unused_webpack_exports, __webpack_require__)`);
+	expect(content).toContain(`eval(__webpack_require__.ts(`);
+});

--- a/packages/rspack-test-tools/tests/configCases/trusted-types/module-runtime-requirement/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/trusted-types/module-runtime-requirement/rspack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].js",
+		trustedTypes: true
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "eval-source-map",
+	target: "web"
+};

--- a/packages/rspack-test-tools/tests/configCases/trusted-types/module-runtime-requirement/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/trusted-types/module-runtime-requirement/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["main.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/trusted-types/module-runtime-requirement/worker.js
+++ b/packages/rspack-test-tools/tests/configCases/trusted-types/module-runtime-requirement/worker.js
@@ -1,0 +1,1 @@
+"this is worker";


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Relate to https://github.com/web-infra-dev/rspack/issues/8512

This pr fix the missing `__webpack_require__` error. `RuntimeGlobal.createScript` should be added to module runtime requirements.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
