### PR TITLE
chore(modern-module): jump the asset entry module concaten for Rslib

### DIFF
--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   CodeGenerationExportsFinalNames, Compilation, CompilationFinishModules,
   CompilationOptimizeChunkModules, CompilationParams, CompilerCompilation, CompilerOptions,
   ConcatenatedModule, ConcatenatedModuleExportsDefinitions, DependenciesBlock, Dependency,
-  DependencyId, LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, PluginContext,
+  DependencyId, LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, PluginContext, SourceType,
 };
 use rspack_error::{error_bail, Result};
 use rspack_hash::RspackHash;
@@ -113,6 +113,17 @@ impl ModernModuleLibraryPlugin {
       .collect::<HashSet<_>>();
 
     for module_id in unconcatenated_module_ids.into_iter() {
+      // jump the asset module when asset module as entry
+      let module_graph = compilation.get_module_graph();
+      let Some(module) = module_graph.module_by_identifier(module_id) else {
+        continue;
+      };
+      let source_types = module.source_types();
+      let is_asset_module = source_types.contains(&SourceType::Asset);
+      if is_asset_module {
+        continue;
+      }
+
       let chunk_runtime = compilation
         .chunk_graph
         .get_module_runtimes(*module_id, &compilation.chunk_by_ukey)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

when set `library.type = "modern-module"` and set asset as entry, there are several bugs

1. not emit asset

2. url is missing

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
