### PR TITLE
fix: duplicate move lock files

### DIFF
--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -91,13 +91,9 @@ impl ScopeManager {
       let _ = match res {
         Ok(new_scopes) => {
           let _ = std::mem::replace(&mut *scopes_lock, new_scopes);
-          println!("save scopes success");
           tx.send(Ok(()))
         }
-        Err(e) => {
-          println!("save scopes failed {:?}", e);
-          tx.send(Err(e))
-        }
+        Err(e) => tx.send(Err(e)),
       };
     }));
 

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -91,9 +91,13 @@ impl ScopeManager {
       let _ = match res {
         Ok(new_scopes) => {
           let _ = std::mem::replace(&mut *scopes_lock, new_scopes);
+          println!("save scopes success");
           tx.send(Ok(()))
         }
-        Err(e) => tx.send(Err(e)),
+        Err(e) => {
+          println!("save scopes failed {:?}", e);
+          tx.send(Err(e))
+        }
       };
     }));
 
@@ -230,21 +234,9 @@ async fn save_scopes(
 ) -> Result<ScopeMap> {
   scopes.retain(|_, scope| scope.loaded());
 
-  for (_, scope) in scopes.iter_mut() {
-    strategy.before_all(scope)?;
-  }
+  strategy.before_all(&mut scopes).await?;
 
-  join_all(
-    scopes
-      .values()
-      .map(|scope| async move { strategy.before_write(scope).await })
-      .collect_vec(),
-  )
-  .await
-  .into_iter()
-  .collect::<Result<Vec<_>>>()?;
-
-  let wrote_results = join_all(
+  let changed = join_all(
     scopes
       .values_mut()
       .map(|scope| async move {
@@ -261,33 +253,14 @@ async fn save_scopes(
   .into_iter()
   .collect::<Result<Vec<WriteScopeResult>>>()?
   .into_iter()
-  .collect_vec();
+  .fold(WriteScopeResult::default(), |mut acc, res| {
+    acc.extend(res);
+    acc
+  });
 
   strategy.write_root_meta(root_meta).await?;
-
-  join_all(
-    scopes
-      .values()
-      .zip(wrote_results)
-      .map(|(scope, scope_wrote_result)| async move {
-        strategy
-          .after_write(
-            scope,
-            scope_wrote_result.wrote_files,
-            scope_wrote_result.removed_files,
-          )
-          .await
-      })
-      .collect_vec(),
-  )
-  .await
-  .into_iter()
-  .collect::<Result<Vec<_>>>()?;
-
-  for (_, scope) in scopes.iter_mut() {
-    strategy.after_all(scope)?;
-  }
-
+  strategy.merge_changed(changed).await?;
+  strategy.after_all(&mut scopes).await?;
   strategy
     .clean_unused(root_meta, &scopes, root_options)
     .await?;

--- a/crates/rspack_storage/src/pack/strategy/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/mod.rs
@@ -137,7 +137,7 @@ pub trait ScopeValidateStrategy {
   async fn validate_packs(&self, scope: &mut PackScope) -> Result<ValidateResult>;
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct WriteScopeResult {
   pub wrote_files: HashSet<Utf8PathBuf>,
   pub removed_files: HashSet<Utf8PathBuf>,
@@ -154,15 +154,9 @@ pub type ScopeUpdate = HashMap<StorageItemKey, Option<StorageItemValue>>;
 #[async_trait]
 pub trait ScopeWriteStrategy {
   fn update_scope(&self, scope: &mut PackScope, updates: ScopeUpdate) -> Result<()>;
-  fn before_all(&self, scope: &mut PackScope) -> Result<()>;
-  async fn before_write(&self, scope: &PackScope) -> Result<()>;
+  async fn before_all(&self, scopes: &mut HashMap<String, PackScope>) -> Result<()>;
   async fn write_packs(&self, scope: &mut PackScope) -> Result<WriteScopeResult>;
   async fn write_meta(&self, scope: &mut PackScope) -> Result<WriteScopeResult>;
-  async fn after_write(
-    &self,
-    scope: &PackScope,
-    wrote_files: HashSet<Utf8PathBuf>,
-    removed_files: HashSet<Utf8PathBuf>,
-  ) -> Result<()>;
-  fn after_all(&self, scope: &mut PackScope) -> Result<()>;
+  async fn merge_changed(&self, changed: WriteScopeResult) -> Result<()>;
+  async fn after_all(&self, scopes: &mut HashMap<String, PackScope>) -> Result<()>;
 }

--- a/crates/rspack_storage/src/pack/strategy/split/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/mod.rs
@@ -8,7 +8,9 @@ mod write_scope;
 
 use std::{hash::Hasher, sync::Arc};
 
-use handle_file::{clean_root, clean_scopes, clean_versions, recovery_move_lock};
+use handle_file::{
+  clean_root, clean_scopes, clean_versions, recovery_move_lock, recovery_remove_lock,
+};
 use itertools::Itertools;
 use rspack_error::{error, Result};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
@@ -58,6 +60,7 @@ impl SplitPackStrategy {
 #[async_trait::async_trait]
 impl RootStrategy for SplitPackStrategy {
   async fn before_load(&self) -> Result<()> {
+    recovery_remove_lock(&self.root, &self.temp_root, self.fs.clone()).await?;
     recovery_move_lock(&self.root, &self.temp_root, self.fs.clone()).await?;
     Ok(())
   }

--- a/crates/rspack_storage/tests/multi.rs
+++ b/crates/rspack_storage/tests/multi.rs
@@ -126,9 +126,7 @@ mod test_storage_multi {
         .expect("should get modified value"),
       format!("scope_1_new_{:0>3}", 111)
     );
-    assert!(scope_data_1
-      .get(&format!("scope_1_key_{:0>3}", 222))
-      .is_none());
+    assert!(!scope_data_1.contains_key(&format!("scope_1_key_{:0>3}", 222)));
 
     let scope_data_2 = storage
       .load("scope_2")
@@ -148,9 +146,7 @@ mod test_storage_multi {
         .expect("should get modified value"),
       format!("scope_2_new_{:0>3}", 333)
     );
-    assert!(scope_data_2
-      .get(&format!("scope_2_key_{:0>3}", 444))
-      .is_none());
+    assert!(!scope_data_2.contains_key(&format!("scope_2_key_{:0>3}", 444)));
     Ok(())
   }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. should not generate move.lock for every scope
2. add lock for removing
3. add test case for multiple scopes

---
> generate by copilot

This pull request refactors the scope management and file handling logic in the `rspack_storage` crate. The changes aim to simplify the code, improve efficiency, and ensure better error handling. The key changes include modifying the scope writing strategy, adding new utility functions, and updating test cases accordingly.

### Scope Management and File Handling Improvements:

* [`crates/rspack_storage/src/pack/manager/mod.rs`](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L233-R235): Refactored the `save_scopes` function to streamline the process by merging the `before_all` and `after_all` steps and introducing the `merge_changed` method. [[1]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L233-R235) [[2]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L264-R259)
* [`crates/rspack_storage/src/pack/strategy/mod.rs`](diffhunk://#diff-23bfa5644cdeabd92730b56d7fc74602d04ee4acda4223ab94aadb026f1d9951L140-R140): Updated the `ScopeWriteStrategy` trait to use the new `merge_changed` method and modified the `before_all` and `after_all` methods to handle multiple scopes. [[1]](diffhunk://#diff-23bfa5644cdeabd92730b56d7fc74602d04ee4acda4223ab94aadb026f1d9951L140-R140) [[2]](diffhunk://#diff-23bfa5644cdeabd92730b56d7fc74602d04ee4acda4223ab94aadb026f1d9951L157-R161)

### New Utility Functions:

* [`crates/rspack_storage/src/pack/strategy/split/handle_file.rs`](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21R13-R62): Added functions `prepare_scope`, `prepare_scope_dirs`, `write_lock`, `remove_lock`, and refactored `move_files` and `recovery_move_lock` to improve file handling. [[1]](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21R13-R62) [[2]](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21L38-R113) [[3]](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21L78-R175) [[4]](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21L109-R199) [[5]](diffhunk://#diff-f0cec9c8e8a12b551383be081fcb736625d4aac72cf3151edd1d470ca1392c21R211-R230)

### Test Case Updates:

* [`crates/rspack_storage/src/pack/strategy/split/util.rs`](diffhunk://#diff-88f90a04aca7ca686fec10642c30a18196a7d0ea6ef6323bdd01d39bda7d6567R12-R20): Introduced the `flag_scope_wrote` function to update the scope's metadata and modified test utilities to use the new scope preparation and merging logic. [[1]](diffhunk://#diff-88f90a04aca7ca686fec10642c30a18196a7d0ea6ef6323bdd01d39bda7d6567R12-R20) [[2]](diffhunk://#diff-88f90a04aca7ca686fec10642c30a18196a7d0ea6ef6323bdd01d39bda7d6567R85-R93) [[3]](diffhunk://#diff-88f90a04aca7ca686fec10642c30a18196a7d0ea6ef6323bdd01d39bda7d6567L229-R256)
* [`crates/rspack_storage/src/pack/strategy/split/validate_scope.rs`](diffhunk://#diff-0dcdffefac7e7e7a6175760fdbe0edf9c6b0a18e1f0f3a972583f99e45dba16dL90-R99): Updated tests to incorporate the new scope preparation and merging methods, ensuring they align with the refactored logic. [[1]](diffhunk://#diff-0dcdffefac7e7e7a6175760fdbe0edf9c6b0a18e1f0f3a972583f99e45dba16dL90-R99) [[2]](diffhunk://#diff-0dcdffefac7e7e7a6175760fdbe0edf9c6b0a18e1f0f3a972583f99e45dba16dL238-R261) [[3]](diffhunk://#diff-0dcdffefac7e7e7a6175760fdbe0edf9c6b0a18e1f0f3a972583f99e45dba16dL262-R272)

### Miscellaneous Changes:

* [`crates/rspack_storage/src/pack/strategy/split/write_scope.rs`](diffhunk://#diff-029fb0be10563625e88b7a9d540b7c057c7d70e9b8fd2df7f4097b7dc9c7c39bL7-R13): Adjusted the `SplitPackStrategy` implementation to use the new utility functions for file operations and scope management. [[1]](diffhunk://#diff-029fb0be10563625e88b7a9d540b7c057c7d70e9b8fd2df7f4097b7dc9c7c39bL7-R13) [[2]](diffhunk://#diff-029fb0be10563625e88b7a9d540b7c057c7d70e9b8fd2df7f4097b7dc9c7c39bL22-R67)
* [`crates/rspack_storage/tests/build.rs`](diffhunk://#diff-22eb7ac3236533e55e769e826418b7f1b220c639ba7d9cb569b75da7c373e893L110-R110): Renamed a test function for clarity.


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
