### PR TITLE
fix: should recognize negative preload value

### DIFF
--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -506,16 +506,16 @@ impl Display for ChunkGroupOrderKey {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ChunkGroupOptions {
   pub name: Option<String>,
-  pub preload_order: Option<u32>,
-  pub prefetch_order: Option<u32>,
+  pub preload_order: Option<i32>,
+  pub prefetch_order: Option<i32>,
   pub fetch_priority: Option<DynamicImportFetchPriority>,
 }
 
 impl ChunkGroupOptions {
   pub fn new(
     name: Option<String>,
-    preload_order: Option<u32>,
-    prefetch_order: Option<u32>,
+    preload_order: Option<i32>,
+    prefetch_order: Option<i32>,
     fetch_priority: Option<DynamicImportFetchPriority>,
   ) -> Self {
     Self {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -148,11 +148,11 @@ impl From<&str> for JavascriptParserUrl {
 #[derive(Debug, Clone, Copy, MergeFrom)]
 pub enum JavascriptParserOrder {
   Disable,
-  Order(u32),
+  Order(i32),
 }
 
 impl JavascriptParserOrder {
-  pub fn get_order(&self) -> Option<u32> {
+  pub fn get_order(&self) -> Option<i32> {
     match self {
       Self::Disable => None,
       Self::Order(o) => Some(*o),
@@ -166,7 +166,7 @@ impl From<&str> for JavascriptParserOrder {
       "false" => Self::Disable,
       "true" => Self::Order(0),
       _ => {
-        if let Ok(order) = value.parse::<u32>() {
+        if let Ok(order) = value.parse::<i32>() {
           Self::Order(order)
         } else {
           Self::Order(0)

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -228,12 +228,12 @@ pub mod expr_name {
   pub const IMPORT_META_WEBPACK_CONTEXT: &str = "import.meta.webpackContext";
 }
 
-pub fn parse_order_string(x: &str) -> Option<u32> {
+pub fn parse_order_string(x: &str) -> Option<i32> {
   match x {
     "true" => Some(0),
     "false" => None,
     _ => {
-      if let Ok(order) = x.parse::<u32>() {
+      if let Ok(order) = x.parse::<i32>() {
         Some(order)
       } else {
         None

--- a/packages/rspack-test-tools/tests/configCases/web/fetch-priority-2/index.js
+++ b/packages/rspack-test-tools/tests/configCases/web/fetch-priority-2/index.js
@@ -1,42 +1,42 @@
 it("should set fetchPriority", () => {
 	import(/* webpackFetchPriority: "high" */ "./a");
-	expect(document.head.children).toHaveLength(3);
-	const script1 = document.head.children[1];
+	expect(document.head.children).toHaveLength(4);
+	const script1 = document.head.children[2];
 	expect(script1.getAttribute("fetchpriority")).toBe("high");
 
 	import(/* webpackFetchPriority: "low" */ "./b");
-	expect(document.head.children).toHaveLength(4);
-	const script2 = document.head.children[3];
+	expect(document.head.children).toHaveLength(5);
+	const script2 = document.head.children[4];
 	expect(script2.getAttribute("fetchpriority")).toBe("low");
 
 	import(/* webpackFetchPriority: "low" */ "./c");
-	expect(document.head.children).toHaveLength(5);
-	const script3 = document.head.children[4];
+	expect(document.head.children).toHaveLength(6);
+	const script3 = document.head.children[5];
 	expect(script3.getAttribute("fetchpriority")).toBe("low");
 
 	import(/* webpackPrefetch: 20, webpackFetchPriority: "auto" */ "./c");
 
 	import("./d")
-	expect(document.head.children).toHaveLength(6);
-	const script4 = document.head.children[5];
+	expect(document.head.children).toHaveLength(7);
+	const script4 = document.head.children[6];
 	expect(script4.getAttribute("fetchpriority")).toBeFalsy();
 
 	import(/* webpackPrefetch: -20 */ "./d3");
-	expect(document.head.children).toHaveLength(7);
-	const script5 = document.head.children[6];
+	expect(document.head.children).toHaveLength(8);
+	const script5 = document.head.children[7];
 	expect(script5.getAttribute("fetchpriority")).toBeFalsy();
 
 	const condition = true;
 
 	if (!condition) {
 		import(/* webpackFetchPriority: "high", webpackChunkName: "one" */ "./e");
-		expect(document.head.children).toHaveLength(8);
-		const script6 = document.head.children[7];
+		expect(document.head.children).toHaveLength(9);
+		const script6 = document.head.children[8];
 		expect(script6.getAttribute("fetchpriority")).toBe("high");
 	} else {
 		import(/* webpackFetchPriority: "low", webpackChunkName: "two" */ "./e");
-		expect(document.head.children).toHaveLength(8);
-		const script6 = document.head.children[7];
+		expect(document.head.children).toHaveLength(9);
+		const script6 = document.head.children[8];
 		expect(script6.getAttribute("fetchpriority")).toBe("low");
 	}
 });

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1210,14 +1210,14 @@ asset normal.js 102 bytes {615} [emitted] (name: normal)
 asset prefetched2.js 102 bytes {424} [emitted] (name: prefetched2)
 asset prefetched3.js 102 bytes {182} [emitted] (name: prefetched3)
 Entrypoint main 13.9 KiB = main.js
-  prefetch: prefetched.js {674} (name: prefetched)
+  prefetch: prefetched.js {674} (name: prefetched), prefetched3.js {182} (name: prefetched3), prefetched2.js {424} (name: prefetched2)
 chunk {182} (runtime: main) prefetched3.js (prefetched3) 1 bytes <{909}> [rendered]
 chunk {424} (runtime: main) prefetched2.js (prefetched2) 1 bytes <{909}> [rendered]
 chunk {481} (runtime: main) inner.js (inner) 1 bytes <{674}> [rendered]
 chunk {615} (runtime: main) normal.js (normal) 1 bytes <{909}> [rendered]
 chunk {674} (runtime: main) prefetched.js (prefetched) 228 bytes <{909}> >{481}< >{857}< (prefetch: {857} {481}) [rendered]
 chunk {857} (runtime: main) inner2.js (inner2) 2 bytes <{674}> [rendered]
-chunk {909} (runtime: main) main.js (main) 436 bytes (javascript) 11 KiB (runtime) >{182}< >{424}< >{615}< >{674}< (prefetch: {674}) [entry] [rendered]"
+chunk {909} (runtime: main) main.js (main) 436 bytes (javascript) 11 KiB (runtime) >{182}< >{424}< >{615}< >{674}< (prefetch: {674} {182} {424}) [entry] [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for prefetch-preload-mixed 1`] = `
@@ -1243,14 +1243,14 @@ asset normal.js 102 bytes [emitted] (name: normal)
 asset preloaded2.js 101 bytes [emitted] (name: preloaded2)
 asset preloaded3.js 100 bytes [emitted] (name: preloaded3)
 Entrypoint main 12.5 KiB = main.js
-  preload: preloaded.js {154} (name: preloaded)
+  preload: preloaded.js {154} (name: preloaded), preloaded3.js {551} (name: preloaded3), preloaded2.js {577} (name: preloaded2)
 chunk (runtime: main) preloaded.js (preloaded) 226 bytes (preload: {857} {481}) [rendered]
 chunk (runtime: main) inner.js (inner) 1 bytes [rendered]
 chunk (runtime: main) preloaded3.js (preloaded3) 1 bytes [rendered]
 chunk (runtime: main) preloaded2.js (preloaded2) 1 bytes [rendered]
 chunk (runtime: main) normal.js (normal) 1 bytes [rendered]
 chunk (runtime: main) inner2.js (inner2) 2 bytes [rendered]
-chunk (runtime: main) main.js (main) 424 bytes (javascript) 9.78 KiB (runtime) (preload: {154}) [entry] [rendered]"
+chunk (runtime: main) main.js (main) 424 bytes (javascript) 9.78 KiB (runtime) (preload: {154} {551} {577}) [entry] [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`webpackPreload` and `webpackPrefetch` magic comments can set preload and prefetch to script tag, the value of these comments determine the priority and the order of preloaded chunks. The value can also be negative, as it is only for ordering.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
