### PR TITLE
chore(workflow): remove duplicated issue label

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.en-US.yml
@@ -2,7 +2,7 @@ name: "🐞 Bug Report"
 description: Report a bug to Rspack
 title: "[Bug]: "
 type: Bug
-labels: ["bug", "pending triage"]
+labels: ["pending triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.en-US.yml
@@ -2,7 +2,7 @@ name: "✨ Feature Request"
 description: Submit a new feature request to Rspack
 title: "[Feature]: "
 type: Enhancement
-labels: ["feat", "pending triage"]
+labels: ["pending triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

The GitHub issue types work well and we can remove the issue label to reduce duplicated information.

![image](https://github.com/user-attachments/assets/8021a2f8-320e-444c-aa41-dc09562c227d)

## Related Links

https://github.com/web-infra-dev/rspack/pull/8663

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
