### PR TITLE
fix(incremental): activate inactive module not codegen

### DIFF
--- a/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/0/a.js
+++ b/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/0/a.js
@@ -1,0 +1,2 @@
+export const value = 42;
+globalThis["activate-inactive-module"] = value;

--- a/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/0/index.js
@@ -1,0 +1,5 @@
+import "./a";
+
+it("should not change the module id for the updated module", async () => {
+  expect(globalThis["activate-inactive-module"]).toBe(undefined);
+})

--- a/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/1/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/1/index.js
@@ -1,0 +1,6 @@
+import { value } from "./a";
+
+it("should not change the module id for the updated module", async () => {
+  expect(globalThis["activate-inactive-module"]).toBe(42);
+  expect(value).toBe(42);
+})

--- a/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/2/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/2/index.js
@@ -1,0 +1,5 @@
+import "./a";
+
+it("should not change the module id for the updated module", async () => {
+  expect(globalThis["activate-inactive-module"]).toBe(undefined);
+})

--- a/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/rspack.config.js
@@ -1,0 +1,11 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /a\.js/,
+				sideEffects: false,
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Activate an inactive module in rebuild, the module don't have codeGenerationResult
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
