### PR TITLE
fix: should recalculate order indices in outdated entrypoint

### DIFF
--- a/tests/plugin-test/css-extract/cases/dependOn-multiple-files-per-entry/expected/entry1.css
+++ b/tests/plugin-test/css-extract/cases/dependOn-multiple-files-per-entry/expected/entry1.css
@@ -1,8 +1,7 @@
-.styleB {
-  background: blue;
-}
-
 .styleA {
   background: red;
 }
 
+.styleB {
+  background: blue;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Code splitting will re-calculate modules' order index of outdated chunk group, however the entrypoints can have dependOn, and thus they can be outdated as well, we need to make sure we can re-calculate order indices of them as well.

For specific fixed case, you can see modified test case

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
