### PR TITLE
fix: parallel routes handling

### DIFF
--- a/crates/node_binding/src/plugins/js_loader/context.rs
+++ b/crates/node_binding/src/plugins/js_loader/context.rs
@@ -85,8 +85,12 @@ impl FromNapiValue for JsSourceMapWrapper {
     let sources_content = match js_source_map.sources_content {
       Some(sources_content) => sources_content
         .into_iter()
-        .map(|source| source.into_string())
-        .collect::<Vec<_>>(),
+        .map(|source| {
+          source
+            .try_into_string()
+            .map_err(|err| napi::Error::from_reason(err.to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?,
       None => vec![],
     };
 

--- a/crates/rspack_loader_next_app/src/create_tree_code_from_path.rs
+++ b/crates/rspack_loader_next_app/src/create_tree_code_from_path.rs
@@ -145,6 +145,15 @@ fn resolve_parallel_segments<'a>(
       }
 
       existing_children_path = Some(app_path);
+
+      if !matched.is_empty()
+        && let Some(i) = matched_children_index
+        && let Segments::Children(c) = matched[i]
+        && c == rest[0]
+      {
+        continue;
+      }
+
       matched_children_index = Some(matched.len());
       matched.push(Segments::Children(rest[0]));
     }

--- a/crates/rspack_loader_next_app/src/is_metadata_route.rs
+++ b/crates/rspack_loader_next_app/src/is_metadata_route.rs
@@ -124,7 +124,7 @@ pub fn is_metadata_route_file(
       ))
       .unwrap()
     },
-    Regex::new(r"^[\\/]{favicon}\.ico$").unwrap(),
+    Regex::new(r"^[\\/]favicon\.ico$").unwrap(),
     Regex::new(&format!(
       r"[\\/]sitemap{}",
       if with_extension {
@@ -200,14 +200,6 @@ pub fn is_metadata_route_file(
   metadata_route_files_regex
     .iter()
     .any(|r| r.is_match(&normalized_app_dir_relative_path))
-}
-
-pub fn is_static_metadata_route_file(app_dir_relative_path: &str) -> bool {
-  is_metadata_route_file(app_dir_relative_path, &vec![], true)
-}
-
-pub fn is_static_metadata_route(page: &str) -> bool {
-  page == "/robots" || page == "/manifest" || is_static_metadata_route_file(page)
 }
 
 pub fn is_metadata_route(route: &str) -> bool {


### PR DESCRIPTION
Fixes infinite loop occurring with parallel routes and applies source map fix to sources content as well. Also fixes tiny typo in metadata regex for favicon. 