### PR TITLE
ci: use ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     with:
       target: x86_64-unknown-linux-gnu
       profile: "debug"
-      native: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS == '"ubuntu-latest"' }}
+      native: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS == '"ubuntu-22.04"' }}
       runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
       skipable: ${{ needs.check-changed.outputs.changed != 'true' }}
 

--- a/.github/workflows/get-runner-labels.yml
+++ b/.github/workflows/get-runner-labels.yml
@@ -37,8 +37,9 @@ jobs:
             WINDOWS_RUNNER_LABELS='${{ vars.WINDOWS_RUNNER_LABELS }}';
           fi
           # set default value
+          # use ubuntu 22.04 to be compatible with playwright docker
           if [[ -z "$LINUX_RUNNER_LABELS" ]]; then
-            LINUX_RUNNER_LABELS='"ubuntu-latest"';
+            LINUX_RUNNER_LABELS='"ubuntu-22.04"';
           fi
           if [[ -z "$MACOS_RUNNER_LABELS" ]]; then
             MACOS_RUNNER_LABELS='"macos-latest"';

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -270,6 +270,8 @@ jobs:
       - name: Run e2e
         uses: ./.github/actions/docker-run
         with:
+          # Jammy uses ubuntu 22.04
+          # If this is to change, make sure to upgrade the ubuntu version in GitHub Actions
           image: mcr.microsoft.com/playwright:v1.47.0-jammy
           # .cache is required by download artifact, and mount in ./.github/actions/docker-run
           # .tool_cache is required by pnpm


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`ubuntu-latest` is rolling out with ubuntu-24. Some glibc versions are no longer supported in the latest version.

Downgrade `ubuntu-latest` to `ubuntu-22.04` to make it compatible with playwright docker `jammy`. I didn't choose
to upgrade playwright docker as it makes us dropping the support for older glibc versions. This is not acceptable.

Ref: https://github.com/actions/runner-images/issues/10636

Failing CI: https://github.com/web-infra-dev/rspack/actions/runs/12408927487/job/3464188805

This is also related to this PR switching us from self-hosted runner to GitHub runner: https://github.com/web-infra-dev/rspack/pull/7243

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
