### PR TITLE
fix: source map file should use contenthash itself

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/output/source-map-filename-contenthash/chunk.js
+++ b/packages/rspack-test-tools/tests/configCases/output/source-map-filename-contenthash/chunk.js
@@ -1,0 +1,1 @@
+"i am a chunk";

--- a/packages/rspack-test-tools/tests/configCases/output/source-map-filename-contenthash/index.js
+++ b/packages/rspack-test-tools/tests/configCases/output/source-map-filename-contenthash/index.js
@@ -1,0 +1,12 @@
+import fs from "fs/promises";
+import("./chunk");
+
+it("source-map-filename-contenthash should have correct name", async function () {
+	const maps = (await fs.readdir(__dirname)).filter(i => i.endsWith(".map"));
+	maps.sort();
+	expect(maps.length).toBe(2);
+	expect(maps.every(m => {
+		let name = m.replace(".js.map", "").split("-");
+		return name[0] !== name[1];
+	})).toBeTruthy();
+});

--- a/packages/rspack-test-tools/tests/configCases/output/source-map-filename-contenthash/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/source-map-filename-contenthash/rspack.config.js
@@ -1,0 +1,13 @@
+/** @type {import("@rspack/core").RspackOptions} */
+module.exports = {
+	entry: {
+		main: "./index"
+	},
+	devtool: "source-map",
+	target: "node",
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[contenthash].js",
+		sourceMapFilename: "[contenthash]-[file].map"
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/output/source-map-filename-contenthash/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/source-map-filename-contenthash/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["main.js"];
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/8597

https://github.com/webpack/webpack/blob/main/lib/SourceMapDevToolPlugin.js#L497-L502

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
