### PR TITLE
ci: linux-musl build failed

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -159,6 +159,10 @@ jobs:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           profile: ${{ inputs.profile }}
           pre: |
+            # musl will enable clang-sys static linking
+            # https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#static
+            # llvm19-dev is used to install llvm-config
+            # clang19-static is used to install libclang.a
             apk add llvm19-dev clang19-static
 
       - name: Build aarch64-unknown-linux-musl in Docker
@@ -170,6 +174,10 @@ jobs:
           profile: ${{ inputs.profile }}
           pre: |
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+            # musl will enable clang-sys static linking
+            # https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#static
+            # llvm19-dev is used to install llvm-config
+            # clang19-static is used to install libclang.a
             apk add llvm19-dev clang19-static
 
       # setup rust target for windows and macos

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -148,7 +148,8 @@ jobs:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
           profile: ${{ inputs.profile }}
-          pre: export CC_aarch64_unknown_linux_gnu=clang
+          pre: |
+            export CC_aarch64_unknown_linux_gnu=clang
 
       - name: Build x86_64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'x86_64-unknown-linux-musl' && steps.check_cache.outputs.files_exists != 'true' && !inputs.skipable }}
@@ -157,6 +158,8 @@ jobs:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           profile: ${{ inputs.profile }}
+          pre: |
+            apk add llvm19-dev clang19-static
 
       - name: Build aarch64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-musl' && steps.check_cache.outputs.files_exists != 'true' && !inputs.skipable }}
@@ -167,6 +170,7 @@ jobs:
           profile: ${{ inputs.profile }}
           pre: |
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+            apk add llvm19-dev clang19-static
 
       # setup rust target for windows and macos
       - name: Setup Rust Target


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Context

linux-musl will build failed when release nightly.

https://github.com/web-infra-dev/rspack/actions/runs/12343546612/job/34444800048

## Summary

This bug is caused by enable static linking for clang-sys, which swc depends on.
https://github.com/wasmerio/wasmer/blob/main/lib/api/Cargo.toml#L172

Install `llvm19-dev` and `clang19-static` will provide the environment to static build.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
