### PR TITLE
feat: persistent cache expose error to compilation.diagnostic

### DIFF
--- a/crates/rspack_core/src/cache/disable.rs
+++ b/crates/rspack_core/src/cache/disable.rs
@@ -1,3 +1,5 @@
+use rspack_error::Result;
+
 use super::Cache;
 use crate::make::MakeArtifact;
 
@@ -9,7 +11,8 @@ pub struct DisableCache;
 
 #[async_trait::async_trait]
 impl Cache for DisableCache {
-  async fn before_make(&self, make_artifact: &mut MakeArtifact) {
+  async fn before_make(&self, make_artifact: &mut MakeArtifact) -> Result<()> {
     *make_artifact = Default::default();
+    Ok(())
   }
 }

--- a/crates/rspack_core/src/cache/persistent/occasion/make/meta.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/meta.rs
@@ -1,9 +1,8 @@
 use std::sync::{atomic::Ordering::Relaxed, Arc};
 
-use rspack_cacheable::{
-  cacheable, from_bytes, to_bytes, with::Inline, DeserializeError, SerializeError,
-};
+use rspack_cacheable::{cacheable, from_bytes, to_bytes, with::Inline};
 use rspack_collections::IdentifierSet;
+use rspack_error::Result;
 use rustc_hash::FxHashSet as HashSet;
 
 use super::Storage;
@@ -34,23 +33,26 @@ pub fn save_meta(
   make_failed_dependencies: &HashSet<BuildDependency>,
   make_failed_module: &IdentifierSet,
   storage: &Arc<dyn Storage>,
-) -> Result<(), SerializeError> {
+) {
   let meta = MetaRef {
     make_failed_dependencies,
     make_failed_module,
     next_dependencies_id: DEPENDENCY_ID.load(Relaxed),
   };
-  storage.set(SCOPE, "default".as_bytes().to_vec(), to_bytes(&meta, &())?);
-  Ok(())
+  storage.set(
+    SCOPE,
+    "default".as_bytes().to_vec(),
+    to_bytes(&meta, &()).expect("should to bytes success"),
+  );
 }
 
 pub async fn recovery_meta(
   storage: &Arc<dyn Storage>,
-) -> Result<(HashSet<BuildDependency>, IdentifierSet), DeserializeError> {
-  let Some((_, value)) = storage.load(SCOPE).await.unwrap_or_default().pop() else {
-    return Err(DeserializeError::MessageError("can not get meta data"));
+) -> Result<(HashSet<BuildDependency>, IdentifierSet)> {
+  let Some((_, value)) = storage.load(SCOPE).await?.pop() else {
+    return Ok(Default::default());
   };
-  let meta: Meta = from_bytes(&value, &())?;
+  let meta: Meta = from_bytes(&value, &()).expect("should from bytes success");
   // TODO make dependency id to string like module id
   if DEPENDENCY_ID.load(Relaxed) < meta.next_dependencies_id {
     DEPENDENCY_ID.store(meta.next_dependencies_id, Relaxed);

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -4,7 +4,7 @@ mod module_graph;
 
 use std::sync::Arc;
 
-use rspack_cacheable::DeserializeError;
+use rspack_error::Result;
 
 use super::super::{cacheable_context::CacheableContext, Storage};
 use crate::make::MakeArtifact;
@@ -48,8 +48,7 @@ impl MakeOccasion {
       missing_dependencies,
       build_dependencies,
       &self.storage,
-    )
-    .expect("should save dependencies success");
+    );
 
     module_graph::save_module_graph(
       module_graph_partial,
@@ -59,14 +58,15 @@ impl MakeOccasion {
       &self.context,
     );
 
-    meta::save_meta(make_failed_dependencies, make_failed_module, &self.storage)
-      .expect("should save make meta");
+    meta::save_meta(make_failed_dependencies, make_failed_module, &self.storage);
   }
 
   #[tracing::instrument(name = "MakeOccasion::recovery", skip_all)]
-  pub async fn recovery(&self) -> Result<MakeArtifact, DeserializeError> {
+  pub async fn recovery(&self) -> Result<MakeArtifact> {
     let mut artifact = MakeArtifact::default();
 
+    // TODO can call recovery with multi thread
+    // TODO return DeserializeError not panic
     let (file_dependencies, context_dependencies, missing_dependencies, build_dependencies) =
       dependencies::recovery_dependencies_info(&self.storage).await?;
     artifact.file_dependencies = file_dependencies;

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -4,9 +4,10 @@ use rayon::prelude::*;
 use rspack_cacheable::{
   cacheable, from_bytes, to_bytes,
   with::{AsOption, AsTuple2, AsVec, Inline},
-  DeserializeError, SerializeError,
+  SerializeError,
 };
 use rspack_collections::IdentifierSet;
+use rspack_error::Result;
 use rustc_hash::FxHashSet as HashSet;
 
 use super::Storage;
@@ -125,11 +126,11 @@ pub fn save_module_graph(
 pub async fn recovery_module_graph(
   storage: &Arc<dyn Storage>,
   context: &CacheableContext,
-) -> Result<(ModuleGraphPartial, HashSet<BuildDependency>), DeserializeError> {
+) -> Result<(ModuleGraphPartial, HashSet<BuildDependency>)> {
   let mut need_check_dep = vec![];
   let mut partial = ModuleGraphPartial::default();
   let mut mg = ModuleGraph::new(vec![], Some(&mut partial));
-  for (_, v) in storage.load(SCOPE).await.unwrap_or_default() {
+  for (_, v) in storage.load(SCOPE).await? {
     let mut node: Node =
       from_bytes(&v, context).expect("unexpected module graph deserialize failed");
     for (dep, parent_block) in node.dependencies {

--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -4,6 +4,7 @@ mod strategy;
 use std::{path::Path, sync::Arc};
 
 use rspack_cacheable::{from_bytes, to_bytes};
+use rspack_error::Result;
 use rspack_fs::FileSystem;
 use rspack_paths::{ArcPath, AssertUtf8};
 use rustc_hash::FxHashSet as HashSet;
@@ -21,15 +22,10 @@ const SCOPE: &str = "snapshot";
 #[derive(Debug)]
 pub struct Snapshot {
   options: SnapshotOptions,
-  // TODO
-  // 1. update compiler.input_file_system to async file system
-  // 2. update this fs to AsyncReadableFileSystem
-  // 3. update add/calc_modified_files to async fn
   fs: Arc<dyn FileSystem>,
   storage: Arc<dyn Storage>,
 }
 
-// TODO remove all of `.expect()` to return error
 impl Snapshot {
   pub fn new(options: SnapshotOptions, fs: Arc<dyn FileSystem>, storage: Arc<dyn Storage>) -> Self {
     Self {
@@ -39,24 +35,24 @@ impl Snapshot {
     }
   }
 
-  pub fn add(&self, paths: impl Iterator<Item = &Path>) {
+  pub async fn add(&self, paths: impl Iterator<Item = &Path>) {
     let default_strategy = StrategyHelper::compile_time();
     let mut helper = StrategyHelper::new(self.fs.clone());
     // TODO use multi thread
     // TODO merge package version file
     for path in paths {
-      // TODO check path exists
       let utf8_path = path.assert_utf8();
+      // check path exists
       if self.fs.metadata(utf8_path).is_err() {
         continue;
       }
-      // TODO directory check all sub file
+      // TODO directory path should check all sub file
       let path_str = utf8_path.as_str();
       if self.options.is_immutable_path(path_str) {
         continue;
       }
       if self.options.is_managed_path(path_str) {
-        if let Some(v) = helper.package_version(path) {
+        if let Some(v) = helper.package_version(path).await {
           self.storage.set(
             SCOPE,
             path.as_os_str().as_encoded_bytes().to_vec(),
@@ -82,17 +78,17 @@ impl Snapshot {
     }
   }
 
-  pub async fn calc_modified_paths(&self) -> (HashSet<ArcPath>, HashSet<ArcPath>) {
+  pub async fn calc_modified_paths(&self) -> Result<(HashSet<ArcPath>, HashSet<ArcPath>)> {
     let mut helper = StrategyHelper::new(self.fs.clone());
     let mut modified_path = HashSet::default();
     let mut deleted_path = HashSet::default();
 
     // TODO use multi thread
-    for (key, value) in self.storage.load(SCOPE).await.unwrap_or_default() {
+    for (key, value) in self.storage.load(SCOPE).await? {
       let path: ArcPath = Path::new(&*String::from_utf8_lossy(&key)).into();
       let strategy: Strategy =
         from_bytes::<Strategy, ()>(&value, &()).expect("should from bytes success");
-      match helper.validate(&path, &strategy) {
+      match helper.validate(&path, &strategy).await {
         ValidateResult::Modified => {
           modified_path.insert(path);
         }
@@ -102,7 +98,7 @@ impl Snapshot {
         ValidateResult::NoChanged => {}
       }
     }
-    (modified_path, deleted_path)
+    Ok((modified_path, deleted_path))
   }
 }
 
@@ -160,15 +156,17 @@ mod tests {
 
     let snapshot = Snapshot::new(options, fs.clone(), storage);
 
-    snapshot.add(
-      [
-        p!("/file1"),
-        p!("/constant"),
-        p!("/node_modules/project/file1"),
-        p!("/node_modules/lib/file1"),
-      ]
-      .into_iter(),
-    );
+    snapshot
+      .add(
+        [
+          p!("/file1"),
+          p!("/constant"),
+          p!("/node_modules/project/file1"),
+          p!("/node_modules/lib/file1"),
+        ]
+        .into_iter(),
+      )
+      .await;
     std::thread::sleep(std::time::Duration::from_millis(100));
     fs.write("/file1".into(), "abcd".as_bytes()).await.unwrap();
     fs.write("/constant".into(), "abcd".as_bytes())
@@ -181,7 +179,7 @@ mod tests {
       .await
       .unwrap();
 
-    let (modified_paths, deleted_paths) = snapshot.calc_modified_paths().await;
+    let (modified_paths, deleted_paths) = snapshot.calc_modified_paths().await.unwrap();
     assert!(deleted_paths.is_empty());
     assert!(!modified_paths.contains(p!("/constant")));
     assert!(modified_paths.contains(p!("/file1")));
@@ -194,8 +192,8 @@ mod tests {
     )
     .await
     .unwrap();
-    snapshot.add([p!("/file1")].into_iter());
-    let (modified_paths, deleted_paths) = snapshot.calc_modified_paths().await;
+    snapshot.add([p!("/file1")].into_iter()).await;
+    let (modified_paths, deleted_paths) = snapshot.calc_modified_paths().await.unwrap();
     assert!(deleted_paths.is_empty());
     assert!(!modified_paths.contains(p!("/constant")));
     assert!(!modified_paths.contains(p!("/file1")));

--- a/crates/rspack_core/src/cache/persistent/version.rs
+++ b/crates/rspack_core/src/cache/persistent/version.rs
@@ -2,27 +2,28 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use rspack_fs::{Error, FileSystem, Result};
+use rspack_fs::FileSystem;
 use rspack_paths::AssertUtf8;
 
 pub fn get_version(
   fs: Arc<dyn FileSystem>,
   dependencies: &Vec<PathBuf>,
   salt: Vec<&str>,
-) -> Result<String> {
+) -> String {
   let mut hasher = DefaultHasher::new();
   for dep in dependencies {
     let path = dep.clone().assert_utf8();
-    let meta = fs.metadata(&path)?;
+    let meta = fs
+      .metadata(&path)
+      .unwrap_or_else(|_| panic!("Failed to get buildDependency({path}) metadata info."));
     if !meta.is_file {
-      return Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        format!("{path:?} is not a file"),
-      )));
+      panic!("buildDependency({path}) is not a file.");
     }
-    let bytes = fs.read(&path)?;
+    let bytes = fs
+      .read(&path)
+      .unwrap_or_else(|_| panic!("Failed to read buildDependency({path}) content."));
     bytes.hash(&mut hasher);
   }
   salt.hash(&mut hasher);
-  Ok(hex::encode(hasher.finish().to_ne_bytes()))
+  hex::encode(hasher.finish().to_ne_bytes())
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Upgrade `Cache` trait methods allow them to return `Result`, and compiler will add returned errors to `compilation.diagnostic`.

Note: SerializeError and DeserializeError are considered unexpected errors and panic directly.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
