### PR TITLE
ci: pnpm cache install pnpm/exe when node16

### DIFF
--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -25,9 +25,20 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Enable corepack
+      if: ${{ inputs.node-version != '16' }}
       shell: bash
       run: |
         corepack enable
+
+    # https://pnpm.io/continuous-integration#github-actions
+    # Uses `packageManagement` field from package.json
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      if: ${{ inputs.node-version == '16' }}
+      with:
+        dest: ${{ runner.tool_cache }}/pnpm
+        # Use `@pnpm/exe` for Node 16
+        standalone: true
 
     - name: Get pnpm store directory
       id: pnpm-cache


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

pnpm@9 does not support node16, use pnpm/exe instead.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
