### PR TITLE
fix: persistent cache save ModuleArgumentDependency.id

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -8,8 +8,7 @@ use rspack_util::ext::DynHash;
 #[cacheable]
 #[derive(Debug, Clone)]
 pub struct ModuleArgumentDependency {
-  #[cacheable(with=Skip)]
-  id: Option<&'static str>,
+  id: Option<String>,
   range: DependencyRange,
   #[cacheable(with=Skip)]
   source_map: Option<SharedSourceMap>,
@@ -17,7 +16,7 @@ pub struct ModuleArgumentDependency {
 
 impl ModuleArgumentDependency {
   pub fn new(
-    id: Option<&'static str>,
+    id: Option<String>,
     range: DependencyRange,
     source_map: Option<SharedSourceMap>,
   ) -> Self {
@@ -55,7 +54,7 @@ impl DependencyTemplate for ModuleArgumentDependency {
       .expect("should have mgm")
       .get_module_argument();
 
-    let content = if let Some(id) = self.id {
+    let content = if let Some(id) = &self.id {
       format!("{module_argument}.{id}")
     } else {
       format!("{module_argument}")

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -401,7 +401,7 @@ impl JavascriptParserPlugin for APIPlugin {
       parser
         .presentational_dependencies
         .push(Box::new(ModuleArgumentDependency::new(
-          Some("id"),
+          Some("id".into()),
           expr.span().into(),
           Some(parser.source_map.clone()),
         )));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -44,7 +44,7 @@ impl JavascriptParser<'_> {
     self
       .presentational_dependencies
       .push(Box::new(ModuleArgumentDependency::new(
-        Some("hot"),
+        Some("hot".into()),
         span.into(),
         Some(self.source_map.clone()),
       )));
@@ -59,7 +59,7 @@ impl JavascriptParser<'_> {
     self
       .presentational_dependencies
       .push(Box::new(ModuleArgumentDependency::new(
-        Some("hot.accept"),
+        Some("hot.accept".into()),
         call_expr.callee.span().into(),
         Some(self.source_map.clone()),
       )));
@@ -95,7 +95,7 @@ impl JavascriptParser<'_> {
     self
       .presentational_dependencies
       .push(Box::new(ModuleArgumentDependency::new(
-        Some("hot.decline"),
+        Some("hot.decline".into()),
         call_expr.callee.span().into(),
         Some(self.source_map.clone()),
       )));

--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -112,6 +112,8 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
     // (undocumented)
     afterAll(context: ITestContext): Promise<void>;
     // (undocumented)
+    build(context: ITestContext): Promise<void>;
+    // (undocumented)
     protected _cacheOptions: ICacheProcessorOptions<T>;
     // (undocumented)
     static defaultOptions<T extends ECompilerType>(this: CacheProcessor<T>, context: ITestContext): TCompilerOptions<T>;

--- a/packages/rspack-test-tools/tests/Cache.test.js
+++ b/packages/rspack-test-tools/tests/Cache.test.js
@@ -4,13 +4,9 @@ process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 const path = require("path");
 const { describeByWalk, createCacheCase } = require("../dist");
 
-function v(name) {
-	return path.join(__dirname, `cache ${name}`);
-}
-
 // Run tests rspack-test-tools/tests/cacheCases in target async-node
 describeByWalk(
-	v("hot async-node"),
+	"cache",
 	(name, src, dist) => {
 		createCacheCase(name, src, dist, "async-node");
 	},

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/file.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/file.js
@@ -3,3 +3,5 @@ export default 1;
 export default 2;
 ---
 export default 3;
+---
+export default 4;

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/index.js
@@ -9,5 +9,7 @@ it("should store and resume asset parser and generator states", async () => {
 	}
 	if (COMPILER_INDEX == 1) {
 		expect(value).toBe(3);
+		await NEXT_HMR();
+		expect(value).toBe(4);
 	}
 });

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/basic/rspack.config.js
@@ -1,4 +1,9 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	context: __dirname
+	context: __dirname,
+	experiments: {
+		cache: {
+			type: "persistent"
+		}
+	}
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

* cacheCase clean cache.storage.directory before first run
* save ModuleArgumentDependency.id to avoid wrong replacement of "module.hot.accept".

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
