### PR TITLE
feat: add macro to get rspack version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,6 +4109,7 @@ version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "regex",
  "syn 2.0.90",
 ]
 

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -31,7 +31,7 @@ pub trait Cache: Debug + Send + Sync {
 }
 
 pub fn new_cache(
-  compiler_path: &String,
+  compiler_path: &str,
   compiler_option: Arc<CompilerOptions>,
   input_filesystem: Arc<dyn FileSystem>,
   intermediate_filesystem: Arc<dyn IntermediateFileSystem>,

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -8,6 +8,7 @@ use std::{path::PathBuf, sync::Arc};
 pub use cacheable_context::{CacheableContext, FromContext};
 use occasion::MakeOccasion;
 use rspack_fs::{FileSystem, IntermediateFileSystem, Result};
+use rspack_macros::rspack_version;
 use rspack_paths::ArcPath;
 use rustc_hash::FxHashSet as HashSet;
 
@@ -36,7 +37,7 @@ pub struct PersistentCache {
 
 impl PersistentCache {
   pub fn new(
-    compiler_path: &String,
+    compiler_path: &str,
     option: &PersistentCacheOptions,
     compiler_options: Arc<CompilerOptions>,
     input_filesystem: Arc<dyn FileSystem>,
@@ -45,7 +46,7 @@ impl PersistentCache {
     let version = version::get_version(
       input_filesystem.clone(),
       &option.build_dependencies,
-      vec![compiler_path, &option.version],
+      vec![compiler_path, &option.version, rspack_version!()],
     )?;
     let storage = create_storage(option.storage.clone(), version, intermediate_filesystem);
     let context = Arc::new(CacheableContext {

--- a/crates/rspack_core/src/cache/persistent/version.rs
+++ b/crates/rspack_core/src/cache/persistent/version.rs
@@ -8,7 +8,7 @@ use rspack_paths::AssertUtf8;
 pub fn get_version(
   fs: Arc<dyn FileSystem>,
   dependencies: &Vec<PathBuf>,
-  salt: Vec<&String>,
+  salt: Vec<&str>,
 ) -> Result<String> {
   let mut hasher = DefaultHasher::new();
   for dep in dependencies {

--- a/crates/rspack_macros/Cargo.toml
+++ b/crates/rspack_macros/Cargo.toml
@@ -12,4 +12,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { workspace = true }
 quote       = { workspace = true }
+regex       = { workspace = true }
 syn         = { workspace = true, features = ["full"] }

--- a/crates/rspack_macros/src/lib.rs
+++ b/crates/rspack_macros/src/lib.rs
@@ -5,6 +5,7 @@ mod cacheable_dyn;
 mod hook;
 mod merge;
 mod plugin;
+mod rspack_version;
 mod runtime_module;
 mod source_map_config;
 
@@ -100,4 +101,10 @@ pub fn disable_cacheable_dyn(
   tokens: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
   cacheable_dyn::disable_cacheable_dyn(tokens)
+}
+
+#[proc_macro]
+pub fn rspack_version(_tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+  let version = rspack_version::rspack_version();
+  quote::quote! { #version }.into()
 }

--- a/crates/rspack_macros/src/rspack_version.rs
+++ b/crates/rspack_macros/src/rspack_version.rs
@@ -1,0 +1,9 @@
+pub fn rspack_version() -> String {
+  let re = regex::Regex::new(r#""version": ?"([0-9\.]+)""#).expect("should create regex");
+  // package.json in project root directory
+  let package_json = include_str!("../../../package.json");
+  let version = re
+    .captures(package_json)
+    .expect("can not found version field in project package.json");
+  version[1].to_string()
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. Add `rspack_version!()` macro to get rspack current version
2. Persistent cache version calculation depends on rspack version

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
