### PR TITLE
perf(cli): lazy import rechoir and interpret

### DIFF
--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -1,11 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { MultiRspackOptions, RspackOptions } from "@rspack/core";
-import interpret from "interpret";
-import rechoir from "rechoir";
-
 import type { RspackCLIOptions } from "../types";
-import crossImport from "./crossImport";
+import crossImport, { dynamicImport } from "./crossImport";
 import findConfig from "./findConfig";
 import isEsmFile from "./isEsmFile";
 import isTsFile from "./isTsFile";
@@ -17,20 +14,24 @@ interface RechoirError extends Error {
 
 const DEFAULT_CONFIG_NAME = "rspack.config" as const;
 
-const registerLoader = (configPath: string) => {
+const registerLoader = async (configPath: string) => {
 	const ext = path.extname(configPath);
 	// TODO implement good `.mts` support after https://github.com/gulpjs/rechoir/issues/43
 	// For ESM and `.mts` you need to use: 'NODE_OPTIONS="--loader ts-node/esm" rspack build --config ./rspack.config.mts'
 	if (isEsmFile(configPath) && isTsFile(configPath)) {
 		return;
 	}
+
+	const { default: interpret } = await dynamicImport("interpret");
 	const extensions = Object.fromEntries(
 		Object.entries(interpret.extensions).filter(([key]) => key === ext)
 	);
 	if (Object.keys(extensions).length === 0) {
 		throw new Error(`config file "${configPath}" is not supported.`);
 	}
+
 	try {
+		const { default: rechoir } = await dynamicImport("rechoir");
 		rechoir.prepare(extensions, configPath);
 	} catch (error) {
 		const failures = (error as RechoirError)?.failures;
@@ -60,12 +61,17 @@ export async function loadRspackConfig(
 		if (!fs.existsSync(configPath)) {
 			throw new Error(`config file "${configPath}" not found.`);
 		}
-		isTsFile(configPath) && registerLoader(configPath);
+		if (isTsFile(configPath)) {
+			await registerLoader(configPath);
+		}
 		return crossImport(configPath, cwd);
 	}
+
 	const defaultConfig = findConfig(path.resolve(cwd, DEFAULT_CONFIG_NAME));
 	if (defaultConfig) {
-		isTsFile(defaultConfig) && registerLoader(defaultConfig);
+		if (isTsFile(defaultConfig)) {
+			await registerLoader(defaultConfig);
+		}
 		return crossImport(defaultConfig, cwd);
 	}
 	return {};


### PR DESCRIPTION
## Summary

`rechoir` and `interpret` are only used when loading `rspack.config.ts` or `rspack.config.mts`.

Lazy importing them can make Rspack CLI 20ms faster in most cases.

<img width="813" alt="Screenshot 2024-12-26 at 17 49 04" src="https://github.com/user-attachments/assets/e488afee-980e-4809-87c7-ac01684c6f44" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
