### PR TITLE
fix: add stdout draw target to multi progress

### DIFF
--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -41,7 +41,8 @@ impl std::fmt::Debug for ProgressPluginOptions {
   }
 }
 
-static MULTI_PROGRESS: LazyLock<MultiProgress> = LazyLock::new(MultiProgress::new);
+static MULTI_PROGRESS: LazyLock<MultiProgress> =
+  LazyLock::new(|| MultiProgress::with_draw_target(ProgressDrawTarget::stdout_with_hz(100)));
 #[derive(Debug, Default)]
 pub struct ProgressPluginDisplayOptions {
   // the prefix name of progress bar
@@ -83,8 +84,7 @@ impl ProgressPlugin {
       ProgressPluginOptions::Handler(_fn) => None,
       ProgressPluginOptions::Default(options) => {
         // default interval is 20, means draw every 1000/20 = 50ms, use 100 to draw every 1000/100 = 10ms
-        let progress_bar =
-          ProgressBar::with_draw_target(Some(100), ProgressDrawTarget::stdout_with_hz(100));
+        let progress_bar = MULTI_PROGRESS.add(ProgressBar::new(100));
 
         let mut progress_bar_style = ProgressStyle::with_template(&options.template)
           .expect("TODO:")
@@ -102,7 +102,6 @@ impl ProgressPlugin {
         Some(progress_bar)
       }
     };
-    let progress_bar = progress_bar.map(|x| MULTI_PROGRESS.add(x));
     Self::new_inner(
       options,
       progress_bar,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/8690

This pull request includes updates to the `ProgressPlugin` in the `crates/rspack_plugin_progress` library to improve the progress bar functionality. The most important changes involve the initialization and usage of the `MultiProgress` instance and the handling of progress bars.

Improvements to progress bar functionality:

* [`crates/rspack_plugin_progress/src/lib.rs`](diffhunk://#diff-74d45e75be91aa846fb37ea837a09fb96f501229aaa991892ccd11f12da006beL44-R45): Modified the `MULTI_PROGRESS` initialization to use `MultiProgress::with_draw_target` with a higher refresh rate for smoother updates.
* [`crates/rspack_plugin_progress/src/lib.rs`](diffhunk://#diff-74d45e75be91aa846fb37ea837a09fb96f501229aaa991892ccd11f12da006beL86-R87): Updated the `ProgressPlugin` implementation to add a new progress bar to the `MULTI_PROGRESS` instance instead of creating a new `ProgressBar` with a draw target.
* [`crates/rspack_plugin_progress/src/lib.rs`](diffhunk://#diff-74d45e75be91aa846fb37ea837a09fb96f501229aaa991892ccd11f12da006beL105): Removed redundant mapping of the progress bar to add it to `MULTI_PROGRESS`, as it is now handled directly during initialization.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
