### PR TITLE
feat: support `match_when_empty` for rule condition 

### DIFF
--- a/crates/rspack_binding_values/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_values/src/raw_options/raw_module/mod.rs
@@ -138,7 +138,7 @@ impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetCondition {
   }
 }
 
-impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetConditionMatch {
+impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetConditionWithEmpty {
   type Error = rspack_error::Error;
 
   fn try_from(x: RawRuleSetCondition) -> rspack_error::Result<Self> {

--- a/crates/rspack_binding_values/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_values/src/raw_options/raw_module/mod.rs
@@ -142,10 +142,7 @@ impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetConditionMatch {
   type Error = rspack_error::Error;
 
   fn try_from(x: RawRuleSetCondition) -> rspack_error::Result<Self> {
-    Ok(Self {
-      condition: x.try_into()?,
-      match_when_empty: None,
-    })
+    Ok(Self::new(x.try_into()?))
   }
 }
 

--- a/crates/rspack_binding_values/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_values/src/raw_options/raw_module/mod.rs
@@ -138,6 +138,17 @@ impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetCondition {
   }
 }
 
+impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetConditionMatch {
+  type Error = rspack_error::Error;
+
+  fn try_from(x: RawRuleSetCondition) -> rspack_error::Result<Self> {
+    Ok(Self {
+      condition: x.try_into()?,
+      match_when_empty: None,
+    })
+  }
+}
+
 type ThreadsafeUse = ThreadsafeFunction<RawFuncUseCtx, Vec<RawModuleRuleUse>>;
 
 #[derive(Debug, Default)]

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -639,7 +639,7 @@ impl RuleSetCondition {
   }
 
   #[async_recursion]
-  pub async fn match_when_empty(&self) -> Result<bool> {
+  async fn match_when_empty(&self) -> Result<bool> {
     let res = match self {
       RuleSetCondition::String(s) => s.len() == 0,
       RuleSetCondition::Regexp(rspack_regex) => rspack_regex.test(""),
@@ -655,7 +655,7 @@ impl RuleSetCondition {
 
 #[derive(Debug)]
 pub struct RuleSetConditionMatch {
-  pub condition: RuleSetCondition,
+  condition: RuleSetCondition,
   match_when_empty: RwLock<Option<bool>>,
 }
 
@@ -759,17 +759,17 @@ pub struct ModuleRule {
   /// Note:
   ///   This is a custom matching rule not initially designed by webpack.
   ///   Only for single-threaded environment interoperation purpose.
-  pub rspack_resource: Option<RuleSetConditionMatch>,
+  pub rspack_resource: Option<RuleSetCondition>,
   /// A condition matcher matching an absolute path.
-  pub test: Option<RuleSetConditionMatch>,
-  pub include: Option<RuleSetConditionMatch>,
-  pub exclude: Option<RuleSetConditionMatch>,
+  pub test: Option<RuleSetCondition>,
+  pub include: Option<RuleSetCondition>,
+  pub exclude: Option<RuleSetCondition>,
   /// A condition matcher matching an absolute path.
-  pub resource: Option<RuleSetConditionMatch>,
+  pub resource: Option<RuleSetCondition>,
   /// A condition matcher against the resource query.
   pub resource_query: Option<RuleSetConditionMatch>,
   pub resource_fragment: Option<RuleSetConditionMatch>,
-  pub dependency: Option<RuleSetConditionMatch>,
+  pub dependency: Option<RuleSetCondition>,
   pub issuer: Option<RuleSetConditionMatch>,
   pub issuer_layer: Option<RuleSetConditionMatch>,
   pub scheme: Option<RuleSetConditionMatch>,

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -641,11 +641,11 @@ impl RuleSetCondition {
   #[async_recursion]
   async fn match_when_empty(&self) -> Result<bool> {
     let res = match self {
-      RuleSetCondition::String(s) => s.len() == 0,
+      RuleSetCondition::String(s) => s.is_empty(),
       RuleSetCondition::Regexp(rspack_regex) => rspack_regex.test(""),
       RuleSetCondition::Logical(logical) => logical.match_when_empty().await?,
       RuleSetCondition::Array(arr) => {
-        arr.len() != 0 && try_any(arr, |c| async move { c.match_when_empty().await }).await?
+        arr.is_empty() && try_any(arr, |c| async move { c.match_when_empty().await }).await?
       }
       RuleSetCondition::Func(func) => func("".into()).await?,
     };

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -87,7 +87,7 @@ pub async fn module_rule_matcher<'a>(
         return Ok(false);
       }
     } else {
-      if !resource_query_rule.condition.match_when_empty().await? {
+      if !resource_query_rule.match_when_empty().await? {
         return Ok(false);
       }
     }
@@ -102,11 +102,7 @@ pub async fn module_rule_matcher<'a>(
         return Ok(false);
       }
     } else {
-      if !resource_fragment_condition
-        .condition
-        .match_when_empty()
-        .await?
-      {
+      if !resource_fragment_condition.match_when_empty().await? {
         return Ok(false);
       }
     }
@@ -121,7 +117,7 @@ pub async fn module_rule_matcher<'a>(
         return Ok(false);
       }
     } else {
-      if !mimetype_condition.condition.match_when_empty().await? {
+      if !mimetype_condition.match_when_empty().await? {
         return Ok(false);
       }
     }
@@ -130,7 +126,7 @@ pub async fn module_rule_matcher<'a>(
   if let Some(scheme_condition) = &module_rule.scheme {
     let scheme = resource_data.get_scheme();
     if scheme.is_none() {
-      if !scheme_condition.condition.match_when_empty().await? {
+      if !scheme_condition.match_when_empty().await? {
         return Ok(false);
       }
     }
@@ -147,7 +143,7 @@ pub async fn module_rule_matcher<'a>(
         }
       }
       None => {
-        if !issuer_rule.condition.match_when_empty().await? {
+        if !issuer_rule.match_when_empty().await? {
           return Ok(false);
         }
       }
@@ -162,7 +158,7 @@ pub async fn module_rule_matcher<'a>(
         }
       }
       None => {
-        if !issuer_layer_rule.condition.match_when_empty().await? {
+        if !issuer_layer_rule.match_when_empty().await? {
           return Ok(false);
         }
       }

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -87,7 +87,9 @@ pub async fn module_rule_matcher<'a>(
         return Ok(false);
       }
     } else {
-      return Ok(false);
+      if !resource_query_rule.condition.match_when_empty().await? {
+        return Ok(false);
+      }
     }
   }
 
@@ -100,7 +102,13 @@ pub async fn module_rule_matcher<'a>(
         return Ok(false);
       }
     } else {
-      return Ok(false);
+      if !resource_fragment_condition
+        .condition
+        .match_when_empty()
+        .await?
+      {
+        return Ok(false);
+      }
     }
   }
 
@@ -113,14 +121,18 @@ pub async fn module_rule_matcher<'a>(
         return Ok(false);
       }
     } else {
-      return Ok(false);
+      if !mimetype_condition.condition.match_when_empty().await? {
+        return Ok(false);
+      }
     }
   }
 
   if let Some(scheme_condition) = &module_rule.scheme {
     let scheme = resource_data.get_scheme();
     if scheme.is_none() {
-      return Ok(false);
+      if !scheme_condition.condition.match_when_empty().await? {
+        return Ok(false);
+      }
     }
     if !scheme_condition.try_match(scheme.as_str().into()).await? {
       return Ok(false);
@@ -134,7 +146,11 @@ pub async fn module_rule_matcher<'a>(
           return Ok(false);
         }
       }
-      None => return Ok(false),
+      None => {
+        if !issuer_rule.condition.match_when_empty().await? {
+          return Ok(false);
+        }
+      }
     }
   }
 
@@ -145,7 +161,11 @@ pub async fn module_rule_matcher<'a>(
           return Ok(false);
         }
       }
-      None => return Ok(false),
+      None => {
+        if !issuer_layer_rule.condition.match_when_empty().await? {
+          return Ok(false);
+        }
+      }
     };
   }
 
@@ -168,11 +188,17 @@ pub async fn module_rule_matcher<'a>(
             return Ok(false);
           }
         } else {
-          return Ok(false);
+          if !matcher.match_when_empty().await? {
+            return Ok(false);
+          }
         }
       }
     } else {
-      return Ok(false);
+      for matcher in description_data.values() {
+        if !matcher.match_when_empty().await? {
+          return Ok(false);
+        }
+      }
     }
   }
 
@@ -184,11 +210,17 @@ pub async fn module_rule_matcher<'a>(
             return Ok(false);
           }
         } else {
-          return Ok(false);
+          if !matcher.match_when_empty().await? {
+            return Ok(false);
+          }
         }
       }
     } else {
-      return Ok(false);
+      for matcher in with.values() {
+        if !matcher.match_when_empty().await? {
+          return Ok(false);
+        }
+      }
     }
   }
 

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -86,10 +86,8 @@ pub async fn module_rule_matcher<'a>(
       {
         return Ok(false);
       }
-    } else {
-      if !resource_query_rule.match_when_empty().await? {
-        return Ok(false);
-      }
+    } else if !resource_query_rule.match_when_empty().await? {
+      return Ok(false);
     }
   }
 
@@ -101,10 +99,8 @@ pub async fn module_rule_matcher<'a>(
       {
         return Ok(false);
       }
-    } else {
-      if !resource_fragment_condition.match_when_empty().await? {
-        return Ok(false);
-      }
+    } else if !resource_fragment_condition.match_when_empty().await? {
+      return Ok(false);
     }
   }
 
@@ -116,19 +112,15 @@ pub async fn module_rule_matcher<'a>(
       {
         return Ok(false);
       }
-    } else {
-      if !mimetype_condition.match_when_empty().await? {
-        return Ok(false);
-      }
+    } else if !mimetype_condition.match_when_empty().await? {
+      return Ok(false);
     }
   }
 
   if let Some(scheme_condition) = &module_rule.scheme {
     let scheme = resource_data.get_scheme();
-    if scheme.is_none() {
-      if !scheme_condition.match_when_empty().await? {
-        return Ok(false);
-      }
+    if scheme.is_none() && !scheme_condition.match_when_empty().await? {
+      return Ok(false);
     }
     if !scheme_condition.try_match(scheme.as_str().into()).await? {
       return Ok(false);
@@ -183,10 +175,8 @@ pub async fn module_rule_matcher<'a>(
           if !matcher.try_match(v.into()).await? {
             return Ok(false);
           }
-        } else {
-          if !matcher.match_when_empty().await? {
-            return Ok(false);
-          }
+        } else if !matcher.match_when_empty().await? {
+          return Ok(false);
         }
       }
     } else {
@@ -205,10 +195,8 @@ pub async fn module_rule_matcher<'a>(
           if !matcher.try_match(v.into()).await? {
             return Ok(false);
           }
-        } else {
-          if !matcher.match_when_empty().await? {
-            return Ok(false);
-          }
+        } else if !matcher.match_when_empty().await? {
+          return Ok(false);
         }
       }
     } else {

--- a/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/a.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/a.js
@@ -1,0 +1,1 @@
+export default "a.js"

--- a/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/index.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/index.js
@@ -1,0 +1,7 @@
+import a1 from "./a.js" with { type: "raw" };
+import a2 from "./a.js"; 
+
+it("should hit loader", () => {
+	expect(a1).toEqual("export default \"a.js\"");
+	expect(a2).toEqual("loader.js");
+});

--- a/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/loader.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/loader.js
@@ -1,0 +1,3 @@
+module.exports = function (content) {
+	return "export default 'loader.js'";
+};

--- a/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/rspack.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+	mode: "development",
+	entry: "./index.js",
+	devtool: false,
+	module: {
+		rules: [
+			{
+				test: /a\.js/,
+				with: {
+					type: {
+						not: "raw"
+					}
+				},
+				use: [
+					{
+						loader: "./loader.js", 
+					 }
+				]
+			},
+			{
+				with: { type: "raw" },
+				type: "asset/source"
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary
Closes https://github.com/web-infra-dev/rspack/issues/8267
Align with webpack https://github.com/webpack/webpack/blob/main/lib/rules/RuleSetCompiler.js#L237

Considering the `match_when_empty` is only calculated once and `TryFrom` can't be async, I use `RwLock` for cache. It's better to run benchmarks to see if there's performance regression.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
