### PR TITLE
feat: support wasm

### DIFF
--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -11,5 +11,5 @@ version     = "0.2.0"
 # Turned on `local_dynamic_tls` to avoid issue: https://github.com/microsoft/mimalloc/issues/147
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 
-[target.'cfg(not(target_os = "linux"))'.dependencies]
+[target.'cfg(not(any(target_os = "linux", target_family = "wasm")))'.dependencies]
 mimalloc = { workspace = true }

--- a/crates/rspack_allocator/src/lib.rs
+++ b/crates/rspack_allocator/src/lib.rs
@@ -1,3 +1,3 @@
 #[global_allocator]
-#[cfg(not(miri))]
+#[cfg(not(any(miri, target_family = "wasm")))]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;


### PR DESCRIPTION
## Description

Related: https://github.com/web-infra-dev/rspack/issues/4550

By following https://github.com/rolldown/rolldown/pull/467, I have made an ugly [MVP](https://x.com/c_punisher/status/1882412147965382689) to run rspack in browser environment.

Since I find that support for wasm is a feature that involves lots of small changes in current codebase, I'd like to list all the known steps in the following tasklist and divide the process into stages:

1. Compile rspack to wasm target, i.e. we can get `.wasm` files by `napi build`. In this stage we mostly add `#[cfg(not(target_family = "wasm"))]` to distinguish platforms.
2. Make rspack wasi available in node.
3. Make rspack wasi available in browser and provide an easy way for users.

## Roadmap

- [x] Compile rspack to wasm target: https://github.com/web-infra-dev/rspack/pull/9585
- Run rspack wasi in node
  - [x] fix: pass regex error https://github.com/web-infra-dev/rspack/pull/9872
  - [x] feat: bump napi to support multi-thread https://github.com/web-infra-dev/rspack/pull/9855
  - [x] fix: too much exports: https://github.com/napi-rs/napi-rs/pull/2523
  - [x] fix: rayon thread pool stucks workers. https://github.com/web-infra-dev/rspack/pull/10478
  - [x] fix: version & platform check: https://github.com/web-infra-dev/rspack/pull/10097
  - [x] fix: `module_export` in `napi` doesn't support wasm target. https://github.com/web-infra-dev/rspack/pull/10437
  - [x] fix: check test cases. https://github.com/web-infra-dev/rspack/pull/10757

## Debugging Hint (Browser)

1. Install https://chromewebstore.google.com/detail/cc++-devtools-support-dwa/pdcpmagijalfljmkmjngeonclgbbannb
2. Set `profile.release.debug = true` in `Cargo.toml` and ensure the wasm file is smaller than 1GB, which is the limitation of the browser
3. Add path mappings by following https://users.rust-lang.org/t/getting-raw-wasm-debugging-working-nicely-in-chrome-devtools/94646#getting-debugging-working-4
4. Add another mappings by following https://issues.chromium.org/issues/401522579#comment5 due to the bugs of the extension in current version.