### PR TITLE
fix: rspack_version macro support match alpha version

### DIFF
--- a/crates/rspack_macros/src/rspack_version.rs
+++ b/crates/rspack_macros/src/rspack_version.rs
@@ -1,5 +1,5 @@
 pub fn rspack_version() -> String {
-  let re = regex::Regex::new(r#""version": ?"([0-9\.]+)""#).expect("should create regex");
+  let re = regex::Regex::new(r#""version": ?"([0-9a-zA-Z\.-]+)""#).expect("should create regex");
   // package.json in project root directory
   let package_json = include_str!("../../../package.json");
   let version = re


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`rspack_version!()` macro support match alpha version like `1.2.0-alpha.0`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
