### PR TITLE
perf(storage): release pack contents after loading

### DIFF
--- a/crates/rspack_storage/src/pack/strategy/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/mod.rs
@@ -111,6 +111,7 @@ pub trait ScopeWriteStrategy {
   async fn update_scope(&self, scope: &mut PackScope, updates: ScopeUpdate) -> Result<()>;
   async fn before_all(&self, scopes: &mut HashMap<String, PackScope>) -> Result<()>;
   async fn optimize_scope(&self, scope: &mut PackScope) -> Result<()>;
+  async fn release_scope(&self, scope: &mut PackScope) -> Result<()>;
   async fn write_packs(&self, scope: &mut PackScope) -> Result<WriteScopeResult>;
   async fn write_meta(&self, scope: &mut PackScope) -> Result<WriteScopeResult>;
   async fn merge_changed(&self, changed: WriteScopeResult) -> Result<()>;

--- a/crates/rspack_storage/src/pack/strategy/split/util.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/util.rs
@@ -260,6 +260,7 @@ pub mod test_pack_utils {
     let mut changed = WriteScopeResult::default();
     changed.extend(strategy.write_packs(scope).await?);
     changed.extend(strategy.write_meta(scope).await?);
+    strategy.release_scope(scope).await?;
     strategy.merge_changed(changed.clone()).await?;
     flag_scope_wrote(scope);
 

--- a/crates/rspack_storage/tests/release.rs
+++ b/crates/rspack_storage/tests/release.rs
@@ -190,6 +190,7 @@ mod test_storage_release {
     let storage = PackStorage::new(options);
     let data = storage.load("test_scope").await?;
     assert_eq!(data.len(), 1000);
+    assert_eq!(get_scope_released_count(&storage, "test_scope").await?, 660);
     Ok(())
   }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

After loading data from storage, release pack contents based on generation to reduce memory consumption

---
This pull request introduces several changes to the `rspack_storage` crate, focusing on enhancing the scope management and release strategy. The most significant updates include adding a new method for releasing scopes, integrating this method into various parts of the codebase, and updating tests to reflect these changes.

Enhancements to scope management:

* [`crates/rspack_storage/src/pack/manager/mod.rs`](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L149-R151): Modified `ScopeManager` to release scopes after getting their contents and saving them. [[1]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4L149-R151) [[2]](diffhunk://#diff-7ee17253ffd9ac23b524cf783f06f220bbd76c2a661480c10b5ded7c24102dc4R274)

Introduction of the release scope method:

* [`crates/rspack_storage/src/pack/strategy/mod.rs`](diffhunk://#diff-23bfa5644cdeabd92730b56d7fc74602d04ee4acda4223ab94aadb026f1d9951R114): Added a new method `release_scope` to the `ScopeWriteStrategy` trait.
* [`crates/rspack_storage/src/pack/strategy/split/write_scope.rs`](diffhunk://#diff-029fb0be10563625e88b7a9d540b7c057c7d70e9b8fd2df7f4097b7dc9c7c39bR165-R181): Implemented the `release_scope` method for `SplitPackStrategy`, which releases the contents of packs based on their generation.

Integration of the release scope method in utilities and tests:

* [`crates/rspack_storage/src/pack/strategy/split/util.rs`](diffhunk://#diff-88f90a04aca7ca686fec10642c30a18196a7d0ea6ef6323bdd01d39bda7d6567R263): Updated utility functions to call `release_scope` after writing packs and metadata.
* [`crates/rspack_storage/tests/release.rs`](diffhunk://#diff-cc693d249e8c27455a0a11ffd194a0f52600c85f3b9b0f891cb008b1aeda0f8fR193): Modified tests to check the count of released scopes, ensuring the new release logic works as expected.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
