### PR TITLE
ci: ecosystem ci shows errors only on comment

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -104,7 +104,7 @@ jobs:
           result-encoding: string
           script: |
             const suiteName = `${{ github.event_name == 'workflow_dispatch' && inputs.suite || '-' }}`;
-            let result = [
+            let suites = [
               "modernjs",
               // "nx",
               "rspress",
@@ -116,10 +116,10 @@ jobs:
               "nuxt",
             ]
             if (suiteName !== "-") {
-              result = allSuite.filter(item => item === suiteName)
+              suites = suites.filter(suite => suite === suiteName)
             }
             return JSON.stringify({
-              include: result.map(suite => ({ suite }))
+              include: suites.map(suite => ({ suite }))
             })
 
   eco-ci:
@@ -174,21 +174,34 @@ jobs:
 
           SUITE='${{ matrix.suite }}'
           SUITE_REF='${{ inputs.suiteRef || '-' }}'
+          CONCLUSION='success'
           if [[ "$SUITE_REF" != "-" ]]; then
             # run test suite with suiteRef
-            pnpm tsx ecosystem-ci.ts run-suites --suite-commit "$SUITE_REF" "$SUITE"
+            pnpm tsx ecosystem-ci.ts run-suites --suite-commit "$SUITE_REF" "$SUITE" || CONCLUSION='failure'
             echo "finish run $SUITE with $SUITE_REF"
           else
             # run test suite
-            pnpm tsx ecosystem-ci.ts run-suites "$SUITE"
+            pnpm tsx ecosystem-ci.ts run-suites "$SUITE" || CONCLUSION='failure'
             echo "finish run $SUITE"
           fi
+          echo "{\"conclusion\":\"$CONCLUSION\"}" >> "$RSPACK_DIR/$SUITE.json"
+      - name: Upload Result
+        uses: actions/upload-artifact@v4
+        with:
+          name: eco-ci-result-${{ matrix.suite }}
+          path: ${{ matrix.suite }}.json
 
   comment-compare-results:
     runs-on: ubuntu-latest
     needs: [create-comment, eco-ci]
     if: ${{ !cancelled() }}
     steps:
+      - name: Download Result
+        uses: actions/download-artifact@v4
+        with:
+          path: results
+          pattern: eco-ci-result-*
+          merge-multiple: true
       - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -206,7 +219,11 @@ jobs:
               .filter(job => job.conclusion !== 'skipped')
               .map(job => {
                 const suite = job.name.replace(/^eco-ci \(([^)]+)\)$/, "$1")
-                return { suite, conclusion: job.conclusion, link: job.html_url }
+                let conclusion = job.conclusion
+                if (conclusion === "success") {
+                  conclusion = require(`./results/${suite}.json`).conclusion;
+                }
+                return { suite, conclusion, link: job.html_url }
               })
 
             const conclusionEmoji = {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR will ignore all failed Ecosystem-ci in the workflow, but comment them in the PR or commit.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
