### PR TITLE
fix: Rspack cssParser will parse failed when url(' ')

### DIFF
--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -164,7 +164,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
           range,
           kind,
         } => {
-          if request.is_empty() {
+          if request.trim().is_empty() {
             continue;
           }
           let request = replace_module_request_prefix(

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-css/simple-url/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-css/simple-url/__snapshots__/output.snap.txt
@@ -1,0 +1,7 @@
+```css title=main.css
+body {
+  background: red url('    ');
+}
+
+
+```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-css/simple-url/index.js
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-css/simple-url/index.js
@@ -1,0 +1,1 @@
+import "./style.css";

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-css/simple-url/style.css
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-css/simple-url/style.css
@@ -1,0 +1,3 @@
+body {
+  background: red url('    ');
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->
fix [issue 8788](https://github.com/web-infra-dev/rspack/issues/8788)
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
