### PR TITLE
docs: enable code blocks search

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1111,8 +1111,8 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@rspress/plugin-rss':
-        specifier: 1.40.2
-        version: 1.40.2(@rspack/tracing@1.2.2)(react@19.0.0)(rspress@1.40.2(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0))))
+        specifier: 1.41.0
+        version: 1.41.0(@rspack/tracing@1.2.2)(react@19.0.0)(rspress@1.41.0(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0))))
       '@types/node':
         specifier: ^20.17.10
         version: 20.17.10
@@ -1136,13 +1136,13 @@ importers:
         version: 3.4.2
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2))
+        version: 1.0.3(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2))
       rsbuild-plugin-open-graph:
         specifier: 1.0.2
-        version: 1.0.2(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2))
+        version: 1.0.2(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2))
       rspress:
-        specifier: 1.40.2
-        version: 1.40.2(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))
+        specifier: 1.41.0
+        version: 1.41.0(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -3161,8 +3161,8 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@remix-run/router@1.21.1':
-    resolution: {integrity: sha512-KeBYSwohb8g4/wCcnksvKTYlg69O62sQeLynn2YE+5z7JWEj95if27kclW9QqbrlsQ2DINI8fjbV3zyuKfwjKg==}
+  '@remix-run/router@1.22.0':
+    resolution: {integrity: sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==}
     engines: {node: '>=14.0.0'}
 
   '@rollup/rollup-android-arm-eabi@4.24.0':
@@ -3345,8 +3345,8 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
-  '@rsbuild/core@1.2.0':
-    resolution: {integrity: sha512-dyAok2W0kv6l2i1MspQZPgUjipuNYl62LusFfgAYCbk6fRmQwZQo8QjPeY6jSDl5/wDDYqIaL/9kZXrAh7Cn3g==}
+  '@rsbuild/core@1.2.3':
+    resolution: {integrity: sha512-lUCt8gQe9E2PI3srcEJ1Na3GQYmsYuvAqK0f/k00HM0pEjrbOFC9Xq2kR85UoXHFqlTCIw/fLLDe91PKRCbKAw==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
@@ -3383,11 +3383,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.2.0':
-    resolution: {integrity: sha512-FXmouSPt6BAA4JdNpJQNnvL8L1m9w67NgyCBVG0hX5f6QkWLaAoRApuC2mPYkwSLJ4DjdfIt2Tdu+hsXk7UKnA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@1.2.2':
     resolution: {integrity: sha512-h23F8zEkXWhwMeScm0ZnN78Zh7hCDalxIWsm7bBS0eKadnlegUDwwCF8WE+8NjWr7bRzv0p3QBWlS5ufkcL4eA==}
     cpu: [arm64]
@@ -3395,11 +3390,6 @@ packages:
 
   '@rspack/binding-darwin-x64@1.1.8':
     resolution: {integrity: sha512-vfqf/c+mcx8rr1M8LnqKmzDdnrgguflZnjGerBLjNerAc+dcUp3lCvNxRIvZ2TkSZZBW8BpCMgjj3n70CZ4VLQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.2.0':
-    resolution: {integrity: sha512-Z1lo83dMcxsgvY+x28iqek7Gj3Xv8xX8GX2A5aqkziUtP4aGgSHBKyxgjTPWZVyA0YM6txp0qR/e+2pxAgg4vw==}
     cpu: [x64]
     os: [darwin]
 
@@ -3413,11 +3403,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.2.0':
-    resolution: {integrity: sha512-6ZYK5kF8KvQ7lhnCwUSJReSBJ7E5RROeFZgFaU9NXV6s5UDM/2/zMve5nKtzv38lGuYrFPI2oQuuaz3zEeoNPQ==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rspack/binding-linux-arm64-gnu@1.2.2':
     resolution: {integrity: sha512-VykY/kiYOzO8E1nYzfJ9+gQEHxb5B6lt5wa8M6xFi5B6jEGU+OsaGskmAZB9/GFImeFDHxDPvhUalI4R9p8O2Q==}
     cpu: [arm64]
@@ -3425,11 +3410,6 @@ packages:
 
   '@rspack/binding-linux-arm64-musl@1.1.8':
     resolution: {integrity: sha512-bX7exULSZwy8xtDh6Z65b6sRC4uSxGuyvSLCEKyhmG6AnJkg0gQMxk3hoO0hWnyGEZgdJEn+jEhk0fjl+6ZRAQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.2.0':
-    resolution: {integrity: sha512-WI197iCA+SHLmnBozedSSwCAeTGM9lBYo4SjxLo24Du0FTdTUI44rFS0g8yRbLoFy4LTzcVEEtKqOW4tnlDLow==}
     cpu: [arm64]
     os: [linux]
 
@@ -3443,11 +3423,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.2.0':
-    resolution: {integrity: sha512-dfaHOz07HdZLslKNgDtTR13CHoogUMsSPRr9cpTwIYOUeseaxkowHqE05KcNdxRV+N7WAwZRbsHupFw35ECY0w==}
-    cpu: [x64]
-    os: [linux]
-
   '@rspack/binding-linux-x64-gnu@1.2.2':
     resolution: {integrity: sha512-o3pDaL+cH5EeRbDE9gZcdZpBgp5iXvYZBBhe8vZQllYgI4zN5MJEuleV7WplG3UwTXlgZg3Kht4RORSOPn96vg==}
     cpu: [x64]
@@ -3455,11 +3430,6 @@ packages:
 
   '@rspack/binding-linux-x64-musl@1.1.8':
     resolution: {integrity: sha512-bnVGB/mQBKEdzOU/CPmcOE3qEXxGOGGW7/i6iLl2MamVOykJq8fYjL9j86yi6L0r009ja16OgWckykQGc4UqGw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.2.0':
-    resolution: {integrity: sha512-1ioVAoi0K+1JlqFIEzTd0Z00eeIYu0F/fDRY1wCNJlPWMjenmTn0lzygPyb/4ndv9kXhqKc/6a2vvVkO+R0sTg==}
     cpu: [x64]
     os: [linux]
 
@@ -3473,11 +3443,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.2.0':
-    resolution: {integrity: sha512-CMk4CsQZuzZgoOZ6BGIodS1SwhrxEZiF3fVXfSrBk0R0Hb2bi9wwQPuDmmK3FwDRXS/incmp0YhPQOP/Mzq8GQ==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@1.2.2':
     resolution: {integrity: sha512-R+PKBYn6uzTaDdVqTHvjqiJPBr5ZHg1wg5UmFDLNH9OklzVFyQh1JInSdJRb7lzfzTRz6bEkkwUFBPQK/CGScw==}
     cpu: [arm64]
@@ -3485,11 +3450,6 @@ packages:
 
   '@rspack/binding-win32-ia32-msvc@1.1.8':
     resolution: {integrity: sha512-FijUxym1INd5fFHwVCLuVP8XEAb4Sk1sMwEEQUlugiDra9ZsLaPw4OgPGxbxkD6SB0DeUz9Zq46Xbcf6d3OgfA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.2.0':
-    resolution: {integrity: sha512-Zm2DoLZmx8t4vxkOKF478y4P/O4sDQ6eZW3fVw1GUNI/B/lX/XwnAfYPKZEtTde9PQ/lFm29VRTH330TRVhagQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -3503,11 +3463,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.2.0':
-    resolution: {integrity: sha512-R2ICWiofKFR49A/CC8PIrPzf9tcCqYS3i8BlXCWKFU0Fy5t4uK8/xIml4lV5KCHSsDsE5c4c2tRm9E6FC8J1aw==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@1.2.2':
     resolution: {integrity: sha512-eeAvaN831KG553cMSHkVldyk6YQn4ujgRHov6r1wtREq7CD3/ka9LMkJUepCN85K7XtwYT0N4KpFIQyf5GTGoA==}
     cpu: [x64]
@@ -3515,9 +3470,6 @@ packages:
 
   '@rspack/binding@1.1.8':
     resolution: {integrity: sha512-+/JzXx1HctfgPj+XtsCTbRkxiaOfAXGZZLEvs7jgp04WgWRSZ5u97WRCePNPvy+sCfOEH/2zw2ZK36Z7oQRGhQ==}
-
-  '@rspack/binding@1.2.0':
-    resolution: {integrity: sha512-Y2DBqzmK+s0mecDKGPujTAZXdwQ62+TezNuIlkA8aKG3YLWTVcUB46Yj3ybNEspohrO+ts8ltksi0drsuGWxkQ==}
 
   '@rspack/binding@1.2.2':
     resolution: {integrity: sha512-GCZwpGFYlLTdJ2soPLwjw9z4LSZ+GdpbHNfBt3Cm/f/bAF8n6mZc7dHUqN893RFh7MPU17HNEL3fMw7XR+6pHg==}
@@ -3528,18 +3480,6 @@ packages:
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
     peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.2.0':
-    resolution: {integrity: sha512-mlALDjPifZpVAC4ML037FvkyCUbNMD2+GLwb1TZhuyVguKpI3FrJab8Zs7+nLvN3pbpWqAb6YBhyqmwCFdb1nw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@rspack/tracing': ^1.x
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@rspack/tracing':
-        optional: true
       '@swc/helpers':
         optional: true
 
@@ -3582,8 +3522,8 @@ packages:
   '@rspack/tracing@1.2.2':
     resolution: {integrity: sha512-/+HWSYSHVWgNeMfpjReW4nO8/Gtvu7Fe3BUVgKA2/z6o8eLiqKvoWmXnWrNVS0uD2C/6bz+8uRlk/872F6UFLw==}
 
-  '@rspress/core@1.40.2':
-    resolution: {integrity: sha512-R7it/enDRG43LSRjqG8MCmWfmEey8Ra0PnyLwjR+staMEykKsx/bnA9vLp9h44vcV4z6b4DKky1eU2AGABgJjA==}
+  '@rspress/core@1.41.0':
+    resolution: {integrity: sha512-UVc32XnkVUv9EcQLAZEck2D2M/4PycEX62dObaLPEN4rgr1cV97Trou8R3/NDCspCbBGIDu1K+l2Cntsbs6ZiQ==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.6':
@@ -3638,40 +3578,40 @@ packages:
     resolution: {integrity: sha512-NpNhTKBIlV3O6ADhoZkgHvBFvXMW2TYlIWmIT1ysJESUBqDpaN9H3Teve5fugjU2pQ2ORBZO6SQGKliMw/8m/Q==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@1.40.2':
-    resolution: {integrity: sha512-F8YKIMOksGAWfu2T+d12RKCgDLyGRn+hRbz8EkNpxcptqRsdTITSNi9wSDO7bPtaR7zLvKLPUVlVA1DK2i2rUA==}
+  '@rspress/plugin-auto-nav-sidebar@1.41.0':
+    resolution: {integrity: sha512-mcdlQq1I4ECIR/8n0HE0HvSSm9i7TqCq5dnX2uenZaim2Bqd3LXL/i70W2uTghnEcEzPND7oRNukiAtzvbnvvQ==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-container-syntax@1.40.2':
-    resolution: {integrity: sha512-3yYEk0rrThuf6Z/Qs4Nb0E1WpmKFMusTmLz1Km68Ni8BLAdq5+MQd5lss8gfCOFsMoBVCTr7iBlYwxWtUI55tw==}
+  '@rspress/plugin-container-syntax@1.41.0':
+    resolution: {integrity: sha512-CRbtMM4+DLhKRsJu512zNOOrFhgf3Bm+Ti9GlEpzKuAoaWJu6bAv9BEIVP7KXGlOgPcpMKrxIOYdsH0dSEjAsA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-last-updated@1.40.2':
-    resolution: {integrity: sha512-uTknDqFZr5p5ir0NOCSRmZunai22yVcfzEduv/4BXzFMDw+fZ83IankzvsuAHgmX4M/rSWmMuAqYkLrLKLlc3g==}
+  '@rspress/plugin-last-updated@1.41.0':
+    resolution: {integrity: sha512-IdEqKvHCBVCfbloJwMKlBSSk5ZS2LxuXOR4g3pj5myfn5N/rFvfYAdTA7pYRdTNu5HVzqGcciKl4Cda8gwDlmQ==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-medium-zoom@1.40.2':
-    resolution: {integrity: sha512-dF4VNWM/9M1isBbMaemMPJfrnCIpOgvPnhC4ZHUG1wdWyKSuDlYKQlEgpQ7keb7+n2mb4vW6zcXQ1+0YZYTIDQ==}
+  '@rspress/plugin-medium-zoom@1.41.0':
+    resolution: {integrity: sha512-TJY0xgilr7FebBGYRSTUXFV1ZwnOc7PAwcHxVCMi2qYxte8PUn0sxSyvUc3laOwVOigT7SvbQVJ0SQRhoVLL1w==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': ^1.40.2
+      '@rspress/runtime': ^1.41.0
 
-  '@rspress/plugin-rss@1.40.2':
-    resolution: {integrity: sha512-T1SeObqqn8oV0qFW5TKW06DTumzXNFw0qN6rHTS6HhlhUD6B65EDuqY5BRaOaILKAgve4TksFq0H7dz/zS91bQ==}
+  '@rspress/plugin-rss@1.41.0':
+    resolution: {integrity: sha512-dub643gqgzJDA+Gghfnhj+IR9m+PWln+JejfSATPKrgIbZCXQYN+x6pkJTPTyan88N5ypHrdChFUpGu5Nyp1Ug==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       react: '>=17.0.0'
-      rspress: ^1.40.2
+      rspress: ^1.41.0
 
-  '@rspress/runtime@1.40.2':
-    resolution: {integrity: sha512-I/u6RDeTadfic5iRedQt6Rw0gcQfagT1ENYseLu75spl/BbBbtDJUetCttK1ZvBoFTbl2gYvJOe8Kpg4433pWw==}
+  '@rspress/runtime@1.41.0':
+    resolution: {integrity: sha512-XlJum+OysogcGLJirA8e+ZucvlZBe03yTaUn4ph8w8TXZXI0bLKYbz5acBAhLr5BccFJqT+AnTCHORku4W6tPw==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/shared@1.40.2':
-    resolution: {integrity: sha512-PCMcSNf2c4UC3aMBRqIgtEJgg23y7FWhGWwT2PfSvmTYEVz9p0S6HWluPenJ/+CHvgc54BPes7dYxiMn/r0kCg==}
+  '@rspress/shared@1.41.0':
+    resolution: {integrity: sha512-mrLwoSPC90bsP8jjn1oxCuNYFE95XAluJghxOx/Qqd8HbAEXzGsSQbHfHVsN9/nJA9FK7Oq4KdLH+ImY+pFWLg==}
 
-  '@rspress/theme-default@1.40.2':
-    resolution: {integrity: sha512-oYY3LlNFX486en34/qev/mivD5oGmOyZaAPKlwlaghqUK+CueRmI81jPPMATqXRtWPR9gEsziqPzbMhj9CofRg==}
+  '@rspress/theme-default@1.41.0':
+    resolution: {integrity: sha512-NkhcpMWXKGsVNJ6Ml12AZOP2LKMgnVVbmtLaQtf1TjECBNXRf6fJtoHbY7ocYrCrnVGE8MAHvV6657KnA4zUnw==}
     engines: {node: '>=14.17.6'}
 
   '@rstack-dev/doc-ui@1.5.2':
@@ -8510,15 +8450,15 @@ packages:
     resolution: {integrity: sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@6.28.2:
-    resolution: {integrity: sha512-O81EWqNJWqvlN/a7eTudAdQm0TbI7hw+WIi7OwwMcTn5JMyZ0ibTFNGz+t+Lju0df4LcqowCegcrK22lB1q9Kw==}
+  react-router-dom@6.29.0:
+    resolution: {integrity: sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.28.2:
-    resolution: {integrity: sha512-BgFY7+wEGVjHCiqaj2XiUBQ1kkzfg6UoKYwEe0wv+FF+HNPCxtS/MVPvLAPH++EsuCMReZl9RYVGqcHLk5ms3A==}
+  react-router@6.29.0:
+    resolution: {integrity: sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -8767,8 +8707,8 @@ packages:
   rspress-plugin-sitemap@1.1.1:
     resolution: {integrity: sha512-usb6zWoi5wFFmBeA9HKR6BhsnnsItudMBarc54GYpuRL55SWkLxyWyMijv14mUI04FI7J7lEmea08uZE0bVKxg==}
 
-  rspress@1.40.2:
-    resolution: {integrity: sha512-1QPhjcQuEYUYx+CN/W0UiNgyqrLBxH4VeMjQO1qoDxjJB9/brQakDqbGq/kmBvanCTpbj1nE0uAjO9zWNDrsig==}
+  rspress@1.41.0:
+    resolution: {integrity: sha512-uGzgmlA6QPHVPBsHQeTiwb74xGH9z7L0GhVAOjrldcTRPi5w7pLQO/JaLi0oZKYOEbAZ0VAI+pOah86FCtGaWA==}
     hasBin: true
 
   run-applescript@7.0.0:
@@ -12647,7 +12587,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@remix-run/router@1.21.1': {}
+  '@remix-run/router@1.22.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.24.0':
     optional: true
@@ -12761,30 +12701,30 @@ snapshots:
       '@swc/helpers': 0.5.15
       core-js: 3.39.0
 
-  '@rsbuild/core@1.2.0(@rspack/tracing@1.2.2)':
+  '@rsbuild/core@1.2.3(@rspack/tracing@1.2.2)':
     dependencies:
-      '@rspack/core': 1.2.0(@rspack/tracing@1.2.2)(@swc/helpers@0.5.15)
+      '@rspack/core': 1.2.2(@rspack/tracing@1.2.2)(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.15
       core-js: 3.40.0
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2))':
+  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2))':
     dependencies:
-      '@rsbuild/core': 1.2.0(@rspack/tracing@1.2.2)
+      '@rsbuild/core': 1.2.3(@rspack/tracing@1.2.2)
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
-  '@rsbuild/plugin-react@1.1.0(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2))':
+  '@rsbuild/plugin-react@1.1.0(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2))':
     dependencies:
-      '@rsbuild/core': 1.2.0(@rspack/tracing@1.2.2)
+      '@rsbuild/core': 1.2.3(@rspack/tracing@1.2.2)
       '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
-  '@rsbuild/plugin-sass@1.2.0(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2))':
+  '@rsbuild/plugin-sass@1.2.0(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2))':
     dependencies:
-      '@rsbuild/core': 1.2.0(@rspack/tracing@1.2.2)
+      '@rsbuild/core': 1.2.3(@rspack/tracing@1.2.2)
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.1
@@ -12803,16 +12743,10 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.1.8':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.2.0':
-    optional: true
-
   '@rspack/binding-darwin-arm64@1.2.2':
     optional: true
 
   '@rspack/binding-darwin-x64@1.1.8':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.2.0':
     optional: true
 
   '@rspack/binding-darwin-x64@1.2.2':
@@ -12821,16 +12755,10 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.1.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.2.0':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@1.2.2':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.1.8':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.2.0':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.2.2':
@@ -12839,16 +12767,10 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.1.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.2.0':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@1.2.2':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.1.8':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.2.0':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.2.2':
@@ -12857,25 +12779,16 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.1.8':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.2.0':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@1.2.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.1.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.2.0':
-    optional: true
-
   '@rspack/binding-win32-ia32-msvc@1.2.2':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.1.8':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.2.0':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.2.2':
@@ -12893,18 +12806,6 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.1.8
       '@rspack/binding-win32-x64-msvc': 1.1.8
 
-  '@rspack/binding@1.2.0':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.2.0
-      '@rspack/binding-darwin-x64': 1.2.0
-      '@rspack/binding-linux-arm64-gnu': 1.2.0
-      '@rspack/binding-linux-arm64-musl': 1.2.0
-      '@rspack/binding-linux-x64-gnu': 1.2.0
-      '@rspack/binding-linux-x64-musl': 1.2.0
-      '@rspack/binding-win32-arm64-msvc': 1.2.0
-      '@rspack/binding-win32-ia32-msvc': 1.2.0
-      '@rspack/binding-win32-x64-msvc': 1.2.0
-
   '@rspack/binding@1.2.2':
     optionalDependencies:
       '@rspack/binding-darwin-arm64': 1.2.2
@@ -12916,7 +12817,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 1.2.2
       '@rspack/binding-win32-ia32-msvc': 1.2.2
       '@rspack/binding-win32-x64-msvc': 1.2.2
-    optional: true
 
   '@rspack/core@1.1.8(@swc/helpers@0.5.15)':
     dependencies:
@@ -12925,16 +12825,6 @@ snapshots:
       '@rspack/lite-tapable': 1.0.1
       caniuse-lite: 1.0.30001676
     optionalDependencies:
-      '@swc/helpers': 0.5.15
-
-  '@rspack/core@1.2.0(@rspack/tracing@1.2.2)(@swc/helpers@0.5.15)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.8.4
-      '@rspack/binding': 1.2.0
-      '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001676
-    optionalDependencies:
-      '@rspack/tracing': 1.2.2
       '@swc/helpers': 0.5.15
 
   '@rspack/core@1.2.2(@rspack/tracing@1.2.2)(@swc/helpers@0.5.15)':
@@ -12946,7 +12836,6 @@ snapshots:
     optionalDependencies:
       '@rspack/tracing': 1.2.2
       '@swc/helpers': 0.5.15
-    optional: true
 
   '@rspack/dev-server@1.0.10(@rspack/core@packages+rspack)(@types/express@4.17.21)(webpack-cli@5.1.4(webpack@5.95.0))(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))':
     dependencies:
@@ -12994,23 +12883,23 @@ snapshots:
       - supports-color
     optional: true
 
-  '@rspress/core@1.40.2(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))':
+  '@rspress/core@1.41.0(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))':
     dependencies:
       '@mdx-js/loader': 2.3.0(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rsbuild/core': 1.2.0(@rspack/tracing@1.2.2)
-      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2))
-      '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2))
-      '@rsbuild/plugin-sass': 1.2.0(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2))
+      '@rsbuild/core': 1.2.3(@rspack/tracing@1.2.2)
+      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2))
+      '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2))
+      '@rsbuild/plugin-sass': 1.2.0(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2))
       '@rspress/mdx-rs': 0.6.6
-      '@rspress/plugin-auto-nav-sidebar': 1.40.2(@rspack/tracing@1.2.2)
-      '@rspress/plugin-container-syntax': 1.40.2(@rspack/tracing@1.2.2)
-      '@rspress/plugin-last-updated': 1.40.2(@rspack/tracing@1.2.2)
-      '@rspress/plugin-medium-zoom': 1.40.2(@rspress/runtime@1.40.2(@rspack/tracing@1.2.2))
-      '@rspress/runtime': 1.40.2(@rspack/tracing@1.2.2)
-      '@rspress/shared': 1.40.2(@rspack/tracing@1.2.2)
-      '@rspress/theme-default': 1.40.2(@rspack/tracing@1.2.2)
+      '@rspress/plugin-auto-nav-sidebar': 1.41.0(@rspack/tracing@1.2.2)
+      '@rspress/plugin-container-syntax': 1.41.0(@rspack/tracing@1.2.2)
+      '@rspress/plugin-last-updated': 1.41.0(@rspack/tracing@1.2.2)
+      '@rspress/plugin-medium-zoom': 1.41.0(@rspress/runtime@1.41.0(@rspack/tracing@1.2.2))
+      '@rspress/runtime': 1.41.0(@rspack/tracing@1.2.2)
+      '@rspress/shared': 1.41.0(@rspack/tracing@1.2.2)
+      '@rspress/theme-default': 1.41.0(@rspack/tracing@1.2.2)
       enhanced-resolve: 5.18.0
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -13029,6 +12918,7 @@ snapshots:
       remark: 14.0.3
       remark-gfm: 3.0.1
       rspack-plugin-virtual-module: 0.1.13
+      tinyglobby: 0.2.10
       unified: 10.1.2
       unist-util-visit: 4.1.2
       unist-util-visit-children: 3.0.0
@@ -13072,65 +12962,63 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.6
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.6
 
-  '@rspress/plugin-auto-nav-sidebar@1.40.2(@rspack/tracing@1.2.2)':
+  '@rspress/plugin-auto-nav-sidebar@1.41.0(@rspack/tracing@1.2.2)':
     dependencies:
-      '@rspress/shared': 1.40.2(@rspack/tracing@1.2.2)
+      '@rspress/shared': 1.41.0(@rspack/tracing@1.2.2)
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-container-syntax@1.40.2(@rspack/tracing@1.2.2)':
+  '@rspress/plugin-container-syntax@1.41.0(@rspack/tracing@1.2.2)':
     dependencies:
-      '@rspress/shared': 1.40.2(@rspack/tracing@1.2.2)
+      '@rspress/shared': 1.41.0(@rspack/tracing@1.2.2)
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-last-updated@1.40.2(@rspack/tracing@1.2.2)':
+  '@rspress/plugin-last-updated@1.41.0(@rspack/tracing@1.2.2)':
     dependencies:
-      '@rspress/shared': 1.40.2(@rspack/tracing@1.2.2)
+      '@rspress/shared': 1.41.0(@rspack/tracing@1.2.2)
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-medium-zoom@1.40.2(@rspress/runtime@1.40.2(@rspack/tracing@1.2.2))':
+  '@rspress/plugin-medium-zoom@1.41.0(@rspress/runtime@1.41.0(@rspack/tracing@1.2.2))':
     dependencies:
-      '@rspress/runtime': 1.40.2(@rspack/tracing@1.2.2)
+      '@rspress/runtime': 1.41.0(@rspack/tracing@1.2.2)
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@1.40.2(@rspack/tracing@1.2.2)(react@19.0.0)(rspress@1.40.2(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0))))':
+  '@rspress/plugin-rss@1.41.0(@rspack/tracing@1.2.2)(react@19.0.0)(rspress@1.41.0(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0))))':
     dependencies:
-      '@rspress/shared': 1.40.2(@rspack/tracing@1.2.2)
+      '@rspress/shared': 1.41.0(@rspack/tracing@1.2.2)
       feed: 4.2.2
       react: 19.0.0
-      rspress: 1.40.2(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))
+      rspress: 1.41.0(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/runtime@1.40.2(@rspack/tracing@1.2.2)':
+  '@rspress/runtime@1.41.0(@rspack/tracing@1.2.2)':
     dependencies:
-      '@rspress/shared': 1.40.2(@rspack/tracing@1.2.2)
+      '@rspress/shared': 1.41.0(@rspack/tracing@1.2.2)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom: 6.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 6.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/shared@1.40.2(@rspack/tracing@1.2.2)':
+  '@rspress/shared@1.41.0(@rspack/tracing@1.2.2)':
     dependencies:
-      '@rsbuild/core': 1.2.0(@rspack/tracing@1.2.2)
+      '@rsbuild/core': 1.2.3(@rspack/tracing@1.2.2)
       chalk: 5.4.1
-      execa: 5.1.1
-      fs-extra: 11.2.0
       gray-matter: 4.0.3
       lodash-es: 4.17.21
       unified: 10.1.2
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/theme-default@1.40.2(@rspack/tracing@1.2.2)':
+  '@rspress/theme-default@1.41.0(@rspack/tracing@1.2.2)':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rspress/runtime': 1.40.2(@rspack/tracing@1.2.2)
-      '@rspress/shared': 1.40.2(@rspack/tracing@1.2.2)
+      '@rspress/runtime': 1.41.0(@rspack/tracing@1.2.2)
+      '@rspress/shared': 1.41.0(@rspack/tracing@1.2.2)
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -19059,16 +18947,16 @@ snapshots:
 
   react-refresh@0.16.0: {}
 
-  react-router-dom@6.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.21.1
+      '@remix-run/router': 1.22.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.28.2(react@18.3.1)
+      react-router: 6.29.0(react@18.3.1)
 
-  react-router@6.28.2(react@18.3.1):
+  react-router@6.29.0(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.21.1
+      '@remix-run/router': 1.22.0
       react: 18.3.1
 
   react-syntax-highlighter@15.6.1(react@18.3.1):
@@ -19360,13 +19248,13 @@ snapshots:
       '@microsoft/api-extractor': 7.48.1(@types/node@20.17.10)
       typescript: 5.7.2
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2)):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2)):
     optionalDependencies:
-      '@rsbuild/core': 1.2.0(@rspack/tracing@1.2.2)
+      '@rsbuild/core': 1.2.3(@rspack/tracing@1.2.2)
 
-  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.2.0(@rspack/tracing@1.2.2)):
+  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.2.3(@rspack/tracing@1.2.2)):
     optionalDependencies:
-      '@rsbuild/core': 1.2.0(@rspack/tracing@1.2.2)
+      '@rsbuild/core': 1.2.3(@rspack/tracing@1.2.2)
 
   rspack-plugin-virtual-module@0.1.13:
     dependencies:
@@ -19376,13 +19264,12 @@ snapshots:
 
   rspress-plugin-sitemap@1.1.1: {}
 
-  rspress@1.40.2(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0))):
+  rspress@1.41.0(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0))):
     dependencies:
-      '@rsbuild/core': 1.2.0(@rspack/tracing@1.2.2)
-      '@rspress/core': 1.40.2(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))
-      '@rspress/shared': 1.40.2(@rspack/tracing@1.2.2)
+      '@rsbuild/core': 1.2.3(@rspack/tracing@1.2.2)
+      '@rspress/core': 1.41.0(@rspack/tracing@1.2.2)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.15))(webpack-cli@5.1.4(webpack@5.95.0)))
+      '@rspress/shared': 1.41.0(@rspack/tracing@1.2.2)
       cac: 6.7.14
-      chalk: 5.4.1
       chokidar: 3.6.0
     transitivePeerDependencies:
       - '@rspack/tracing'

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@rspress/plugin-rss": "1.40.2",
+    "@rspress/plugin-rss": "1.41.0",
     "@types/node": "^20.17.10",
     "@types/react": "^19.0.8",
     "@types/semver": "^7.5.6",
@@ -40,7 +40,7 @@
     "prettier": "3.4.2",
     "rsbuild-plugin-google-analytics": "1.0.3",
     "rsbuild-plugin-open-graph": "1.0.2",
-    "rspress": "1.40.2",
+    "rspress": "1.41.0",
     "rspress-plugin-font-open-sans": "1.0.0",
     "rspress-plugin-sitemap": "^1.1.1",
     "typescript": "^5.7.2"

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
     checkDeadLinks: true,
     highlightLanguages: [['rs', 'rust']],
   },
+  search: {
+    codeBlocks: true,
+  },
   route: {
     cleanUrls: true,
   },
@@ -136,8 +139,7 @@ export default defineConfig({
   ],
   builderConfig: {
     dev: {
-      // TODO: @JSerFeng needs to fix this
-      // lazyCompilation: true,
+      lazyCompilation: true,
     },
     plugins: [
       pluginGoogleAnalytics({ id: 'G-XKKCNZZNJD' }),


### PR DESCRIPTION
## Summary

- Bump Rspress to v1.41.0.
- Enable code blocks search feature.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
