### PR TITLE
fix: should not cache tracing instance

### DIFF
--- a/packages/rspack-tracing/types/index.d.ts
+++ b/packages/rspack-tracing/types/index.d.ts
@@ -1,4 +1,5 @@
 export function initOpenTelemetry(): Promise<void>;
 export function shutdownOpenTelemetry(): Promise<void>;
 export { trace, propagation, context } from "@opentelemetry/api";
+export type { TraceAPI, ContextAPI, PropagationAPI } from "@opentelemetry/api";
 export type { Tracer, Context } from "@opentelemetry/api";

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -380,7 +380,7 @@ async function getCachedTracing() {
 }
 
 async function tryTrace(context: JsLoaderContext) {
-	let cachedTracing = await getCachedTracing();
+	const cachedTracing = await getCachedTracing();
 	if (cachedTracing) {
 		const { trace, propagation, context: tracingContext } = cachedTracing;
 		const tracer = trace.getTracer("rspack-loader-runner");

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -26,7 +26,7 @@ import {
 	SourceMapSource
 } from "webpack-sources";
 
-import type { Context, Tracer } from "@rspack/tracing";
+import type { ContextAPI, PropagationAPI, TraceAPI } from "@rspack/tracing";
 import type { Compilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import { Module } from "../Module";
@@ -340,36 +340,64 @@ function getCurrentLoader(
 	}
 	return null;
 }
-let tracingCache!: { tracer?: Tracer; activeContext?: Context };
-async function tryTrace(context: JsLoaderContext) {
+
+// FIXME: a temporary fix, we may need to change @rspack/tracing to commonjs really fix it
+let cachedTracing:
+	| {
+			trace: TraceAPI;
+			propagation: PropagationAPI;
+			context: ContextAPI;
+	  }
+	| null
+	| undefined;
+
+async function getCachedTracing() {
 	// disable tracing in non-profile mode
 	if (!process.env.RSPACK_PROFILE) {
-		return {};
+		cachedTracing = null;
+		return cachedTracing;
 	}
-	try {
-		const {
-			trace,
-			propagation,
-			context: tracingContext
-		} = await import("@rspack/tracing");
+	if (cachedTracing) {
+		return cachedTracing;
+	}
+	if (cachedTracing === undefined) {
+		try {
+			const tracing = await import("@rspack/tracing");
+			cachedTracing = {
+				trace: tracing.trace,
+				propagation: tracing.propagation,
+				context: tracing.context
+			};
+			return cachedTracing;
+		} catch (e) {
+			cachedTracing = null;
+			return cachedTracing;
+		}
+	} else {
+		cachedTracing = null;
+		return cachedTracing;
+	}
+}
+
+async function tryTrace(context: JsLoaderContext) {
+	let cachedTracing = await getCachedTracing();
+	if (cachedTracing) {
+		const { trace, propagation, context: tracingContext } = cachedTracing;
 		const tracer = trace.getTracer("rspack-loader-runner");
 		const activeContext = propagation.extract(
 			tracingContext.active(),
 			context.__internal__tracingCarrier
 		);
-		tracingCache = { tracer, activeContext };
-		return tracingCache;
-	} catch (error) {
-		tracingCache = {};
-		return tracingCache;
+		return { trace, tracer, activeContext };
 	}
+	return null;
 }
 
 export async function runLoaders(
 	compiler: Compiler,
 	context: JsLoaderContext
 ): Promise<JsLoaderContext> {
-	const { tracer, activeContext } = await tryTrace(context);
+	const { tracer, activeContext } = (await tryTrace(context)) ?? {};
 
 	const loaderState = context.loaderState;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Only cache `@rspack/tracing` instead of tracing instance to avoid tracing being written to the incorrect context.

After:

<img width="1290" alt="image" src="https://github.com/user-attachments/assets/6f124ffb-88cf-4df8-ac51-edfb16baec35" />


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
