### PR TITLE
build: remove no-dts-cache

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -32,7 +32,6 @@ async function build() {
 			"--no-js",
 			// "--no-const-enum",
 			"--no-dts-header",
-			"--no-dts-cache",
 			"--pipe",
 			`"node ./scripts/dts-header.js"`
 		];


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Previously, I disabled dts cache to keep dts generation stable. However, this might has impact on cases where some crate is built incrementally so that the binding of these crates are failed to generate.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
