### PR TITLE
ci: declare minimal permissions for Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
+permissions:
+  # Allow commenting on issues for `reusable-build.yml`
+  issues: write
+
 jobs:
   get-runner-labels:
     name: Get Runner Labels
@@ -361,8 +365,7 @@ jobs:
 
   failure_notification:
     name: Failure Notification
-    needs:
-      [test-linux, test-windows, test-mac, rust_check, rust_test]
+    needs: [test-linux, test-windows, test-mac, rust_check, rust_test]
     if: ${{ failure() && !cancelled() && github.ref_name == 'main' && github.repository_owner == 'web-infra-dev' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -16,6 +16,12 @@ on:
     tags-ignore:
       - "**"
 
+permissions:
+  # Allow commenting on commits
+  contents: write
+  # Allow commenting on issues
+  issues: write
+
 jobs:
   get-runner-labels:
     name: Get Runner Labels

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -34,6 +34,12 @@ on:
     tags-ignore:
       - "**"
 
+permissions:
+  # Allow commenting on commits
+  contents: write
+  # Allow commenting on issues
+  issues: write
+
 jobs:
   get-runner-labels:
     name: Get Runner Labels
@@ -121,17 +127,17 @@ jobs:
       fail-fast: false
     name: eco-ci (${{ matrix.suite }})
     runs-on: ubuntu-22.04
-#    runs-on: ${{ fromJSON(needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS) }}
+    #    runs-on: ${{ fromJSON(needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/head', inputs.pr) || github.sha }}
 
-#      - name: Clean
-#        uses: ./.github/actions/clean
-#        with:
-#          target: x86_64-unknown-linux-gnu
+      #      - name: Clean
+      #        uses: ./.github/actions/clean
+      #        with:
+      #          target: x86_64-unknown-linux-gnu
 
       - name: Download bindings
         uses: ./.github/actions/download-artifact

--- a/.github/workflows/label-auto-comment.yml
+++ b/.github/workflows/label-auto-comment.yml
@@ -8,17 +8,19 @@ on:
 
 permissions:
   contents: read
+  # for `actions-cool/issues-helper` to update issues
+  issues: write
+  # for `actions-cool/issues-helper` to update PRs
+  pull-requests: write
 
 jobs:
   issue-labeled:
     permissions:
-      issues: write # for actions-cool/issues-helper to update issues
-      pull-requests: write # for actions-cool/issues-helper to update PRs
     runs-on: ubuntu-latest
     steps:
       - name: 🤔 Need Reproduce
         if: github.event.label.name == 'need reproduction'
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: "create-comment"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -27,7 +29,7 @@ jobs:
             Hello @${{ github.event.issue.user.login }}, sorry we can't investigate the problem further without reproduction demo, please provide a repro demo by forking [rspack-repro](https://github.com/web-infra-dev/rspack-repro), or provide a minimal GitHub repository by yourself. Issues labeled by `need reproduction` will be closed if no activities in 14 days.
       - name: invalid
         if: github.event.label.name == 'invalid'
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: "create-comment,close-issue"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -6,13 +6,19 @@ on:
       - opened
       - edited
 
+permissions:
+  # Allow `github/issue-labeler` to add labels
+  issues: write
+  # Allow `amannn/action-semantic-pull-request` to read pull requests
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
       # https://github.com/amannn/action-semantic-pull-request
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -4,6 +4,10 @@ name: Preview Commit
 on:
   workflow_call:
 
+permissions:
+  # Allow commenting on issues for `reusable-build.yml`
+  issues: write
+
 jobs:
   get-runner-labels:
     name: Get Runner Labels

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -96,5 +96,4 @@ jobs:
           ./x version snapshot
           ./x publish snapshot --tag canary
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.RSPACK_CANARY_RELEASE_TOKEN }}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -19,6 +19,8 @@ on:
 permissions:
   # To publish packages with provenance
   id-token: write
+  # Allow commenting on issues for `reusable-build.yml`
+  issues: write
 
 jobs:
   get-runner-labels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,6 @@ jobs:
         run: |
           ./x publish stable --tag ${{inputs.tag}} ${{inputs.dry_run && '--dry-run' || '--no-dry-run'}} ${{inputs.push_tags && '--push-tags' || '--no-push-tags'}}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -62,6 +62,10 @@ on:
         required: false
         type: string
 
+permissions:
+  # Allow commenting on issues
+  issues: write
+
 jobs:
   build:
     name: Build
@@ -386,7 +390,7 @@ jobs:
       ### Note that, We can't merge this script, because this script only runs on main branch
       - name: Update main branch test compatibility metric
         if: ${{ github.repository_owner == 'web-infra-dev' && inputs.target == 'x86_64-unknown-linux-gnu' && github.ref_name == 'main' && matrix.node == '18' && !inputs.skipable }}
-        run: node ./tests/webpack-test/scripts/generate.js ${{ secrets.GITHUB_TOKEN }} ${{ github.sha }}
+        run: node ./tests/webpack-test/scripts/generate.js ${{ github.sha }}
 
       # ### update metric diff against main branch when pull request change
       - name: Update

--- a/tests/webpack-test/scripts/generate.js
+++ b/tests/webpack-test/scripts/generate.js
@@ -2,11 +2,8 @@ const fs = require("fs");
 const path = require("path");
 const { run } = require("./utils");
 
-const GITHUB_ACTOR = process.env.GITHUB_ACTOR;
-const [, , token, commit_sha] = process.argv;
-const repoUrl = token
-	? `https://${GITHUB_ACTOR}:${token}@github.com/web-infra-dev/rspack.git`
-	: "https://github.com/web-infra-dev/rspack";
+const [, , commit_sha] = process.argv;
+const repoUrl = 'https://github.com/web-infra-dev/rspack.git';
 
 (async () => {
 	const rootDir = path.resolve(__dirname, "../../../");


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Declare minimal permissions for GitHub Actions, and remove some unused `GITHUB_TOKEN`.

Ref: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
