### PR TITLE
fix(dll): json stringify non-numeric request in code generation

### DIFF
--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
-use rspack_util::source_map::ModuleSourceMapConfig;
+use rspack_util::{json_stringify, source_map::ModuleSourceMapConfig};
 
 use super::delegated_source_dependency::DelegatedSourceDependency;
 use crate::{DllManifestContentItem, DllManifestContentItemExports};
@@ -143,7 +143,7 @@ impl Module for DelegatedModule {
     let str = match source_module {
       Some(_) => {
         let mut s = format!(
-          "module.exports = {}",
+          "module.exports = ({})",
           module_raw(
             compilation,
             &mut code_generation_result.runtime_requirements,
@@ -157,6 +157,10 @@ impl Module for DelegatedModule {
           .request
           .as_ref()
           .expect("manifest content should have `id`.");
+
+        let request = request
+          .parse::<u32>()
+          .map_or(json_stringify(request), |_| request.to_owned());
 
         match self.delegation_type.as_ref() {
           "require" => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
fix #9076
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
In [webpack](https://github.com/webpack/webpack/blob/3919c844eca394d73ca930e4fc5506fb86e2b094/lib/DelegatedModule.js#L160-L167), the request type can be a number, so when using `JSON.stringify`, no need to check if the request is a numeric string. In Rspack, we need to do this, or it will break existing [tests](https://github.com/web-infra-dev/rspack/blob/060ab07284cbcb4800e7f842e2843632d0310466/tests/webpack-test/configCases/dll-plugin/1-use-dll/index.js#L34-L36).
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
