### PR TITLE
perf(incremental): compute affected cgm incrementally

### DIFF
--- a/crates/rspack_binding_values/src/chunk_group.rs
+++ b/crates/rspack_binding_values/src/chunk_group.rs
@@ -69,7 +69,7 @@ impl JsChunkGroup {
 
     for origin in origins {
       js_origins.push(JsChunkGroupOrigin {
-        module: origin.module_id.and_then(|module_id| {
+        module: origin.module.and_then(|module_id| {
           compilation.module_by_identifier(&module_id).map(|module| {
             JsModuleWrapper::new(module.as_ref(), self.compilation_id, Some(compilation))
           })

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -17,7 +17,7 @@ use crate::{LibraryOptions, ModuleIdentifier, PublicPath};
 
 #[derive(Debug, Clone)]
 pub struct OriginRecord {
-  pub module_id: Option<ModuleIdentifier>,
+  pub module: Option<ModuleIdentifier>,
   pub loc: Option<DependencyLocation>,
   pub request: Option<String>,
 }
@@ -304,13 +304,13 @@ impl ChunkGroup {
     request: Option<String>,
   ) {
     self.origins.push(OriginRecord {
-      module_id,
+      module: module_id,
       loc,
       request,
     });
   }
 
-  pub fn origins(&self) -> &Vec<OriginRecord> {
+  pub fn origins(&self) -> &[OriginRecord] {
     &self.origins
   }
 

--- a/crates/rspack_core/src/incremental/mutations.rs
+++ b/crates/rspack_core/src/incremental/mutations.rs
@@ -1,16 +1,17 @@
 use std::{
   fmt,
   hash::{Hash, Hasher},
+  sync::RwLock,
 };
 
 use once_cell::sync::OnceCell;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use rspack_collections::{IdentifierDashMap, IdentifierMap, IdentifierSet, UkeySet};
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rspack_collections::{IdentifierMap, IdentifierSet, UkeySet};
 use rustc_hash::FxHasher;
 
 use crate::{
-  AffectType, ChunkGraph, ChunkUkey, Compilation, Module, ModuleGraph, ModuleGraphConnection,
-  ModuleIdentifier,
+  AffectType, ChunkGraph, ChunkUkey, Compilation, Logger, Module, ModuleGraph,
+  ModuleGraphConnection, ModuleIdentifier,
 };
 
 #[derive(Debug, Default)]
@@ -19,7 +20,17 @@ pub struct Mutations {
 
   affected_modules_with_module_graph: OnceCell<IdentifierSet>,
   affected_modules_with_chunk_graph: OnceCell<IdentifierSet>,
-  modules_with_chunk_graph_cache: IdentifierDashMap<Option<u64>>,
+  // we need the cache to check the affected modules (with chunk graph) is really affected or not
+  // because usually people will still enable splitChunks for dev mode, and that will cause lots of
+  // chunks can't reuse from the preivous compilation by incremental build chunk graph (code splitting),
+  // and affect lots of modules, but actually most of the affected modules are not really affected, which
+  // can be detected by this cache.
+  // An alternative way is to give chunk a chunk identifier, but currently I don't have a good idea to
+  // choose what as the chunk identifier.
+  // (probably the chunk name, and the chunk index in its chunk group, webpack RecordIdsPlugin use this way:
+  // https://github.com/webpack/webpack/blob/3612d36e44bda5644dc3b353e2cade7fe442ba59/lib/RecordIdsPlugin.js#L126)
+  // I leave it at that for now. I leave it to future to decide :)
+  modules_with_chunk_graph_cache: RwLock<IdentifierMap<Option<u64>>>,
   affected_chunks_with_chunk_graph: OnceCell<UkeySet<ChunkUkey>>,
 }
 
@@ -77,7 +88,6 @@ impl Mutations {
     self.inner.is_empty()
   }
 
-  // TODO: remove this
   pub fn swap_modules_with_chunk_graph_cache(&mut self, to: &mut Self) {
     std::mem::swap(
       &mut self.modules_with_chunk_graph_cache,
@@ -148,26 +158,41 @@ impl Mutations {
       .affected_modules_with_chunk_graph
       .get_or_init(|| {
         let module_graph = compilation.get_module_graph();
-        let mut updated_modules =
+        let mut affected_modules =
           self.get_affected_modules_with_module_graph(&compilation.get_module_graph());
+        let mut maybe_affected_modules = IdentifierSet::default();
         for mutation in self.iter() {
           match mutation {
             Mutation::ModuleSetAsync { module } => {
-              updated_modules.insert(*module);
+              affected_modules.insert(*module);
             }
             Mutation::ModuleSetId { module } => {
-              updated_modules.insert(*module);
-              updated_modules.extend(
+              affected_modules.insert(*module);
+              affected_modules.extend(
                 module_graph
                   .get_incoming_connections(module)
                   .filter_map(|c| c.original_module_identifier),
+              );
+            }
+            Mutation::ChunkSetId { chunk } => {
+              let chunk = compilation.chunk_by_ukey.expect_get(chunk);
+              maybe_affected_modules.extend(
+                chunk
+                  .groups()
+                  .iter()
+                  .flat_map(|group| {
+                    let group = compilation.chunk_group_by_ukey.expect_get(group);
+                    group.origins()
+                  })
+                  .filter_map(|origin| origin.module),
               );
             }
             _ => {}
           }
         }
         compute_affected_modules_with_chunk_graph(
-          updated_modules,
+          affected_modules,
+          maybe_affected_modules,
           self
             .iter()
             .filter_map(|mutation| match mutation {
@@ -308,11 +333,16 @@ fn compute_affected_modules_with_module_graph(
 
 #[tracing::instrument(skip_all)]
 fn compute_affected_modules_with_chunk_graph(
-  updated_modules: IdentifierSet,
+  sure_affected_modules: IdentifierSet,
+  maybe_affected_modules: IdentifierSet,
   revoked_modules: IdentifierSet,
-  cache: &IdentifierDashMap<Option<u64>>,
+  cache: &RwLock<IdentifierMap<Option<u64>>>,
   compilation: &Compilation,
 ) -> IdentifierSet {
+  let logger = compilation.get_logger("rspack.incremental (affected modules with chunk graph)");
+  let sure_affected_modules_len = sure_affected_modules.len();
+  let maybe_affected_modules_len = maybe_affected_modules.len();
+
   #[tracing::instrument(skip_all, fields(module = ?module.identifier()))]
   fn create_block_invalidate_key(
     chunk_graph: &ChunkGraph,
@@ -334,36 +364,54 @@ fn compute_affected_modules_with_chunk_graph(
     hasher.finish()
   }
 
-  for module in revoked_modules {
-    cache.remove(&module);
-  }
-  for module in updated_modules {
-    cache.insert(module, None);
+  {
+    let mut write_cache = cache.write().expect("should have write lock");
+    // GC the revoked modules from the cache
+    for module in revoked_modules {
+      write_cache.remove(&module);
+    }
+    for module in &sure_affected_modules {
+      write_cache.insert(*module, None);
+    }
   }
 
-  let module_graph = compilation.get_module_graph();
-  let affected_modules: IdentifierMap<u64> = cache
-    .par_iter()
-    .filter_map(|item| {
-      let (module_identifier, &old_invalidate_key) = item.pair();
-      let module = module_graph
-        .module_by_identifier(module_identifier)
-        .expect("should have module");
-      let invalidate_key =
-        create_block_invalidate_key(&compilation.chunk_graph, compilation, module.as_ref());
-      if old_invalidate_key.is_none()
-        || matches!(old_invalidate_key, Some(old) if old != invalidate_key)
-      {
-        Some((*module_identifier, invalidate_key))
-      } else {
-        None
-      }
-    })
-    .collect();
-  for (&module_identifier, &invalidate_key) in affected_modules.iter() {
-    cache.insert(module_identifier, Some(invalidate_key));
+  // Only check the cache for the updated modules, which is "maybe affected"
+  let update_cache_entries: IdentifierMap<Option<u64>> = {
+    let module_graph = compilation.get_module_graph();
+    let read_cache = cache.read().expect("should have read lock");
+    sure_affected_modules
+      .into_par_iter()
+      .chain(maybe_affected_modules)
+      .filter_map(|module_identifier| {
+        let module = module_graph
+          .module_by_identifier(&module_identifier)
+          .expect("should have module");
+        let invalidate_key =
+          create_block_invalidate_key(&compilation.chunk_graph, compilation, module.as_ref());
+        if let Some(Some(old_invalidate_key)) = read_cache.get(&module_identifier)
+          && *old_invalidate_key == invalidate_key
+        {
+          return None;
+        }
+        Some((module_identifier, Some(invalidate_key)))
+      })
+      .collect()
+  };
+
+  // Update the cache for those really affected modules
+  let affected_modules: IdentifierSet = update_cache_entries.keys().copied().collect();
+  {
+    let mut write_cache = cache.write().expect("should have write lock");
+    write_cache.extend(update_cache_entries);
   }
-  affected_modules.keys().copied().collect()
+
+  logger.log(format!(
+    "{} modules are really affected, {} modules are maybe affected",
+    affected_modules.len() - sure_affected_modules_len,
+    maybe_affected_modules_len,
+  ));
+
+  affected_modules
 }
 
 fn compute_affected_chunks_with_chunk_graph(

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -330,10 +330,10 @@ impl Stats<'_> {
           .flat_map(|ukey| {
             let chunk_group = chunk_group_by_ukey.expect_get(ukey);
             chunk_group.origins().iter().map(|origin| {
-              let module_identifier = origin.module_id;
+              let module_identifier = origin.module;
 
               let module_name = origin
-                .module_id
+                .module
                 .map(|identifier| {
                   module_graph
                     .module_by_identifier(&identifier)
@@ -343,7 +343,7 @@ impl Stats<'_> {
                 .unwrap_or_default();
 
               let module_id = origin
-                .module_id
+                .module
                 .map(|identifier| {
                   ChunkGraph::get_module_id(&self.compilation.module_ids, identifier)
                     .map(|s| s.to_string())

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1030,7 +1030,7 @@ chunk {909} (runtime: main) main.js (main) 524 bytes (javascript) 6.82 KiB (runt
   ./modules/f.js [544] 1 bytes {909} [dependent] [built] [code generated]
 chunk {919} (runtime: main) chunk.js (chunk) 4 bytes <{909}> [rendered]
   > [10] ./index.js 3:8-4:19
-  > 9:4-10:15
+  > [10] ./index.js 9:4-10:15
   ./modules/a.js [839] 1 bytes {295} {37} {405} {919} [built] [code generated]
   ./modules/b.js [836] 1 bytes {295} {37} {919} [built] [code generated]
   ./modules/c.js [115] 1 bytes {405} {919} [built] [code generated]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Use `chunk_group.origins()` to help compute affected modules with chunk graph more performance way, before we need to `create_block_invalidate_key` for all modules, which is a global effect, now we `create_block_invalidate_key` incrementally, we use `Mutation::ChunkSetId { chunk }` chunk to find the chunk group, and use the `ChunkGroup::origins()` to find the module, and only `create_block_invalidate_key` for these modules.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
