### PR TITLE
fix: allow custom `lazyCompilation.backend.client`

### DIFF
--- a/packages/rspack/src/builtin-plugin/lazy-compilation/plugin.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/plugin.ts
@@ -31,12 +31,12 @@ export default class LazyCompilationPlugin {
 
 	apply(compiler: Compiler) {
 		const backend = getBackend({
-			...this.backend,
 			client: require.resolve(
 				`../hot/lazy-compilation-${
 					compiler.options.externalsPresets.node ? "node" : "web"
 				}.js`
-			)
+			),
+			...this.backend
 		});
 
 		new BuiltinLazyCompilationPlugin(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

There is an option [`experiments.lazyCompilation.backend.client`](https://rspack.dev/config/experiments#experimentslazycompilation) that can specify custom client of LazyCompilation.

But it doesn't seem to work since it will always be overwritten by `hot/lazy-compilation-web.js` or `hot/lazy-compilation-node.js`

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
