### PR TITLE
ci: fix workflow permission issues

### DIFF
--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -21,6 +21,8 @@ permissions:
   contents: write
   # Allow commenting on issues
   issues: write
+  # Allow commenting on pull requests
+  pull-requests: write
 
 jobs:
   get-runner-labels:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -39,6 +39,8 @@ permissions:
   contents: write
   # Allow commenting on issues
   issues: write
+  # Allow commenting on pull requests
+  pull-requests: write
 
 jobs:
   get-runner-labels:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -388,9 +388,10 @@ jobs:
 
       ### write the latest metric into branch gh-pages
       ### Note that, We can't merge this script, because this script only runs on main branch
-      - name: Update main branch test compatibility metric
-        if: ${{ github.repository_owner == 'web-infra-dev' && inputs.target == 'x86_64-unknown-linux-gnu' && github.ref_name == 'main' && matrix.node == '18' && !inputs.skipable }}
-        run: node ./tests/webpack-test/scripts/generate.js ${{ github.sha }}
+      ### [Note] This step requires push permission and should be refactored.
+      # - name: Update main branch test compatibility metric
+      #   if: ${{ github.repository_owner == 'web-infra-dev' && inputs.target == 'x86_64-unknown-linux-gnu' && github.ref_name == 'main' && matrix.node == '18' && !inputs.skipable }}
+      #   run: node ./tests/webpack-test/scripts/generate.js ${{ github.sha }}
 
       # ### update metric diff against main branch when pull request change
       - name: Update


### PR DESCRIPTION
## Summary

Fix permission issues:

- Add `pull-requests: write` to allow commenting on pull requests
- Disable `Update main branch test compatibility metric` because this step requires push permission and should be refactored, @LingyuCoder 

Related: https://github.com/web-infra-dev/rspack/pull/9018

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
