### PR TITLE
fix: lazy compilation use persistent cache restart failure

### DIFF
--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use cow_utils::CowUtils;
-use rspack_cacheable::{cacheable, cacheable_dyn};
+use rspack_cacheable::{cacheable, cacheable_dyn, with::Unsupported};
 use rspack_collections::Identifiable;
 use rspack_core::{
   impl_module_meta_info, module_namespace_promise, module_update_hash,
@@ -45,6 +45,8 @@ pub(crate) struct LazyCompilationProxyModule {
 
   pub active: bool,
   pub data: String,
+  /// The client field will be refreshed when rspack restart, so this field does not support caching
+  #[cacheable(with=Unsupported)]
   pub client: String,
 }
 

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/index.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@/fixtures";
+
+test("should load success", async ({ page, rspack }) => {
+	await page.getByText("Click me").click();
+	let component_count = await page.getByText("Component").count();
+	expect(component_count).toBe(1);
+
+	const responsePromise = page.waitForResponse(
+		response =>
+			response.url().includes("lazy-compilation-using") &&
+			response.request().method() === "GET",
+		{ timeout: 5000 }
+	);
+	await rspack.reboot();
+	await page.reload();
+	await responsePromise;
+
+	await page.getByText("Click me").click();
+	component_count = await page.getByText("Component").count();
+	expect(component_count).toBe(1);
+});

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/rspack.config.js
@@ -1,0 +1,22 @@
+const rspack = require("@rspack/core");
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+	context: __dirname,
+	entry: {
+		main: ["./src/component.js", "./src/index.js"]
+	},
+	stats: "none",
+	mode: "production",
+	plugins: [new rspack.HtmlRspackPlugin()],
+	cache: true,
+	experiments: {
+		lazyCompilation: true,
+		cache: {
+			type: "persistent"
+		}
+	},
+	devServer: {
+		hot: true
+	}
+};

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/src/component.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/src/component.js
@@ -1,0 +1,3 @@
+const button = document.createElement("button");
+button.textContent = "Component";
+document.body.appendChild(button);

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/src/index.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/src/index.js
@@ -1,0 +1,3 @@
+const button = document.createElement("button");
+button.textContent = "Click me";
+document.body.appendChild(button);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The client field in `LazyCompilationProxyModule` will contains port info which can not be shared between different compiler.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
