### PR TITLE
fix(exernals): add hash to distinguish conflict id

### DIFF
--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -1,8 +1,9 @@
-use std::{borrow::Cow, iter};
+use std::{borrow::Cow, hash::Hash, iter};
 
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_error::{error, impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_hash::RspackHash;
 use rspack_macros::impl_source_map_config;
 use rspack_util::{ext::DynHash, json_stringify, source_map::SourceMapKind};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
@@ -334,7 +335,19 @@ impl ExternalModule {
       ),
       "module" if let Some(request) = request => {
         if compilation.options.output.module {
-          let id = to_identifier(&request.primary);
+          let id: Cow<'_, str> = if to_identifier(&request.primary) != request.primary {
+            let mut hasher = RspackHash::from(&compilation.options.output);
+            request.primary.hash(&mut hasher);
+            let hash_suffix = hasher.digest(&compilation.options.output.hash_digest);
+            Cow::Owned(format!(
+              "{}_{}",
+              to_identifier(&request.primary),
+              hash_suffix.rendered(8)
+            ))
+          } else {
+            to_identifier(&request.primary)
+          };
+
           chunk_init_fragments.push(
             NormalInitFragment::new(
               format!(

--- a/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
@@ -328,7 +328,7 @@ export * from "external2-alias";
 `;
 
 exports[`config config/externals/reexport-star exported tests reexport star from external module 2`] = `
-import * as __WEBPACK_EXTERNAL_MODULE_external1_alias__ from "external1-alias";
+import * as __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__ from "external1-alias";
 export * from "external1-alias";
 
 ;// CONCATENATED MODULE: external "external1-alias"
@@ -340,13 +340,13 @@ export * from "external1-alias";
 
 
 
-var __webpack_exports__a = __WEBPACK_EXTERNAL_MODULE_external1_alias__.a;
-var __webpack_exports__b = __WEBPACK_EXTERNAL_MODULE_external1_alias__.b;
-export { __WEBPACK_EXTERNAL_MODULE_external1_alias__ as n1, __webpack_exports__a as a, __webpack_exports__b as b };
+var __webpack_exports__a = __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__.a;
+var __webpack_exports__b = __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__.b;
+export { __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__ as n1, __webpack_exports__a as a, __webpack_exports__b as b };
 `;
 
 exports[`config config/externals/reexport-star exported tests reexport star from external module 3`] = `
-import * as __WEBPACK_EXTERNAL_MODULE_external1_alias__ from "external1-alias";
+import * as __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__ from "external1-alias";
 
 ;// CONCATENATED MODULE: external "external1-alias"
 

--- a/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/_a/foo.mjs
+++ b/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/_a/foo.mjs
@@ -1,0 +1,1 @@
+export const foo = 'foo2'

--- a/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/a/foo.mjs
+++ b/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/a/foo.mjs
@@ -1,0 +1,1 @@
+export const foo = 'foo1'

--- a/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/index.js
@@ -1,0 +1,7 @@
+import { foo as foo1 } from './a/foo.mjs'
+import { foo as foo2 } from './_a/foo.mjs'
+
+it("foo1 and foo2 should from different namespace import identifier", () => {
+	expect(foo1).toBe("foo1");
+	expect(foo2).toBe("foo2");
+});

--- a/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/rspack.config.js
@@ -1,0 +1,27 @@
+const rspack = require("@rspack/core");
+
+/** @type {function(any, any): import("@rspack/core").Configuration[]} */
+module.exports = (env, { testPath }) => {
+	return {
+	  externals: [/.*foo.*/],
+		externalsType: "module",
+		output: {
+			module: true,
+			chunkFormat: "module",
+			filename: "[name].mjs"
+		},
+		experiments: {
+			outputModule: true
+		},
+		optimization: {
+			minimize: true,
+			concatenateModules: true,
+		},
+			plugins: [
+				new rspack.CopyRspackPlugin({
+					patterns: ["./a/**/*", "./_a/**/*"],
+				}),
+			]
+	};
+}
+

--- a/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../dist").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["main.mjs"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/index.js
@@ -5,10 +5,10 @@ it("modern-module-dynamic-import-runtime", () => {
 	const initialChunk = fs.readFileSync(path.resolve(__dirname, "main.js"), "utf-8");
 	const asyncChunk = fs.readFileSync(path.resolve(__dirname, "async.js"), "utf-8");
 
-	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_lit_alias__ from "lit-alias"');
-	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_svelte_alias__ from "svelte-alias"');
-	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_react_alias__ from "react-alias"');
-	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_angular_alias__ from "angular-alias"');
+	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_lit_alias_9f8ad874__ from "lit-alias"');
+	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_svelte_alias_b2b3c54d__ from "svelte-alias"');
+	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_react_alias_fd8b3826__ from "react-alias"');
+	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_angular_alias_7d25287d__ from "angular-alias"');
 	expect(initialChunk).toContain('const reactNs = await import("react-alias")');
 	expect(initialChunk).toContain('const vueNs = await import("vue-alias")');
 	expect(initialChunk).toContain('const jqueryNs = await import("jquery-alias", { with: {"type":"url"} })');

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
@@ -29,8 +29,8 @@ module.exports = {
 				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
 					const bundle = Object.values(assets)[0]._value
 					expect(bundle).toContain(`var __webpack_exports__cjsInterop = (foo_default());
-var __webpack_exports__defaultImport = __WEBPACK_EXTERNAL_MODULE_external_module__["default"];
-var __webpack_exports__namedImport = __WEBPACK_EXTERNAL_MODULE_external_module__.namedImport;`)
+var __webpack_exports__defaultImport = __WEBPACK_EXTERNAL_MODULE_external_module_43054e33__["default"];
+var __webpack_exports__namedImport = __WEBPACK_EXTERNAL_MODULE_external_module_43054e33__.namedImport;`)
 				});
 			};
 			this.hooks.compilation.tap("testcase", handler);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix https://github.com/web-infra-dev/rslib/issues/580, port https://github.com/webpack/webpack/blob/7701ae43203e9d93d661c9a663c41fccd8e242aa/lib/ExternalModule.js#L239-L244 of webpack.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
