### PR TITLE
test: add cache test cases

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -107,6 +107,33 @@ export class BuiltinProcessor<T extends ECompilerType> extends SnapshotProcessor
 }
 
 // @public (undocumented)
+export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
+    constructor(_cacheOptions: ICacheProcessorOptions<T>);
+    // (undocumented)
+    afterAll(context: ITestContext): Promise<void>;
+    // (undocumented)
+    protected _cacheOptions: ICacheProcessorOptions<T>;
+    // (undocumented)
+    static defaultOptions<T extends ECompilerType>(this: CacheProcessor<T>, context: ITestContext): TCompilerOptions<T>;
+    // (undocumented)
+    static findBundle<T extends ECompilerType>(this: CacheProcessor<T>, context: ITestContext): string[];
+    // (undocumented)
+    static overrideOptions<T extends ECompilerType>(this: CacheProcessor<T>, context: ITestContext, options: TCompilerOptions<T>): void;
+    // (undocumented)
+    run(env: ITestEnv, context: ITestContext): Promise<void>;
+    // (undocumented)
+    protected runner: ITestRunner | null;
+    // (undocumented)
+    protected updateOptions: TUpdateOptions;
+}
+
+// @public (undocumented)
+export class CacheRunnerFactory<T extends ECompilerType> extends BasicRunnerFactory<T> {
+    // (undocumented)
+    protected createRunner(file: string, stats: TCompilerStatsCompilation<T>, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
+}
+
+// @public (undocumented)
 export function checkChunkModules(statsJson: any, chunkModulesMap: any, strict?: boolean): boolean;
 
 // @public (undocumented)
@@ -152,6 +179,9 @@ export class ConfigProcessor<T extends ECompilerType> extends MultiTaskProcessor
 
 // @public (undocumented)
 export function createBuiltinCase(name: string, src: string, dist: string): void;
+
+// @public (undocumented)
+export function createCacheCase(name: string, src: string, dist: string, target: TCompilerOptions<ECompilerType.Rspack>["target"]): void;
 
 // @public (undocumented)
 export function createCompilerCase(name: string, src: string, dist: string, testConfig: string): void;
@@ -568,6 +598,12 @@ export interface IBasicRunnerOptions<T extends ECompilerType> {
 
 // @public (undocumented)
 export interface IBuiltinProcessorOptions<T extends ECompilerType> extends Omit<ISnapshotProcessorOptions<T>, "runable"> {
+}
+
+// @public (undocumented)
+export interface ICacheProcessorOptions<T extends ECompilerType> extends Omit<IBasicProcessorOptions<T>, "runable"> {
+    // (undocumented)
+    target: TCompilerOptions<T>["target"];
 }
 
 // @public (undocumented)

--- a/packages/rspack-test-tools/src/case/cache.ts
+++ b/packages/rspack-test-tools/src/case/cache.ts
@@ -1,0 +1,44 @@
+import { CacheProcessor } from "../processor/cache";
+import { CacheRunnerFactory } from "../runner";
+import { BasicCaseCreator } from "../test/creator";
+import { ECompilerType, type TCompilerOptions } from "../type";
+
+type TTarget = TCompilerOptions<ECompilerType.Rspack>["target"];
+
+const creators: Map<
+	TTarget,
+	BasicCaseCreator<ECompilerType.Rspack>
+> = new Map();
+
+function getCreator(target: TTarget) {
+	if (!creators.has(target)) {
+		creators.set(
+			target,
+			new BasicCaseCreator({
+				clean: true,
+				describe: true,
+				target,
+				steps: ({ name, target }) => [
+					new CacheProcessor({
+						name,
+						target: target as TTarget,
+						compilerType: ECompilerType.Rspack,
+						configFiles: ["rspack.config.js", "webpack.config.js"]
+					})
+				],
+				runner: CacheRunnerFactory
+			})
+		);
+	}
+	return creators.get(target)!;
+}
+
+export function createCacheCase(
+	name: string,
+	src: string,
+	dist: string,
+	target: TCompilerOptions<ECompilerType.Rspack>["target"]
+) {
+	const creator = getCreator(target);
+	creator.create(name, src, dist);
+}

--- a/packages/rspack-test-tools/src/case/index.ts
+++ b/packages/rspack-test-tools/src/case/index.ts
@@ -15,3 +15,4 @@ export * from "./stats-output";
 export * from "./treeshaking";
 export * from "./watch";
 export * from "./new-incremental";
+export * from "./cache";

--- a/packages/rspack-test-tools/src/helper/loaders/hot-update.ts
+++ b/packages/rspack-test-tools/src/helper/loaders/hot-update.ts
@@ -1,0 +1,38 @@
+import { TUpdateOptions } from "../../type";
+
+export default function (this: any, c: string) {
+	let content = c;
+	if (content.includes("NEXT_HMR")) {
+		content = `
+			${content}
+			let __hmr_children__ = [...module.children];
+			let __hmr_used_exports__ = __hmr_children__.reduce((res, child) => {
+				res[child] = __webpack_module_cache__[child].exports;
+				return res;
+			}, {});
+			module.hot.accept(__hmr_children__, () => {
+				__hmr_children__.forEach((child) => {
+					const reexports = __webpack_require__(child);
+					for (let key in reexports) {
+						Object.defineProperty(__hmr_used_exports__[child], key, {
+							configurable: true,
+							enumerable: true,
+							get: () => reexports[key]
+						});
+					}
+				});
+			});
+		`;
+	}
+	content = content.replace(/NEXT_HMR/g, "NEXT_HMR.bind(null, module)");
+
+	const options: TUpdateOptions = this.getOptions();
+	const items = content.split(/---+\r?\n/g);
+	if (items.length <= 1) {
+		return content;
+	}
+
+	options.totalUpdates = Math.max(options.totalUpdates, items.length);
+	options.changedFiles.push(this.resourcePath);
+	return items[options.updateIndex];
+}

--- a/packages/rspack-test-tools/src/helper/loaders/hot-update.ts
+++ b/packages/rspack-test-tools/src/helper/loaders/hot-update.ts
@@ -1,4 +1,4 @@
-import { TUpdateOptions } from "../../type";
+import type { TUpdateOptions } from "../../type";
 
 export default function (this: any, c: string) {
 	let content = c;

--- a/packages/rspack-test-tools/src/helper/plugins/hot-update.ts
+++ b/packages/rspack-test-tools/src/helper/plugins/hot-update.ts
@@ -1,5 +1,5 @@
-import { Compiler } from "@rspack/core";
-import { TUpdateOptions } from "../../type";
+import type { Compiler } from "@rspack/core";
+import type { TUpdateOptions } from "../../type";
 
 export class TestHotUpdatePlugin {
 	constructor(private updateOptions: TUpdateOptions) {}

--- a/packages/rspack-test-tools/src/helper/plugins/hot-update.ts
+++ b/packages/rspack-test-tools/src/helper/plugins/hot-update.ts
@@ -1,0 +1,40 @@
+import { Compiler } from "@rspack/core";
+import { TUpdateOptions } from "../../type";
+
+export class TestHotUpdatePlugin {
+	constructor(private updateOptions: TUpdateOptions) {}
+	apply(compiler: Compiler) {
+		compiler.hooks.beforeRun.tap("TestHotUpdatePlugin", () => {
+			compiler.modifiedFiles = new Set(this.updateOptions.changedFiles);
+			this.updateOptions.changedFiles = [];
+		});
+
+		compiler.hooks.compilation.tap("TestHotUpdatePlugin", compilation => {
+			compilation.hooks.additionalTreeRuntimeRequirements.tap(
+				"HMR_TEST_PLUGIN",
+				(_chunk: any, set: any) => {
+					set.add(compiler.webpack.RuntimeGlobals.moduleCache);
+				}
+			);
+			compilation.hooks.runtimeModule.tap(
+				"HMR_TEST_PLUGIN",
+				(module: any, _set: any) => {
+					if (module.constructorName === "DefinePropertyGettersRuntimeModule") {
+						module.source.source = Buffer.from(
+							`
+										__webpack_require__.d = function (exports, definition) {
+												for (var key in definition) {
+														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
+														}
+												}
+										};
+										`,
+							"utf-8"
+						);
+					}
+				}
+			);
+		});
+	}
+}

--- a/packages/rspack-test-tools/src/helper/plugins/index.ts
+++ b/packages/rspack-test-tools/src/helper/plugins/index.ts
@@ -1,0 +1,1 @@
+export * from "./hot-update";

--- a/packages/rspack-test-tools/src/processor/cache.ts
+++ b/packages/rspack-test-tools/src/processor/cache.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { rspack } from "@rspack/core";
 
+import { TestHotUpdatePlugin } from "../helper/plugins";
 import {
 	ECompilerType,
 	type ITestContext,
@@ -10,7 +11,6 @@ import {
 	type TUpdateOptions
 } from "../type";
 import { BasicProcessor, type IBasicProcessorOptions } from "./basic";
-import { TestHotUpdatePlugin } from "../helper/plugins";
 
 export interface ICacheProcessorOptions<T extends ECompilerType>
 	extends Omit<IBasicProcessorOptions<T>, "runable"> {

--- a/packages/rspack-test-tools/src/processor/cache.ts
+++ b/packages/rspack-test-tools/src/processor/cache.ts
@@ -1,0 +1,164 @@
+import path from "node:path";
+import { rspack } from "@rspack/core";
+
+import {
+	ECompilerType,
+	type ITestContext,
+	type ITestEnv,
+	type ITestRunner,
+	type TCompilerOptions,
+	type TUpdateOptions
+} from "../type";
+import { BasicProcessor, type IBasicProcessorOptions } from "./basic";
+import { TestHotUpdatePlugin } from "../helper/plugins";
+
+export interface ICacheProcessorOptions<T extends ECompilerType>
+	extends Omit<IBasicProcessorOptions<T>, "runable"> {
+	target: TCompilerOptions<T>["target"];
+}
+
+export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
+	protected updateOptions: TUpdateOptions;
+	protected runner: ITestRunner | null = null;
+
+	constructor(protected _cacheOptions: ICacheProcessorOptions<T>) {
+		const fakeUpdateLoaderOptions: TUpdateOptions = {
+			updateIndex: 0,
+			totalUpdates: 1,
+			changedFiles: []
+		};
+		super({
+			defaultOptions: CacheProcessor.defaultOptions,
+			overrideOptions: CacheProcessor.overrideOptions,
+			findBundle: CacheProcessor.findBundle,
+			runable: true,
+			..._cacheOptions
+		});
+		this.updateOptions = fakeUpdateLoaderOptions;
+	}
+
+	async run(env: ITestEnv, context: ITestContext) {
+		context.setValue(
+			this._options.name,
+			"hotUpdateContext",
+			this.updateOptions
+		);
+		await super.run(env, context);
+	}
+
+	static findBundle<T extends ECompilerType>(
+		this: CacheProcessor<T>,
+		context: ITestContext
+	): string[] {
+		const files: string[] = [];
+		const prefiles: string[] = [];
+		const compiler = context.getCompiler(this._cacheOptions.name);
+		if (!compiler) throw new Error("Compiler should exists when find bundle");
+		const stats = compiler.getStats();
+		if (!stats) throw new Error("Stats should exists when find bundle");
+		const info = stats.toJson({ all: false, entrypoints: true });
+		if (
+			this._cacheOptions.target === "web" ||
+			this._cacheOptions.target === "webworker"
+		) {
+			for (const file of info.entrypoints!.main.assets!) {
+				if (file.name.endsWith(".js")) {
+					files.push(file.name);
+				} else {
+					prefiles.push(file.name);
+				}
+			}
+		} else {
+			const assets = info.entrypoints!.main.assets!.filter(s =>
+				s.name.endsWith(".js")
+			);
+			files.push(assets[assets.length - 1].name);
+		}
+		return [...prefiles, ...files];
+	}
+
+	async afterAll(context: ITestContext) {
+		await super.afterAll(context);
+		if (
+			this.updateOptions.updateIndex + 1 !==
+			this.updateOptions.totalUpdates
+		) {
+			throw new Error(
+				`Should run all hot steps (${this.updateOptions.updateIndex + 1} / ${this.updateOptions.totalUpdates}): ${this._options.name}`
+			);
+		}
+	}
+
+	static defaultOptions<T extends ECompilerType>(
+		this: CacheProcessor<T>,
+		context: ITestContext
+	): TCompilerOptions<T> {
+		const options = {
+			context: context.getSource(),
+			mode: "development",
+			devtool: false,
+			output: {
+				path: context.getDist(),
+				filename: "bundle.js",
+				chunkFilename: "[name].chunk.[fullhash].js",
+				publicPath: "https://test.cases/path/",
+				library: { type: "commonjs2" }
+			},
+			optimization: {
+				moduleIds: "named"
+			},
+			target: this._cacheOptions.target,
+			experiments: {
+				css: true,
+				rspackFuture: {
+					bundlerInfo: {
+						force: false
+					}
+				}
+			}
+		} as TCompilerOptions<T>;
+
+		if (this._cacheOptions.compilerType === ECompilerType.Rspack) {
+			options.plugins ??= [];
+			(options as TCompilerOptions<ECompilerType.Rspack>).plugins!.push(
+				new rspack.HotModuleReplacementPlugin()
+			);
+		}
+
+		return options;
+	}
+
+	static overrideOptions<T extends ECompilerType>(
+		this: CacheProcessor<T>,
+		context: ITestContext,
+		options: TCompilerOptions<T>
+	): void {
+		if (!options.entry) {
+			options.entry = "./index.js";
+		}
+
+		options.module ??= {};
+		for (const cssModuleType of ["css/auto", "css/module", "css"] as const) {
+			options.module!.generator ??= {};
+			options.module!.generator[cssModuleType] ??= {};
+			options.module!.generator[cssModuleType]!.exportsOnly ??=
+				this._cacheOptions.target === "async-node";
+		}
+		options.module.rules ??= [];
+		options.module.rules.push({
+			test: /\.(js|css|json)/,
+			use: [
+				{
+					loader: path.resolve(__dirname, "../helper/loaders/hot-update.js"),
+					options: this.updateOptions
+				}
+			]
+		});
+		if (this._cacheOptions.compilerType === ECompilerType.Rspack) {
+			options.plugins ??= [];
+			(options as TCompilerOptions<ECompilerType.Rspack>).plugins!.push(
+				new TestHotUpdatePlugin(this.updateOptions)
+			);
+		}
+	}
+}

--- a/packages/rspack-test-tools/src/processor/index.ts
+++ b/packages/rspack-test-tools/src/processor/index.ts
@@ -17,3 +17,4 @@ export * from "./snapshot";
 export * from "./stats";
 export * from "./stats-api";
 export * from "./watch";
+export * from "./cache";

--- a/packages/rspack-test-tools/src/runner/cache.ts
+++ b/packages/rspack-test-tools/src/runner/cache.ts
@@ -1,0 +1,150 @@
+import type { StatsCompilation } from "@rspack/core";
+
+import checkArrayExpectation from "../helper/legacy/checkArrayExpectation";
+import {
+	type ECompilerType,
+	EDocumentType,
+	type ITestEnv,
+	type ITestRunner,
+	type TCompilerOptions,
+	type TCompilerStatsCompilation,
+	type TUpdateOptions
+} from "../type";
+import { BasicRunnerFactory } from "./basic";
+import { WebRunner } from "./runner/web";
+
+export class CacheRunnerFactory<
+	T extends ECompilerType
+> extends BasicRunnerFactory<T> {
+	protected createRunner(
+		file: string,
+		stats: TCompilerStatsCompilation<T>,
+		compilerOptions: TCompilerOptions<T>,
+		env: ITestEnv
+	): ITestRunner {
+		const compiler = this.context.getCompiler(this.name);
+		let compilerIndex = 0;
+		const testConfig = this.context.getTestConfig();
+		const source = this.context.getSource();
+		const dist = this.context.getDist();
+		const hotUpdateContext = this.context.getValue<TUpdateOptions>(
+			this.name,
+			"hotUpdateContext"
+		)!;
+		const getWebRunner = () => {
+			return new WebRunner({
+				dom:
+					this.context.getValue(this.name, "documentType") ||
+					EDocumentType.JSDOM,
+				env,
+				stats,
+				name: this.name,
+				runInNewContext: false,
+				testConfig: {
+					...testConfig,
+					moduleScope(ms, stats) {
+						const moduleScope =
+							typeof testConfig.moduleScope === "function"
+								? testConfig.moduleScope(ms, stats)
+								: ms;
+
+						moduleScope.COMPILER_INDEX = compilerIndex;
+						moduleScope.NEXT_HMR = nextHmr;
+						moduleScope.NEXT_START = nextStart;
+						return moduleScope;
+					}
+				},
+				source,
+				dist,
+				compilerOptions
+			});
+		};
+		const nextHmr = async (
+			m: any,
+			options?: any
+		): Promise<TCompilerStatsCompilation<T>> => {
+			hotUpdateContext.updateIndex++;
+			const stats = await compiler.build();
+			if (!stats) {
+				throw new Error("Should generate stats during build");
+			}
+			const jsonStats = stats.toJson({
+				// errorDetails: true
+			});
+
+			checkArrayExpectation(
+				source,
+				jsonStats,
+				"error",
+				`errors${hotUpdateContext.updateIndex}`,
+				"Error",
+				function (err: any) {
+					throw err;
+				}
+			);
+			checkArrayExpectation(
+				source,
+				jsonStats,
+				"warning",
+				`warnings${hotUpdateContext.updateIndex}`,
+				"Warning",
+				function (err: any) {
+					throw err;
+				}
+			);
+
+			const updatedModules = await m.hot.check(options || true);
+			if (!updatedModules) {
+				throw new Error("No update available");
+			}
+
+			return jsonStats as StatsCompilation;
+		};
+
+		const nextStart = async (): Promise<TCompilerStatsCompilation<T>> => {
+			await compiler.close();
+			compiler.createCompiler();
+
+			hotUpdateContext.changedFiles = [];
+			hotUpdateContext.updateIndex++;
+			const stats = await compiler.build();
+			if (!stats) {
+				throw new Error("Should generate stats during build");
+			}
+			const jsonStats = stats.toJson({
+				// errorDetails: true
+			});
+
+			checkArrayExpectation(
+				source,
+				jsonStats,
+				"error",
+				`errors${hotUpdateContext.updateIndex}`,
+				"Error",
+				function (err: any) {
+					throw err;
+				}
+			);
+			checkArrayExpectation(
+				source,
+				jsonStats,
+				"warning",
+				`warnings${hotUpdateContext.updateIndex}`,
+				"Warning",
+				function (err: any) {
+					throw err;
+				}
+			);
+			env.it(
+				`NEXT_START run with compilerIndex==${compilerIndex + 1}`,
+				async () => {
+					compilerIndex++;
+					return getWebRunner().run(file);
+				}
+			);
+			return jsonStats as StatsCompilation;
+		};
+
+		return getWebRunner();
+	}
+}

--- a/packages/rspack-test-tools/src/runner/index.ts
+++ b/packages/rspack-test-tools/src/runner/index.ts
@@ -6,3 +6,4 @@ export * from "./normal";
 export * from "./runner";
 export * from "./type";
 export * from "./watch";
+export * from "./cache";

--- a/packages/rspack-test-tools/tests/Cache.test.js
+++ b/packages/rspack-test-tools/tests/Cache.test.js
@@ -1,0 +1,22 @@
+// Need to run some webpack-test
+process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
+
+const path = require("path");
+const { describeByWalk, createCacheCase } = require("../dist");
+
+function v(name) {
+	return path.join(__dirname, `cache ${name}`);
+}
+
+// Run tests rspack-test-tools/tests/cacheCases in target async-node
+describeByWalk(
+	v("hot async-node"),
+	(name, src, dist) => {
+		createCacheCase(name, src, dist, "async-node");
+	},
+	{
+		source: path.resolve(__dirname, "./cacheCases"),
+		dist: path.resolve(__dirname, `./js/cache/async-node`),
+		exclude: [/^css$/]
+	}
+);

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/file.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/file.js
@@ -1,0 +1,3 @@
+export default 1;
+---
+export default 2;

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/file.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/file.js
@@ -1,3 +1,5 @@
 export default 1;
 ---
 export default 2;
+---
+export default 3;

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/index.js
@@ -3,10 +3,12 @@ import value from "./file";
 it("should store and resume asset parser and generator states", async () => {
 	if (COMPILER_INDEX == 0) {
 		expect(value).toBe(1);
+		await NEXT_HMR();
+		expect(value).toBe(2);
 		await NEXT_START();
 	}
 	if (COMPILER_INDEX == 1) {
-		expect(value).toBe(2);
+		expect(value).toBe(3);
 	}
 
 	//		expect(value).toBe(1);

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/index.js
@@ -1,0 +1,19 @@
+import value from "./file";
+
+it("should store and resume asset parser and generator states", async () => {
+	if (COMPILER_INDEX == 0) {
+		expect(value).toBe(1);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(value).toBe(2);
+	}
+
+	//		expect(value).toBe(1);
+	//		await NEXT_START();
+	//	}
+	//	if (COMPILER_INDEX == 1) {
+
+	//		expect(value).toBe(2);
+	//	}
+});

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/rspack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR will add `cacheCases` to test persistent cache, and it contains some new built-in test methods and variables:

* `NEXT_HMR` will run with hmr update, and it works same as `NEXT(require("../../update.js")(done))` in hot cases.
* `NEXT_START` will generate a new compiler to rebuild, and rerun the assets code.
* `COMPILER_INDEX` is used to distinguish different compilers.

see the `basic` test case for more info.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
