### PR TITLE
fix: copy filename_template into split chunks

### DIFF
--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -320,6 +320,9 @@ impl Chunk {
       });
     new_chunk.id_name_hints.extend(self.id_name_hints.clone());
     new_chunk.runtime = merge_runtime(&new_chunk.runtime, &self.runtime);
+    if (new_chunk.filename_template.is_none()) {
+      new_chunk.filename_template = self.filename_template.clone();
+    }
   }
 
   pub fn can_be_initial(&self, chunk_group_by_ukey: &ChunkGroupByUkey) -> bool {

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -320,7 +320,7 @@ impl Chunk {
       });
     new_chunk.id_name_hints.extend(self.id_name_hints.clone());
     new_chunk.runtime = merge_runtime(&new_chunk.runtime, &self.runtime);
-    if (new_chunk.filename_template.is_none()) {
+    if new_chunk.filename_template.is_none() {
       new_chunk.filename_template = self.filename_template.clone();
     }
   }

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -651,9 +651,6 @@ impl SplitChunksPlugin {
           };
           let new_part_ukey = new_part.ukey();
           chunk.split(new_part, &mut compilation.chunk_group_by_ukey);
-          if let Some(filename_template) = chunk.filename_template() {
-            new_part.set_filename_template(Some(filename_template.clone()));
-          }
           if let Some(mutations) = compilation.incremental.mutations_write() {
             mutations.add(Mutation::ChunkSplit {
               from: old_chunk,

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -651,6 +651,9 @@ impl SplitChunksPlugin {
           };
           let new_part_ukey = new_part.ukey();
           chunk.split(new_part, &mut compilation.chunk_group_by_ukey);
+          if let Some(filename_template) = chunk.filename_template() {
+            new_part.set_filename_template(Some(filename_template.clone()));
+          }
           if let Some(mutations) = compilation.incremental.mutations_write() {
             mutations.add(Mutation::ChunkSplit {
               from: old_chunk,

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -2242,6 +2242,19 @@ chunk (runtime: main) main.js (main) (id hint: common) xx bytes (javascript) xx 
 production (Rspack x.x.x) compiled successfully"
 `;
 
+exports[`StatsTestCases should print correct stats for split-chunks-cache-group-filename 1`] = `
+"Entrypoint main 5.88 KiB = 990.vendors.js 352 bytes 961.vendors.js 352 bytes 727.vendors.js 352 bytes main.js 4.85 KiB
+chunk (runtime: main) 727.vendors.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
+  ./node_modules/c.js 20 bytes [built] [code generated]
+chunk (runtime: main) main.js (main) 80 bytes (javascript) 2.86 KiB (runtime) [entry] [rendered]
+  ./index.js 80 bytes [built] [code generated]
+chunk (runtime: main) 961.vendors.js (id hint: vendors) 20 bytes [initial] [rendered]
+  ./node_modules/b.js 20 bytes [built] [code generated]
+chunk (runtime: main) 990.vendors.js (id hint: vendors) 20 bytes [initial] [rendered]
+  ./node_modules/a.js 20 bytes [built] [code generated]
+Rspack x.x.x compiled successfully in X.23"
+`;
+
 exports[`StatsTestCases should print correct stats for split-chunks-chunk-name 1`] = `
 "Entrypoint main xx KiB = default/main.js
 chunk (runtime: main) default/async-xxx.js (async-a) xx bytes <{909}> [rendered]

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -2243,15 +2243,15 @@ production (Rspack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-cache-group-filename 1`] = `
-"Entrypoint main 5.88 KiB = 990.vendors.js 352 bytes 961.vendors.js 352 bytes 727.vendors.js 352 bytes main.js 4.85 KiB
-chunk (runtime: main) 727.vendors.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-  ./node_modules/c.js 20 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 80 bytes (javascript) 2.86 KiB (runtime) [entry] [rendered]
-  ./index.js 80 bytes [built] [code generated]
-chunk (runtime: main) 961.vendors.js (id hint: vendors) 20 bytes [initial] [rendered]
-  ./node_modules/b.js 20 bytes [built] [code generated]
-chunk (runtime: main) 990.vendors.js (id hint: vendors) 20 bytes [initial] [rendered]
-  ./node_modules/a.js 20 bytes [built] [code generated]
+"Entrypoint main xx KiB = 990.vendors.js xx bytes 961.vendors.js xx bytes 727.vendors.js xx bytes main.js xx KiB
+chunk (runtime: main) 727.vendors.js (id hint: vendors) xx bytes [initial] [rendered] split chunk (cache group: vendors)
+  ./node_modules/c.js xx bytes [built] [code generated]
+chunk (runtime: main) main.js (main) xx bytes (javascript) xx KiB (runtime) [entry] [rendered]
+  ./index.js xx bytes [built] [code generated]
+chunk (runtime: main) 961.vendors.js (id hint: vendors) xx bytes [initial] [rendered]
+  ./node_modules/b.js xx bytes [built] [code generated]
+chunk (runtime: main) 990.vendors.js (id hint: vendors) xx bytes [initial] [rendered]
+  ./node_modules/a.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X.23"
 `;
 

--- a/tests/webpack-test/statsCases/split-chunks-cache-group-filename/index.js
+++ b/tests/webpack-test/statsCases/split-chunks-cache-group-filename/index.js
@@ -1,0 +1,5 @@
+import a from "a";
+import b from "b";
+import c from "c";
+
+console.log(a, b, c);

--- a/tests/webpack-test/statsCases/split-chunks-cache-group-filename/node_modules/a.js
+++ b/tests/webpack-test/statsCases/split-chunks-cache-group-filename/node_modules/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/tests/webpack-test/statsCases/split-chunks-cache-group-filename/node_modules/b.js
+++ b/tests/webpack-test/statsCases/split-chunks-cache-group-filename/node_modules/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/tests/webpack-test/statsCases/split-chunks-cache-group-filename/node_modules/c.js
+++ b/tests/webpack-test/statsCases/split-chunks-cache-group-filename/node_modules/c.js
@@ -1,0 +1,1 @@
+export default "c";

--- a/tests/webpack-test/statsCases/split-chunks-cache-group-filename/webpack.config.js
+++ b/tests/webpack-test/statsCases/split-chunks-cache-group-filename/webpack.config.js
@@ -1,0 +1,25 @@
+/** @type {import("../../../types").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: {
+		main: "./"
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				default: false,
+				vendors: {
+					chunks: "initial",
+					filename: "[name].vendors.js",
+					minSize: 1,
+					maxInitialSize: 1,
+					test: /[\\/]node_modules[\\/]/
+				}
+			}
+		}
+	},
+	stats: {
+		assets: false,
+		chunks: true
+	}
+};


### PR DESCRIPTION
## Summary

This is a reimplementation of a PR I opened against webpack (https://github.com/webpack/webpack/pull/19104). We found that the `splitChunks.cacheGroups.{cacheGroup}.filename` config option was not being respected for any split initial chunks created based on the `maxSize`-based deterministic grouping.

I added a stats test case which configures `vendors` cache group (with `filename` options) for anything in `node_modules` but with a small `maxSize` so it creates many little chunks. This is the diff for the test from before and after the fix in case it helps:

```diff
- Entrypoint main 5.88 KiB = 990.js 352 bytes 961.js 352 bytes 727.vendors.js 352 bytes main.js 4.85 KiB
+ Entrypoint main 5.88 KiB = 990.vendors.js 352 bytes 961.vendors.js 352 bytes 727.vendors.js 352 bytes main.js 4.85 KiB
  chunk (runtime: main) 727.vendors.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
    ./node_modules/c.js 20 bytes [built] [code generated]
  chunk (runtime: main) main.js (main) 80 bytes (javascript) 2.86 KiB (runtime) [entry] [rendered]
    ./index.js 80 bytes [built] [code generated]
- chunk (runtime: main) 961.js (id hint: vendors) 20 bytes [initial] [rendered]
+ chunk (runtime: main) 961.vendors.js (id hint: vendors) 20 bytes [initial] [rendered]
    ./node_modules/b.js 20 bytes [built] [code generated]
- chunk (runtime: main) 990.js (id hint: vendors) 20 bytes [initial] [rendered]
+ chunk (runtime: main) 990.vendors.js (id hint: vendors) 20 bytes [initial] [rendered]
    ./node_modules/a.js 20 bytes [built] [code generated]
```        

### Alternatives considered

It seems like we could move this logic in to the `split` method on the `Chunk` struct but I'm not sure if that is preferred.  


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
