### PR TITLE
refactor: better storage error format

### DIFF
--- a/crates/rspack_storage/src/fs/error.rs
+++ b/crates/rspack_storage/src/fs/error.rs
@@ -105,15 +105,14 @@ impl std::fmt::Display for BatchFSError {
     write!(f, "{}", self.message)?;
     if let Some(join_error) = &self.join_error {
       write!(f, " due to `{}`", join_error)?;
-    }
-    if self.errors.len() == 1 {
-      write!(f, "{}", self.errors[0])?;
     } else {
-      for error in &self.errors {
-        write!(f, "\n- {}", error)?;
+      for error in self.errors.iter().take(5) {
+        write!(f, "\n{}", error)?;
+      }
+      if self.errors.len() > 5 {
+        write!(f, "\n...")?;
       }
     }
-
     Ok(())
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

just do not show too much nested error info

---

This pull request includes several changes to improve error handling and formatting in the `rspack_storage` crate. The most important changes include making the `ErrorReason` enum public, implementing the `Display` trait for `ErrorReason`, and modifying the `Display` implementation for `Error` and `BatchFSError` to enhance error message formatting.

Error handling and formatting improvements:

* [`crates/rspack_storage/src/error.rs`](diffhunk://#diff-30e3d1454b1f75b32cc703d5d35daa438d8e153413d48bcee123a2bd48c104a4L37-R69): Made the `ErrorReason` enum public and implemented the `Display` trait for it to provide better error message formatting.
* [`crates/rspack_storage/src/error.rs`](diffhunk://#diff-30e3d1454b1f75b32cc703d5d35daa438d8e153413d48bcee123a2bd48c104a4L127-L161): Modified the `Display` implementation for `Error` to use the new `Display` implementation of `ErrorReason`, simplifying the error message construction.
* [`crates/rspack_storage/src/fs/error.rs`](diffhunk://#diff-41796af0aafac09250436debae15b8b72fe1c68ec338d053c127f52bdd9638fcL108-L116): Updated the `Display` implementation for `BatchFSError` to limit the number of errors displayed and add ellipsis if there are more than five errors.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
