### PR TITLE
chore: add profile choice for release canary

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -7,6 +7,14 @@ on:
         required: true
         type: string
         description: "Commit SHA"
+      profile:
+        required: true
+        type: choice
+        default: release
+        options:
+          - release
+          - release-debug
+        description: "release-debug means release with debug info for profile"
 
 permissions:
   # To publish packages with provenance
@@ -49,6 +57,7 @@ jobs:
       ref: ${{inputs.commit}}
       target: ${{ matrix.array.target }}
       runner: ${{ matrix.array.runner }}
+      profile: ${{inputs.profile}}
       test: false
 
   release:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:rs": "node ./scripts/check_rust_dependency.cjs",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",
     "build:binding:release": "pnpm --filter @rspack/binding run build:release",
+    "build:binding:release-debug": "pnpm --filter @rspack/binding run build:release-debug",
     "build:binding:release-prod": "pnpm --filter @rspack/binding run build:release-prod",
     "prepare": "is-ci || husky",
     "test:diff": "pnpm --filter \"@rspack/*\" test:diff",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
sometimes we need to do profile for users which we don't have access permission, so release with debug info will help we collect more profile info about it
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
