### PR TITLE
fix:amd-define-in-parameter (#9078)

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -348,7 +348,12 @@ impl CommonJsImportsParserPlugin {
 }
 
 impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
-  fn can_rename(&self, parser: &mut JavascriptParser, str: &str) -> Option<bool> {
+  fn can_rename(
+    &self,
+    parser: &mut JavascriptParser,
+    str: &str,
+    _is_parameter: bool,
+  ) -> Option<bool> {
     if str == expr_name::REQUIRE && parser.is_unresolved_ident(str) {
       Some(true)
     } else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
@@ -358,7 +358,7 @@ pub(super) struct DefineParserPlugin {
 }
 
 impl JavascriptParserPlugin for DefineParserPlugin {
-  fn can_rename(&self, _: &mut JavascriptParser, str: &str) -> Option<bool> {
+  fn can_rename(&self, _: &mut JavascriptParser, str: &str, _is_parameter: bool) -> Option<bool> {
     self.walk_data.can_rename.contains(str).then_some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -490,9 +490,14 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     None
   }
 
-  fn can_rename(&self, parser: &mut JavascriptParser, str: &str) -> Option<bool> {
+  fn can_rename(
+    &self,
+    parser: &mut JavascriptParser,
+    str: &str,
+    is_parameter: bool,
+  ) -> Option<bool> {
     for plugin in &self.plugins {
-      let res = plugin.can_rename(parser, str);
+      let res = plugin.can_rename(parser, str, is_parameter);
       // `SyncBailHook`
       if res.is_some() {
         return res;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
@@ -81,7 +81,12 @@ impl ProvidePlugin {
 }
 
 impl JavascriptParserPlugin for ProvidePlugin {
-  fn can_rename(&self, _parser: &mut JavascriptParser, str: &str) -> Option<bool> {
+  fn can_rename(
+    &self,
+    _parser: &mut JavascriptParser,
+    str: &str,
+    _is_parameter: bool,
+  ) -> Option<bool> {
     let names = self.cached_names();
     names.iter().any(|l| l.eq(str)).then_some(true)
   }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_js_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_js_stuff_plugin.rs
@@ -174,8 +174,13 @@ impl JavascriptParserPlugin for RequireJsStuffPlugin {
     None
   }
 
-  fn can_rename(&self, _parser: &mut JavascriptParser, for_name: &str) -> Option<bool> {
-    if for_name == DEFINE {
+  fn can_rename(
+    &self,
+    _parser: &mut JavascriptParser,
+    for_name: &str,
+    is_parameter: bool,
+  ) -> Option<bool> {
+    if for_name == DEFINE && !is_parameter {
       return Some(true);
     }
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -33,7 +33,12 @@ pub trait JavascriptParserPlugin {
   /// The return value will have no effect.
   fn top_level_for_of_await_stmt(&self, _parser: &mut JavascriptParser, _stmt: &ForOfStmt) {}
 
-  fn can_rename(&self, _parser: &mut JavascriptParser, _str: &str) -> Option<bool> {
+  fn can_rename(
+    &self,
+    _parser: &mut JavascriptParser,
+    _str: &str,
+    _is_parameter: bool,
+  ) -> Option<bool> {
     None
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -44,7 +44,12 @@ pub struct URLPlugin {
 }
 
 impl JavascriptParserPlugin for URLPlugin {
-  fn can_rename(&self, _parser: &mut JavascriptParser, for_name: &str) -> Option<bool> {
+  fn can_rename(
+    &self,
+    _parser: &mut JavascriptParser,
+    for_name: &str,
+    _is_parameter: bool,
+  ) -> Option<bool> {
     (for_name == "URL").then_some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -367,7 +367,7 @@ impl JavascriptParser<'_> {
       {
         let drive = self.plugin_drive.clone();
         if drive
-          .can_rename(self, &renamed_identifier)
+          .can_rename(self, &renamed_identifier, false)
           .unwrap_or_default()
         {
           if !drive
@@ -800,7 +800,7 @@ impl JavascriptParser<'_> {
       for param in &expr.function.params {
         let ident = param.pat.as_ident().expect("should be a `BindingIdent`");
         fn_params.push(ident);
-        if get_variable_info(self, &Expr::Ident(ident.id.clone())).is_none() {
+        if get_variable_info(self, &Expr::Ident(ident.id.clone()), true).is_none() {
           scope_params.push(Cow::Borrowed(&param.pat));
         }
       }
@@ -808,7 +808,7 @@ impl JavascriptParser<'_> {
       for param in &expr.params {
         let ident = param.as_ident().expect("should be a `BindingIdent`");
         fn_params.push(ident);
-        if get_variable_info(self, &Expr::Ident(ident.id.clone())).is_none() {
+        if get_variable_info(self, &Expr::Ident(ident.id.clone()), true).is_none() {
           scope_params.push(Cow::Borrowed(param));
         }
       }
@@ -1080,7 +1080,9 @@ impl JavascriptParser<'_> {
       if let Some(rename_identifier) = self.get_rename_identifier(&expr.right)
         && let drive = self.plugin_drive.clone()
         && rename_identifier
-          .call_hooks_name(self, |this, for_name| drive.can_rename(this, for_name))
+          .call_hooks_name(self, |this, for_name| {
+            drive.can_rename(this, for_name, false)
+          })
           .unwrap_or_default()
       {
         if !rename_identifier
@@ -1485,11 +1487,14 @@ fn member_prop_len(member_prop: &MemberProp) -> Option<usize> {
 fn get_variable_info<'p>(
   parser: &'p mut JavascriptParser,
   expr: &Expr,
+  is_parameter: bool,
 ) -> Option<&'p VariableInfo> {
   if let Some(rename_identifier) = parser.get_rename_identifier(expr)
     && let drive = parser.plugin_drive.clone()
     && rename_identifier
-      .call_hooks_name(parser, |this, for_name| drive.can_rename(this, for_name))
+      .call_hooks_name(parser, |this, for_name| {
+        drive.can_rename(this, for_name, is_parameter)
+      })
       .unwrap_or_default()
     && !rename_identifier
       .call_hooks_name(parser, |this, for_name| drive.rename(this, expr, for_name))
@@ -1504,7 +1509,9 @@ fn get_variable_name(parser: &mut JavascriptParser, expr: &Expr) -> Option<Strin
   if let Some(rename_identifier) = parser.get_rename_identifier(expr)
     && let drive = parser.plugin_drive.clone()
     && rename_identifier
-      .call_hooks_name(parser, |this, for_name| drive.can_rename(this, for_name))
+      .call_hooks_name(parser, |this, for_name| {
+        drive.can_rename(this, for_name, false)
+      })
       .unwrap_or_default()
     && !rename_identifier
       .call_hooks_name(parser, |this, for_name| drive.rename(this, expr, for_name))

--- a/packages/rspack-test-tools/tests/normalCases/amd/define-in-function-parameter/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/amd/define-in-function-parameter/index.js
@@ -1,0 +1,9 @@
+
+it("((function (define) {...}) (define)) should compile well", function () {
+	// Throws an exception message if it is a compilation exception:
+	// (function (__webpack_require__.amdD) {
+	// SyntaxError: Unexpected token '.'
+
+	expect(() => require('./lib')).toThrow('define cannot be used indirect');
+});
+

--- a/packages/rspack-test-tools/tests/normalCases/amd/define-in-function-parameter/lib.js
+++ b/packages/rspack-test-tools/tests/normalCases/amd/define-in-function-parameter/lib.js
@@ -1,0 +1,7 @@
+(function (define) {
+	if (define) {
+		define(function () { return {} });
+	}
+})(
+	define
+);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

to fix: #9078

I couldn't find a way to get the parent of Expr. I can only add a parameter to describe if the ident is a function's formal parameter. I'm not sure if this is appropriate.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
