### PR TITLE
fix: patched mimalloc to use `MADV_DONTNEED` than `MADV_FREE` on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,9 +2671,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.39"
-source = "git+https://github.com/h-a-n-a/mimalloc_rust.git?rev=fc360a444dd6a4d8de6eb73fea7e964c0c16405f#fc360a444dd6a4d8de6eb73fea7e964c0c16405f"
+name = "libmimalloc-sys-rspack"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7997f74815cc4b73f7b1897f13aed74d8ea49e7d86192d9c08779edfc9e1d9f"
 dependencies = [
  "cc",
  "libc",
@@ -2949,11 +2950,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimalloc"
-version = "0.1.43"
-source = "git+https://github.com/h-a-n-a/mimalloc_rust.git?rev=fc360a444dd6a4d8de6eb73fea7e964c0c16405f#fc360a444dd6a4d8de6eb73fea7e964c0c16405f"
+name = "mimalloc-rspack"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63bb1f78735e4b7d309a05ea64f47b70a9b0ca3d0b6a6e4470f99915cdb836c6"
 dependencies = [
- "libmimalloc-sys",
+ "libmimalloc-sys-rspack",
 ]
 
 [[package]]
@@ -4186,7 +4188,7 @@ dependencies = [
 name = "rspack_allocator"
 version = "0.2.0"
 dependencies = [
- "mimalloc",
+ "mimalloc-rspack",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,8 +2673,7 @@ dependencies = [
 [[package]]
 name = "libmimalloc-sys"
 version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+source = "git+https://github.com/h-a-n-a/mimalloc_rust.git?rev=fc360a444dd6a4d8de6eb73fea7e964c0c16405f#fc360a444dd6a4d8de6eb73fea7e964c0c16405f"
 dependencies = [
  "cc",
  "libc",
@@ -2952,8 +2951,7 @@ dependencies = [
 [[package]]
 name = "mimalloc"
 version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+source = "git+https://github.com/h-a-n-a/mimalloc_rust.git?rev=fc360a444dd6a4d8de6eb73fea7e964c0c16405f#fc360a444dd6a4d8de6eb73fea7e964c0c16405f"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ itertools          = { version = "0.14.0" }
 json               = { version = "0.12.4" }
 lightningcss       = { version = "1.0.0-alpha.63" }
 linked_hash_set    = { version = "0.1.5" }
-mimalloc           = { version = "0.1.43" }
+mimalloc           = { git = "https://github.com/h-a-n-a/mimalloc_rust.git", rev = "fc360a444dd6a4d8de6eb73fea7e964c0c16405f" }
 mime_guess         = { version = "2.0.5" }
 once_cell          = { version = "1.20.2" }
 parcel_sourcemap   = { version = "2.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ itertools          = { version = "0.14.0" }
 json               = { version = "0.12.4" }
 lightningcss       = { version = "1.0.0-alpha.63" }
 linked_hash_set    = { version = "0.1.5" }
-mimalloc           = { git = "https://github.com/h-a-n-a/mimalloc_rust.git", rev = "fc360a444dd6a4d8de6eb73fea7e964c0c16405f" }
+mimalloc           = { version = "0.1.44", package = "mimalloc-rspack" }
 mime_guess         = { version = "2.0.5" }
 once_cell          = { version = "1.20.2" }
 parcel_sourcemap   = { version = "2.1.1" }
@@ -188,6 +188,8 @@ rspack_swc_plugin_import               = { version = "0.2.0", path = "crates/swc
 rspack_testing                         = { version = "0.2.0", path = "crates/rspack_testing" }
 rspack_tracing                         = { version = "0.2.0", path = "crates/rspack_tracing" }
 rspack_util                            = { version = "0.2.0", path = "crates/rspack_util" }
+
+
 [workspace.metadata.release]
 rate-limit = { existing-packages = 70, new-packages = 70 }
 [profile.dev]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Use patched mimalloc to use `MADV_DONTNEED` instead of `MADV_FREE` on reseting memory.
This also takes effect on macOS.

While `MADV_FREE` is faster than `MADV_DONTNEED`, it does not affect the `RSS` as `MADV_DONTNEED` does.
To reiterate, using `MADV_DONTNEED` means process-level memory statistics like RSS will be more 
accurately reflect the amount of physical memory being used by rspack.

Even this does not show any evidence that it would cause OOM issues, the fact seems stay the opposite 
with [reported incidents in go](https://github.com/golang/go/issues/42354).  GoLang team and many have encountered this issue and have reverted the option to `MADV_DONTNEED` in https://github.com/golang/go/issues/42330.

Rspack uses mimalloc for memory management.
The default strategy of mimalloc@2 is to **purge** the memory instead of reseting them. 
However, in some cases, it would still reset memory (mi_free_block_mt, freeing blocks multi-thread): 
![image](https://github.com/user-attachments/assets/ac549355-fd3a-4265-ac1b-273b7c70822d)

With this patch, `MADV_FREE` is replaced with `MADV_DONTNEED`:
![image](https://github.com/user-attachments/assets/adf927e7-673a-4a3a-93eb-8bac4ea48e24)

Related: https://github.com/microsoft/mimalloc/issues/776
Rspack related: https://github.com/web-infra-dev/rspack/issues/8976
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
