### PR TITLE
perf: caching require @rspack/tracing

### DIFF
--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -327,8 +327,12 @@ function getCurrentLoader(
 	}
 	return null;
 }
-
+// FIXME: a temporary fix, we may need to change @rspack/tracing to commonjs really fix it
+let tracingCache!: { tracer: any; activeContext: any };
 async function tryTrace(context: JsLoaderContext) {
+	if (tracingCache) {
+		return tracingCache;
+	}
 	try {
 		const {
 			trace,
@@ -340,9 +344,11 @@ async function tryTrace(context: JsLoaderContext) {
 			tracingContext.active(),
 			context.__internal__tracingCarrier
 		);
-		return { tracer, activeContext };
+		tracingCache = { tracer, activeContext };
+		return tracingCache;
 	} catch (error) {
-		return { tracer: null, activeContext: null };
+		tracingCache = { tracer: null, activeContext: null };
+		return tracingCache;
 	}
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
import('@rspack/tracing') doesn't have cache, so it runs every time tryTrace executes, add cache for performance
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
