### PR TITLE
feat: initialize compiler options builder

### DIFF
--- a/crates/rspack_core/src/options/compiler_options_builder.rs
+++ b/crates/rspack_core/src/options/compiler_options_builder.rs
@@ -1,0 +1,1383 @@
+use indexmap::IndexMap;
+use rspack_hash::{HashDigest, HashFunction, HashSalt};
+use rspack_paths::{AssertUtf8, Utf8PathBuf};
+use rspack_regex::RspackRegex;
+use rustc_hash::FxHashMap as HashMap;
+
+use super::{
+  get_targets_properties, AssetParserDataUrl, AssetParserDataUrlOptions, AssetParserOptions,
+  ByDependency, CacheOptions, ChunkLoading, ChunkLoadingType, CleanOptions, CompilerOptions,
+  Context, CrossOriginLoading, CssAutoGeneratorOptions, CssAutoParserOptions, CssExportsConvention,
+  CssGeneratorOptions, CssModuleGeneratorOptions, CssModuleParserOptions, CssParserOptions,
+  DynamicImportMode, EntryDescription, Environment, ExperimentCacheOptions, Experiments, Filename,
+  FilenameTemplate, GeneratorOptions, GeneratorOptionsMap, JavascriptParserOptions,
+  JavascriptParserOrder, JavascriptParserUrl, LibraryName, LibraryNonUmdObject, LibraryOptions,
+  Mode, ModuleNoParseRules, ModuleOptions, ModuleRule, ModuleRuleEffect, OutputOptions,
+  ParserOptions, ParserOptionsMap, PathInfo, PublicPath, Resolve, RspackFuture, RuleSetCondition,
+  RuleSetLogicalConditions, Target, TargetProperties, TrustedTypes, WasmLoading, WasmLoadingType,
+};
+use crate::{incremental::IncrementalPasses, ModuleType};
+
+macro_rules! d {
+  ($o:expr, $v:expr) => {{
+    $o.unwrap_or($v)
+  }};
+}
+
+macro_rules! f {
+  ($o:expr, $v:expr) => {{
+    $o.unwrap_or_else($v)
+  }};
+}
+
+#[derive(Debug, Default)]
+pub struct CompilerOptionsBuilder {
+  target: Option<Target>,
+  entry: IndexMap<String, EntryDescription>,
+  context: Option<Context>,
+  cache: Option<CacheOptions>,
+  mode: Option<Mode>,
+  bail: Option<bool>,
+  experiments: Option<ExperimentsBuilder>,
+  module: Option<ModuleOptionsBuilder>,
+  output: Option<OutputOptionsBuilder>,
+}
+
+impl CompilerOptions {
+  pub fn builder() -> CompilerOptionsBuilder {
+    CompilerOptionsBuilder::default()
+  }
+}
+
+impl CompilerOptionsBuilder {
+  pub fn target(&mut self, target: Target) -> &mut Self {
+    self.target = Some(target);
+    self
+  }
+
+  pub fn entry(&mut self, entry_name: String, entry_description: EntryDescription) -> &mut Self {
+    self.entry.insert(entry_name, entry_description);
+    self
+  }
+
+  pub fn context<V>(&mut self, context: V) -> &mut Self
+  where
+    V: Into<Context>,
+  {
+    self.context = Some(context.into());
+    self
+  }
+
+  pub fn cache(&mut self, cache: CacheOptions) -> &mut Self {
+    self.cache = Some(cache);
+    self
+  }
+
+  pub fn mode(&mut self, mode: Mode) -> &mut Self {
+    self.mode = Some(mode);
+    self
+  }
+
+  pub fn bail(&mut self, bail: bool) -> &mut Self {
+    self.bail = Some(bail);
+    self
+  }
+
+  pub fn module<V>(&mut self, module: V) -> &mut Self
+  where
+    V: Into<ModuleOptionsBuilder>,
+  {
+    self.module = Some(module.into());
+    self
+  }
+
+  pub fn output<V>(&mut self, output: V) -> &mut Self
+  where
+    V: Into<OutputOptionsBuilder>,
+  {
+    self.output = Some(output.into());
+    self
+  }
+
+  pub fn experiments<V>(&mut self, experiments: V) -> &mut Self
+  where
+    V: Into<ExperimentsBuilder>,
+  {
+    self.experiments = Some(experiments.into());
+    self
+  }
+
+  pub fn build(&mut self) -> CompilerOptions {
+    let context = self.context.take().unwrap_or_else(|| {
+      std::env::current_dir()
+        .expect("`current_dir` should be available")
+        .assert_utf8()
+        .into()
+    });
+
+    // TODO: support browserlist default target
+    let target = f!(self.target.take(), || vec!["web".to_string()]);
+
+    let target_properties = get_targets_properties(&target, &context);
+    let development = matches!(self.mode, Some(Mode::Development));
+    let production = matches!(self.mode, Some(Mode::Production) | None);
+    let mode = d!(self.mode.take(), Mode::Production);
+
+    let bail = self.bail.unwrap_or(false);
+    let cache = d!(self.cache.take(), {
+      if development {
+        CacheOptions::Memory
+      } else {
+        CacheOptions::Disabled
+      }
+    });
+
+    let mut experiments = self.apply_experiments(development, production);
+    // Disable experiments cache if global cache is set to `Disabled`
+    if matches!(cache, CacheOptions::Disabled) {
+      experiments.cache = ExperimentCacheOptions::Disabled;
+    }
+
+    // TODO: support css
+    let css = true;
+    // TODO: support async web assembly
+    let async_web_assembly = false;
+    // TODO: support experiment output module
+    let output_module = Some(false);
+
+    let module = self.apply_module(async_web_assembly, css, Some(&target_properties));
+
+    // TODO: options
+    let entry = self.entry.clone();
+    let output = self.apply_output(
+      context.clone(),
+      output_module,
+      Some(&target_properties),
+      target.iter().any(|t| t.starts_with("browserslist")),
+      development,
+      &entry,
+      false,
+    );
+
+    CompilerOptions {
+      context,
+      output,
+      mode,
+      resolve: Default::default(),
+      resolve_loader: Default::default(),
+      module,
+      stats: Default::default(),
+      cache,
+      experiments,
+      node: Default::default(),
+      optimization: Default::default(),
+      profile: Default::default(),
+      amd: None,
+      bail,
+      __references: Default::default(),
+    }
+  }
+
+  fn apply_module(
+    &mut self,
+    async_web_assembly: bool,
+    css: bool,
+    target_properties: Option<&TargetProperties>,
+  ) -> ModuleOptions {
+    self
+      .module
+      .take()
+      .unwrap_or_else(ModuleOptions::builder)
+      .build(async_web_assembly, css, target_properties)
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  fn apply_output(
+    &mut self,
+    context: Context,
+    output_module: Option<bool>,
+    target_properties: Option<&TargetProperties>,
+    is_affected_by_browserslist: bool,
+    development: bool,
+    entry: &IndexMap<String, EntryDescription>,
+    future_defaults: bool,
+  ) -> OutputOptions {
+    self
+      .output
+      .take()
+      .unwrap_or_else(OutputOptions::builder)
+      .build(
+        context.clone(),
+        output_module,
+        target_properties,
+        is_affected_by_browserslist,
+        development,
+        entry,
+        future_defaults,
+      )
+  }
+
+  fn apply_experiments(&mut self, development: bool, production: bool) -> Experiments {
+    self
+      .experiments
+      .take()
+      .unwrap_or_else(Experiments::builder)
+      .build(development, production)
+  }
+
+  // fn apply_output()
+}
+
+#[derive(Debug, Default)]
+pub struct ModuleOptionsBuilder {
+  rules: Vec<ModuleRule>,
+  parser: Option<ParserOptionsMap>,
+  generator: Option<GeneratorOptionsMap>,
+  no_parse: Option<ModuleNoParseRules>,
+}
+
+impl ModuleOptions {
+  pub fn builder() -> ModuleOptionsBuilder {
+    ModuleOptionsBuilder::default()
+  }
+}
+
+impl ModuleOptionsBuilder {
+  pub fn rule(&mut self, rule: ModuleRule) -> &mut Self {
+    self.rules.push(rule);
+    self
+  }
+
+  pub fn rules(&mut self, mut rules: Vec<ModuleRule>) -> &mut Self {
+    self.rules.append(&mut rules);
+    self
+  }
+
+  pub fn parser(&mut self, parser: ParserOptionsMap) -> &mut Self {
+    match &mut self.parser {
+      Some(p) => p.extend(parser.clone()),
+      None => self.parser = Some(parser),
+    }
+    self
+  }
+
+  pub fn generator(&mut self, generator: GeneratorOptionsMap) -> &mut Self {
+    match &mut self.generator {
+      Some(g) => g.extend(generator.clone()),
+      None => self.generator = Some(generator),
+    }
+    self
+  }
+
+  pub fn no_parse(&mut self, no_parse: ModuleNoParseRules) -> &mut Self {
+    self.no_parse = Some(no_parse);
+    self
+  }
+
+  pub fn build(
+    &mut self,
+    async_web_assembly: bool,
+    css: bool,
+    target_properties: Option<&TargetProperties>,
+  ) -> ModuleOptions {
+    let parser = self.parser.get_or_insert(ParserOptionsMap::default());
+
+    if !parser.contains_key("asset") {
+      parser.insert(
+        "asset".to_string(),
+        ParserOptions::Asset(AssetParserOptions {
+          data_url_condition: Some(AssetParserDataUrl::Options(AssetParserDataUrlOptions {
+            max_size: Some(8096.0),
+          })),
+        }),
+      );
+    }
+
+    if !parser.contains_key("javascript") {
+      parser.insert(
+        "javascript".to_string(),
+        ParserOptions::Javascript(JavascriptParserOptions {
+          dynamic_import_mode: Some(DynamicImportMode::Lazy),
+          dynamic_import_preload: Some(JavascriptParserOrder::Disable),
+          dynamic_import_prefetch: Some(JavascriptParserOrder::Disable),
+          dynamic_import_fetch_priority: None,
+          url: Some(JavascriptParserUrl::Enable),
+          expr_context_critical: Some(true),
+          wrapped_context_critical: Some(false),
+          wrapped_context_reg_exp: Some(RspackRegex::new(".*").expect("should initialize `Regex`")),
+          strict_export_presence: Some(false),
+          worker: Some(vec!["...".to_string()]),
+          import_meta: Some(true),
+          require_as_expression: Some(true),
+          require_dynamic: Some(true),
+          require_resolve: Some(true),
+          import_dynamic: Some(true),
+          ..Default::default()
+        }),
+      );
+    }
+
+    if css {
+      let generator = self.generator.get_or_insert(GeneratorOptionsMap::default());
+
+      let css_parser_options = ParserOptions::Css(CssParserOptions {
+        named_exports: Some(true),
+      });
+      parser.insert("css".to_string(), css_parser_options.clone());
+
+      let css_auto_parser_options = ParserOptions::CssAuto(CssAutoParserOptions {
+        named_exports: Some(true),
+      });
+      parser.insert("css/auto".to_string(), css_auto_parser_options);
+
+      let css_module_parser_options = ParserOptions::CssModule(CssModuleParserOptions {
+        named_exports: Some(true),
+      });
+      parser.insert("css/module".to_string(), css_module_parser_options);
+
+      // CSS generator options
+      let exports_only = target_properties.map_or(true, |t| !t.document());
+
+      generator.insert(
+        "css".to_string(),
+        GeneratorOptions::Css(CssGeneratorOptions {
+          exports_only: Some(exports_only),
+          es_module: Some(true),
+        }),
+      );
+
+      generator.insert(
+        "css/auto".to_string(),
+        GeneratorOptions::CssAuto(CssAutoGeneratorOptions {
+          exports_only: Some(exports_only),
+          exports_convention: Some(CssExportsConvention::default()),
+          local_ident_name: Some("[uniqueName]-[id]-[local]".into()),
+
+          es_module: Some(true),
+        }),
+      );
+
+      generator.insert(
+        "css/module".to_string(),
+        GeneratorOptions::CssModule(CssModuleGeneratorOptions {
+          exports_only: Some(exports_only),
+          exports_convention: Some(CssExportsConvention::default()),
+          local_ident_name: Some("[uniqueName]-[id]-[local]".into()),
+          es_module: Some(true),
+        }),
+      );
+    }
+
+    let default_rules = default_rules(async_web_assembly, css);
+
+    ModuleOptions {
+      rules: vec![
+        ModuleRule {
+          rules: Some(default_rules),
+          ..Default::default()
+        },
+        ModuleRule {
+          rules: Some(std::mem::take(&mut self.rules)),
+          ..Default::default()
+        },
+      ],
+      parser: self.parser.take(),
+      generator: self.generator.take(),
+      no_parse: self.no_parse.take(),
+    }
+  }
+}
+
+fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
+  let mut rules = vec![
+    // application/node
+    ModuleRule {
+      mimetype: Some(RuleSetCondition::String("application/node".into()).into()),
+      effect: ModuleRuleEffect {
+        r#type: Some(ModuleType::JsAuto),
+        ..Default::default()
+      },
+      ..Default::default()
+    },
+    // .json
+    ModuleRule {
+      test: Some(RuleSetCondition::Regexp(
+        RspackRegex::new(r"\.json$").expect("should initialize `Regex`"),
+      )),
+      effect: ModuleRuleEffect {
+        r#type: Some(ModuleType::Json),
+        ..Default::default()
+      },
+      ..Default::default()
+    },
+    // application/json
+    ModuleRule {
+      mimetype: Some(RuleSetCondition::String("application/json".into()).into()),
+      effect: ModuleRuleEffect {
+        r#type: Some(ModuleType::Json),
+        ..Default::default()
+      },
+      ..Default::default()
+    },
+    // .mjs
+    ModuleRule {
+      test: Some(RuleSetCondition::Regexp(
+        RspackRegex::new(r"\.mjs$").expect("should initialize `Regex`"),
+      )),
+      effect: ModuleRuleEffect {
+        r#type: Some(ModuleType::JsEsm),
+        resolve: Some(Resolve {
+          by_dependency: Some(ByDependency::from_iter([(
+            "esm".into(),
+            Resolve {
+              fully_specified: Some(true),
+              ..Default::default()
+            },
+          )])),
+          ..Default::default()
+        }),
+        ..Default::default()
+      },
+      ..Default::default()
+    },
+    // .js with type:module
+    ModuleRule {
+      test: Some(RuleSetCondition::Regexp(
+        RspackRegex::new(r"\.js$").expect("should initialize `Regex`"),
+      )),
+      description_data: Some(HashMap::from_iter([(
+        "type".into(),
+        RuleSetCondition::String("module".into()).into(),
+      )])),
+      effect: ModuleRuleEffect {
+        r#type: Some(ModuleType::JsEsm),
+        resolve: Some(Resolve {
+          by_dependency: Some(ByDependency::from_iter([(
+            "esm".into(),
+            Resolve {
+              fully_specified: Some(true),
+              ..Default::default()
+            },
+          )])),
+          ..Default::default()
+        }),
+        ..Default::default()
+      },
+      ..Default::default()
+    },
+    // .cjs
+    ModuleRule {
+      test: Some(RuleSetCondition::Regexp(
+        RspackRegex::new(r"\.cjs$").expect("should initialize `Regex`"),
+      )),
+      effect: ModuleRuleEffect {
+        r#type: Some(ModuleType::JsDynamic),
+        ..Default::default()
+      },
+      ..Default::default()
+    },
+    // .js with type:commonjs
+    ModuleRule {
+      test: Some(RuleSetCondition::Regexp(
+        RspackRegex::new(r"\.js$").expect("should initialize `Regex`"),
+      )),
+      description_data: Some(HashMap::from_iter([(
+        "type".into(),
+        RuleSetCondition::String("commonjs".into()).into(),
+      )])),
+      effect: ModuleRuleEffect {
+        r#type: Some(ModuleType::JsDynamic),
+        ..Default::default()
+      },
+      ..Default::default()
+    },
+    // text/javascript or application/javascript
+    ModuleRule {
+      mimetype: Some(
+        RuleSetCondition::Logical(Box::new(RuleSetLogicalConditions {
+          or: Some(vec![
+            RuleSetCondition::String("text/javascript".into()),
+            RuleSetCondition::String("application/javascript".into()),
+          ]),
+          ..Default::default()
+        }))
+        .into(),
+      ),
+      effect: ModuleRuleEffect {
+        r#type: Some(ModuleType::JsEsm),
+        resolve: Some(Resolve {
+          by_dependency: Some(ByDependency::from_iter([(
+            "esm".into(),
+            Resolve {
+              fully_specified: Some(true),
+              ..Default::default()
+            },
+          )])),
+          ..Default::default()
+        }),
+        ..Default::default()
+      },
+      ..Default::default()
+    },
+  ];
+
+  // Add WebAssembly rules if enabled
+  if async_web_assembly {
+    rules.extend(vec![
+      ModuleRule {
+        test: Some(RuleSetCondition::Regexp(
+          RspackRegex::new(r"\.wasm$").expect("should initialize `Regex`"),
+        )),
+        effect: ModuleRuleEffect {
+          r#type: Some(ModuleType::WasmAsync),
+          ..Default::default()
+        },
+        rules: Some(vec![ModuleRule {
+          description_data: Some(HashMap::from_iter([(
+            "type".into(),
+            RuleSetCondition::String("module".into()).into(),
+          )])),
+          effect: ModuleRuleEffect {
+            resolve: Some(Resolve {
+              fully_specified: Some(true),
+              ..Default::default()
+            }),
+            ..Default::default()
+          },
+          ..Default::default()
+        }]),
+        ..Default::default()
+      },
+      ModuleRule {
+        mimetype: Some(RuleSetCondition::String("application/wasm".into()).into()),
+        effect: ModuleRuleEffect {
+          r#type: Some(ModuleType::WasmAsync),
+          ..Default::default()
+        },
+        rules: Some(vec![ModuleRule {
+          description_data: Some(HashMap::from_iter([(
+            "type".into(),
+            RuleSetCondition::String("module".into()).into(),
+          )])),
+          effect: ModuleRuleEffect {
+            resolve: Some(Resolve {
+              fully_specified: Some(true),
+              ..Default::default()
+            }),
+            ..Default::default()
+          },
+          ..Default::default()
+        }]),
+        ..Default::default()
+      },
+    ]);
+  }
+
+  // Add CSS rules if enabled
+  if css {
+    let resolve = Resolve {
+      fully_specified: Some(true),
+      prefer_relative: Some(true),
+      ..Default::default()
+    };
+
+    rules.extend(vec![
+      ModuleRule {
+        test: Some(RuleSetCondition::Regexp(
+          RspackRegex::new(r"\.css$").expect("should initialize `Regex`"),
+        )),
+        effect: ModuleRuleEffect {
+          r#type: Some(ModuleType::CssAuto),
+          resolve: Some(resolve.clone()),
+          ..Default::default()
+        },
+        ..Default::default()
+      },
+      ModuleRule {
+        mimetype: Some(RuleSetCondition::String("text/css+module".into()).into()),
+        effect: ModuleRuleEffect {
+          r#type: Some(ModuleType::CssModule),
+          resolve: Some(resolve.clone()),
+          ..Default::default()
+        },
+        ..Default::default()
+      },
+      ModuleRule {
+        mimetype: Some(RuleSetCondition::String("text/css".into()).into()),
+        effect: ModuleRuleEffect {
+          r#type: Some(ModuleType::Css),
+          resolve: Some(resolve),
+          ..Default::default()
+        },
+        ..Default::default()
+      },
+    ]);
+  }
+
+  // Add URL dependency rules
+  rules.extend(vec![
+    ModuleRule {
+      dependency: Some(RuleSetCondition::String("url".into())),
+      one_of: Some(vec![
+        ModuleRule {
+          scheme: Some(
+            RuleSetCondition::Regexp(
+              RspackRegex::new("^data$").expect("should initialize `Regex`"),
+            )
+            .into(),
+          ),
+          effect: ModuleRuleEffect {
+            r#type: Some(ModuleType::AssetInline),
+            ..Default::default()
+          },
+          ..Default::default()
+        },
+        ModuleRule {
+          effect: ModuleRuleEffect {
+            r#type: Some(ModuleType::AssetResource),
+            ..Default::default()
+          },
+          ..Default::default()
+        },
+      ]),
+      ..Default::default()
+    },
+    ModuleRule {
+      with: Some(HashMap::from_iter([(
+        "type".into(),
+        RuleSetCondition::String("json".into()).into(),
+      )])),
+      effect: ModuleRuleEffect {
+        r#type: Some(ModuleType::Json),
+        ..Default::default()
+      },
+      ..Default::default()
+    },
+  ]);
+
+  rules
+}
+
+#[derive(Debug, Default)]
+pub struct OutputOptionsBuilder {
+  path: Option<Utf8PathBuf>,
+  pathinfo: Option<PathInfo>,
+  clean: Option<CleanOptions>,
+  public_path: Option<PublicPath>,
+  asset_module_filename: Option<Filename>,
+  wasm_loading: Option<WasmLoading>,
+  webassembly_module_filename: Option<FilenameTemplate>,
+  unique_name: Option<String>,
+  chunk_loading: Option<ChunkLoading>,
+  chunk_loading_global: Option<String>,
+  chunk_load_timeout: Option<u32>,
+  chunk_format: Option<String>,
+  charset: Option<bool>,
+  filename: Option<Filename>,
+  chunk_filename: Option<Filename>,
+  cross_origin_loading: Option<CrossOriginLoading>,
+  css_filename: Option<Filename>,
+  css_chunk_filename: Option<Filename>,
+  hot_update_main_filename: Option<FilenameTemplate>,
+  hot_update_chunk_filename: Option<FilenameTemplate>,
+  hot_update_global: Option<String>,
+  library: Option<LibraryOptions>,
+  enabled_library_types: Option<Vec<String>>,
+  strict_module_error_handling: Option<bool>,
+  global_object: Option<String>,
+  import_function_name: Option<String>,
+  import_meta_name: Option<String>,
+  iife: Option<bool>,
+  module: Option<bool>,
+  trusted_types: Option<TrustedTypes>,
+  source_map_filename: Option<FilenameTemplate>,
+  hash_function: Option<HashFunction>,
+  hash_digest: Option<HashDigest>,
+  hash_digest_length: Option<usize>,
+  hash_salt: Option<HashSalt>,
+  async_chunks: Option<bool>,
+  worker_chunk_loading: Option<ChunkLoading>,
+  worker_wasm_loading: Option<WasmLoading>,
+  worker_public_path: Option<String>,
+  script_type: Option<String>,
+  environment: Option<Environment>,
+  compare_before_emit: Option<bool>,
+}
+
+impl OutputOptionsBuilder {
+  pub fn path<V>(&mut self, path: V) -> &mut Self
+  where
+    V: Into<Utf8PathBuf>,
+  {
+    self.path = Some(path.into());
+    self
+  }
+
+  pub fn pathinfo(&mut self, pathinfo: PathInfo) -> &mut Self {
+    self.pathinfo = Some(pathinfo);
+    self
+  }
+
+  pub fn clean(&mut self, clean: CleanOptions) -> &mut Self {
+    self.clean = Some(clean);
+    self
+  }
+
+  pub fn public_path(&mut self, public_path: PublicPath) -> &mut Self {
+    self.public_path = Some(public_path);
+    self
+  }
+
+  pub fn asset_module_filename(&mut self, filename: Filename) -> &mut Self {
+    self.asset_module_filename = Some(filename);
+    self
+  }
+
+  pub fn wasm_loading(&mut self, loading: WasmLoading) -> &mut Self {
+    self.wasm_loading = Some(loading);
+    self
+  }
+
+  pub fn webassembly_module_filename(&mut self, filename: FilenameTemplate) -> &mut Self {
+    self.webassembly_module_filename = Some(filename);
+    self
+  }
+
+  pub fn unique_name(&mut self, name: String) -> &mut Self {
+    self.unique_name = Some(name);
+    self
+  }
+
+  pub fn chunk_loading(&mut self, loading: ChunkLoading) -> &mut Self {
+    self.chunk_loading = Some(loading);
+    self
+  }
+
+  pub fn chunk_loading_global(&mut self, global: String) -> &mut Self {
+    self.chunk_loading_global = Some(global);
+    self
+  }
+
+  pub fn chunk_load_timeout(&mut self, timeout: u32) -> &mut Self {
+    self.chunk_load_timeout = Some(timeout);
+    self
+  }
+
+  pub fn chunk_format(&mut self, chunk_format: String) -> &mut Self {
+    self.chunk_format = Some(chunk_format);
+    self
+  }
+
+  pub fn charset(&mut self, charset: bool) -> &mut Self {
+    self.charset = Some(charset);
+    self
+  }
+
+  pub fn filename(&mut self, filename: Filename) -> &mut Self {
+    self.filename = Some(filename);
+    self
+  }
+
+  pub fn chunk_filename(&mut self, filename: Filename) -> &mut Self {
+    self.chunk_filename = Some(filename);
+    self
+  }
+
+  pub fn cross_origin_loading(&mut self, loading: CrossOriginLoading) -> &mut Self {
+    self.cross_origin_loading = Some(loading);
+    self
+  }
+
+  pub fn css_filename(&mut self, filename: Filename) -> &mut Self {
+    self.css_filename = Some(filename);
+    self
+  }
+
+  pub fn css_chunk_filename(&mut self, filename: Filename) -> &mut Self {
+    self.css_chunk_filename = Some(filename);
+    self
+  }
+
+  pub fn hot_update_main_filename(&mut self, filename: FilenameTemplate) -> &mut Self {
+    self.hot_update_main_filename = Some(filename);
+    self
+  }
+
+  pub fn hot_update_chunk_filename(&mut self, filename: FilenameTemplate) -> &mut Self {
+    self.hot_update_chunk_filename = Some(filename);
+    self
+  }
+
+  pub fn hot_update_global(&mut self, global: String) -> &mut Self {
+    self.hot_update_global = Some(global);
+    self
+  }
+
+  pub fn library(&mut self, library: LibraryOptions) -> &mut Self {
+    self.library = Some(library);
+    self
+  }
+
+  pub fn enabled_library_types(&mut self, types: Vec<String>) -> &mut Self {
+    self.enabled_library_types = Some(types);
+    self
+  }
+
+  pub fn strict_module_error_handling(&mut self, strict: bool) -> &mut Self {
+    self.strict_module_error_handling = Some(strict);
+    self
+  }
+
+  pub fn global_object(&mut self, object: String) -> &mut Self {
+    self.global_object = Some(object);
+    self
+  }
+
+  pub fn import_function_name(&mut self, name: String) -> &mut Self {
+    self.import_function_name = Some(name);
+    self
+  }
+
+  pub fn import_meta_name(&mut self, name: String) -> &mut Self {
+    self.import_meta_name = Some(name);
+    self
+  }
+
+  pub fn iife(&mut self, iife: bool) -> &mut Self {
+    self.iife = Some(iife);
+    self
+  }
+
+  pub fn module(&mut self, module: bool) -> &mut Self {
+    self.module = Some(module);
+    self
+  }
+
+  pub fn trusted_types(&mut self, trusted_types: TrustedTypes) -> &mut Self {
+    self.trusted_types = Some(trusted_types);
+    self
+  }
+
+  pub fn source_map_filename(&mut self, filename: FilenameTemplate) -> &mut Self {
+    self.source_map_filename = Some(filename);
+    self
+  }
+
+  pub fn hash_function(&mut self, function: HashFunction) -> &mut Self {
+    self.hash_function = Some(function);
+    self
+  }
+
+  pub fn hash_digest(&mut self, digest: HashDigest) -> &mut Self {
+    self.hash_digest = Some(digest);
+    self
+  }
+
+  pub fn hash_digest_length(&mut self, length: usize) -> &mut Self {
+    self.hash_digest_length = Some(length);
+    self
+  }
+
+  pub fn hash_salt(&mut self, salt: HashSalt) -> &mut Self {
+    self.hash_salt = Some(salt);
+    self
+  }
+
+  pub fn async_chunks(&mut self, async_chunks: bool) -> &mut Self {
+    self.async_chunks = Some(async_chunks);
+    self
+  }
+
+  pub fn worker_chunk_loading(&mut self, loading: ChunkLoading) -> &mut Self {
+    self.worker_chunk_loading = Some(loading);
+    self
+  }
+
+  pub fn worker_wasm_loading(&mut self, loading: WasmLoading) -> &mut Self {
+    self.worker_wasm_loading = Some(loading);
+    self
+  }
+
+  pub fn worker_public_path(&mut self, path: String) -> &mut Self {
+    self.worker_public_path = Some(path);
+    self
+  }
+
+  pub fn script_type(&mut self, script_type: String) -> &mut Self {
+    self.script_type = Some(script_type);
+    self
+  }
+
+  pub fn environment(&mut self, environment: Environment) -> &mut Self {
+    self.environment = Some(environment);
+    self
+  }
+
+  pub fn compare_before_emit(&mut self, compare: bool) -> &mut Self {
+    self.compare_before_emit = Some(compare);
+    self
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  pub fn build(
+    &mut self,
+    context: Context,
+    output_module: Option<bool>,
+    target_properties: Option<&TargetProperties>,
+    is_affected_by_browserslist: bool,
+    development: bool,
+    _entry: &IndexMap<String, EntryDescription>,
+    _future_defaults: bool,
+  ) -> OutputOptions {
+    let output_module = output_module.unwrap_or(false);
+    let tp = target_properties;
+
+    let path = f!(self.path.take(), || { context.as_path().join("dist") });
+
+    let pathinfo = f!(self.pathinfo.take(), || {
+      if development {
+        PathInfo::Bool(true)
+      } else {
+        PathInfo::Bool(false)
+      }
+    });
+
+    let clean = d!(self.clean.take(), CleanOptions::CleanAll(false));
+
+    let public_path = f!(self.public_path.take(), || {
+      if tp.is_some_and(|t| t.document() || t.import_scripts()) {
+        PublicPath::Auto
+      } else {
+        PublicPath::Filename("".into())
+      }
+    });
+
+    let asset_module_filename = f!(self.asset_module_filename.take(), || {
+      "[hash][ext][query]".into()
+    });
+
+    let filename = f!(self.filename.take(), || {
+      if output_module {
+        "[name].mjs".into()
+      } else {
+        "[name].js".into()
+      }
+    });
+
+    let chunk_filename = f!(self.chunk_filename.take(), || {
+      // Get template string from filename if it's not a function
+      if let Some(template) = filename.template() {
+        let has_name = template.contains("[name]");
+        let has_id = template.contains("[id]");
+        let has_chunk_hash = template.contains("[chunkhash]");
+        let has_content_hash = template.contains("[contenthash]");
+
+        // Anything changing depending on chunk is fine
+        if has_chunk_hash || has_content_hash || has_name || has_id {
+          filename.clone()
+        } else {
+          // Otherwise prefix "[id]." in front of the basename to make it changing
+          let new_template = regex::Regex::new(r"(^|\/)([^/]*(?:\?|$))")
+            .expect("should initialize `Regex`")
+            .replace(template, "$1[id].$2")
+            .into_owned();
+          Filename::from(new_template)
+        }
+      } else {
+        // If filename is a function, use default
+        "[id].js".into()
+      }
+    });
+
+    let css_filename = f!(self.css_filename.take(), || {
+      if let Some(template) = filename.template() {
+        let new_template = regex::Regex::new(r"\.[mc]?js(\?|$)")
+          .expect("should initialize `Regex`")
+          .replace(template, ".css$1")
+          .into_owned();
+        Filename::from(new_template)
+      } else {
+        "[id].css".into()
+      }
+    });
+
+    let css_chunk_filename = f!(self.css_chunk_filename.take(), || {
+      if let Some(template) = chunk_filename.template() {
+        let new_template = regex::Regex::new(r"\.[mc]?js(\?|$)")
+          .expect("should initialize `Regex`")
+          .replace(template, ".css$1")
+          .into_owned();
+        Filename::from(new_template)
+      } else {
+        "[id].css".into()
+      }
+    });
+
+    let hot_update_chunk_filename = f!(self.hot_update_chunk_filename.take(), || {
+      format!(
+        "[id].[fullhash].hot-update.{}",
+        if output_module { "mjs" } else { "js" }
+      )
+      .into()
+    });
+
+    let hot_update_main_filename = f!(self.hot_update_main_filename.take(), || {
+      "[runtime].[fullhash].hot-update.json".into()
+    });
+
+    // Generate unique name from library name or package.json
+    let unique_name = f!(self.unique_name.take(), || {
+      if let Some(library) = &self.library {
+        if let Some(name) = &library.name {
+          let library_name = match name {
+            LibraryName::NonUmdObject(LibraryNonUmdObject::String(s)) => s.clone(),
+            LibraryName::NonUmdObject(LibraryNonUmdObject::Array(arr)) => arr.join("."),
+            LibraryName::UmdObject(obj) => {
+              obj.root.as_ref().map(|r| r.join(".")).unwrap_or_default()
+            }
+          };
+
+          // Clean up library name using regex
+          let re = regex::Regex::new(
+            r"^\[(\\*[\w:]+\\*)\](\.)|(\.)\[(\\*[\w:]+\\*)\](\.|\z)|\[(\\*[\w:]+\\*)\]",
+          )
+          .expect("failed to create regex");
+
+          let cleaned_name = re.replace_all(&library_name, |caps: &regex::Captures| {
+            let content = caps
+              .get(1)
+              .or_else(|| caps.get(4))
+              .or_else(|| caps.get(6))
+              .map_or("", |m| m.as_str());
+
+            if content.starts_with('\\') && content.ends_with('\\') {
+              format!(
+                "{}{}{}",
+                caps.get(3).map_or("", |_| "."),
+                format_args!("[{}]", &content[1..content.len() - 1]),
+                caps.get(2).map_or("", |_| ".")
+              )
+            } else {
+              String::new()
+            }
+          });
+
+          if !cleaned_name.is_empty() {
+            return cleaned_name.into_owned();
+          }
+        }
+      }
+
+      // Try reading from package.json
+      let pkg_path = path.join("package.json");
+      if let Ok(pkg_content) = std::fs::read_to_string(pkg_path) {
+        if let Ok(pkg_json) = serde_json::from_str::<serde_json::Value>(&pkg_content) {
+          if let Some(name) = pkg_json.get("name").and_then(|n| n.as_str()) {
+            return name.to_string();
+          }
+        }
+      }
+      String::new()
+    });
+
+    let chunk_loading_global = f!(self.chunk_loading_global.take(), || {
+      format!("webpackChunk{}", crate::utils::to_identifier(&unique_name))
+    });
+
+    let hot_update_global = f!(self.hot_update_global.take(), || {
+      format!(
+        "webpackHotUpdate{}",
+        crate::utils::to_identifier(&unique_name)
+      )
+    });
+
+    // TODO: do not panic
+    let chunk_format = f!(self.chunk_format.take(), || {
+      if let Some(tp) = tp {
+        let help_message = if is_affected_by_browserslist {
+          "Make sure that your 'browserslist' includes only platforms that support these features or select an appropriate 'target' to allow selecting a chunk format by default. Alternatively specify the 'output.chunkFormat' directly."
+        } else {
+          "Select an appropriate 'target' to allow selecting one by default, or specify the 'output.chunkFormat' directly."
+        };
+
+        if output_module {
+          if tp.dynamic_import() {
+            "module".to_string()
+          } else if tp.document() {
+            "array-push".to_string()
+          } else {
+            panic!("For the selected environment is no default ESM chunk format available:\nESM exports can be chosen when 'import()' is available.\nJSONP Array push can be chosen when 'document' is available.\n{help_message}");
+          }
+        } else if tp.document() {
+          "array-push".to_string()
+        } else if tp.require() || tp.node_builtins() {
+          "commonjs".to_string()
+        } else if tp.import_scripts() {
+          "array-push".to_string()
+        } else {
+          panic!("For the selected environment is no default script chunk format available:\nJSONP Array push can be chosen when 'document' or 'importScripts' is available.\nCommonJs exports can be chosen when 'require' or node builtins are available.\n{help_message}");
+        }
+      } else {
+        panic!("Chunk format can't be selected by default when no target is specified");
+      }
+    });
+
+    let chunk_loading = f!(self.chunk_loading.take(), || {
+      if let Some(tp) = tp {
+        match &*chunk_format {
+          "array-push" => {
+            if tp.document() {
+              ChunkLoading::Enable(ChunkLoadingType::Jsonp)
+            } else if tp.import_scripts() {
+              ChunkLoading::Enable(ChunkLoadingType::ImportScripts)
+            } else {
+              ChunkLoading::Disable
+            }
+          }
+          "commonjs" => {
+            if tp.require() {
+              ChunkLoading::Enable(ChunkLoadingType::Require)
+            } else if tp.node_builtins() {
+              ChunkLoading::Enable(ChunkLoadingType::AsyncNode)
+            } else {
+              ChunkLoading::Disable
+            }
+          }
+          "module" => {
+            if tp.dynamic_import() {
+              ChunkLoading::Enable(ChunkLoadingType::Import)
+            } else {
+              ChunkLoading::Disable
+            }
+          }
+          _ => ChunkLoading::Disable,
+        }
+      } else {
+        ChunkLoading::Disable
+      }
+    });
+
+    let worker_chunk_loading = f!(self.worker_chunk_loading.take(), || {
+      if let Some(tp) = tp {
+        match &*chunk_format {
+          "array-push" => {
+            if tp.import_scripts_in_worker() {
+              ChunkLoading::Enable(ChunkLoadingType::ImportScripts)
+            } else {
+              ChunkLoading::Disable
+            }
+          }
+          "commonjs" => {
+            if tp.require() {
+              ChunkLoading::Enable(ChunkLoadingType::Require)
+            } else if tp.node_builtins() {
+              ChunkLoading::Enable(ChunkLoadingType::AsyncNode)
+            } else {
+              ChunkLoading::Disable
+            }
+          }
+          "module" => {
+            if tp.dynamic_import_in_worker() {
+              ChunkLoading::Enable(ChunkLoadingType::Import)
+            } else {
+              ChunkLoading::Disable
+            }
+          }
+          _ => ChunkLoading::Disable,
+        }
+      } else {
+        ChunkLoading::Disable
+      }
+    });
+
+    let wasm_loading = f!(self.wasm_loading.take(), || {
+      if let Some(tp) = tp {
+        if tp.fetch_wasm() {
+          WasmLoading::Enable(WasmLoadingType::Fetch)
+        } else if tp.node_builtins() {
+          if output_module {
+            WasmLoading::Enable(WasmLoadingType::AsyncNodeModule)
+          } else {
+            WasmLoading::Enable(WasmLoadingType::AsyncNode)
+          }
+        } else {
+          WasmLoading::Disable
+        }
+      } else {
+        WasmLoading::Disable
+      }
+    });
+
+    let worker_wasm_loading = f!(self.worker_wasm_loading.take(), || wasm_loading.clone());
+
+    let global_object = f!(self.global_object.take(), || {
+      if let Some(tp) = tp {
+        if tp.global() {
+          "global".into()
+        } else if tp.global_this() {
+          "globalThis".into()
+        } else {
+          "self".into()
+        }
+      } else {
+        "self".into()
+      }
+    });
+
+    let environment = Environment {
+      r#const: tp.and_then(|t| t.r#const),
+      arrow_function: tp.and_then(|t| t.arrow_function),
+      node_prefix_for_core_modules: tp.and_then(|t| t.node_prefix_for_core_modules),
+    };
+
+    OutputOptions {
+      path,
+      pathinfo,
+      clean,
+      asset_module_filename,
+      public_path,
+      wasm_loading,
+      webassembly_module_filename: self
+        .webassembly_module_filename
+        .take()
+        .unwrap_or_else(|| "[hash].module.wasm".into()),
+      unique_name,
+      chunk_loading,
+      chunk_loading_global,
+      chunk_load_timeout: self.chunk_load_timeout.take().unwrap_or(120_000),
+      charset: self.charset.take().unwrap_or(true),
+      filename,
+      chunk_filename,
+      cross_origin_loading: self
+        .cross_origin_loading
+        .take()
+        .unwrap_or(CrossOriginLoading::Disable),
+      css_filename,
+      css_chunk_filename,
+      hot_update_main_filename,
+      hot_update_chunk_filename,
+      hot_update_global,
+      library: self.library.take(),
+      enabled_library_types: self.enabled_library_types.take(),
+      strict_module_error_handling: self.strict_module_error_handling.take().unwrap_or(false),
+      global_object,
+      import_function_name: self
+        .import_function_name
+        .take()
+        .unwrap_or_else(|| "import".into()),
+      import_meta_name: self
+        .import_meta_name
+        .take()
+        .unwrap_or_else(|| "import.meta".into()),
+      iife: self.iife.take().unwrap_or(!output_module),
+      module: self.module.take().unwrap_or(output_module),
+      trusted_types: self.trusted_types.take(),
+      source_map_filename: self
+        .source_map_filename
+        .take()
+        .unwrap_or_else(|| "[file].map[query]".into()),
+      hash_function: self.hash_function.take().unwrap_or(HashFunction::Xxhash64),
+      hash_digest: self.hash_digest.take().unwrap_or(HashDigest::Hex),
+      hash_digest_length: self.hash_digest_length.take().unwrap_or(16),
+      hash_salt: match self.hash_salt.take() {
+        Some(salt) => salt,
+        None => HashSalt::None,
+      },
+      async_chunks: self.async_chunks.take().unwrap_or(true),
+      worker_chunk_loading,
+      worker_wasm_loading,
+      worker_public_path: self.worker_public_path.take().unwrap_or_default(),
+      script_type: self.script_type.take().unwrap_or_else(|| {
+        if output_module {
+          "module".into()
+        } else {
+          String::new()
+        }
+      }),
+      environment,
+      compare_before_emit: self.compare_before_emit.take().unwrap_or(true),
+    }
+  }
+}
+
+impl OutputOptions {
+  pub fn builder() -> OutputOptionsBuilder {
+    OutputOptionsBuilder::default()
+  }
+}
+
+#[derive(Debug, Default)]
+pub struct ExperimentsBuilder {
+  layers: Option<bool>,
+  incremental: Option<IncrementalPasses>,
+  top_level_await: Option<bool>,
+  rspack_future: Option<RspackFuture>,
+  cache: Option<ExperimentCacheOptions>,
+  css: Option<bool>,
+  async_web_assembly: Option<bool>,
+}
+
+impl Experiments {
+  pub fn builder() -> ExperimentsBuilder {
+    ExperimentsBuilder::default()
+  }
+}
+impl ExperimentsBuilder {
+  pub fn layers(&mut self, layers: bool) -> &mut Self {
+    self.layers = Some(layers);
+    self
+  }
+
+  pub fn incremental(&mut self, incremental: IncrementalPasses) -> &mut Self {
+    self.incremental = Some(incremental);
+    self
+  }
+
+  pub fn top_level_await(&mut self, top_level_await: bool) -> &mut Self {
+    self.top_level_await = Some(top_level_await);
+    self
+  }
+
+  pub fn cache(&mut self, cache: ExperimentCacheOptions) -> &mut Self {
+    self.cache = Some(cache);
+    self
+  }
+
+  pub fn css(&mut self, css: bool) -> &mut Self {
+    self.css = Some(css);
+    self
+  }
+
+  pub fn async_web_assembly(&mut self, async_web_assembly: bool) -> &mut Self {
+    self.async_web_assembly = Some(async_web_assembly);
+    self
+  }
+
+  pub fn build(&mut self, development: bool, production: bool) -> Experiments {
+    let layers = d!(self.layers, false);
+    let incremental = f!(self.incremental.take(), || {
+      if !production {
+        IncrementalPasses::MAKE | IncrementalPasses::EMIT_ASSETS
+      } else {
+        IncrementalPasses::empty()
+      }
+    });
+    let top_level_await = d!(self.top_level_await, true);
+    let rspack_future = d!(self.rspack_future.take(), RspackFuture {});
+    let cache = f!(self.cache.take(), || {
+      if development {
+        ExperimentCacheOptions::Memory
+      } else {
+        ExperimentCacheOptions::Disabled
+      }
+    });
+
+    Experiments {
+      layers,
+      incremental,
+      top_level_await,
+      rspack_future,
+      cache,
+    }
+  }
+}

--- a/crates/rspack_core/src/options/entry.rs
+++ b/crates/rspack_core/src/options/entry.rs
@@ -15,6 +15,7 @@ pub struct EntryDescription {
   pub public_path: Option<PublicPath>,
   pub base_uri: Option<String>,
   pub filename: Option<Filename>,
+  pub depend_on: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/rspack_core/src/options/experiments/cache.rs
+++ b/crates/rspack_core/src/options/experiments/cache.rs
@@ -1,6 +1,6 @@
 use crate::cache::persistent::PersistentCacheOptions;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CacheOptions {
   Disabled,
   Memory,

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -171,6 +171,12 @@ impl<F> FromStr for Filename<F> {
   }
 }
 
+impl<F> From<&str> for Filename<F> {
+  fn from(value: &str) -> Self {
+    Filename::from_str(value).expect("infallible")
+  }
+}
+
 #[inline]
 fn hash_len(hash: &str, len: Option<usize>) -> usize {
   let hash_len = hash.len();

--- a/crates/rspack_core/src/options/mod.rs
+++ b/crates/rspack_core/src/options/mod.rs
@@ -1,6 +1,8 @@
 mod compiler_options;
+mod compiler_options_builder;
 
 pub use compiler_options::*;
+pub use compiler_options_builder::*;
 mod entry;
 pub use entry::*;
 mod optimizations;
@@ -31,3 +33,5 @@ mod filename;
 pub use filename::*;
 mod clean_options;
 pub use clean_options::*;
+mod target;
+pub use target::*;

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -1,5 +1,7 @@
 use std::{
   fmt::{self, Debug},
+  ops::{Deref, DerefMut},
+  str::FromStr,
   sync::Arc,
 };
 
@@ -16,8 +18,22 @@ use tokio::sync::OnceCell;
 
 use crate::{Compilation, Filename, Module, ModuleType, PublicPath, Resolve};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ParserOptionsMap(HashMap<String, ParserOptions>);
+
+impl Deref for ParserOptionsMap {
+  type Target = HashMap<String, ParserOptions>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for ParserOptionsMap {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
 
 impl FromIterator<(String, ParserOptions)> for ParserOptionsMap {
   fn from_iter<I: IntoIterator<Item = (String, ParserOptions)>>(i: I) -> Self {
@@ -230,7 +246,7 @@ impl From<&str> for OverrideStrict {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, Default)]
 pub struct JavascriptParserOptions {
   pub dynamic_import_mode: Option<DynamicImportMode>,
   pub dynamic_import_preload: Option<JavascriptParserOrder>,
@@ -296,8 +312,22 @@ pub struct JsonParserOptions {
   pub exports_depth: Option<u32>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct GeneratorOptionsMap(HashMap<String, GeneratorOptions>);
+
+impl Deref for GeneratorOptionsMap {
+  type Target = HashMap<String, GeneratorOptions>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for GeneratorOptionsMap {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
 
 impl FromIterator<(String, GeneratorOptions)> for GeneratorOptionsMap {
   fn from_iter<I: IntoIterator<Item = (String, GeneratorOptions)>>(i: I) -> Self {
@@ -515,6 +545,14 @@ impl From<String> for LocalIdentName {
   }
 }
 
+impl From<&str> for LocalIdentName {
+  fn from(value: &str) -> Self {
+    Self {
+      template: crate::FilenameTemplate::from_str(value).expect("should be infalliable"),
+    }
+  }
+}
+
 #[cacheable]
 #[derive(Debug, Clone, Copy)]
 struct ExportsConventionFlags(u8);
@@ -688,6 +726,12 @@ impl RuleSetConditionWithEmpty {
   }
 }
 
+impl From<RuleSetCondition> for RuleSetConditionWithEmpty {
+  fn from(condition: RuleSetCondition) -> Self {
+    Self::new(condition)
+  }
+}
+
 #[derive(Debug, Default)]
 pub struct RuleSetLogicalConditions {
   pub and: Option<Vec<RuleSetCondition>>,
@@ -755,7 +799,7 @@ pub struct ModuleRuleUseLoader {
 pub type FnUse =
   Box<dyn Fn(FuncUseCtx) -> BoxFuture<'static, Result<Vec<ModuleRuleUseLoader>>> + Sync + Send>;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ModuleRule {
   /// A conditional match matching an absolute path + query + fragment.
   /// Note:
@@ -783,7 +827,7 @@ pub struct ModuleRule {
   pub effect: ModuleRuleEffect,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ModuleRuleEffect {
   pub side_effects: Option<bool>,
   /// The `ModuleType` to use for the matched resource.

--- a/crates/rspack_core/src/options/optimizations.rs
+++ b/crates/rspack_core/src/options/optimizations.rs
@@ -119,7 +119,7 @@ impl From<&str> for MangleExportsOption {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Optimization {
   pub remove_available_modules: bool,
   pub side_effects: SideEffectOption,

--- a/crates/rspack_core/src/options/target.rs
+++ b/crates/rspack_core/src/options/target.rs
@@ -1,0 +1,461 @@
+use super::Context;
+
+pub type Target = Vec<String>;
+
+#[derive(Debug, Default)]
+pub struct TargetProperties {
+  pub web: Option<bool>,
+  pub browser: Option<bool>,
+  pub webworker: Option<bool>,
+  pub node: Option<bool>,
+  pub electron: Option<bool>,
+  pub nwjs: Option<bool>,
+  pub electron_main: Option<bool>,
+  pub electron_preload: Option<bool>,
+  pub electron_renderer: Option<bool>,
+  pub require: Option<bool>,
+  pub node_builtins: Option<bool>,
+  pub node_prefix_for_core_modules: Option<bool>,
+  pub document: Option<bool>,
+  pub import_scripts: Option<bool>,
+  pub import_scripts_in_worker: Option<bool>,
+  pub fetch_wasm: Option<bool>,
+  pub global: Option<bool>,
+  pub global_this: Option<bool>,
+  pub big_int_literal: Option<bool>,
+  pub r#const: Option<bool>,
+  pub arrow_function: Option<bool>,
+  pub for_of: Option<bool>,
+  pub destructuring: Option<bool>,
+  pub dynamic_import: Option<bool>,
+  pub dynamic_import_in_worker: Option<bool>,
+  pub module: Option<bool>,
+  pub optional_chaining: Option<bool>,
+  pub template_literal: Option<bool>,
+  pub async_function: Option<bool>,
+}
+
+impl TargetProperties {
+  pub fn web(&self) -> bool {
+    self.web.unwrap_or(false)
+  }
+  pub fn browser(&self) -> bool {
+    self.browser.unwrap_or(false)
+  }
+  pub fn webworker(&self) -> bool {
+    self.webworker.unwrap_or(false)
+  }
+  pub fn node(&self) -> bool {
+    self.node.unwrap_or(false)
+  }
+  pub fn electron(&self) -> bool {
+    self.electron.unwrap_or(false)
+  }
+  pub fn nwjs(&self) -> bool {
+    self.nwjs.unwrap_or(false)
+  }
+  pub fn electron_main(&self) -> bool {
+    self.electron_main.unwrap_or(false)
+  }
+  pub fn electron_preload(&self) -> bool {
+    self.electron_preload.unwrap_or(false)
+  }
+  pub fn electron_renderer(&self) -> bool {
+    self.electron_renderer.unwrap_or(false)
+  }
+  pub fn require(&self) -> bool {
+    self.require.unwrap_or(false)
+  }
+  pub fn node_builtins(&self) -> bool {
+    self.node_builtins.unwrap_or(false)
+  }
+  pub fn node_prefix_for_core_modules(&self) -> bool {
+    self.node_prefix_for_core_modules.unwrap_or(false)
+  }
+  pub fn document(&self) -> bool {
+    self.document.unwrap_or(false)
+  }
+  pub fn import_scripts(&self) -> bool {
+    self.import_scripts.unwrap_or(false)
+  }
+  pub fn import_scripts_in_worker(&self) -> bool {
+    self.import_scripts_in_worker.unwrap_or(false)
+  }
+  pub fn fetch_wasm(&self) -> bool {
+    self.fetch_wasm.unwrap_or(false)
+  }
+  pub fn global(&self) -> bool {
+    self.global.unwrap_or(false)
+  }
+  pub fn global_this(&self) -> bool {
+    self.global_this.unwrap_or(false)
+  }
+  pub fn big_int_literal(&self) -> bool {
+    self.big_int_literal.unwrap_or(false)
+  }
+  pub fn r#const(&self) -> bool {
+    self.r#const.unwrap_or(false)
+  }
+  pub fn arrow_function(&self) -> bool {
+    self.arrow_function.unwrap_or(false)
+  }
+  pub fn for_of(&self) -> bool {
+    self.for_of.unwrap_or(false)
+  }
+  pub fn destructuring(&self) -> bool {
+    self.destructuring.unwrap_or(false)
+  }
+  pub fn dynamic_import(&self) -> bool {
+    self.dynamic_import.unwrap_or(false)
+  }
+  pub fn dynamic_import_in_worker(&self) -> bool {
+    self.dynamic_import_in_worker.unwrap_or(false)
+  }
+  pub fn module(&self) -> bool {
+    self.module.unwrap_or(false)
+  }
+  pub fn optional_chaining(&self) -> bool {
+    self.optional_chaining.unwrap_or(false)
+  }
+  pub fn template_literal(&self) -> bool {
+    self.template_literal.unwrap_or(false)
+  }
+  pub fn async_function(&self) -> bool {
+    self.async_function.unwrap_or(false)
+  }
+}
+
+fn version_dependent(
+  major: u32,
+  minor: Option<u32>,
+  target_major: Option<u32>,
+  target_minor: Option<u32>,
+) -> bool {
+  match (target_major, target_minor) {
+    (Some(t_major), Some(t_minor)) => {
+      t_major > major || (t_major == major && t_minor >= minor.unwrap_or(0))
+    }
+    (Some(t_major), None) => t_major >= major,
+    _ => false,
+  }
+}
+
+fn merge_target_properties(target_properties: &[TargetProperties]) -> TargetProperties {
+  let mut result = TargetProperties::default();
+
+  // Helper macro to merge a specific field across all target properties
+  macro_rules! merge_field {
+    ($field:ident) => {{
+      let mut has_true = false;
+      let mut has_false = false;
+
+      for tp in target_properties {
+        match tp.$field {
+          Some(true) => has_true = true,
+          Some(false) => has_false = true,
+          None => {}
+        }
+      }
+
+      if has_true || has_false {
+        result.$field = (has_false && has_true).then_some(has_true);
+      }
+    }};
+  }
+
+  // Merge all fields
+  merge_field!(web);
+  merge_field!(browser);
+  merge_field!(webworker);
+  merge_field!(node);
+  merge_field!(electron);
+  merge_field!(nwjs);
+  merge_field!(electron_main);
+  merge_field!(electron_preload);
+  merge_field!(electron_renderer);
+  merge_field!(require);
+  merge_field!(node_builtins);
+  merge_field!(node_prefix_for_core_modules);
+  merge_field!(document);
+  merge_field!(import_scripts);
+  merge_field!(import_scripts_in_worker);
+  merge_field!(fetch_wasm);
+  merge_field!(global);
+  merge_field!(global_this);
+  merge_field!(big_int_literal);
+  merge_field!(r#const);
+  merge_field!(arrow_function);
+  merge_field!(for_of);
+  merge_field!(destructuring);
+  merge_field!(dynamic_import);
+  merge_field!(dynamic_import_in_worker);
+  merge_field!(module);
+  merge_field!(optional_chaining);
+  merge_field!(template_literal);
+  merge_field!(async_function);
+
+  result
+}
+
+fn get_target_properties(target: &str, _context: &Context) -> TargetProperties {
+  // Parse target string
+  if let Some(captures) = regex::Regex::new(r"^(async-)?node((\d+)(?:\.(\d+))?)?$")
+    .expect("should initialize `Regex`")
+    .captures(target)
+  {
+    let async_flag = captures.get(1).is_some();
+    let major = captures.get(3).map(|m| {
+      m.as_str()
+        .parse::<u32>()
+        .expect("should initialize `Regex`")
+    });
+    let minor = captures.get(4).map(|m| {
+      m.as_str()
+        .parse::<u32>()
+        .expect("should initialize `Regex`")
+    });
+
+    return TargetProperties {
+      node: Some(true),
+      electron: Some(false),
+      nwjs: Some(false),
+      web: Some(false),
+      webworker: Some(false),
+      browser: Some(false),
+      require: Some(!async_flag),
+      node_builtins: Some(true),
+      node_prefix_for_core_modules: Some(match major {
+        Some(m) if m < 15 => version_dependent(14, Some(18), major, minor),
+        Some(_) => version_dependent(16, None, major, minor),
+        None => false,
+      }),
+      global: Some(true),
+      document: Some(false),
+      fetch_wasm: Some(false),
+      import_scripts: Some(false),
+      import_scripts_in_worker: Some(false),
+      global_this: Some(version_dependent(12, None, major, minor)),
+      r#const: Some(version_dependent(6, None, major, minor)),
+      template_literal: Some(version_dependent(4, None, major, minor)),
+      optional_chaining: Some(version_dependent(14, None, major, minor)),
+      arrow_function: Some(version_dependent(6, None, major, minor)),
+      async_function: Some(version_dependent(7, Some(6), major, minor)),
+      for_of: Some(version_dependent(5, None, major, minor)),
+      destructuring: Some(version_dependent(6, None, major, minor)),
+      big_int_literal: Some(version_dependent(10, Some(4), major, minor)),
+      dynamic_import: Some(version_dependent(12, Some(17), major, minor)),
+      dynamic_import_in_worker: if major.is_some() { Some(false) } else { None },
+      module: Some(version_dependent(12, Some(17), major, minor)),
+      ..Default::default()
+    };
+  }
+
+  // TODO: Handle browserslist target
+  //if let Some(captures) = regex::Regex::new(r"^browserslist(?::(.+))?$")
+  //  .expect("should initialize `Regex`")
+  //  .captures(target)
+  //{
+  //  let rest = captures.get(1).map(|m| m.as_str().trim());
+  //  // TODO: Implement browserslist handling
+  //  // For now return default web target
+  //  return TargetProperties {
+  //    web: Some(true),
+  //    browser: Some(true),
+  //    webworker: None,
+  //    node: Some(false),
+  //    electron: Some(false),
+  //    nwjs: Some(false),
+  //    document: Some(true),
+  //    import_scripts_in_worker: Some(true),
+  //    fetch_wasm: Some(true),
+  //    node_builtins: Some(false),
+  //    import_scripts: Some(false),
+  //    require: Some(false),
+  //    global: Some(false),
+  //    ..Default::default()
+  //  };
+  //}
+
+  // Handle web target
+  if target == "web" {
+    return TargetProperties {
+      web: Some(true),
+      browser: Some(true),
+      webworker: None,
+      node: Some(false),
+      electron: Some(false),
+      nwjs: Some(false),
+      document: Some(true),
+      import_scripts_in_worker: Some(true),
+      fetch_wasm: Some(true),
+      node_builtins: Some(false),
+      import_scripts: Some(false),
+      require: Some(false),
+      global: Some(false),
+      ..Default::default()
+    };
+  }
+
+  // Webworker target
+  if target == "webworker" {
+    return TargetProperties {
+      web: Some(true),
+      browser: Some(true),
+      webworker: Some(true),
+      node: Some(false),
+      electron: Some(false),
+      nwjs: Some(false),
+      import_scripts: Some(true),
+      import_scripts_in_worker: Some(true),
+      fetch_wasm: Some(true),
+      node_builtins: Some(false),
+      require: Some(false),
+      document: Some(false),
+      global: Some(false),
+      ..Default::default()
+    };
+  }
+
+  // Electron target
+  if let Some(captures) =
+    regex::Regex::new(r"^electron((\d+)(?:\.(\d+))?)?-(main|preload|renderer)$")
+      .expect("should initialize `Regex`")
+      .captures(target)
+  {
+    let major = captures.get(2).map(|m| {
+      m.as_str()
+        .parse::<u32>()
+        .expect("should initialize `Regex`")
+    });
+    let minor = captures.get(3).map(|m| {
+      m.as_str()
+        .parse::<u32>()
+        .expect("should initialize `Regex`")
+    });
+    let context = captures
+      .get(4)
+      .map(|m| m.as_str())
+      .expect("should initialize `Regex`");
+
+    return TargetProperties {
+      node: Some(true),
+      electron: Some(true),
+      web: Some(context != "main"),
+      webworker: Some(false),
+      browser: Some(false),
+      nwjs: Some(false),
+      electron_main: Some(context == "main"),
+      electron_preload: Some(context == "preload"),
+      electron_renderer: Some(context == "renderer"),
+      global: Some(true),
+      node_builtins: Some(true),
+      node_prefix_for_core_modules: Some(version_dependent(15, None, major, minor)),
+      require: Some(true),
+      document: Some(context == "renderer"),
+      fetch_wasm: Some(context == "renderer"),
+      import_scripts: Some(false),
+      import_scripts_in_worker: Some(true),
+      global_this: Some(version_dependent(5, None, major, minor)),
+      r#const: Some(version_dependent(1, Some(1), major, minor)),
+      template_literal: Some(version_dependent(1, Some(1), major, minor)),
+      optional_chaining: Some(version_dependent(8, None, major, minor)),
+      arrow_function: Some(version_dependent(1, Some(1), major, minor)),
+      async_function: Some(version_dependent(1, Some(7), major, minor)),
+      for_of: Some(version_dependent(0, Some(36), major, minor)),
+      destructuring: Some(version_dependent(1, Some(1), major, minor)),
+      big_int_literal: Some(version_dependent(4, None, major, minor)),
+      dynamic_import: Some(version_dependent(11, None, major, minor)),
+      dynamic_import_in_worker: if major.is_some() { Some(false) } else { None },
+      module: Some(version_dependent(11, None, major, minor)),
+    };
+  }
+
+  // NW.js target
+  if let Some(captures) = regex::Regex::new(r"^(?:nwjs|node-webkit)((\d+)(?:\.(\d+))?)?$")
+    .expect("should initialize `Regex`")
+    .captures(target)
+  {
+    let major = captures.get(2).map(|m| {
+      m.as_str()
+        .parse::<u32>()
+        .expect("should initialize `Regex`")
+    });
+    let minor = captures.get(3).map(|m| {
+      m.as_str()
+        .parse::<u32>()
+        .expect("should initialize `Regex`")
+    });
+
+    return TargetProperties {
+      node: Some(true),
+      web: Some(true),
+      nwjs: Some(true),
+      webworker: None,
+      browser: Some(false),
+      electron: Some(false),
+      global: Some(true),
+      node_builtins: Some(true),
+      document: Some(false),
+      import_scripts_in_worker: Some(false),
+      fetch_wasm: Some(false),
+      import_scripts: Some(false),
+      require: Some(false),
+      global_this: Some(version_dependent(0, Some(43), major, minor)),
+      r#const: Some(version_dependent(0, Some(15), major, minor)),
+      template_literal: Some(version_dependent(0, Some(13), major, minor)),
+      optional_chaining: Some(version_dependent(0, Some(44), major, minor)),
+      arrow_function: Some(version_dependent(0, Some(15), major, minor)),
+      async_function: Some(version_dependent(0, Some(21), major, minor)),
+      for_of: Some(version_dependent(0, Some(13), major, minor)),
+      destructuring: Some(version_dependent(0, Some(15), major, minor)),
+      big_int_literal: Some(version_dependent(0, Some(32), major, minor)),
+      dynamic_import: Some(version_dependent(0, Some(43), major, minor)),
+      dynamic_import_in_worker: if major.is_some() { Some(false) } else { None },
+      module: Some(version_dependent(0, Some(43), major, minor)),
+      ..Default::default()
+    };
+  }
+
+  // ES version target
+  if let Some(captures) = regex::Regex::new(r"^es(\d+)$")
+    .expect("should initialize `Regex`")
+    .captures(target)
+  {
+    let mut version = captures
+      .get(1)
+      .expect("should initialize `Regex`")
+      .as_str()
+      .parse::<u32>()
+      .expect("should initialize `Regex`");
+    if version < 1000 {
+      version += 2009;
+    }
+
+    return TargetProperties {
+      r#const: Some(version >= 2015),
+      template_literal: Some(version >= 2015),
+      optional_chaining: Some(version >= 2020),
+      arrow_function: Some(version >= 2015),
+      for_of: Some(version >= 2015),
+      destructuring: Some(version >= 2015),
+      module: Some(version >= 2015),
+      async_function: Some(version >= 2017),
+      global_this: Some(version >= 2020),
+      big_int_literal: Some(version >= 2020),
+      dynamic_import: Some(version >= 2020),
+      dynamic_import_in_worker: Some(version >= 2020),
+      ..Default::default()
+    };
+  }
+
+  panic!("Unknown target {target}");
+}
+
+pub fn get_targets_properties(targets: &[String], context: &Context) -> TargetProperties {
+  merge_target_properties(
+    &targets
+      .iter()
+      .map(|t| get_target_properties(t, context))
+      .collect::<Vec<_>>(),
+  )
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This is the first PR of aligning rust options with JS. 
This feature is still under development. APIs added in this PR are still unusable.
Things are subject to change.

This PR includes:
- Initialize `CompilerOptionsBuilder` on rust side.


Should sync https://github.com/web-infra-dev/rspack/pull/8802/files#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60cc later.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
