### PR TITLE
docs(glossary): use "module specifier" instead of "request"

### DIFF
--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -380,10 +380,10 @@ function resolve(
 ): void;
 ```
 
-Resolve a request.
+Resolve a module specifier.
 
 - `context` must be the absolute path to a directory. This directory is used as the starting location for resolving.
-- `request` is the request to be resolved.
+- `request` is the module specifier to be resolved.
 - `callback` is a callback function that gives the resolved path.
 
 ## this.mode

--- a/website/docs/en/api/loader-api/inline-match-resource.mdx
+++ b/website/docs/en/api/loader-api/inline-match-resource.mdx
@@ -4,7 +4,7 @@ import WebpackLicense from '@components/WebpackLicense';
 
 # Inline matchResource
 
-Inline matchResource allows you to dynamically change the matching rules when loading resources. You can set the `matchResource` for a request by prefixing `<match-resource>!=!` to the request.
+Inline matchResource allows you to dynamically change the matching rules when loading resources. You can set the `matchResource` for a module specifier by prefixing `<match-resource>!=!` to the module specifier.
 
 When a `matchResource` is set, it will be used to match with the `module.rules` instead of the original resource. This can be useful if further loaders should be applied to the resource, or if the module type needs to be changed.
 

--- a/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
@@ -113,7 +113,7 @@ Returning module instance or `false` is not supported for now.
 
 `AsyncSeriesBailHook<[ResolveData]>`
 
-Called after the request is resolved.
+Called after the module specifier is resolved.
 
 The `afterResolve` hook is used to further process or modify the results after the module has been resolved. It is called at the end of the module resolution process, which means that at this stage, the module's path, request information, etc., have already been determined.
 
@@ -143,9 +143,9 @@ compiler.hooks.compilation.tap(
 
 `AsyncSeriesBailHook<[ResourceDataWithData]>`
 
-Called before a request with scheme (URI) is resolved.
+Called before a module specifier with scheme (URI) is resolved.
 
-The `resolveForScheme` is typically used to handle module requests that have a specific protocol, such as `file://`, `https://`, etc.
+The `resolveForScheme` is typically used to handle module specifiers that have a specific protocol, such as `file://`, `https://`, etc.
 
 ```js
 compiler.hooks.compilation.tap(

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -284,7 +284,7 @@ function requireContext(
 
 ```js
 // Create a context, with files from the test directory that
-// can be required with a request ending with `.test.js`.
+// can be required with a module specifier ending with `.test.js`.
 const context = require.context('./test', false, /\.test\.js$/);
 ```
 
@@ -342,7 +342,7 @@ function requireEnsure(
    * By passing the same chunkName to various require.ensure() calls,
    * we can combine their code into a single chunk, resulting in only one bundle that the browser must load.
    */
-  chunkName?: String
+  chunkName?: string
 ): Context;
 ```
 

--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -173,7 +173,7 @@ function webpackContext(
 
 ```js
 // Create a context, with files from the test directory that
-// can be required with a request ending with `.test.js`.
+// can be required with a module specifier ending with `.test.js`.
 const context = import.meta.webpackContext('./test', {
   recursive: false,
   regExp: /\.test\.js$/,
@@ -210,7 +210,7 @@ The context returned by `import.meta.webpackContext()` is a function that takes 
 
 This function has three properties: `resolve`, `keys`, and `id`.
 
-- `resolve` is a function and returns the module id of the parsed request.
+- `resolve` is a function and returns the module id of the parsed module specifier.
 - `keys` is a function that returns an array of all possible requests that the context module can handle.
 - `id` is the module id of the context module. This may be useful for `module.hot.accept`.
 

--- a/website/docs/en/config/stats.mdx
+++ b/website/docs/en/config/stats.mdx
@@ -512,7 +512,7 @@ Whether to add information about the Rspack version used.
 
 <PropertyType type="string" />
 
-Whether to display the [base directory](/config/context), an absolute path for shortening the request information.
+Whether to display the [base directory](/config/context) as an absolute path for shortening the module specifier.
 
 ### stats.publicPath
 

--- a/website/docs/en/misc/glossary.mdx
+++ b/website/docs/en/misc/glossary.mdx
@@ -46,6 +46,14 @@ An application can be split into multiple files called modules, which may be Jav
 
 A module's type determines how it will be parsed and handled by the bundler. For example, we can tell Rspack that the module is a JavaScript module by specifying the module type as JavaScript, and Rspack will use the JavaScript parser to parse the module. If the specified module type is CSS, then Rspack will use a CSS parser to parse the module.
 
+## module specifier
+
+A module specifier is a string that can be resolved to a path to the module file. For example, in the following code, `./modules/foo.js` is a module specifier.
+
+```js
+import { foo } from './modules/foo.js';
+```
+
 ## module resolution
 
 Module resolution is the process of calculating the file path indicated by a module specifier. For example, an import statement includes a module specifier, and Rspack will use the module resolution algorithm to find the corresponding file path.

--- a/website/docs/en/plugins/webpack/dll-reference-plugin.mdx
+++ b/website/docs/en/plugins/webpack/dll-reference-plugin.mdx
@@ -36,7 +36,7 @@ type DllReferencePluginOptionsContent = {
 
 type DllReferencePluginOptionsManifest = {
   /**
-   * The mappings from request to module info.
+   * The mappings from module specifier to module info.
    */
   content: DllReferencePluginOptionsContent;
   /**
@@ -101,7 +101,7 @@ type DllReferencePluginOptions =
     }
   | {
       /**
-       * The mappings from request to module info.
+       * The mappings from module specifier to module info.
        */
       content: DllReferencePluginOptionsContent;
       /**

--- a/website/docs/en/plugins/webpack/entry-plugin.mdx
+++ b/website/docs/en/plugins/webpack/entry-plugin.mdx
@@ -16,7 +16,7 @@ The module is resolved from `entry` in `context` (absolute path).
 
 ### entry
 
-The request path for the entry module.
+The module path for the entry module.
 
 - **Type:** `string`
 

--- a/website/docs/en/types/chunk-group.mdx
+++ b/website/docs/en/types/chunk-group.mdx
@@ -8,7 +8,7 @@ type ChunkGroup = {
   origins: ReadonlyArray<{
     // where this chunk group is imported
     module?: Module;
-    request?: String;
+    request?: string;
   }>;
   isInitial(): boolean; // whether this chunk group will be loaded on initial page load
   getFiles(): ReadonlyArray<string>; // the files contained this chunk group

--- a/website/docs/en/types/entrypoint.mdx
+++ b/website/docs/en/types/entrypoint.mdx
@@ -8,7 +8,7 @@ type Entrypoint = {
   origins: ReadonlyArray<{
     // the origin request of this entrypoint
     module?: Module;
-    request?: String;
+    request?: string;
   }>;
   isInitial(): boolean; // whether this chunk group will be loaded on initial page load
   getFiles(): ReadonlyArray<string>; // the files contained this chunk group

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -375,10 +375,10 @@ function resolve(
 ): void;
 ```
 
-解析一个 request。
+解析一个模块标识符。
 
 - `context` 必须是一个目录的绝对路径。此目录用作解析的起始位置。
-- `request` 是要被解析的 request。
+- `request` 是要被解析的模块标识符。
 - `callback` 是一个处理解析路径的回调函数。
 
 ## this.mode

--- a/website/docs/zh/api/loader-api/inline-match-resource.mdx
+++ b/website/docs/zh/api/loader-api/inline-match-resource.mdx
@@ -4,7 +4,7 @@ import WebpackLicense from '@components/WebpackLicense';
 
 # 内联 matchResource
 
-Inline matchResource 允许你在加载资源时动态改变匹配规则。你可以通过在请求前添加 `<match-resource>!=!` 前缀来为该请求设置 `matchResource`。
+Inline matchResource 允许你在加载资源时动态改变匹配规则。你可以通过在模块标识符前添加 `<match-resource>!=!` 前缀来为该模块标识符设置 `matchResource`。
 
 当 `matchResource` 被设置时，它将被用来与 `module.rules` 而不是原始资源进行匹配。当如果有更多的 loader 应该应用到资源上，或者需要改变模块的类型，这可能很有用。
 

--- a/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
@@ -113,7 +113,7 @@ compiler.hooks.compilation.tap(
 
 `AsyncSeriesBailHook<[ResolveData]>`
 
-在模块的请求被解析后调用。
+在模块标识符被解析后调用。
 
 `afterResolve` 用于在模块解析完成之后，进一步处理或修改模块的解析结果。它在模块解析过程的末尾触发，意味着在这个阶段，模块的路径、请求信息等已经确定。
 
@@ -143,9 +143,9 @@ compiler.hooks.compilation.tap(
 
 `AsyncSeriesBailHook<[ResourceDataWithData]>`
 
-在带有 scheme 的解析（URI）请求之前调用。
+在解析带有 scheme（URI）的模块标识符之前调用。
 
-`resolveForScheme` 通常用于处理具有特定协议的模块请求，例如 `file://`、`https://` 等。
+`resolveForScheme` 通常用于处理具有特定协议的模块标识符，例如 `file://`、`https://` 等。
 
 ```js
 compiler.hooks.compilation.tap(

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -341,7 +341,7 @@ function requireEnsure(
    * 通过指定相同的 chunkName 来合并多个 require.ensure() 调用的代码，从而只生成一个 bundle，
    * 从而减少浏览器加载的次数。
    */
-  chunkName?: String
+  chunkName?: string
 ): Context;
 ```
 

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -210,7 +210,7 @@ Rspack 在编译时，会通过静态分析来解析 `import.meta.webpackContext
 
 这个函数有三个属性：`resolve`，`keys` 与 `id`。
 
-- `resolve` 是一个函数，它返回 request 被解析后得到的模块 id。
+- `resolve` 是一个函数，它返回模块标识符被解析后得到的模块 id。
 - `keys` 也是一个函数，它返回一个数组，由所有可能被此上下文模块处理的请求组成。
 - `id` 是上下文模块的模块 id. 它可能在使用 `module.hot.accept` 时会用到。
 

--- a/website/docs/zh/config/stats.mdx
+++ b/website/docs/zh/config/stats.mdx
@@ -512,7 +512,7 @@ module.exports = {
 
 <PropertyType type="string" />
 
-是否展示构建的[基础目录](/config/context)，为绝对路径，可用来缩短请求信息长度。
+是否展示构建的 [基础目录](/config/context) 为绝对路径，可用来缩短模块标识符的长度。
 
 ### stats.publicPath
 

--- a/website/docs/zh/misc/glossary.mdx
+++ b/website/docs/zh/misc/glossary.mdx
@@ -40,7 +40,16 @@ Loader 是用来转换模块内容的。例如，我们可以使用 loader 将 T
 
 ## module type（模块类型）
 
+module specifier
 模块类型是模块的一种属性，它们可以通过不同的方式进行解析和处理。我们可以通过指明模块的模块类型来告诉 Rspack 如何处理它们。例如，我们可以通过指定模块类型为 JavaScript 来告诉 Rspack 该模块是一个 JavaScript 模块，然后 Rspack 就会使用 JavaScript 解析器来解析该模块，如果指定的模块类型为 CSS，那么 Rspack 就会使用 CSS 解析器来解析该模块。
+
+## （模块标识符）
+
+模块标识符是一个可以解析为模块文件路径的字符串。例如，在下面的代码中，`./modules/foo.js` 就是模块标识符。
+
+```js
+import { foo } from './modules/foo.js';
+```
 
 ## module resolution（模块解析）
 

--- a/website/docs/zh/plugins/webpack/dll-reference-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/dll-reference-plugin.mdx
@@ -35,7 +35,7 @@ type DllReferencePluginOptionsContent = {
 
 type DllReferencePluginOptionsManifest = {
   /**
-   * The mappings from request to module info.
+   * The mappings from module specifier to module info.
    */
   content: DllReferencePluginOptionsContent;
   /**
@@ -100,7 +100,7 @@ type DllReferencePluginOptions =
     }
   | {
       /**
-       * The mappings from request to module info.
+       * The mappings from module specifier to module info.
        */
       content: DllReferencePluginOptionsContent;
       /**

--- a/website/docs/zh/types/chunk-group.mdx
+++ b/website/docs/zh/types/chunk-group.mdx
@@ -8,7 +8,7 @@ type ChunkGroup = {
   origins: ReadonlyArray<{
     // chunk group 被引入的来源模块信息
     module?: Module;
-    request?: String;
+    request?: string;
   }>;
   isInitial(): boolean; // 是否在页面初始加载
   getFiles(): ReadonlyArray<string>; // 关联的文件列表

--- a/website/docs/zh/types/entrypoint.mdx
+++ b/website/docs/zh/types/entrypoint.mdx
@@ -8,7 +8,7 @@ type Entrypoint = {
   origins: ReadonlyArray<{
     // entrypoint 被引入的来源
     module?: Module;
-    request?: String;
+    request?: string;
   }>;
   isInitial(): boolean; // 是否在页面初始加载
   getFiles(): ReadonlyArray<string>; // 关联的文件列表


### PR DESCRIPTION
## Summary

"module specifier" is a term used in the ES modules standard to mean "a string that can resolve to a path to the module file"

- Add "module specifier" to the glossary page.
- Replace "request" with "module specifier".

## Ref

From MDN:

> The module specifier provides a string that the JavaScript environment can resolve to a path to the module file.
> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#importing_features_into_your_script

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
