### PR TITLE
fix!: handle glob patterns ending with /** in CopyRspackPlugin

### DIFF
--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -439,10 +439,17 @@ impl CopyRspackPlugin {
       }
       FromType::Glob => {
         need_add_context_to_dependency = true;
-        if Path::new(orig_from).is_absolute() {
+        let glob_query = if Path::new(orig_from).is_absolute() {
           orig_from.into()
         } else {
           context.join(orig_from).as_str().to_string()
+        };
+        // A glob pattern ending with /** should match all files within a directory, not just the directory itself.
+        // Since the standard glob only matches directories, we append /* to align with webpack's behavior.
+        if glob_query.ends_with("/**") {
+          format!("{glob_query}/*")
+        } else {
+          glob_query
         }
       }
     };

--- a/tests/plugin-test/copy-plugin/CopyPlugin.test.js
+++ b/tests/plugin-test/copy-plugin/CopyPlugin.test.js
@@ -264,6 +264,22 @@ describe("CopyPlugin", () => {
 				.catch(done);
 		});
 
+		it('should work when "from" is a glob ending with /**', done => {
+			runEmit({
+				expectedAssetKeys: [
+					"directory/nested/nestedfile.txt",
+					"directory/nested/deep-nested/deepnested.txt"
+				],
+				patterns: [
+					{
+						from: "directory/nested/**"
+					}
+				]
+			})
+				.then(done)
+				.catch(done);
+		});
+
 		it.skip("should exclude path with linux path segment separators", done => {
 			runEmit({
 				expectedAssetKeys: [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

**Attention: This PR includes a breaking change, but it is necessary to align with webpack's behavior.**

fix #8801 

A glob pattern ending with /** should match all files within a directory, not just the directory itself.
Since the standard glob only matches directories (refer to https://github.com/rust-lang/glob/issues/129), we append /* to align with webpack's behavior.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
