### PR TITLE
chore(deps): bump textwrap 0.16 for deduplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,7 +2582,7 @@ dependencies = [
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
- "textwrap 0.16.1",
+ "textwrap",
  "thiserror 1.0.69",
  "unicode-width 0.1.12",
 ]
@@ -3918,7 +3918,7 @@ dependencies = [
  "rspack_paths",
  "swc_core",
  "termcolor",
- "textwrap 0.15.2",
+ "textwrap",
  "thiserror 1.0.69",
  "unicode-width 0.2.0",
 ]
@@ -6791,17 +6791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width 0.1.12",
 ]
 
 [[package]]

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -20,7 +20,7 @@ rspack_collections = { workspace = true }
 rspack_paths       = { workspace = true }
 swc_core           = { workspace = true, features = ["common", "common_concurrent"] }
 termcolor          = "1.4.1"
-textwrap           = "0.15.2"
+textwrap           = "0.16.1"
 thiserror          = "1.0.69"
 
 unicode-width = "0.2.0"


### PR DESCRIPTION
## Summary

Fix the duplicated `textwrap` dependency:

![image](https://github.com/user-attachments/assets/d97a5cf6-e0ac-4cf9-802d-d2ea8640b0b3)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
