### PR TITLE
fix: should not tree shaking used ident accidentally in composes

### DIFF
--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -425,6 +425,7 @@ impl Plugin for CssPlugin {
           .expect("should have CssGeneratorOptions");
         Box::new(CssParserAndGenerator {
           exports: None,
+          local_names: None,
           convention: None,
           local_ident_name: None,
           exports_only: g.exports_only.expect("should have exports_only"),
@@ -445,6 +446,7 @@ impl Plugin for CssPlugin {
           .expect("should have CssModuleGeneratorOptions");
         Box::new(CssParserAndGenerator {
           exports: None,
+          local_names: None,
           convention: Some(
             g.exports_convention
               .expect("should have exports_convention"),
@@ -472,6 +474,7 @@ impl Plugin for CssPlugin {
           .expect("should have CssAutoGeneratorOptions");
         Box::new(CssParserAndGenerator {
           exports: None,
+          local_names: None,
           convention: Some(
             g.exports_convention
               .expect("should have exports_convention"),

--- a/packages/rspack-test-tools/tests/configCases/css/minify-lightning-css-remove-unused-local-idents/index.js
+++ b/packages/rspack-test-tools/tests/configCases/css/minify-lightning-css-remove-unused-local-idents/index.js
@@ -4,12 +4,14 @@ it("should remove unused local idents", async () => {
 	const fs = __non_webpack_require__("fs");
 	const path = __non_webpack_require__("path");
 	expect(styles.a).toBe("./style.module-a");
-	expect(styles['local/used']).toBe("./style.module-local/used");
+	expect(styles["local/used"]).toBe("./style.module-local/used");
+	expect(styles["composed-local"]).toBe("./style.module-composed-local");
 
 	if (!EXPORTS_ONLY) {
 		const css = await fs.promises.readFile(path.resolve(__dirname, "./bundle0.css"), "utf-8");
 		expect(css).not.toContain(".module-b")
 		expect(css).toContain("local\\/used")
 		expect(css).not.toContain("local\\/unused")
+		expect(css).toContain("composed-local")
 	}
 })

--- a/packages/rspack-test-tools/tests/configCases/css/minify-lightning-css-remove-unused-local-idents/style.module.css
+++ b/packages/rspack-test-tools/tests/configCases/css/minify-lightning-css-remove-unused-local-idents/style.module.css
@@ -13,3 +13,11 @@
 .local\/unused {
   color: blue
 }
+
+.compose {
+  composes: composed-local;
+}
+
+.composed-local {
+  background-color: green;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

When we remove unused css local ident, we should only remove those whose `UseState` is explicit `Unused`

Eg.

```css
.foo {}

.bar {
  composes: foo
}
```

If `bar` is unused, we should not remove its composes

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
