### PR TITLE
feat(storage): improve storage memory

### DIFF
--- a/crates/rspack_core/src/cache/persistent/storage/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/storage/mod.rs
@@ -32,6 +32,8 @@ pub fn create_storage(
         pack_size: 500 * 1024,
         expire: 7 * 24 * 60 * 60 * 1000,
         fs: Arc::new(BridgeFileSystem(fs)),
+        fresh_generation: Some(1),
+        release_generation: Some(2),
         version,
       };
       Arc::new(PackStorage::new(option))

--- a/crates/rspack_storage/src/pack/data/meta.rs
+++ b/crates/rspack_storage/src/pack/data/meta.rs
@@ -11,6 +11,7 @@ pub struct PackFileMeta {
   pub name: String,
   pub size: usize,
   pub wrote: bool,
+  pub generation: usize,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -52,6 +53,7 @@ pub struct ScopeMeta {
   pub path: Utf8PathBuf,
   pub bucket_size: usize,
   pub pack_size: usize,
+  pub generation: usize,
   pub packs: Vec<Vec<PackFileMeta>>,
 }
 
@@ -65,6 +67,7 @@ impl ScopeMeta {
       path: Self::get_path(dir),
       bucket_size: options.bucket_size,
       pack_size: options.pack_size,
+      generation: 0,
       packs,
     }
   }

--- a/crates/rspack_storage/src/pack/data/mod.rs
+++ b/crates/rspack_storage/src/pack/data/mod.rs
@@ -5,5 +5,5 @@ mod scope;
 
 pub use meta::{current_time, PackFileMeta, RootMeta, RootMetaFrom, ScopeMeta};
 pub use options::{PackOptions, RootOptions};
-pub use pack::{Pack, PackContents, PackKeys};
+pub use pack::{Pack, PackContents, PackGenerations, PackKeys};
 pub use scope::{PackScope, RootMetaState};

--- a/crates/rspack_storage/src/pack/data/pack.rs
+++ b/crates/rspack_storage/src/pack/data/pack.rs
@@ -6,6 +6,7 @@ use crate::{ItemKey, ItemValue};
 
 pub type PackKeys = Vec<Arc<ItemKey>>;
 pub type PackContents = Vec<Arc<ItemValue>>;
+pub type PackGenerations = Vec<usize>;
 
 #[derive(Debug, Default)]
 pub enum PackKeysState {
@@ -80,6 +81,7 @@ pub struct Pack {
   pub path: Utf8PathBuf,
   pub keys: PackKeysState,
   pub contents: PackContentsState,
+  pub generations: PackGenerations,
 }
 
 impl Pack {
@@ -88,6 +90,7 @@ impl Pack {
       path,
       keys: Default::default(),
       contents: Default::default(),
+      generations: Default::default(),
     }
   }
 
@@ -97,11 +100,20 @@ impl Pack {
   }
 
   pub fn size(&self) -> usize {
-    self
+    let key_size = self
       .keys
       .expect_value()
       .iter()
-      .chain(self.contents.expect_value().iter())
-      .fold(0_usize, |acc, item| acc + item.len())
+      .fold(0_usize, |acc, item| acc + item.len());
+    let content_size = self
+      .contents
+      .expect_value()
+      .iter()
+      .fold(0_usize, |acc, item| acc + item.len());
+    let generation_size = self
+      .generations
+      .iter()
+      .fold(0_usize, |acc, item| acc + item.to_string().len());
+    key_size + content_size + generation_size
   }
 }

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -254,6 +254,8 @@ async fn save_scopes(
     scopes
       .values_mut()
       .map(|scope| async move {
+        strategy.optimize_packs(scope).await?;
+
         let mut res = WriteScopeResult::default();
         if scope.loaded() {
           res.extend(strategy.write_packs(scope).await?);

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -48,7 +48,7 @@ impl ScopeManager {
     let strategy = self.strategy.clone();
     let scopes = self.scopes.clone();
     let root_meta = self.root_meta.clone();
-    block_on(tokio::task::unconstrained(async move {
+    block_on(async move {
       let mut scopes_guard = scopes.lock().await;
       match update_scopes(
         &mut scopes_guard,
@@ -71,7 +71,7 @@ impl ScopeManager {
         }
         Err(e) => Err(e),
       }
-    }))?;
+    })?;
 
     let strategy = self.strategy.clone();
     let scopes = self.scopes.clone();

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -3,10 +3,8 @@ mod queue;
 use std::sync::Arc;
 
 use futures::future::join_all;
-use itertools::Itertools;
 use pollster::block_on;
 use queue::TaskQueue;
-use rayon::iter::{ParallelBridge, ParallelIterator};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::{oneshot, Mutex};
@@ -50,14 +48,16 @@ impl ScopeManager {
     let strategy = self.strategy.clone();
     let scopes = self.scopes.clone();
     let root_meta = self.root_meta.clone();
-    block_on(async move {
+    block_on(tokio::task::unconstrained(async move {
       let mut scopes_guard = scopes.lock().await;
       match update_scopes(
         &mut scopes_guard,
         updates,
         pack_options.clone(),
         strategy.as_ref(),
-      ) {
+      )
+      .await
+      {
         Ok(_) => {
           *root_meta.lock().await = RootMetaState::Value(Some(RootMeta::new(
             scopes_guard
@@ -71,7 +71,7 @@ impl ScopeManager {
         }
         Err(e) => Err(e),
       }
-    })?;
+    }))?;
 
     let strategy = self.strategy.clone();
     let scopes = self.scopes.clone();
@@ -204,7 +204,7 @@ impl ScopeManager {
   }
 }
 
-fn update_scopes(
+async fn update_scopes(
   scopes: &mut ScopeMap,
   mut updates: ScopeUpdates,
   pack_options: Arc<PackOptions>,
@@ -220,22 +220,25 @@ fn update_scopes(
     });
   }
 
-  scopes
-    .iter_mut()
-    .filter_map(|(name, scope)| {
-      updates
-        .remove(name.to_string().as_str())
-        .and_then(|scope_update| {
-          if scope_update.is_empty() {
-            None
-          } else {
-            Some((scope, scope_update))
-          }
-        })
-    })
-    .par_bridge()
-    .map(|(scope, scope_update)| strategy.update_scope(scope, scope_update))
-    .collect::<Result<Vec<_>>>()?;
+  join_all(
+    scopes
+      .iter_mut()
+      .filter_map(|(name, scope)| {
+        updates
+          .remove(name.to_string().as_str())
+          .and_then(|scope_update| {
+            if scope_update.is_empty() {
+              None
+            } else {
+              Some((scope, scope_update))
+            }
+          })
+      })
+      .map(|(scope, scope_update)| strategy.update_scope(scope, scope_update)),
+  )
+  .await
+  .into_iter()
+  .collect::<Result<Vec<_>>>()?;
 
   Ok(())
 }
@@ -250,21 +253,23 @@ async fn save_scopes(
 
   strategy.before_all(&mut scopes).await?;
 
-  let changed = join_all(
+  join_all(
     scopes
       .values_mut()
-      .map(|scope| async move {
-        strategy.optimize_packs(scope).await?;
-
-        let mut res = WriteScopeResult::default();
-        if scope.loaded() {
-          res.extend(strategy.write_packs(scope).await?);
-          res.extend(strategy.write_meta(scope).await?);
-        }
-        Ok(res)
-      })
-      .collect_vec(),
+      .map(|scope| strategy.optimize_scope(scope)),
   )
+  .await
+  .into_iter()
+  .collect::<Result<Vec<_>>>()?;
+
+  let changed = join_all(scopes.values_mut().map(|scope| async move {
+    let mut res = WriteScopeResult::default();
+    if scope.loaded() {
+      res.extend(strategy.write_packs(scope).await?);
+      res.extend(strategy.write_meta(scope).await?);
+    }
+    Ok(res)
+  }))
   .await
   .into_iter()
   .collect::<Result<Vec<WriteScopeResult>>>()?
@@ -277,9 +282,7 @@ async fn save_scopes(
   strategy.write_root_meta(root_meta).await?;
   strategy.merge_changed(changed).await?;
   strategy.after_all(&mut scopes).await?;
-  strategy
-    .clean_unused(root_meta, &scopes, root_options)
-    .await?;
+  strategy.clean(root_meta, &scopes, root_options).await?;
 
   Ok(scopes.into_iter().collect())
 }
@@ -343,6 +346,8 @@ mod tests {
       root.to_path_buf(),
       temp.to_path_buf(),
       fs.clone(),
+      Some(1),
+      Some(2),
     ));
     let manager = ScopeManager::new(root_options, pack_options, strategy);
 
@@ -397,6 +402,8 @@ mod tests {
       root.to_path_buf(),
       temp.to_path_buf(),
       fs.clone(),
+      Some(1),
+      Some(2),
     ));
     let manager = ScopeManager::new(root_options, pack_options, strategy);
 
@@ -480,6 +487,8 @@ mod tests {
       root.to_path_buf(),
       temp.to_path_buf(),
       fs.clone(),
+      Some(1),
+      Some(2),
     ));
     let manager = ScopeManager::new(root_options.clone(), pack_options.clone(), strategy.clone());
     // should report error when invalid failed

--- a/crates/rspack_storage/src/pack/manager/queue.rs
+++ b/crates/rspack_storage/src/pack/manager/queue.rs
@@ -11,6 +11,12 @@ impl Debug for TaskQueue {
   }
 }
 
+impl Default for TaskQueue {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl TaskQueue {
   pub fn new() -> Self {
     TaskQueue(LazyLock::new(|| {

--- a/crates/rspack_storage/src/pack/mod.rs
+++ b/crates/rspack_storage/src/pack/mod.rs
@@ -19,8 +19,8 @@ use crate::{error::Result, FileSystem, ItemKey, ItemPairs, ItemValue, Storage};
 pub type ScopeUpdates = HashMap<&'static str, ScopeUpdate>;
 #[derive(Debug)]
 pub struct PackStorage {
-  manager: ScopeManager,
-  updates: Mutex<ScopeUpdates>,
+  pub manager: ScopeManager,
+  pub updates: Mutex<ScopeUpdates>,
 }
 
 pub struct PackStorageOptions {

--- a/crates/rspack_storage/src/pack/mod.rs
+++ b/crates/rspack_storage/src/pack/mod.rs
@@ -32,6 +32,8 @@ pub struct PackStorageOptions {
   pub expire: u64,
   pub version: String,
   pub clean: bool,
+  pub fresh_generation: Option<usize>,
+  pub release_generation: Option<usize>,
 }
 
 impl PackStorage {
@@ -51,6 +53,8 @@ impl PackStorage {
           options.root.join(&options.version).assert_utf8(),
           options.temp_root.join(&options.version).assert_utf8(),
           options.fs,
+          options.fresh_generation,
+          options.release_generation,
         )),
       ),
       updates: Default::default(),

--- a/crates/rspack_storage/src/pack/strategy/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/mod.rs
@@ -38,7 +38,7 @@ pub trait RootStrategy {
   async fn read_root_meta(&self) -> Result<Option<RootMeta>>;
   async fn write_root_meta(&self, root_meta: &RootMeta) -> Result<()>;
   async fn validate_root(&self, root_meta: &RootMeta) -> Result<ValidateResult>;
-  async fn clean_unused(
+  async fn clean(
     &self,
     root_meta: &RootMeta,
     scopes: &HashMap<String, PackScope>,
@@ -60,14 +60,20 @@ pub trait PackReadStrategy {
 
 #[async_trait]
 pub trait PackWriteStrategy {
-  fn update_packs(
+  async fn update_packs(
     &self,
     dir: Utf8PathBuf,
     generation: usize,
     options: &PackOptions,
     packs: HashMap<PackFileMeta, Pack>,
     updates: HashMap<ItemKey, Option<ItemValue>>,
-  ) -> UpdatePacksResult;
+  ) -> Result<UpdatePacksResult>;
+  async fn optimize_packs(
+    &self,
+    dir: Utf8PathBuf,
+    options: &PackOptions,
+    packs: Vec<(PackFileMeta, Pack)>,
+  ) -> Result<UpdatePacksResult>;
   async fn write_pack(&self, pack: &Pack) -> Result<()>;
 }
 
@@ -102,9 +108,9 @@ impl WriteScopeResult {
 pub type ScopeUpdate = HashMap<ItemKey, Option<ItemValue>>;
 #[async_trait]
 pub trait ScopeWriteStrategy {
-  fn update_scope(&self, scope: &mut PackScope, updates: ScopeUpdate) -> Result<()>;
+  async fn update_scope(&self, scope: &mut PackScope, updates: ScopeUpdate) -> Result<()>;
   async fn before_all(&self, scopes: &mut HashMap<String, PackScope>) -> Result<()>;
-  async fn optimize_packs(&self, scope: &mut PackScope) -> Result<()>;
+  async fn optimize_scope(&self, scope: &mut PackScope) -> Result<()>;
   async fn write_packs(&self, scope: &mut PackScope) -> Result<WriteScopeResult>;
   async fn write_meta(&self, scope: &mut PackScope) -> Result<WriteScopeResult>;
   async fn merge_changed(&self, changed: WriteScopeResult) -> Result<()>;

--- a/crates/rspack_storage/src/pack/strategy/split/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/mod.rs
@@ -32,14 +32,24 @@ pub struct SplitPackStrategy {
   pub fs: Arc<dyn FileSystem>,
   pub root: Arc<Utf8PathBuf>,
   pub temp_root: Arc<Utf8PathBuf>,
+  pub fresh_generation: Option<usize>,
+  pub release_generation: Option<usize>,
 }
 
 impl SplitPackStrategy {
-  pub fn new(root: Utf8PathBuf, temp_root: Utf8PathBuf, fs: Arc<dyn FileSystem>) -> Self {
+  pub fn new(
+    root: Utf8PathBuf,
+    temp_root: Utf8PathBuf,
+    fs: Arc<dyn FileSystem>,
+    fresh_generation: Option<usize>,
+    release_generation: Option<usize>,
+  ) -> Self {
     Self {
       fs,
       root: Arc::new(root),
       temp_root: Arc::new(temp_root),
+      fresh_generation,
+      release_generation,
     }
   }
 
@@ -124,7 +134,7 @@ impl RootStrategy for SplitPackStrategy {
     }
   }
 
-  async fn clean_unused(
+  async fn clean(
     &self,
     root_meta: &RootMeta,
     scopes: &HashMap<String, PackScope>,

--- a/crates/rspack_storage/src/pack/strategy/split/read_scope.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/read_scope.rs
@@ -238,7 +238,7 @@ struct ReadContentsResult {
 }
 
 fn read_contents_filter(pack: &Pack, _: &PackFileMeta) -> bool {
-  pack.keys.loaded() && !pack.contents.loaded()
+  pack.keys.loaded() && (!pack.contents.loaded() || pack.contents.is_released())
 }
 
 async fn read_contents(

--- a/crates/rspack_storage/src/pack/strategy/split/util.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/util.rs
@@ -290,7 +290,15 @@ pub mod test_pack_utils {
     ];
 
     fs.into_iter()
-      .map(|(fs, root)| SplitPackStrategy::new(root.join("cache"), root.join("temp"), fs.clone()))
+      .map(|(fs, root)| {
+        SplitPackStrategy::new(
+          root.join("cache"),
+          root.join("temp"),
+          fs.clone(),
+          Some(1_usize),
+          Some(2_usize),
+        )
+      })
       .collect_vec()
   }
 }

--- a/crates/rspack_storage/src/pack/strategy/split/validate_scope.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/validate_scope.rs
@@ -259,6 +259,7 @@ mod tests {
       let updates = mock_updates(0, 100, 30, UpdateVal::Value("val".to_string()));
       strategy
         .update_scope(&mut mock_scope, updates)
+        .await
         .expect("should update scope");
 
       prepare_scope(

--- a/crates/rspack_storage/src/pack/strategy/split/write_pack.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/write_pack.rs
@@ -350,11 +350,11 @@ fn create(
   new_packs
 }
 
-fn create_pack(dir: &Utf8Path, candiates: Vec<PackItemCandidate>) -> (PackFileMeta, Pack) {
+fn create_pack(dir: &Utf8Path, candidates: Vec<PackItemCandidate>) -> (PackFileMeta, Pack) {
   let mut keys = vec![];
   let mut contents = vec![];
   let mut generations = vec![];
-  for candidate in candiates {
+  for candidate in candidates {
     keys.push(candidate.key);
     contents.push(candidate.value);
     generations.push(candidate.generation);

--- a/crates/rspack_storage/src/pack/strategy/split/write_pack.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/write_pack.rs
@@ -136,7 +136,7 @@ impl PackWriteStrategy for SplitPackStrategy {
             .1
         })
         .collect_vec(),
-      &self,
+      self,
     )
     .await?;
 

--- a/crates/rspack_storage/tests/dev.rs
+++ b/crates/rspack_storage/tests/dev.rs
@@ -35,6 +35,8 @@ mod test_storage_dev {
       pack_size: 200,
       expire: 7 * 24 * 60 * 60 * 1000,
       clean: true,
+      fresh_generation: Some(1),
+      release_generation: Some(2),
     }
   }
 
@@ -53,7 +55,7 @@ mod test_storage_dev {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?;
+    storage.trigger_save()?.await.expect("should save")?;
 
     assert_eq!(storage.load("test_scope").await?.len(), 300);
     for i in 300..700 {

--- a/crates/rspack_storage/tests/error.rs
+++ b/crates/rspack_storage/tests/error.rs
@@ -35,6 +35,8 @@ mod test_storage_error {
       pack_size: 200,
       expire: 7 * 24 * 60 * 60 * 1000,
       clean: true,
+      fresh_generation: Some(1),
+      release_generation: Some(2),
     }
   }
 

--- a/crates/rspack_storage/tests/expire.rs
+++ b/crates/rspack_storage/tests/expire.rs
@@ -35,6 +35,8 @@ mod test_storage_expire {
       pack_size: 200,
       expire: 0,
       clean: true,
+      fresh_generation: Some(1),
+      release_generation: Some(2),
     });
     let data = storage.load("test_scope").await?;
     assert!(data.is_empty());
@@ -71,6 +73,8 @@ mod test_storage_expire {
       pack_size: 200,
       expire: 0,
       clean: true,
+      fresh_generation: Some(1),
+      release_generation: Some(2),
     });
     assert!(storage.load("test_scope").await.is_err_and(|e| {
       e.to_string()
@@ -96,6 +100,8 @@ mod test_storage_expire {
       pack_size: 200,
       expire: 7 * 24 * 60 * 60 * 1000,
       clean: true,
+      fresh_generation: Some(1),
+      release_generation: Some(2),
     });
     let data = storage.load("test_scope").await?;
     assert!(data.is_empty());

--- a/crates/rspack_storage/tests/lock.rs
+++ b/crates/rspack_storage/tests/lock.rs
@@ -98,6 +98,8 @@ mod test_storage_lock {
       pack_size: 100,
       expire: 7 * 24 * 60 * 60 * 1000,
       clean: true,
+      fresh_generation: Some(1),
+      release_generation: Some(2),
     });
     let data = storage.load("test_scope").await?;
     assert!(data.is_empty());
@@ -134,6 +136,8 @@ mod test_storage_lock {
       pack_size: 100,
       expire: 7 * 24 * 60 * 60 * 1000,
       clean: true,
+      fresh_generation: Some(1),
+      release_generation: Some(2),
     });
     assert_eq!(storage.load("test_scope").await?.len(), 100);
     Ok(())
@@ -154,6 +158,8 @@ mod test_storage_lock {
       pack_size: 100,
       expire: 7 * 24 * 60 * 60 * 1000,
       clean: true,
+      fresh_generation: Some(1),
+      release_generation: Some(2),
     });
     assert!(storage.load("test_scope").await.is_err_and(|e| {
       e.to_string()

--- a/crates/rspack_storage/tests/multi.rs
+++ b/crates/rspack_storage/tests/multi.rs
@@ -35,6 +35,8 @@ mod test_storage_multi {
       pack_size: 200,
       expire: 7 * 24 * 60 * 60 * 1000,
       clean: true,
+      fresh_generation: Some(1),
+      release_generation: Some(2),
     }
   }
 

--- a/crates/rspack_storage/tests/release.rs
+++ b/crates/rspack_storage/tests/release.rs
@@ -32,7 +32,7 @@ mod test_storage_dev {
       temp_root: temp_root.into(),
       fs,
       bucket_size: 1,
-      pack_size: 200,
+      pack_size: 10000,
       expire: 7 * 24 * 60 * 60 * 1000,
       clean: true,
       fresh_generation: Some(1),

--- a/crates/rspack_storage/tests/release.rs
+++ b/crates/rspack_storage/tests/release.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
-mod test_storage_build {
-  use std::{collections::HashMap, path::PathBuf, sync::Arc};
+mod test_storage_dev {
+  use std::{path::PathBuf, sync::Arc};
 
   use rspack_fs::{MemoryFileSystem, NativeFileSystem};
   use rspack_paths::{AssertUtf8, Utf8PathBuf};
@@ -10,13 +10,13 @@ mod test_storage_build {
 
   pub fn get_native_path(p: &str) -> (PathBuf, PathBuf) {
     let base = std::env::temp_dir()
-      .join("rspack_test/storage/test_storage_build")
+      .join("rspack_test/storage/test_storage_dev")
       .join(p);
     (base.join("cache"), base.join("temp"))
   }
 
   pub fn get_memory_path(p: &str) -> (PathBuf, PathBuf) {
-    let base = PathBuf::from("/rspack_test/storage/test_storage_build/").join(p);
+    let base = PathBuf::from("/rspack_test/storage/test_storage_dev/").join(p);
     (base.join("cache"), base.join("temp"))
   }
 
@@ -31,7 +31,7 @@ mod test_storage_build {
       root: root.into(),
       temp_root: temp_root.into(),
       fs,
-      bucket_size: 10,
+      bucket_size: 1,
       pack_size: 200,
       expire: 7 * 24 * 60 * 60 * 1000,
       clean: true,
@@ -40,7 +40,7 @@ mod test_storage_build {
     }
   }
 
-  async fn test_initial_build(
+  async fn test_initial_dev(
     root: &Utf8PathBuf,
     fs: Arc<dyn FileSystem>,
     options: PackStorageOptions,
@@ -55,69 +55,83 @@ mod test_storage_build {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    let rx = storage.trigger_save()?;
-    rx.await.expect("should save")?;
+    storage.trigger_save()?.await.expect("should save")?;
+
+    for i in 0..100 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("new_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    storage.trigger_save()?.await.expect("should save")?;
+
+    for i in 100..200 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("new_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    storage.trigger_save()?.await.expect("should save")?;
+
+    for i in 200..300 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("new_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    storage.trigger_save()?.await.expect("should save")?;
+
+    for i in 300..400 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("new_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    storage.trigger_save()?.await.expect("should save")?;
+
+    for i in 400..500 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("new_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    storage.trigger_save()?.await.expect("should save")?;
+
+    for i in 500..600 {
+      storage.set(
+        "test_scope",
+        format!("key_{:0>3}", i).as_bytes().to_vec(),
+        format!("new_{:0>3}", i).as_bytes().to_vec(),
+      );
+    }
+    storage.trigger_save()?.await.expect("should save")?;
+
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())
   }
 
-  async fn test_recovery_modify(
-    root: &Utf8PathBuf,
-    fs: Arc<dyn FileSystem>,
-    options: PackStorageOptions,
-  ) -> Result<()> {
+  async fn test_recovery_modify(options: PackStorageOptions) -> Result<()> {
     let storage = PackStorage::new(options);
     let data = storage.load("test_scope").await?;
     assert_eq!(data.len(), 1000);
-    storage.set(
-      "test_scope",
-      format!("key_{:0>3}", 222).as_bytes().to_vec(),
-      format!("new_{:0>3}", 222).as_bytes().to_vec(),
-    );
-    storage.remove("test_scope", format!("key_{:0>3}", 333).as_bytes().as_ref());
-    let rx = storage.trigger_save()?;
-    rx.await.expect("should save")?;
-    assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
-    Ok(())
-  }
-
-  async fn test_recovery_final(
-    _root: &Utf8PathBuf,
-    _fs: Arc<dyn FileSystem>,
-    options: PackStorageOptions,
-  ) -> Result<()> {
-    let storage = PackStorage::new(options);
-    let data = storage
-      .load("test_scope")
-      .await?
-      .into_iter()
-      .map(|(k, v)| {
-        (
-          String::from_utf8(k.to_vec()).expect("should be utf8"),
-          String::from_utf8(v.to_vec()).expect("should be utf8"),
-        )
-      })
-      .collect::<HashMap<_, _>>();
-    assert_eq!(data.len(), 999);
-    assert_eq!(
-      *data
-        .get(&format!("key_{:0>3}", 222))
-        .expect("should get modified value"),
-      format!("new_{:0>3}", 222)
-    );
     Ok(())
   }
 
   #[tokio::test]
   #[cfg_attr(miri, ignore)]
-  async fn test_build() {
+  async fn test_dev() {
     let cases = [
       (
-        get_native_path("test_build_native"),
+        get_native_path("test_dev_native"),
         Arc::new(BridgeFileSystem(Arc::new(NativeFileSystem {}))),
       ),
       (
-        get_memory_path("test_build_memory"),
+        get_memory_path("test_dev_memory"),
         Arc::new(BridgeFileSystem(Arc::new(MemoryFileSystem::default()))),
       ),
     ];
@@ -131,7 +145,7 @@ mod test_storage_build {
         .await
         .expect("should remove temp root");
 
-      let _ = test_initial_build(
+      let _ = test_initial_dev(
         &root.join(&version),
         fs.clone(),
         create_pack_options(&root, &temp_root, &version, fs.clone()),
@@ -139,21 +153,9 @@ mod test_storage_build {
       .await
       .map_err(|e| panic!("{}", e));
 
-      let _ = test_recovery_modify(
-        &root.join(&version),
-        fs.clone(),
-        create_pack_options(&root, &temp_root, &version, fs.clone()),
-      )
-      .await
-      .map_err(|e| panic!("{}", e));
-
-      let _ = test_recovery_final(
-        &root.join(&version),
-        fs.clone(),
-        create_pack_options(&root, &temp_root, &version, fs.clone()),
-      )
-      .await
-      .map_err(|e| panic!("{}", e));
+      let _ = test_recovery_modify(create_pack_options(&root, &temp_root, &version, fs.clone()))
+        .await
+        .map_err(|e| panic!("{}", e));
     }
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

> RFC: https://github.com/web-infra-dev/rspack/discussions/8646

In the previous design, there would be a complete backup of the storage data items in the memory to ensure that the incremental data could be updated correctly, and then look for an opportunity to synchronize to the disk. Even if the synchronization failed, no rollback operation was needed.

However, this would lead to a long-term occupation of memory, increasing the overall memory overhead by 20%~30%. But if these memories were released directly, a large number of files would need to be read again in the next update for reasonable packing. Therefore, the concept of generations (similar to the mem cache of webpack) was introduced.

Each storage update would increase the generation, which usually occurred at the end of a compilation. For each data item, the generation in which it was produced would be retained, and the generation of the data pack would be the maximum value of the generations of all the data in this pack. After the data in a data pack changed, the data would be poured out of the pack. At this time, for the poured data and the changed data, since they must be written to the file, they could be sorted by generation at this time, and the data generated earlier would be placed in a pack together, so that they were less likely to be modified.

For the data packs that were not modified in the memory and were generated recently (determined by `fresh_generation`), they could also be poured and added to the optimization to improve the effect. If the generation of the data packs was quite different from the current one (determined by `release_generation`), it meant that this data pack had not been modified recently and could be released from the memory. But only the contents of the data items in these packs would be released, not the keys of the data items in the packs. When the data item in the package was modified, the file would need to be read again to obtain the contents of the pack again, and this would trigger file reading. However, since the generation was only detected and the data was released after the file was clearly written, reading the file was usually reliable.

---
> generated by copilot

This pull request introduces several changes to the persistent storage and pack management system to support generation tracking and improve asynchronous operations. The most important changes include adding generation tracking to various structures, updating asynchronous handling in `ScopeManager`, and modifying the pack strategy interfaces.

### Generation Tracking Enhancements:
* [`crates/rspack_core/src/cache/persistent/storage/mod.rs`](diffhunk://#diff-fc358700a45834149b1a49449a1a243c076e8f9399a5bc6fb43e0f225b987ebbR35-R36): Added `fresh_generation` and `release_generation` options to `create_storage`.
* [`crates/rspack_storage/src/pack/data/meta.rs`](diffhunk://#diff-2a74a786f96b99d0dea97760c878ab13e0bb3e6f9fe022e4d65537e47c046e6bR14): Added `generation` field to `PackFileMeta` and `ScopeMeta` structs. [[1]](diffhunk://#diff-2a74a786f96b99d0dea97760c878ab13e0bb3e6f9fe022e4d65537e47c046e6bR14) [[2]](diffhunk://#diff-2a74a786f96b99d0dea97760c878ab13e0bb3e6f9fe022e4d65537e47c046e6bR56)
* [`crates/rspack_storage/src/pack/data/pack.rs`](diffhunk://#diff-84f3d196004f36c16a2e22edef733a608ea2abf13d1282776e81687e0aac9c77R9): Introduced `PackGenerations` type and updated `Pack` struct to include `generations`. Added `release` and `is_released` methods to `PackContentsState`. [[1]](diffhunk://#diff-84f3d196004f36c16a2e22edef733a608ea2abf13d1282776e81687e0aac9c77R9) [[2]](diffhunk://#diff-84f3d196004f36c16a2e22edef733a608ea2abf13d1282776e81687e0aac9c77R50) [[3]](diffhunk://#diff-84f3d196004f36c16a2e22edef733a608ea2abf13d1282776e81687e0aac9c77R80-R93) [[4]](diffhunk://#diff-84f3d196004f36c16a2e22edef733a608ea2abf13d1282776e81687e0aac9c77R102-R127)

### Asynchronous Handling:
* [`crates/rspack_storage/src/pack/manager/mod.rs`](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L60-R60): Converted `update_scopes` and `save_scopes` functions to asynchronous. Modified `ScopeManager` to await `update_scopes`. [[1]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L60-R60) [[2]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L207-R207) [[3]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4R223) [[4]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L236-R240) [[5]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L253-R272) [[6]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L278-R285)

### Pack Strategy Interface Updates:
* [`crates/rspack_storage/src/pack/strategy/mod.rs`](diffhunk://#diff-23bfa5644cdeabd92730b56d7fc74602d04ee4acda4223ab94aadb026f1d9951L40-R76): Updated `PackReadStrategy` and `PackWriteStrategy` interfaces to handle generations. Added `optimize_scope` method to `ScopeWriteStrategy`. [[1]](diffhunk://#diff-23bfa5644cdeabd92730b56d7fc74602d04ee4acda4223ab94aadb026f1d9951L40-R76) [[2]](diffhunk://#diff-23bfa5644cdeabd92730b56d7fc74602d04ee4acda4223ab94aadb026f1d9951L97-R113)
* [`crates/rspack_storage/src/pack/strategy/split/mod.rs`](diffhunk://#diff-71fc8ce3833c81075c48d66ac687350a4871c73661d480a198e15c874632b365R35-R52): Modified `SplitPackStrategy` to include `fresh_generation` and `release_generation`. Updated `clean_unused` to `clean`. [[1]](diffhunk://#diff-71fc8ce3833c81075c48d66ac687350a4871c73661d480a198e15c874632b365R35-R52) [[2]](diffhunk://#diff-71fc8ce3833c81075c48d66ac687350a4871c73661d480a198e15c874632b365L127-R137)
* [`crates/rspack_storage/src/pack/strategy/split/read_pack.rs`](diffhunk://#diff-8bca9fb7e01414bff743e611437aeb5fa6785cd2d7f070cd14aa8e49c5c00a62L10-R11): Enhanced `read_pack_contents` to support reading generations. [[1]](diffhunk://#diff-8bca9fb7e01414bff743e611437aeb5fa6785cd2d7f070cd14aa8e49c5c00a62L10-R11) [[2]](diffhunk://#diff-8bca9fb7e01414bff743e611437aeb5fa6785cd2d7f070cd14aa8e49c5c00a62R24) [[3]](diffhunk://#diff-8bca9fb7e01414bff743e611437aeb5fa6785cd2d7f070cd14aa8e49c5c00a62R40-R53) [[4]](diffhunk://#diff-8bca9fb7e01414bff743e611437aeb5fa6785cd2d7f070cd14aa8e49c5c00a62R91-R116)

These changes collectively enhance the functionality and performance of the storage system by introducing generation tracking and improving asynchronous operations.


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
