### PR TITLE
fix: generate wrong chunk filename runtime code on win32

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -6,9 +6,8 @@ use rspack_collections::{DatabaseItem, Identifier, UkeyIndexMap, UkeyIndexSet};
 use rspack_core::{
   get_filename_without_hash_length, impl_runtime_module,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
-  Chunk, Chunk, ChunkGraph, ChunkGraph, ChunkUkey, ChunkUkey, Compilation, Compilation, Filename,
-  Filename, FilenameTemplate, FilenameTemplate, NoFilenameFn, PathData, PathData, RuntimeGlobals,
-  RuntimeGlobals, RuntimeModule, RuntimeModule, SourceType, SourceType,
+  Chunk, ChunkGraph, ChunkUkey, Compilation, Filename, FilenameTemplate, NoFilenameFn, PathData,
+  RuntimeGlobals, RuntimeModule, SourceType,
 };
 use rspack_util::{infallible::ResultInfallibleExt, itoa};
 use rustc_hash::FxHashMap;

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -302,8 +302,18 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
         let filename = compilation
           .get_path(
             &Filename::<NoFilenameFn>::from(
-              serde_json::to_string(fake_filename.render(PathData::default(), None)?.as_str())
-                .expect("invalid json to_string"),
+              serde_json::to_string(
+                fake_filename
+                  .render(
+                    PathData::default()
+                      .chunk_id_optional(chunk_id.as_deref())
+                      .chunk_hash_optional(chunk_hash.as_deref())
+                      .chunk_name_optional(chunk_name.as_deref()),
+                    None,
+                  )?
+                  .as_str(),
+              )
+              .expect("invalid json to_string"),
             ),
             PathData::default()
               .chunk_id_optional(chunk_id.as_deref())

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -306,9 +306,8 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
                 fake_filename
                   .render(
                     PathData::default()
-                      .chunk_id_optional(chunk_id.as_deref())
-                      .chunk_hash_optional(chunk_hash.as_deref())
-                      .chunk_name_optional(chunk_name.as_deref()),
+                      .chunk_name_optional(chunk.name())
+                      .chunk_id_optional(chunk.id()),
                     None,
                   )?
                   .as_str(),

--- a/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/a.js
+++ b/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/b.js
+++ b/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/index.js
+++ b/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/index.js
@@ -1,0 +1,7 @@
+it("should generate async chunk", async function () {
+  const a = await import("./a");
+  expect(a.default).toBe("a");
+
+  const b = await import("./b");
+  expect(b.default).toBe("b");
+});

--- a/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/rspack.config.js
@@ -1,0 +1,8 @@
+const path = require("path");
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	output: {
+		chunkFilename: path.win32.join('./', 'js/[name].[chunkhash:8].chunk.js'),
+	},
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/8601

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
