### PR TITLE
test: add missing `findBundle` option to ensure test cases are executed

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-child-compiler/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-child-compiler/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+    findBundle: (i, options) => {
+        return ["main.js"];
+    }
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-file-context/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-file-context/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+    findBundle: (i, options) => {
+        return ["main.js"];
+    }
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Partially fixes #9056.

The `findBundle` option also needs to be added to a few other test cases, but those tests are a bit more tricky to fix. See #9056.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
