### PR TITLE
docs: persistent cache example set root.cache to true

### DIFF
--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -374,6 +374,7 @@ Configuring `experiment.cache` to `false` to disable cache, which is no differen
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: false,
   },
@@ -386,6 +387,7 @@ Configuring `experiment.cache` to `true` or `{ "type": "memory" }` to enable mem
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: true,
   },
@@ -398,6 +400,7 @@ Configuring `experiment.cache` to `{ "type": "persistent" }` to enable persisten
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: {
       type: 'persistent',
@@ -420,6 +423,7 @@ It's recommended to set `cache.buildDependencies`: [__filename] in your rspack c
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: {
       type: 'persistent',
@@ -475,6 +479,7 @@ Configure cache storage. Currently only file system storage is supported. The ca
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: {
       type: 'persistent',

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -373,6 +373,7 @@ type ExperimentCacheOptions =
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: false,
   },
@@ -385,6 +386,7 @@ module.exports = {
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: true,
   },
@@ -397,6 +399,7 @@ module.exports = {
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: {
       type: 'persistent',
@@ -419,6 +422,7 @@ module.exports = {
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: {
       type: 'persistent',
@@ -474,6 +478,7 @@ module.exports = {
 
 ```js title="rspack.config.js"
 module.exports = {
+  cache: true,
   experiments: {
     cache: {
       type: 'persistent',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

In production mode, `root.cache` will automatically be set to false, which will make persistent caching ineffective and hard to spot. This PR will set cache to true in the example code to avoid this.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
