### PR TITLE
ci: disable pkg preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,15 +451,16 @@ jobs:
           URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}
           LARK_WEBHOOK_URL: ${{secrets.LARK_WEBHOOK_URL}}
 
-  pkg-preview:
-    name: Pkg Preview
-    needs:
-      - test-linux
-      - test-windows
-      - cargo-deny
-      - lint
-      - rust_check
-      - rust_test
-    # after merged to main branch
-    if: ${{ !failure() && github.event_name == 'push' }}
-    uses: ./.github/workflows/preview-commit.yml
+  # TODO: enable it after self hosted runners are ready
+  # pkg-preview:
+  #   name: Pkg Preview
+  #   needs:
+  #     - test-linux
+  #     - test-windows
+  #     - cargo-deny
+  #     - lint
+  #     - rust_check
+  #     - rust_test
+  #   # after merged to main branch
+  #   if: ${{ !failure() && github.event_name == 'push' }}
+  #   uses: ./.github/workflows/preview-commit.yml


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Because self-hosted runners are offline, the rspack team does not have enough runners. So disable the pkg preview action temporarily.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
