### PR TITLE
ci: disable miri, eco-ci and benchmark check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,9 @@ jobs:
   run_benchmark:
     name: Run benchmark
     runs-on: ubuntu-latest
-    if: github.ref_name == 'main' && github.repository_owner == 'web-infra-dev'
+    # TODO: enable it after security tokens are added
+    # if: github.ref_name == 'main' && github.repository_owner == 'web-infra-dev'
+    if: false
     steps:
       - name: Run Benchmark
         uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -402,7 +404,9 @@ jobs:
   run_ecosystem_ci:
     name: Run Ecosystem CI
     runs-on: ubuntu-latest
-    if: github.ref_name == 'main' && github.repository_owner == 'web-infra-dev'
+    # TODO: enable it after security tokens are added
+    # if: github.ref_name == 'main' && github.repository_owner == 'web-infra-dev'
+    if: false
     steps:
       - name: Run Ecosystem CI
         id: eco_ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,7 @@ jobs:
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           shared-key: check
+          # TODO: enable it after self host runners are ready
           miri: false
 
       # Compile test without debug info for reducing the CI cache size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           shared-key: check
-          miri: true
+          miri: false
 
       # Compile test without debug info for reducing the CI cache size
       - name: Change profile.test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,9 @@ jobs:
   rust_test_miri:
     name: Rust test miri
     needs: [get-runner-labels, rust_changes]
-    if: needs.rust_changes.outputs.changed == 'true' && github.ref_name == 'main' && github.repository_owner == 'web-infra-dev'
+    # TODO: enable it after self hosted runners are ready
+    # if: needs.rust_changes.outputs.changed == 'true' && github.ref_name == 'main' && github.repository_owner == 'web-infra-dev'
+    if: false
     runs-on: ${{ fromJSON(needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS) }}
     steps:
       - uses: actions/checkout@v4
@@ -337,8 +339,7 @@ jobs:
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           shared-key: check
-          # TODO: enable it after self host runners are ready
-          miri: false
+          miri: true
 
       # Compile test without debug info for reducing the CI cache size
       - name: Change profile.test


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Because self-hosted runners are offline, the rspack team does not have enough runners. So disable the miri action temporarily.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
