### PR TITLE
fix: correct type for `loaderContext.importModule`

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3363,9 +3363,9 @@ export interface LoaderContext<OptionsType = {}> {
     getResolve(options: Resolve): ((context: string, request: string, callback: ResolveCallback) => void) | ((context: string, request: string) => Promise<string | false | undefined>);
     // (undocumented)
     hot?: boolean;
-    importModule(request: string, options: ImportModuleOptions | undefined, callback: (err?: null | Error, exports?: any) => any): void;
+    importModule<T = any>(request: string, options: ImportModuleOptions | undefined, callback: (err?: null | Error, exports?: T) => any): void;
     // (undocumented)
-    importModule(request: string, options?: ImportModuleOptions): Promise<any>;
+    importModule<T = any>(request: string, options?: ImportModuleOptions): Promise<T>;
     // (undocumented)
     loaderIndex: number;
     loaders: LoaderObject[];

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2426,6 +2426,13 @@ export type ImportFunctionName = string;
 // @public
 export type ImportMetaName = string;
 
+// @public (undocumented)
+interface ImportModuleOptions {
+    baseUri?: string;
+    layer?: string;
+    publicPath?: PublicPath;
+}
+
 // @public
 export type Incremental = {
     make?: boolean;
@@ -3356,12 +3363,9 @@ export interface LoaderContext<OptionsType = {}> {
     getResolve(options: Resolve): ((context: string, request: string, callback: ResolveCallback) => void) | ((context: string, request: string) => Promise<string | false | undefined>);
     // (undocumented)
     hot?: boolean;
+    importModule(request: string, options: ImportModuleOptions | undefined, callback: (err?: null | Error, exports?: any) => any): void;
     // (undocumented)
-    importModule(request: string, options: {
-        layer?: string;
-        publicPath?: PublicPath;
-        baseUri?: string;
-    }, callback: (err?: Error, res?: any) => void): void;
+    importModule(request: string, options?: ImportModuleOptions): Promise<any>;
     // (undocumented)
     loaderIndex: number;
     loaders: LoaderObject[];

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -202,12 +202,15 @@ export interface LoaderContext<OptionsType = {}> {
 	 * });
 	 * ```
 	 */
-	importModule(
+	importModule<T = any>(
 		request: string,
 		options: ImportModuleOptions | undefined,
-		callback: (err?: null | Error, exports?: any) => any
+		callback: (err?: null | Error, exports?: T) => any
 	): void;
-	importModule(request: string, options?: ImportModuleOptions): Promise<any>;
+	importModule<T = any>(
+		request: string,
+		options?: ImportModuleOptions
+	): Promise<T>;
 
 	fs: any;
 	/**

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -95,6 +95,21 @@ interface LoaderExperiments {
 	emitDiagnostic(diagnostic: Diagnostic): void;
 }
 
+export interface ImportModuleOptions {
+	/**
+	 * Specify a layer in which this module is placed/compiled
+	 */
+	layer?: string;
+	/**
+	 * The public path used for the built modules
+	 */
+	publicPath?: PublicPath;
+	/**
+	 * Target base uri
+	 */
+	baseUri?: string;
+}
+
 export interface LoaderContext<OptionsType = {}> {
 	version: 2;
 	resource: string;
@@ -173,11 +188,27 @@ export interface LoaderContext<OptionsType = {}> {
 	getContextDependencies(): string[];
 	getMissingDependencies(): string[];
 	addBuildDependency(file: string): void;
+
+	/**
+	 * Compile and execute a module at the build time.
+	 * This is an alternative lightweight solution for the child compiler.
+	 * `importModule` will return a Promise if no callback is provided.
+	 *
+	 * @example
+	 * ```ts
+	 * const modulePath = path.resolve(__dirname, 'some-module.ts');
+	 * const moduleExports = await this.importModule(modulePath, {
+	 *   // optional options
+	 * });
+	 * ```
+	 */
 	importModule(
 		request: string,
-		options: { layer?: string; publicPath?: PublicPath; baseUri?: string },
-		callback: (err?: Error, res?: any) => void
+		options: ImportModuleOptions | undefined,
+		callback: (err?: null | Error, exports?: any) => any
 	): void;
+	importModule(request: string, options?: ImportModuleOptions): Promise<any>;
+
 	fs: any;
 	/**
 	 * This is an experimental API and maybe subject to change.

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -402,7 +402,9 @@ export async function runLoaders(
 		missingDependencies.length = 0;
 		context.cacheable = true;
 	};
+
 	loaderContext.importModule = function importModule(
+		this: LoaderContext,
 		request,
 		userOptions,
 		callback
@@ -490,7 +492,8 @@ export async function runLoaders(
 					}
 				}
 			);
-	};
+	} as LoaderContext["importModule"];
+
 	Object.defineProperty(loaderContext, "resource", {
 		enumerable: true,
 		get: () => {


### PR DESCRIPTION
## Summary

Align the `loaderContext.importModule()` type definition with webpack and add generics to specify the type of export.

Ref: https://github.com/webpack/webpack/blob/964c0315df0ee86a2b4edfdf621afa19db140d4f/declarations/LoaderContext.d.ts#L90-L95

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
