### PR TITLE
refactor: remove `NormalModule` last_successful_build_meta field

### DIFF
--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -596,9 +596,11 @@ impl Module for NormalModule {
         parse_meta: loader_result.parse_meta,
       })?
       .split_into_parts();
+    if diagnostics.iter().any(|d| d.severity() == Severity::Error) {
+      build_meta = Default::default();
+    }
     if !diagnostics.is_empty() {
       self.add_diagnostics(diagnostics);
-      build_meta = Default::default();
     }
     let optimization_bailouts = if let Some(side_effects_bailout) = side_effects_bailout {
       let short_id = self.readable_identifier(&build_context.compiler_options.context);

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -152,7 +152,6 @@ pub struct NormalModule {
   build_info: Option<BuildInfo>,
   build_meta: Option<BuildMeta>,
   parsed: bool,
-  last_successful_build_meta: BuildMeta,
 }
 
 #[cacheable]
@@ -240,7 +239,6 @@ impl NormalModule {
       build_meta: None,
       parsed: false,
       source_map_kind: SourceMapKind::empty(),
-      last_successful_build_meta: BuildMeta::default(),
     }
   }
 
@@ -600,9 +598,7 @@ impl Module for NormalModule {
       .split_into_parts();
     if !diagnostics.is_empty() {
       self.add_diagnostics(diagnostics);
-      build_meta = self.last_successful_build_meta.clone();
-    } else {
-      self.last_successful_build_meta = build_meta.clone();
+      build_meta = Default::default();
     }
     let optimization_bailouts = if let Some(side_effects_bailout) = side_effects_bailout {
       let short_id = self.readable_identifier(&build_context.compiler_options.context);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The `last_successful_build_meta` is used to avoid parent module interop code error when current module rebuild failed, but rspack will always remove the module which need rebuild and use [fix_build_meta](https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_core/src/compiler/make/cutout/fix_build_meta.rs) to achieve the same effect.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
