### PR TITLE
fix: should run invalidation when watching is invalid

### DIFF
--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -727,7 +727,6 @@ fn get_undo_path(filename: &str, output_path: &str, enforce_relative: bool) -> S
   let mut depth: isize = -1;
   let mut append = "".into();
 
-  // eslint-disable-next-line no-param-reassign
   let output_path = output_path.strip_suffix('\\').unwrap_or(output_path);
   let mut output_path = output_path
     .strip_suffix('/')

--- a/packages/rspack-test-tools/tests/compilerCases/invalidation-multi-times.js
+++ b/packages/rspack-test-tools/tests/compilerCases/invalidation-multi-times.js
@@ -1,0 +1,47 @@
+const path = require('path');
+
+const mockFn = jest.fn(() => {});
+
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.watchRun.tap("MyPlugin", mockFn)
+	}
+}
+
+/** @type {import('../../dist').TCompilerCaseConfig} */
+module.exports = {
+	description: "should be invalidated correctly",
+	options(context) {
+		return {
+			context: context.getSource(),
+			entry: "./abc",
+			plugins: [new MyPlugin()]
+		};
+	},
+	async build(_, compiler) {
+		try {
+			await new Promise((resolve, reject) => {
+				let firstRun = true;
+				compiler.watch({}, (err) => {
+					if (err) {
+						return reject(err);
+					}
+					if (firstRun) {
+						firstRun = false;
+						compiler.watching.lazyCompilationInvalidate(path.resolve(__dirname, "../fixtures/a.js"));
+						compiler.watching.lazyCompilationInvalidate(path.resolve(__dirname, "../fixtures/b.js"));
+						setTimeout(() => {
+							resolve()
+						}, 2000)
+					}
+				});
+			});
+		} catch(err) {
+			throw err
+		}
+
+	},
+	async check() {
+		expect(mockFn).toHaveBeenCalledTimes(3);
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Align with webpack.

If invalidate after watching is running, watching should invalidate again when invalidate is done.

For example: there are 2 files.

Once invalidate on file one, the compiler is running, then I invoke invalidate file two, watching is invalid as there are another files to be invalidated. Watching should invoke invalidate again 

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
