### PR TITLE
fix: transform nested webpack require with innerGraph enabled

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -98,9 +98,9 @@ impl JavascriptParserPlugin for CompatibilityPlugin {
     decl: &swc_core::ecma::ast::VarDeclarator,
     _statement: &swc_core::ecma::ast::VarDecl,
   ) -> Option<bool> {
-    if let Some(ident) = decl.name.as_ident()
-      && ident.sym.as_str() == RuntimeGlobals::REQUIRE.name()
-    {
+    let ident = decl.name.as_ident()?;
+
+    if ident.sym.as_str() == RuntimeGlobals::REQUIRE.name() {
       let start = ident.span().real_lo();
       let end = ident.span().real_hi();
       self.tag_nested_require_data(
@@ -111,7 +111,17 @@ impl JavascriptParserPlugin for CompatibilityPlugin {
         end,
       );
       return Some(true);
+    } else if ident.sym == RuntimeGlobals::EXPORTS.name() {
+      self.tag_nested_require_data(
+        parser,
+        ident.sym.to_string(),
+        "__nested_webpack_exports__".to_string(),
+        ident.span().real_lo(),
+        ident.span().real_hi(),
+      );
+      return Some(true);
     }
+
     None
   }
 

--- a/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/index.js
@@ -1,0 +1,1 @@
+require("./lib");

--- a/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/lib.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/lib.js
@@ -1,0 +1,8 @@
+var __webpack_exports__ = {};
+__webpack_exports__.e = 42;
+
+it("rename top level (avoid override by inner graph top level symbol)", () => {
+  expect(__webpack_exports__.e).toBe(42);
+  const lib2 = require("./lib2");
+  expect(lib2.a).toBe(1)
+});

--- a/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/lib2.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/lib2.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/rspack.config.js
@@ -1,0 +1,7 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: "production",
+  optimization: {
+    innerGraph: true,
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix: #8647

CompatiblePlugin parser hook relies on hookMap `for_name`, `for_name` is identifier name usually, but when the variable is tagged, `for_name` is the tagged name.

InnerGraph will tag all pure variables, and skip other plugins to continue handing the same identifier. InnerGraph treats `var __webpack_exports__ = {}` as pure declarator, it tags the variable `__webpack_exports__`, make CompatiblePlugin not able to transform it

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
