### PR TITLE
fix: mf parse range not compat with safari

### DIFF
--- a/crates/rspack_plugin_mf/src/sharing/consumesCommon.js
+++ b/crates/rspack_plugin_mf/src/sharing/consumesCommon.js
@@ -105,10 +105,17 @@ var parseRange = function(str) {
     // hyphen     ::= partial ( ' ' ) * ' - ' ( ' ' ) * partial
     const items = str.split(/\s+-\s+/);
     if (items.length === 1) {
-      const items = str
-        .trim()
-        .split(/(?<=[-0-9A-Za-z])\s+/g)
-        .map(parseSimple);
+			str = str.trim();
+			const items = [];
+			const r = /[-0-9A-Za-z]\s+/g;
+			var start = 0;
+			var match;
+			while ((match = r.exec(str))) {
+				const end = match.index + 1;
+				items.push(parseSimple(str.slice(start, end).trim()));
+				start = end;
+			}
+			items.push(parseSimple(str.slice(start).trim()));
       return combine(items, 2);
     }
     const a = parsePartial(items[0]);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #8704

Avoid zero-width assertion regex for older version safari

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
