### PR TITLE
docs: fix invalid `cacheGroups` example

### DIFF
--- a/website/docs/en/guide/optimization/code-splitting.mdx
+++ b/website/docs/en/guide/optimization/code-splitting.mdx
@@ -121,8 +121,10 @@ module.exports = {
   optimization: {
     splitChunks: {
       cacheGroups: {
-        test: /\/some-lib\//,
-        name: 'lib',
+        someLib: {
+          test: /\/some-lib\//,
+          name: 'lib',
+        },
       },
     },
   },

--- a/website/docs/zh/guide/optimization/code-splitting.mdx
+++ b/website/docs/zh/guide/optimization/code-splitting.mdx
@@ -121,8 +121,10 @@ module.exports = {
   optimization: {
     splitChunks: {
       cacheGroups: {
-        test: /\/some-lib\//,
-        name: 'lib',
+        someLib: {
+          test: /\/some-lib\//,
+          name: 'lib',
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Fix an invalid `cacheGroups` example in the documentation.

resolve https://github.com/web-infra-dev/rspack/issues/8993

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
