### PR TITLE
fix: correct lazy compilation backend options schema

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -6360,7 +6360,7 @@ export const rspackOptions: z.ZodObject<{
         lazyCompilation: z.ZodUnion<[z.ZodOptional<z.ZodBoolean>, z.ZodObject<{
             backend: z.ZodOptional<z.ZodObject<{
                 client: z.ZodOptional<z.ZodString>;
-                listen: z.ZodUnion<[z.ZodOptional<z.ZodNumber>, z.ZodObject<{
+                listen: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodNumber, z.ZodObject<{
                     port: z.ZodOptional<z.ZodNumber>;
                     host: z.ZodOptional<z.ZodString>;
                     backlog: z.ZodOptional<z.ZodNumber>;
@@ -6387,8 +6387,9 @@ export const rspackOptions: z.ZodObject<{
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
-                }>]>;
+                }>]>, z.ZodFunction<z.ZodTuple<[z.ZodAny], z.ZodUnknown>, z.ZodVoid>]>>;
                 protocol: z.ZodOptional<z.ZodEnum<["http", "https"]>>;
+                server: z.ZodOptional<z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodAny>, z.ZodFunction<z.ZodTuple<[], z.ZodUnknown>, z.ZodAny>]>>;
             }, "strip", z.ZodTypeAny, {
                 client?: string | undefined;
                 listen?: number | {
@@ -6400,8 +6401,9 @@ export const rspackOptions: z.ZodObject<{
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
-                } | undefined;
+                } | ((args_0: any, ...args: unknown[]) => void) | undefined;
                 protocol?: "http" | "https" | undefined;
+                server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             }, {
                 client?: string | undefined;
                 listen?: number | {
@@ -6413,8 +6415,9 @@ export const rspackOptions: z.ZodObject<{
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
-                } | undefined;
+                } | ((args_0: any, ...args: unknown[]) => void) | undefined;
                 protocol?: "http" | "https" | undefined;
+                server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             }>>;
             imports: z.ZodOptional<z.ZodBoolean>;
             entries: z.ZodOptional<z.ZodBoolean>;
@@ -6434,8 +6437,9 @@ export const rspackOptions: z.ZodObject<{
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
-                } | undefined;
+                } | ((args_0: any, ...args: unknown[]) => void) | undefined;
                 protocol?: "http" | "https" | undefined;
+                server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
         }, {
             entries?: boolean | undefined;
@@ -6452,8 +6456,9 @@ export const rspackOptions: z.ZodObject<{
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
-                } | undefined;
+                } | ((args_0: any, ...args: unknown[]) => void) | undefined;
                 protocol?: "http" | "https" | undefined;
+                server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
         }>]>;
         asyncWebAssembly: z.ZodOptional<z.ZodBoolean>;
@@ -6572,8 +6577,9 @@ export const rspackOptions: z.ZodObject<{
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
-                } | undefined;
+                } | ((args_0: any, ...args: unknown[]) => void) | undefined;
                 protocol?: "http" | "https" | undefined;
+                server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
         } | undefined;
         asyncWebAssembly?: boolean | undefined;
@@ -6639,8 +6645,9 @@ export const rspackOptions: z.ZodObject<{
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
-                } | undefined;
+                } | ((args_0: any, ...args: unknown[]) => void) | undefined;
                 protocol?: "http" | "https" | undefined;
+                server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
         } | undefined;
         asyncWebAssembly?: boolean | undefined;
@@ -8585,8 +8592,9 @@ export const rspackOptions: z.ZodObject<{
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
-                } | undefined;
+                } | ((args_0: any, ...args: unknown[]) => void) | undefined;
                 protocol?: "http" | "https" | undefined;
+                server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
         } | undefined;
         asyncWebAssembly?: boolean | undefined;
@@ -9190,8 +9198,9 @@ export const rspackOptions: z.ZodObject<{
                     readableAll?: boolean | undefined;
                     writableAll?: boolean | undefined;
                     ipv6Only?: boolean | undefined;
-                } | undefined;
+                } | ((args_0: any, ...args: unknown[]) => void) | undefined;
                 protocol?: "http" | "https" | undefined;
+                server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
         } | undefined;
         asyncWebAssembly?: boolean | undefined;

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1338,8 +1338,13 @@ const lazyCompilationOptions = z.object({
 	backend: z
 		.object({
 			client: z.string().optional(),
-			listen: z.number().optional().or(listenOptions),
-			protocol: z.enum(["http", "https"]).optional()
+			listen: z
+				.number()
+				.or(listenOptions)
+				.or(z.function().args(z.any()).returns(z.void()))
+				.optional(),
+			protocol: z.enum(["http", "https"]).optional(),
+			server: z.record(z.any()).or(z.function().returns(z.any())).optional()
 		})
 		.optional(),
 	imports: z.boolean().optional(),


### PR DESCRIPTION
## Summary

The zod schema for the `lazyCompilation.backend` configuration is out of date and this PR updates the schema to match with the type declaration.

See: https://rspack.dev/config/experiments#experimentslazycompilation

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
