### PR TITLE
refactor: simplify file system code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4026,6 +4026,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "rspack_error",
  "rspack_fs",
  "rspack_napi",
  "rspack_paths",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,7 +4011,6 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "dunce",
- "futures",
  "rspack_error",
  "rspack_paths",
  "tokio",
@@ -4022,7 +4021,6 @@ name = "rspack_fs_node"
 version = "0.2.0"
 dependencies = [
  "async-trait",
- "futures",
  "napi",
  "napi-build",
  "napi-derive",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -2127,21 +2127,21 @@ export interface RegisterJsTaps {
 }
 
 export interface ThreadsafeNodeFS {
-  writeFile: (name: string, content: Buffer) => Promise<void> | void
-  removeFile: (name: string) => Promise<void> | void
-  mkdir: (name: string) => Promise<void> | void
-  mkdirp: (name: string) => Promise<string | void> | string | void
-  removeDirAll: (name: string) => Promise<string | void> | string | void
-  readDir: (name: string) => Promise<string[] | void> | string[] | void
-  readFile: (name: string) => Promise<Buffer | string | void> | Buffer | string | void
-  stat: (name: string) => Promise<NodeFsStats | void> | NodeFsStats | void
-  lstat: (name: string) => Promise<NodeFsStats | void> | NodeFsStats | void
-  open: (name: string, flags: string) => Promise<number | void> | number | void
-  rename: (from: string, to: string) => Promise<void> | void
-  close: (fd: number) => Promise<void> | void
-  write: (fd: number, content: Buffer, position: number) => Promise<number | void> | number | void
-  writeAll: (fd: number, content: Buffer) => Promise<number | void> | number | void
-  read: (fd: number, length: number, position: number) => Promise<Buffer | void> | Buffer | void
-  readUntil: (fd: number, code: number, position: number) => Promise<Buffer | void> | Buffer | void
-  readToEnd: (fd: number, position: number) => Promise<Buffer | void> | Buffer | void
+  writeFile: (name: string, content: Buffer) => Promise<void>
+  removeFile: (name: string) => Promise<void>
+  mkdir: (name: string) => Promise<void>
+  mkdirp: (name: string) => Promise<string | void>
+  removeDirAll: (name: string) => Promise<string | void>
+  readDir: (name: string) => Promise<string[] | void>
+  readFile: (name: string) => Promise<Buffer | string | void>
+  stat: (name: string) => Promise<NodeFsStats | void>
+  lstat: (name: string) => Promise<NodeFsStats | void>
+  open: (name: string, flags: string) => Promise<number | void>
+  rename: (from: string, to: string) => Promise<void>
+  close: (fd: number) => Promise<void>
+  write: (fd: number, content: Buffer, position: number) => Promise<number | void>
+  writeAll: (fd: number, content: Buffer) => Promise<number | void>
+  read: (fd: number, length: number, position: number) => Promise<Buffer | void>
+  readUntil: (fd: number, code: number, position: number) => Promise<Buffer | void>
+  readToEnd: (fd: number, position: number) => Promise<Buffer | void>
 }

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1081,6 +1081,7 @@ export interface JsTap {
 export interface NodeFsStats {
   isFile: boolean
   isDirectory: boolean
+  isSymlink: boolean
   atimeMs: number
   mtimeMs: number
   ctimeMs: number

--- a/crates/rspack_fs/Cargo.toml
+++ b/crates/rspack_fs/Cargo.toml
@@ -9,7 +9,6 @@ version     = "0.2.0"
 [dependencies]
 async-trait  = { workspace = true }
 dunce        = { version = "1.0.5" }
-futures      = { workspace = true }
 rspack_error = { path = "../rspack_error", version = "0.2.0" }
 rspack_paths = { path = "../rspack_paths", version = "0.2.0" }
 tokio        = { workspace = true, features = ["fs", "test-util", "macros"] }

--- a/crates/rspack_fs/src/memory_fs.rs
+++ b/crates/rspack_fs/src/memory_fs.rs
@@ -5,7 +5,6 @@ use std::{
   time::{SystemTime, UNIX_EPOCH},
 };
 
-use futures::future::BoxFuture;
 use rspack_paths::{AssertUtf8, Utf8Path, Utf8PathBuf};
 
 use crate::{
@@ -232,6 +231,7 @@ impl WritableFileSystem for MemoryFileSystem {
   }
 }
 
+#[async_trait::async_trait]
 impl ReadableFileSystem for MemoryFileSystem {
   fn read(&self, path: &Utf8Path) -> Result<Vec<u8>> {
     let files = self.files.lock().expect("should get lock");
@@ -257,9 +257,9 @@ impl ReadableFileSystem for MemoryFileSystem {
     let path = dunce::canonicalize(path)?;
     Ok(path.assert_utf8())
   }
-  fn async_read<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>> {
-    let fut = async move { ReadableFileSystem::read(self, file) };
-    Box::pin(fut)
+
+  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>> {
+    ReadableFileSystem::read(self, file)
   }
 }
 

--- a/crates/rspack_fs/src/memory_fs.rs
+++ b/crates/rspack_fs/src/memory_fs.rs
@@ -211,29 +211,24 @@ impl WritableFileSystem for MemoryFileSystem {
     Ok(())
   }
 
-  fn remove_file<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<()>> {
-    let fut = async move { self._remove_file(file) };
-    Box::pin(fut)
+  async fn remove_file(&self, file: &Utf8Path) -> Result<()> {
+    self._remove_file(file)
   }
 
-  fn remove_dir_all<'a>(&'a self, dir: &'a Utf8Path) -> BoxFuture<'a, Result<()>> {
-    let fut = async move { self._remove_dir_all(dir) };
-    Box::pin(fut)
+  async fn remove_dir_all(&self, dir: &Utf8Path) -> Result<()> {
+    self._remove_dir_all(dir)
   }
 
-  fn read_dir<'a>(&'a self, dir: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<String>>> {
-    let fut = async move { self._read_dir(dir) };
-    Box::pin(fut)
+  async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>> {
+    self._read_dir(dir)
   }
 
-  fn read_file<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>> {
-    let fut = async move { ReadableFileSystem::read(self, file) };
-    Box::pin(fut)
+  async fn read_file(&self, file: &Utf8Path) -> Result<Vec<u8>> {
+    ReadableFileSystem::read(self, file)
   }
 
-  fn stat<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<FileMetadata>> {
-    let fut = async move { ReadableFileSystem::metadata(self, file) };
-    Box::pin(fut)
+  async fn stat(&self, file: &Utf8Path) -> Result<FileMetadata> {
+    ReadableFileSystem::metadata(self, file)
   }
 }
 

--- a/crates/rspack_fs/src/native_fs.rs
+++ b/crates/rspack_fs/src/native_fs.rs
@@ -3,7 +3,6 @@ use std::{
   io::{BufRead, BufReader, BufWriter, Read, Write},
 };
 
-use futures::future::BoxFuture;
 use rspack_paths::{AssertUtf8, Utf8Path, Utf8PathBuf};
 
 use crate::{
@@ -57,6 +56,7 @@ impl WritableFileSystem for NativeFileSystem {
   }
 }
 
+#[async_trait::async_trait]
 impl ReadableFileSystem for NativeFileSystem {
   fn read(&self, path: &Utf8Path) -> Result<Vec<u8>> {
     fs::read(path).map_err(Error::from)
@@ -77,9 +77,8 @@ impl ReadableFileSystem for NativeFileSystem {
     Ok(path.assert_utf8())
   }
 
-  fn async_read<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>> {
-    let fut = async move { tokio::fs::read(file).await.map_err(Error::from) };
-    Box::pin(fut)
+  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>> {
+    tokio::fs::read(file).await.map_err(Error::from)
   }
 }
 

--- a/crates/rspack_fs/src/native_fs.rs
+++ b/crates/rspack_fs/src/native_fs.rs
@@ -28,41 +28,32 @@ impl WritableFileSystem for NativeFileSystem {
     fs::write(file, data).map_err(Error::from)
   }
 
-  fn remove_file<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<()>> {
-    let fut = async move { tokio::fs::remove_file(file).await.map_err(Error::from) };
-    Box::pin(fut)
+  async fn remove_file(&self, file: &Utf8Path) -> Result<()> {
+    tokio::fs::remove_file(file).await.map_err(Error::from)
   }
 
-  fn remove_dir_all<'a>(&'a self, dir: &'a Utf8Path) -> BoxFuture<'a, Result<()>> {
+  async fn remove_dir_all(&self, dir: &Utf8Path) -> Result<()> {
     let dir = dir.to_path_buf();
-    let fut = async move { tokio::fs::remove_dir_all(dir).await.map_err(Error::from) };
-    Box::pin(fut)
+    tokio::fs::remove_dir_all(dir).await.map_err(Error::from)
   }
 
-  fn read_dir<'a>(&'a self, dir: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<String>>> {
+  async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>> {
     let dir = dir.to_path_buf();
-    let fut = async move {
-      let mut reader = tokio::fs::read_dir(dir).await.map_err(Error::from)?;
-      let mut res = vec![];
-      while let Some(entry) = reader.next_entry().await.map_err(Error::from)? {
-        res.push(entry.file_name().to_string_lossy().to_string());
-      }
-      Ok(res)
-    };
-    Box::pin(fut)
+    let mut reader = tokio::fs::read_dir(dir).await.map_err(Error::from)?;
+    let mut res = vec![];
+    while let Some(entry) = reader.next_entry().await.map_err(Error::from)? {
+      res.push(entry.file_name().to_string_lossy().to_string());
+    }
+    Ok(res)
   }
 
-  fn read_file<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>> {
-    let fut = async move { tokio::fs::read(file).await.map_err(Error::from) };
-    Box::pin(fut)
+  async fn read_file(&self, file: &Utf8Path) -> Result<Vec<u8>> {
+    tokio::fs::read(file).await.map_err(Error::from)
   }
 
-  fn stat<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<FileMetadata>> {
-    let fut = async move {
-      let metadata = tokio::fs::metadata(file).await.map_err(Error::from)?;
-      FileMetadata::try_from(metadata)
-    };
-    Box::pin(fut)
+  async fn stat(&self, file: &Utf8Path) -> Result<FileMetadata> {
+    let metadata = tokio::fs::metadata(file).await.map_err(Error::from)?;
+    FileMetadata::try_from(metadata)
   }
 }
 

--- a/crates/rspack_fs/src/read.rs
+++ b/crates/rspack_fs/src/read.rs
@@ -1,10 +1,11 @@
 use std::fmt::Debug;
 
-use futures::future::BoxFuture;
 use rspack_paths::Utf8Path;
 use rspack_paths::Utf8PathBuf;
 
 use crate::{FileMetadata, Result};
+
+#[async_trait::async_trait]
 pub trait ReadableFileSystem: Debug + Send + Sync {
   /// See [std::fs::read]
   fn read(&self, path: &Utf8Path) -> Result<Vec<u8>>;
@@ -20,5 +21,5 @@ pub trait ReadableFileSystem: Debug + Send + Sync {
   /// Read the entire contents of a file into a bytes vector.
   ///
   /// Error: This function will return an error if path does not already exist.
-  fn async_read<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>>;
+  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>>;
 }

--- a/crates/rspack_fs/src/write.rs
+++ b/crates/rspack_fs/src/write.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 
-use futures::future::BoxFuture;
 use rspack_paths::Utf8Path;
 
 use super::{FileMetadata, Result};
@@ -27,16 +26,16 @@ pub trait WritableFileSystem: Debug + Send + Sync {
   async fn write(&self, file: &Utf8Path, data: &[u8]) -> Result<()>;
 
   /// Removes a file from the filesystem.
-  fn remove_file<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<()>>;
+  async fn remove_file(&self, file: &Utf8Path) -> Result<()>;
 
   /// Removes a directory at this path, after removing all its contents. Use carefully.
-  fn remove_dir_all<'a>(&'a self, dir: &'a Utf8Path) -> BoxFuture<'a, Result<()>>;
+  async fn remove_dir_all(&self, dir: &Utf8Path) -> Result<()>;
 
   /// Returns a list of all files in a directory.
-  fn read_dir<'a>(&'a self, dir: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<String>>>;
+  async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>>;
 
   /// Read the entire contents of a file into a bytes vector.
-  fn read_file<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>>;
+  async fn read_file(&self, file: &Utf8Path) -> Result<Vec<u8>>;
 
-  fn stat<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<FileMetadata>>;
+  async fn stat(&self, file: &Utf8Path) -> Result<FileMetadata>;
 }

--- a/crates/rspack_fs_node/Cargo.toml
+++ b/crates/rspack_fs_node/Cargo.toml
@@ -14,6 +14,7 @@ async-trait  = { workspace = true }
 futures      = { workspace = true }
 napi         = { workspace = true, features = ["napi4", "tokio_rt"] }
 napi-derive  = { workspace = true }
+rspack_error = { workspace = true }
 rspack_fs    = { workspace = true }
 rspack_napi  = { workspace = true }
 rspack_paths = { workspace = true }

--- a/crates/rspack_fs_node/Cargo.toml
+++ b/crates/rspack_fs_node/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait  = { workspace = true }
-futures      = { workspace = true }
 napi         = { workspace = true, features = ["napi4", "tokio_rt"] }
 napi-derive  = { workspace = true }
 rspack_error = { workspace = true }

--- a/crates/rspack_fs_node/src/node.rs
+++ b/crates/rspack_fs_node/src/node.rs
@@ -47,6 +47,7 @@ pub struct ThreadsafeNodeFS {
 pub struct NodeFsStats {
   pub is_file: bool,
   pub is_directory: bool,
+  pub is_symlink: bool,
   pub atime_ms: u32,
   pub mtime_ms: u32,
   pub ctime_ms: u32,
@@ -59,7 +60,7 @@ impl From<NodeFsStats> for FileMetadata {
     Self {
       is_file: value.is_file,
       is_directory: value.is_directory,
-      is_symlink: false,
+      is_symlink: value.is_symlink,
       atime_ms: value.atime_ms as u64,
       mtime_ms: value.mtime_ms as u64,
       ctime_ms: value.ctime_ms as u64,

--- a/crates/rspack_fs_node/src/node.rs
+++ b/crates/rspack_fs_node/src/node.rs
@@ -1,4 +1,4 @@
-use napi::bindgen_prelude::{Buffer, Either3};
+use napi::bindgen_prelude::{Buffer, Either3, Promise};
 use napi::Either;
 use napi_derive::napi;
 use rspack_fs::FileMetadata;
@@ -7,46 +7,40 @@ use rspack_napi::threadsafe_function::ThreadsafeFunction;
 #[derive(Debug)]
 #[napi(object, object_to_js = false, js_name = "ThreadsafeNodeFS")]
 pub struct ThreadsafeNodeFS {
-  #[napi(ts_type = "(name: string, content: Buffer) => Promise<void> | void")]
-  pub write_file: ThreadsafeFunction<(String, Buffer), ()>,
-  #[napi(ts_type = "(name: string) => Promise<void> | void")]
-  pub remove_file: ThreadsafeFunction<String, ()>,
-  #[napi(ts_type = "(name: string) => Promise<void> | void")]
-  pub mkdir: ThreadsafeFunction<String, ()>,
-  #[napi(ts_type = "(name: string) => Promise<string | void> | string | void")]
-  pub mkdirp: ThreadsafeFunction<String, Either<String, ()>>,
-  #[napi(ts_type = "(name: string) => Promise<string | void> | string | void")]
-  pub remove_dir_all: ThreadsafeFunction<String, Either<String, ()>>,
-  #[napi(ts_type = "(name: string) => Promise<string[] | void> | string[] | void")]
-  pub read_dir: ThreadsafeFunction<String, Either<Vec<String>, ()>>,
-  #[napi(ts_type = "(name: string) => Promise<Buffer | string | void> | Buffer | string | void")]
-  pub read_file: ThreadsafeFunction<String, Either3<Buffer, String, ()>>,
-  #[napi(ts_type = "(name: string) => Promise<NodeFsStats | void> | NodeFsStats | void")]
-  pub stat: ThreadsafeFunction<String, Either<NodeFsStats, ()>>,
-  #[napi(ts_type = "(name: string) => Promise<NodeFsStats | void> | NodeFsStats | void")]
-  pub lstat: ThreadsafeFunction<String, Either<NodeFsStats, ()>>,
-  #[napi(ts_type = "(name: string, flags: string) => Promise<number | void> | number | void")]
-  pub open: ThreadsafeFunction<(String, String), Either<i32, ()>>,
-  #[napi(ts_type = "(from: string, to: string) => Promise<void> | void")]
-  pub rename: ThreadsafeFunction<(String, String), ()>,
-  #[napi(ts_type = "(fd: number) => Promise<void> | void")]
-  pub close: ThreadsafeFunction<i32, ()>,
-  #[napi(
-    ts_type = "(fd: number, content: Buffer, position: number) => Promise<number | void> | number | void"
-  )]
-  pub write: ThreadsafeFunction<(i32, Buffer, u32), Either<u32, ()>>,
-  #[napi(ts_type = "(fd: number, content: Buffer) => Promise<number | void> | number | void")]
-  pub write_all: ThreadsafeFunction<(i32, Buffer), ()>,
-  #[napi(
-    ts_type = "(fd: number, length: number, position: number) => Promise<Buffer | void> | Buffer | void"
-  )]
-  pub read: ThreadsafeFunction<(i32, u32, u32), Either<Buffer, ()>>,
-  #[napi(
-    ts_type = "(fd: number, code: number, position: number) => Promise<Buffer | void> | Buffer | void"
-  )]
-  pub read_until: ThreadsafeFunction<(i32, u8, u32), Either<Buffer, ()>>,
-  #[napi(ts_type = "(fd: number, position: number) => Promise<Buffer | void> | Buffer | void")]
-  pub read_to_end: ThreadsafeFunction<(i32, u32), Either<Buffer, ()>>,
+  #[napi(ts_type = "(name: string, content: Buffer) => Promise<void>")]
+  pub write_file: ThreadsafeFunction<(String, Buffer), Promise<()>>,
+  #[napi(ts_type = "(name: string) => Promise<void>")]
+  pub remove_file: ThreadsafeFunction<String, Promise<()>>,
+  #[napi(ts_type = "(name: string) => Promise<void>")]
+  pub mkdir: ThreadsafeFunction<String, Promise<()>>,
+  #[napi(ts_type = "(name: string) => Promise<string | void>")]
+  pub mkdirp: ThreadsafeFunction<String, Promise<Either<String, ()>>>,
+  #[napi(ts_type = "(name: string) => Promise<string | void>")]
+  pub remove_dir_all: ThreadsafeFunction<String, Promise<Either<String, ()>>>,
+  #[napi(ts_type = "(name: string) => Promise<string[] | void>")]
+  pub read_dir: ThreadsafeFunction<String, Promise<Either<Vec<String>, ()>>>,
+  #[napi(ts_type = "(name: string) => Promise<Buffer | string | void>")]
+  pub read_file: ThreadsafeFunction<String, Promise<Either3<Buffer, String, ()>>>,
+  #[napi(ts_type = "(name: string) => Promise<NodeFsStats | void>")]
+  pub stat: ThreadsafeFunction<String, Promise<Either<NodeFsStats, ()>>>,
+  #[napi(ts_type = "(name: string) => Promise<NodeFsStats | void>")]
+  pub lstat: ThreadsafeFunction<String, Promise<Either<NodeFsStats, ()>>>,
+  #[napi(ts_type = "(name: string, flags: string) => Promise<number | void>")]
+  pub open: ThreadsafeFunction<(String, String), Promise<Either<i32, ()>>>,
+  #[napi(ts_type = "(from: string, to: string) => Promise<void>")]
+  pub rename: ThreadsafeFunction<(String, String), Promise<()>>,
+  #[napi(ts_type = "(fd: number) => Promise<void>")]
+  pub close: ThreadsafeFunction<i32, Promise<()>>,
+  #[napi(ts_type = "(fd: number, content: Buffer, position: number) => Promise<number | void>")]
+  pub write: ThreadsafeFunction<(i32, Buffer, u32), Promise<Either<u32, ()>>>,
+  #[napi(ts_type = "(fd: number, content: Buffer) => Promise<number | void>")]
+  pub write_all: ThreadsafeFunction<(i32, Buffer), Promise<()>>,
+  #[napi(ts_type = "(fd: number, length: number, position: number) => Promise<Buffer | void>")]
+  pub read: ThreadsafeFunction<(i32, u32, u32), Promise<Either<Buffer, ()>>>,
+  #[napi(ts_type = "(fd: number, code: number, position: number) => Promise<Buffer | void>")]
+  pub read_until: ThreadsafeFunction<(i32, u8, u32), Promise<Either<Buffer, ()>>>,
+  #[napi(ts_type = "(fd: number, position: number) => Promise<Buffer | void>")]
+  pub read_to_end: ThreadsafeFunction<(i32, u32), Promise<Either<Buffer, ()>>>,
 }
 
 #[napi(object, object_to_js = false)]

--- a/crates/rspack_fs_node/src/write.rs
+++ b/crates/rspack_fs_node/src/write.rs
@@ -26,55 +26,45 @@ impl NodeFileSystem {
 #[async_trait]
 impl WritableFileSystem for NodeFileSystem {
   async fn create_dir(&self, dir: &Utf8Path) -> Result<()> {
-    let fut = async {
-      let dir = dir.as_str().to_string();
-      self.0.mkdir.call_with_promise(dir).await.map_err(|e| {
+    let dir = dir.as_str().to_string();
+    self.0.mkdir.call_with_promise(dir).await.map_err(|e| {
+      Error::Io(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        e.to_string(),
+      ))
+    })
+  }
+
+  async fn create_dir_all(&self, dir: &Utf8Path) -> Result<()> {
+    let dir = dir.as_str().to_string();
+    self
+      .0
+      .mkdirp
+      .call_with_promise(dir)
+      .await
+      .map_err(|e| {
         Error::Io(std::io::Error::new(
           std::io::ErrorKind::Other,
           e.to_string(),
         ))
       })
-    };
-
-    fut.await
-  }
-
-  async fn create_dir_all(&self, dir: &Utf8Path) -> Result<()> {
-    let fut = async {
-      let dir = dir.as_str().to_string();
-      self
-        .0
-        .mkdirp
-        .call_with_promise(dir)
-        .await
-        .map_err(|e| {
-          Error::Io(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            e.to_string(),
-          ))
-        })
-        .map(|_| ())
-    };
-    fut.await
+      .map(|_| ())
   }
 
   async fn write(&self, file: &Utf8Path, data: &[u8]) -> Result<()> {
-    let fut = async {
-      let file = file.as_str().to_string();
-      let data = data.to_vec();
-      self
-        .0
-        .write_file
-        .call_with_promise((file, data.into()))
-        .await
-        .map_err(|e| {
-          Error::Io(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            e.to_string(),
-          ))
-        })
-    };
-    fut.await
+    let file = file.as_str().to_string();
+    let data = data.to_vec();
+    self
+      .0
+      .write_file
+      .call_with_promise((file, data.into()))
+      .await
+      .map_err(|e| {
+        Error::Io(std::io::Error::new(
+          std::io::ErrorKind::Other,
+          e.to_string(),
+        ))
+      })
   }
 
   async fn remove_file(&self, file: &Utf8Path) -> Result<()> {
@@ -173,22 +163,19 @@ impl WritableFileSystem for NodeFileSystem {
 #[async_trait]
 impl IntermediateFileSystemExtras for NodeFileSystem {
   async fn rename(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
-    let fut = async {
-      let from = from.as_str().to_string();
-      let to = to.as_str().to_string();
-      self
-        .0
-        .rename
-        .call_with_promise((from, to))
-        .await
-        .map_err(|e| {
-          Error::Io(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            e.to_string(),
-          ))
-        })
-    };
-    fut.await
+    let from = from.as_str().to_string();
+    let to = to.as_str().to_string();
+    self
+      .0
+      .rename
+      .call_with_promise((from, to))
+      .await
+      .map_err(|e| {
+        Error::Io(std::io::Error::new(
+          std::io::ErrorKind::Other,
+          e.to_string(),
+        ))
+      })
   }
 
   async fn create_read_stream(&self, file: &Utf8Path) -> Result<Box<dyn ReadStream>> {

--- a/crates/rspack_fs_node/src/write.rs
+++ b/crates/rspack_fs_node/src/write.rs
@@ -10,6 +10,17 @@ use rspack_paths::Utf8Path;
 
 use crate::node::ThreadsafeNodeFS;
 
+fn map_error_to_fs_error(e: rspack_error::Error) -> Error {
+  Error::Io(std::io::Error::new(
+    std::io::ErrorKind::Other,
+    e.to_string(),
+  ))
+}
+
+fn new_fs_error(msg: &str) -> Error {
+  Error::Io(std::io::Error::new(std::io::ErrorKind::Other, msg))
+}
+
 pub struct NodeFileSystem(Arc<ThreadsafeNodeFS>);
 
 impl std::fmt::Debug for NodeFileSystem {
@@ -27,12 +38,12 @@ impl NodeFileSystem {
 impl WritableFileSystem for NodeFileSystem {
   async fn create_dir(&self, dir: &Utf8Path) -> Result<()> {
     let dir = dir.as_str().to_string();
-    self.0.mkdir.call_with_promise(dir).await.map_err(|e| {
-      Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        e.to_string(),
-      ))
-    })
+    self
+      .0
+      .mkdir
+      .call_with_promise(dir)
+      .await
+      .map_err(map_error_to_fs_error)
   }
 
   async fn create_dir_all(&self, dir: &Utf8Path) -> Result<()> {
@@ -42,12 +53,7 @@ impl WritableFileSystem for NodeFileSystem {
       .mkdirp
       .call_with_promise(dir)
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })
+      .map_err(map_error_to_fs_error)
       .map(|_| ())
   }
 
@@ -59,12 +65,7 @@ impl WritableFileSystem for NodeFileSystem {
       .write_file
       .call_with_promise((file, data.into()))
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })
+      .map_err(map_error_to_fs_error)
   }
 
   async fn remove_file(&self, file: &Utf8Path) -> Result<()> {
@@ -74,12 +75,7 @@ impl WritableFileSystem for NodeFileSystem {
       .remove_file
       .call_with_promise(file)
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })
+      .map_err(map_error_to_fs_error)
       .map(|_| ())
   }
 
@@ -90,30 +86,22 @@ impl WritableFileSystem for NodeFileSystem {
       .remove_dir_all
       .call_with_promise(dir)
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })
+      .map_err(map_error_to_fs_error)
       .map(|_| ())
   }
 
   // TODO: support read_dir options
   async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>> {
     let dir = dir.as_str().to_string();
-    let res = self.0.read_dir.call_with_promise(dir).await.map_err(|e| {
-      Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        e.to_string(),
-      ))
-    })?;
+    let res = self
+      .0
+      .read_dir
+      .call_with_promise(dir)
+      .await
+      .map_err(map_error_to_fs_error)?;
     match res {
       Either::A(files) => Ok(files),
-      Either::B(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "output file system call read dir failed",
-      ))),
+      Either::B(_) => Err(new_fs_error("output file system call read dir failed:")),
     }
   }
 
@@ -125,37 +113,26 @@ impl WritableFileSystem for NodeFileSystem {
       .read_file
       .call_with_promise(file)
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })?;
+      .map_err(map_error_to_fs_error)?;
 
     match res {
       Either3::A(data) => Ok(data.to_vec()),
       Either3::B(str) => Ok(str.into_bytes()),
-      Either3::C(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "output file system call read file failed",
-      ))),
+      Either3::C(_) => Err(new_fs_error("output file system call read file failed:")),
     }
   }
 
   async fn stat(&self, file: &Utf8Path) -> Result<FileMetadata> {
     let file = file.as_str().to_string();
-    let res = self.0.stat.call_with_promise(file).await.map_err(|e| {
-      Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        e.to_string(),
-      ))
-    })?;
+    let res = self
+      .0
+      .stat
+      .call_with_promise(file)
+      .await
+      .map_err(map_error_to_fs_error)?;
     match res {
       Either::A(stat) => Ok(FileMetadata::from(stat)),
-      Either::B(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "output file system call stat failed",
-      ))),
+      Either::B(_) => Err(new_fs_error("output file system call stat failed:")),
     }
   }
 }
@@ -170,12 +147,7 @@ impl IntermediateFileSystemExtras for NodeFileSystem {
       .rename
       .call_with_promise((from, to))
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })
+      .map_err(map_error_to_fs_error)
   }
 
   async fn create_read_stream(&self, file: &Utf8Path) -> Result<Box<dyn ReadStream>> {
@@ -202,24 +174,16 @@ impl NodeReadStream {
       .open
       .call_with_promise((file.as_str().to_string(), "r".to_string()))
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })?;
+      .map_err(map_error_to_fs_error)?;
 
     match res {
       Either::A(fd) => Ok(Self { fd, pos: 0, fs }),
-      Either::B(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "file system call read open failed",
-      ))),
+      Either::B(_) => Err(new_fs_error("file system call read open failed:")),
     }
   }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl ReadStream for NodeReadStream {
   async fn read(&mut self, buf: &mut [u8]) -> Result<()> {
     let length = buf.len();
@@ -228,12 +192,7 @@ impl ReadStream for NodeReadStream {
       .read
       .call_with_promise((self.fd, length as u32, self.pos as u32))
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })?;
+      .map_err(map_error_to_fs_error)?;
 
     match buffer {
       Either::A(buffer) => {
@@ -241,10 +200,7 @@ impl ReadStream for NodeReadStream {
         buf.copy_from_slice(&buffer);
         Ok(())
       }
-      Either::B(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "file system call read failed",
-      ))),
+      Either::B(_) => Err(new_fs_error("file system call read failed:")),
     }
   }
 
@@ -254,12 +210,7 @@ impl ReadStream for NodeReadStream {
       .read_until
       .call_with_promise((self.fd, byte, self.pos as u32))
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })?;
+      .map_err(map_error_to_fs_error)?;
 
     match buffer {
       Either::A(buffer) => {
@@ -267,10 +218,7 @@ impl ReadStream for NodeReadStream {
         buf.copy_from_slice(&buffer);
         Ok(buffer.len())
       }
-      Either::B(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "file system call read until failed",
-      ))),
+      Either::B(_) => Err(new_fs_error("file system call read until failed:")),
     }
   }
   async fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
@@ -279,12 +227,7 @@ impl ReadStream for NodeReadStream {
       .read_to_end
       .call_with_promise((self.fd, self.pos as u32))
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })?;
+      .map_err(map_error_to_fs_error)?;
 
     match buffer {
       Either::A(buffer) => {
@@ -292,10 +235,7 @@ impl ReadStream for NodeReadStream {
         buf.copy_from_slice(&buffer);
         Ok(buffer.len())
       }
-      Either::B(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "file system call read to end failed",
-      ))),
+      Either::B(_) => Err(new_fs_error("file system call read to end failed:")),
     }
   }
   async fn skip(&mut self, offset: usize) -> Result<()> {
@@ -303,12 +243,12 @@ impl ReadStream for NodeReadStream {
     Ok(())
   }
   async fn close(&mut self) -> Result<()> {
-    self.fs.close.call_with_promise(self.fd).await.map_err(|e| {
-      Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        e.to_string(),
-      ))
-    })
+    self
+      .fs
+      .close
+      .call_with_promise(self.fd)
+      .await
+      .map_err(map_error_to_fs_error)
   }
 }
 
@@ -325,24 +265,16 @@ impl NodeWriteStream {
       .open
       .call_with_promise((file.as_str().to_string(), "w+".to_string()))
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })?;
+      .map_err(map_error_to_fs_error)?;
 
     match res {
       Either::A(fd) => Ok(Self { fd, pos: 0, fs }),
-      Either::B(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "file system call write open failed",
-      ))),
+      Either::B(_) => Err(new_fs_error("file system call write open failed:")),
     }
   }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl WriteStream for NodeWriteStream {
   async fn write(&mut self, buf: &[u8]) -> Result<usize> {
     let res = self
@@ -350,22 +282,14 @@ impl WriteStream for NodeWriteStream {
       .write
       .call_with_promise((self.fd, buf.to_vec().into(), self.pos as u32))
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })?;
+      .map_err(map_error_to_fs_error)?;
 
     match res {
       Either::A(size) => {
         self.pos += size as usize;
         Ok(size as usize)
       }
-      Either::B(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "file system call write failed",
-      ))),
+      Either::B(_) => Err(new_fs_error("file system call write failed:")),
     }
   }
   async fn write_all(&mut self, buf: &[u8]) -> Result<()> {
@@ -374,22 +298,17 @@ impl WriteStream for NodeWriteStream {
       .write_all
       .call_with_promise((self.fd, buf.to_vec().into()))
       .await
-      .map_err(|e| {
-        Error::Io(std::io::Error::new(
-          std::io::ErrorKind::Other,
-          e.to_string(),
-        ))
-      })
+      .map_err(map_error_to_fs_error)
   }
   async fn flush(&mut self) -> Result<()> {
     Ok(())
   }
   async fn close(&mut self) -> Result<()> {
-    self.fs.close.call_with_promise(self.fd).await.map_err(|e| {
-      Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        e.to_string(),
-      ))
-    })
+    self
+      .fs
+      .close
+      .call_with_promise(self.fd)
+      .await
+      .map_err(map_error_to_fs_error)
   }
 }

--- a/packages/rspack/src/FileSystem.ts
+++ b/packages/rspack/src/FileSystem.ts
@@ -12,67 +12,58 @@ import { memoizeFn } from "./util/memoize";
 
 const BUFFER_SIZE = 1000;
 
+const ASYNC_NOOP = async () => {};
+
 const NOOP_FILESYSTEM: ThreadsafeNodeFS = {
-	writeFile() {},
-	removeFile() {},
-	mkdir() {},
-	mkdirp() {},
-	removeDirAll() {},
-	readDir: () => {},
-	readFile: () => {},
-	stat: () => {},
-	lstat: () => {},
-	open: () => {},
-	rename: () => {},
-	close: () => {},
-	write: () => {},
-	writeAll: () => {},
-	read: () => {},
-	readUntil: () => {},
-	readToEnd: () => {}
+	writeFile: ASYNC_NOOP,
+	removeFile: ASYNC_NOOP,
+	mkdir: ASYNC_NOOP,
+	mkdirp: ASYNC_NOOP,
+	removeDirAll: ASYNC_NOOP,
+	readDir: ASYNC_NOOP,
+	readFile: ASYNC_NOOP,
+	stat: ASYNC_NOOP,
+	lstat: ASYNC_NOOP,
+	open: ASYNC_NOOP,
+	rename: ASYNC_NOOP,
+	close: ASYNC_NOOP,
+	write: ASYNC_NOOP,
+	writeAll: ASYNC_NOOP,
+	read: ASYNC_NOOP,
+	readUntil: ASYNC_NOOP,
+	readToEnd: ASYNC_NOOP
 };
 
 class ThreadsafeOutputNodeFS implements ThreadsafeNodeFS {
-	writeFile!: (name: string, content: Buffer) => Promise<void> | void;
-	removeFile!: (name: string) => Promise<void> | void;
-	mkdir!: (name: string) => Promise<void> | void;
-	mkdirp!: (name: string) => Promise<string | void> | string | void;
-	removeDirAll!: (name: string) => Promise<string | void> | string | void;
-	readDir!: (name: string) => Promise<string[] | void> | string[] | void;
-	readFile!: (
-		name: string
-	) => Promise<Buffer | string | void> | Buffer | string | void;
-	stat!: (name: string) => Promise<NodeFsStats | void> | NodeFsStats | void;
-	lstat!: (name: string) => Promise<NodeFsStats | void> | NodeFsStats | void;
-	open!: (
-		name: string,
-		flags: string
-	) => Promise<number | void> | number | void;
-	rename!: (from: string, to: string) => Promise<void> | void;
-	close!: (fd: number) => Promise<void> | void;
+	writeFile!: (name: string, content: Buffer) => Promise<void>;
+	removeFile!: (name: string) => Promise<void>;
+	mkdir!: (name: string) => Promise<void>;
+	mkdirp!: (name: string) => Promise<string | void>;
+	removeDirAll!: (name: string) => Promise<string | void>;
+	readDir!: (name: string) => Promise<string[] | void>;
+	readFile!: (name: string) => Promise<Buffer | string | void>;
+	stat!: (name: string) => Promise<NodeFsStats | void>;
+	lstat!: (name: string) => Promise<NodeFsStats | void>;
+	open!: (name: string, flags: string) => Promise<number | void>;
+	rename!: (from: string, to: string) => Promise<void>;
+	close!: (fd: number) => Promise<void>;
 	write!: (
 		fd: number,
 		content: Buffer,
 		position: number
-	) => Promise<number | void> | number | void;
-	writeAll!: (
-		fd: number,
-		content: Buffer
-	) => Promise<number | void> | number | void;
+	) => Promise<number | void>;
+	writeAll!: (fd: number, content: Buffer) => Promise<number | void>;
 	read!: (
 		fd: number,
 		length: number,
 		position: number
-	) => Promise<Buffer | void> | Buffer | void;
+	) => Promise<Buffer | void>;
 	readUntil!: (
 		fd: number,
 		code: number,
 		position: number
-	) => Promise<Buffer | void> | Buffer | void;
-	readToEnd!: (
-		fd: number,
-		position: number
-	) => Promise<Buffer | void> | Buffer | void;
+	) => Promise<Buffer | void>;
+	readToEnd!: (fd: number, position: number) => Promise<Buffer | void>;
 
 	constructor(fs?: OutputFileSystem) {
 		Object.assign(this, NOOP_FILESYSTEM);

--- a/packages/rspack/src/FileSystem.ts
+++ b/packages/rspack/src/FileSystem.ts
@@ -87,17 +87,7 @@ class ThreadsafeOutputNodeFS implements ThreadsafeNodeFS {
 			const statFn = util.promisify(fs.stat.bind(fs));
 			return async (filePath: string) => {
 				const res = await statFn(filePath);
-				return (
-					res && {
-						isFile: res.isFile(),
-						isDirectory: res.isDirectory(),
-						atimeMs: res.atimeMs,
-						mtimeMs: res.atimeMs,
-						ctimeMs: res.atimeMs,
-						birthtimeMs: res.birthtimeMs,
-						size: res.size
-					}
-				);
+				return res && ThreadsafeOutputNodeFS.__to_binding_stat(res);
 			};
 		});
 		this.lstat = memoizeFn(() => {
@@ -117,6 +107,7 @@ class ThreadsafeOutputNodeFS implements ThreadsafeNodeFS {
 		return {
 			isFile: stat.isFile(),
 			isDirectory: stat.isDirectory(),
+			isSymlink: stat.isSymbolicLink(),
 			atimeMs: stat.atimeMs,
 			mtimeMs: stat.atimeMs,
 			ctimeMs: stat.atimeMs,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

cherry pick refactor changes in #8643

- refactor: Unify the return values of `ThreadsafeNodeFS` methods into promises to simplify the code
- refactor: change `fn <'a>() -> BoxFuture<'a, Result<()>>;` to `async fn() -> Result<()>`
- refactor: remove unnecessary async blocks
- refactor(rspack_fs_node): create map_error_to_fs_error util to replace duplicate closures
- refactor(rspack_fs_node): create new_fs_error to simplify code
- fix: `NodeFileStats` lacks the `is_symlink` field

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
