### PR TITLE
fix: get resolved module

### DIFF
--- a/crates/rspack_binding_values/src/module_graph.rs
+++ b/crates/rspack_binding_values/src/module_graph.rs
@@ -49,12 +49,9 @@ impl JsModuleGraph {
     let (compilation, module_graph) = self.as_ref()?;
     Ok(
       match module_graph.connection_by_dependency_id(&js_dependency.dependency_id) {
-        Some(connection) => match connection.resolved_original_module_identifier {
-          Some(identifier) => compilation.module_by_identifier(&identifier).map(|module| {
-            JsModuleWrapper::new(module.as_ref(), compilation.id(), Some(compilation))
-          }),
-          None => None,
-        },
+        Some(connection) => module_graph
+          .module_by_identifier(&connection.resolved_module)
+          .map(|module| JsModuleWrapper::new(module.as_ref(), compilation.id(), Some(compilation))),
         None => None,
       },
     )

--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -11,6 +11,7 @@ pub struct ModuleGraphConnection {
   /// The referencing module identifier
   pub original_module_identifier: Option<ModuleIdentifier>,
   pub resolved_original_module_identifier: Option<ModuleIdentifier>,
+  pub resolved_module: ModuleIdentifier,
 
   /// The referenced module identifier
   module_identifier: ModuleIdentifier,
@@ -46,6 +47,7 @@ impl ModuleGraphConnection {
       active,
       conditional,
       resolved_original_module_identifier: original_module_identifier,
+      resolved_module: module_identifier,
     }
   }
 

--- a/packages/rspack-test-tools/tests/configCases/module-graph/get-module/foo.js
+++ b/packages/rspack-test-tools/tests/configCases/module-graph/get-module/foo.js
@@ -1,0 +1,1 @@
+export const foo = "foo";

--- a/packages/rspack-test-tools/tests/configCases/module-graph/get-module/index.js
+++ b/packages/rspack-test-tools/tests/configCases/module-graph/get-module/index.js
@@ -1,0 +1,3 @@
+import { foo } from "./foo";
+
+globalThis[Symbol()] = foo;

--- a/packages/rspack-test-tools/tests/configCases/module-graph/get-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module-graph/get-module/rspack.config.js
@@ -8,11 +8,15 @@ class Plugin {
      */
     apply(compiler) {
         compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
-            compilation.hooks.finishModules.tap(PLUGIN_NAME, () => {
+            compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, () => {
                 const entry = Array.from(compilation.entries.values())[0];
                 const entryDependency = entry.dependencies[0];
-                const refModule = compilation.moduleGraph.getModule(entryDependency);
-                expect(normalize(refModule.request)).toBe(normalize(join(__dirname, 'index.js')));
+
+                const module = compilation.moduleGraph.getModule(entryDependency);
+                expect(module.modules.length).toBe(2);
+
+                const resolvedModule = compilation.moduleGraph.getResolvedModule(entryDependency);
+                expect(normalize(resolvedModule.request)).toBe(normalize(join(__dirname, 'index.js')));
             });
         });
 
@@ -28,5 +32,8 @@ module.exports = {
     },
     plugins: [
         new Plugin()
-    ]
+    ],
+    optimization: {
+        concatenateModules: true
+    }
 };

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -48,7 +48,7 @@ import type { JsExportsInfo } from '@rspack/binding';
 import type { JsFactoryMeta } from '@rspack/binding';
 import { JsHtmlPluginTag } from '@rspack/binding';
 import { JsLoaderItem } from '@rspack/binding';
-import { JsModule } from '@rspack/binding';
+import type { JsModule } from '@rspack/binding';
 import type { JsModuleGraph } from '@rspack/binding';
 import type { JsModuleGraphConnection } from '@rspack/binding';
 import { JsRuntimeModule } from '@rspack/binding';
@@ -5533,6 +5533,7 @@ export const rspackOptions: z.ZodObject<{
         layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
     }, "strict", z.ZodTypeAny, {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -5556,11 +5557,11 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }, {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -5584,7 +5585,6 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>, z.ZodFunction<z.ZodTuple<[], z.ZodUnknown>, z.ZodUnion<[z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
@@ -5667,6 +5667,7 @@ export const rspackOptions: z.ZodObject<{
         layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
     }, "strict", z.ZodTypeAny, {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -5690,11 +5691,11 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }, {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -5718,7 +5719,6 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>, z.ZodPromise<z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
@@ -5801,6 +5801,7 @@ export const rspackOptions: z.ZodObject<{
         layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
     }, "strict", z.ZodTypeAny, {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -5824,11 +5825,11 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }, {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -5852,7 +5853,6 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>>]>>]>>;
@@ -6807,14 +6807,16 @@ export const rspackOptions: z.ZodObject<{
         errorsSpace: z.ZodOptional<z.ZodNumber>;
         warningsSpace: z.ZodOptional<z.ZodNumber>;
     }, "strict", z.ZodTypeAny, {
+        modules?: boolean | undefined;
+        chunks?: boolean | undefined;
+        ids?: boolean | undefined;
+        runtime?: boolean | undefined;
+        hash?: boolean | undefined;
         all?: boolean | undefined;
         version?: boolean | undefined;
-        runtime?: boolean | undefined;
         publicPath?: boolean | undefined;
         preset?: boolean | "none" | "verbose" | "normal" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
-        chunks?: boolean | undefined;
-        modules?: boolean | undefined;
         entrypoints?: boolean | "auto" | undefined;
         chunkGroups?: boolean | undefined;
         warnings?: boolean | undefined;
@@ -6822,12 +6824,10 @@ export const rspackOptions: z.ZodObject<{
         errors?: boolean | undefined;
         errorsCount?: boolean | undefined;
         colors?: boolean | undefined;
-        hash?: boolean | undefined;
         reasons?: boolean | undefined;
         outputPath?: boolean | undefined;
         chunkModules?: boolean | undefined;
         chunkRelations?: boolean | undefined;
-        ids?: boolean | undefined;
         timings?: boolean | undefined;
         builtAt?: boolean | undefined;
         moduleAssets?: boolean | undefined;
@@ -6884,14 +6884,16 @@ export const rspackOptions: z.ZodObject<{
         errorsSpace?: number | undefined;
         warningsSpace?: number | undefined;
     }, {
+        modules?: boolean | undefined;
+        chunks?: boolean | undefined;
+        ids?: boolean | undefined;
+        runtime?: boolean | undefined;
+        hash?: boolean | undefined;
         all?: boolean | undefined;
         version?: boolean | undefined;
-        runtime?: boolean | undefined;
         publicPath?: boolean | undefined;
         preset?: boolean | "none" | "verbose" | "normal" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
-        chunks?: boolean | undefined;
-        modules?: boolean | undefined;
         entrypoints?: boolean | "auto" | undefined;
         chunkGroups?: boolean | undefined;
         warnings?: boolean | undefined;
@@ -6899,12 +6901,10 @@ export const rspackOptions: z.ZodObject<{
         errors?: boolean | undefined;
         errorsCount?: boolean | undefined;
         colors?: boolean | undefined;
-        hash?: boolean | undefined;
         reasons?: boolean | undefined;
         outputPath?: boolean | undefined;
         chunkModules?: boolean | undefined;
         chunkRelations?: boolean | undefined;
-        ids?: boolean | undefined;
         timings?: boolean | undefined;
         builtAt?: boolean | undefined;
         moduleAssets?: boolean | undefined;
@@ -7002,10 +7002,10 @@ export const rspackOptions: z.ZodObject<{
                 type: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>>;
                 idHint: z.ZodOptional<z.ZodString>;
             }, "strict", z.ZodTypeAny, {
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 type?: string | RegExp | undefined;
                 chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 usedExports?: boolean | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 maxSize?: number | Record<string, number> | undefined;
@@ -7022,10 +7022,10 @@ export const rspackOptions: z.ZodObject<{
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
             }, {
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 type?: string | RegExp | undefined;
                 chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 usedExports?: boolean | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 maxSize?: number | Record<string, number> | undefined;
@@ -7066,15 +7066,15 @@ export const rspackOptions: z.ZodObject<{
             }>>;
             hidePathInfo: z.ZodOptional<z.ZodBoolean>;
         }, "strict", z.ZodTypeAny, {
-            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             usedExports?: boolean | undefined;
             defaultSizeTypes?: string[] | undefined;
             cacheGroups?: Record<string, false | {
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 type?: string | RegExp | undefined;
                 chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 usedExports?: boolean | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 maxSize?: number | Record<string, number> | undefined;
@@ -7109,15 +7109,15 @@ export const rspackOptions: z.ZodObject<{
             maxInitialRequests?: number | undefined;
             automaticNameDelimiter?: string | undefined;
         }, {
-            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             usedExports?: boolean | undefined;
             defaultSizeTypes?: string[] | undefined;
             cacheGroups?: Record<string, false | {
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 type?: string | RegExp | undefined;
                 chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 usedExports?: boolean | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 maxSize?: number | Record<string, number> | undefined;
@@ -7186,20 +7186,20 @@ export const rspackOptions: z.ZodObject<{
         providedExports?: boolean | undefined;
         sideEffects?: boolean | "flag" | undefined;
         moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | "size" | "total-size" | undefined;
+        chunkIds?: "size" | "named" | "natural" | "deterministic" | "total-size" | undefined;
         minimize?: boolean | undefined;
         minimizer?: (false | "" | 0 | "..." | t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
         mergeDuplicateChunks?: boolean | undefined;
         splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             usedExports?: boolean | undefined;
             defaultSizeTypes?: string[] | undefined;
             cacheGroups?: Record<string, false | {
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 type?: string | RegExp | undefined;
                 chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 usedExports?: boolean | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 maxSize?: number | Record<string, number> | undefined;
@@ -7244,7 +7244,7 @@ export const rspackOptions: z.ZodObject<{
         realContentHash?: boolean | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
-        mangleExports?: boolean | "deterministic" | "size" | undefined;
+        mangleExports?: boolean | "size" | "deterministic" | undefined;
         nodeEnv?: string | false | undefined;
         emitOnErrors?: boolean | undefined;
         avoidEntryIife?: boolean | undefined;
@@ -7253,20 +7253,20 @@ export const rspackOptions: z.ZodObject<{
         providedExports?: boolean | undefined;
         sideEffects?: boolean | "flag" | undefined;
         moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | "size" | "total-size" | undefined;
+        chunkIds?: "size" | "named" | "natural" | "deterministic" | "total-size" | undefined;
         minimize?: boolean | undefined;
         minimizer?: (false | "" | 0 | "..." | t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
         mergeDuplicateChunks?: boolean | undefined;
         splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             usedExports?: boolean | undefined;
             defaultSizeTypes?: string[] | undefined;
             cacheGroups?: Record<string, false | {
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 type?: string | RegExp | undefined;
                 chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 usedExports?: boolean | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 maxSize?: number | Record<string, number> | undefined;
@@ -7311,7 +7311,7 @@ export const rspackOptions: z.ZodObject<{
         realContentHash?: boolean | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
-        mangleExports?: boolean | "deterministic" | "size" | undefined;
+        mangleExports?: boolean | "size" | "deterministic" | undefined;
         nodeEnv?: string | false | undefined;
         emitOnErrors?: boolean | undefined;
         avoidEntryIife?: boolean | undefined;
@@ -8350,6 +8350,9 @@ export const rspackOptions: z.ZodObject<{
         maxEntrypointSize?: number | undefined;
     }>, z.ZodLiteral<false>]>>;
 }, "strict", z.ZodTypeAny, {
+    dependencies?: string[] | undefined;
+    context?: string | undefined;
+    name?: string | undefined;
     module?: {
         defaultRules?: (false | "" | 0 | t.RuleSetRule | "..." | null | undefined)[] | undefined;
         rules?: (false | "" | 0 | t.RuleSetRule | "..." | null | undefined)[] | undefined;
@@ -8499,7 +8502,6 @@ export const rspackOptions: z.ZodObject<{
         } | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     } | undefined;
-    name?: string | undefined;
     profile?: boolean | undefined;
     cache?: boolean | undefined;
     amd?: false | Record<string, any> | undefined;
@@ -8514,7 +8516,6 @@ export const rspackOptions: z.ZodObject<{
         hints?: false | "error" | "warning" | undefined;
         maxEntrypointSize?: number | undefined;
     } | undefined;
-    context?: string | undefined;
     mode?: "development" | "production" | "none" | undefined;
     experiments?: {
         css?: boolean | undefined;
@@ -8586,14 +8587,16 @@ export const rspackOptions: z.ZodObject<{
     devtool?: false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map" | undefined;
     resolve?: t.ResolveOptions | undefined;
     stats?: boolean | "none" | "verbose" | "normal" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | {
+        modules?: boolean | undefined;
+        chunks?: boolean | undefined;
+        ids?: boolean | undefined;
+        runtime?: boolean | undefined;
+        hash?: boolean | undefined;
         all?: boolean | undefined;
         version?: boolean | undefined;
-        runtime?: boolean | undefined;
         publicPath?: boolean | undefined;
         preset?: boolean | "none" | "verbose" | "normal" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
-        chunks?: boolean | undefined;
-        modules?: boolean | undefined;
         entrypoints?: boolean | "auto" | undefined;
         chunkGroups?: boolean | undefined;
         warnings?: boolean | undefined;
@@ -8601,12 +8604,10 @@ export const rspackOptions: z.ZodObject<{
         errors?: boolean | undefined;
         errorsCount?: boolean | undefined;
         colors?: boolean | undefined;
-        hash?: boolean | undefined;
         reasons?: boolean | undefined;
         outputPath?: boolean | undefined;
         chunkModules?: boolean | undefined;
         chunkRelations?: boolean | undefined;
-        ids?: boolean | undefined;
         timings?: boolean | undefined;
         builtAt?: boolean | undefined;
         moduleAssets?: boolean | undefined;
@@ -8668,6 +8669,7 @@ export const rspackOptions: z.ZodObject<{
     target?: false | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist" | ("async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist")[] | undefined;
     entry?: string | string[] | Record<string, string | string[] | {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -8691,11 +8693,11 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }> | ((...args: unknown[]) => string | string[] | Record<string, string | string[] | {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -8719,11 +8721,11 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }> | Promise<string | string[] | Record<string, string | string[] | {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -8747,11 +8749,9 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }>>) | undefined;
-    dependencies?: string[] | undefined;
     output?: {
         module?: boolean | undefined;
         chunkLoading?: string | false | undefined;
@@ -8878,20 +8878,20 @@ export const rspackOptions: z.ZodObject<{
         providedExports?: boolean | undefined;
         sideEffects?: boolean | "flag" | undefined;
         moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | "size" | "total-size" | undefined;
+        chunkIds?: "size" | "named" | "natural" | "deterministic" | "total-size" | undefined;
         minimize?: boolean | undefined;
         minimizer?: (false | "" | 0 | "..." | t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
         mergeDuplicateChunks?: boolean | undefined;
         splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             usedExports?: boolean | undefined;
             defaultSizeTypes?: string[] | undefined;
             cacheGroups?: Record<string, false | {
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 type?: string | RegExp | undefined;
                 chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 usedExports?: boolean | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 maxSize?: number | Record<string, number> | undefined;
@@ -8936,7 +8936,7 @@ export const rspackOptions: z.ZodObject<{
         realContentHash?: boolean | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
-        mangleExports?: boolean | "deterministic" | "size" | undefined;
+        mangleExports?: boolean | "size" | "deterministic" | undefined;
         nodeEnv?: string | false | undefined;
         emitOnErrors?: boolean | undefined;
         avoidEntryIife?: boolean | undefined;
@@ -8954,6 +8954,9 @@ export const rspackOptions: z.ZodObject<{
     ignoreWarnings?: (RegExp | ((args_0: Error, args_1: Compilation, ...args: unknown[]) => boolean))[] | undefined;
     bail?: boolean | undefined;
 }, {
+    dependencies?: string[] | undefined;
+    context?: string | undefined;
+    name?: string | undefined;
     module?: {
         defaultRules?: (false | "" | 0 | t.RuleSetRule | "..." | null | undefined)[] | undefined;
         rules?: (false | "" | 0 | t.RuleSetRule | "..." | null | undefined)[] | undefined;
@@ -9103,7 +9106,6 @@ export const rspackOptions: z.ZodObject<{
         } | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     } | undefined;
-    name?: string | undefined;
     profile?: boolean | undefined;
     cache?: boolean | undefined;
     amd?: false | Record<string, any> | undefined;
@@ -9118,7 +9120,6 @@ export const rspackOptions: z.ZodObject<{
         hints?: false | "error" | "warning" | undefined;
         maxEntrypointSize?: number | undefined;
     } | undefined;
-    context?: string | undefined;
     mode?: "development" | "production" | "none" | undefined;
     experiments?: {
         css?: boolean | undefined;
@@ -9190,14 +9191,16 @@ export const rspackOptions: z.ZodObject<{
     devtool?: false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map" | undefined;
     resolve?: t.ResolveOptions | undefined;
     stats?: boolean | "none" | "verbose" | "normal" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | {
+        modules?: boolean | undefined;
+        chunks?: boolean | undefined;
+        ids?: boolean | undefined;
+        runtime?: boolean | undefined;
+        hash?: boolean | undefined;
         all?: boolean | undefined;
         version?: boolean | undefined;
-        runtime?: boolean | undefined;
         publicPath?: boolean | undefined;
         preset?: boolean | "none" | "verbose" | "normal" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
-        chunks?: boolean | undefined;
-        modules?: boolean | undefined;
         entrypoints?: boolean | "auto" | undefined;
         chunkGroups?: boolean | undefined;
         warnings?: boolean | undefined;
@@ -9205,12 +9208,10 @@ export const rspackOptions: z.ZodObject<{
         errors?: boolean | undefined;
         errorsCount?: boolean | undefined;
         colors?: boolean | undefined;
-        hash?: boolean | undefined;
         reasons?: boolean | undefined;
         outputPath?: boolean | undefined;
         chunkModules?: boolean | undefined;
         chunkRelations?: boolean | undefined;
-        ids?: boolean | undefined;
         timings?: boolean | undefined;
         builtAt?: boolean | undefined;
         moduleAssets?: boolean | undefined;
@@ -9272,6 +9273,7 @@ export const rspackOptions: z.ZodObject<{
     target?: false | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist" | ("async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist")[] | undefined;
     entry?: string | string[] | Record<string, string | string[] | {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -9295,11 +9297,11 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }> | ((...args: unknown[]) => string | string[] | Record<string, string | string[] | {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -9323,11 +9325,11 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }> | Promise<string | string[] | Record<string, string | string[] | {
         import: string | string[];
+        layer?: string | null | undefined;
         runtime?: string | false | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
@@ -9351,11 +9353,9 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
-        layer?: string | null | undefined;
         wasmLoading?: string | false | undefined;
         dependOn?: string | string[] | undefined;
     }>>) | undefined;
-    dependencies?: string[] | undefined;
     output?: {
         module?: boolean | undefined;
         chunkLoading?: string | false | undefined;
@@ -9482,20 +9482,20 @@ export const rspackOptions: z.ZodObject<{
         providedExports?: boolean | undefined;
         sideEffects?: boolean | "flag" | undefined;
         moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | "size" | "total-size" | undefined;
+        chunkIds?: "size" | "named" | "natural" | "deterministic" | "total-size" | undefined;
         minimize?: boolean | undefined;
         minimizer?: (false | "" | 0 | "..." | t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
         mergeDuplicateChunks?: boolean | undefined;
         splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             usedExports?: boolean | undefined;
             defaultSizeTypes?: string[] | undefined;
             cacheGroups?: Record<string, false | {
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 type?: string | RegExp | undefined;
                 chunks?: RegExp | "initial" | "async" | "all" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 usedExports?: boolean | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 maxSize?: number | Record<string, number> | undefined;
@@ -9540,7 +9540,7 @@ export const rspackOptions: z.ZodObject<{
         realContentHash?: boolean | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
-        mangleExports?: boolean | "deterministic" | "size" | undefined;
+        mangleExports?: boolean | "size" | "deterministic" | undefined;
         nodeEnv?: string | false | undefined;
         emitOnErrors?: boolean | undefined;
         avoidEntryIife?: boolean | undefined;

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -204,14 +204,12 @@ export class Module {
 	/**
 	 * Records the dynamically added fields for Module on the JavaScript side.
 	 * These fields are generally used within a plugin, so they do not need to be passed back to the Rust side.
-	 * @see {@link Compilation#customModules}
 	 */
 	buildInfo: Record<string, any>;
 
 	/**
 	 * Records the dynamically added fields for Module on the JavaScript side.
 	 * These fields are generally used within a plugin, so they do not need to be passed back to the Rust side.
-	 * @see {@link Compilation#customModules}
 	 */
 	buildMeta: Record<string, any>;
 	declare readonly modules: Module[] | undefined;

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -5,10 +5,9 @@ import type {
 	JsCreateData,
 	JsFactoryMeta
 } from "@rspack/binding";
-import { JsModule } from "@rspack/binding";
+import type { JsModule } from "@rspack/binding";
 import type { Source } from "webpack-sources";
 
-import type { Compilation } from "./Compilation";
 import { DependenciesBlock } from "./DependenciesBlock";
 import { Dependency } from "./Dependency";
 import { JsSource } from "./util/source";
@@ -291,30 +290,21 @@ export class Module {
 			modules: {
 				enumerable: true,
 				get(): Module[] | undefined {
-					if (module instanceof JsModule) {
-						return module.modules
-							? module.modules.map(m => Module.__from_binding(m))
-							: undefined;
-					}
-					return undefined;
+					return module.modules
+						? module.modules.map(m => Module.__from_binding(m))
+						: undefined;
 				}
 			},
 			blocks: {
 				enumerable: true,
 				get(): DependenciesBlock[] {
-					if ("blocks" in module) {
-						return module.blocks.map(b => DependenciesBlock.__from_binding(b));
-					}
-					return [];
+					return module.blocks.map(b => DependenciesBlock.__from_binding(b));
 				}
 			},
 			dependencies: {
 				enumerable: true,
 				get(): Dependency[] {
-					if ("dependencies" in module) {
-						return module.dependencies.map(d => Dependency.__from_binding(d));
-					}
-					return [];
+					return module.dependencies.map(d => Dependency.__from_binding(d));
 				}
 			},
 			useSourceMap: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

`moduleGraph.getResolvedModule(dependency)` is used to access the module that is constructed through the dependency during the build phase. 

`moduleGraph.getModule(dependency)` is utilized to access the module corresponding to the dependency in the current module graph. For instance, during the `processAssets` phase, the `concatenateModules` optimization is performed, and multiple dependencies might point to the same concatenated module. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
