### PR TITLE
feat: cache storage move lock file

### DIFF
--- a/crates/rspack_storage/src/pack/data/meta.rs
+++ b/crates/rspack_storage/src/pack/data/meta.rs
@@ -14,16 +14,25 @@ pub struct PackFileMeta {
 }
 
 #[derive(Debug, Default, Clone)]
+pub enum RootMetaFrom {
+  #[default]
+  New,
+  File,
+}
+
+#[derive(Debug, Default, Clone)]
 pub struct RootMeta {
-  pub last_modified: u64,
+  pub expire_time: u64,
   pub scopes: HashSet<String>,
+  pub from: RootMetaFrom,
 }
 
 impl RootMeta {
-  pub fn new(scopes: HashSet<String>) -> Self {
+  pub fn new(scopes: HashSet<String>, expire: u64) -> Self {
     Self {
       scopes,
-      last_modified: current_time(),
+      expire_time: current_time() + expire,
+      from: RootMetaFrom::New,
     }
   }
   pub fn get_path(dir: &Utf8Path) -> Utf8PathBuf {

--- a/crates/rspack_storage/src/pack/data/mod.rs
+++ b/crates/rspack_storage/src/pack/data/mod.rs
@@ -3,7 +3,7 @@ mod options;
 mod pack;
 mod scope;
 
-pub use meta::{current_time, PackFileMeta, RootMeta, ScopeMeta};
+pub use meta::{current_time, PackFileMeta, RootMeta, RootMetaFrom, ScopeMeta};
 pub use options::{PackOptions, RootOptions};
 pub use pack::{Pack, PackContents, PackKeys};
 pub use scope::{PackScope, RootMetaState};

--- a/crates/rspack_storage/src/pack/fs/mod.rs
+++ b/crates/rspack_storage/src/pack/fs/mod.rs
@@ -107,11 +107,13 @@ impl PackFS for PackBridgeFS {
   }
 
   async fn remove_file(&self, path: &Utf8Path) -> Result<()> {
-    self
-      .0
-      .remove_file(path)
-      .await
-      .map_err(|e| PackFsError::from_fs_error(path, PackFsErrorOpt::Remove, e))?;
+    if self.exists(path).await? {
+      self
+        .0
+        .remove_file(path)
+        .await
+        .map_err(|e| PackFsError::from_fs_error(path, PackFsErrorOpt::Remove, e))?;
+    }
     Ok(())
   }
 

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -100,6 +100,8 @@ impl ScopeManager {
   }
 
   pub async fn load(&self, name: &'static str) -> Result<StorageContent> {
+    self.strategy.before_load().await?;
+
     if matches!(*self.root_meta.lock().await, RootMetaState::Pending) {
       let loaded = self.strategy.read_root_meta().await?;
       if let Some(meta) = &loaded {

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -263,6 +263,8 @@ async fn save_scopes(
   .into_iter()
   .collect_vec();
 
+  strategy.write_root_meta(root_meta).await?;
+
   join_all(
     scopes
       .values()
@@ -281,8 +283,6 @@ async fn save_scopes(
   .await
   .into_iter()
   .collect::<Result<Vec<_>>>()?;
-
-  strategy.write_root_meta(root_meta).await?;
 
   for (_, scope) in scopes.iter_mut() {
     strategy.after_all(scope)?;

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -141,6 +141,11 @@ impl ScopeManager {
           self.strategy.ensure_contents(scope).await?;
           Ok(scope.get_contents())
         }
+        // create empty scope if not exists
+        ValidateResult::NotExists => {
+          self.clear_scope(name).await;
+          Ok(vec![])
+        }
         // clear scope if invalid
         ValidateResult::Invalid(_) => {
           self.clear_scope(name).await;
@@ -159,12 +164,12 @@ impl ScopeManager {
     let root_meta_guard = self.root_meta.lock().await;
     // no root, no scope
     let Some(root_meta) = root_meta_guard.expect_value() else {
-      return Ok(ValidateResult::invalid("root meta not exists"));
+      return Ok(ValidateResult::NotExists);
     };
     // no scope, need to create a new one
     let mut scopes_guard = self.scopes.lock().await;
     let Some(scope) = scopes_guard.get_mut(name) else {
-      return Ok(ValidateResult::invalid("scope not found in root meta"));
+      return Ok(ValidateResult::NotExists);
     };
 
     // scope exists, validate it

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -65,6 +65,7 @@ impl ScopeManager {
               .filter(|(_, scope)| scope.loaded())
               .map(|(name, _)| name.clone())
               .collect::<HashSet<_>>(),
+            self.root_options.expire,
           )));
           Ok(())
         }
@@ -173,10 +174,7 @@ impl ScopeManager {
     };
 
     // scope exists, validate it
-    let validated = self
-      .strategy
-      .validate_root(root_meta, self.root_options.expire)
-      .await?;
+    let validated = self.strategy.validate_root(root_meta).await?;
     if validated.is_valid() {
       self.strategy.ensure_meta(scope).await?;
       let validated = self.strategy.validate_meta(scope).await?;

--- a/crates/rspack_storage/src/pack/strategy/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/mod.rs
@@ -78,6 +78,7 @@ pub struct InvalidDetail {
 
 #[derive(Debug)]
 pub enum ValidateResult {
+  NotExists,
   Valid,
   Invalid(InvalidDetail),
 }
@@ -103,6 +104,7 @@ impl ValidateResult {
 impl std::fmt::Display for ValidateResult {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
+      ValidateResult::NotExists => write!(f, "validation failed due to not exists"),
       ValidateResult::Valid => write!(f, "validation passed"),
       ValidateResult::Invalid(e) => {
         let mut pack_info_lines = e

--- a/crates/rspack_storage/src/pack/strategy/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/mod.rs
@@ -34,7 +34,7 @@ pub trait RootStrategy {
   async fn before_load(&self) -> Result<()>;
   async fn read_root_meta(&self) -> Result<Option<RootMeta>>;
   async fn write_root_meta(&self, root_meta: &RootMeta) -> Result<()>;
-  async fn validate_root(&self, root_meta: &RootMeta, expire: u64) -> Result<ValidateResult>;
+  async fn validate_root(&self, root_meta: &RootMeta) -> Result<ValidateResult>;
   async fn clean_unused(
     &self,
     root_meta: &RootMeta,

--- a/crates/rspack_storage/src/pack/strategy/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/mod.rs
@@ -31,6 +31,7 @@ pub trait ScopeStrategy:
 
 #[async_trait]
 pub trait RootStrategy {
+  async fn before_load(&self) -> Result<()>;
   async fn read_root_meta(&self) -> Result<Option<RootMeta>>;
   async fn write_root_meta(&self, root_meta: &RootMeta) -> Result<()>;
   async fn validate_root(&self, root_meta: &RootMeta, expire: u64) -> Result<ValidateResult>;

--- a/crates/rspack_storage/src/pack/strategy/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/mod.rs
@@ -78,7 +78,6 @@ pub struct InvalidDetail {
 
 #[derive(Debug)]
 pub enum ValidateResult {
-  NotExists,
   Valid,
   Invalid(InvalidDetail),
 }
@@ -104,7 +103,6 @@ impl ValidateResult {
 impl std::fmt::Display for ValidateResult {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
-      ValidateResult::NotExists => write!(f, "validation failed due to not exists"),
       ValidateResult::Valid => write!(f, "validation passed"),
       ValidateResult::Invalid(e) => {
         let mut pack_info_lines = e

--- a/crates/rspack_storage/src/pack/strategy/split/write_scope.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/write_scope.rs
@@ -38,7 +38,7 @@ impl ScopeWriteStrategy for SplitPackStrategy {
     removed_files: HashSet<Utf8PathBuf>,
   ) -> Result<()> {
     remove_files(removed_files, self.fs.clone()).await?;
-    move_temp_files(wrote_files, self.fs.clone(), &self.root, &self.temp_root).await?;
+    move_temp_files(wrote_files, &self.root, &self.temp_root, self.fs.clone()).await?;
     self.fs.remove_dir(&self.temp_root).await?;
     Ok(())
   }

--- a/crates/rspack_storage/tests/build.rs
+++ b/crates/rspack_storage/tests/build.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-#[cfg_attr(miri, ignore)]
 mod test_storage_build {
   use std::{collections::HashMap, path::PathBuf, sync::Arc};
 

--- a/crates/rspack_storage/tests/build.rs
+++ b/crates/rspack_storage/tests/build.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
-mod test_storage_dev {
+#[cfg_attr(miri, ignore)]
+mod test_storage_build {
   use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
   use rspack_error::Result;
@@ -9,13 +10,13 @@ mod test_storage_dev {
 
   pub fn get_native_path(p: &str) -> (PathBuf, PathBuf) {
     let base = std::env::temp_dir()
-      .join("./rspack_test/storage/test_storage_dev")
+      .join("rspack_test/storage/test_storage_build")
       .join(p);
     (base.join("cache"), base.join("temp"))
   }
 
   pub fn get_memory_path(p: &str) -> (PathBuf, PathBuf) {
-    let base = PathBuf::from("/test_storage_dev/").join(p);
+    let base = PathBuf::from("/rspack_test/storage/test_storage_build/").join(p);
     (base.join("cache"), base.join("temp"))
   }
 
@@ -37,7 +38,7 @@ mod test_storage_dev {
     }
   }
 
-  async fn test_initial_dev(
+  async fn test_initial_build(
     root: &Utf8PathBuf,
     fs: Arc<dyn PackFS>,
     options: PackStorageOptions,
@@ -45,26 +46,7 @@ mod test_storage_dev {
     let storage = PackStorage::new(options);
     let data = storage.load("test_scope").await?;
     assert!(data.is_empty());
-    for i in 0..300 {
-      storage.set(
-        "test_scope",
-        format!("key_{:0>3}", i).as_bytes().to_vec(),
-        format!("val_{:0>3}", i).as_bytes().to_vec(),
-      );
-    }
-    storage.trigger_save()?;
-    assert_eq!(storage.load("test_scope").await?.len(), 300);
-    for i in 300..700 {
-      storage.set(
-        "test_scope",
-        format!("key_{:0>3}", i).as_bytes().to_vec(),
-        format!("val_{:0>3}", i).as_bytes().to_vec(),
-      );
-    }
-    storage.trigger_save()?;
-    assert_eq!(storage.load("test_scope").await?.len(), 700);
-
-    for i in 700..1000 {
+    for i in 0..1000 {
       storage.set(
         "test_scope",
         format!("key_{:0>3}", i).as_bytes().to_vec(),
@@ -72,8 +54,6 @@ mod test_storage_dev {
       );
     }
     let rx = storage.trigger_save()?;
-    assert_eq!(storage.load("test_scope").await?.len(), 1000);
-
     rx.await.expect("should save")?;
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())
@@ -89,22 +69,11 @@ mod test_storage_dev {
     assert_eq!(data.len(), 1000);
     storage.set(
       "test_scope",
-      format!("key_{:0>3}", 100).as_bytes().to_vec(),
-      format!("new_{:0>3}", 100).as_bytes().to_vec(),
+      format!("key_{:0>3}", 222).as_bytes().to_vec(),
+      format!("new_{:0>3}", 222).as_bytes().to_vec(),
     );
-    storage.remove("test_scope", format!("key_{:0>3}", 200).as_bytes().as_ref());
-    storage.trigger_save()?;
-    assert_eq!(storage.load("test_scope").await?.len(), 999);
-
-    storage.set(
-      "test_scope",
-      format!("key_{:0>3}", 300).as_bytes().to_vec(),
-      format!("new_{:0>3}", 300).as_bytes().to_vec(),
-    );
-    storage.remove("test_scope", format!("key_{:0>3}", 400).as_bytes().as_ref());
+    storage.remove("test_scope", format!("key_{:0>3}", 333).as_bytes().as_ref());
     let rx = storage.trigger_save()?;
-    assert_eq!(storage.load("test_scope").await?.len(), 998);
-
     rx.await.expect("should save")?;
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())
@@ -127,14 +96,13 @@ mod test_storage_dev {
         )
       })
       .collect::<HashMap<_, _>>();
-    assert_eq!(data.len(), 998);
+    assert_eq!(data.len(), 999);
     assert_eq!(
       *data
-        .get(&format!("key_{:0>3}", 300))
+        .get(&format!("key_{:0>3}", 222))
         .expect("should get modified value"),
-      format!("new_{:0>3}", 300)
+      format!("new_{:0>3}", 222)
     );
-    assert!(!data.contains_key(&format!("key_{:0>3}", 400)));
     Ok(())
   }
 
@@ -143,11 +111,11 @@ mod test_storage_dev {
   async fn test_dev() {
     let cases = [
       (
-        get_native_path("test_recovery_native"),
+        get_native_path("test_build_native"),
         Arc::new(PackBridgeFS(Arc::new(NativeFileSystem {}))),
       ),
       (
-        get_memory_path("test_recovery_memory"),
+        get_memory_path("test_build_memory"),
         Arc::new(PackBridgeFS(Arc::new(MemoryFileSystem::default()))),
       ),
     ];
@@ -161,7 +129,7 @@ mod test_storage_dev {
         .await
         .expect("should remove temp root");
 
-      let _ = test_initial_dev(
+      let _ = test_initial_build(
         &root.join(&version),
         fs.clone(),
         create_pack_options(&root, &temp_root, &version, fs.clone()),

--- a/crates/rspack_storage/tests/dev.rs
+++ b/crates/rspack_storage/tests/dev.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-#[cfg_attr(miri, ignore)]
 mod test_storage_dev {
   use std::{collections::HashMap, path::PathBuf, sync::Arc};
 

--- a/crates/rspack_storage/tests/dev.rs
+++ b/crates/rspack_storage/tests/dev.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
-mod test_storage_build {
+#[cfg_attr(miri, ignore)]
+mod test_storage_dev {
   use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
   use rspack_error::Result;
@@ -9,13 +10,13 @@ mod test_storage_build {
 
   pub fn get_native_path(p: &str) -> (PathBuf, PathBuf) {
     let base = std::env::temp_dir()
-      .join("./rspack_test/storage/test_storage_build")
+      .join("rspack_test/storage/test_storage_dev")
       .join(p);
     (base.join("cache"), base.join("temp"))
   }
 
   pub fn get_memory_path(p: &str) -> (PathBuf, PathBuf) {
-    let base = PathBuf::from("/test_storage_build/").join(p);
+    let base = PathBuf::from("/rspack_test/storage/test_storage_dev/").join(p);
     (base.join("cache"), base.join("temp"))
   }
 
@@ -37,7 +38,7 @@ mod test_storage_build {
     }
   }
 
-  async fn test_initial_build(
+  async fn test_initial_dev(
     root: &Utf8PathBuf,
     fs: Arc<dyn PackFS>,
     options: PackStorageOptions,
@@ -45,7 +46,27 @@ mod test_storage_build {
     let storage = PackStorage::new(options);
     let data = storage.load("test_scope").await?;
     assert!(data.is_empty());
-    for i in 0..1000 {
+    for i in 0..300 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("val_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    storage.trigger_save()?;
+
+    assert_eq!(storage.load("test_scope").await?.len(), 300);
+    for i in 300..700 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("val_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    storage.trigger_save()?;
+
+    assert_eq!(storage.load("test_scope").await?.len(), 700);
+    for i in 700..1000 {
       storage.set(
         "test_scope",
         format!("key_{:0>3}", i).as_bytes().to_vec(),
@@ -53,7 +74,10 @@ mod test_storage_build {
       );
     }
     let rx = storage.trigger_save()?;
+
+    assert_eq!(storage.load("test_scope").await?.len(), 1000);
     rx.await.expect("should save")?;
+
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())
   }
@@ -68,11 +92,22 @@ mod test_storage_build {
     assert_eq!(data.len(), 1000);
     storage.set(
       "test_scope",
-      format!("key_{:0>3}", 222).as_bytes().to_vec(),
-      format!("new_{:0>3}", 222).as_bytes().to_vec(),
+      format!("key_{:0>3}", 100).as_bytes().to_vec(),
+      format!("new_{:0>3}", 100).as_bytes().to_vec(),
     );
-    storage.remove("test_scope", format!("key_{:0>3}", 333).as_bytes().as_ref());
+    storage.remove("test_scope", format!("key_{:0>3}", 200).as_bytes().as_ref());
+    storage.trigger_save()?;
+    assert_eq!(storage.load("test_scope").await?.len(), 999);
+
+    storage.set(
+      "test_scope",
+      format!("key_{:0>3}", 300).as_bytes().to_vec(),
+      format!("new_{:0>3}", 300).as_bytes().to_vec(),
+    );
+    storage.remove("test_scope", format!("key_{:0>3}", 400).as_bytes().as_ref());
     let rx = storage.trigger_save()?;
+    assert_eq!(storage.load("test_scope").await?.len(), 998);
+
     rx.await.expect("should save")?;
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())
@@ -95,26 +130,27 @@ mod test_storage_build {
         )
       })
       .collect::<HashMap<_, _>>();
-    assert_eq!(data.len(), 999);
+    assert_eq!(data.len(), 998);
     assert_eq!(
       *data
-        .get(&format!("key_{:0>3}", 222))
+        .get(&format!("key_{:0>3}", 300))
         .expect("should get modified value"),
-      format!("new_{:0>3}", 222)
+      format!("new_{:0>3}", 300)
     );
+    assert!(!data.contains_key(&format!("key_{:0>3}", 400)));
     Ok(())
   }
 
   #[tokio::test]
   #[cfg_attr(miri, ignore)]
-  async fn test_build() {
+  async fn test_dev() {
     let cases = [
       (
-        get_native_path("test_recovery_native"),
+        get_native_path("test_dev_native"),
         Arc::new(PackBridgeFS(Arc::new(NativeFileSystem {}))),
       ),
       (
-        get_memory_path("test_recovery_memory"),
+        get_memory_path("test_dev_memory"),
         Arc::new(PackBridgeFS(Arc::new(MemoryFileSystem::default()))),
       ),
     ];
@@ -128,7 +164,7 @@ mod test_storage_build {
         .await
         .expect("should remove temp root");
 
-      let _ = test_initial_build(
+      let _ = test_initial_dev(
         &root.join(&version),
         fs.clone(),
         create_pack_options(&root, &temp_root, &version, fs.clone()),

--- a/crates/rspack_storage/tests/error.rs
+++ b/crates/rspack_storage/tests/error.rs
@@ -9,13 +9,13 @@ mod test_storage_error {
 
   pub fn get_native_path(p: &str) -> (PathBuf, PathBuf) {
     let base = std::env::temp_dir()
-      .join("./rspack_test/storage/test_storage_error")
+      .join("rspack_test/storage/test_storage_error")
       .join(p);
     (base.join("cache"), base.join("temp"))
   }
 
   pub fn get_memory_path(p: &str) -> (PathBuf, PathBuf) {
-    let base = PathBuf::from("/test_storage_error/").join(p);
+    let base = PathBuf::from("/rspack_test/storage/test_storage_error/").join(p);
     (base.join("cache"), base.join("temp"))
   }
 
@@ -158,11 +158,11 @@ mod test_storage_error {
   async fn test_error() {
     let cases = [
       (
-        get_native_path("test_recovery_native"),
+        get_native_path("test_error_native"),
         Arc::new(PackBridgeFS(Arc::new(NativeFileSystem {}))),
       ),
       (
-        get_memory_path("test_recovery_memory"),
+        get_memory_path("test_error_memory"),
         Arc::new(PackBridgeFS(Arc::new(MemoryFileSystem::default()))),
       ),
     ];

--- a/crates/rspack_storage/tests/expire.rs
+++ b/crates/rspack_storage/tests/expire.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-#[cfg_attr(miri, ignore)]
 mod test_storage_expire {
   use std::{path::PathBuf, sync::Arc};
 
@@ -120,6 +119,7 @@ mod test_storage_expire {
   }
 
   #[tokio::test]
+  #[cfg_attr(miri, ignore)]
   async fn test_version_expire() {
     let cases = [
       (

--- a/crates/rspack_storage/tests/expire.rs
+++ b/crates/rspack_storage/tests/expire.rs
@@ -1,0 +1,156 @@
+#[cfg(test)]
+#[cfg_attr(miri, ignore)]
+mod test_storage_expire {
+  use std::{path::PathBuf, sync::Arc};
+
+  use rspack_error::Result;
+  use rspack_fs::{MemoryFileSystem, NativeFileSystem};
+  use rspack_paths::{AssertUtf8, Utf8PathBuf};
+  use rspack_storage::{PackBridgeFS, PackFS, PackStorage, PackStorageOptions, Storage};
+
+  pub fn get_native_path(p: &str) -> (PathBuf, PathBuf) {
+    let base = std::env::temp_dir()
+      .join("./rspack_test/storage/test_storage_expire")
+      .join(p);
+    (base.join("cache"), base.join("temp"))
+  }
+
+  pub fn get_memory_path(p: &str) -> (PathBuf, PathBuf) {
+    let base = PathBuf::from("/test_storage_expire/").join(p);
+    (base.join("cache"), base.join("temp"))
+  }
+
+  async fn test_initial_build(
+    version: &str,
+    root: &Utf8PathBuf,
+    temp_root: &Utf8PathBuf,
+    fs: Arc<dyn PackFS>,
+  ) -> Result<()> {
+    let storage = PackStorage::new(PackStorageOptions {
+      version: version.to_string(),
+      root: root.into(),
+      temp_root: temp_root.into(),
+      fs: fs.clone(),
+      bucket_size: 2,
+      pack_size: 200,
+      expire: 0,
+      clean: true,
+    });
+    let data = storage.load("test_scope").await?;
+    assert!(data.is_empty());
+    for i in 0..100 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("val_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    let rx = storage.trigger_save()?;
+    assert_eq!(storage.load("test_scope").await?.len(), 100);
+
+    rx.await.expect("should save")?;
+    assert!(
+      fs.exists(&root.join(version).join("test_scope/scope_meta"))
+        .await?
+    );
+    Ok(())
+  }
+
+  async fn test_recovery_expire(
+    version: &str,
+    root: &Utf8PathBuf,
+    temp_root: &Utf8PathBuf,
+    fs: Arc<dyn PackFS>,
+  ) -> Result<()> {
+    let storage = PackStorage::new(PackStorageOptions {
+      version: version.to_string(),
+      root: root.into(),
+      temp_root: temp_root.into(),
+      fs: fs.clone(),
+      bucket_size: 2,
+      pack_size: 200,
+      expire: 0,
+      clean: true,
+    });
+    assert!(storage.load("test_scope").await.is_err_and(|e| {
+      e.to_string()
+        .contains("validation failed due to cache expired")
+    }));
+
+    Ok(())
+  }
+
+  async fn test_remove_expired(
+    last_versoin: &str,
+    version: &str,
+    root: &Utf8PathBuf,
+    temp_root: &Utf8PathBuf,
+    fs: Arc<dyn PackFS>,
+  ) -> Result<()> {
+    let storage = PackStorage::new(PackStorageOptions {
+      version: version.to_string(),
+      root: root.into(),
+      temp_root: temp_root.into(),
+      fs: fs.clone(),
+      bucket_size: 2,
+      pack_size: 200,
+      expire: 7 * 24 * 60 * 60 * 1000,
+      clean: true,
+    });
+    let data = storage.load("test_scope").await?;
+    assert!(data.is_empty());
+    storage.set(
+      "test_scope",
+      format!("key_{:0>3}", 0).as_bytes().to_vec(),
+      format!("val_{:0>3}", 0).as_bytes().to_vec(),
+    );
+    let rx = storage.trigger_save()?;
+
+    rx.await.expect("should save")?;
+    assert!(
+      fs.exists(&root.join(version).join("test_scope/scope_meta"))
+        .await?
+    );
+    assert!(
+      !(fs
+        .exists(&root.join(last_versoin).join("test_scope/scope_meta"))
+        .await?)
+    );
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn test_version_expire() {
+    let cases = [
+      (
+        get_native_path("test_expire_native"),
+        Arc::new(PackBridgeFS(Arc::new(NativeFileSystem {}))),
+      ),
+      (
+        get_memory_path("test_expire_memory"),
+        Arc::new(PackBridgeFS(Arc::new(MemoryFileSystem::default()))),
+      ),
+    ];
+
+    for ((root, temp_root), fs) in cases {
+      let root = root.assert_utf8();
+      let temp_root = temp_root.assert_utf8();
+      fs.remove_dir(&root).await.expect("should remove root");
+      fs.remove_dir(&temp_root)
+        .await
+        .expect("should remove temp root");
+
+      let _ = test_initial_build("xxx", &root, &temp_root, fs.clone())
+        .await
+        .map_err(|e| panic!("{}", e));
+
+      let _ = test_recovery_expire("xxx", &root, &temp_root, fs.clone())
+        .await
+        .map_err(|e| panic!("{}", e));
+
+      let _ = test_remove_expired("xxx", "xxx2", &root, &temp_root, fs.clone())
+        .await
+        .map_err(|e| panic!("{}", e));
+    }
+  }
+}

--- a/crates/rspack_storage/tests/expire.rs
+++ b/crates/rspack_storage/tests/expire.rs
@@ -10,13 +10,13 @@ mod test_storage_expire {
 
   pub fn get_native_path(p: &str) -> (PathBuf, PathBuf) {
     let base = std::env::temp_dir()
-      .join("./rspack_test/storage/test_storage_expire")
+      .join("rspack_test/storage/test_storage_expire")
       .join(p);
     (base.join("cache"), base.join("temp"))
   }
 
   pub fn get_memory_path(p: &str) -> (PathBuf, PathBuf) {
-    let base = PathBuf::from("/test_storage_expire/").join(p);
+    let base = PathBuf::from("/rspack_test/storage/test_storage_expire/").join(p);
     (base.join("cache"), base.join("temp"))
   }
 

--- a/crates/rspack_storage/tests/lock.rs
+++ b/crates/rspack_storage/tests/lock.rs
@@ -1,0 +1,257 @@
+#[cfg(test)]
+#[cfg_attr(miri, ignore)]
+mod test_storage_lock {
+  use std::{
+    path::PathBuf,
+    sync::{atomic::AtomicUsize, Arc},
+  };
+
+  use rspack_error::{error, Result};
+  use rspack_fs::{FileMetadata, MemoryFileSystem, NativeFileSystem, ReadStream, WriteStream};
+  use rspack_paths::{AssertUtf8, Utf8Path, Utf8PathBuf};
+  use rspack_storage::{PackBridgeFS, PackFS, PackStorage, PackStorageOptions, Storage};
+  use rustc_hash::FxHashSet as HashSet;
+
+  #[derive(Debug)]
+  pub struct MockPackFS {
+    pub fs: Arc<dyn PackFS>,
+    pub moved: AtomicUsize,
+    pub break_on: usize,
+  }
+
+  #[async_trait::async_trait]
+  impl PackFS for MockPackFS {
+    async fn exists(&self, path: &Utf8Path) -> Result<bool> {
+      self.fs.exists(path).await
+    }
+
+    async fn remove_dir(&self, path: &Utf8Path) -> Result<()> {
+      self.fs.remove_dir(path).await
+    }
+
+    async fn ensure_dir(&self, path: &Utf8Path) -> Result<()> {
+      self.fs.ensure_dir(path).await
+    }
+
+    async fn write_file(&self, path: &Utf8Path) -> Result<Box<dyn WriteStream>> {
+      self.fs.write_file(path).await
+    }
+
+    async fn read_file(&self, path: &Utf8Path) -> Result<Box<dyn ReadStream>> {
+      self.fs.read_file(path).await
+    }
+
+    async fn read_dir(&self, path: &Utf8Path) -> Result<HashSet<String>> {
+      self.fs.read_dir(path).await
+    }
+
+    async fn metadata(&self, path: &Utf8Path) -> Result<FileMetadata> {
+      self.fs.metadata(path).await
+    }
+
+    async fn remove_file(&self, path: &Utf8Path) -> Result<()> {
+      self.fs.remove_file(path).await
+    }
+
+    async fn move_file(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
+      let moved = self.moved.load(std::sync::atomic::Ordering::Relaxed);
+      if moved == self.break_on {
+        Err(error!("move failed"))
+      } else {
+        self
+          .moved
+          .store(moved + 1, std::sync::atomic::Ordering::Relaxed);
+        self.fs.move_file(from, to).await
+      }
+    }
+  }
+
+  pub fn get_native_path(p: &str) -> (PathBuf, PathBuf) {
+    let base = std::env::temp_dir()
+      .join("rspack_test/storage/test_storage_lock")
+      .join(p);
+    (base.join("cache"), base.join("temp"))
+  }
+
+  pub fn get_memory_path(p: &str) -> (PathBuf, PathBuf) {
+    let base = PathBuf::from("/rspack_test/storage/test_storage_lock/").join(p);
+    (base.join("cache"), base.join("temp"))
+  }
+
+  async fn test_generate_lock(
+    version: &str,
+    root: &Utf8PathBuf,
+    temp_root: &Utf8PathBuf,
+    fs: Arc<dyn PackFS>,
+  ) -> Result<()> {
+    let storage = PackStorage::new(PackStorageOptions {
+      version: version.to_string(),
+      root: root.into(),
+      temp_root: temp_root.into(),
+      fs: fs.clone(),
+      bucket_size: 1,
+      pack_size: 100,
+      expire: 7 * 24 * 60 * 60 * 1000,
+      clean: true,
+    });
+    let data = storage.load("test_scope").await?;
+    assert!(data.is_empty());
+    for i in 0..100 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("val_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    let rx = storage.trigger_save()?;
+    assert_eq!(storage.load("test_scope").await?.len(), 100);
+
+    assert!(rx
+      .await
+      .expect("should save")
+      .is_err_and(|e| e.to_string().contains("move failed")));
+    assert!(fs.exists(&root.join(version).join("move.lock")).await?);
+    Ok(())
+  }
+
+  async fn test_recovery_lock(
+    version: &str,
+    root: &Utf8PathBuf,
+    temp_root: &Utf8PathBuf,
+    fs: Arc<dyn PackFS>,
+  ) -> Result<()> {
+    let storage = PackStorage::new(PackStorageOptions {
+      version: version.to_string(),
+      root: root.into(),
+      temp_root: temp_root.into(),
+      fs: fs.clone(),
+      bucket_size: 1,
+      pack_size: 100,
+      expire: 7 * 24 * 60 * 60 * 1000,
+      clean: true,
+    });
+    assert_eq!(storage.load("test_scope").await?.len(), 100);
+    Ok(())
+  }
+
+  async fn test_recovery_lock_failed(
+    version: &str,
+    root: &Utf8PathBuf,
+    temp_root: &Utf8PathBuf,
+    fs: Arc<dyn PackFS>,
+  ) -> Result<()> {
+    let storage = PackStorage::new(PackStorageOptions {
+      version: version.to_string(),
+      root: root.into(),
+      temp_root: temp_root.into(),
+      fs: fs.clone(),
+      bucket_size: 1,
+      pack_size: 100,
+      expire: 7 * 24 * 60 * 60 * 1000,
+      clean: true,
+    });
+    assert!(storage.load("test_scope").await.is_err_and(|e| {
+      e.to_string()
+        .contains("incomplete storage due to `move.lock` from an unexpected directory")
+    }));
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn test_consume_lock() {
+    let cases = [
+      (
+        get_native_path("test_lock_native"),
+        Arc::new(PackBridgeFS(Arc::new(NativeFileSystem {}))),
+      ),
+      (
+        get_memory_path("test_lock_memory"),
+        Arc::new(PackBridgeFS(Arc::new(MemoryFileSystem::default()))),
+      ),
+    ];
+
+    for ((root, temp_root), fs) in cases {
+      let root = root.assert_utf8();
+      let temp_root = temp_root.assert_utf8();
+      fs.remove_dir(&root).await.expect("should remove root");
+      fs.remove_dir(&temp_root)
+        .await
+        .expect("should remove temp root");
+
+      let _ = test_generate_lock(
+        "xxx",
+        &root,
+        &temp_root,
+        Arc::new(MockPackFS {
+          fs: fs.clone(),
+          moved: AtomicUsize::new(0),
+          break_on: 3,
+        }),
+      )
+      .await
+      .map_err(|e| panic!("{}", e));
+
+      let _ = test_recovery_lock(
+        "xxx",
+        &root,
+        &temp_root,
+        Arc::new(MockPackFS {
+          fs: fs.clone(),
+          moved: AtomicUsize::new(0),
+          break_on: 9999,
+        }),
+      )
+      .await
+      .map_err(|e| panic!("{}", e));
+    }
+  }
+
+  #[tokio::test]
+  async fn test_consume_lock_failed() {
+    let cases = [
+      (
+        get_native_path("test_lock_fail_native"),
+        Arc::new(PackBridgeFS(Arc::new(NativeFileSystem {}))),
+      ),
+      (
+        get_memory_path("test_lock_fail_memory"),
+        Arc::new(PackBridgeFS(Arc::new(MemoryFileSystem::default()))),
+      ),
+    ];
+
+    for ((root, temp_root), fs) in cases {
+      let root = root.assert_utf8();
+      let temp_root = temp_root.assert_utf8();
+      fs.remove_dir(&root).await.expect("should remove root");
+      fs.remove_dir(&temp_root)
+        .await
+        .expect("should remove temp root");
+
+      let _ = test_generate_lock(
+        "xxx",
+        &root,
+        &temp_root,
+        Arc::new(MockPackFS {
+          fs: fs.clone(),
+          moved: AtomicUsize::new(0),
+          break_on: 3,
+        }),
+      )
+      .await
+      .map_err(|e| panic!("{}", e));
+
+      let _ = test_recovery_lock_failed(
+        "xxx",
+        &root,
+        &temp_root.join("other"),
+        Arc::new(MockPackFS {
+          fs: fs.clone(),
+          moved: AtomicUsize::new(0),
+          break_on: 9999,
+        }),
+      )
+      .await
+      .map_err(|e| panic!("{}", e));
+    }
+  }
+}

--- a/crates/rspack_storage/tests/lock.rs
+++ b/crates/rspack_storage/tests/lock.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-#[cfg_attr(miri, ignore)]
 mod test_storage_lock {
   use std::{
     path::PathBuf,
@@ -158,6 +157,7 @@ mod test_storage_lock {
   }
 
   #[tokio::test]
+  #[cfg_attr(miri, ignore)]
   async fn test_consume_lock() {
     let cases = [
       (
@@ -207,6 +207,7 @@ mod test_storage_lock {
   }
 
   #[tokio::test]
+  #[cfg_attr(miri, ignore)]
   async fn test_consume_lock_failed() {
     let cases = [
       (


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Add a `move.lock` file to make sure that a batch of move operations can be atomic

---
> Generate by copilot

This pull request includes several changes to the `rspack_storage` crate that enhance the handling of file operations, scope management, and root metadata. The most important changes include the introduction of a new `RootMetaFrom` enum, improved error handling, and the addition of new methods for managing file operations.

Improvements to root metadata and scope management:

* [`crates/rspack_storage/src/pack/data/meta.rs`](diffhunk://#diff-2a74a786f96b99d0dea97760c878ab13e0bb3e6f9fe022e4d65537e47c046e6bR16-R35): Introduced the `RootMetaFrom` enum and modified the `RootMeta` struct to include an `expire_time` field and a `from` field of type `RootMetaFrom`. Updated the `new` method to initialize these fields.
* [`crates/rspack_storage/src/pack/manager/mod.rs`](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4R103-L120): Added a new method `clear_scope` to the `ScopeManager` and updated the `load` method to handle root metadata loading and validation more robustly. [[1]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4R103-L120) [[2]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L134-R158) [[3]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L183-R177)
* [`crates/rspack_storage/src/pack/strategy/mod.rs`](diffhunk://#diff-23bfa5644cdeabd92730b56d7fc74602d04ee4acda4223ab94aadb026f1d9951R34-R37): Added a `before_load` method to the `RootStrategy` trait to handle pre-load operations. Updated the `validate_root` method to check the `expire_time` field instead of `last_modified`. [[1]](diffhunk://#diff-23bfa5644cdeabd92730b56d7fc74602d04ee4acda4223ab94aadb026f1d9951R34-R37) [[2]](diffhunk://#diff-71fc8ce3833c81075c48d66ac687350a4871c73661d480a198e15c874632b365L80-R86) [[3]](diffhunk://#diff-71fc8ce3833c81075c48d66ac687350a4871c73661d480a198e15c874632b365L100-R116)

Enhancements to file operations:

* [`crates/rspack_storage/src/pack/fs/mod.rs`](diffhunk://#diff-0d226a1fcc173a946ee95151142f68c791d4eff46dba854c92d1daa651c97541R110-R116): Added a check in the `remove_file` method to ensure the file exists before attempting to remove it.
* [`crates/rspack_storage/src/pack/strategy/split/handle_file.rs`](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21L16-R118): Improved error handling in the `remove_files`, `move_temp_files`, `clean_scopes`, and `clean_root` functions by collecting and reporting errors in a more detailed manner. [[1]](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21L16-R118) [[2]](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21L65-R139) [[3]](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21L111-R320)

Other changes:

* [`crates/rspack_storage/tests/build.rs`](diffhunk://#diff-22eb7ac3236533e55e769e826418b7f1b220c639ba7d9cb569b75da7c373e893L3-R3): Renamed the test module from `test_storage_dev` to `test_storage_build`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
