### PR TITLE
fix: use cgm hash to verify rename inline modules cache

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -1572,7 +1572,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       Vec<DependencyId>,
     > = IndexMap::default();
 
-    for dep_id in module_graph.get_ordered_all_dependencies(&module) {
+    for dep_id in module_graph.get_ordered_outgoing_connections(&module) {
       let dep = module_graph
         .dependency_by_id(dep_id)
         .expect("should have dep");

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -284,7 +284,9 @@ impl ChunkGraph {
         .expect("should have module")
         .as_ref();
       module.get_exports_type(&mg, strict).hash(&mut hasher);
-      self.get_module_graph_hash_without_connections(module, compilation, runtime);
+      self
+        .get_module_graph_hash_without_connections(module, compilation, runtime)
+        .hash(&mut hasher);
     }
     hasher.finish()
   }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -270,7 +270,10 @@ impl ChunkGraph {
     let mg = compilation.get_module_graph();
     let mut visited_modules = IdentifierSet::default();
     visited_modules.insert(module.identifier());
-    for connection in mg.get_outgoing_connections(&module.identifier()) {
+    for connection in mg
+      .get_ordered_outgoing_connections(&module.identifier())
+      .filter_map(|c| mg.connection_by_dependency_id(c))
+    {
       let module_identifier = connection.module_identifier();
       if visited_modules.contains(module_identifier) {
         continue;

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -789,7 +789,7 @@ impl<'a> ModuleGraph<'a> {
     exports_info.get_export_info(self, export_name)
   }
 
-  pub(crate) fn get_ordered_all_dependencies(
+  pub(crate) fn get_ordered_outgoing_connections(
     &self,
     module_identifier: &ModuleIdentifier,
   ) -> impl Iterator<Item = &DependencyId> {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -158,7 +158,7 @@ pub fn esm_import_dependency_apply<T: ModuleDependency>(
   } = code_generatable_context;
   let ref_module = module_graph.module_identifier_by_dependency_id(module_dependency.id());
   let import_var = compilation.get_import_var(module_dependency.id());
-  //
+
   // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/dependencies/HarmonyImportDependency.js#L282-L285
   let module_key = ref_module
     .map(|i| i.as_str())

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -912,11 +912,12 @@ impl JsPlugin {
                       module_scope_idents,
                       used_in_non_inlined: Vec::new(),
                     };
+                    let runtime = compilation.chunk_by_ukey.expect_get(chunk_ukey).runtime();
 
                     self.rename_module_cache.inlined_modules_to_info.insert(
                       ident,
                       WithHash {
-                        hash: m.build_info().and_then(|i| i.hash.clone()),
+                        hash: ChunkGraph::get_module_hash(compilation, ident, runtime).cloned(),
                         value: info.clone(),
                       },
                     );
@@ -925,6 +926,7 @@ impl JsPlugin {
                   } else {
                     let mut idents_vec = vec![];
                     let module_ident = m.identifier();
+                    let runtime = compilation.chunk_by_ukey.expect_get(chunk_ukey).runtime();
 
                     for ident in collector.ids {
                       if ident.id.ctxt == global_ctxt {
@@ -940,7 +942,8 @@ impl JsPlugin {
                       .insert(
                         module_ident,
                         WithHash {
-                          hash: m.build_info().and_then(|i| i.hash.clone()),
+                          hash: ChunkGraph::get_module_hash(compilation, module_ident, runtime)
+                            .cloned(),
                           value: idents_vec.clone(),
                         },
                       );

--- a/packages/rspack-test-tools/tests/statsAPICases/cache-enabled.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/cache-enabled.js
@@ -5,6 +5,7 @@ module.exports = {
 	description:
 		"should have any cache hits log of modules in incremental rebuild mode",
 	options(context) {
+		debugger;
 		return {
 			context: context.getSource(),
 			entry: "./fixtures/abc",

--- a/packages/rspack-test-tools/tests/statsAPICases/cache-enabled.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/cache-enabled.js
@@ -5,7 +5,6 @@ module.exports = {
 	description:
 		"should have any cache hits log of modules in incremental rebuild mode",
 	options(context) {
-		debugger;
 		return {
 			context: context.getSource(),
 			entry: "./fixtures/abc",

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/foo.js
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/foo.js
@@ -1,0 +1,1 @@
+export const v = 'foo'

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/index.js
@@ -1,0 +1,5 @@
+import {value} from "./module";
+
+it("should have correct export from re-exports", function () {
+	expect(value).toBe("foo");
+});

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/module.js
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/module.js
@@ -1,0 +1,2 @@
+import {v} from './reexports'
+export const value = '' + v;

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/package.json
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/reexports-deep.js
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/reexports-deep.js
@@ -1,0 +1,2 @@
+import {v} from './foo';
+export {v};

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/reexports.js
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/0/reexports.js
@@ -1,0 +1,1 @@
+export { v } from "./reexports-deep";

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/1/module.js
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/1/module.js
@@ -1,0 +1,1 @@
+export { v as value } from "./reexports";

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/rspack.config.js
@@ -1,0 +1,7 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		sideEffects: true,
+		providedExports: true,
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Use ChunkGraph module hash to verify the `rename_module_cache`, `build_info().hash` represents the module's `originalSource`, but it's possible to generate different result with the same `originalSource` (checkout added test).

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
