### PR TITLE
docs: clarify support for JavaScriptModulesPlugin as partial

### DIFF
--- a/website/components/PluginSupportStatusTable.tsx
+++ b/website/components/PluginSupportStatusTable.tsx
@@ -373,7 +373,10 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'JavascriptModulesPlugin',
-    status: SupportStatus.FullySupported,
+    status: SupportStatus.partiallySupported,
+    notes: {
+      en: 'Static `getCompilationHooks()` method does not return all hooks',
+    },
   },
   {
     name: 'LibManifestPlugin',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
Currently the plugin support table claims full support for `JavascriptModulesPlugin`, but that's not correct.  The static `getCompilationHooks` method only returns the `chunkHash` hook, but there are quite a few more.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
For example, my plugin [`transform-async-modules-webpack-plugin`](https://github.com/steverep/transform-async-modules-webpack-plugin) cannot be `rspack` compatible because it uses the `renderModuleContent` tap.  Here's the full list of hooks:

https://github.com/webpack/webpack/blob/8a04c64e5e8e1b7ed1fd4b942a3d277296f14ef9/lib/javascript/JavascriptModulesPlugin.js#L175-L190



## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
