### PR TITLE
refactor: module.build directly updates build_info and build_meta

### DIFF
--- a/crates/rspack_binding_values/src/raw_options/raw_builtins/raw_dll.rs
+++ b/crates/rspack_binding_values/src/raw_options/raw_builtins/raw_dll.rs
@@ -105,7 +105,7 @@ impl From<RawDllManifestContentItem> for DllManifestContentItem {
     });
 
     Self {
-      build_meta: value.build_meta.map(|meta| meta.into()),
+      build_meta: value.build_meta.map(|meta| meta.into()).unwrap_or_default(),
       exports,
       id: value.id.map(|id| match id {
         Either::A(n) => ModuleId::from(n),

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -78,12 +78,11 @@ impl MakeOccasion {
     let mut missing_dep = FileCounter::default();
     let mut build_dep = FileCounter::default();
     for (_, module) in artifact.get_module_graph().modules() {
-      if let Some(build_info) = module.build_info() {
-        file_dep.add_batch_file(&build_info.file_dependencies);
-        context_dep.add_batch_file(&build_info.context_dependencies);
-        missing_dep.add_batch_file(&build_info.missing_dependencies);
-        build_dep.add_batch_file(&build_info.build_dependencies);
-      }
+      let build_info = module.build_info();
+      file_dep.add_batch_file(&build_info.file_dependencies);
+      context_dep.add_batch_file(&build_info.context_dependencies);
+      missing_dep.add_batch_file(&build_info.missing_dependencies);
+      build_dep.add_batch_file(&build_info.build_dependencies);
     }
     artifact.file_dependencies = file_dep;
     artifact.context_dependencies = context_dep;

--- a/crates/rspack_core/src/compiler/make/cutout/fix_build_meta.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/fix_build_meta.rs
@@ -18,11 +18,9 @@ impl FixBuildMeta {
     let module = module_graph
       .module_by_identifier(module_identifier)
       .expect("should have module");
-    if let Some(build_meta) = module.build_meta() {
-      self
-        .origin_module_build_meta
-        .insert(*module_identifier, build_meta.clone());
-    }
+    self
+      .origin_module_build_meta
+      .insert(*module_identifier, module.build_meta().clone());
   }
 
   pub fn fix_artifact(self, artifact: &mut MakeArtifact) {
@@ -31,7 +29,7 @@ impl FixBuildMeta {
       if let Some(module) = module_graph.module_by_identifier_mut(&id) {
         if let Some(module) = module.as_normal_module_mut() {
           if matches!(module.source(), NormalModuleSource::BuiltFailed(_)) {
-            module.set_build_meta(build_meta);
+            *module.build_meta_mut() = build_meta;
           }
         }
       }

--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -309,19 +309,19 @@ mod t {
       todo!()
     }
 
-    fn build_info(&self) -> Option<&BuildInfo> {
+    fn build_info(&self) -> &BuildInfo {
       todo!()
     }
 
-    fn set_build_info(&mut self, _build_info: BuildInfo) {
+    fn build_info_mut(&mut self) -> &mut BuildInfo {
       todo!()
     }
 
-    fn build_meta(&self) -> Option<&BuildMeta> {
+    fn build_meta(&self) -> &BuildMeta {
       todo!()
     }
 
-    fn set_build_meta(&mut self, _build_meta: BuildMeta) {
+    fn build_meta_mut(&mut self) -> &mut BuildMeta {
       todo!()
     }
 

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -62,20 +62,20 @@ impl MakeArtifact {
     let module = module_graph
       .module_by_identifier(module_identifier)
       .expect("should have module");
-    if let Some(build_info) = module.build_info() {
-      self
-        .file_dependencies
-        .remove_batch_file(&build_info.file_dependencies);
-      self
-        .context_dependencies
-        .remove_batch_file(&build_info.context_dependencies);
-      self
-        .missing_dependencies
-        .remove_batch_file(&build_info.missing_dependencies);
-      self
-        .build_dependencies
-        .remove_batch_file(&build_info.build_dependencies);
-    }
+    let build_info = module.build_info();
+    self
+      .file_dependencies
+      .remove_batch_file(&build_info.file_dependencies);
+    self
+      .context_dependencies
+      .remove_batch_file(&build_info.context_dependencies);
+    self
+      .missing_dependencies
+      .remove_batch_file(&build_info.missing_dependencies);
+    self
+      .build_dependencies
+      .remove_batch_file(&build_info.build_dependencies);
+
     self.revoked_modules.insert(*module_identifier);
     module_graph.revoke_module(module_identifier)
   }

--- a/crates/rspack_core/src/compiler/make/repair/build.rs
+++ b/crates/rspack_core/src/compiler/make/repair/build.rs
@@ -6,8 +6,8 @@ use rspack_fs::ReadableFileSystem;
 use super::{process_dependencies::ProcessDependenciesTask, MakeTaskContext};
 use crate::{
   utils::task_loop::{Task, TaskResult, TaskType},
-  AsyncDependenciesBlock, BoxDependency, BuildContext, BuildInfo, BuildResult, CompilationId,
-  CompilerOptions, DependencyParents, Module, ModuleProfile, ResolverFactory, SharedPluginDriver,
+  AsyncDependenciesBlock, BoxDependency, BuildContext, BuildResult, CompilationId, CompilerOptions,
+  DependencyParents, Module, ModuleProfile, ResolverFactory, SharedPluginDriver,
 };
 
 #[derive(Debug)]
@@ -110,18 +110,13 @@ impl Task<MakeTaskContext> for BuildResultTask {
       compilation_id,
     } = *self;
 
-    module.set_build_info(build_result.build_info);
-    module.set_build_meta(build_result.build_meta);
-
     plugin_driver
       .compilation_hooks
       .succeed_module
       .call(compilation_id, &mut module)
       .await?;
 
-    let build_info_default = BuildInfo::default();
-
-    let build_info = module.build_info().unwrap_or(&build_info_default);
+    let build_info = module.build_info();
 
     let artifact = &mut context.artifact;
     let module_graph =

--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -222,22 +222,20 @@ impl Task<MakeTaskContext> for ExecuteTask {
       |mut res, m| {
         let module = module_graph.module_by_identifier(m).expect("unreachable");
         let build_info = &module.build_info();
-        if let Some(info) = build_info {
-          res
-            .file_dependencies
-            .extend(info.file_dependencies.iter().cloned());
-          res
-            .context_dependencies
-            .extend(info.context_dependencies.iter().cloned());
-          res
-            .missing_dependencies
-            .extend(info.missing_dependencies.iter().cloned());
-          res
-            .build_dependencies
-            .extend(info.build_dependencies.iter().cloned());
-          if !info.cacheable {
-            res.cacheable = false;
-          }
+        res
+          .file_dependencies
+          .extend(build_info.file_dependencies.iter().cloned());
+        res
+          .context_dependencies
+          .extend(build_info.context_dependencies.iter().cloned());
+        res
+          .missing_dependencies
+          .extend(build_info.missing_dependencies.iter().cloned());
+        res
+          .build_dependencies
+          .extend(build_info.build_dependencies.iter().cloned());
+        if !build_info.cacheable {
+          res.cacheable = false;
         }
         res
       },

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -168,8 +168,8 @@ pub struct ContextModule {
   identifier: Identifier,
   options: ContextModuleOptions,
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
   #[debug(skip)]
   #[cacheable(with=Unsupported)]
   resolve_dependencies: ResolveContextModuleDependencies,
@@ -186,8 +186,12 @@ impl ContextModule {
       identifier: create_identifier(&options),
       options,
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
+      build_info: Default::default(),
+      build_meta: BuildMeta {
+        exports_type: BuildMetaExportsType::Default,
+        default_object: BuildMetaDefaultObject::RedirectWarn { ignore: false },
+        ..Default::default()
+      },
       source_map_kind: SourceMapKind::empty(),
       resolve_dependencies,
     }
@@ -975,18 +979,9 @@ impl Module for ContextModule {
     let mut context_dependencies: HashSet<ArcPath> = Default::default();
     context_dependencies.insert(self.options.resource.as_std_path().into());
 
-    let build_info = BuildInfo {
-      context_dependencies,
-      ..Default::default()
-    };
+    self.build_info.context_dependencies = context_dependencies;
 
     Ok(BuildResult {
-      build_info,
-      build_meta: BuildMeta {
-        exports_type: BuildMetaExportsType::Default,
-        default_object: BuildMetaDefaultObject::RedirectWarn { ignore: false },
-        ..Default::default()
-      },
       dependencies,
       blocks,
       optimization_bailouts: vec![],

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -920,7 +920,7 @@ impl<'a> ModuleGraph<'a> {
   pub fn get_module_hash(&self, module_id: &ModuleIdentifier) -> Option<&RspackHashDigest> {
     self
       .module_by_identifier(module_id)
-      .and_then(|mgm| mgm.build_info().as_ref().and_then(|i| i.hash.as_ref()))
+      .and_then(|m| m.build_info().hash.as_ref())
   }
 
   /// We can't insert all sort of things into one hashmap like javascript, so we create different

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -149,8 +149,8 @@ pub struct NormalModule {
   presentational_dependencies: Option<Vec<Box<dyn DependencyTemplate>>>,
 
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
   parsed: bool,
 }
 
@@ -235,8 +235,8 @@ impl NormalModule {
       code_generation_dependencies: None,
       presentational_dependencies: None,
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
+      build_info: Default::default(),
+      build_meta: Default::default(),
       parsed: false,
       source_map_kind: SourceMapKind::empty(),
     }
@@ -410,9 +410,6 @@ impl Module for NormalModule {
   ) -> Result<BuildResult> {
     self.clear_diagnostics();
 
-    let mut build_info = BuildInfo::default();
-    let mut build_meta = BuildMeta::default();
-
     // so does webpack
     self.parsed = true;
 
@@ -452,22 +449,22 @@ impl Module for NormalModule {
       Ok(r) => r.split_into_parts(),
       Err(mut r) => {
         let diagnostic = if let Some(captured_error) = r.downcast_mut::<CapturedLoaderError>() {
-          build_info.file_dependencies = captured_error
+          self.build_info.file_dependencies = captured_error
             .take_file_dependencies()
             .into_iter()
             .map(Into::into)
             .collect();
-          build_info.context_dependencies = captured_error
+          self.build_info.context_dependencies = captured_error
             .take_context_dependencies()
             .into_iter()
             .map(Into::into)
             .collect();
-          build_info.missing_dependencies = captured_error
+          self.build_info.missing_dependencies = captured_error
             .take_missing_dependencies()
             .into_iter()
             .map(Into::into)
             .collect();
-          build_info.build_dependencies = captured_error
+          self.build_info.build_dependencies = captured_error
             .take_build_dependencies()
             .into_iter()
             .map(Into::into)
@@ -499,11 +496,9 @@ impl Module for NormalModule {
         self.source = NormalModuleSource::BuiltFailed(diagnostic.clone());
         self.add_diagnostic(diagnostic);
 
-        build_info.hash =
-          Some(self.init_build_hash(&build_context.compiler_options.output, &build_meta));
+        self.build_info.hash =
+          Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
         return Ok(BuildResult {
-          build_info,
-          build_meta,
           dependencies: Vec::new(),
           blocks: Vec::new(),
           optimization_bailouts: vec![],
@@ -525,23 +520,23 @@ impl Module for NormalModule {
     };
     let original_source = self.create_source(content, loader_result.source_map)?;
 
-    build_info.cacheable = loader_result.cacheable;
-    build_info.file_dependencies = loader_result
+    self.build_info.cacheable = loader_result.cacheable;
+    self.build_info.file_dependencies = loader_result
       .file_dependencies
       .into_iter()
       .map(Into::into)
       .collect();
-    build_info.context_dependencies = loader_result
+    self.build_info.context_dependencies = loader_result
       .context_dependencies
       .into_iter()
       .map(Into::into)
       .collect();
-    build_info.missing_dependencies = loader_result
+    self.build_info.missing_dependencies = loader_result
       .missing_dependencies
       .into_iter()
       .map(Into::into)
       .collect();
-    build_info.build_dependencies = loader_result
+    self.build_info.build_dependencies = loader_result
       .build_dependencies
       .into_iter()
       .map(Into::into)
@@ -554,12 +549,10 @@ impl Module for NormalModule {
       self.code_generation_dependencies = Some(Vec::new());
       self.presentational_dependencies = Some(Vec::new());
 
-      build_info.hash =
-        Some(self.init_build_hash(&build_context.compiler_options.output, &build_meta));
+      self.build_info.hash =
+        Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
 
       return Ok(BuildResult {
-        build_info,
-        build_meta,
         dependencies: Vec::new(),
         blocks: Vec::new(),
         optimization_bailouts: Vec::new(),
@@ -591,13 +584,13 @@ impl Module for NormalModule {
         resource_data: &self.resource_data,
         compiler_options: &build_context.compiler_options,
         additional_data: loader_result.additional_data,
-        build_info: &mut build_info,
-        build_meta: &mut build_meta,
+        build_info: &mut self.build_info,
+        build_meta: &mut self.build_meta,
         parse_meta: loader_result.parse_meta,
       })?
       .split_into_parts();
     if diagnostics.iter().any(|d| d.severity() == Severity::Error) {
-      build_meta = Default::default();
+      self.build_meta = Default::default();
     }
     if !diagnostics.is_empty() {
       self.add_diagnostics(diagnostics);
@@ -618,12 +611,10 @@ impl Module for NormalModule {
     self.code_generation_dependencies = Some(code_generation_dependencies);
     self.presentational_dependencies = Some(presentational_dependencies);
 
-    build_info.hash =
-      Some(self.init_build_hash(&build_context.compiler_options.output, &build_meta));
+    self.build_info.hash =
+      Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
 
     Ok(BuildResult {
-      build_info,
-      build_meta,
       dependencies,
       blocks,
       optimization_bailouts,
@@ -695,12 +686,7 @@ impl Module for NormalModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<()> {
-    self
-      .build_info
-      .as_ref()
-      .expect("should update_hash after build")
-      .hash
-      .dyn_hash(hasher);
+    self.build_info.hash.dyn_hash(hasher);
     // For built failed NormalModule, hash will be calculated by build_info.hash, which contains error message
     if matches!(&self.source, NormalModuleSource::BuiltSucceed(_)) {
       self
@@ -774,9 +760,7 @@ impl Module for NormalModule {
     if let Some(side_effect_free) = self.factory_meta().and_then(|m| m.side_effect_free) {
       return ConnectionState::Bool(!side_effect_free);
     }
-    if let Some(side_effect_free) = self.build_meta().and_then(|m| m.side_effect_free)
-      && side_effect_free
-    {
+    if Some(true) == self.build_meta().side_effect_free {
       // use module chain instead of is_evaluating_side_effects to mut module graph
       if module_chain.contains(&self.identifier()) {
         return ConnectionState::CircularConnection;

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -218,12 +218,7 @@ impl ExportPresenceMode {
       ExportPresenceMode::None => None,
       ExportPresenceMode::Warn => Some(false),
       ExportPresenceMode::Error => Some(true),
-      ExportPresenceMode::Auto => Some(
-        module
-          .build_meta()
-          .map(|m| m.strict_esm_module)
-          .unwrap_or_default(),
-      ),
+      ExportPresenceMode::Auto => Some(module.build_meta().strict_esm_module),
     }
   }
 }

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -8,9 +8,9 @@ use rspack_sources::{BoxSource, RawStringSource, Source, SourceExt};
 use rspack_util::source_map::SourceMapKind;
 
 use crate::{
-  dependencies_block::AsyncDependenciesBlockIdentifier, impl_module_meta_info, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Context, DependenciesBlock,
-  DependencyId, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  dependencies_block::AsyncDependenciesBlockIdentifier, impl_module_meta_info, BuildInfo,
+  BuildMeta, CodeGenerationResult, Context, DependenciesBlock, DependencyId, Module,
+  ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 use crate::{module_update_hash, Compilation, ConcatenationScope, FactoryMeta};
 
@@ -26,8 +26,8 @@ pub struct RawModule {
   readable_identifier: String,
   runtime_requirements: RuntimeGlobals,
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
 }
 
 static RAW_MODULE_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -48,8 +48,12 @@ impl RawModule {
       readable_identifier,
       runtime_requirements,
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
+      build_info: BuildInfo {
+        cacheable: true,
+        strict: true,
+        ..Default::default()
+      },
+      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -110,22 +114,6 @@ impl Module for RawModule {
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     f64::max(1.0, self.source.size() as f64)
-  }
-
-  async fn build(
-    &mut self,
-    _build_context: BuildContext,
-    _: Option<&Compilation>,
-  ) -> Result<BuildResult> {
-    Ok(BuildResult {
-      build_info: BuildInfo {
-        cacheable: true,
-        strict: true,
-        ..Default::default()
-      },
-      dependencies: vec![],
-      ..Default::default()
-    })
   }
 
   // #[tracing::instrument("RawModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -9,10 +9,9 @@ use rspack_sources::Source;
 use rspack_util::source_map::SourceMapKind;
 
 use crate::{
-  impl_module_meta_info, AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkUkey, CodeGenerationResult, Compilation, ConcatenationScope, Context,
-  DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleIdentifier,
-  ModuleType, RuntimeSpec, SourceType,
+  impl_module_meta_info, AsyncDependenciesBlockIdentifier, BuildInfo, BuildMeta, ChunkUkey,
+  CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId,
+  FactoryMeta, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
 };
 
 #[impl_source_map_config]
@@ -24,8 +23,8 @@ pub struct SelfModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
 }
 
 impl SelfModule {
@@ -37,8 +36,11 @@ impl SelfModule {
       blocks: Default::default(),
       dependencies: Default::default(),
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
+      build_info: BuildInfo {
+        strict: true,
+        ..Default::default()
+      },
+      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -107,25 +109,6 @@ impl Module for SelfModule {
 
   fn chunk_condition(&self, _chunk: &ChunkUkey, _compilation: &Compilation) -> Option<bool> {
     None
-  }
-
-  async fn build(
-    &mut self,
-    _build_context: BuildContext,
-    _: Option<&Compilation>,
-  ) -> Result<BuildResult> {
-    let build_info = BuildInfo {
-      strict: true,
-      ..Default::default()
-    };
-
-    Ok(BuildResult {
-      build_info,
-      build_meta: Default::default(),
-      dependencies: Vec::new(),
-      blocks: Vec::new(),
-      optimization_bailouts: vec![],
-    })
   }
 
   // #[tracing::instrument("SelfModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -841,7 +841,7 @@ impl Stats<'_> {
       stats.name_for_condition = module.name_for_condition().map(|n| n.to_string());
       stats.pre_order_index = module_graph.get_pre_order_index(&identifier);
       stats.post_order_index = module_graph.get_post_order_index(&identifier);
-      stats.cacheable = module.build_info().map(|i| i.cacheable);
+      stats.cacheable = Some(module.build_info().cacheable);
       stats.optional = Some(module_graph.is_optional(&identifier));
       stats.orphan = Some(orphan);
       stats.dependent = dependent;

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -147,17 +147,21 @@ pub fn impl_runtime_module(
 
       fn set_factory_meta(&mut self, v: ::rspack_core::FactoryMeta) {}
 
-      fn build_info(&self) -> Option<&::rspack_core::BuildInfo> {
-        None
+      fn build_info(&self) -> &::rspack_core::BuildInfo {
+        unreachable!()
       }
 
-      fn set_build_info(&mut self, v: ::rspack_core::BuildInfo) {}
-
-      fn build_meta(&self) -> Option<&::rspack_core::BuildMeta> {
-        None
+      fn build_info_mut(&mut self) -> &mut ::rspack_core::BuildInfo {
+        unreachable!()
       }
 
-      fn set_build_meta(&mut self, v: ::rspack_core::BuildMeta) {}
+      fn build_meta(&self) -> &::rspack_core::BuildMeta {
+        unreachable!()
+      }
+
+      fn build_meta_mut(&mut self) -> &mut ::rspack_core::BuildMeta {
+        unreachable!()
+      }
 
       fn get_diagnostics(&self) -> Vec<::rspack_error::Diagnostic> {
         vec![]

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -23,9 +23,9 @@ pub struct DllModule {
 
   factory_meta: Option<FactoryMeta>,
 
-  build_info: Option<BuildInfo>,
+  build_info: BuildInfo,
 
-  build_meta: Option<BuildMeta>,
+  build_meta: BuildMeta,
 
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
 
@@ -123,7 +123,7 @@ impl Module for DllModule {
   }
 
   fn need_build(&self) -> bool {
-    self.build_meta.is_none()
+    false
   }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -33,8 +33,8 @@ pub struct DelegatedModule {
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
 }
 
 impl DelegatedModule {
@@ -112,9 +112,9 @@ impl Module for DelegatedModule {
         false,
       )) as BoxDependency,
     ];
+    self.build_meta = self.delegate_data.build_meta.clone();
     Ok(BuildResult {
       dependencies,
-      build_meta: self.delegate_data.build_meta.clone().unwrap_or_default(),
       ..Default::default()
     })
   }
@@ -193,7 +193,7 @@ impl Module for DelegatedModule {
   }
 
   fn need_build(&self) -> bool {
-    self.build_meta.is_none()
+    false
   }
 
   fn update_hash(

--- a/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
+++ b/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
@@ -75,23 +75,17 @@ async fn succeed_module(
     side_effect_free: Some(false),
   });
 
-  let module_concatenation_bailout = module
-    .build_info()
-    .and_then(|info| info.module_concatenation_bailout.as_ref());
-
-  if module_concatenation_bailout.is_none() {
+  let module_identifier = module.identifier();
+  let build_info = module.build_info_mut();
+  if build_info.module_concatenation_bailout.is_none() {
     // webpack avoid those modules be concatenated using add a virtual module_graph_connection.
     // see: https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/FlagAllModulesAsUsedPlugin.js#L42
     // Rspack need incremental build, so we should not add virtual connection to module.
     // We can add a bail reason to avoid those modules be concatenated.
-    let mut build_info = module.build_info().cloned().unwrap_or_default();
     build_info.module_concatenation_bailout = Some(format!(
       "Module {} is referenced by {}",
-      module.identifier(),
-      &self.explanation
+      module_identifier, &self.explanation
     ));
-
-    module.set_build_info(build_info);
   }
 
   Ok(())

--- a/crates/rspack_plugin_dll/src/lib.rs
+++ b/crates/rspack_plugin_dll/src/lib.rs
@@ -44,8 +44,7 @@ impl Serialize for DllManifestContentItemExports {
 #[derive(Debug, Default, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DllManifestContentItem {
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub build_meta: Option<BuildMeta>,
+  pub build_meta: BuildMeta,
 
   #[serde(skip_serializing_if = "Option::is_none")]
   pub exports: Option<DllManifestContentItemExports>,

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -150,13 +150,11 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
 
         let id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier());
 
-        let build_meta = module.build_meta();
-
         manifest_content.insert(
           ident.into_owned(),
           DllManifestContentItem {
             id: id.map(|id| id.to_owned()),
-            build_meta: build_meta.cloned(),
+            build_meta: module.build_meta().clone(),
             exports: provided_exports,
           },
         );

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -72,7 +72,7 @@ impl DependencyTemplate for ESMCompatibilityDependency {
         InitFragmentStage::StageAsyncBoundary,
         0,
         InitFragmentKey::unique(),
-        Some(format!("\n__webpack_async_result__();\n}} catch(e) {{ __webpack_async_result__(e); }} }}{});", if matches!(module.build_meta().as_ref().map(|meta| meta.has_top_level_await), Some(true)) { ", 1" } else { "" })),
+        Some(format!("\n__webpack_async_result__();\n}} catch(e) {{ __webpack_async_result__(e); }} }}{});", if module.build_meta().has_top_level_await { ", 1" } else { "" })),
       )));
     }
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -94,8 +94,7 @@ impl ESMExportImportedSpecifierDependency {
       .get_parent_module(&self.id)
       .and_then(|ident| module_graph.module_by_identifier(ident))
       .expect("should have mgm")
-      .build_info()
-      .expect("should have build info");
+      .build_info();
     &build_info.esm_named_exports
   }
 
@@ -109,7 +108,7 @@ impl ESMExportImportedSpecifierDependency {
       .and_then(|ident| module_graph.module_by_identifier(ident));
 
     if let Some(module) = module {
-      let build_info = module.build_info().expect("should have build info");
+      let build_info = module.build_info();
       Some(&build_info.all_star_exports)
     } else {
       None

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -243,13 +243,8 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
   let parent_module = module_graph
     .module_by_identifier(parent_module_identifier)
     .expect("should have module");
-  let exports_type = imported_module.get_exports_type(
-    module_graph,
-    parent_module
-      .build_meta()
-      .expect("should have build_meta")
-      .strict_esm_module,
-  );
+  let exports_type =
+    imported_module.get_exports_type(module_graph, parent_module.build_meta().strict_esm_module);
   let create_error = |message: String| {
     let (severity, title) = if should_error {
       (Severity::Error, "ESModulesLinkingError")
@@ -373,10 +368,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       if !ids.is_empty()
         && ids[0] != "default"
         && matches!(
-          imported_module
-            .build_meta()
-            .expect("should have build_meta")
-            .default_object,
+          imported_module.build_meta().default_object,
           BuildMetaDefaultObject::RedirectWarn { ignore: false }
         )
       {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -26,8 +26,7 @@ pub fn create_import_dependency_referenced_exports(
         let Some(strict) = mg
           .get_parent_module(dependency_id)
           .and_then(|id| mg.module_by_identifier(id))
-          .and_then(|m| m.build_meta())
-          .map(|bm| bm.strict_esm_module)
+          .map(|m| m.build_meta().strict_esm_module)
         else {
           return create_exports_object_referenced();
         };

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -320,12 +320,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     _cg: &ChunkGraph,
   ) -> Option<Cow<'static, str>> {
     // Only ES modules are valid for optimization
-    if module.build_meta().is_none()
-      || module
-        .build_meta()
-        .map(|meta| meta.exports_type != BuildMetaExportsType::Namespace)
-        .unwrap_or_default()
-    {
+    if module.build_meta().exports_type != BuildMetaExportsType::Namespace {
       return Some("Module is not an ECMAScript module".into());
     }
 
@@ -343,9 +338,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       return Some("Module is not an ECMAScript module".into());
     }
 
-    if let Some(info) = module.build_info()
-      && let Some(bailout) = info.module_concatenation_bailout.as_deref()
-    {
+    if let Some(bailout) = module.build_info().module_concatenation_bailout.as_deref() {
       return Some(format!("Module uses {bailout}").into());
     }
     None

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -33,9 +33,7 @@ fn render_module_content(
   _source: &mut RenderSource,
   init_fragments: &mut ChunkInitFragments,
 ) -> Result<()> {
-  if let Some(build_info) = module.build_info()
-    && build_info.need_create_require
-  {
+  if module.build_info().need_create_require {
     let need_prefix = compilation
       .options
       .output

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -46,11 +46,8 @@ impl<'a> FlagDependencyExportsState<'a> {
         .mg
         .module_by_identifier(&module_id)
         .expect("should have module");
-      let is_module_without_exports = if let Some(build_meta) = module.build_meta() {
-        build_meta.exports_type == BuildMetaExportsType::Unset
-      } else {
-        true
-      };
+      let is_module_without_exports =
+        module.build_meta().exports_type == BuildMetaExportsType::Unset;
       if is_module_without_exports {
         let other_exports_info = exports_info.other_exports_info(self.mg);
         if !matches!(
@@ -63,12 +60,7 @@ impl<'a> FlagDependencyExportsState<'a> {
         }
       }
 
-      if !module
-        .build_info()
-        .as_ref()
-        .map(|item| item.hash.is_some())
-        .unwrap_or_default()
-      {
+      if module.build_info().hash.is_none() {
         exports_info.set_has_provide_info(self.mg);
         q.enqueue(module_id);
         continue;

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -301,10 +301,10 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       .expect("should have module");
     let mgm_exports_info = mgm.exports;
     if !used_exports.is_empty() {
-      let need_insert = match module.build_meta() {
-        Some(build_meta) => matches!(build_meta.exports_type, BuildMetaExportsType::Unset),
-        None => true,
-      };
+      let need_insert = matches!(
+        module.build_meta().exports_type,
+        BuildMetaExportsType::Unset
+      );
       if need_insert {
         let flag = mgm_exports_info.set_used_without_info(&mut module_graph, runtime.as_ref());
         if flag {

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -47,7 +47,7 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
     let module = module_graph
       .module_by_identifier(&module_identifier)
       .expect("should have module");
-    let build_meta = module.build_meta().expect("should have build meta");
+    let build_meta = module.build_meta();
     if build_meta.has_top_level_await {
       async_modules.insert(module_identifier);
     } else {

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -54,11 +54,10 @@ fn optimize_code_generation(&self, compilation: &mut Compilation) -> Result<()> 
     ) else {
       continue;
     };
-    let is_namespace = module
-      .build_meta()
-      .as_ref()
-      .map(|meta| matches!(meta.exports_type, BuildMetaExportsType::Namespace))
-      .unwrap_or_default();
+    let is_namespace = matches!(
+      module.build_meta().exports_type,
+      BuildMetaExportsType::Namespace
+    );
     let exports_info = mgm.exports;
     mangle_exports_info(&mut mg, self.deterministic, exports_info, is_namespace);
   }

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -580,7 +580,7 @@ impl ModuleConcatenationPlugin {
       side_effect_connection_state: box_module
         .get_side_effects_connection_state(&module_graph, &mut IdentifierSet::default()),
       factory_meta: box_module.factory_meta().cloned(),
-      build_meta: box_module.build_meta().cloned(),
+      build_meta: box_module.build_meta().clone(),
     };
     let modules = modules_set
       .iter()
@@ -765,11 +765,7 @@ impl ModuleConcatenationPlugin {
           return (false, false, module_id, bailout_reason);
         }
 
-        if !m
-          .and_then(|m| m.build_info())
-          .expect("should have build info")
-          .strict
-        {
+        if !m.expect("should have module").build_info().strict {
           bailout_reason.push("Module is not in strict mode".into());
           return (false, false, module_id, bailout_reason);
         }

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -188,10 +188,7 @@ pub fn render_module(
       "(function ({}) {{\n",
       args.join(", ")
     )));
-    if let Some(build_info) = &module.build_info()
-      && build_info.strict
-      && !all_strict
-    {
+    if module.build_info().strict && !all_strict {
       sources.add(RawStringSource::from_static("\"use strict\";\n"));
     }
     sources.add(render_source.source);

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -174,8 +174,8 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           .expect("should have module identifier");
         let json_data = module
           .build_info()
+          .json_data
           .as_ref()
-          .and_then(|info| info.json_data.as_ref())
           .expect("should have json data");
         let exports_info = module_graph.get_exports_info(&module.identifier());
 

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -28,8 +28,8 @@ static SOURCE_TYPE: [SourceType; 1] = [SourceType::JavaScript];
 #[cacheable]
 #[derive(Debug)]
 pub(crate) struct LazyCompilationProxyModule {
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
   factory_meta: Option<FactoryMeta>,
   cacheable: bool,
 
@@ -77,8 +77,8 @@ impl LazyCompilationProxyModule {
     let identifier = format!("lazy-compilation-proxy|{original_module}").into();
 
     Self {
-      build_info: None,
-      build_meta: None,
+      build_info: Default::default(),
+      build_meta: Default::default(),
       cacheable,
       create_data,
       readable_identifier,
@@ -170,13 +170,10 @@ impl Module for LazyCompilationProxyModule {
     files.extend(self.create_data.file_dependencies.clone());
     files.insert(Path::new(&self.resource).into());
 
+    self.build_info.cacheable = self.cacheable;
+    self.build_info.file_dependencies = files;
+
     Ok(BuildResult {
-      build_info: BuildInfo {
-        cacheable: self.cacheable,
-        file_dependencies: files,
-        ..Default::default()
-      },
-      build_meta: BuildMeta::default(),
       dependencies,
       blocks,
       optimization_bailouts: vec![],

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -332,11 +332,7 @@ fn embed_in_runtime_bailout(
     .data
     .get::<CodeGenerationDataTopLevelDeclarations>()
     .map(|d| d.inner())
-    .or_else(|| {
-      module
-        .build_info()
-        .and_then(|build_info| build_info.top_level_declarations.as_ref())
-    });
+    .or_else(|| module.build_info().top_level_declarations.as_ref());
   if let Some(top_level_decls) = top_level_decls {
     let full_name = self.get_resolved_full_name(&options, compilation, chunk);
     if let Some(base) = full_name.first()

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -34,8 +34,8 @@ pub struct ContainerEntryModule {
   exposes: Vec<(String, ExposeOptions)>,
   share_scope: String,
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
   enhanced: bool,
 }
 
@@ -59,8 +59,15 @@ impl ContainerEntryModule {
       exposes,
       share_scope,
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
+      build_info: BuildInfo {
+        strict: true,
+        top_level_declarations: Some(FxHashSet::default()),
+        ..Default::default()
+      },
+      build_meta: BuildMeta {
+        exports_type: BuildMetaExportsType::Namespace,
+        ..Default::default()
+      },
       source_map_kind: SourceMapKind::empty(),
       enhanced,
     }
@@ -161,15 +168,6 @@ impl Module for ContainerEntryModule {
     )));
 
     Ok(BuildResult {
-      build_info: BuildInfo {
-        strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
-        ..Default::default()
-      },
-      build_meta: BuildMeta {
-        exports_type: BuildMetaExportsType::Namespace,
-        ..Default::default()
-      },
       dependencies,
       blocks,
       ..Default::default()

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -28,8 +28,8 @@ pub struct FallbackModule {
   lib_ident: String,
   requests: Vec<String>,
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
 }
 
 impl FallbackModule {
@@ -50,8 +50,11 @@ impl FallbackModule {
       lib_ident,
       requests,
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
+      build_info: BuildInfo {
+        strict: true,
+        ..Default::default()
+      },
+      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -127,19 +130,12 @@ impl Module for FallbackModule {
     _build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
-    let build_info = BuildInfo {
-      strict: true,
-      ..Default::default()
-    };
-
     let mut dependencies: Vec<BoxDependency> = Vec::new();
     for request in &self.requests {
       dependencies.push(Box::new(FallbackItemDependency::new(request.clone())))
     }
 
     Ok(BuildResult {
-      build_info,
-      build_meta: Default::default(),
       dependencies,
       blocks: Vec::new(),
       optimization_bailouts: vec![],

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -37,8 +37,8 @@ pub struct RemoteModule {
   pub share_scope: String,
   pub remote_key: String,
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
 }
 
 impl RemoteModule {
@@ -68,8 +68,11 @@ impl RemoteModule {
       share_scope,
       remote_key,
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
+      build_info: BuildInfo {
+        strict: true,
+        ..Default::default()
+      },
+      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -145,11 +148,6 @@ impl Module for RemoteModule {
     _build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
-    let build_info = BuildInfo {
-      strict: true,
-      ..Default::default()
-    };
-
     let mut dependencies: Vec<BoxDependency> = Vec::new();
     if self.external_requests.len() == 1 {
       let dep = RemoteToExternalDependency::new(self.external_requests[0].clone());
@@ -160,8 +158,6 @@ impl Module for RemoteModule {
     }
 
     Ok(BuildResult {
-      build_info,
-      build_meta: Default::default(),
       dependencies,
       blocks: Vec::new(),
       optimization_bailouts: vec![],

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -33,8 +33,8 @@ pub struct ConsumeSharedModule {
   context: Context,
   options: ConsumeOptions,
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
 }
 
 impl ConsumeSharedModule {
@@ -78,8 +78,8 @@ impl ConsumeSharedModule {
       context,
       options,
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
+      build_info: Default::default(),
+      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -168,8 +168,6 @@ impl Module for ConsumeSharedModule {
     }
 
     Ok(BuildResult {
-      build_info: Default::default(),
-      build_meta: Default::default(),
       dependencies,
       blocks,
       ..Default::default()

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -41,8 +41,8 @@ pub struct ProvideSharedModule {
   required_version: Option<ConsumeVersion>,
   strict_version: Option<bool>,
   factory_meta: Option<FactoryMeta>,
-  build_info: Option<BuildInfo>,
-  build_meta: Option<BuildMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
 }
 
 impl ProvideSharedModule {
@@ -76,8 +76,11 @@ impl ProvideSharedModule {
       required_version,
       strict_version,
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
+      build_info: BuildInfo {
+        strict: true,
+        ..Default::default()
+      },
+      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -160,11 +163,6 @@ impl Module for ProvideSharedModule {
     }
 
     Ok(BuildResult {
-      build_info: BuildInfo {
-        strict: true,
-        ..Default::default()
-      },
-      build_meta: Default::default(),
       dependencies,
       blocks,
       ..Default::default()


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Currently module.build returns build_info and build_meta, and they are set after the build call is completed. This PR will
1. make module.build update module.build_info and module.build_meta directly without calling `set_build_info` and `set_build_meta`.
```rust
pub struct BuildResult {
//  pub build_meta: BuildMeta,
//  pub build_info: BuildInfo,
  ...
}

trait Module for NormalModule {
  fn build(&mut self) -> Result<BuildResult> {
    self.build_info = Default::default();
    self.build_meta = Default::default();
    ..
  }
}
```
2. update module trait so that `build_info` and `build_meta` are returned without `Option`
```diff
trait Module {
-  fn build_info(&self) -> Option<&BuildInfo>
+  fn build_info(&self) -> &BuildInfo
-  fn build_meta(&self) -> Option<&BuildMeta>
+  fn build_meta(&self) -> &BuildMeta
}
```
3. add `build_info_mut` and `build_meta_mut` to replace `set_build_info` and `set_build_meta`
```diff
trait Module {
-  fn set_build_info(&self, info: BuildInfo);
+  fn build_info_mut(&mut self) -> &mut BuildInfo;
-  fn set_build_meta(&self, meta: BuildMeta);
+  fn build_meta_mut(&mut self) -> &mut BuildMeta;
}
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
