### PR TITLE
chore: bump inventory 0.1 -> 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,16 +1147,6 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
@@ -1887,17 +1877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghost"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b697dbd8bfcc35d0ee91698aaa379af096368ba8837d279cc097b276edda45"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.95",
-]
-
-[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,24 +2466,11 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.1.11"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
+checksum = "3b31349d02fe60f80bbbab1a9402364cad7460626d6030494b08ac4a2075bf81"
 dependencies = [
- "ctor 0.1.26",
- "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "rustversion",
 ]
 
 [[package]]
@@ -3045,7 +3011,7 @@ checksum = "5de0beff58a431b3bd6568b690bcf55d72d8dd7f8e0e613a0193a8a9a8eef26b"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
- "ctor 0.2.9",
+ "ctor",
  "napi-build",
  "napi-sys",
  "serde",
@@ -4320,6 +4286,7 @@ dependencies = [
  "smol_str",
  "swc_core",
  "ustr-fxhash",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4338,6 +4305,7 @@ dependencies = [
  "serde_json",
  "swc_core",
  "ustr-fxhash",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ napi-build  = { version = "2.1.4" }
 napi-derive = { version = "3.0.0-alpha.22" }
 
 # Serialize and Deserialize
-inventory = { version = "=0.1" }
+inventory = { version = "0.3.17" }
 rkyv      = { version = "=0.8.8" }
 
 # Must be pinned with the same swc versions

--- a/crates/rspack_cacheable/Cargo.toml
+++ b/crates/rspack_cacheable/Cargo.toml
@@ -26,3 +26,4 @@ serde_json      = { workspace = true }
 smol_str        = { workspace = true }
 swc_core        = { workspace = true, features = ["ecma_ast"] }
 ustr            = { workspace = true }
+xxhash-rust     = { workspace = true, features = ["const_xxh64"] }

--- a/crates/rspack_cacheable/src/dyn/validation.rs
+++ b/crates/rspack_cacheable/src/dyn/validation.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use rkyv::bytecheck::CheckBytes;
 
+use super::VTablePtr;
 use crate::{DeserializeError, Validator};
 
 type CheckBytesDyn = unsafe fn(*const u8, &mut Validator<'_>) -> Result<(), DeserializeError>;
@@ -20,13 +21,13 @@ where
 }
 
 pub struct CheckBytesEntry {
-  vtable: usize,
+  vtable: VTablePtr,
   check_bytes_dyn: CheckBytesDyn,
 }
 
 impl CheckBytesEntry {
   #[doc(hidden)]
-  pub fn new(vtable: usize, check_bytes_dyn: CheckBytesDyn) -> Self {
+  pub const fn new(vtable: VTablePtr, check_bytes_dyn: CheckBytesDyn) -> Self {
     Self {
       vtable,
       check_bytes_dyn,
@@ -36,7 +37,7 @@ impl CheckBytesEntry {
 
 inventory::collect!(CheckBytesEntry);
 
-pub static CHECK_BYTES_REGISTRY: std::sync::LazyLock<HashMap<usize, CheckBytesDyn>> =
+pub static CHECK_BYTES_REGISTRY: std::sync::LazyLock<HashMap<VTablePtr, CheckBytesDyn>> =
   std::sync::LazyLock::new(|| {
     let mut result = HashMap::default();
     for entry in inventory::iter::<CheckBytesEntry> {

--- a/crates/rspack_cacheable/src/dyn/vtable_ptr.rs
+++ b/crates/rspack_cacheable/src/dyn/vtable_ptr.rs
@@ -1,0 +1,16 @@
+use rkyv::ptr_meta::DynMetadata;
+
+/// A untyped wrapper for vtable
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub struct VTablePtr(DynMetadata<()>);
+
+impl VTablePtr {
+  pub const unsafe fn new<T: ?Sized>(vtable: DynMetadata<T>) -> Self {
+    Self(core::mem::transmute(vtable))
+  }
+  pub const unsafe fn cast<T: ?Sized>(self) -> DynMetadata<T> {
+    core::mem::transmute(self.0)
+  }
+}
+unsafe impl Send for VTablePtr {}
+unsafe impl Sync for VTablePtr {}

--- a/crates/rspack_cacheable/src/dyn/vtable_ptr.rs
+++ b/crates/rspack_cacheable/src/dyn/vtable_ptr.rs
@@ -5,9 +5,14 @@ use rkyv::ptr_meta::DynMetadata;
 pub struct VTablePtr(DynMetadata<()>);
 
 impl VTablePtr {
-  pub const unsafe fn new<T: ?Sized>(vtable: DynMetadata<T>) -> Self {
-    Self(core::mem::transmute(vtable))
+  pub const fn new<T: ?Sized>(vtable: DynMetadata<T>) -> Self {
+    // Creating VTablePtr is safe while using it is unsafe, just like raw pointers in rust.
+    Self(unsafe { core::mem::transmute::<DynMetadata<T>, DynMetadata<()>>(vtable) })
   }
+
+  /// # Safety
+  /// The casting target `T` must be consistent with the `T` in VTablePtr::new<T>
+  /// Currently it is implemented by store VTablePtr as values in HashMap to associate the types with __DYN_ID
   pub const unsafe fn cast<T: ?Sized>(self) -> DynMetadata<T> {
     core::mem::transmute(self.0)
   }

--- a/crates/rspack_cacheable/src/lib.rs
+++ b/crates/rspack_cacheable/src/lib.rs
@@ -19,3 +19,4 @@ pub mod __private {
 
 pub use deserialize::{from_bytes, DeserializeError, Deserializer, Validator};
 pub use serialize::{to_bytes, SerializeError, Serializer};
+pub use xxhash_rust;

--- a/crates/rspack_cacheable_test/Cargo.toml
+++ b/crates/rspack_cacheable_test/Cargo.toml
@@ -21,3 +21,4 @@ rustc-hash       = { workspace = true }
 serde_json       = { workspace = true }
 swc_core         = { workspace = true, features = ["ecma_ast"] }
 ustr             = { workspace = true }
+xxhash-rust      = { workspace = true, features = ["const_xxh64"] }

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
@@ -145,11 +145,9 @@ fn test_manual_cacheable_dyn_macro() {
     };
 
     const fn get_vtable() -> VTablePtr {
-      unsafe {
-        VTablePtr::new(ptr_meta::metadata(
-          core::ptr::null::<Archived<Dog>>() as *const <dyn Animal as ArchiveUnsized>::Archived
-        ))
-      }
+      VTablePtr::new(ptr_meta::metadata(
+        core::ptr::null::<Archived<Dog>>() as *const <dyn Animal as ArchiveUnsized>::Archived
+      ))
     }
     inventory::submit! { DynEntry::new(__DYN_ID_DOG_ANIMAL, get_vtable()) }
     inventory::submit! { CheckBytesEntry::new(get_vtable(), default_check_bytes_dyn::<Archived<Dog>>) }
@@ -209,11 +207,9 @@ fn test_manual_cacheable_dyn_macro() {
     };
 
     const fn get_vtable() -> VTablePtr {
-      unsafe {
-        VTablePtr::new(ptr_meta::metadata(
-          core::ptr::null::<Archived<Cat>>() as *const <dyn Animal as ArchiveUnsized>::Archived
-        ))
-      }
+      VTablePtr::new(ptr_meta::metadata(
+        core::ptr::null::<Archived<Cat>>() as *const <dyn Animal as ArchiveUnsized>::Archived
+      ))
     }
     inventory::submit! { DynEntry::new(__DYN_ID_CAT_ANIMAL, get_vtable()) }
     inventory::submit! { CheckBytesEntry::new(get_vtable(), default_check_bytes_dyn::<Archived<Cat>>) }

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
@@ -1,4 +1,4 @@
-use rspack_cacheable::{cacheable, from_bytes, to_bytes};
+use rspack_cacheable::{cacheable, from_bytes, r#dyn::VTablePtr, to_bytes};
 
 #[test]
 #[cfg_attr(miri, ignore)]
@@ -99,7 +99,7 @@ fn test_manual_cacheable_dyn_macro() {
         value: *const Self,
         context: &mut Validator,
       ) -> Result<(), DeserializeError> {
-        let vtable: usize = std::mem::transmute(ptr_meta::metadata(value));
+        let vtable = VTablePtr::new(ptr_meta::metadata(value));
         if let Some(check_bytes_dyn) = CHECK_BYTES_REGISTRY.get(&vtable) {
           check_bytes_dyn(value.cast(), context)?;
           Ok(())
@@ -115,13 +115,8 @@ fn test_manual_cacheable_dyn_macro() {
     color: String,
   }
 
-  static __DYN_ID_DOG_ANIMAL: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| {
-    use std::hash::{DefaultHasher, Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
-    module_path!().hash(&mut hasher);
-    line!().hash(&mut hasher);
-    hasher.finish()
-  });
+  const __DYN_ID_DOG_ANIMAL: u64 =
+    xxhash_rust::const_xxh64::xxh64(concat!(module_path!(), ":", line!()).as_bytes(), 0);
 
   impl Animal for Dog {
     fn color(&self) -> &str {
@@ -132,7 +127,7 @@ fn test_manual_cacheable_dyn_macro() {
     }
 
     fn __dyn_id(&self) -> u64 {
-      *__DYN_ID_DOG_ANIMAL
+      __DYN_ID_DOG_ANIMAL
     }
   }
 
@@ -149,14 +144,14 @@ fn test_manual_cacheable_dyn_macro() {
       DeserializeError, Deserializer,
     };
 
-    fn get_vtable() -> usize {
+    const fn get_vtable() -> VTablePtr {
       unsafe {
-        core::mem::transmute(ptr_meta::metadata(
+        VTablePtr::new(ptr_meta::metadata(
           core::ptr::null::<Archived<Dog>>() as *const <dyn Animal as ArchiveUnsized>::Archived
         ))
       }
     }
-    inventory::submit! { DynEntry::new(*__DYN_ID_DOG_ANIMAL, get_vtable()) }
+    inventory::submit! { DynEntry::new(__DYN_ID_DOG_ANIMAL, get_vtable()) }
     inventory::submit! { CheckBytesEntry::new(get_vtable(), default_check_bytes_dyn::<Archived<Dog>>) }
 
     impl DeserializeDyn<dyn Animal> for ArchivedDog
@@ -184,13 +179,8 @@ fn test_manual_cacheable_dyn_macro() {
     color: String,
   }
 
-  static __DYN_ID_CAT_ANIMAL: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| {
-    use std::hash::{DefaultHasher, Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
-    module_path!().hash(&mut hasher);
-    line!().hash(&mut hasher);
-    hasher.finish()
-  });
+  const __DYN_ID_CAT_ANIMAL: u64 =
+    xxhash_rust::const_xxh64::xxh64(concat!(module_path!(), ":", line!()).as_bytes(), 0);
 
   impl Animal for Cat {
     fn color(&self) -> &str {
@@ -201,7 +191,7 @@ fn test_manual_cacheable_dyn_macro() {
     }
 
     fn __dyn_id(&self) -> u64 {
-      *__DYN_ID_CAT_ANIMAL
+      __DYN_ID_CAT_ANIMAL
     }
   }
 
@@ -218,14 +208,14 @@ fn test_manual_cacheable_dyn_macro() {
       DeserializeError, Deserializer,
     };
 
-    fn get_vtable() -> usize {
+    const fn get_vtable() -> VTablePtr {
       unsafe {
-        core::mem::transmute(ptr_meta::metadata(
+        VTablePtr::new(ptr_meta::metadata(
           core::ptr::null::<Archived<Cat>>() as *const <dyn Animal as ArchiveUnsized>::Archived
         ))
       }
     }
-    inventory::submit! { DynEntry::new(*__DYN_ID_CAT_ANIMAL, get_vtable()) }
+    inventory::submit! { DynEntry::new(__DYN_ID_CAT_ANIMAL, get_vtable()) }
     inventory::submit! { CheckBytesEntry::new(get_vtable(), default_check_bytes_dyn::<Archived<Cat>>) }
 
     impl DeserializeDyn<dyn Animal> for ArchivedCat

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
@@ -144,10 +144,8 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
     };
 
     const fn get_vtable() -> VTablePtr {
-      unsafe {
-        VTablePtr::new(ptr_meta::metadata(core::ptr::null::<Archived<Dog>>()
-          as *const <dyn Animal<&'static str> as ArchiveUnsized>::Archived))
-      }
+      VTablePtr::new(ptr_meta::metadata(core::ptr::null::<Archived<Dog>>()
+        as *const <dyn Animal<&'static str> as ArchiveUnsized>::Archived))
     }
     inventory::submit! { DynEntry::new(__DYN_ID_DOG_ANIMAL, get_vtable()) }
     inventory::submit! { CheckBytesEntry::new(get_vtable(), default_check_bytes_dyn::<Archived<Dog>>) }
@@ -206,10 +204,8 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
     };
 
     const fn get_vtable() -> VTablePtr {
-      unsafe {
-        VTablePtr::new(ptr_meta::metadata(core::ptr::null::<Archived<Cat>>()
-          as *const <dyn Animal<String> as ArchiveUnsized>::Archived))
-      }
+      VTablePtr::new(ptr_meta::metadata(core::ptr::null::<Archived<Cat>>()
+        as *const <dyn Animal<String> as ArchiveUnsized>::Archived))
     }
     inventory::submit! { DynEntry::new(__DYN_ID_CAT_ANIMAL, get_vtable()) }
     inventory::submit! { CheckBytesEntry::new(get_vtable(), default_check_bytes_dyn::<Archived<Cat>>)}

--- a/crates/rspack_macros/src/cacheable_dyn.rs
+++ b/crates/rspack_macros/src/cacheable_dyn.rs
@@ -204,11 +204,9 @@ pub fn impl_impl(mut input: ItemImpl) -> TokenStream {
           };
 
           const fn get_vtable() -> VTablePtr {
-              unsafe {
-                  VTablePtr::new(ptr_meta::metadata(
-                      core::ptr::null::<Archived<#target_ident>>() as *const <dyn #trait_ident as ArchiveUnsized>::Archived
-                  ))
-              }
+              VTablePtr::new(ptr_meta::metadata(
+                  core::ptr::null::<Archived<#target_ident>>() as *const <dyn #trait_ident as ArchiveUnsized>::Archived
+              ))
           }
           inventory::submit! { DynEntry::new(#dyn_id_ident, get_vtable()) }
           inventory::submit! { CheckBytesEntry::new(get_vtable(), default_check_bytes_dyn::<Archived<#target_ident>>) }


### PR DESCRIPTION
## Summary

Rspack persistent cache depends on [inventory](https://github.com/dtolnay/inventory/releases) v0.1. But it supports wasm in v0.3. The main barrier to upgrade is https://github.com/dtolnay/inventory/releases/tag/0.2.0. So this pr makes the following changes:
1. Mark the functions used in `inventory!` with `const`.
2. Calculate `__DYN_ID` with `xxhash-rust`, which supports calculating hash in const context(compile time). I think this also improves the performance.
3. Transmute dyn vtable to a new `VTablePtr` struct with `Send` and `Sync` rather than `usize`, and use `unsafe` to guarantee the safety. The reason is that transmuting a vtable address to `usize` is not permitted by rustc since it is unknown in compile time.

This pr does not mean there is no other problem to use persistent cache in wasm. But at least it's something beneficial.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
