### PR TITLE
docs: fix link for bundle size link in English locale

### DIFF
--- a/website/docs/en/guide/optimization/analysis.mdx
+++ b/website/docs/en/guide/optimization/analysis.mdx
@@ -29,7 +29,7 @@ Rsdoctor provides the `Bundle Size` module, which is mainly used to analyze the 
   style={{ margin: 'auto' }}
 />
 
-Click on the **"Bundle Size"** option in the navigation bar to view the Bundle analysis report. You can see more details from this page: [Bundle Size](https://rsdoctor.dev/zh/guide/usage/bundle-size)
+Click on the **"Bundle Size"** option in the navigation bar to view the Bundle analysis report. You can see more details from this page: [Bundle Size](https://rsdoctor.dev/guide/usage/bundle-size)
 
 ### Reduce duplicate dependencies
 


### PR DESCRIPTION
## Summary

Even for the English locale, the link points to the Chinese documentation. This fixes the link back.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
