### PR TITLE
fix: lazy compilation request handler should filter lazy-compilation request

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -7,6 +7,7 @@
 /// <reference types="node" />
 
 import type { Abortable } from 'node:events';
+import type { AddressInfo } from 'node:net';
 import { AsyncParallelHook } from '@rspack/lite-tapable';
 import { AsyncSeriesBailHook } from '@rspack/lite-tapable';
 import * as binding from '@rspack/binding';
@@ -75,9 +76,9 @@ import { RawRuntimeChunkOptions } from '@rspack/binding';
 import { Resolver as Resolver_2 } from './Resolver';
 import { RspackOptionsNormalized as RspackOptionsNormalized_2 } from '.';
 import type { SecureContextOptions } from 'node:tls';
-import type { Server } from 'node:net';
 import type { ServerOptions } from 'node:http';
 import type { ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
 import { RawSourceMapDevToolPluginOptions as SourceMapDevToolPluginOptions } from '@rspack/binding';
 import sources = require('../compiled/webpack-sources');
 import { SyncBailHook } from '@rspack/lite-tapable';
@@ -10095,6 +10096,24 @@ type SafeParseSuccess<Output> = {
 
 // @public (undocumented)
 export type ScriptType = false | "text/javascript" | "module";
+
+// @public (undocumented)
+interface Server {
+    // (undocumented)
+    address(): AddressInfo;
+    // (undocumented)
+    close(callback: (err?: any) => void): void;
+    // (undocumented)
+    listen(listenOptions?: number | ListenOptions): void;
+    // (undocumented)
+    off(event: "request", callback: (req: IncomingMessage, res: ServerResponse) => void): void;
+    // (undocumented)
+    on(event: "request", callback: (req: IncomingMessage, res: ServerResponse) => void): void;
+    // (undocumented)
+    on(event: "connection", callback: (socket: Socket) => void): void;
+    // (undocumented)
+    on(event: "listening", callback: (err?: Error) => void): void;
+}
 
 // @public (undocumented)
 type ServerOptionsHttps<Request extends typeof IncomingMessage = typeof IncomingMessage, Response extends typeof ServerResponse = typeof ServerResponse> = SecureContextOptions & TlsOptions & ServerOptions<Request, Response>;

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
@@ -2,16 +2,33 @@
  * MIT License http://www.opensource.org/licenses/mit-license.php
  * Author Tobias Koppers @sokra
  */
-
 import type {
 	IncomingMessage,
 	ServerOptions as ServerOptionsImport,
 	ServerResponse
 } from "node:http";
-import type { AddressInfo, ListenOptions, Server, Socket } from "node:net";
+import type { AddressInfo, ListenOptions, Socket } from "node:net";
 import type { SecureContextOptions, TlsOptions } from "node:tls";
 
 import type { Compiler } from "../..";
+
+interface Server {
+	on(
+		event: "request",
+		callback: (req: IncomingMessage, res: ServerResponse) => void
+	): void;
+	on(event: "connection", callback: (socket: Socket) => void): void;
+	on(event: "listening", callback: (err?: Error) => void): void;
+
+	off(
+		event: "request",
+		callback: (req: IncomingMessage, res: ServerResponse) => void
+	): void;
+
+	address(): AddressInfo;
+	close(callback: (err?: any) => void): void;
+	listen(listenOptions?: number | ListenOptions): void;
+}
 
 export interface LazyCompilationDefaultBackendOptions {
 	/**
@@ -82,20 +99,20 @@ const getBackend =
 		const listen =
 			typeof options.listen === "function"
 				? options.listen
-				: typeof options.server === "function"
+				: typeof options.server === "function" && !options.listen
 					? // if user offers custom server, no need to listen
 						() => {}
 					: (server: Server) => {
 							let listen = options.listen;
 							if (typeof listen === "object" && !("port" in listen))
 								listen = { ...listen, port: undefined };
-							server.listen(listen);
+							server.listen(listen as ListenOptions);
 						};
 
 		const protocol = options.protocol || (isHttps ? "https" : "http");
 
-		const requestListener = (req: any, res: ServerResponse) => {
-			if (!req.url.startsWith(prefix)) {
+		const requestListener = (req: IncomingMessage, res: ServerResponse) => {
+			if (!req.url?.startsWith(prefix)) {
 				return;
 			}
 			const keys = req.url.slice(prefix.length).split("@");
@@ -148,9 +165,6 @@ const getBackend =
 				sockets.delete(socket);
 			});
 			if (isClosing) socket.destroy();
-		});
-		server.on("clientError", e => {
-			if (e.message !== "Server is disposing") logger.warn(e);
 		});
 		server.on("listening", (err: any) => {
 			if (err) return callback(err);

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
@@ -103,7 +103,7 @@ const getBackend =
 					? // if user offers custom server, no need to listen
 						() => {}
 					: (server: Server) => {
-							let listen = options.listen;
+							let { listen } = options;
 							if (typeof listen === "object" && !("port" in listen))
 								listen = { ...listen, port: undefined };
 							server.listen(listen as ListenOptions);

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
@@ -82,16 +82,22 @@ const getBackend =
 		const listen =
 			typeof options.listen === "function"
 				? options.listen
-				: (server: Server) => {
-						let listen = options.listen;
-						if (typeof listen === "object" && !("port" in listen))
-							listen = { ...listen, port: undefined };
-						server.listen(listen);
-					};
+				: typeof options.server === "function"
+					? // if user offers custom server, no need to listen
+						() => {}
+					: (server: Server) => {
+							let listen = options.listen;
+							if (typeof listen === "object" && !("port" in listen))
+								listen = { ...listen, port: undefined };
+							server.listen(listen);
+						};
 
 		const protocol = options.protocol || (isHttps ? "https" : "http");
 
 		const requestListener = (req: any, res: ServerResponse) => {
+			if (!req.url.startsWith(prefix)) {
+				return;
+			}
 			const keys = req.url.slice(prefix.length).split("@");
 			req.socket.on("close", () => {
 				setTimeout(() => {

--- a/tests/e2e/cases/css/css-filename/index.test.ts
+++ b/tests/e2e/cases/css/css-filename/index.test.ts
@@ -3,7 +3,6 @@ import { test, expect } from "@/fixtures";
 test("should update css with filename", async ({
 	page,
 	fileAction,
-	rspack
 }) => {
 	await expect(page.locator("body")).toHaveCSS("color", "rgb(255, 0, 0)");
 	fileAction.updateFile("src/index.css", content =>

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -168,25 +168,107 @@ In addition, you can also configure a `test` parameter for more fine-grained con
 The current lazy compilation aligns with the webpack implementation, **and is still in the experimental stage**. In some scenarios, lazy compilation might not work as expected, or the performance improvement may be insignificant.
 :::
 
-### lazyCompilation.backend.listen
+## experiments.lazyCompilation.backend
 
-- **Type:** `number | ListenOptions`
+- **Type:** `LazyCompilationBackendOptions`
 
 ```ts
-type ListenOptions = {
+type LazyCompilationBackendOptions = {
+  /**
+   * Custom client script path.
+   */
+  client?: string;
+  /**
+   * Specify the port or options to listen from the server.
+   */
+  listen?: number | ListenOptions | ((server: Server) => void);
+  /**
+   * Specify the protocol used by the client.
+   */
+  protocol?: 'http' | 'https';
+  /**
+   * Specify how to create a server that handles EventSource requests.
+   */
+  server?:
+    | ServerOptionsImport<typeof IncomingMessage>
+    | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
+    | (() => Server);
+};
+```
+
+Enabling lazy compilation will start a separate server to handle requests from clients. You can customize the behavior of the server by configuring `lazyCompilation.backend`, and you can also provide your own server instance.
+
+### lazyCompilation.backend.server
+
+- **Type:** `ServerOptionsImport<typeof IncomingMessage>
+      | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
+      | (() => Server)`
+
+```js title="rspack.config.js"
+module.exports = {
+  experiments: {
+    lazyCompilation: {
+      backend: {
+        server() {
+          return yourServer;
+        },
+      },
+    },
+  },
+};
+```
+
+You can provide a custom server instance to handle requests from clients for `lazy-compilation`. The provided server must meet the following interface requirements.
+
+```ts
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { AddressInfo, ListenOptions, Socket } from 'node:net';
+
+interface Server {
+  // Register callback function to handle requests
+  on(
+    event: 'request',
+    callback: (req: IncomingMessage, res: ServerResponse) => void,
+  ): void;
+
+  // Register callback function for new client connections
+  on(event: 'connection', callback: (socket: Socket) => void): void;
+
+  // Register callback function for new client connections
+  on(event: 'listening', callback: (err?: Error) => void): void;
+
+  // Unregister registered callbacks
+  off(event: string, callback: () => void): void;
+
+  // Show address information of the server
+  address(): AddressInfo;
+
+  close(callback: (err?: any) => void): void;
+
+  listen(listenOption: number | ListenOption): void;
+}
+```
+
+### lazyCompilation.backend.listen
+
+- **Type:** `number|ListenOption`
+
+```ts
+type ListenOption = {
   port?: number | undefined;
   host?: string | undefined;
   backlog?: number | undefined;
   path?: string | undefined;
   exclusive?: boolean | undefined;
-  readableAll?: boolean | undefined;
-  writableAll?: boolean | undefined;
-  /**
-   * @default false
-   */
-  ipv6Only?: boolean | undefined;
+  readableAll?: boolean | null;
+  writableAll?: boolean | null;
+  ip6Only?: boolean | null;
 };
 ```
+
+Specify how the sever listens ,you can pass in object form listening configuration,such as specifying listening ports,you can also pass in functions control how listen is done .
+
+If you provide your own service instance,the service's listen is called by provider unless explicitly configured with functional forms of listening.
 
 ### Exclude HMR client
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -111,27 +111,7 @@ export default {
 type LazyCompilationOptions =
   | boolean
   | {
-      backend?: {
-        /**
-         * A custom client script path.
-         */
-        client?: string;
-        /**
-         * Specifies where to listen to from the server.
-         */
-        listen?: number | ListenOptions | ((server: Server) => void);
-        /**
-         * Specifies the protocol the client should use to connect to the server.
-         */
-        protocol?: 'http' | 'https';
-        /**
-         * Specifies how to create the server handling the EventSource requests.
-         */
-        server?:
-          | ServerOptionsImport<typeof IncomingMessage>
-          | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
-          | (() => Server);
-      };
+      backend?: LazyCompilationBackendOptions;
       /**
        * Enable lazy compilation for entries.
        */
@@ -200,9 +180,14 @@ Enabling lazy compilation will start a separate server to handle requests from c
 
 ### lazyCompilation.backend.server
 
-- **Type:** `ServerOptionsImport<typeof IncomingMessage>
-      | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
-      | (() => Server)`
+- **Type:**
+
+```ts
+type ServerOptions =
+  | ServerOptionsImport<typeof IncomingMessage>
+  | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
+  | (() => Server);
+```
 
 ```js title="rspack.config.js"
 module.exports = {
@@ -251,10 +236,10 @@ interface Server {
 
 ### lazyCompilation.backend.listen
 
-- **Type:** `number|ListenOption`
+- **Type:** `number | ListenOptions | ((server: Server) => void)`
 
 ```ts
-type ListenOption = {
+type ListenOptions = {
   port?: number | undefined;
   host?: string | undefined;
   backlog?: number | undefined;
@@ -266,9 +251,9 @@ type ListenOption = {
 };
 ```
 
-Specify how the sever listens ,you can pass in object form listening configuration,such as specifying listening ports,you can also pass in functions control how listen is done .
+Specify how the sever listens ,you can pass in object form listening configuration,such as specifying listening ports,you can also pass in functions control how listen is done.
 
-If you provide your own service instance,the service's listen is called by provider unless explicitly configured with functional forms of listening.
+When providing a custom server instance, you are responsible for calling the server's `listen` method to start the service, unless you explicitly configure a function forms` listen` option.
 
 ### Exclude HMR client
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -111,27 +111,7 @@ export default {
 type LazyCompilationOptions =
   | boolean
   | {
-      backend?: {
-        /**
-         * 自定义客户端脚本路径。
-         */
-        client?: string;
-        /**
-         * 指定从服务器监听的端口或选项。
-         */
-        listen?: number | ListenOptions | ((server: Server) => void);
-        /**
-         * 指定客户端使用的协议。
-         */
-        protocol?: 'http' | 'https';
-        /**
-         * 指定如何创建处理 EventSource 请求的服务器。
-         */
-        server?:
-          | ServerOptionsImport<typeof IncomingMessage>
-          | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
-          | (() => Server);
-      };
+      backend?: LazyCompilationBackendOptions;
       /**
        * 为 entries 启用 lazy compilation
        */
@@ -200,9 +180,14 @@ type LazyCompilationBackendOptions = {
 
 ### lazyCompilation.backend.server
 
-- **类型：** `ServerOptionsImport<typeof IncomingMessage>
-      | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
-      | (() => Server)`
+- **类型：**
+
+```ts
+type ServerOptions =
+  | ServerOptionsImport<typeof IncomingMessage>
+  | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
+  | (() => Server);
+```
 
 ```js title="rspack.config.js"
 module.exports = {
@@ -218,7 +203,7 @@ module.exports = {
 };
 ```
 
-你可以提供自定义的 server 实例，用于处理客户端发来的 `lazy-compilation` 请求，server 要能够满足如下接口。
+你可以提供自定义的 server 实例，用于处理客户端发来的 `lazy-compilation` 请求，该 server 需要能够满足如下接口：
 
 ```ts
 import type { IncomingMessage, ServerResponse } from 'node:http';
@@ -253,7 +238,7 @@ interface Server {
 
 ### lazyCompilation.backend.listen
 
-- **类型：** `number | ListenOptions`
+- **类型：** `number | ListenOptions | ((server: Server) => void)`
 
 ```ts
 type ListenOptions = {
@@ -273,7 +258,7 @@ type ListenOptions = {
 
 指定 server 如何监听，可以传入对象形式的监听配置，例如指定监听端口，也可以传入函数控制如何进行 listen。
 
-如果你提供了自己的 server 实例，server 的 listen 由提供方自行调用，除非显式地配置了函数形式的 listen。
+当你提供自定义的 server 实例时，除非明确配置了函数形式的 `listen` 选项，否则需要自行负责调用 server 的 `listen` 方法来启动服务。
 
 ### 排除 HMR client
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -168,6 +168,89 @@ export default {
 当前 lazy compilation 是对齐 webpack 实现的，**并且仍处于实验性阶段**。在部分场景下，lazy compilation 可能无法按照预期工作，或是性能提升不明显。
 :::
 
+## experiments.lazyCompilation.backend
+
+- **类型：** `LazyCompilationBackendOptions`
+
+```ts
+type LazyCompilationBackendOptions = {
+  /**
+   * 自定义客户端脚本路径。
+   */
+  client?: string;
+  /**
+   * 指定从服务器监听的端口或选项。
+   */
+  listen?: number | ListenOptions | ((server: Server) => void);
+  /**
+   * 指定客户端使用的协议。
+   */
+  protocol?: 'http' | 'https';
+  /**
+   * 指定如何创建处理 EventSource 请求的服务器。
+   */
+  server?:
+    | ServerOptionsImport<typeof IncomingMessage>
+    | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
+    | (() => Server);
+};
+```
+
+开启 lazy compilation 默认会启动一个独立的 server 来处理客户端发来的请求，你可以通过配置 `lazyCompilation.backend` 来自定义 server 的行为，你还可以提供你自己的 server 实例。
+
+### lazyCompilation.backend.server
+
+- **类型：** `ServerOptionsImport<typeof IncomingMessage>
+      | ServerOptionsHttps<typeof IncomingMessage, typeof ServerResponse>
+      | (() => Server)`
+
+```js title="rspack.config.js"
+module.exports = {
+  experiments: {
+    lazyCompilation: {
+      backend: {
+        server() {
+          return yourServer;
+        },
+      },
+    },
+  },
+};
+```
+
+你可以提供自定义的 server 实例，用于处理客户端发来的 `lazy-compilation` 请求，server 要能够满足如下接口。
+
+```ts
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { AddressInfo, ListenOptions, Socket } from 'node:net';
+
+interface Server {
+  // 注册回调函数处理请求
+  on(
+    event: 'request',
+    callback: (req: IncomingMessage, res: ServerResponse) => void,
+  ): void;
+
+  // 注册回调函数处理新的 client 连接
+  on(event: 'connection', callback: (socket: Socket) => void): void;
+
+  // 注册回调函数处理新的 client 连接
+  on(event: 'listening', callback: (err?: Error) => void): void;
+
+  // 销毁注册的回调函数
+  off(event: string, callback: () => void): void;
+
+  // 展示 server 的地址信息
+  address(): AddressInfo;
+
+  // 关闭 server
+  close(callback: (err?: any) => void): void;
+
+  // server 开始监听请求
+  listen(listenOptions?: number | ListenOptions): void;
+}
+```
+
 ### lazyCompilation.backend.listen
 
 - **类型：** `number | ListenOptions`
@@ -187,6 +270,10 @@ type ListenOptions = {
   ipv6Only?: boolean | undefined;
 };
 ```
+
+指定 server 如何监听，可以传入对象形式的监听配置，例如指定监听端口，也可以传入函数控制如何进行 listen。
+
+如果你提供了自己的 server 实例，server 的 listen 由提供方自行调用，除非显式地配置了函数形式的 listen。
 
 ### 排除 HMR client
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The requestHandler of lazyCompilation should only handle request from lazy-compilation client.

If user defines `lazyCompilation.backend.server`, setup of the server should be handled by user who provide the server, so the listen method should be called by user as well.
But if user specify the listen behavior explicitly, lazyCompilation will use that listen

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
