### PR TITLE
chore(workflow): let renovate pin GitHub Action digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
 	$schema: "https://docs.renovatebot.com/renovate-schema.json",
 	timezone: "Asia/Shanghai",
-	extends: [":dependencyDashboard"],
+	extends: [":dependencyDashboard", "helpers:pinGitHubActionDigests"],
 	schedule: ["before 8am on wednesday"],
 	enabledManagers: ["github-actions", "cargo", "npm"],
 	lockFileMaintenance: {


### PR DESCRIPTION
## Summary

Add `helpers:pinGitHubActionDigests` to let renovate automatically pin action digests.

This change should fix all the `Unpinned tag for a non-immutable Action in workflow` alerts in https://github.com/web-infra-dev/rsbuild/security/code-scanning.

- Here is an example: https://github.com/web-infra-dev/rsbuild/pull/4498
- Related docs: https://docs.renovatebot.com/modules/manager/github-actions/#additional-information

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
