### PR TITLE
fix: incremental stage are compatible with empty artifact

### DIFF
--- a/crates/rspack_core/src/cgm_hash_results.rs
+++ b/crates/rspack_core/src/cgm_hash_results.rs
@@ -9,6 +9,10 @@ pub struct CgmHashResults {
 }
 
 impl CgmHashResults {
+  pub fn is_empty(&self) -> bool {
+    self.module_to_hashes.is_empty()
+  }
+
   pub fn get(&self, module: &ModuleIdentifier, runtime: &RuntimeSpec) -> Option<&RspackHashDigest> {
     let hashes = self.module_to_hashes.get(module)?;
     hashes.get(runtime)

--- a/crates/rspack_core/src/cgm_runtime_requirement_results.rs
+++ b/crates/rspack_core/src/cgm_runtime_requirement_results.rs
@@ -8,6 +8,10 @@ pub struct CgmRuntimeRequirementsResults {
 }
 
 impl CgmRuntimeRequirementsResults {
+  pub fn is_empty(&self) -> bool {
+    self.module_to_runtime_requirements.is_empty()
+  }
+
   pub fn get(&self, module: &ModuleIdentifier, runtime: &RuntimeSpec) -> Option<&RuntimeGlobals> {
     let requirements = self.module_to_runtime_requirements.get(module)?;
     requirements.get(runtime)

--- a/crates/rspack_core/src/code_generation_results.rs
+++ b/crates/rspack_core/src/code_generation_results.rs
@@ -194,6 +194,10 @@ pub struct CodeGenerationResults {
 }
 
 impl CodeGenerationResults {
+  pub fn is_empty(&self) -> bool {
+    self.module_generation_result_map.is_empty() && self.map.is_empty()
+  }
+
   pub fn get_one(&self, module_identifier: &ModuleIdentifier) -> Option<&CodeGenerationResult> {
     self
       .map

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1021,7 +1021,9 @@ impl Compilation {
     let mutations = self
       .incremental
       .mutations_read(IncrementalPasses::CHUNKS_RENDER);
-    let chunks = if let Some(mutations) = mutations {
+    let chunks = if let Some(mutations) = mutations
+      && !self.chunk_render_results.is_empty()
+    {
       let removed_chunks = mutations.iter().filter_map(|mutation| match mutation {
         Mutation::ChunkRemove { chunk } => Some(*chunk),
         _ => None,
@@ -1222,7 +1224,10 @@ impl Compilation {
     let mutations = self
       .incremental
       .mutations_read(IncrementalPasses::DEPENDENCIES_DIAGNOSTICS);
-    let modules = if let Some(mutations) = mutations {
+    // TODO move diagnostic collect to make
+    let modules = if let Some(mutations) = mutations
+      && !self.dependencies_diagnostics.is_empty()
+    {
       let revoked_modules = mutations.iter().filter_map(|mutation| match mutation {
         Mutation::ModuleRemove { module } => Some(*module),
         _ => None,
@@ -1349,6 +1354,7 @@ impl Compilation {
     let create_module_hashes_modules = if let Some(mutations) = self
       .incremental
       .mutations_read(IncrementalPasses::MODULES_HASHES)
+      && !self.cgm_hash_results.is_empty()
     {
       let revoked_modules = mutations.iter().filter_map(|mutation| match mutation {
         Mutation::ModuleRemove { module } => Some(*module),
@@ -1381,6 +1387,7 @@ impl Compilation {
     let code_generation_modules = if let Some(mutations) = self
       .incremental
       .mutations_read(IncrementalPasses::MODULES_CODEGEN)
+      && !self.code_generation_results.is_empty()
     {
       let revoked_modules = mutations.iter().filter_map(|mutation| match mutation {
         Mutation::ModuleRemove { module } => Some(*module),
@@ -1407,6 +1414,7 @@ impl Compilation {
     let process_runtime_requirements_modules = if let Some(mutations) = self
       .incremental
       .mutations_read(IncrementalPasses::MODULES_RUNTIME_REQUIREMENTS)
+      && !self.cgm_runtime_requirements_results.is_empty()
     {
       let revoked_modules = mutations.iter().filter_map(|mutation| match mutation {
         Mutation::ModuleRemove { module } => Some(*module),
@@ -1438,6 +1446,7 @@ impl Compilation {
     let process_runtime_requirements_chunks = if let Some(mutations) = self
       .incremental
       .mutations_read(IncrementalPasses::CHUNKS_RUNTIME_REQUIREMENTS)
+      && !self.cgc_runtime_requirements_results.is_empty()
     {
       let removed_chunks = mutations.iter().filter_map(|mutation| match mutation {
         Mutation::ChunkRemove { chunk } => Some(chunk),
@@ -1479,6 +1488,7 @@ impl Compilation {
     let create_hash_chunks = if let Some(mutations) = self
       .incremental
       .mutations_read(IncrementalPasses::CHUNKS_HASHES)
+      && !self.chunk_hashes_results.is_empty()
     {
       let removed_chunks = mutations.iter().filter_map(|mutation| match mutation {
         Mutation::ChunkRemove { chunk } => Some(*chunk),

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -132,6 +132,7 @@ fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<()> {
   let mut modules: IdentifierSet = if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::MODULE_IDS)
+    && !module_ids.is_empty()
   {
     mutations
       .iter()


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Context

* cold start `make_artifact` will contains all of modules in `built_modules`, and incremental rebuilds using "built_modules" in other stages are no different from full builds
* hot start `make_artifact` will constains updated modules in `built_modules` only, and the incremental rebuilds will be panic.

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The hot start will recovery `make_artifact` but other stage artifact will be empty, so that the incremental rebuild will be panic because of lose previous artifact data.

For incremental rebuild should be compatible with empty artifact. It should fully rebuild when receiving an empty artifact. 

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
