### PR TITLE
feat: add chunkGraph.getNumberOfEntryModules

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -72,7 +72,7 @@ export declare class JsChunk {
 export declare class JsChunkGraph {
   getChunkModules(chunk: JsChunk): JsModule[]
   getChunkEntryModules(chunk: JsChunk): JsModule[]
-  getNumberOfChunkEntryModules(chunk: JsChunk): number
+  getNumberOfEntryModules(chunk: JsChunk): number
   getChunkEntryDependentChunksIterable(chunk: JsChunk): JsChunk[]
   getChunkModulesIterableBySourceType(chunk: JsChunk, sourceType: string): JsModule[]
   getModuleChunks(module: JsModule): JsChunk[]

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -72,6 +72,7 @@ export declare class JsChunk {
 export declare class JsChunkGraph {
   getChunkModules(chunk: JsChunk): JsModule[]
   getChunkEntryModules(chunk: JsChunk): JsModule[]
+  getNumberOfChunkEntryModules(chunk: JsChunk): number
   getChunkEntryDependentChunksIterable(chunk: JsChunk): JsChunk[]
   getChunkModulesIterableBySourceType(chunk: JsChunk, sourceType: string): JsModule[]
   getModuleChunks(module: JsModule): JsChunk[]

--- a/crates/rspack_binding_values/src/chunk_graph.rs
+++ b/crates/rspack_binding_values/src/chunk_graph.rs
@@ -61,6 +61,17 @@ impl JsChunkGraph {
     )
   }
 
+  #[napi(ts_return_type = "number")]
+  pub fn get_number_of_chunk_entry_modules(&self, chunk: &JsChunk) -> Result<u32> {
+    let compilation = self.as_ref()?;
+
+    Ok(
+      compilation
+        .chunk_graph
+        .get_number_of_chunk_entry_modules(&chunk.chunk_ukey) as u32,
+    )
+  }
+
   #[napi(ts_return_type = "JsChunk[]")]
   pub fn get_chunk_entry_dependent_chunks_iterable(
     &self,

--- a/crates/rspack_binding_values/src/chunk_graph.rs
+++ b/crates/rspack_binding_values/src/chunk_graph.rs
@@ -62,13 +62,13 @@ impl JsChunkGraph {
   }
 
   #[napi(ts_return_type = "number")]
-  pub fn get_number_of_chunk_entry_modules(&self, chunk: &JsChunk) -> Result<u32> {
+  pub fn get_number_of_entry_modules(&self, chunk: &JsChunk) -> Result<u32> {
     let compilation = self.as_ref()?;
 
     Ok(
       compilation
         .chunk_graph
-        .get_number_of_chunk_entry_modules(&chunk.chunk_ukey) as u32,
+        .get_number_of_entry_modules(&chunk.chunk_ukey) as u32,
     )
   }
 

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -215,13 +215,6 @@ impl ChunkGraph {
     chunk_graph_chunk.entry_modules.keys().copied().collect()
   }
 
-  pub fn get_number_of_chunk_entry_modules(&self, chunk_ukey: &ChunkUkey) -> usize {
-    self
-      .expect_chunk_graph_chunk(chunk_ukey)
-      .entry_modules
-      .len()
-  }
-
   pub fn get_chunk_entry_modules_with_chunk_group_iterable(
     &self,
     chunk_ukey: &ChunkUkey,

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -215,6 +215,13 @@ impl ChunkGraph {
     chunk_graph_chunk.entry_modules.keys().copied().collect()
   }
 
+  pub fn get_number_of_chunk_entry_modules(&self, chunk_ukey: &ChunkUkey) -> usize {
+    self
+      .expect_chunk_graph_chunk(chunk_ukey)
+      .entry_modules
+      .len()
+  }
+
   pub fn get_chunk_entry_modules_with_chunk_group_iterable(
     &self,
     chunk_ukey: &ChunkUkey,

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/bar.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/bar.js
@@ -1,0 +1,1 @@
+const bar = "bar";

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/baz.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/baz.js
@@ -1,0 +1,1 @@
+const baz = "baz";

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/foo.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/foo.js
@@ -1,0 +1,1 @@
+const foo = "foo";

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/rspack.config.js
@@ -1,0 +1,35 @@
+class Plugin {
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+    apply(compiler) {
+        compiler.hooks.compilation.tap("Test", compilation => {
+            compilation.hooks.processAssets.tap("Test", () => {
+							for (const chunk of compilation.chunks) {
+								const num = compilation.chunkGraph.getNumberOfEntryModules(chunk);
+								const entryModules = compilation.chunkGraph.getChunkEntryModulesIterable(chunk);
+                expect(Array.from(entryModules)).toHaveLength(num);
+							}
+            });
+        });
+    }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+    target: 'web',
+    node: false,
+    entry: {
+        main: "./foo.js",
+				multi: ["./bar.js", "./baz.js"]
+    },
+    output: {
+        filename: "[name].js"
+    },
+    optimization: {
+        sideEffects: false,
+    },
+    plugins: [
+        new Plugin()
+    ]
+};

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -504,6 +504,8 @@ class ChunkGraph {
     getModuleChunksIterable(module: Module): Iterable<Chunk>;
     // (undocumented)
     getModuleId(module: Module): string | null;
+    // (undocumented)
+    getNumberOfEntryModules(chunk: Chunk): number;
 }
 
 // @public (undocumented)

--- a/packages/rspack/src/ChunkGraph.ts
+++ b/packages/rspack/src/ChunkGraph.ts
@@ -33,7 +33,7 @@ export class ChunkGraph {
 	}
 
 	getNumberOfEntryModules(chunk: Chunk): number {
-		return this.#inner.getNumberOfChunkEntryModules(Chunk.__to_binding(chunk));
+		return this.#inner.getNumberOfEntryModules(Chunk.__to_binding(chunk));
 	}
 
 	getChunkEntryDependentChunksIterable(chunk: Chunk): Iterable<Chunk> {

--- a/packages/rspack/src/ChunkGraph.ts
+++ b/packages/rspack/src/ChunkGraph.ts
@@ -32,6 +32,10 @@ export class ChunkGraph {
 			.map(binding => Module.__from_binding(binding));
 	}
 
+	getNumberOfEntryModules(chunk: Chunk): number {
+		return this.#inner.getNumberOfChunkEntryModules(Chunk.__to_binding(chunk));
+	}
+
 	getChunkEntryDependentChunksIterable(chunk: Chunk): Iterable<Chunk> {
 		return this.#inner
 			.getChunkEntryDependentChunksIterable(Chunk.__to_binding(chunk))


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Implement the `chunkGraph.getNumberOfEntryModules` API of Webpack.

See: https://github.com/webpack/webpack/blob/3919c844eca394d73ca930e4fc5506fb86e2b094/lib/ChunkGraph.js#L1187

This allows getting the number of entry modules without iterating over it(which has better performance).

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] **Tests updated** (or not required).
- [x] Documentation updated (or **not required**).
