### PR TITLE
chore(renovate): Enable lockFileMaintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,9 @@
 	extends: [":dependencyDashboard"],
 	schedule: ["before 8am on wednesday"],
 	enabledManagers: ["github-actions", "cargo", "npm"],
+	lockFileMaintenance: {
+		enabled: true
+	},
 	ignorePaths: [
 		"**/fixtures/**",
 		"**/tests/**",


### PR DESCRIPTION
## Summary

Renovate does not update indirect transitive dependencies without this option.

- renovatebot/renovate#15762

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
