### PR TITLE
fix: the wrong filename was passed when calling the assetEmitted hook

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -344,8 +344,8 @@ impl Compiler {
     asset: &CompilationAsset,
   ) -> Result<()> {
     if let Some(source) = asset.get_source() {
-      let (filename, query) = filename.split_once('?').unwrap_or((filename, ""));
-      let file_path = output_path.join(filename);
+      let (target_file, query) = filename.split_once('?').unwrap_or((filename, ""));
+      let file_path = output_path.join(target_file);
       self
         .output_filesystem
         .create_dir_all(
@@ -360,9 +360,9 @@ impl Compiler {
       let mut immutable = asset.info.immutable.unwrap_or(false);
       if !query.is_empty() {
         immutable = immutable
-          && (include_hash(filename, &asset.info.content_hash)
-            || include_hash(filename, &asset.info.chunk_hash)
-            || include_hash(filename, &asset.info.full_hash));
+          && (include_hash(target_file, &asset.info.content_hash)
+            || include_hash(target_file, &asset.info.chunk_hash)
+            || include_hash(target_file, &asset.info.full_hash));
       }
 
       let stat = match self

--- a/packages/rspack-test-tools/tests/configCases/hooks/rspack-issue-8676/index.css
+++ b/packages/rspack-test-tools/tests/configCases/hooks/rspack-issue-8676/index.css
@@ -1,0 +1,3 @@
+.class {
+  background: #fff;
+}

--- a/packages/rspack-test-tools/tests/configCases/hooks/rspack-issue-8676/index.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/rspack-issue-8676/index.js
@@ -1,0 +1,1 @@
+import "./index.css?v=2";

--- a/packages/rspack-test-tools/tests/configCases/hooks/rspack-issue-8676/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/rspack-issue-8676/rspack.config.js
@@ -1,0 +1,31 @@
+class Plugin {
+	apply(compiler) {
+		let testRuned = false;
+		compiler.hooks.assetEmitted.tap("test", (filename, info) => {
+			const { targetPath, content } = info;
+			if (targetPath.endsWith(".css")) {
+				testRuned = true;
+				expect(content).toBeDefined();
+				expect(filename.endsWith(".css?v=2")).toBeTruthy();
+			}
+		});
+		compiler.hooks.done.tap("test", () => {
+			expect(testRuned).toBeTruthy();
+		});
+	}
+}
+
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+	target: "web",
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				type: "asset/resource"
+			}
+		]
+	},
+	plugins: [new Plugin()]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
fix #8676
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
The filename passed in here should include the query, as the content will be retrieved using `getAsset(filename)` on the JavaScript side.
https://github.com/web-infra-dev/rspack/blob/2e65ed6a9c779be9f796dfdc8b693c767e24f355/crates/rspack_core/src/compiler/mod.rs#L412-L417

https://github.com/web-infra-dev/rspack/blob/2e65ed6a9c779be9f796dfdc8b693c767e24f355/packages/rspack/src/Compiler.ts#L925-L935
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
