### PR TITLE
fix: module concatenation for dynamic export info

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -47,11 +47,11 @@ use crate::{
   ChunkGraph, ChunkInitFragments, CodeGenerationDataTopLevelDeclarations,
   CodeGenerationExportsFinalNames, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
   ConcatenationScope, ConnectionState, Context, DependenciesBlock, DependencyId,
-  DependencyTemplate, DependencyType, ErrorSpan, ExportInfo, ExportInfoProvided, ExportsArgument,
-  ExportsType, FactoryMeta, IdentCollector, LibIdentOptions, Module, ModuleDependency, ModuleGraph,
-  ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleType, Resolve, RuntimeCondition,
-  RuntimeGlobals, RuntimeSpec, SourceType, SpanExt, Template, UsageState, UsedName, DEFAULT_EXPORT,
-  NAMESPACE_OBJECT_EXPORT,
+  DependencyTemplate, DependencyType, ErrorSpan, ExportInfoOrTemporaryDataHashKey,
+  ExportInfoProvided, ExportsArgument, ExportsType, FactoryMeta, IdentCollector, LibIdentOptions,
+  Module, ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleLayer,
+  ModuleType, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SourceType, SpanExt,
+  Template, UsageState, UsedName, DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
 };
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
@@ -1888,7 +1888,7 @@ impl ConcatenatedModule {
     as_call: bool,
     strict_esm_module: bool,
     asi_safe: Option<bool>,
-    already_visited: &mut HashSet<ExportInfo>,
+    already_visited: &mut HashSet<ExportInfoOrTemporaryDataHashKey>,
   ) -> Binding {
     let info = module_to_info_map
       .get(info_id)
@@ -2050,9 +2050,10 @@ impl ConcatenatedModule {
     let exports_info = mg.get_exports_info(&info.id());
     // webpack use get_exports_info here, https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L377-L377
     // But in our arch, there is no way to modify module graph during code_generation phase
-    let export_info = exports_info.get_read_only_export_info(mg, &export_name[0]);
+    let export_info = exports_info.get_export_info_without_mut_module_graph(mg, &export_name[0]);
+    let export_info_hash_key = export_info.as_hash_key();
 
-    if already_visited.contains(&export_info) {
+    if already_visited.contains(&export_info_hash_key) {
       return Binding::Raw(RawBinding {
         raw_name: "/* circular reexport */ Object(function x() { x() }())".into(),
         ids: Vec::new(),
@@ -2062,7 +2063,7 @@ impl ConcatenatedModule {
       });
     }
 
-    already_visited.insert(export_info);
+    already_visited.insert(export_info_hash_key);
 
     match info {
       ModuleInfo::Concatenated(info) => {

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -47,11 +47,11 @@ use crate::{
   ChunkGraph, ChunkInitFragments, CodeGenerationDataTopLevelDeclarations,
   CodeGenerationExportsFinalNames, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
   ConcatenationScope, ConnectionState, Context, DependenciesBlock, DependencyId,
-  DependencyTemplate, DependencyType, ErrorSpan, ExportInfoOrTemporaryDataHashKey,
-  ExportInfoProvided, ExportsArgument, ExportsType, FactoryMeta, IdentCollector, LibIdentOptions,
-  Module, ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleLayer,
-  ModuleType, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SourceType, SpanExt,
-  Template, UsageState, UsedName, DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
+  DependencyTemplate, DependencyType, ErrorSpan, ExportInfoProvided, ExportsArgument, ExportsType,
+  FactoryMeta, IdentCollector, LibIdentOptions, MaybeDynamicTargetExportInfoHashKey, Module,
+  ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleType,
+  Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SourceType, SpanExt, Template,
+  UsageState, UsedName, DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
 };
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
@@ -1888,7 +1888,7 @@ impl ConcatenatedModule {
     as_call: bool,
     strict_esm_module: bool,
     asi_safe: Option<bool>,
-    already_visited: &mut HashSet<ExportInfoOrTemporaryDataHashKey>,
+    already_visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
   ) -> Binding {
     let info = module_to_info_map
       .get(info_id)
@@ -2048,8 +2048,8 @@ impl ConcatenatedModule {
     }
 
     let exports_info = mg.get_exports_info(&info.id());
-    // webpack use get_exports_info here, https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L377-L377
-    // But in our arch, there is no way to modify module graph during code_generation phase
+    // webpack use `get_exports_info` here, https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L377-L377
+    // But in our arch, there is no way to modify module graph during code_generation phase, so we use `get_export_info_without_mut_module_graph` instead.`
     let export_info = exports_info.get_export_info_without_mut_module_graph(mg, &export_name[0]);
     let export_info_hash_key = export_info.as_hash_key();
 

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1795,9 +1795,9 @@ impl ExportInfoData {
   }
 }
 
-// The reture value of `get_export_info_without_mut_module_graph`, when a module's exportType
+// The return value of `get_export_info_without_mut_module_graph`, when a module's exportType
 // is undefined, FlagDependencyExportsPlugin can't analyze the exports statically. In webpack,
-// it's possiable to add a exportInfo with `provided: null` by `get_export_info` in some
+// it's possible to add a exportInfo with `provided: null` by `get_export_info` in some
 // optimization plugins:
 //   - https://github.com/webpack/webpack/blob/964c0315df0ee86a2b4edfdf621afa19db140d4f/lib/ExportsInfo.js#L1367 called by SideEffectsFlagPlugin
 //   - https://github.com/webpack/webpack/blob/964c0315df0ee86a2b4edfdf621afa19db140d4f/lib/optimize/ConcatenatedModule.js#L399 called by ModuleConcatenationPlugin

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -832,23 +832,21 @@ fn do_optimize_incoming_connection(
     let cache_clone = cache.clone();
     let target = export_info.move_target(
       &mut module_graph,
-      Rc::new(
-        move |target: &ResolvedExportInfoTarget, mg: &mut ModuleGraph| {
-          let mut cache = cache_clone.borrow_mut();
-          let state = if let Some(state) = cache.get(&target.module) {
-            *state
-          } else {
-            let state = mg
-              .module_by_identifier(&target.module)
-              .expect("should have module")
-              .get_side_effects_connection_state(mg, &mut IdentifierSet::default());
-            cache.insert(target.module, state);
-            state
-          };
+      Rc::new(move |target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
+        let mut cache = cache_clone.borrow_mut();
+        let state = if let Some(state) = cache.get(&target.module) {
+          *state
+        } else {
+          let state = mg
+            .module_by_identifier(&target.module)
+            .expect("should have module")
+            .get_side_effects_connection_state(mg, &mut IdentifierSet::default());
+          cache.insert(target.module, state);
+          state
+        };
 
-          state == ConnectionState::Bool(false)
-        },
-      ),
+        state == ConnectionState::Bool(false)
+      }),
       Arc::new(
         move |target: &ResolvedExportInfoTarget, mg: &mut ModuleGraph| {
           if !mg.update_module(&dependency_id, &target.module) {
@@ -888,24 +886,22 @@ fn do_optimize_incoming_connection(
     let export_info = cur_exports_info.get_export_info(&mut module_graph, &ids[0]);
 
     let cache = cache.clone();
-    let target = export_info.get_target_mut(
-      &mut module_graph,
-      Rc::new(
-        move |target: &ResolvedExportInfoTarget, mg: &mut ModuleGraph| {
-          let mut cache = cache.borrow_mut();
-          let state = if let Some(state) = cache.get(&target.module) {
-            *state
-          } else {
-            let state = mg
-              .module_by_identifier(&target.module)
-              .expect("should have module graph")
-              .get_side_effects_connection_state(mg, &mut IdentifierSet::default());
-            cache.insert(target.module, state);
-            state
-          };
-          state == ConnectionState::Bool(false)
-        },
-      ),
+    let target = export_info.get_target_with_filter(
+      &module_graph,
+      Rc::new(move |target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
+        let mut cache = cache.borrow_mut();
+        let state = if let Some(state) = cache.get(&target.module) {
+          *state
+        } else {
+          let state = mg
+            .module_by_identifier(&target.module)
+            .expect("should have module graph")
+            .get_side_effects_connection_state(mg, &mut IdentifierSet::default());
+          cache.insert(target.module, state);
+          state
+        };
+        state == ConnectionState::Bool(false)
+      }),
     );
     let Some(target) = target else {
       return;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/index.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/index.js
@@ -1,0 +1,16 @@
+import { Out } from "./lib/a"
+
+it("should generate correct export for dynamic reexports (consume shared module)", () => {
+  expect(Out).toBe(42)
+})
+
+it("should correctly concat modules", () => {
+  const chunk = __STATS__.chunks[0];
+  expect(chunk.names).toEqual(["main"]);
+  expect(chunk.modules.map(module => {
+    if (module.name.startsWith("consume shared module")) {
+      return module.name.slice(0, 44)
+    }
+    return module.name
+  })).toEqual(["./index.js + 2 modules", "./lib/c.js", "consume shared module (default) ./lib/c.js@*"]);
+})

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/lib/a.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/lib/a.js
@@ -1,0 +1,1 @@
+export * from "./b"

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/lib/b.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/lib/b.js
@@ -1,0 +1,1 @@
+export * from "./c"

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/lib/c.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/lib/c.js
@@ -1,0 +1,1 @@
+export const Out = 42;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/rspack.config.js
@@ -1,0 +1,18 @@
+const rspack = require("@rspack/core")
+
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+	optimization: {
+		concatenateModules: true,
+	},
+	plugins: [
+		new rspack.sharing.ConsumeSharedPlugin({
+			consumes: {
+				"./lib/c.js": {
+					singleton: true,
+					eager: true,
+				}
+			}
+		})
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/index.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/index.js
@@ -1,0 +1,11 @@
+import { Out } from "./lib/a"
+
+it("should generate correct export for dynamic reexports (dynamic cjs)", () => {
+  expect(Out).toBe(42)
+})
+
+it("should correctly concat modules", () => {
+  const chunk = __STATS__.chunks[0];
+  expect(chunk.names).toEqual(["main"]);
+  expect(chunk.modules.map(module => module.name)).toEqual(["./index.js + 2 modules", "./lib/c.js"]);
+})

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/lib/a.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/lib/a.js
@@ -1,0 +1,1 @@
+export * from "./b"

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/lib/b.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/lib/b.js
@@ -1,0 +1,1 @@
+export * from "./c"

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/lib/c.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/lib/c.js
@@ -1,0 +1,2 @@
+let e = exports;
+e.Out = 42;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/rspack.config.js
@@ -1,0 +1,6 @@
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+	optimization: {
+		concatenateModules: true,
+	},
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`get_export_info` needs mutable module graph for dynamic export info, but we use immutable module graph in codegen phase for some reasons, we can't easily change it to mutable, so introduce `get_export_info_without_mut_module_graph` for these cases.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
