### PR TITLE
fix: rspack_version macro use json to parse package.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4096,9 +4096,9 @@ dependencies = [
 name = "rspack_macros"
 version = "0.2.0"
 dependencies = [
+ "json",
  "proc-macro2",
  "quote",
- "regex",
  "syn 2.0.92",
 ]
 

--- a/crates/rspack_macros/Cargo.toml
+++ b/crates/rspack_macros/Cargo.toml
@@ -10,7 +10,7 @@ version     = "0.2.0"
 proc-macro = true
 
 [dependencies]
+json        = { workspace = true }
 proc-macro2 = { workspace = true }
 quote       = { workspace = true }
-regex       = { workspace = true }
 syn         = { workspace = true, features = ["full"] }

--- a/crates/rspack_macros/src/rspack_version.rs
+++ b/crates/rspack_macros/src/rspack_version.rs
@@ -1,9 +1,10 @@
 pub fn rspack_version() -> String {
-  let re = regex::Regex::new(r#""version": ?"([0-9a-zA-Z\.-]+)""#).expect("should create regex");
   // package.json in project root directory
   let package_json = include_str!("../../../package.json");
-  let version = re
-    .captures(package_json)
-    .expect("can not found version field in project package.json");
-  version[1].to_string()
+  let mut pkg =
+    json::parse(package_json).expect("can not parse package.json in project root directory");
+  let Some(version) = pkg["version"].take_string() else {
+    panic!("version field in package.json is not a string");
+  };
+  version
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Use json crate to parse package.json to get version field in `rspack_version!()` macro.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
