### PR TITLE
ci: use corepack instead of pnpm/action-setup

### DIFF
--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -24,14 +24,10 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    # https://pnpm.io/continuous-integration#github-actions
-    # Uses `packageManagement` field from package.json
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        dest: ${{ runner.tool_cache }}/pnpm
-        # Use `@pnpm/exe` for Node 16
-        standalone: ${{ inputs.node-version == '16' }}
+    - name: Enable corepack
+      shell: bash
+      run: |
+        corepack enable
 
     - name: Get pnpm store directory
       id: pnpm-cache

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -271,6 +271,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Run e2e
         uses: ./.github/actions/docker-run
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -271,8 +271,12 @@ jobs:
         with:
           node-version: 20
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Calculate Node Bin Path
+        id: calculate-node-bin-path
+        shell: bash
+        run: |
+          NODE_BIN_PATH=$(dirname $(which node))
+          echo "path=$NODE_BIN_PATH" >> $GITHUB_OUTPUT
 
       - name: Run e2e
         uses: ./.github/actions/docker-run
@@ -282,9 +286,9 @@ jobs:
           image: mcr.microsoft.com/playwright:v1.47.0-jammy
           # .cache is required by download artifact, and mount in ./.github/actions/docker-run
           # .tool_cache is required by pnpm
-          options: -v ${{ runner.tool_cache }}:$HOME/.tool_cache
+          options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}}
           script: |
-            export PATH=$HOME/.tool_cache/pnpm/node_modules/.bin:$PATH
+            export PATH=${{ steps.calculate-node-bin-path.outputs.path }}:$PATH
             pnpm run build:js
             pnpm run test:e2e
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The pnpm/action-setup will install pnpm with an immutable version. However, in ecosystem-benchmark and ecosystem-ci, we need to clone the repo and run `pnpm i`. Using corepack can avoid the problem of inconsistent pnpm versions.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
