### PR TITLE
chore(deps): bump `fast-glob` to v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ast_node"
@@ -1426,9 +1426,12 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fast-glob"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb10ed0f8a3dca52477be37ac0fb8f9d1fd4cd8d311b4484bdd45c1c56e0c9ec"
+checksum = "e9a6095b6cc0ab2b09399cdda221ba1a42021ee80f8e5ba23696a416ff3db2d1"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "fastrand"

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -12,7 +12,7 @@ bitflags = { workspace = true }
 cow-utils = { workspace = true }
 dashmap = { workspace = true }
 either = { workspace = true }
-fast-glob = "0.4.0"
+fast-glob = "0.4.1"
 indexmap = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
## Summary

Related to https://github.com/shulaoda/fast-glob/pull/6

@SyMind further optimized the brace expansion match functionality, achieving a performance improvement of nearly `35%` on my local machine and approximately `49%` on `CodSpeed`.

## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
