### PR TITLE
fix(core): don't panic when accept invalid sourcemap

### DIFF
--- a/crates/rspack_napi/src/ext/js_string_ext.rs
+++ b/crates/rspack_napi/src/ext/js_string_ext.rs
@@ -1,7 +1,9 @@
 use napi::JsString;
+use rspack_error::{miette::IntoDiagnostic, Result};
 
 pub trait JsStringExt {
   fn into_string(self) -> String;
+  fn try_into_string(self) -> Result<String>;
 }
 
 impl JsStringExt for JsString {
@@ -12,5 +14,15 @@ impl JsStringExt for JsString {
       .as_str()
       .expect("Should as_str")
       .to_string()
+  }
+  fn try_into_string(self) -> Result<String> {
+    Ok(
+      self
+        .into_utf8()
+        .into_diagnostic()?
+        .as_str()
+        .into_diagnostic()?
+        .to_string(),
+    )
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
rspack shouldn't panic when accept invalid sourcemap
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
