### PR TITLE
docs: fix canary package name

### DIFF
--- a/website/docs/en/contribute/development/releasing.md
+++ b/website/docs/en/contribute/development/releasing.md
@@ -46,9 +46,7 @@ Take pnpm as an example:
 {
   "pnpm": {
     "overrides": {
-      "@rspack/binding": "npm:@rspack/binding-canary@nightly",
-      "@rspack/core": "npm:@rspack/core-canary@nightly",
-      "@rspack/plugin-react-refresh": "npm:@rspack/plugin-react-refresh@nightly"
+      "@rspack/core": "npm:@rspack-canary/core@nightly"
     },
     "peerDependencyRules": {
       "allowAny": ["@rspack/*"]

--- a/website/docs/zh/contribute/development/releasing.md
+++ b/website/docs/zh/contribute/development/releasing.md
@@ -46,9 +46,7 @@ nightly 构建完全复制了全量发布构建，以便尽早发现错误。
 {
   "pnpm": {
     "overrides": {
-      "@rspack/binding": "npm:@rspack/binding-canary@nightly",
-      "@rspack/core": "npm:@rspack/core-canary@nightly",
-      "@rspack/plugin-react-refresh": "npm:@rspack/plugin-react-refresh@nightly"
+      "@rspack/core": "npm:@rspack-canary/core@nightly"
     },
     "peerDependencyRules": {
       "allowAny": ["@rspack/*"]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Canary version package name has changed from `@rspack/core-canary` to `@rspack-canary/core`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
