### PR TITLE
test: refresh modified file mtime when run NEXT_START

### DIFF
--- a/packages/rspack-test-tools/src/helper/util/refreshModifyTime.ts
+++ b/packages/rspack-test-tools/src/helper/util/refreshModifyTime.ts
@@ -1,4 +1,4 @@
-import { readFile, stat, writeFile } from "fs-extra";
+import { readFile, writeFile } from "fs-extra";
 
 export async function refreshModifyTime(file: string) {
 	const data = await readFile(file);

--- a/packages/rspack-test-tools/src/helper/util/refreshModifyTime.ts
+++ b/packages/rspack-test-tools/src/helper/util/refreshModifyTime.ts
@@ -1,9 +1,6 @@
 import { readFile, stat, writeFile } from "fs-extra";
 
 export async function refreshModifyTime(file: string) {
-	const before = await stat(file);
 	const data = await readFile(file);
 	await writeFile(file, data);
-	const after = await stat(file);
-	console.log(before.mtime, after.mtime);
 }

--- a/packages/rspack-test-tools/src/helper/util/refreshModifyTime.ts
+++ b/packages/rspack-test-tools/src/helper/util/refreshModifyTime.ts
@@ -1,0 +1,9 @@
+import { readFile, stat, writeFile } from "fs-extra";
+
+export async function refreshModifyTime(file: string) {
+	const before = await stat(file);
+	const data = await readFile(file);
+	await writeFile(file, data);
+	const after = await stat(file);
+	console.log(before.mtime, after.mtime);
+}

--- a/packages/rspack-test-tools/src/processor/cache.ts
+++ b/packages/rspack-test-tools/src/processor/cache.ts
@@ -95,7 +95,8 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
 	): TCompilerOptions<T> {
 		const options = {
 			context: context.getSource(),
-			mode: "development",
+			mode: "production",
+			cache: true,
 			devtool: false,
 			output: {
 				path: context.getDist(),

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/index.js
@@ -10,12 +10,4 @@ it("should store and resume asset parser and generator states", async () => {
 	if (COMPILER_INDEX == 1) {
 		expect(value).toBe(3);
 	}
-
-	//		expect(value).toBe(1);
-	//		await NEXT_START();
-	//	}
-	//	if (COMPILER_INDEX == 1) {
-
-	//		expect(value).toBe(2);
-	//	}
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`NEXT_START` in cache case will generate a new compiler to rebuild, we should refresh the modified file mtime to test the snapshot module in persistent cache

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
