### PR TITLE
fix(rspack-test-tools): use `process.cwd()` when outside Rspack

### DIFF
--- a/packages/rspack-test-tools/src/helper/expect/placeholder.ts
+++ b/packages/rspack-test-tools/src/helper/expect/placeholder.ts
@@ -5,7 +5,10 @@ import { createSnapshotSerializer } from "path-serializer";
 // 2. replace <RSPACK_ROOT> etc
 // 3. transform win32 sep
 const placeholderSerializer = createSnapshotSerializer({
-	root: path.resolve(__dirname, "../../../../../"),
+	root: __dirname.includes("node_modules")
+		? // Use `process.cwd()` when using outside Rspack
+			process.cwd()
+		: path.resolve(__dirname, "../../../../../"),
 	replace: [
 		{
 			match: path.resolve(__dirname, "../../../"),


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

In #8161, the snapshot is serialized by `path-serializer`. But it cannot serialize paths correctly when using `@rspack/test-tools` in an external project:

```diff
- fileName: "<PROJECT_ROOT>/path/to/index.js",
+ fileName: "<HOME>/project/path/to/index.js",
```

In this patch, we use `process.cwd()` when `@rspack/test-tools` is in `node_modules`, which would work as expected.


```diff
- fileName: "<PROJECT_ROOT>/path/to/index.js",
+ fileName: "<ROOT>/path/to/index.js",
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
