### PR TITLE
chore(deps): stop updating inventory with renovate ci

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,7 +60,8 @@
 				"owo-colors",
 				"miette",
 				"rkyv",
-				"rspack_resolver"
+				"rspack_resolver",
+				"inventory"
 			]
 		},
 		{
@@ -93,7 +94,14 @@
 		{
 			groupName: "ignored crates",
 			matchManagers: ["cargo"],
-			matchPackageNames: ["ustr", "textwrap", "owo-colors", "miette", "rkyv"],
+			matchPackageNames: [
+				"ustr",
+				"textwrap",
+				"owo-colors",
+				"miette",
+				"rkyv",
+				"inventory"
+			],
 			enabled: false
 		},
 		{


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The latest version of inventory is not compatible with persistent cache. cc @jerrykingxyz @LingyuCoder 

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/e5d24d1f-d958-4ac4-9ed3-72fc7da554bf" />


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
