### PR TITLE
chore: enable no-dts-cache by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4223,6 +4223,7 @@ dependencies = [
  "glob",
  "heck 0.5.0",
  "napi",
+ "napi-build",
  "napi-derive",
  "pollster",
  "rspack_cacheable",

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -57,6 +57,7 @@ async function build() {
 			args.push("--no-default-features");
 			args.push("--features plugin");
 		}
+		args.push("--no-dts-cache");
 
 		console.log(`Run command: napi ${args.join(' ')}`);
 

--- a/crates/rspack_binding_values/Cargo.toml
+++ b/crates/rspack_binding_values/Cargo.toml
@@ -5,7 +5,8 @@ license     = "MIT"
 name        = "rspack_binding_values"
 repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.2.0"
-
+[lib]
+crate-type = ["cdylib", "rlib"]
 [features]
 plugin = ["rspack_loader_swc/plugin"]
 
@@ -86,3 +87,6 @@ rspack_plugin_wasm                     = { workspace = true }
 rspack_plugin_web_worker_template      = { workspace = true }
 rspack_plugin_worker                   = { workspace = true }
 rspack_tracing                         = { workspace = true }
+
+[build-dependencies]
+napi-build = { workspace = true }

--- a/crates/rspack_binding_values/build.rs
+++ b/crates/rspack_binding_values/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+  napi_build::setup();
+
+  // Rebuild binding options if and only if it's built for crate `node_binding`
+  if std::env::var("OUT_DIR")
+    .expect("should exist")
+    .contains("node_binding")
+  {
+    println!("cargo:rerun-if-changed=../node_binding");
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
when dts-cache enabled bindind.d.ts will wrongly generate empty definition which will cause ts error

the missing dts is caused by there're some crate napi which doesn't contain build.rs so we add build.rs for every crate which contains napi, thank you @Brooooooklyn's help
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
