### PR TITLE
ci: should skip trim paths for doc changes

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -109,6 +109,7 @@ jobs:
           echo 'incremental = false' >> Cargo.toml
 
       - name: Trim paths
+        if: ${{ !inputs.skipable }}
         shell: bash
         run: |
           echo $'\n' >> .cargo/config.toml


### PR DESCRIPTION
## Summary

Fix the CI when only changed some docs, such as:

https://github.com/web-infra-dev/rspack/actions/runs/12374467008/job/34537086579?pr=8745

![image](https://github.com/user-attachments/assets/4c298d62-a8a3-41de-bda3-ed610eac218a)

Ref: https://github.com/web-infra-dev/rspack/pull/8722

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
