### PR TITLE
docs: fix loader API getLogger types documentation

### DIFF
--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -490,7 +490,7 @@ Whether a source map should be generated.
 - **Type:**
 
 ```ts
-function getLogger(name?: string): void;
+function getLogger(name?: string): Logger;
 ```
 
 Get the logger of this compilation, through which messages can be logged.

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -483,7 +483,7 @@ module.exports = function loader(source) {
 - **类型：**
 
 ```ts
-function getLogger(name?: string): void;
+function getLogger(name?: string): Logger;
 ```
 
 获取此次编译过程的 logger，可通过该 logger 记录消息。


### PR DESCRIPTION
## Summary

Fixing the inaccurate documentation for the loader api `getLogger()`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
