### PR TITLE
fix: sync minify file comments from SWC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4750,6 +4750,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar_path",
+ "swc_config",
  "swc_core",
  "unicase",
 ]

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -23,6 +23,7 @@ serde_json    = { workspace = true }
 sugar_path    = { workspace = true }
 unicase       = { workspace = true }
 
-swc_core = { workspace = true, features = ["ecma_ast"] }
+swc_config = { workspace = true }
+swc_core   = { workspace = true, features = ["base", "ecma_ast"] }
 
 rspack_regex = { workspace = true }

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -1,4 +1,12 @@
-use swc_core::atoms::Atom;
+use swc_config::config_types::BoolOr;
+use swc_core::{
+  atoms::Atom,
+  base::config::JsMinifyCommentOption,
+  common::{
+    comments::{Comment, CommentKind, SingleThreadedComments},
+    BytePos,
+  },
+};
 
 pub fn normalize_custom_filename(source: &str) -> &str {
   if source.starts_with('<') && source.ends_with('>') {
@@ -25,4 +33,52 @@ fn test_normalize_custom_filename() {
   let input = "<custom_filename>";
   let expected_output = "custom_filename";
   assert_eq!(normalize_custom_filename(input), expected_output);
+}
+
+/**
+ * Some code is modified based on
+ * https://github.com/swc-project/swc/blob/e6fc5327b1a309eae840fe1ec3a2367adab37430/crates/swc_compiler_base/src/lib.rs#L342
+ * Apache-2.0 licensed
+ * Author Donny/강동윤
+ * Copyright (c)
+ */
+pub fn minify_file_comments(
+  comments: &SingleThreadedComments,
+  preserve_comments: BoolOr<JsMinifyCommentOption>,
+  preserve_annotations: bool,
+) {
+  match preserve_comments {
+    BoolOr::Bool(true) | BoolOr::Data(JsMinifyCommentOption::PreserveAllComments) => {}
+
+    BoolOr::Data(JsMinifyCommentOption::PreserveSomeComments) => {
+      let preserve_excl = |_: &BytePos, vc: &mut std::vec::Vec<Comment>| -> bool {
+        // Preserve license comments.
+        //
+        // See https://github.com/terser/terser/blob/798135e04baddd94fea403cfaab4ba8b22b1b524/lib/output.js#L175-L181
+        vc.retain(|c: &Comment| {
+          c.text.contains("@lic")
+            || c.text.contains("@preserve")
+            || c.text.contains("@copyright")
+            || c.text.contains("@cc_on")
+            || (preserve_annotations
+              && (c.text.contains("__PURE__")
+                || c.text.contains("__INLINE__")
+                || c.text.contains("__NOINLINE__")
+                || c.text.contains("@vite-ignore")))
+            || (c.kind == CommentKind::Block && c.text.starts_with('!'))
+        });
+        !vc.is_empty()
+      };
+      let (mut l, mut t) = comments.borrow_all_mut();
+
+      l.retain(preserve_excl);
+      t.retain(preserve_excl);
+    }
+
+    BoolOr::Bool(false) => {
+      let (mut l, mut t) = comments.borrow_all_mut();
+      l.clear();
+      t.clear();
+    }
+  }
 }

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/minify/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/minify/__snapshots__/output.snap.txt
@@ -1,0 +1,23 @@
+```js title=main.js
+"use strict";
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
+"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  Button: function() { return Button; },
+  button: function() { return button; }
+});
+/*! Legal Comment */ // normal comment
+const Button = ()=>/*#__PURE__*/ jsx('button', {});
+const button = /* @__PURE__ */ new Button();
+
+
+}),
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
+
+}
+]);
+```

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/minify/index.js
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/minify/index.js
@@ -1,0 +1,5 @@
+/*! Legal Comment */
+
+// normal comment
+export const Button = () => /*#__PURE__*/ jsx('button', {})
+export const button = /* @__PURE__ */ new Button()

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/minify/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/minify/rspack.config.js
@@ -1,0 +1,32 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								target: "es2015",
+								preserveAllComments: true,
+								minify: {
+                  compress: true,
+                },
+								parser: {
+									syntax: "ecmascript",
+									jsx: true,
+									dynamicImport: true,
+									classProperty: true,
+									exportNamespaceFrom: true,
+									exportDefaultFrom: true
+								}
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-some-preserve-annotations/a.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-some-preserve-annotations/a.js
@@ -1,0 +1,4 @@
+const Button = () => /*#__PURE__*/ jsx('button', {})
+const button = /* @__PURE__ */ new Button()
+
+module.exports = { Button, button }

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-some-preserve-annotations/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-some-preserve-annotations/index.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+const path = require("path");
+
+it("[minify-comment-some]: should keep annotation and remove others", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "a.js"), "utf-8");
+
+	expect(content).toContain("/*#__PURE__*/");
+	expect(content).toContain("/* @__PURE__ */");
+});

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-some-preserve-annotations/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-some-preserve-annotations/rspack.config.js
@@ -1,0 +1,26 @@
+const rspack = require("@rspack/core");
+/**
+ * @type {import("@rspack/core").Configuration}
+ */
+module.exports = {
+	entry: {
+		a: "./a",
+		main: "./index"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		minimize: true
+	},
+	plugins: [
+		new rspack.SwcJsMinimizerRspackPlugin({
+			minimizerOptions: {
+				format: {
+					comments: "some",
+					preserveAnnotations: true
+				}
+			}
+		})
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-some-preserve-annotations/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-some-preserve-annotations/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["main.js"];
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix https://github.com/web-infra-dev/rslib/issues/418.

The behavior of the new `minify_file_comments` function in `swc_loader` remains consistent with the current implementation:

1. `preserveAllComments: true`
2. `preserveAllComments: false`:
   1. `minify.format.comments: "all"`: true
   2. `minify.format.comments: "some"`: false
   3. `minify.format.comments: false`: false

In the future, you can directly use [`preserve_annotations`](https://github.com/swc-project/swc/blob/e6fc5327b1a309eae840fe1ec3a2367adab37430/crates/swc/src/config/mod.rs#L808) here.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
