### PR TITLE
feat: pass compiler_path to rust Compiler

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -211,7 +211,7 @@ export declare class RawExternalItemFnCtx {
 }
 
 export declare class Rspack {
-  constructor(options: RawOptions, builtinPlugins: Array<BuiltinPlugin>, registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS, resolverFactoryReference: JsResolverFactory)
+  constructor(compilerPath: string, options: RawOptions, builtinPlugins: Array<BuiltinPlugin>, registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS, resolverFactoryReference: JsResolverFactory)
   setNonSkippableRegisters(kinds: Array<RegisterJsTapKind>): void
   /** Build with the given option passed to the constructor */
   build(callback: (err: null | Error) => void): void

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -37,9 +37,11 @@ pub struct Rspack {
 
 #[napi]
 impl Rspack {
+  #[allow(clippy::too_many_arguments)]
   #[napi(constructor)]
   pub fn new(
     env: Env,
+    compiler_path: String,
     options: RawOptions,
     builtin_plugins: Vec<BuiltinPlugin>,
     register_js_taps: RegisterJsTaps,
@@ -68,6 +70,7 @@ impl Rspack {
     let loader_resolver_factory = (*resolver_factory_reference)
       .get_loader_resolver_factory(compiler_options.resolve_loader.clone());
     let rspack = rspack_core::Compiler::new(
+      compiler_path,
       compiler_options,
       plugins,
       rspack_binding_options::buildtime_plugins::buildtime_plugins(),

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -52,6 +52,7 @@ pub struct CompilerHooks {
 
 #[derive(Debug)]
 pub struct Compiler {
+  pub compiler_path: String,
   pub options: Arc<CompilerOptions>,
   pub output_filesystem: Box<dyn WritableFileSystem>,
   pub intermediate_filesystem: Box<dyn WritableFileSystem>,
@@ -72,6 +73,7 @@ impl Compiler {
   #[instrument(skip_all)]
   #[allow(clippy::too_many_arguments)]
   pub fn new(
+    compiler_path: String,
     options: CompilerOptions,
     plugins: Vec<BoxPlugin>,
     buildtime_plugins: Vec<BoxPlugin>,
@@ -116,6 +118,7 @@ impl Compiler {
       intermediate_filesystem.unwrap_or_else(|| Box::new(NativeFileSystem {}));
 
     Self {
+      compiler_path,
       options: options.clone(),
       compilation: Compilation::new(
         options,

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -1621,6 +1621,7 @@ class Compiler {
 		};
 
 		this.#instance = new instanceBinding.Rspack(
+			this.compilerPath,
 			rawOptions,
 			this.#builtinPlugins,
 			this.#registers,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR will make `compiler_path` accessible to the Rust Compiler, and this field is useful in persistent cache.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
