### PR TITLE
fix(types): missing `lazyCompilation.backend.server` option

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -23,6 +23,7 @@ import { ExternalObject } from '@rspack/binding';
 import fs from 'graceful-fs';
 import { fs as fs_2 } from 'fs';
 import { HookMap } from '@rspack/lite-tapable';
+import type { IncomingMessage } from 'node:http';
 import { inspect } from 'node:util';
 import type { JsAddingRuntimeModule } from '@rspack/binding';
 import { JsAfterEmitData } from '@rspack/binding';
@@ -55,6 +56,7 @@ import type { JsStats } from '@rspack/binding';
 import type { JsStatsCompilation } from '@rspack/binding';
 import type { JsStatsError } from '@rspack/binding';
 import type { JsStatsWarning } from '@rspack/binding';
+import type { ListenOptions } from 'node:net';
 import * as liteTapable from '@rspack/lite-tapable';
 import { Logger as Logger_2 } from './logging/Logger';
 import { RawCopyPattern } from '@rspack/binding';
@@ -66,11 +68,16 @@ import { RawProgressPluginOptions } from '@rspack/binding';
 import { RawProvideOptions } from '@rspack/binding';
 import { RawRuntimeChunkOptions } from '@rspack/binding';
 import { RspackOptionsNormalized as RspackOptionsNormalized_2 } from '.';
+import type { SecureContextOptions } from 'node:tls';
+import type { Server } from 'node:net';
+import type { ServerOptions } from 'node:http';
+import type { ServerResponse } from 'node:http';
 import { RawSourceMapDevToolPluginOptions as SourceMapDevToolPluginOptions } from '@rspack/binding';
 import sources = require('../compiled/webpack-sources');
 import { SyncBailHook } from '@rspack/lite-tapable';
 import { SyncHook } from '@rspack/lite-tapable';
 import { SyncWaterfallHook } from '@rspack/lite-tapable';
+import type { TlsOptions } from 'node:tls';
 import type * as webpackDevServer from 'webpack-dev-server';
 
 // @public (undocumented)
@@ -3147,13 +3154,17 @@ type KnownStatsProfile = {
 // @public
 export type Layer = string | null;
 
+// @public (undocumented)
+interface LazyCompilationDefaultBackendOptions {
+    client?: string;
+    listen?: number | ListenOptions | ((server: Server) => void);
+    protocol?: "http" | "https";
+    server?: ServerOptions<typeof IncomingMessage> | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse> | (() => Server);
+}
+
 // @public
 export type LazyCompilationOptions = {
-    backend?: {
-        client?: string;
-        listen?: number | ListenOptions;
-        protocol?: "http" | "https";
-    };
+    backend?: LazyCompilationDefaultBackendOptions;
     imports?: boolean;
     entries?: boolean;
     test?: RegExp | ((module: any) => boolean);
@@ -3292,18 +3303,6 @@ const LimitChunkCountPlugin: {
         raw(compiler: Compiler_2): BuiltinPlugin;
         apply(compiler: Compiler_2): void;
     };
-};
-
-// @public
-type ListenOptions = {
-    port?: number;
-    host?: string;
-    backlog?: number;
-    path?: string;
-    exclusive?: boolean;
-    readableAll?: boolean;
-    writableAll?: boolean;
-    ipv6Only?: boolean;
 };
 
 // @public (undocumented)
@@ -6071,6 +6070,7 @@ export const rspackOptions: z.ZodObject<{
         compareBeforeEmit: z.ZodOptional<z.ZodBoolean>;
     }, "strict", z.ZodTypeAny, {
         module?: boolean | undefined;
+        path?: string | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
@@ -6105,7 +6105,6 @@ export const rspackOptions: z.ZodObject<{
             root?: string | undefined;
         } | undefined;
         umdNamedDefine?: boolean | undefined;
-        path?: string | undefined;
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | {
             keep?: string | undefined;
@@ -6170,6 +6169,7 @@ export const rspackOptions: z.ZodObject<{
         strictModuleExceptionHandling?: boolean | undefined;
     }, {
         module?: boolean | undefined;
+        path?: string | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
@@ -6204,7 +6204,6 @@ export const rspackOptions: z.ZodObject<{
             root?: string | undefined;
         } | undefined;
         umdNamedDefine?: boolean | undefined;
-        path?: string | undefined;
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | {
             keep?: string | undefined;
@@ -6344,19 +6343,19 @@ export const rspackOptions: z.ZodObject<{
                     writableAll: z.ZodOptional<z.ZodBoolean>;
                     ipv6Only: z.ZodOptional<z.ZodBoolean>;
                 }, "strip", z.ZodTypeAny, {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
                 }, {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
@@ -6366,10 +6365,10 @@ export const rspackOptions: z.ZodObject<{
             }, "strip", z.ZodTypeAny, {
                 client?: string | undefined;
                 listen?: number | {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
@@ -6379,10 +6378,10 @@ export const rspackOptions: z.ZodObject<{
             }, {
                 client?: string | undefined;
                 listen?: number | {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
@@ -6400,10 +6399,10 @@ export const rspackOptions: z.ZodObject<{
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
@@ -6418,10 +6417,10 @@ export const rspackOptions: z.ZodObject<{
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
@@ -6537,10 +6536,10 @@ export const rspackOptions: z.ZodObject<{
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
@@ -6603,10 +6602,10 @@ export const rspackOptions: z.ZodObject<{
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
@@ -8548,10 +8547,10 @@ export const rspackOptions: z.ZodObject<{
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
@@ -8760,6 +8759,7 @@ export const rspackOptions: z.ZodObject<{
     }>>) | undefined;
     output?: {
         module?: boolean | undefined;
+        path?: string | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
@@ -8794,7 +8794,6 @@ export const rspackOptions: z.ZodObject<{
             root?: string | undefined;
         } | undefined;
         umdNamedDefine?: boolean | undefined;
-        path?: string | undefined;
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | {
             keep?: string | undefined;
@@ -9152,10 +9151,10 @@ export const rspackOptions: z.ZodObject<{
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
-                    path?: string | undefined;
                     port?: number | undefined;
                     host?: string | undefined;
                     backlog?: number | undefined;
+                    path?: string | undefined;
                     exclusive?: boolean | undefined;
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
@@ -9364,6 +9363,7 @@ export const rspackOptions: z.ZodObject<{
     }>>) | undefined;
     output?: {
         module?: boolean | undefined;
+        path?: string | undefined;
         chunkLoading?: string | false | undefined;
         asyncChunks?: boolean | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
@@ -9398,7 +9398,6 @@ export const rspackOptions: z.ZodObject<{
             root?: string | undefined;
         } | undefined;
         umdNamedDefine?: boolean | undefined;
-        path?: string | undefined;
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | {
             keep?: string | undefined;
@@ -9892,6 +9891,9 @@ type SafeParseSuccess<Output> = {
 
 // @public (undocumented)
 export type ScriptType = false | "text/javascript" | "module";
+
+// @public (undocumented)
+type ServerOptionsHttps<Request extends typeof IncomingMessage = typeof IncomingMessage, Response extends typeof ServerResponse = typeof ServerResponse> = SecureContextOptions & TlsOptions & ServerOptions<Request, Response>;
 
 // @public (undocumented)
 export type Shared = (SharedItem | SharedObject)[] | SharedObject;

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
@@ -15,7 +15,7 @@ import type { Compiler } from "../..";
 
 export interface LazyCompilationDefaultBackendOptions {
 	/**
-	 * A custom client.
+	 * A custom client script path.
 	 */
 	client?: string;
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3,6 +3,7 @@ import type * as webpackDevServer from "webpack-dev-server";
 import type { Compilation, PathData } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import type { Module } from "../Module";
+import type { LazyCompilationDefaultBackendOptions } from "../builtin-plugin/lazy-compilation/backend";
 import type { Chunk } from "../exports";
 
 export type FilenameTemplate = string;
@@ -2415,64 +2416,13 @@ export type RspackFutureOptions = {
 };
 
 /**
- * Options for server listening.
- */
-type ListenOptions = {
-	/**
-	 * The port to listen on.
-	 */
-	port?: number;
-	/**
-	 * The host to listen on.
-	 */
-	host?: string;
-	/**
-	 * The backlog of connections.
-	 */
-	backlog?: number;
-	/**
-	 * The path for Unix socket.
-	 */
-	path?: string;
-	/**
-	 * Whether the server is exclusive.
-	 */
-	exclusive?: boolean;
-	/**
-	 * Whether the socket is readable by all users.
-	 */
-	readableAll?: boolean;
-	/**
-	 * Whether the socket is writable by all users.
-	 */
-	writableAll?: boolean;
-	/**
-	 * Whether to use IPv6 only.
-	 */
-	ipv6Only?: boolean;
-};
-
-/**
  * Options for lazy compilation.
  */
 export type LazyCompilationOptions = {
 	/**
 	 * Backend configuration for lazy compilation.
 	 */
-	backend?: {
-		/**
-		 * Client script path.
-		 */
-		client?: string;
-		/**
-		 * Listening options.
-		 */
-		listen?: number | ListenOptions;
-		/**
-		 * Protocol to use.
-		 */
-		protocol?: "http" | "https";
-	};
+	backend?: LazyCompilationDefaultBackendOptions;
 	/**
 	 * Enable lazy compilation for imports.
 	 */

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2527,19 +2527,23 @@ export type Experiments = {
 	cache?: ExperimentCacheOptions;
 	/**
 	 * Enable lazy compilation.
+	 * @default false
 	 */
 	lazyCompilation?: boolean | LazyCompilationOptions;
 	/**
 	 * Enable async WebAssembly.
 	 * Support the new WebAssembly according to the [updated specification](https://github.com/WebAssembly/esm-integration), it makes a WebAssembly module an async module.
+	 * @default false
 	 */
 	asyncWebAssembly?: boolean;
 	/**
 	 * Enable output as ES module.
+	 * @default false
 	 */
 	outputModule?: boolean;
 	/**
 	 * Enable top-level await.
+	 * @default true
 	 */
 	topLevelAwait?: boolean;
 	/**
@@ -2566,6 +2570,7 @@ export type Experiments = {
 	incremental?: boolean | Incremental;
 	/**
 	 * Enable future default options.
+	 * @default false
 	 */
 	futureDefaults?: boolean;
 	/**

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -107,17 +107,24 @@ type LazyCompilationOptions =
   | {
       backend?: {
         /**
-         * A custom client.
+         * A custom client script path.
          */
         client?: string;
         /**
-         * Specify where to listen to from the server.
+         * Specifies where to listen to from the server.
          */
-        listen?: number | ListenOptions;
+        listen?: number | ListenOptions | ((server: Server) => void);
         /**
-         * Specify the protocol the client should use to connect to the server.
+         * Specifies the protocol the client should use to connect to the server.
          */
         protocol?: 'http' | 'https';
+        /**
+         * Specifies how to create the server handling the EventSource requests.
+         */
+        server?:
+          | ServerOptionsImport<typeof IncomingMessage>
+          | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
+          | (() => Server);
       };
       /**
        * Enable lazy compilation for entries.

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -72,6 +72,9 @@ module.exports = {
 
 ## experiments.futureDefaults
 
+- **Type:** `boolean`
+- **Default:** `false`
+
 Use defaults of the next major Rspack and show warnings in any problematic places.
 
 ```js title="rspack.config.js"
@@ -83,6 +86,9 @@ module.exports = {
 ```
 
 ## experiments.topLevelAwait
+
+- **Type:** `boolean`
+- **Default:** `true`
 
 Enable support for [Top-level await](https://github.com/tc39/proposal-top-level-await), `Top-level await` can only be used in modules with [ModuleType](/config/module#ruletype) is `javascript/esm`.
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -72,6 +72,9 @@ module.exports = {
 
 ## experiments.futureDefaults
 
+- **类型：** `boolean`
+- **默认值：** `false`
+
 使用下一个主版本 Rspack 的默认值，并在任何有问题的地方显示警告。
 
 ```js title="rspack.config.js"
@@ -83,6 +86,9 @@ module.exports = {
 ```
 
 ## experiments.topLevelAwait
+
+- **类型：** `boolean`
+- **默认值：** `true`
 
 开启打包 [Top-level await](https://github.com/tc39/proposal-top-level-await) 的支持，`Top-level await` 仅能在 [ModuleType](/config/module#ruletype) 为 `javascript/esm` 的模块中使用。
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -107,17 +107,24 @@ type LazyCompilationOptions =
   | {
       backend?: {
         /**
-         * A custom client.
+         * 自定义客户端脚本路径。
          */
         client?: string;
         /**
-         * Specify where to listen to from the server.
+         * 指定从服务器监听的端口或选项。
          */
-        listen?: number | ListenOptions;
+        listen?: number | ListenOptions | ((server: Server) => void);
         /**
-         * Specify the protocol the client should use to connect to the server.
+         * 指定客户端使用的协议。
          */
         protocol?: 'http' | 'https';
+        /**
+         * 指定如何创建处理 EventSource 请求的服务器。
+         */
+        server?:
+          | ServerOptionsImport<typeof IncomingMessage>
+          | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
+          | (() => Server);
       };
       /**
        * 为 entries 启用 lazy compilation


### PR DESCRIPTION
## Summary

Fix missing `lazyCompilation.backend.server` option. This option is implemented, but lacks a definition in the public types.

We can reuse the `LazyCompilationDefaultBackendOptions` type to fix this.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
