### PR TITLE
perf(cli): remove Node.js semver checker

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -39,7 +39,6 @@
     "exit-hook": "^4.0.0",
     "interpret": "^3.1.1",
     "rechoir": "^0.8.0",
-    "semver": "^7.6.2",
     "webpack-bundle-analyzer": "4.6.1",
     "yargs": "17.6.2"
   },
@@ -48,7 +47,6 @@
     "@rspack/core": "workspace:*",
     "@types/interpret": "^1.1.3",
     "@types/rechoir": "^0.6.1",
-    "@types/semver": "^7.5.6",
     "@types/webpack-bundle-analyzer": "^4.6.0",
     "@types/yargs": "17.0.33",
     "concat-stream": "^2.0.0",

--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -13,7 +13,6 @@ import {
 } from "@rspack/core";
 import * as rspackCore from "@rspack/core";
 import { createColors, isColorSupported } from "colorette";
-import semver from "semver";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { BuildCommand } from "./commands/build";
@@ -100,12 +99,6 @@ export class RspackCLI {
 		};
 	}
 	async run(argv: string[]) {
-		if (semver.lt(semver.clean(process.version)!, "14.0.0")) {
-			this.getLogger().warn(
-				`Minimum recommended Node.js version is 14.0.0, current version is ${process.version}`
-			);
-		}
-
 		this.program.showHelpOnFail(false);
 		this.program.usage("[options]");
 		this.program.scriptName("rspack");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,9 +385,6 @@ importers:
       rechoir:
         specifier: ^0.8.0
         version: 0.8.0
-      semver:
-        specifier: ^7.6.2
-        version: 7.6.3
       webpack-bundle-analyzer:
         specifier: 4.6.1
         version: 4.6.1
@@ -407,9 +404,6 @@ importers:
       '@types/rechoir':
         specifier: ^0.6.1
         version: 0.6.4
-      '@types/semver':
-        specifier: ^7.5.6
-        version: 7.5.8
       '@types/webpack-bundle-analyzer':
         specifier: ^4.6.0
         version: 4.7.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.94.0))


### PR DESCRIPTION
## Summary

Since Rspack already uses the `engines` filed to limit the minimal Node.js version, it seems unnecessary to run `semver` to check the Node.js version at runtime.

Removing the `semver()` calls can make Rspack CLI 30~40ms faster in all cases.

<img width="811" alt="Screenshot 2024-12-26 at 17 42 50" src="https://github.com/user-attachments/assets/69812ad0-ced3-4923-8c86-c663c00299ed" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
