### PR TITLE
fix: align default options with JS

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,4 +1,4 @@
-include = ["Cargo.toml", "crates/*/*.toml"]
+include = ["Cargo.toml", "crates/*/*.toml", "tasks/*/*.toml"]
 
 # https://taplo.tamasfe.dev/configuration/formatter-options.html
 [formatting]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2466,13 +2466,13 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
 dependencies = [
  "console",
- "lazy_static",
  "linked-hash-map",
+ "once_cell",
  "regex",
  "serde",
  "similar",
@@ -4144,6 +4144,7 @@ dependencies = [
  "bitflags 2.6.0",
  "enum-tag",
  "indexmap 2.7.0",
+ "insta",
  "regex",
  "rspack_core",
  "rspack_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ heck               = { version = "0.5.0" }
 hex                = { version = "0.4.3" }
 indexmap           = { version = "2.7.0" }
 indoc              = { version = "2.0.5" }
+insta              = { version = "1.42.0" }
 itertools          = { version = "0.14.0" }
 json               = { version = "0.12.4" }
 lightningcss       = { version = "1.0.0-alpha.63" }

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -41,6 +41,7 @@ rspack_plugin_wasm                    = { workspace = true }
 rspack_plugin_worker                  = { workspace = true }
 
 [dev-dependencies]
+insta = { workspace = true, features = ["filters"] }
 tokio = { workspace = true }
 
 [lints]

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -61,7 +61,7 @@ use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_hash::{HashDigest, HashFunction, HashSalt};
 use rspack_paths::{AssertUtf8, Utf8PathBuf};
 use rspack_regex::RspackRegex;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use serde_json::json;
 use target::{get_targets_properties, TargetProperties};
 
@@ -662,6 +662,15 @@ impl CompilerOptionsBuilder {
     let production = matches!(self.mode, Some(Mode::Production) | None);
     let mode = d!(self.mode.take(), Mode::Production);
 
+    if self.entry.is_empty() {
+      self
+        .entry
+        .insert("main".to_string(), EntryDescription::default());
+    }
+    self.entry.iter_mut().for_each(|(_, entry)| {
+      entry.import.get_or_insert(vec!["./src".to_string()]);
+    });
+
     let devtool = f!(self.devtool.take(), || {
       if development {
         Devtool::Eval
@@ -934,7 +943,8 @@ impl CompilerOptionsBuilder {
           depend_on: desc.depend_on,
           layer: None,
         };
-        desc.import.into_iter().for_each(|import| {
+        // SAFETY: `desc.import` is not `None` as entry has been normalized above.
+        expect!(desc.import).into_iter().for_each(|import| {
           builder_context
             .plugins
             .push(BuiltinPluginOptions::EntryPlugin((
@@ -1102,6 +1112,7 @@ fn get_resolve_defaults(
       },
     ),
     ("commonjs".into(), cjs_deps()),
+    ("amd".into(), cjs_deps()),
     ("unknown".into(), cjs_deps()),
   ];
 
@@ -2728,47 +2739,59 @@ impl OutputOptionsBuilder {
         .push(BuiltinPluginOptions::EnableLibraryPlugin(ty.clone()));
     }
 
-    let enabled_chunk_loading_types = f!(self.enabled_chunk_loading_types.take(), || {
-      let mut enabled_chunk_loading_types = vec![];
-      if let ChunkLoading::Enable(ty) = &chunk_loading {
-        enabled_chunk_loading_types.push(ty.clone());
-      }
-      if let ChunkLoading::Enable(ty) = &worker_chunk_loading {
-        enabled_chunk_loading_types.push(ty.clone());
-      }
-      for (_, desc) in entry.iter() {
-        if let Some(ChunkLoading::Enable(ty)) = &desc.chunk_loading {
-          enabled_chunk_loading_types.push(ty.clone());
+    let enabled_chunk_loading_types = f!(
+      self
+        .enabled_chunk_loading_types
+        .take()
+        .map(|types| { types.into_iter().collect::<HashSet<_>>() }),
+      || {
+        let mut enabled_chunk_loading_types = HashSet::default();
+        if let ChunkLoading::Enable(ty) = &chunk_loading {
+          enabled_chunk_loading_types.insert(ty.clone());
         }
+        if let ChunkLoading::Enable(ty) = &worker_chunk_loading {
+          enabled_chunk_loading_types.insert(ty.clone());
+        }
+        for (_, desc) in entry.iter() {
+          if let Some(ChunkLoading::Enable(ty)) = &desc.chunk_loading {
+            enabled_chunk_loading_types.insert(ty.clone());
+          }
+        }
+        enabled_chunk_loading_types
       }
-      enabled_chunk_loading_types
-    });
-    for ty in enabled_chunk_loading_types.iter() {
+    );
+    for ty in enabled_chunk_loading_types {
       builder_context
         .plugins
-        .push(BuiltinPluginOptions::EnableChunkLoadingPlugin(ty.clone()));
+        .push(BuiltinPluginOptions::EnableChunkLoadingPlugin(ty));
     }
 
-    let enabled_wasm_loading_types = f!(self.enabled_wasm_loading_types.take(), || {
-      let mut enabled_wasm_loading_types = vec![];
-      if let WasmLoading::Enable(ty) = wasm_loading {
-        enabled_wasm_loading_types.push(ty);
+    let enabled_wasm_loading_types = f!(
+      self
+        .enabled_wasm_loading_types
+        .take()
+        .map(|types| { types.into_iter().collect::<HashSet<_>>() }),
+      || {
+        let mut enabled_wasm_loading_types = HashSet::default();
+        if let WasmLoading::Enable(ty) = wasm_loading {
+          enabled_wasm_loading_types.insert(ty);
+        }
+        if let WasmLoading::Enable(ty) = worker_wasm_loading {
+          enabled_wasm_loading_types.insert(ty);
+        }
+        // for (_, desc) in entry.iter() {
+        //   if let Some(wasm_loading) = &desc.wasm_loading {
+        //     enabled_wasm_loading_types.push(wasm_loading.clone());
+        //   }
+        // }
+        enabled_wasm_loading_types
       }
-      if let WasmLoading::Enable(ty) = worker_wasm_loading {
-        enabled_wasm_loading_types.push(ty);
-      }
-      // for (_, desc) in entry.iter() {
-      //   if let Some(wasm_loading) = &desc.wasm_loading {
-      //     enabled_wasm_loading_types.push(wasm_loading.clone());
-      //   }
-      // }
-      enabled_wasm_loading_types
-    });
+    );
 
-    for ty in enabled_wasm_loading_types.iter() {
+    for ty in enabled_wasm_loading_types {
       builder_context
         .plugins
-        .push(BuiltinPluginOptions::EnableWasmLoadingPlugin(*ty));
+        .push(BuiltinPluginOptions::EnableWasmLoadingPlugin(ty));
     }
 
     let script_type = f!(self.script_type.take(), || {
@@ -2779,21 +2802,35 @@ impl OutputOptionsBuilder {
       }
     });
 
-    let environment = Environment {
-      r#const: tp.and_then(|t| t.r#const),
-      arrow_function: tp.and_then(|t| t.arrow_function),
-      node_prefix_for_core_modules: tp.and_then(|t| t.node_prefix_for_core_modules),
-      async_function: tp.and_then(|t| t.async_function),
-      big_int_literal: tp.and_then(|t| t.big_int_literal),
-      destructuring: tp.and_then(|t| t.destructuring),
-      for_of: tp.and_then(|t| t.for_of),
-      global_this: tp.and_then(|t| t.global_this),
-      optional_chaining: tp.and_then(|t| t.optional_chaining),
-      document: tp.and_then(|t| t.document),
-      dynamic_import: tp.and_then(|t| t.dynamic_import),
-      template_literal: tp.and_then(|t| t.template_literal),
-      module: tp.and_then(|t| t.module),
-    };
+    macro_rules! optimistic {
+      ($tp:expr) => {
+        matches!($tp, Some(true)) || $tp.is_none()
+      };
+    }
+    macro_rules! conditionally_optimistic {
+      ($tp:expr, $condition:expr) => {
+        ($tp.is_none() && $condition) || $tp.unwrap_or_default()
+      };
+    }
+
+    let mut environment = f!(self.environment.take(), Environment::default);
+    environment.global_this = tp.and_then(|t| t.global_this);
+    environment.big_int_literal = tp.map(|t| optimistic!(t.big_int_literal));
+    environment.r#const = tp.map(|t| optimistic!(t.r#const));
+    environment.arrow_function = tp.map(|t| optimistic!(t.arrow_function));
+    environment.async_function = tp.map(|t| optimistic!(t.async_function));
+    environment.for_of = tp.map(|t| optimistic!(t.for_of));
+    environment.destructuring = tp.map(|t| optimistic!(t.destructuring));
+    environment.optional_chaining = tp.map(|t| optimistic!(t.optional_chaining));
+    environment.node_prefix_for_core_modules =
+      tp.map(|t| optimistic!(t.node_prefix_for_core_modules));
+    environment.template_literal = tp.map(|t| optimistic!(t.template_literal));
+    environment.dynamic_import =
+      tp.map(|t| conditionally_optimistic!(t.dynamic_import, output_module));
+    environment.dynamic_import_in_worker =
+      tp.map(|t| conditionally_optimistic!(t.dynamic_import_in_worker, output_module));
+    environment.module = tp.map(|t| conditionally_optimistic!(t.module, output_module));
+    environment.document = tp.map(|t| optimistic!(t.document));
 
     OutputOptions {
       path,
@@ -3288,22 +3325,26 @@ impl OptimizationOptionsBuilder {
     });
     builder_context.plugins.extend(minimizer);
 
-    let node_env = f!(self.node_env.take(), || {
+    let node_env = self.node_env.take().or_else(|| {
       if production {
-        "production".to_string()
+        Some("production".to_string())
+      } else if development {
+        Some("development".to_string())
       } else {
-        "development".to_string()
+        None
       }
     });
-    builder_context
-      .plugins
-      .push(BuiltinPluginOptions::DefinePlugin(
-        [(
-          "process.env.NODE_ENV".to_string(),
-          format!("{}", json!(node_env)).into(),
-        )]
-        .into(),
-      ));
+    if let Some(node_env) = node_env {
+      builder_context
+        .plugins
+        .push(BuiltinPluginOptions::DefinePlugin(
+          [(
+            "process.env.NODE_ENV".to_string(),
+            format!("{}", json!(node_env)).into(),
+          )]
+          .into(),
+        ));
+    }
 
     Optimization {
       remove_available_modules,

--- a/crates/rspack/tests/defaults.rs
+++ b/crates/rspack/tests/defaults.rs
@@ -1,0 +1,18 @@
+use rspack::builder::{BuilderContext, CompilerOptionsBuilder};
+use rspack_core::Mode;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn default_options() {
+  let mut builder_context = BuilderContext::default();
+  let options = CompilerOptionsBuilder::default()
+    .mode(Mode::None)
+    .build(&mut builder_context);
+  let cwd = std::env::current_dir().unwrap();
+
+  let mut settings = insta::Settings::clone_current();
+  settings.add_filter(&cwd.to_string_lossy(), "<cwd>");
+  settings.bind(|| {
+    insta::assert_debug_snapshot!(options);
+    insta::assert_debug_snapshot!(builder_context);
+  });
+}

--- a/crates/rspack/tests/snapshots/defaults__default_options-2.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options-2.snap
@@ -1,0 +1,54 @@
+---
+source: crates/rspack/tests/defaults.rs
+expression: builder_context
+---
+BuilderContext {
+    plugins: [
+        ArrayPushCallbackChunkFormatPlugin,
+        EnableChunkLoadingPlugin(
+            Jsonp,
+        ),
+        EnableChunkLoadingPlugin(
+            ImportScripts,
+        ),
+        EnableWasmLoadingPlugin(
+            Fetch,
+        ),
+        RemoveEmptyChunksPlugin,
+        MergeDuplicateChunksPlugin,
+        NaturalModuleIdsPlugin,
+        NaturalChunkIdsPlugin,
+        SideEffectsFlagPlugin,
+        FlagDependencyExportsPlugin,
+        EntryPlugin(
+            (
+                "./src",
+                EntryOptions {
+                    name: Some(
+                        "main",
+                    ),
+                    runtime: None,
+                    chunk_loading: None,
+                    async_chunks: None,
+                    public_path: None,
+                    base_uri: None,
+                    filename: None,
+                    library: None,
+                    depend_on: None,
+                    layer: None,
+                },
+            ),
+        ),
+        ChunkPrefetchPreloadPlugin,
+        JavascriptModulesPlugin,
+        JsonModulesPlugin,
+        AssetModulesPlugin,
+        RuntimePlugin,
+        InferAsyncModulesPlugin,
+        APIPlugin,
+        DataUriPlugin,
+        FileUriPlugin,
+        EnsureChunkConditionsPlugin,
+        WorkerPlugin,
+    ],
+}

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1,0 +1,1367 @@
+---
+source: crates/rspack/tests/defaults.rs
+expression: options
+---
+CompilerOptions {
+    name: None,
+    context: Context {
+        inner: "<cwd>",
+    },
+    output: OutputOptions {
+        path: "<cwd>/dist",
+        pathinfo: Bool(
+            false,
+        ),
+        clean: CleanAll(
+            false,
+        ),
+        public_path: Auto,
+        asset_module_filename: Filename(
+            Template(
+                "[hash][ext][query]",
+            ),
+        ),
+        wasm_loading: Enable(
+            Fetch,
+        ),
+        webassembly_module_filename: Filename(
+            Template(
+                "[hash].module.wasm",
+            ),
+        ),
+        unique_name: "",
+        chunk_loading: Enable(
+            Jsonp,
+        ),
+        chunk_loading_global: "webpackChunk",
+        chunk_load_timeout: 120000,
+        charset: true,
+        filename: Filename(
+            Template(
+                "[name].js",
+            ),
+        ),
+        chunk_filename: Filename(
+            Template(
+                "[name].js",
+            ),
+        ),
+        cross_origin_loading: Disable,
+        css_filename: Filename(
+            Template(
+                "[name].css",
+            ),
+        ),
+        css_chunk_filename: Filename(
+            Template(
+                "[name].css",
+            ),
+        ),
+        hot_update_main_filename: Filename(
+            Template(
+                "[runtime].[fullhash].hot-update.json",
+            ),
+        ),
+        hot_update_chunk_filename: Filename(
+            Template(
+                "[id].[fullhash].hot-update.js",
+            ),
+        ),
+        hot_update_global: "webpackHotUpdate",
+        library: None,
+        enabled_library_types: Some(
+            [],
+        ),
+        strict_module_error_handling: false,
+        global_object: "self",
+        import_function_name: "import",
+        import_meta_name: "import.meta",
+        iife: true,
+        module: false,
+        trusted_types: None,
+        source_map_filename: Filename(
+            Template(
+                "[file].map[query]",
+            ),
+        ),
+        hash_function: Xxhash64,
+        hash_digest: Hex,
+        hash_digest_length: 16,
+        hash_salt: None,
+        async_chunks: true,
+        worker_chunk_loading: Enable(
+            ImportScripts,
+        ),
+        worker_wasm_loading: Enable(
+            Fetch,
+        ),
+        worker_public_path: "",
+        script_type: "",
+        environment: Environment {
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            node_prefix_for_core_modules: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            document: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            for_of: Some(
+                true,
+            ),
+            global_this: None,
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                true,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+        },
+        compare_before_emit: true,
+    },
+    mode: None,
+    resolve: Resolve {
+        extensions: Some(
+            [],
+        ),
+        alias: None,
+        prefer_relative: None,
+        prefer_absolute: None,
+        symlinks: None,
+        main_files: Some(
+            [
+                "index",
+            ],
+        ),
+        main_fields: Some(
+            [
+                "main",
+            ],
+        ),
+        condition_names: Some(
+            [
+                "webpack",
+                "production",
+                "browser",
+            ],
+        ),
+        tsconfig: None,
+        modules: Some(
+            [
+                "node_modules",
+            ],
+        ),
+        fallback: None,
+        fully_specified: None,
+        exports_fields: Some(
+            [
+                [
+                    "exports",
+                ],
+            ],
+        ),
+        extension_alias: None,
+        alias_fields: Some(
+            [],
+        ),
+        roots: Some(
+            [
+                "<cwd>",
+            ],
+        ),
+        restrictions: None,
+        imports_fields: Some(
+            [
+                [
+                    "imports",
+                ],
+            ],
+        ),
+        by_dependency: Some(
+            ByDependency(
+                {
+                    "wasm": Resolve {
+                        extensions: Some(
+                            [
+                                ".js",
+                                ".json",
+                                ".wasm",
+                            ],
+                        ),
+                        alias: None,
+                        prefer_relative: None,
+                        prefer_absolute: None,
+                        symlinks: None,
+                        main_files: None,
+                        main_fields: Some(
+                            [
+                                "browser",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        condition_names: Some(
+                            [
+                                "import",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        tsconfig: None,
+                        modules: None,
+                        fallback: None,
+                        fully_specified: None,
+                        exports_fields: None,
+                        extension_alias: None,
+                        alias_fields: Some(
+                            [
+                                [
+                                    "browser",
+                                ],
+                            ],
+                        ),
+                        roots: None,
+                        restrictions: None,
+                        imports_fields: None,
+                        by_dependency: None,
+                        description_files: None,
+                        enforce_extension: None,
+                        pnp: None,
+                    },
+                    "esm": Resolve {
+                        extensions: Some(
+                            [
+                                ".js",
+                                ".json",
+                                ".wasm",
+                            ],
+                        ),
+                        alias: None,
+                        prefer_relative: None,
+                        prefer_absolute: None,
+                        symlinks: None,
+                        main_files: None,
+                        main_fields: Some(
+                            [
+                                "browser",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        condition_names: Some(
+                            [
+                                "import",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        tsconfig: None,
+                        modules: None,
+                        fallback: None,
+                        fully_specified: None,
+                        exports_fields: None,
+                        extension_alias: None,
+                        alias_fields: Some(
+                            [
+                                [
+                                    "browser",
+                                ],
+                            ],
+                        ),
+                        roots: None,
+                        restrictions: None,
+                        imports_fields: None,
+                        by_dependency: None,
+                        description_files: None,
+                        enforce_extension: None,
+                        pnp: None,
+                    },
+                    "url": Resolve {
+                        extensions: None,
+                        alias: None,
+                        prefer_relative: Some(
+                            true,
+                        ),
+                        prefer_absolute: None,
+                        symlinks: None,
+                        main_files: None,
+                        main_fields: None,
+                        condition_names: None,
+                        tsconfig: None,
+                        modules: None,
+                        fallback: None,
+                        fully_specified: None,
+                        exports_fields: None,
+                        extension_alias: None,
+                        alias_fields: None,
+                        roots: None,
+                        restrictions: None,
+                        imports_fields: None,
+                        by_dependency: None,
+                        description_files: None,
+                        enforce_extension: None,
+                        pnp: None,
+                    },
+                    "worker": Resolve {
+                        extensions: Some(
+                            [
+                                ".js",
+                                ".json",
+                                ".wasm",
+                            ],
+                        ),
+                        alias: None,
+                        prefer_relative: Some(
+                            true,
+                        ),
+                        prefer_absolute: None,
+                        symlinks: None,
+                        main_files: None,
+                        main_fields: Some(
+                            [
+                                "browser",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        condition_names: Some(
+                            [
+                                "import",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        tsconfig: None,
+                        modules: None,
+                        fallback: None,
+                        fully_specified: None,
+                        exports_fields: None,
+                        extension_alias: None,
+                        alias_fields: Some(
+                            [
+                                [
+                                    "browser",
+                                ],
+                            ],
+                        ),
+                        roots: None,
+                        restrictions: None,
+                        imports_fields: None,
+                        by_dependency: None,
+                        description_files: None,
+                        enforce_extension: None,
+                        pnp: None,
+                    },
+                    "commonjs": Resolve {
+                        extensions: Some(
+                            [
+                                ".js",
+                                ".json",
+                                ".wasm",
+                            ],
+                        ),
+                        alias: None,
+                        prefer_relative: None,
+                        prefer_absolute: None,
+                        symlinks: None,
+                        main_files: None,
+                        main_fields: Some(
+                            [
+                                "browser",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        condition_names: Some(
+                            [
+                                "require",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        tsconfig: None,
+                        modules: None,
+                        fallback: None,
+                        fully_specified: None,
+                        exports_fields: None,
+                        extension_alias: None,
+                        alias_fields: Some(
+                            [
+                                [
+                                    "browser",
+                                ],
+                            ],
+                        ),
+                        roots: None,
+                        restrictions: None,
+                        imports_fields: None,
+                        by_dependency: None,
+                        description_files: None,
+                        enforce_extension: None,
+                        pnp: None,
+                    },
+                    "amd": Resolve {
+                        extensions: Some(
+                            [
+                                ".js",
+                                ".json",
+                                ".wasm",
+                            ],
+                        ),
+                        alias: None,
+                        prefer_relative: None,
+                        prefer_absolute: None,
+                        symlinks: None,
+                        main_files: None,
+                        main_fields: Some(
+                            [
+                                "browser",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        condition_names: Some(
+                            [
+                                "require",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        tsconfig: None,
+                        modules: None,
+                        fallback: None,
+                        fully_specified: None,
+                        exports_fields: None,
+                        extension_alias: None,
+                        alias_fields: Some(
+                            [
+                                [
+                                    "browser",
+                                ],
+                            ],
+                        ),
+                        roots: None,
+                        restrictions: None,
+                        imports_fields: None,
+                        by_dependency: None,
+                        description_files: None,
+                        enforce_extension: None,
+                        pnp: None,
+                    },
+                    "unknown": Resolve {
+                        extensions: Some(
+                            [
+                                ".js",
+                                ".json",
+                                ".wasm",
+                            ],
+                        ),
+                        alias: None,
+                        prefer_relative: None,
+                        prefer_absolute: None,
+                        symlinks: None,
+                        main_files: None,
+                        main_fields: Some(
+                            [
+                                "browser",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        condition_names: Some(
+                            [
+                                "require",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        tsconfig: None,
+                        modules: None,
+                        fallback: None,
+                        fully_specified: None,
+                        exports_fields: None,
+                        extension_alias: None,
+                        alias_fields: Some(
+                            [
+                                [
+                                    "browser",
+                                ],
+                            ],
+                        ),
+                        roots: None,
+                        restrictions: None,
+                        imports_fields: None,
+                        by_dependency: None,
+                        description_files: None,
+                        enforce_extension: None,
+                        pnp: None,
+                    },
+                },
+            ),
+        ),
+        description_files: None,
+        enforce_extension: None,
+        pnp: None,
+    },
+    resolve_loader: Resolve {
+        extensions: Some(
+            [
+                ".js",
+            ],
+        ),
+        alias: None,
+        prefer_relative: None,
+        prefer_absolute: None,
+        symlinks: None,
+        main_files: Some(
+            [
+                "index",
+            ],
+        ),
+        main_fields: Some(
+            [
+                "loader",
+                "main",
+            ],
+        ),
+        condition_names: Some(
+            [
+                "loader",
+                "require",
+                "node",
+            ],
+        ),
+        tsconfig: None,
+        modules: None,
+        fallback: None,
+        fully_specified: None,
+        exports_fields: Some(
+            [
+                [
+                    "exports",
+                ],
+            ],
+        ),
+        extension_alias: None,
+        alias_fields: None,
+        roots: None,
+        restrictions: None,
+        imports_fields: None,
+        by_dependency: None,
+        description_files: None,
+        enforce_extension: None,
+        pnp: None,
+    },
+    module: ModuleOptions {
+        rules: [
+            ModuleRule {
+                rspack_resource: None,
+                test: None,
+                include: None,
+                exclude: None,
+                resource: None,
+                resource_query: None,
+                resource_fragment: None,
+                dependency: None,
+                issuer: None,
+                issuer_layer: None,
+                scheme: None,
+                mimetype: None,
+                description_data: None,
+                with: None,
+                one_of: None,
+                rules: Some(
+                    [
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: None,
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: None,
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: Some(
+                                RuleSetConditionWithEmpty {
+                                    condition: "application/node",
+                                    match_when_empty: OnceCell {
+                                        value: None,
+                                    },
+                                },
+                            ),
+                            description_data: None,
+                            with: None,
+                            one_of: None,
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: Some(
+                                    JsAuto,
+                                ),
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: None,
+                                enforce: Normal,
+                            },
+                        },
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: Some(
+                                "Func(...)",
+                            ),
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: None,
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: None,
+                            description_data: None,
+                            with: None,
+                            one_of: None,
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: Some(
+                                    Json,
+                                ),
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: None,
+                                enforce: Normal,
+                            },
+                        },
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: None,
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: None,
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: Some(
+                                RuleSetConditionWithEmpty {
+                                    condition: "application/json",
+                                    match_when_empty: OnceCell {
+                                        value: None,
+                                    },
+                                },
+                            ),
+                            description_data: None,
+                            with: None,
+                            one_of: None,
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: Some(
+                                    Json,
+                                ),
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: None,
+                                enforce: Normal,
+                            },
+                        },
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: Some(
+                                "Func(...)",
+                            ),
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: None,
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: None,
+                            description_data: None,
+                            with: None,
+                            one_of: None,
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: Some(
+                                    JsEsm,
+                                ),
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: Some(
+                                    Resolve {
+                                        extensions: None,
+                                        alias: None,
+                                        prefer_relative: None,
+                                        prefer_absolute: None,
+                                        symlinks: None,
+                                        main_files: None,
+                                        main_fields: None,
+                                        condition_names: None,
+                                        tsconfig: None,
+                                        modules: None,
+                                        fallback: None,
+                                        fully_specified: None,
+                                        exports_fields: None,
+                                        extension_alias: None,
+                                        alias_fields: None,
+                                        roots: None,
+                                        restrictions: None,
+                                        imports_fields: None,
+                                        by_dependency: Some(
+                                            ByDependency(
+                                                {
+                                                    "esm": Resolve {
+                                                        extensions: None,
+                                                        alias: None,
+                                                        prefer_relative: None,
+                                                        prefer_absolute: None,
+                                                        symlinks: None,
+                                                        main_files: None,
+                                                        main_fields: None,
+                                                        condition_names: None,
+                                                        tsconfig: None,
+                                                        modules: None,
+                                                        fallback: None,
+                                                        fully_specified: Some(
+                                                            true,
+                                                        ),
+                                                        exports_fields: None,
+                                                        extension_alias: None,
+                                                        alias_fields: None,
+                                                        roots: None,
+                                                        restrictions: None,
+                                                        imports_fields: None,
+                                                        by_dependency: None,
+                                                        description_files: None,
+                                                        enforce_extension: None,
+                                                        pnp: None,
+                                                    },
+                                                },
+                                            ),
+                                        ),
+                                        description_files: None,
+                                        enforce_extension: None,
+                                        pnp: None,
+                                    },
+                                ),
+                                enforce: Normal,
+                            },
+                        },
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: Some(
+                                "Func(...)",
+                            ),
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: None,
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: None,
+                            description_data: Some(
+                                {
+                                    "type": RuleSetConditionWithEmpty {
+                                        condition: "module",
+                                        match_when_empty: OnceCell {
+                                            value: None,
+                                        },
+                                    },
+                                },
+                            ),
+                            with: None,
+                            one_of: None,
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: Some(
+                                    JsEsm,
+                                ),
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: Some(
+                                    Resolve {
+                                        extensions: None,
+                                        alias: None,
+                                        prefer_relative: None,
+                                        prefer_absolute: None,
+                                        symlinks: None,
+                                        main_files: None,
+                                        main_fields: None,
+                                        condition_names: None,
+                                        tsconfig: None,
+                                        modules: None,
+                                        fallback: None,
+                                        fully_specified: None,
+                                        exports_fields: None,
+                                        extension_alias: None,
+                                        alias_fields: None,
+                                        roots: None,
+                                        restrictions: None,
+                                        imports_fields: None,
+                                        by_dependency: Some(
+                                            ByDependency(
+                                                {
+                                                    "esm": Resolve {
+                                                        extensions: None,
+                                                        alias: None,
+                                                        prefer_relative: None,
+                                                        prefer_absolute: None,
+                                                        symlinks: None,
+                                                        main_files: None,
+                                                        main_fields: None,
+                                                        condition_names: None,
+                                                        tsconfig: None,
+                                                        modules: None,
+                                                        fallback: None,
+                                                        fully_specified: Some(
+                                                            true,
+                                                        ),
+                                                        exports_fields: None,
+                                                        extension_alias: None,
+                                                        alias_fields: None,
+                                                        roots: None,
+                                                        restrictions: None,
+                                                        imports_fields: None,
+                                                        by_dependency: None,
+                                                        description_files: None,
+                                                        enforce_extension: None,
+                                                        pnp: None,
+                                                    },
+                                                },
+                                            ),
+                                        ),
+                                        description_files: None,
+                                        enforce_extension: None,
+                                        pnp: None,
+                                    },
+                                ),
+                                enforce: Normal,
+                            },
+                        },
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: Some(
+                                "Func(...)",
+                            ),
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: None,
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: None,
+                            description_data: None,
+                            with: None,
+                            one_of: None,
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: Some(
+                                    JsDynamic,
+                                ),
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: None,
+                                enforce: Normal,
+                            },
+                        },
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: Some(
+                                "Func(...)",
+                            ),
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: None,
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: None,
+                            description_data: Some(
+                                {
+                                    "type": RuleSetConditionWithEmpty {
+                                        condition: "commonjs",
+                                        match_when_empty: OnceCell {
+                                            value: None,
+                                        },
+                                    },
+                                },
+                            ),
+                            with: None,
+                            one_of: None,
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: Some(
+                                    JsDynamic,
+                                ),
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: None,
+                                enforce: Normal,
+                            },
+                        },
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: None,
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: None,
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: Some(
+                                RuleSetConditionWithEmpty {
+                                    condition: RuleSetLogicalConditions {
+                                        and: None,
+                                        or: Some(
+                                            [
+                                                "text/javascript",
+                                                "application/javascript",
+                                            ],
+                                        ),
+                                        not: None,
+                                    },
+                                    match_when_empty: OnceCell {
+                                        value: None,
+                                    },
+                                },
+                            ),
+                            description_data: None,
+                            with: None,
+                            one_of: None,
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: Some(
+                                    JsEsm,
+                                ),
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: Some(
+                                    Resolve {
+                                        extensions: None,
+                                        alias: None,
+                                        prefer_relative: None,
+                                        prefer_absolute: None,
+                                        symlinks: None,
+                                        main_files: None,
+                                        main_fields: None,
+                                        condition_names: None,
+                                        tsconfig: None,
+                                        modules: None,
+                                        fallback: None,
+                                        fully_specified: None,
+                                        exports_fields: None,
+                                        extension_alias: None,
+                                        alias_fields: None,
+                                        roots: None,
+                                        restrictions: None,
+                                        imports_fields: None,
+                                        by_dependency: Some(
+                                            ByDependency(
+                                                {
+                                                    "esm": Resolve {
+                                                        extensions: None,
+                                                        alias: None,
+                                                        prefer_relative: None,
+                                                        prefer_absolute: None,
+                                                        symlinks: None,
+                                                        main_files: None,
+                                                        main_fields: None,
+                                                        condition_names: None,
+                                                        tsconfig: None,
+                                                        modules: None,
+                                                        fallback: None,
+                                                        fully_specified: Some(
+                                                            true,
+                                                        ),
+                                                        exports_fields: None,
+                                                        extension_alias: None,
+                                                        alias_fields: None,
+                                                        roots: None,
+                                                        restrictions: None,
+                                                        imports_fields: None,
+                                                        by_dependency: None,
+                                                        description_files: None,
+                                                        enforce_extension: None,
+                                                        pnp: None,
+                                                    },
+                                                },
+                                            ),
+                                        ),
+                                        description_files: None,
+                                        enforce_extension: None,
+                                        pnp: None,
+                                    },
+                                ),
+                                enforce: Normal,
+                            },
+                        },
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: None,
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: Some(
+                                "url",
+                            ),
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: None,
+                            description_data: None,
+                            with: None,
+                            one_of: Some(
+                                [
+                                    ModuleRule {
+                                        rspack_resource: None,
+                                        test: None,
+                                        include: None,
+                                        exclude: None,
+                                        resource: None,
+                                        resource_query: None,
+                                        resource_fragment: None,
+                                        dependency: None,
+                                        issuer: None,
+                                        issuer_layer: None,
+                                        scheme: Some(
+                                            RuleSetConditionWithEmpty {
+                                                condition: "data",
+                                                match_when_empty: OnceCell {
+                                                    value: None,
+                                                },
+                                            },
+                                        ),
+                                        mimetype: None,
+                                        description_data: None,
+                                        with: None,
+                                        one_of: None,
+                                        rules: None,
+                                        effect: ModuleRuleEffect {
+                                            side_effects: None,
+                                            type: Some(
+                                                AssetInline,
+                                            ),
+                                            layer: None,
+                                            use: ,
+                                            parser: None,
+                                            generator: None,
+                                            resolve: None,
+                                            enforce: Normal,
+                                        },
+                                    },
+                                    ModuleRule {
+                                        rspack_resource: None,
+                                        test: None,
+                                        include: None,
+                                        exclude: None,
+                                        resource: None,
+                                        resource_query: None,
+                                        resource_fragment: None,
+                                        dependency: None,
+                                        issuer: None,
+                                        issuer_layer: None,
+                                        scheme: None,
+                                        mimetype: None,
+                                        description_data: None,
+                                        with: None,
+                                        one_of: None,
+                                        rules: None,
+                                        effect: ModuleRuleEffect {
+                                            side_effects: None,
+                                            type: Some(
+                                                AssetResource,
+                                            ),
+                                            layer: None,
+                                            use: ,
+                                            parser: None,
+                                            generator: None,
+                                            resolve: None,
+                                            enforce: Normal,
+                                        },
+                                    },
+                                ],
+                            ),
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: None,
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: None,
+                                enforce: Normal,
+                            },
+                        },
+                        ModuleRule {
+                            rspack_resource: None,
+                            test: None,
+                            include: None,
+                            exclude: None,
+                            resource: None,
+                            resource_query: None,
+                            resource_fragment: None,
+                            dependency: None,
+                            issuer: None,
+                            issuer_layer: None,
+                            scheme: None,
+                            mimetype: None,
+                            description_data: None,
+                            with: Some(
+                                {
+                                    "type": RuleSetConditionWithEmpty {
+                                        condition: "json",
+                                        match_when_empty: OnceCell {
+                                            value: None,
+                                        },
+                                    },
+                                },
+                            ),
+                            one_of: None,
+                            rules: None,
+                            effect: ModuleRuleEffect {
+                                side_effects: None,
+                                type: Some(
+                                    Json,
+                                ),
+                                layer: None,
+                                use: ,
+                                parser: None,
+                                generator: None,
+                                resolve: None,
+                                enforce: Normal,
+                            },
+                        },
+                    ],
+                ),
+                effect: ModuleRuleEffect {
+                    side_effects: None,
+                    type: None,
+                    layer: None,
+                    use: ,
+                    parser: None,
+                    generator: None,
+                    resolve: None,
+                    enforce: Normal,
+                },
+            },
+            ModuleRule {
+                rspack_resource: None,
+                test: None,
+                include: None,
+                exclude: None,
+                resource: None,
+                resource_query: None,
+                resource_fragment: None,
+                dependency: None,
+                issuer: None,
+                issuer_layer: None,
+                scheme: None,
+                mimetype: None,
+                description_data: None,
+                with: None,
+                one_of: None,
+                rules: Some(
+                    [],
+                ),
+                effect: ModuleRuleEffect {
+                    side_effects: None,
+                    type: None,
+                    layer: None,
+                    use: ,
+                    parser: None,
+                    generator: None,
+                    resolve: None,
+                    enforce: Normal,
+                },
+            },
+        ],
+        parser: Some(
+            ParserOptionsMap(
+                {
+                    "asset": Asset(
+                        AssetParserOptions {
+                            data_url_condition: Some(
+                                Options(
+                                    AssetParserDataUrlOptions {
+                                        max_size: Some(
+                                            8096.0,
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    "javascript": Javascript(
+                        JavascriptParserOptions {
+                            dynamic_import_mode: Some(
+                                Lazy,
+                            ),
+                            dynamic_import_preload: Some(
+                                Disable,
+                            ),
+                            dynamic_import_prefetch: Some(
+                                Disable,
+                            ),
+                            dynamic_import_fetch_priority: None,
+                            url: Some(
+                                Enable,
+                            ),
+                            expr_context_critical: Some(
+                                true,
+                            ),
+                            wrapped_context_critical: Some(
+                                false,
+                            ),
+                            wrapped_context_reg_exp: Some(
+                                RspackRegex {
+                                    flags: "",
+                                    source: ".*",
+                                },
+                            ),
+                            exports_presence: None,
+                            import_exports_presence: None,
+                            reexport_exports_presence: None,
+                            strict_export_presence: Some(
+                                false,
+                            ),
+                            worker: Some(
+                                [
+                                    "...",
+                                ],
+                            ),
+                            override_strict: None,
+                            import_meta: Some(
+                                true,
+                            ),
+                            require_as_expression: Some(
+                                true,
+                            ),
+                            require_dynamic: Some(
+                                true,
+                            ),
+                            require_resolve: Some(
+                                true,
+                            ),
+                            import_dynamic: Some(
+                                true,
+                            ),
+                        },
+                    ),
+                    "json": Json(
+                        JsonParserOptions {
+                            exports_depth: Some(
+                                4294967295,
+                            ),
+                            parse: ParseOption::None,
+                        },
+                    ),
+                },
+            ),
+        ),
+        generator: None,
+        no_parse: None,
+    },
+    stats: StatsOptions {
+        colors: true,
+    },
+    cache: Disabled,
+    experiments: Experiments {
+        layers: false,
+        incremental: IncrementalPasses(
+            MAKE | EMIT_ASSETS,
+        ),
+        parallel_code_splitting: false,
+        top_level_await: true,
+        rspack_future: RspackFuture,
+        cache: Disabled,
+    },
+    node: Some(
+        NodeOption {
+            dirname: WarnMock,
+            global: Warn,
+            filename: WarnMock,
+        },
+    ),
+    optimization: Optimization {
+        remove_available_modules: false,
+        side_effects: Flag,
+        provided_exports: true,
+        used_exports: False,
+        inner_graph: false,
+        mangle_exports: False,
+        concatenate_modules: false,
+        avoid_entry_iife: false,
+    },
+    profile: false,
+    amd: None,
+    bail: false,
+    __references: {},
+}

--- a/crates/rspack_binding_values/src/raw_options/raw_output.rs
+++ b/crates/rspack_binding_values/src/raw_options/raw_output.rs
@@ -56,6 +56,7 @@ pub struct RawEnvironment {
   pub module: Option<bool>,
   pub optional_chaining: Option<bool>,
   pub template_literal: Option<bool>,
+  pub dynamic_import_in_worker: Option<bool>,
 }
 
 impl From<RawEnvironment> for Environment {
@@ -74,6 +75,7 @@ impl From<RawEnvironment> for Environment {
       module: value.module,
       optional_chaining: value.optional_chaining,
       template_literal: value.template_literal,
+      dynamic_import_in_worker: value.dynamic_import_in_worker,
     }
   }
 }

--- a/crates/rspack_core/src/options/entry.rs
+++ b/crates/rspack_core/src/options/entry.rs
@@ -8,7 +8,7 @@ pub type EntryItem = Vec<String>;
 
 #[derive(Debug, Clone, Default)]
 pub struct EntryDescription {
-  pub import: EntryItem,
+  pub import: Option<EntryItem>,
   pub runtime: Option<String>,
   pub chunk_loading: Option<ChunkLoading>,
   pub async_chunks: Option<bool>,
@@ -25,7 +25,7 @@ where
 {
   fn from(value: V) -> Self {
     Self {
-      import: vec![value.into()],
+      import: Some(vec![value.into()]),
       ..Default::default()
     }
   }

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -177,7 +177,7 @@ impl From<&str> for WasmLoading {
   }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WasmLoadingType {
   Fetch,
   AsyncNode,
@@ -472,7 +472,7 @@ pub struct LibraryCustomUmdObject {
   pub root: Option<Vec<String>>,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Environment {
   pub r#const: Option<bool>,
   pub arrow_function: Option<bool>,
@@ -487,6 +487,7 @@ pub struct Environment {
   pub module: Option<bool>,
   pub optional_chaining: Option<bool>,
   pub template_literal: Option<bool>,
+  pub dynamic_import_in_worker: Option<bool>,
 }
 
 impl Environment {
@@ -520,6 +521,10 @@ impl Environment {
 
   pub fn supports_dynamic_import(&self) -> bool {
     self.dynamic_import.unwrap_or_default()
+  }
+
+  pub fn supports_dynamic_import_in_worker(&self) -> bool {
+    self.dynamic_import_in_worker.unwrap_or_default()
   }
 
   pub fn supports_for_of(&self) -> bool {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR adds default option test. Default option of `Compiler::builder` should be aligned with JS.
This was done by compare Rust options with JS options manually.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or not required).
