### PR TITLE
chore(renovate): split npm updates into fine-grained PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,14 +79,25 @@
 		{
 			groupName: "Rspack",
 			matchManagers: ["npm"],
-			matchPackageNames: ["/@rspack/"]
+			matchPackageNames: ["/^@rspack/"]
 		},
 		// Babel npm packages
 		{
 			groupName: "babel",
-			groupSlug: "babel",
 			matchManagers: ["npm"],
 			matchPackageNames: ["/babel/"]
+		},
+		// Types npm packages
+		{
+			groupName: "types",
+			matchManagers: ["npm"],
+			matchPackageNames: ["/^@types/"]
+		},
+		// SWC npm packages
+		{
+			groupName: "SWC",
+			matchManagers: ["npm"],
+			matchPackageNames: ["/^@swc/"]
 		},
 		// Rspack crates
 		{

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -75,18 +75,21 @@
 			groupName: "napi",
 			matchPackagePrefixes: ["napi", "@napi-rs/"]
 		},
+		// Rspack npm packages
 		{
-			// rspack packages
-			groupName: "@rspack/dev-server @rspack/plugin-react-refresh @rspack/plugin-preact-refresh",
+			groupName: "Rspack",
 			matchManagers: ["npm"],
-			matchPackageNames: [
-				"@rspack/dev-server",
-				"@rspack/plugin-react-refresh",
-				"@rspack/plugin-preact-refresh"
-			]
+			matchPackageNames: ["/@rspack/"]
 		},
+		// Babel npm packages
 		{
-			// rspack crates
+			groupName: "babel",
+			groupSlug: "babel",
+			matchManagers: ["npm"],
+			matchPackageNames: ["/babel/"]
+		},
+		// Rspack crates
+		{
 			groupName: "crate rspack_resolver",
 			matchManagers: ["cargo"],
 			matchPackageNames: ["rspack_resolver"]
@@ -123,20 +126,15 @@
 				"@biomejs/biome",
 				"prettier"
 			],
-			// bump major in a separate PR
-			matchUpdateTypes: ["patch", "minor"]
+			// bump major and minor in a separate PR
+			matchUpdateTypes: ["patch"]
 		},
 		{
 			groupName: "npm dependencies",
 			matchManagers: ["npm"],
 			matchDepTypes: ["dependencies"],
-			excludePackageNames: [
-				"@rspack/dev-server",
-				"@rspack/plugin-react-refresh",
-				"@rspack/plugin-preact-refresh"
-			],
-			// bump major in a separate PR
-			matchUpdateTypes: ["patch", "minor"]
+			// bump major and minor in a separate PR
+			matchUpdateTypes: ["patch"]
 		},
 		{
 			groupName: "webpack",
@@ -167,8 +165,8 @@
 			matchManagers: ["npm"],
 			matchPackageNames: ["@biomejs/biome", "prettier"]
 		},
+		// Rspress npm packages
 		{
-			// document
 			groupName: "rspress",
 			matchManagers: ["npm"],
 			matchFileNames: ["website/package.json"],


### PR DESCRIPTION
## Summary

Rspack's npm updates have not been merged for a long time, see:

https://github.com/web-infra-dev/rspack/pull/8419
https://github.com/web-infra-dev/rspack/pull/8420

These PRs contains too many updates, making them difficult to merge. We can split npm updates into fine-grained PRs to make them eaiser to merge.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
