### PR TITLE
docs(typo): Fix rspack.config typo in nestjs

### DIFF
--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -10,7 +10,7 @@ When building Node.js applications with Rspack, you may encounter dependencies t
 ```js title="rspack.config.js"
 module.exports = {
   module: {
-    rule: [
+    rules: [
       {
         test: /\.node$/,
         use: [

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -9,7 +9,7 @@ Rspack 不仅能用于构建前端应用，也可以用于构建 Node.js 应用�
 ```js title="rspack.config.js"
 module.exports = {
   module: {
-    rule: [
+    rules: [
       {
         test: /\.node$/,
         use: [


### PR DESCRIPTION
## Summary

After executing `cross-env BUILD=true rspack build`, it will appear

```
Invalid configuration object. Rspack has been initialized using a configuration object that does not match the API schema.
- Unrecognized key(s) in object: 'rule' at "module"
```

After comparing the [example content](https://github.com/rspack-contrib/rspack-examples/blob/03aa9913fe1208173111488860a56bfd56d15aaf/rspack/nestjs/rspack.config.js#L15), I found that `rule` should be `rules`.

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
