### PR TITLE
chore: allow prettier to format more test files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,6 @@
 package.json
 
 # Ignore generated
-
 dist/
 packages/rspack/src/config/schema.check.js
 
@@ -12,9 +11,14 @@ packages/rspack/src/config/schema.check.js
 packages/**/etc/**/*
 packages/rspack-test-tools/template/**/*
 packages/rspack-test-tools/src/helper/legacy/**/*
-packages/rspack-test-tools/tests/**/*
+packages/rspack-test-tools/tests/**/*.*
+packages/rspack-test-tools/tests/**/DO_NOT_REMOVE
+!packages/rspack-test-tools/tests/**/*.test.ts
+!packages/rspack-test-tools/tests/**/*.test.js
+!packages/rspack-test-tools/tests/**/*.config.js
 
 crates/**/*
 target/**/*
 tests/**/*
+
 !tests/**/test.filter.js

--- a/packages/rspack-test-tools/tests/Compiler.test.js
+++ b/packages/rspack-test-tools/tests/Compiler.test.js
@@ -2,9 +2,13 @@ const path = require("path");
 const { createCompilerCase, describeByWalk } = require("..");
 const srcDir = path.resolve(__dirname, "./fixtures");
 
-describeByWalk(__filename, (name, testConfig, dist) => {
-	createCompilerCase(name, srcDir, dist, testConfig);
-}, {
-	level: 1,
-	type: 'file'
-});
+describeByWalk(
+	__filename,
+	(name, testConfig, dist) => {
+		createCompilerCase(name, srcDir, dist, testConfig);
+	},
+	{
+		level: 1,
+		type: "file"
+	}
+);

--- a/packages/rspack-test-tools/tests/Defaults.test.js
+++ b/packages/rspack-test-tools/tests/Defaults.test.js
@@ -18,7 +18,11 @@ function getWebpackDefaultConfig(cwd, config) {
 function getObjectPaths(obj, parentPaths = []) {
 	return Object.keys(obj).reduce((paths, key) => {
 		const fullPath = [...parentPaths, key];
-		if (typeof obj[key] === "object" && obj[key] !== null && !Array.isArray(obj[key])) {
+		if (
+			typeof obj[key] === "object" &&
+			obj[key] !== null &&
+			!Array.isArray(obj[key])
+		) {
 			return [...paths, fullPath, ...getObjectPaths(obj[key], fullPath)];
 		} else {
 			return [...paths, fullPath];
@@ -33,33 +37,54 @@ function deleteObjectPaths(obj, predicate, parentPaths = []) {
 			delete obj[key];
 			continue;
 		}
-		if (typeof obj[key] === "object" && obj[key] !== null && !Array.isArray(obj[key])) {
+		if (
+			typeof obj[key] === "object" &&
+			obj[key] !== null &&
+			!Array.isArray(obj[key])
+		) {
 			deleteObjectPaths(obj[key], predicate, fullPath);
 		}
 	}
 }
 
 function filterObjectPaths(obj, paths) {
-	return deleteObjectPaths(obj, fullPath => !paths.some(p => p.length === fullPath.length && p.every((e, i) => e === fullPath[i])));
+	return deleteObjectPaths(
+		obj,
+		fullPath =>
+			!paths.some(
+				p =>
+					p.length === fullPath.length && p.every((e, i) => e === fullPath[i])
+			)
+	);
 }
 
 function trimObjectPaths(obj, paths) {
-	return deleteObjectPaths(obj, fullPath => paths.some(p => p.length === fullPath.length && p.every((e, i) => e === fullPath[i])));
+	return deleteObjectPaths(obj, fullPath =>
+		paths.some(
+			p => p.length === fullPath.length && p.every((e, i) => e === fullPath[i])
+		)
+	);
 }
 
 const cwd = path.resolve(__dirname, "..");
 
 function assertWebpackConfig(config) {
-	const rspackBaseConfig = DefaultsConfigProcessor.getDefaultConfig(cwd, config);
+	const rspackBaseConfig = DefaultsConfigProcessor.getDefaultConfig(
+		cwd,
+		config
+	);
 	const webpackBaseConfig = getWebpackDefaultConfig(cwd, config);
 	const rspackSupportedConfig = getObjectPaths(rspackBaseConfig);
-	const defaultsPath = path.resolve(__dirname, "../../rspack/src/config/defaults.ts");
+	const defaultsPath = path.resolve(
+		__dirname,
+		"../../rspack/src/config/defaults.ts"
+	);
 	const defaultsContent = fs.readFileSync(defaultsPath, "utf-8");
 	const regex = /\/\/\sIGNORE\((.+?)\):\s/g;
 	const ignoredPaths = [];
 	let matches;
-	while (matches = regex.exec(defaultsContent)) {
-		ignoredPaths.push(matches[1].split('.'));
+	while ((matches = regex.exec(defaultsContent))) {
+		ignoredPaths.push(matches[1].split("."));
 	}
 	trimObjectPaths(rspackBaseConfig, ignoredPaths);
 	trimObjectPaths(webpackBaseConfig, ignoredPaths);
@@ -68,7 +93,9 @@ function assertWebpackConfig(config) {
 }
 
 describe("Base Defaults Snapshot", () => {
-	const baseConfig = DefaultsConfigProcessor.getDefaultConfig(cwd, { mode: "none" });
+	const baseConfig = DefaultsConfigProcessor.getDefaultConfig(cwd, {
+		mode: "none"
+	});
 
 	it("should have the correct base config", () => {
 		expect(baseConfig).toMatchSnapshot();
@@ -88,15 +115,20 @@ describe("Base Defaults Snapshot", () => {
 
 	it("should be align to webpack base config for experiments.futureDefaults: true", () => {
 		assertWebpackConfig({
-			mode: "production", experiments: {
+			mode: "production",
+			experiments: {
 				futureDefaults: true
 			}
 		});
 	});
 });
 
-describeByWalk(__filename, (name, src, dist) => {
-	createDefaultsCase(name, src);
-}, {
-	type: "file",
-});
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createDefaultsCase(name, src);
+	},
+	{
+		type: "file"
+	}
+);

--- a/packages/rspack-test-tools/tests/Diagnostics.test.js
+++ b/packages/rspack-test-tools/tests/Diagnostics.test.js
@@ -2,6 +2,6 @@ const { describeByWalk, createDiagnosticCase } = require("..");
 
 describeByWalk(__filename, (name, src, dist) => {
 	createDiagnosticCase(name, src, dist, {
-		absoluteDist: false,
+		absoluteDist: false
 	});
 });

--- a/packages/rspack-test-tools/tests/Error.test.js
+++ b/packages/rspack-test-tools/tests/Error.test.js
@@ -2,9 +2,13 @@ const path = require("path");
 const { createErrorCase, describeByWalk } = require("../dist");
 const caseDir = path.resolve(__dirname, "./errorCases");
 
-describeByWalk(__filename, (name, testConfig, dist) => {
-	createErrorCase(name, caseDir, dist, testConfig);
-}, {
-	level: 1,
-	type: 'file'
-});
+describeByWalk(
+	__filename,
+	(name, testConfig, dist) => {
+		createErrorCase(name, caseDir, dist, testConfig);
+	},
+	{
+		level: 1,
+		type: "file"
+	}
+);

--- a/packages/rspack-test-tools/tests/Hash.test.js
+++ b/packages/rspack-test-tools/tests/Hash.test.js
@@ -1,8 +1,12 @@
 const { createHashCase, describeByWalk } = require("../dist");
 
-describeByWalk(__filename, (name, src, dist) => {
-	createHashCase(name, src, dist);
-}, {
-	level: 1,
-	absoluteDist: false
-});
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createHashCase(name, src, dist);
+	},
+	{
+		level: 1,
+		absoluteDist: false
+	}
+);

--- a/packages/rspack-test-tools/tests/HotNode.test.js
+++ b/packages/rspack-test-tools/tests/HotNode.test.js
@@ -1,10 +1,14 @@
 const path = require("path");
 const { describeByWalk, createHotCase } = require("../dist");
 
-describeByWalk(__filename, (name, src, dist) => {
-	createHotCase(name, src, dist, "async-node");
-}, {
-	source: path.resolve(__dirname, "./hotCases"),
-	dist: path.resolve(__dirname, `./js/hot-node`),
-	exclude: [/^css$/]
-});
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createHotCase(name, src, dist, "async-node");
+	},
+	{
+		source: path.resolve(__dirname, "./hotCases"),
+		dist: path.resolve(__dirname, `./js/hot-node`),
+		exclude: [/^css$/]
+	}
+);

--- a/packages/rspack-test-tools/tests/HotWeb.test.js
+++ b/packages/rspack-test-tools/tests/HotWeb.test.js
@@ -1,9 +1,13 @@
 const path = require("path");
 const { describeByWalk, createHotCase } = require("../dist");
 
-describeByWalk(__filename, (name, src, dist) => {
-	createHotCase(name, src, dist, "web");
-}, {
-	source: path.resolve(__dirname, "./hotCases"),
-	dist: path.resolve(__dirname, `./js/hot-web`)
-});
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createHotCase(name, src, dist, "web");
+	},
+	{
+		source: path.resolve(__dirname, "./hotCases"),
+		dist: path.resolve(__dirname, `./js/hot-web`)
+	}
+);

--- a/packages/rspack-test-tools/tests/HotWorker.test.js
+++ b/packages/rspack-test-tools/tests/HotWorker.test.js
@@ -1,10 +1,14 @@
 const path = require("path");
 const { describeByWalk, createHotCase } = require("../dist");
 
-describeByWalk(__filename, (name, src, dist) => {
-	createHotCase(name, src, dist, "webworker");
-}, {
-	source: path.resolve(__dirname, "./hotCases"),
-	dist: path.resolve(__dirname, `./js/hot-worker`),
-	exclude: [/^css$/]
-});
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createHotCase(name, src, dist, "webworker");
+	},
+	{
+		source: path.resolve(__dirname, "./hotCases"),
+		dist: path.resolve(__dirname, `./js/hot-worker`),
+		exclude: [/^css$/]
+	}
+);

--- a/packages/rspack-test-tools/tests/NewCodeSplitting-config.test.js
+++ b/packages/rspack-test-tools/tests/NewCodeSplitting-config.test.js
@@ -2,10 +2,14 @@ const path = require("path");
 const { describeByWalk, createConfigNewCodeSplittingCase } = require("..");
 
 // Run tests rspack-test-tools/tests/configCases
-describeByWalk("new-code-splitting config cases", (name, src, dist) => {
-	createConfigNewCodeSplittingCase(name, src, dist);
-}, {
-	source: path.resolve(__dirname, "./configCases"),
-	dist: path.resolve(__dirname, `./js/new-code-splitting-config`),
-	exclude: [/esm-external/, /container-1/]
-});
+describeByWalk(
+	"new-code-splitting config cases",
+	(name, src, dist) => {
+		createConfigNewCodeSplittingCase(name, src, dist);
+	},
+	{
+		source: path.resolve(__dirname, "./configCases"),
+		dist: path.resolve(__dirname, `./js/new-code-splitting-config`),
+		exclude: [/esm-external/, /container-1/]
+	}
+);

--- a/packages/rspack-test-tools/tests/NewCodeSplitting-stats-output.test.js
+++ b/packages/rspack-test-tools/tests/NewCodeSplitting-stats-output.test.js
@@ -1,5 +1,10 @@
 const path = require("path");
-const { describeByWalk, StatsProcessor, BasicCaseCreator, ECompilerType } = require("..");
+const {
+	describeByWalk,
+	StatsProcessor,
+	BasicCaseCreator,
+	ECompilerType
+} = require("..");
 
 const creator = new BasicCaseCreator({
 	clean: true,
@@ -9,7 +14,7 @@ const creator = new BasicCaseCreator({
 			name,
 			compilerType: ECompilerType.Rspack,
 			configFiles: ["rspack.config.js", "webpack.config.js"],
-			snapshotName: 'NewCodeSplittingStatsOutput',
+			snapshotName: "NewCodeSplittingStatsOutput",
 			overrideOptions(index, context, options) {
 				options.experiments ??= {};
 				options.experiments.parallelCodeSplitting ??= true;
@@ -20,10 +25,14 @@ const creator = new BasicCaseCreator({
 	description: () => "should print correct stats for"
 });
 
-describeByWalk('new code splitting stats output', (name, src, dist) => {
-	creator.create(name, src, dist);
-}, {
-	level: 1,
-	source: path.resolve(__dirname, './statsOutputCases'),
-	dist: path.resolve(__dirname, `./js/new-code-splitting-stats-output`),
-});
+describeByWalk(
+	"new code splitting stats output",
+	(name, src, dist) => {
+		creator.create(name, src, dist);
+	},
+	{
+		level: 1,
+		source: path.resolve(__dirname, "./statsOutputCases"),
+		dist: path.resolve(__dirname, `./js/new-code-splitting-stats-output`)
+	}
+);

--- a/packages/rspack-test-tools/tests/NewIncremental-node.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-node.test.js
@@ -1,41 +1,51 @@
 // Need to run some webpack-test
-process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
+process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
 const { describeByWalk, createHotNewIncrementalCase } = require("../dist");
 
 function v(name) {
-	return path.join(__dirname, `new-incremental ${name}`)
+	return path.join(__dirname, `new-incremental ${name}`);
 }
 
 // Run tests rspack-test-tools/tests/hotCases in target async-node
-describeByWalk(v("hot async-node"), (name, src, dist) => {
-	createHotNewIncrementalCase(name, src, dist, "async-node", "jsdom");
-}, {
-	source: path.resolve(__dirname, "./hotCases"),
-	dist: path.resolve(__dirname, `./js/new-incremental/hot-async-node`),
-	exclude: [/^css$/]
-});
+describeByWalk(
+	v("hot async-node"),
+	(name, src, dist) => {
+		createHotNewIncrementalCase(name, src, dist, "async-node", "jsdom");
+	},
+	{
+		source: path.resolve(__dirname, "./hotCases"),
+		dist: path.resolve(__dirname, `./js/new-incremental/hot-async-node`),
+		exclude: [/^css$/]
+	}
+);
 
 // Run tests webpack-test/hotCases in target async-node
-describeByWalk(v("hot async-node (webpack-test)"), (name, src, dist) => {
-	createHotNewIncrementalCase(name, src, dist, "async-node", "fake");
-}, {
-	source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
-	dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-async-node`),
-	exclude: [
-		/move-between-runtime/,
-	]
-});
+describeByWalk(
+	v("hot async-node (webpack-test)"),
+	(name, src, dist) => {
+		createHotNewIncrementalCase(name, src, dist, "async-node", "fake");
+	},
+	{
+		source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
+		dist: path.resolve(
+			__dirname,
+			`./js/new-incremental/webpack-test/hot-async-node`
+		),
+		exclude: [/move-between-runtime/]
+	}
+);
 
 // Run tests webpack-test/hotCases in target node
-describeByWalk(v("hot node (webpack-test)"), (name, src, dist) => {
-	createHotNewIncrementalCase(name, src, dist, "node", "fake");
-}, {
-	source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
-	dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-node`),
-	exclude: [
-		/move-between-runtime/,
-	]
-});
-
+describeByWalk(
+	v("hot node (webpack-test)"),
+	(name, src, dist) => {
+		createHotNewIncrementalCase(name, src, dist, "node", "fake");
+	},
+	{
+		source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
+		dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-node`),
+		exclude: [/move-between-runtime/]
+	}
+);

--- a/packages/rspack-test-tools/tests/NewIncremental-watch-webpack.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-watch-webpack.test.js
@@ -1,32 +1,33 @@
 // Need to run some webpack-test
-process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
+process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
 const { describeByWalk, createWatchNewIncrementalCase } = require("../dist");
 
 function v(name) {
-	return path.join(__dirname, `new-incremental ${name}`)
+	return path.join(__dirname, `new-incremental ${name}`);
 }
 
-
 // Run tests webpack-test/watchCases
-describeByWalk(v("watch (webpack-test)"), (name, src, dist) => {
-	const tempDir = path.resolve(__dirname, `./js/new-incremental/webpack-test/temp`);
-	createWatchNewIncrementalCase(
-		name,
-		src,
-		dist,
-		path.join(tempDir, name),
-	);
-}, {
-	source: path.resolve(__dirname, "../../../tests/webpack-test/watchCases"),
-	dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/watch`),
-	exclude: [
-		/module-concatenation-plugin/,
-		/missing-module/,
-		/caching-inner-source/,
-		/production/,
-		/warnings-contribute-to-hash/,
-		/issue-8766/,
-	]
-});
+describeByWalk(
+	v("watch (webpack-test)"),
+	(name, src, dist) => {
+		const tempDir = path.resolve(
+			__dirname,
+			`./js/new-incremental/webpack-test/temp`
+		);
+		createWatchNewIncrementalCase(name, src, dist, path.join(tempDir, name));
+	},
+	{
+		source: path.resolve(__dirname, "../../../tests/webpack-test/watchCases"),
+		dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/watch`),
+		exclude: [
+			/module-concatenation-plugin/,
+			/missing-module/,
+			/caching-inner-source/,
+			/production/,
+			/warnings-contribute-to-hash/,
+			/issue-8766/
+		]
+	}
+);

--- a/packages/rspack-test-tools/tests/NewIncremental-watch.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-watch.test.js
@@ -1,24 +1,22 @@
 // Need to run some webpack-test
-process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
+process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
 const { describeByWalk, createWatchNewIncrementalCase } = require("../dist");
 
 function v(name) {
-	return path.join(__dirname, `new-incremental ${name}`)
+	return path.join(__dirname, `new-incremental ${name}`);
 }
 
-
 // Run tests rspack-test-tools/tests/watchCases
-describeByWalk(v("watch"), (name, src, dist) => {
-	const tempDir = path.resolve(__dirname, `./js/new-incremental/temp`);
-	createWatchNewIncrementalCase(
-		name,
-		src,
-		dist,
-		path.join(tempDir, name),
-	);
-}, {
-	source: path.resolve(__dirname, "./watchCases"),
-	dist: path.resolve(__dirname, `./js/new-incremental/watch`),
-});
+describeByWalk(
+	v("watch"),
+	(name, src, dist) => {
+		const tempDir = path.resolve(__dirname, `./js/new-incremental/temp`);
+		createWatchNewIncrementalCase(name, src, dist, path.join(tempDir, name));
+	},
+	{
+		source: path.resolve(__dirname, "./watchCases"),
+		dist: path.resolve(__dirname, `./js/new-incremental/watch`)
+	}
+);

--- a/packages/rspack-test-tools/tests/NewIncremental-web.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-web.test.js
@@ -1,29 +1,34 @@
 // Need to run some webpack-test
-process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
+process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
 const { describeByWalk, createHotNewIncrementalCase } = require("../dist");
 
 function v(name) {
-	return path.join(__dirname, `new-incremental ${name}`)
+	return path.join(__dirname, `new-incremental ${name}`);
 }
 
-
 // Run tests rspack-test-tools/tests/hotCases in target web
-describeByWalk(v("hot web"), (name, src, dist) => {
-	createHotNewIncrementalCase(name, src, dist, "web", "jsdom");
-}, {
-	source: path.resolve(__dirname, "./hotCases"),
-	dist: path.resolve(__dirname, `./js/new-incremental/hot-web`)
-});
+describeByWalk(
+	v("hot web"),
+	(name, src, dist) => {
+		createHotNewIncrementalCase(name, src, dist, "web", "jsdom");
+	},
+	{
+		source: path.resolve(__dirname, "./hotCases"),
+		dist: path.resolve(__dirname, `./js/new-incremental/hot-web`)
+	}
+);
 
 // Run tests webpack-test/hotCases in target web
-describeByWalk(v("hot web (webpack-test)"), (name, src, dist) => {
-	createHotNewIncrementalCase(name, src, dist, "web", "fake");
-}, {
-	source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
-	dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-web`),
-	exclude: [
-		/move-between-runtime/,
-	]
-});
+describeByWalk(
+	v("hot web (webpack-test)"),
+	(name, src, dist) => {
+		createHotNewIncrementalCase(name, src, dist, "web", "fake");
+	},
+	{
+		source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
+		dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-web`),
+		exclude: [/move-between-runtime/]
+	}
+);

--- a/packages/rspack-test-tools/tests/NewIncremental-webworker.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-webworker.test.js
@@ -1,30 +1,38 @@
 // Need to run some webpack-test
-process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
+process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
 const { describeByWalk, createHotNewIncrementalCase } = require("../dist");
 
 function v(name) {
-	return path.join(__dirname, `new-incremental ${name}`)
+	return path.join(__dirname, `new-incremental ${name}`);
 }
 
 // Run tests rspack-test-tools/tests/hotCases in target webworker
-describeByWalk(v("hot webworker"), (name, src, dist) => {
-	createHotNewIncrementalCase(name, src, dist, "webworker", "jsdom");
-}, {
-	source: path.resolve(__dirname, "./hotCases"),
-	dist: path.resolve(__dirname, `./js/new-incremental/hot-worker`),
-	exclude: [/^css$/]
-});
-
+describeByWalk(
+	v("hot webworker"),
+	(name, src, dist) => {
+		createHotNewIncrementalCase(name, src, dist, "webworker", "jsdom");
+	},
+	{
+		source: path.resolve(__dirname, "./hotCases"),
+		dist: path.resolve(__dirname, `./js/new-incremental/hot-worker`),
+		exclude: [/^css$/]
+	}
+);
 
 // Run tests webpack-test/hotCases in target webworker
-describeByWalk(v("hot webworker (webpack-test)"), (name, src, dist) => {
-	createHotNewIncrementalCase(name, src, dist, "webworker", "fake");
-}, {
-	source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
-	dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-webworker`),
-	exclude: [
-		/move-between-runtime/,
-	]
-});
+describeByWalk(
+	v("hot webworker (webpack-test)"),
+	(name, src, dist) => {
+		createHotNewIncrementalCase(name, src, dist, "webworker", "fake");
+	},
+	{
+		source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
+		dist: path.resolve(
+			__dirname,
+			`./js/new-incremental/webpack-test/hot-webworker`
+		),
+		exclude: [/move-between-runtime/]
+	}
+);

--- a/packages/rspack-test-tools/tests/Normal.test.js
+++ b/packages/rspack-test-tools/tests/Normal.test.js
@@ -3,4 +3,3 @@ const { createNormalCase, describeByWalk } = require("..");
 describeByWalk(__filename, (name, src, dist) => {
 	createNormalCase(name, src, dist);
 });
-

--- a/packages/rspack-test-tools/tests/StatsAPI.test.js
+++ b/packages/rspack-test-tools/tests/StatsAPI.test.js
@@ -1,11 +1,14 @@
 const { createStatsAPICase, describeByWalk } = require("..");
 const srcDir = __dirname;
 
-describeByWalk(__filename, (name, testConfig, dist) => {
-	createStatsAPICase(name, srcDir, "none", testConfig);
-}, {
-	absoluteDist: false,
-	level: 1,
-	type: "file",
-});
-
+describeByWalk(
+	__filename,
+	(name, testConfig, dist) => {
+		createStatsAPICase(name, srcDir, "none", testConfig);
+	},
+	{
+		absoluteDist: false,
+		level: 1,
+		type: "file"
+	}
+);

--- a/packages/rspack-test-tools/tests/StatsOutput.test.js
+++ b/packages/rspack-test-tools/tests/StatsOutput.test.js
@@ -1,8 +1,11 @@
 const { createStatsOutputCase, describeByWalk } = require("..");
 
-describeByWalk(__filename, (name, src, dist) => {
-	createStatsOutputCase(name, src, dist);
-}, {
-	level: 1,
-});
-
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createStatsOutputCase(name, src, dist);
+	},
+	{
+		level: 1
+	}
+);

--- a/packages/rspack-test-tools/tests/TreeShaking.test.js
+++ b/packages/rspack-test-tools/tests/TreeShaking.test.js
@@ -1,9 +1,11 @@
 const { createTreeShakingCase, describeByWalk } = require("..");
 
-describeByWalk(__filename, (name, src, dist) => {
-	createTreeShakingCase(name, src, dist);
-}, {
-	level: 1,
-});
-
-
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createTreeShakingCase(name, src, dist);
+	},
+	{
+		level: 1
+	}
+);

--- a/packages/rspack-test-tools/tests/Watch.test.js
+++ b/packages/rspack-test-tools/tests/Watch.test.js
@@ -3,10 +3,5 @@ const { describeByWalk, createWatchCase } = require("../dist");
 const tempDir = path.resolve(__dirname, `./js/temp`);
 
 describeByWalk(__filename, (name, src, dist) => {
-	createWatchCase(
-		name,
-		src,
-		dist,
-		path.join(tempDir, name),
-	);
+	createWatchCase(name, src, dist, path.join(tempDir, name));
 });

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/filename/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/filename/rspack.config.js
@@ -10,5 +10,5 @@ module.exports = {
 				filename: "[name].[contenthash].html"
 			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/builtinCases/samples/ancestor-has-all-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/ancestor-has-all-modules/rspack.config.js
@@ -8,5 +8,5 @@ module.exports = {
 	optimization: {
 		providedExports: true,
 		usedExports: "global"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/builtinCases/samples/cycle-dynamic-entry/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/cycle-dynamic-entry/rspack.config.js
@@ -4,5 +4,5 @@ module.exports = {
 		removeAvailableModules: true,
 		providedExports: true,
 		usedExports: "global"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/builtinCases/samples/cycle-entry/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/cycle-entry/rspack.config.js
@@ -12,5 +12,5 @@ module.exports = {
 		removeAvailableModules: true,
 		providedExports: true,
 		usedExports: "global"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/builtinCases/samples/intersection/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/intersection/rspack.config.js
@@ -12,5 +12,5 @@ module.exports = {
 		removeAvailableModules: true,
 		providedExports: true,
 		usedExports: "global"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/builtinCases/samples/parent-have-partial-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/parent-have-partial-module/rspack.config.js
@@ -9,5 +9,5 @@ module.exports = {
 		removeAvailableModules: true,
 		providedExports: true,
 		usedExports: "global"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/builtinCases/samples/self-import/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/self-import/rspack.config.js
@@ -4,5 +4,5 @@ module.exports = {
 		removeAvailableModules: true,
 		providedExports: true,
 		usedExports: "global"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/builtinCases/samples/simple/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/simple/rspack.config.js
@@ -4,5 +4,5 @@ module.exports = {
 		removeAvailableModules: true,
 		providedExports: true,
 		usedExports: "global"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/issue-8006/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/issue-8006/rspack.config.js
@@ -19,5 +19,5 @@ module.exports = {
 				]
 			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/minify/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/minify/rspack.config.js
@@ -12,8 +12,8 @@ module.exports = {
 								target: "es2015",
 								preserveAllComments: true,
 								minify: {
-                  compress: true,
-                },
+									compress: true
+								},
 								parser: {
 									syntax: "ecmascript",
 									jsx: true,
@@ -28,5 +28,5 @@ module.exports = {
 				]
 			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/define-function/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/define-function/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/define-object/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/define-object/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/define-others/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/define-others/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/define-with-deps/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/define-with-deps/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/define-with-name/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/define-with-name/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/define-wrapper/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/define-wrapper/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/real-amd-libs/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/real-amd-libs/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/require-error-callback/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/require-error-callback/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/require-local-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/require-local-module/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/require-unsupported/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/require-unsupported/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/require-wrapper/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/require-wrapper/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/require/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/require/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: {},
+	amd: {}
 };

--- a/packages/rspack-test-tools/tests/configCases/amd/requirejs-stuffs/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/amd/requirejs-stuffs/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	amd: { jQuery: true },
+	amd: { jQuery: true }
 };

--- a/packages/rspack-test-tools/tests/configCases/asset/disable-emit-for-asset/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/disable-emit-for-asset/rspack.config.js
@@ -7,8 +7,8 @@ module.exports = {
 	module: {
 		generator: {
 			asset: {
-				emit: false,
-			},
+				emit: false
+			}
 		},
 		parser: {
 			asset: {
@@ -20,7 +20,7 @@ module.exports = {
 		rules: [
 			{
 				test: /\.png$/,
-				type: "asset",
+				type: "asset"
 			},
 			{
 				test: /\.jpg$/,

--- a/packages/rspack-test-tools/tests/configCases/asset/disable-emit-for-resource/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/disable-emit-for-resource/rspack.config.js
@@ -6,14 +6,14 @@ module.exports = {
 	},
 	module: {
 		generator: {
-			'asset/resource': {
-				emit: false,
-			},
+			"asset/resource": {
+				emit: false
+			}
 		},
 		rules: [
 			{
 				test: /\.png$/,
-				type: "asset/resource",
+				type: "asset/resource"
 			},
 			{
 				test: /\.jpg$/,

--- a/packages/rspack-test-tools/tests/configCases/asset/preserve-import/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/preserve-import/rspack.config.js
@@ -4,7 +4,7 @@ const assert = require("assert");
 module.exports = {
 	context: __dirname,
 	entry: {
-		index: './img.png'
+		index: "./img.png"
 	},
 	module: {
 		rules: [
@@ -25,8 +25,8 @@ module.exports = {
 						let list = Object.keys(assets);
 						const js = list.find(item => item.endsWith("js"));
 						const jsContent = assets[js].source().toString();
-						assert(/require\(['"]\.\/(\w*)\.png['"]\)/.test(jsContent))
-					})
+						assert(/require\(['"]\.\/(\w*)\.png['"]\)/.test(jsContent));
+					});
 				});
 			}
 		})()

--- a/packages/rspack-test-tools/tests/configCases/asset/rename-asset/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/rename-asset/rspack.config.js
@@ -3,27 +3,26 @@ const assert = require("assert").strict;
 const pluginName = "plugin";
 
 class Plugin {
-  apply(compiler) {
-    compiler.hooks.compilation.tap("Test", compilation => {
-      compilation.hooks.processAssets.tap(
-        {
-          name: "Test",
-          stage: -100
-        },
-        () => {
-          compilation.renameAsset("chunk.js", "renamed.js");
-        }
-      );
-    });
-
-  }
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", compilation => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: "Test",
+					stage: -100
+				},
+				() => {
+					compilation.renameAsset("chunk.js", "renamed.js");
+				}
+			);
+		});
+	}
 }
 
 /**@type {import('@rspack/core').Configuration}*/
 module.exports = {
-  context: __dirname,
-  output: {
-    chunkFilename: "chunk.js"
-  },
-  plugins: [new Plugin()]
+	context: __dirname,
+	output: {
+		chunkFilename: "chunk.js"
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/asset/webpack-sources/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/webpack-sources/rspack.config.js
@@ -1,36 +1,37 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    context: __dirname,
-    devtool: "source-map",
-    module: {
-        rules: [
-            {
-                test: /\.png$/,
-                type: "asset/resource",
-                generator: {
-                    filename: '[name][ext]'
-                }
-            }
-        ],
-    },
-    plugins: [
-        compiler => {
-            compiler.hooks.thisCompilation.tap("PLUGIN", compilation => {
-                compilation.hooks.processAssets.tap(
-                    {
-                        name: "PLUGIN",
-                        stage:
-                            compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_TRANSFER,
-                        additionalAssets: true,
-                    },
-                    assets => {
-                        const { RawSource, SourceMapSource } = compiler.webpack.sources;
+	context: __dirname,
+	devtool: "source-map",
+	module: {
+		rules: [
+			{
+				test: /\.png$/,
+				type: "asset/resource",
+				generator: {
+					filename: "[name][ext]"
+				}
+			}
+		]
+	},
+	plugins: [
+		compiler => {
+			compiler.hooks.thisCompilation.tap("PLUGIN", compilation => {
+				compilation.hooks.processAssets.tap(
+					{
+						name: "PLUGIN",
+						stage:
+							compiler.webpack.Compilation
+								.PROCESS_ASSETS_STAGE_OPTIMIZE_TRANSFER,
+						additionalAssets: true
+					},
+					assets => {
+						const { RawSource, SourceMapSource } = compiler.webpack.sources;
 
-                        expect(assets['img.png']).toBeInstanceOf(RawSource);
-                        expect(assets['bundle0.js']).toBeInstanceOf(SourceMapSource);
-                    }
-                );
-            });
-        }
-    ]
+						expect(assets["img.png"]).toBeInstanceOf(RawSource);
+						expect(assets["bundle0.js"]).toBeInstanceOf(SourceMapSource);
+					}
+				);
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/asset/with-dollar-sign/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/with-dollar-sign/rspack.config.js
@@ -7,9 +7,9 @@ module.exports = {
 				test: /\.png$/,
 				type: "asset/resource",
 				generator: {
-					filename: '[name][ext]'
+					filename: "[name][ext]"
 				}
 			}
-		],
+		]
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/basic-include/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/basic-include/rspack.config.js
@@ -1,10 +1,10 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		parser: {
-			'css/auto': {
+			"css/auto": {
 				namedExports: true
 			}
 		},
@@ -12,15 +12,15 @@ module.exports = {
 			{
 				test: /\.css$/,
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				},
 				use: [
 					{
 						loader: "builtin:lightningcss-loader",
 						/** @type {import("@rspack/core").LightningcssLoaderOptions} */
 						options: {
-							unusedSymbols: ['unused'],
-							targets: 'ie 10',
+							unusedSymbols: ["unused"],
+							targets: "ie 10",
 							exclude: {
 								nesting: true
 							}

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/basic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/basic/rspack.config.js
@@ -2,7 +2,7 @@
 module.exports = {
 	module: {
 		parser: {
-			'css/auto': {
+			"css/auto": {
 				namedExports: true
 			}
 		},
@@ -14,8 +14,8 @@ module.exports = {
 						loader: "builtin:lightningcss-loader",
 						/** @type {import("@rspack/core").LightningcssLoaderOptions} */
 						options: {
-							unusedSymbols: ['unused'],
-							targets: '> 0.2%'
+							unusedSymbols: ["unused"],
+							targets: "> 0.2%"
 						}
 					}
 				],

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/minify/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/minify/rspack.config.js
@@ -1,11 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [
@@ -17,11 +17,7 @@ module.exports = {
 						/** @type {import("@rspack/core").LightningcssLoaderOptions} */
 						options: {
 							minify: true,
-							targets: [
-								'Edge >= 12',
-								'iOS >= 8',
-								'Android >= 4.0'
-							]
+							targets: ["Edge >= 12", "iOS >= 8", "Android >= 4.0"]
 						}
 					}
 				],

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/prefixes-with-targets-array/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/prefixes-with-targets-array/rspack.config.js
@@ -1,11 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [
@@ -16,11 +16,7 @@ module.exports = {
 						loader: "builtin:lightningcss-loader",
 						/** @type {import("@rspack/core").LightningcssLoaderOptions} */
 						options: {
-							targets: [
-								'Edge >= 12',
-								'iOS >= 8',
-								'Android >= 4.0'
-							]
+							targets: ["Edge >= 12", "iOS >= 8", "Android >= 4.0"]
 						}
 					}
 				],

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/prefixes-with-targets-string/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/prefixes-with-targets-string/rspack.config.js
@@ -1,11 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [
@@ -16,9 +16,7 @@ module.exports = {
 						loader: "builtin:lightningcss-loader",
 						/** @type {import("@rspack/core").LightningcssLoaderOptions} */
 						options: {
-							targets: [
-								'Edge >= 12'
-							]
+							targets: ["Edge >= 12"]
 						}
 					}
 				],

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/with-css-extract/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/with-css-extract/rspack.config.js
@@ -2,7 +2,7 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -15,9 +15,7 @@ module.exports = {
 						loader: "builtin:lightningcss-loader",
 						/** @type {import("@rspack/core").LightningcssLoaderOptions} */
 						options: {
-							targets: [
-								'Edge >= 12'
-							]
+							targets: ["Edge >= 12"]
 						}
 					}
 				],
@@ -27,7 +25,7 @@ module.exports = {
 	},
 	plugins: [
 		new rspack.CssExtractRspackPlugin({
-			filename: 'bundle0.css'
+			filename: "bundle0.css"
 		})
 	],
 	experiments: {

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/wth-css-extract-postcss/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/wth-css-extract-postcss/rspack.config.js
@@ -2,7 +2,7 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -15,18 +15,14 @@ module.exports = {
 						loader: "builtin:lightningcss-loader",
 						/** @type {import("@rspack/core").LightningcssLoaderOptions} */
 						options: {
-							targets: [
-								'Edge >= 12'
-							]
+							targets: ["Edge >= 12"]
 						}
 					},
 					{
 						loader: "postcss-loader",
 						options: {
 							postcssOptions: {
-								plugins: [
-									"postcss-pxtorem"
-								]
+								plugins: ["postcss-pxtorem"]
 							}
 						}
 					}
@@ -37,7 +33,7 @@ module.exports = {
 	},
 	plugins: [
 		new rspack.CssExtractRspackPlugin({
-			filename: 'bundle0.css'
+			filename: "bundle0.css"
 		})
 	],
 	experiments: {

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/rspack.config.js
@@ -28,4 +28,4 @@ module.exports = {
 			CONTEXT: JSON.stringify(__dirname)
 		})
 	]
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/rspack.config.js
@@ -28,4 +28,4 @@ module.exports = {
 			CONTEXT: JSON.stringify(__dirname)
 		})
 	]
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/issue-4597/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/issue-4597/rspack.config.js
@@ -7,7 +7,7 @@ const config = {
 		generator: {
 			"css/auto": {
 				exportsOnly: false
-			},
+			}
 		},
 		rules: [
 			{

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/plugin-import/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/plugin-import/rspack.config.js
@@ -71,8 +71,9 @@ module.exports = {
 								style: true
 							},
 							{
-								libraryName: './src/legacy-babel-plugin-import',
-								customName: './src/legacy-babel-plugin-import/lib/{{ legacyKebabCase member }}/{{ legacySnakeCase member }}',
+								libraryName: "./src/legacy-babel-plugin-import",
+								customName:
+									"./src/legacy-babel-plugin-import/lib/{{ legacyKebabCase member }}/{{ legacySnakeCase member }}",
 								style: false
 							}
 						]

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/preact-refresh/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/preact-refresh/rspack.config.js
@@ -1,6 +1,6 @@
-const { rspack } = require("@rspack/core")
+const { rspack } = require("@rspack/core");
 const PreactRefreshPlugin = require("@rspack/plugin-preact-refresh");
-const { ConcatSource, RawSource } = require("webpack-sources")
+const { ConcatSource, RawSource } = require("webpack-sources");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: "./index.jsx",
@@ -19,7 +19,7 @@ module.exports = {
 						parser: {
 							syntax: "ecmascript",
 							jsx: true,
-							sourceMap: true,
+							sourceMap: true
 						},
 						transform: {
 							react: {
@@ -43,14 +43,17 @@ module.exports = {
 		}),
 		{
 			apply(compiler) {
-				compiler.hooks.compilation.tap("_", (compilation) => {
-					compilation.hooks.processAssets.tap("_", (assets) => {
-						compilation.updateAsset("bundle0.js",new ConcatSource(
-							new RawSource("const self = globalThis;"), // mock self to NodeJs specific global object
-							assets["bundle0.js"]
-						))
-					})
-				})
+				compiler.hooks.compilation.tap("_", compilation => {
+					compilation.hooks.processAssets.tap("_", assets => {
+						compilation.updateAsset(
+							"bundle0.js",
+							new ConcatSource(
+								new RawSource("const self = globalThis;"), // mock self to NodeJs specific global object
+								assets["bundle0.js"]
+							)
+						);
+					});
+				});
 			}
 		}
 	]

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/react-refresh/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/react-refresh/rspack.config.js
@@ -1,4 +1,4 @@
-const { rspack } = require("@rspack/core")
+const { rspack } = require("@rspack/core");
 const ReactRefreshPlugin = require("@rspack/plugin-react-refresh");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -18,7 +18,7 @@ module.exports = {
 						parser: {
 							syntax: "ecmascript",
 							jsx: true,
-							sourceMap: true,
+							sourceMap: true
 						},
 						transform: {
 							react: {

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/swc-loader-incompatible-wasm-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/swc-loader-incompatible-wasm-plugin/rspack.config.js
@@ -1,91 +1,88 @@
-
-
-const { rspack } = require('@rspack/core');
-const path = require('path');
-const { RawSource } = require('webpack-sources');
+const { rspack } = require("@rspack/core");
+const path = require("path");
+const { RawSource } = require("webpack-sources");
 
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
-  context: __dirname,
-  entry: {
-    main: './src/index.jsx',
-  },
-  resolve: {
-    extensions: ['...', '.jsx'],
-    alias: {
-      '@swc/helpers': path.dirname(require.resolve('@swc/helpers/package.json')),
-    },
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(jsx|js)$/,
-        use: {
-          loader: 'builtin:swc-loader',
-          options: {
-            // Enable source map
-            sourceMap: true,
-            target: 'es5',
-            jsc: {
-              parser: {
-                syntax: 'ecmascript',
-                jsx: true,
-              },
-              externalHelpers: true,
-              preserveAllComments: false,
-              transform: {
-                react: {
-                  runtime: 'automatic',
-                  pragma: 'React.createElement',
-                  pragmaFrag: 'React.Fragment',
-                  throwIfNamespace: true,
-                  useBuiltins: false,
-                },
-              },
-              experimental: {
-                cacheRoot: __dirname + "/.swc",
-                plugins: [
-                  [
-                    __dirname + "/node_modules/swc-wasm-plugin",
-                    {
-                      exclude: ["error"]
-                    }
-                  ]
-                ]
-              }
-            },
-          },
-        },
-        type: 'javascript/auto',
-      },
-      {
-        test: /\.(png|svg|jpg)$/,
-        type: 'asset/resource',
-      },
-    ],
-  },
-  optimization: {
-    minimize: false, // Disabling minification because it takes too long on CI
-  },
-  plugins: [
-    new rspack.HtmlRspackPlugin({
-      template: './index.html',
-    }),
-    {
-      // Replace all assets with empty content to avoid evaluation that causes errors
-      apply(compiler) {
-        compiler.hooks.compilation.tap("_", (compilation) => {
-          compilation.hooks.processAssets.tap("_", (assets) => {
-            let names = Object.keys(assets);
-            names.forEach(name => {
-              assets[name] = new RawSource("")
-            })
-          })
-        })
-      }
-    }
-  ],
-  experiments: { css: true }
+	context: __dirname,
+	entry: {
+		main: "./src/index.jsx"
+	},
+	resolve: {
+		extensions: ["...", ".jsx"],
+		alias: {
+			"@swc/helpers": path.dirname(require.resolve("@swc/helpers/package.json"))
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /\.(jsx|js)$/,
+				use: {
+					loader: "builtin:swc-loader",
+					options: {
+						// Enable source map
+						sourceMap: true,
+						target: "es5",
+						jsc: {
+							parser: {
+								syntax: "ecmascript",
+								jsx: true
+							},
+							externalHelpers: true,
+							preserveAllComments: false,
+							transform: {
+								react: {
+									runtime: "automatic",
+									pragma: "React.createElement",
+									pragmaFrag: "React.Fragment",
+									throwIfNamespace: true,
+									useBuiltins: false
+								}
+							},
+							experimental: {
+								cacheRoot: __dirname + "/.swc",
+								plugins: [
+									[
+										__dirname + "/node_modules/swc-wasm-plugin",
+										{
+											exclude: ["error"]
+										}
+									]
+								]
+							}
+						}
+					}
+				},
+				type: "javascript/auto"
+			},
+			{
+				test: /\.(png|svg|jpg)$/,
+				type: "asset/resource"
+			}
+		]
+	},
+	optimization: {
+		minimize: false // Disabling minification because it takes too long on CI
+	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		{
+			// Replace all assets with empty content to avoid evaluation that causes errors
+			apply(compiler) {
+				compiler.hooks.compilation.tap("_", compilation => {
+					compilation.hooks.processAssets.tap("_", assets => {
+						let names = Object.keys(assets);
+						names.forEach(name => {
+							assets[name] = new RawSource("");
+						});
+					});
+				});
+			}
+		}
+	],
+	experiments: { css: true }
 };
 module.exports = config;
-

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/swc-loader-incompatible-wasm-plugin/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/swc-loader-incompatible-wasm-plugin/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  noTests: true,
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/swc-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/swc-plugin/rspack.config.js
@@ -18,13 +18,13 @@ module.exports = {
 									[
 										"@swc/plugin-remove-console",
 										{
-											"exclude": ["error"]
+											exclude: ["error"]
 										}
 									]
-								],
-							},
-						},
-					},
+								]
+							}
+						}
+					}
 				},
 				type: "javascript/auto"
 			}

--- a/packages/rspack-test-tools/tests/configCases/builtins/banner-stage/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/banner-stage/rspack.config.js
@@ -41,15 +41,13 @@ module.exports = {
 		new rspack.BannerPlugin("PROCESS_ASSETS_STAGE_ADDITIONS"), // Defaults to be PROCESS_ASSETS_STAGE_ADDITIONS(-100)
 
 		// Fotter
-		new rspack.BannerPlugin(
-			{
-				banner: "PROCESS_ASSETS_STAGE_REPORT",
-				footer: true,
-				entryOnly: true,
-				exclude: [/a\.js/],
-				stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT // 5000
-			}
-		),
+		new rspack.BannerPlugin({
+			banner: "PROCESS_ASSETS_STAGE_REPORT",
+			footer: true,
+			entryOnly: true,
+			exclude: [/a\.js/],
+			stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT // 5000
+		}),
 		new rspack.BannerPlugin({
 			banner: "PROCESS_ASSETS_STAGE_PRE_PROCESS",
 			footer: true,
@@ -63,6 +61,6 @@ module.exports = {
 			entryOnly: true,
 			exclude: [/a\.js/],
 			stage: rspack.Compilation.PROCESS_ASSETS_STAGE_DERIVED // -200
-		}),
+		})
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/code-generation-keep-comments/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/code-generation-keep-comments/rspack.config.js
@@ -1,3 +1,2 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
-};
+module.exports = {};

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-auto/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-auto/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -8,7 +8,7 @@ module.exports = {
 				test: /\.css$/,
 				type: "css/auto",
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-exports-only/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-exports-only/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 				test: /\.css$/,
 				type: "css/module",
 				generator: {
-					exportsOnly: true,
+					exportsOnly: true
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-camelCase/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-camelCase/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 				test: /\.css$/,
 				type: "css/module",
 				generator: {
-					exportsConvention: "camel-case",
+					exportsConvention: "camel-case"
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-camelCaseOnly/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-camelCaseOnly/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 				test: /\.css$/,
 				type: "css/module",
 				generator: {
-					exportsConvention: "camel-case-only",
+					exportsConvention: "camel-case-only"
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-dashes/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-dashes/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 				test: /\.css$/,
 				type: "css/module",
 				generator: {
-					exportsConvention: "dashes",
+					exportsConvention: "dashes"
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/builtins/define/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/define/rspack.config.js
@@ -30,7 +30,7 @@ module.exports = {
 			REGEXP: "/abc/i",
 			OBJECT:
 				'{UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}',
-			OBJECT2: '{ FN: function() {} }',
+			OBJECT2: "{ FN: function() {} }",
 			"P1.P2.P3": "301",
 			"P1.P2.P4": '"302"',
 			P1: "303",

--- a/packages/rspack-test-tools/tests/configCases/builtins/entry-plugin-filename-function/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/entry-plugin-filename-function/rspack.config.js
@@ -2,10 +2,10 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  plugins: [
-    new rspack.EntryPlugin(__dirname, "./a.js", {
-      filename: "pages/[name].js",
-      name: "a",
-    }),
-  ],
+	plugins: [
+		new rspack.EntryPlugin(__dirname, "./a.js", {
+			filename: "pages/[name].js",
+			name: "a"
+		})
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/entry-plugin-filename-function/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/entry-plugin-filename-function/test.config.js
@@ -1,7 +1,5 @@
 module.exports = {
-	findBundle: function() {
-		return [
-			"./pages/a.js",
-		]
+	findBundle: function () {
+		return ["./pages/a.js"];
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/entry-plugin-filename-string/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/entry-plugin-filename-string/rspack.config.js
@@ -2,10 +2,10 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  plugins: [
-    new rspack.EntryPlugin(__dirname, "./a.js", {
-      filename: () => "pages/[name].js",
-      name: "a",
-    }),
-  ],
+	plugins: [
+		new rspack.EntryPlugin(__dirname, "./a.js", {
+			filename: () => "pages/[name].js",
+			name: "a"
+		})
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/entry-plugin-filename-string/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/entry-plugin-filename-string/test.config.js
@@ -1,7 +1,5 @@
 module.exports = {
-	findBundle: function() {
-		return [
-			"./pages/a.js",
-		]
+	findBundle: function () {
+		return ["./pages/a.js"];
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute-publicpath-auto/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute-publicpath-auto/rspack.config.js
@@ -4,7 +4,7 @@ const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	output: {
-	    publicPath: "auto",
+		publicPath: "auto"
 	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative-publicpath-auto/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative-publicpath-auto/rspack.config.js
@@ -4,7 +4,7 @@ const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	output: {
-	    publicPath: "auto",
+		publicPath: "auto"
 	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-issue-8410/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-issue-8410/rspack.config.js
@@ -21,7 +21,7 @@ module.exports = {
 		foorBar: "./index.js"
 	},
 	output: {
-	    filename: "[name].js",
+		filename: "[name].js"
 	},
 	plugins: [new rspack.HtmlRspackPlugin({}), new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-param-not-found/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-param-not-found/rspack.config.js
@@ -4,7 +4,8 @@ const { rspack } = require("@rspack/core");
 module.exports = {
 	plugins: [
 		new rspack.HtmlRspackPlugin({
-			templateContent: "<!DOCTYPE html><html><head><title><%= title %></title></head><body></body></html>",
+			templateContent:
+				"<!DOCTYPE html><html><head><title><%= title %></title></head><body></body></html>"
 		})
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-template-parameters/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-template-parameters/rspack.config.js
@@ -11,12 +11,12 @@ module.exports = {
 		rules: [
 			{
 				test: /\.css$/,
-				use: [CssExtractRspackPlugin.loader, "css-loader"],
-			},
-		],
+				use: [CssExtractRspackPlugin.loader, "css-loader"]
+			}
+		]
 	},
 	experiments: {
-		css: false,
+		css: false
 	},
 	plugins: [
 		new CssExtractRspackPlugin(),
@@ -30,8 +30,8 @@ module.exports = {
 			inject: false,
 			favicon: "./favicon.ico",
 			templateParameters: {
-				foo: "bar",
-			},
+				foo: "bar"
+			}
 		})
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/ignore-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/ignore-plugin/rspack.config.js
@@ -4,7 +4,7 @@ const { rspack } = require("@rspack/core");
 module.exports = {
 	plugins: [
 		new rspack.IgnorePlugin({
-			resourceRegExp: /^\.\/b$/,
+			resourceRegExp: /^\.\/b$/
 		}),
 		new rspack.IgnorePlugin({
 			resourceRegExp: /^\.\/c$/,
@@ -13,6 +13,6 @@ module.exports = {
 		new rspack.IgnorePlugin({
 			resourceRegExp: /^\.\/d$/,
 			contextRegExp: /test-ignore$/
-		}),
+		})
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/provide-not-resolved/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/provide-not-resolved/rspack.config.js
@@ -7,7 +7,7 @@ module.exports = {
 	},
 	plugins: [
 		new rspack.ProvidePlugin({
-			foo: "not-exist",
+			foo: "not-exist"
 		})
-	],
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/builtins/should_not_warn_export_destructring/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/should_not_warn_export_destructring/rspack.config.js
@@ -1,4 +1,2 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
-
-};
+module.exports = {};

--- a/packages/rspack-test-tools/tests/configCases/builtins/should_not_warn_when_commjs_not_export/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/should_not_warn_when_commjs_not_export/rspack.config.js
@@ -1,4 +1,2 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
-
-};
+module.exports = {};

--- a/packages/rspack-test-tools/tests/configCases/builtins/should_not_warn_when_src_format_is_umd/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/should_not_warn_when_src_format_is_umd/rspack.config.js
@@ -1,4 +1,2 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
-
-};
+module.exports = {};

--- a/packages/rspack-test-tools/tests/configCases/cache/memory/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/cache/memory/rspack.config.js
@@ -3,19 +3,21 @@ const PLUGIN_NAME = "MyPlugin";
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	cache: true,
-	plugins: [{
-		apply(compiler) {
-			compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
-				compilation.hooks.finishModules.tapPromise(PLUGIN_NAME, async () => {
-					const cache = compilation.getCache(PLUGIN_NAME);
-					await cache.storePromise('data', null, "some data");
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+					compilation.hooks.finishModules.tapPromise(PLUGIN_NAME, async () => {
+						const cache = compilation.getCache(PLUGIN_NAME);
+						await cache.storePromise("data", null, "some data");
+					});
+					compilation.hooks.processAssets.tapPromise(PLUGIN_NAME, async () => {
+						const cache = compilation.getCache(PLUGIN_NAME);
+						const data = await cache.getPromise("data", null);
+						expect(data).toBe("some data");
+					});
 				});
-				compilation.hooks.processAssets.tapPromise(PLUGIN_NAME, async () => {
-					const cache = compilation.getCache(PLUGIN_NAME);
-					const data = await cache.getPromise('data', null);
-					expect(data).toBe("some data");
-				});
-			});
+			}
 		}
-	}],
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/get-block-chunk-group/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/get-block-chunk-group/rspack.config.js
@@ -1,32 +1,30 @@
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.compilation.tap("Test", compilation => {
-            compilation.hooks.processAssets.tap("Test", () => {
-                const entry = compilation.entries.get("main");
-                const entryDependency = entry.dependencies[0];
-                const entryModule = compilation.moduleGraph.getModule(entryDependency);
-                const block = entryModule.blocks[0];
-                const chunkGroup = compilation.chunkGraph.getBlockChunkGroup(block);
-                expect(chunkGroup.name).toBe("foo");
-            });
-        });
-    }
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", compilation => {
+			compilation.hooks.processAssets.tap("Test", () => {
+				const entry = compilation.entries.get("main");
+				const entryDependency = entry.dependencies[0];
+				const entryModule = compilation.moduleGraph.getModule(entryDependency);
+				const block = entryModule.blocks[0];
+				const chunkGroup = compilation.chunkGraph.getBlockChunkGroup(block);
+				expect(chunkGroup.name).toBe("foo");
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: 'web',
-    node: false,
-    entry: {
-        main: "./index.js"
-    },
-    output: {
-        filename: "[name].js"
-    },
-    optimization: {
-        sideEffects: false,
-    },
-    plugins: [
-        new Plugin()
-    ]
+	target: "web",
+	node: false,
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		sideEffects: false
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/get-module-chunks/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/get-module-chunks/rspack.config.js
@@ -1,31 +1,29 @@
 const path = require("path");
 
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.compilation.tap("Test", compilation => {
-            compilation.hooks.processAssets.tap("Test", () => {
-                const chunk = Array.from(compilation.chunks)[0];
-                const modules = compilation.chunkGraph.getChunkModules(chunk);
-                expect(modules[0].resource).toBe(path.join(__dirname, "index.js"));
-            });
-        });
-    }
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", compilation => {
+			compilation.hooks.processAssets.tap("Test", () => {
+				const chunk = Array.from(compilation.chunks)[0];
+				const modules = compilation.chunkGraph.getChunkModules(chunk);
+				expect(modules[0].resource).toBe(path.join(__dirname, "index.js"));
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: 'web',
-    node: false,
-    entry: {
-        main: "./index.js"
-    },
-    output: {
-        filename: "[name].js"
-    },
-    optimization: {
-        sideEffects: false,
-    },
-    plugins: [
-        new Plugin()
-    ]
+	target: "web",
+	node: false,
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		sideEffects: false
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/get-module-id/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/get-module-id/rspack.config.js
@@ -1,29 +1,27 @@
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.compilation.tap("Test", compilation => {
-            compilation.hooks.processAssets.tap("Test", () => {
-                const module = Array.from(compilation.modules)[0];
-                const moduleId = compilation.chunkGraph.getModuleId(module);
-                expect(moduleId).toBeTruthy();
-            });
-        });
-    }
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", compilation => {
+			compilation.hooks.processAssets.tap("Test", () => {
+				const module = Array.from(compilation.modules)[0];
+				const moduleId = compilation.chunkGraph.getModuleId(module);
+				expect(moduleId).toBeTruthy();
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: 'web',
-    node: false,
-    entry: {
-        main: "./index.js"
-    },
-    output: {
-        filename: "[name].js"
-    },
-    optimization: {
-        sideEffects: false,
-    },
-    plugins: [
-        new Plugin()
-    ]
+	target: "web",
+	node: false,
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		sideEffects: false
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/get-number-of-entry-modules/rspack.config.js
@@ -2,34 +2,33 @@ class Plugin {
 	/**
 	 * @param {import("@rspack/core").Compiler} compiler
 	 */
-    apply(compiler) {
-        compiler.hooks.compilation.tap("Test", compilation => {
-            compilation.hooks.processAssets.tap("Test", () => {
-							for (const chunk of compilation.chunks) {
-								const num = compilation.chunkGraph.getNumberOfEntryModules(chunk);
-								const entryModules = compilation.chunkGraph.getChunkEntryModulesIterable(chunk);
-                expect(Array.from(entryModules)).toHaveLength(num);
-							}
-            });
-        });
-    }
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", compilation => {
+			compilation.hooks.processAssets.tap("Test", () => {
+				for (const chunk of compilation.chunks) {
+					const num = compilation.chunkGraph.getNumberOfEntryModules(chunk);
+					const entryModules =
+						compilation.chunkGraph.getChunkEntryModulesIterable(chunk);
+					expect(Array.from(entryModules)).toHaveLength(num);
+				}
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: 'web',
-    node: false,
-    entry: {
-        main: "./foo.js",
-				multi: ["./bar.js", "./baz.js"]
-    },
-    output: {
-        filename: "[name].js"
-    },
-    optimization: {
-        sideEffects: false,
-    },
-    plugins: [
-        new Plugin()
-    ]
+	target: "web",
+	node: false,
+	entry: {
+		main: "./foo.js",
+		multi: ["./bar.js", "./baz.js"]
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		sideEffects: false
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/chunk-index/available-modules-order-index/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-index/available-modules-order-index/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	entry: {
 		main: "./main.js"
@@ -15,7 +15,7 @@ module.exports = {
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		}
 	},

--- a/packages/rspack-test-tools/tests/configCases/chunk-index/available-modules-order-index/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-index/available-modules-order-index/test.config.js
@@ -1,6 +1,14 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
 	findBundle: function (i, options) {
-		return ["A.css", "shared.css", "main.js", "A.js", "shared.js", "B.js", "B-2.js"];
+		return [
+			"A.css",
+			"shared.css",
+			"main.js",
+			"A.js",
+			"shared.js",
+			"B.js",
+			"B-2.js"
+		];
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-4800/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-4800/rspack.config.js
@@ -1,4 +1,2 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
-
-};
+module.exports = {};

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/worker-loader/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	target: "async-node"
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/chunks/module-order-index/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunks/module-order-index/rspack.config.js
@@ -2,22 +2,24 @@
 module.exports = {
 	target: "node",
 	entry: {
-		'main': './index.js'
+		main: "./index.js"
 	},
 	plugins: [
 		{
 			/**@param {import("@rspack/core").Compiler} compiler */
 			apply(compiler) {
-				compiler.hooks.thisCompilation.tap('test', (compilation) => {
-					compilation.hooks.afterSeal.tap('test', () => {
-						let entrypoint = compilation.entrypoints.get('main')
+				compiler.hooks.thisCompilation.tap("test", compilation => {
+					compilation.hooks.afterSeal.tap("test", () => {
+						let entrypoint = compilation.entrypoints.get("main");
 
-						compilation.chunkGraph.getChunkModules(entrypoint.chunks[0]).forEach((m) => {
-							expect(entrypoint.getModulePreOrderIndex(m)).toBeDefined();
-							expect(entrypoint.getModulePostOrderIndex(m)).toBeDefined();
-						})
-					})
-				})
+						compilation.chunkGraph
+							.getChunkModules(entrypoint.chunks[0])
+							.forEach(m => {
+								expect(entrypoint.getModulePreOrderIndex(m)).toBeDefined();
+								expect(entrypoint.getModulePostOrderIndex(m)).toBeDefined();
+							});
+					});
+				});
 			}
 		}
 	]

--- a/packages/rspack-test-tools/tests/configCases/cjs-tree-shaking/cjs-interop/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/cjs-tree-shaking/cjs-interop/rspack.config.js
@@ -3,5 +3,5 @@ module.exports = {
 	mode: "production",
 	optimization: {
 		minimize: false
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/cjs-tree-shaking/export-require-bailout/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/cjs-tree-shaking/export-require-bailout/rspack.config.js
@@ -3,5 +3,5 @@ module.exports = {
 	mode: "production",
 	optimization: {
 		sideEffects: true
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/cjs-tree-shaking/export-require-unused/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/cjs-tree-shaking/export-require-unused/rspack.config.js
@@ -2,5 +2,5 @@
 module.exports = {
 	optimization: {
 		usedExports: true
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/cjs-tree-shaking/rspack-issue-5282/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/cjs-tree-shaking/rspack-issue-5282/rspack.config.js
@@ -4,5 +4,5 @@ module.exports = {
 	optimization: {
 		minimize: false,
 		moduleIds: "named"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/clean/ignore-string/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/clean/ignore-string/rspack.config.js
@@ -5,38 +5,38 @@ const readDir = require("../enabled/readdir");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    clean: {
-      keep: "ignored/dir"
-    }
-  },
-  plugins: [
-    compiler => {
-      let once = true;
-      compiler.hooks.thisCompilation.tap("Test", compilation => {
-        compilation.hooks.processAssets.tap("Test", assets => {
-          if (once) {
-            const outputPath = compilation.getPath(compiler.outputPath, {});
-            const customDir = path.join(
-              outputPath,
-              "this/dir/should/be/removed"
-            );
-            const ignoredDir = path.join(
-              outputPath,
-              "this/is/ignored/dir/that/should/not/be/removed"
-            );
-            fs.mkdirSync(customDir, { recursive: true });
-            fs.writeFileSync(path.join(customDir, "file.ext"), "");
-            fs.mkdirSync(ignoredDir, { recursive: true });
-            fs.writeFileSync(path.join(ignoredDir, "file.ext"), "");
-            once = false;
-          }
-          assets["this/dir/should/not/be/removed/file.ext"] = new RawSource("");
-        });
-      });
-      compiler.hooks.afterEmit.tap("Test", compilation => {
-        const outputPath = compilation.getPath(compiler.outputPath, {});
-        expect(readDir(outputPath)).toMatchInlineSnapshot(`
+	output: {
+		clean: {
+			keep: "ignored/dir"
+		}
+	},
+	plugins: [
+		compiler => {
+			let once = true;
+			compiler.hooks.thisCompilation.tap("Test", compilation => {
+				compilation.hooks.processAssets.tap("Test", assets => {
+					if (once) {
+						const outputPath = compilation.getPath(compiler.outputPath, {});
+						const customDir = path.join(
+							outputPath,
+							"this/dir/should/be/removed"
+						);
+						const ignoredDir = path.join(
+							outputPath,
+							"this/is/ignored/dir/that/should/not/be/removed"
+						);
+						fs.mkdirSync(customDir, { recursive: true });
+						fs.writeFileSync(path.join(customDir, "file.ext"), "");
+						fs.mkdirSync(ignoredDir, { recursive: true });
+						fs.writeFileSync(path.join(ignoredDir, "file.ext"), "");
+						once = false;
+					}
+					assets["this/dir/should/not/be/removed/file.ext"] = new RawSource("");
+				});
+			});
+			compiler.hooks.afterEmit.tap("Test", compilation => {
+				const outputPath = compilation.getPath(compiler.outputPath, {});
+				expect(readDir(outputPath)).toMatchInlineSnapshot(`
 			Object {
 			  directories: Array [
 			    this,
@@ -52,7 +52,7 @@ module.exports = {
 			  ],
 			}
 		`);
-      });
-    }
-  ]
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/code-generation/path-ends-with-star/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/code-generation/path-ends-with-star/rspack.config.js
@@ -4,7 +4,7 @@ const entry = `it("should generate valid code", async () => {${
 	isWindows
 		? `expect("skip windows").toBe("skip windows");`
 		: `const { staticA, dynamicA } = await import("./entry.mjs"); expect(staticA.a).toBe(1); expect(dynamicA.a).toBe(1);`
-	}});`;
+}});`;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {

--- a/packages/rspack-test-tools/tests/configCases/compilation/add-include/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/add-include/rspack.config.js
@@ -4,75 +4,77 @@ const fs = require("fs");
 const PLUGIN_NAME = "plugin";
 
 class Plugin {
-    /**
-     * @param {import("@rspack/core").Compiler} compiler
-     */
-    apply(compiler) {
-        const { EntryPlugin } = compiler.webpack;
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		const { EntryPlugin } = compiler.webpack;
 
-        const modules = {};
-        compiler.hooks.finishMake.tapPromise(PLUGIN_NAME, compilation => {
-            const tasks = [];
-            tasks.push(
-                new Promise((resolve, reject) => {
-                    compilation.addInclude(
-                        compiler.context,
-                        EntryPlugin.createDependency(path.resolve(__dirname, "foo.js")),
-                        {},
-                        (err, module) => {
-                            if (err) {
-                                reject(err);
-                                return;
-                            }
-                            const exportsInfo = compilation.moduleGraph.getExportsInfo(module);
-                            exportsInfo.setUsedInUnknownWay("main");
-                            modules["foo"] = module;
-                            resolve(module);
-                        }
-                    );
-                })
-            );
-            tasks.push(
-                new Promise((resolve, reject) => {
-                    compilation.addInclude(
-                        compiler.context,
-                        EntryPlugin.createDependency(path.resolve(__dirname, "bar.js")),
-                        {},
-                        (err, module) => {
-                            if (err) {
-                                reject(err);
-                                return;
-                            }
-                            const exportsInfo = compilation.moduleGraph.getExportsInfo(module);
-                            exportsInfo.setUsedInUnknownWay("main");
-                            modules["bar"] = module;
-                            resolve(module);
-                        }
-                    );
-                })
-            );
-            return Promise.all(tasks);
-        });
+		const modules = {};
+		compiler.hooks.finishMake.tapPromise(PLUGIN_NAME, compilation => {
+			const tasks = [];
+			tasks.push(
+				new Promise((resolve, reject) => {
+					compilation.addInclude(
+						compiler.context,
+						EntryPlugin.createDependency(path.resolve(__dirname, "foo.js")),
+						{},
+						(err, module) => {
+							if (err) {
+								reject(err);
+								return;
+							}
+							const exportsInfo =
+								compilation.moduleGraph.getExportsInfo(module);
+							exportsInfo.setUsedInUnknownWay("main");
+							modules["foo"] = module;
+							resolve(module);
+						}
+					);
+				})
+			);
+			tasks.push(
+				new Promise((resolve, reject) => {
+					compilation.addInclude(
+						compiler.context,
+						EntryPlugin.createDependency(path.resolve(__dirname, "bar.js")),
+						{},
+						(err, module) => {
+							if (err) {
+								reject(err);
+								return;
+							}
+							const exportsInfo =
+								compilation.moduleGraph.getExportsInfo(module);
+							exportsInfo.setUsedInUnknownWay("main");
+							modules["bar"] = module;
+							resolve(module);
+						}
+					);
+				})
+			);
+			return Promise.all(tasks);
+		});
 
-        const manifest = {};
-        compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
-            compilation.hooks.processAssets.tap(PLUGIN_NAME, () => {
-                for (const [key, module] of Object.entries(modules)) {
-                    const moduleId = compilation.chunkGraph.getModuleId(module);
-                    manifest[key] = moduleId;
-                }
-                fs.writeFileSync(
-                    path.join(compiler.outputPath, "manifest.json"),
-                    JSON.stringify(manifest),
-                    "utf-8"
-                );
-            });
-        });
-    }
+		const manifest = {};
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.processAssets.tap(PLUGIN_NAME, () => {
+				for (const [key, module] of Object.entries(modules)) {
+					const moduleId = compilation.chunkGraph.getModuleId(module);
+					manifest[key] = moduleId;
+				}
+				fs.writeFileSync(
+					path.join(compiler.outputPath, "manifest.json"),
+					JSON.stringify(manifest),
+					"utf-8"
+				);
+			});
+		});
+	}
 }
 
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-    entry: "./index.js",
-    plugins: [new Plugin()]
+	entry: "./index.js",
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/compilation/entries/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/entries/rspack.config.js
@@ -1,35 +1,34 @@
 const PLUGIN_NAME = "plugin";
 
 class Plugin {
-    /**
-     * @param {import("@rspack/core").Compiler} compiler
-     */
-    apply(compiler) {
-        compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.seal.tap(PLUGIN_NAME, () => {
+				expect(Array.from(compilation.entries.keys())).toEqual(["main", "foo"]);
 
-            compilation.hooks.seal.tap(PLUGIN_NAME, () => {
-                expect(Array.from(compilation.entries.keys())).toEqual(["main", "foo"]);
+				const entry = compilation.entries.get("foo");
+				expect(entry.dependencies.length).toEqual(1);
+				expect(entry.options.asyncChunks).toEqual(true);
 
-                const entry = compilation.entries.get("foo");
-                expect(entry.dependencies.length).toEqual(1);
-                expect(entry.options.asyncChunks).toEqual(true);
-
-                compilation.entries.delete("foo");
-            })
-        });
-    }
+				compilation.entries.delete("foo");
+			});
+		});
+	}
 }
 
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-    entry: {
-        main: {
-            import: "./index.js",
-        },
-        foo: {
-            import: "./foo.js",
-            asyncChunks: true
-        }
-    },
-    plugins: [new Plugin()]
+	entry: {
+		main: {
+			import: "./index.js"
+		},
+		foo: {
+			import: "./foo.js",
+			asyncChunks: true
+		}
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/compilation/module-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/module-modules/rspack.config.js
@@ -1,30 +1,28 @@
 const PLUGIN_NAME = "plugin";
 
 class Plugin {
-    /**
-     * @param {import("@rspack/core").Compiler} compiler
-     */
-    apply(compiler) {
-        compiler.hooks.make.tap(PLUGIN_NAME, (compilation) => {
-            compilation.hooks.processAssets.tap(
-                PLUGIN_NAME,
-                () => {
-                    const entrypoint = Array.from(compilation.entrypoints.values())[0];
-                    const entrypointChunk = entrypoint.chunks[0];
-                    const entrypointModule = compilation.chunkGraph.getChunkModules(entrypointChunk)[0];
-                    expect(entrypointModule.modules[0].rawRequest).toBe("./foo");
-                    expect(entrypointModule.modules[1].rawRequest).toBe("./index.js");
-                }
-            )
-        });
-    }
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.make.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.processAssets.tap(PLUGIN_NAME, () => {
+				const entrypoint = Array.from(compilation.entrypoints.values())[0];
+				const entrypointChunk = entrypoint.chunks[0];
+				const entrypointModule =
+					compilation.chunkGraph.getChunkModules(entrypointChunk)[0];
+				expect(entrypointModule.modules[0].rawRequest).toBe("./foo");
+				expect(entrypointModule.modules[1].rawRequest).toBe("./index.js");
+			});
+		});
+	}
 }
 
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-    entry: "./index.js",
-    plugins: [new Plugin()],
-    optimization: {
-        concatenateModules: true,
-    }
+	entry: "./index.js",
+	plugins: [new Plugin()],
+	optimization: {
+		concatenateModules: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/compilation/modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/modules/rspack.config.js
@@ -3,30 +3,32 @@ const { rspack } = require("@rspack/core");
 const PLUGIN_NAME = "plugin";
 
 class Plugin {
-    /**
-     * @param {import("@rspack/core").Compiler} compiler
-     */
-    apply(compiler) {
-        compiler.hooks.make.tap(PLUGIN_NAME, (compilation) => {
-            compilation.hooks.processAssets.tap(
-                {
-                    name: PLUGIN_NAME,
-                    stage: rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
-                },
-                () => {
-                    const module = Array.from(compilation.modules).find(module => module.rawRequest === "./index.js");
-                    const block = module.blocks[0];
-                    const dependency = module.dependencies[0];
-                    expect(block.dependencies[0].request).toBe("./a");
-                    expect(dependency.request).toBe("./b");
-                }
-            )
-        });
-    }
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.make.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: PLUGIN_NAME,
+					stage: rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+				},
+				() => {
+					const module = Array.from(compilation.modules).find(
+						module => module.rawRequest === "./index.js"
+					);
+					const block = module.blocks[0];
+					const dependency = module.dependencies[0];
+					expect(block.dependencies[0].request).toBe("./a");
+					expect(dependency.request).toBe("./b");
+				}
+			);
+		});
+	}
 }
 
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-    entry: "./index.js",
-    plugins: [new Plugin()]
+	entry: "./index.js",
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module/rspack.config.js
@@ -5,7 +5,7 @@ class Plugin {
 		let initial = true;
 		compiler.hooks.compilation.tap(pluginName, compilation => {
 			compilation.hooks.finishModules.tapPromise(pluginName, async modules => {
-				modules = [...modules]
+				modules = [...modules];
 				const oldModule = modules.find(item => item.resource.endsWith("a.js"));
 				if (!oldModule) {
 					throw new Error("module not found");
@@ -13,9 +13,9 @@ class Plugin {
 				if (initial) {
 					initial = false;
 
-					expect(
-						oldModule.originalSource().source().includes("a = 1")
-					).toBe(true);
+					expect(oldModule.originalSource().source().includes("a = 1")).toBe(
+						true
+					);
 
 					const newModule = await new Promise((res, rej) => {
 						compilation.rebuildModule(oldModule, function (err, m) {
@@ -27,9 +27,9 @@ class Plugin {
 						});
 					});
 
-					expect(
-						newModule.originalSource().source().includes("a = 2")
-					).toBe(true);
+					expect(newModule.originalSource().source().includes("a = 2")).toBe(
+						true
+					);
 				}
 			});
 		});

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/rspack.config.js
@@ -1,47 +1,49 @@
 let firstChunkAsset = null;
 
 class CheckAssetPlugin {
-  apply(compiler) {
-    compiler.hooks.thisCompilation.tap("TestPlugin", compilation => {
-      compilation.hooks.afterProcessAssets.tap("TestPlugin", assets => {
-        const chunkAsset = Object.keys(assets).find(asset => asset.startsWith("chunk."));
-        if (!chunkAsset) {
-          throw new Error("chunk asset not found");
-        }
-        if (firstChunkAsset === null) {
-          firstChunkAsset = chunkAsset;
-        } else {
-          expect(firstChunkAsset).not.toEqual(chunkAsset);
-        }
-      });
-    });
-  }
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap("TestPlugin", compilation => {
+			compilation.hooks.afterProcessAssets.tap("TestPlugin", assets => {
+				const chunkAsset = Object.keys(assets).find(asset =>
+					asset.startsWith("chunk.")
+				);
+				if (!chunkAsset) {
+					throw new Error("chunk asset not found");
+				}
+				if (firstChunkAsset === null) {
+					firstChunkAsset = chunkAsset;
+				} else {
+					expect(firstChunkAsset).not.toEqual(chunkAsset);
+				}
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = [
-  {
-    mode: "production",
-    entry: "./main.js",
-    output: {
-      chunkFilename: "chunk.[chunkhash].js",
-    },
-    optimization: {
-      concatenateModules: true,
-      minimize: false
-    },
-    plugins: [new CheckAssetPlugin()]
-  },
-  {
-    mode: "production",
-    entry: "./main.js",
-    output: {
-      chunkFilename: "chunk.[chunkhash].js",
-    },
-    optimization: {
-      concatenateModules: true,
-      minimize: false
-    },
-    plugins: [new CheckAssetPlugin()]
-  }
+	{
+		mode: "production",
+		entry: "./main.js",
+		output: {
+			chunkFilename: "chunk.[chunkhash].js"
+		},
+		optimization: {
+			concatenateModules: true,
+			minimize: false
+		},
+		plugins: [new CheckAssetPlugin()]
+	},
+	{
+		mode: "production",
+		entry: "./main.js",
+		output: {
+			chunkFilename: "chunk.[chunkhash].js"
+		},
+		optimization: {
+			concatenateModules: true,
+			minimize: false
+		},
+		plugins: [new CheckAssetPlugin()]
+	}
 ];

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consume-shared/rspack.config.js
@@ -1,16 +1,16 @@
-const { rspack } = require("@rspack/core")
+const { rspack } = require("@rspack/core");
 
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	optimization: {
-		concatenateModules: true,
+		concatenateModules: true
 	},
 	plugins: [
 		new rspack.sharing.ConsumeSharedPlugin({
 			consumes: {
 				"./lib/c.js": {
 					singleton: true,
-					eager: true,
+					eager: true
 				}
 			}
 		})

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/dynamic-cjs/rspack.config.js
@@ -1,6 +1,6 @@
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	optimization: {
-		concatenateModules: true,
-	},
+		concatenateModules: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/rspack.config.js
@@ -1,13 +1,13 @@
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-  mode: "development",
-  entry: {
-    main: "./index.js"
-  },
-  optimization: {
-    providedExports: true,
-    usedExports: true,
-    concatenateModules: true,
-    minimize: false
-  },
+	mode: "development",
+	entry: {
+		main: "./index.js"
+	},
+	optimization: {
+		providedExports: true,
+		usedExports: true,
+		concatenateModules: true,
+		minimize: false
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/require-null/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/require-null/rspack.config.js
@@ -1,26 +1,26 @@
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-  mode: "production",
-  entry: "./index.js",
-  output: {
-    filename: "[name].js",
-  },
-  target: "node",
-  optimization: {
-    providedExports: true,
-    usedExports: true,
-    concatenateModules: true,
-    sideEffects: true,
-    minimize: false,
-    splitChunks: {
-      cacheGroups: {
-        lib: {
-          name: "lib",
-          chunks: "all",
-          test: /[\\/]lib[\\/]/,
-          minSize: 0,
-        }
-      }
-    }
-  },
+	mode: "production",
+	entry: "./index.js",
+	output: {
+		filename: "[name].js"
+	},
+	target: "node",
+	optimization: {
+		providedExports: true,
+		usedExports: true,
+		concatenateModules: true,
+		sideEffects: true,
+		minimize: false,
+		splitChunks: {
+			cacheGroups: {
+				lib: {
+					name: "lib",
+					chunks: "all",
+					test: /[\\/]lib[\\/]/,
+					minSize: 0
+				}
+			}
+		}
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-condition/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-condition/rspack.config.js
@@ -1,12 +1,12 @@
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-	mode: 'production',
+	mode: "production",
 	entry: {
-		a: './a.js',
-		b: './b.js',
+		a: "./a.js",
+		b: "./b.js"
 	},
 	output: {
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	module: {
 		rules: [
@@ -22,15 +22,15 @@ module.exports = {
 		usedExports: true,
 		innerGraph: true,
 		splitChunks: {
-			chunks: 'all',
+			chunks: "all",
 			minSize: 0,
 			cacheGroups: {
 				shared: {
 					test: /(shared|utils|value)/,
-					name: 'shared',
+					name: "shared",
 					enforce: true
 				}
 			}
 		}
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-condition/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-condition/test.config.js
@@ -1,9 +1,5 @@
 /** @type {import("../../../../dist").TDiffCaseConfig} */
 module.exports = {
 	modules: true,
-	files: [
-		'shared.js',
-		'a.js',
-		'b.js',
-	],
+	files: ["shared.js", "a.js", "b.js"]
 };

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/with-css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/with-css/rspack.config.js
@@ -14,7 +14,7 @@ module.exports = {
 				test: /\.css$/,
 				type: "css/module",
 				parser: {
-					namedExports: false,
+					namedExports: false
 				},
 				generator: {
 					exportsOnly: true,
@@ -24,6 +24,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		css: true,
+		css: true
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/container-1-0/environment-es5/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-0/environment-es5/rspack.config.js
@@ -1,16 +1,17 @@
-const { ModuleFederationPluginV1: ModuleFederationPlugin } = require("@rspack/core").container;
+const { ModuleFederationPluginV1: ModuleFederationPlugin } =
+	require("@rspack/core").container;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    filename: "[name].js"
-  },
+	output: {
+		filename: "[name].js"
+	},
 	mode: "development",
 	target: ["async-node", "es5"],
 	plugins: [
 		new ModuleFederationPlugin({
 			name: "A",
-      filename: "container-a.js",
+			filename: "container-a.js",
 			library: {
 				type: "commonjs-module"
 			},
@@ -19,8 +20,8 @@ module.exports = {
 			},
 			remoteType: "commonjs-module",
 			remotes: {
-        "A": "./container-a.js",
+				A: "./container-a.js"
 			}
-		}),
+		})
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/container-1-0/init-sharing-without-config/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-0/init-sharing-without-config/rspack.config.js
@@ -1,8 +1,7 @@
-const { ModuleFederationPluginV1: ModuleFederationPlugin } = require("@rspack/core").container;
+const { ModuleFederationPluginV1: ModuleFederationPlugin } =
+	require("@rspack/core").container;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	plugins: [
-		new ModuleFederationPlugin({}),
-	]
+	plugins: [new ModuleFederationPlugin({})]
 };

--- a/packages/rspack-test-tools/tests/configCases/container-1-0/multi-container-same-runtime/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-0/multi-container-same-runtime/rspack.config.js
@@ -1,17 +1,18 @@
-const { ContainerPlugin, ContainerReferencePlugin } = require("@rspack/core").container;
+const { ContainerPlugin, ContainerReferencePlugin } =
+	require("@rspack/core").container;
 
 const RUNTIME = "container-runtime";
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    filename: "[name].js"
-  },
+	output: {
+		filename: "[name].js"
+	},
 	plugins: [
 		new ContainerPlugin({
 			name: "A",
-      runtime: RUNTIME,
-      filename: "container-a.js",
+			runtime: RUNTIME,
+			filename: "container-a.js",
 			library: {
 				type: "commonjs-module"
 			},
@@ -21,8 +22,8 @@ module.exports = {
 		}),
 		new ContainerPlugin({
 			name: "B",
-      runtime: RUNTIME,
-      filename: "container-b.js",
+			runtime: RUNTIME,
+			filename: "container-b.js",
 			library: {
 				type: "commonjs-module"
 			},
@@ -30,12 +31,12 @@ module.exports = {
 				".": "./b"
 			}
 		}),
-    new ContainerReferencePlugin({
+		new ContainerReferencePlugin({
 			remoteType: "commonjs-module",
-      remotes: {
-        "A": "./container-a.js",
-        "B": "./container-b.js",
-      }
-    })
+			remotes: {
+				A: "./container-a.js",
+				B: "./container-b.js"
+			}
+		})
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/container-1-0/runtime-chunk-single/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-0/runtime-chunk-single/rspack.config.js
@@ -1,18 +1,19 @@
-const { ModuleFederationPluginV1: ModuleFederationPlugin } = require("@rspack/core").container;
+const { ModuleFederationPluginV1: ModuleFederationPlugin } =
+	require("@rspack/core").container;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    filename: "[name].js"
-  },
+	output: {
+		filename: "[name].js"
+	},
 	mode: "development",
 	optimization: {
-		runtimeChunk: "single",
+		runtimeChunk: "single"
 	},
 	plugins: [
 		new ModuleFederationPlugin({
 			name: "A",
-      filename: "container-a.js",
+			filename: "container-a.js",
 			library: {
 				type: "commonjs-module"
 			},
@@ -21,8 +22,8 @@ module.exports = {
 			},
 			remoteType: "commonjs-module",
 			remotes: {
-        "A": "./container-a.js",
+				A: "./container-a.js"
 			}
-		}),
+		})
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/0-container-full/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/0-container-full/rspack.config.js
@@ -38,7 +38,7 @@ module.exports = [
 	},
 	{
 		experiments: {
-			outputModule: true,
+			outputModule: true
 		},
 		output: {
 			filename: "module/[name].mjs",

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/1-container-full/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/1-container-full/rspack.config.js
@@ -44,7 +44,7 @@ module.exports = [
 	{
 		...common,
 		experiments: {
-			outputModule: true,
+			outputModule: true
 		},
 		output: {
 			filename: "module/[name].mjs",

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/2-transitive-overriding/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/2-transitive-overriding/rspack.config.js
@@ -5,7 +5,7 @@ module.exports = {
 	optimization: {
 		chunkIds: "named",
 		moduleIds: "named",
-		concatenateModules: false,
+		concatenateModules: false
 	},
 	output: {
 		uniqueName: "2-transitive-overriding"

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/chunk-matcher/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/chunk-matcher/rspack.config.js
@@ -5,7 +5,7 @@ const common = {
 	entry: {
 		main: "./index.js"
 	},
-	target: 'async-node',
+	target: "async-node",
 	optimization: {
 		runtimeChunk: "single"
 	}
@@ -33,10 +33,10 @@ module.exports = [
 			new ModuleFederationPlugin({
 				name: "container",
 				library: { type: "commonjs-module" },
-				runtimePlugins: [require.resolve('./runtimePlugin.js')],
+				runtimePlugins: [require.resolve("./runtimePlugin.js")],
 				filename: "container.js",
 				remotes: {
-					containerA: "../0-container-full/container.js",
+					containerA: "../0-container-full/container.js"
 				},
 				...commonMF
 			})

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/federation-instance-in-runtime-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/federation-instance-in-runtime-plugin/rspack.config.js
@@ -4,7 +4,7 @@ const { ModuleFederationPlugin } = require("@rspack/core").container;
 module.exports = {
 	optimization: {
 		// concatenateModules: false,
-		moduleIds: 'named'
+		moduleIds: "named"
 	},
 	plugins: [
 		new ModuleFederationPlugin({

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/module-federation-with-shareScope/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/module-federation-with-shareScope/rspack.config.js
@@ -6,7 +6,7 @@ const common = {
 	},
 	optimization: {
 		runtimeChunk: "single"
-	},
+	}
 };
 
 /** @type {ConstructorParameters<typeof ModuleFederationPlugin>[0]} */

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/provide-sharing-extra-data/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/provide-sharing-extra-data/rspack.config.js
@@ -15,7 +15,7 @@ module.exports = {
 					requiredVersion: false,
 					singleton: true,
 					strictVersion: false,
-					version: "0.1.2",
+					version: "0.1.2"
 				}
 			}
 		})

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/share-strategy/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/share-strategy/rspack.config.js
@@ -8,14 +8,14 @@ module.exports = {
 	},
 	plugins: [
 		new ModuleFederationPlugin({
-			shareStrategy:'loaded-first',
+			shareStrategy: "loaded-first",
 			shared: {
 				react: {
 					version: false,
 					requiredVersion: false,
 					singleton: true,
 					strictVersion: false,
-					version: "0.1.2",
+					version: "0.1.2"
 				}
 			}
 		})

--- a/packages/rspack-test-tools/tests/configCases/context-module/critical-warning/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/context-module/critical-warning/rspack.config.js
@@ -1,11 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  module: {
-    parser: {
-      javascript: {
-        exprContextCritical: true,
-        wrappedContextCritical: true,
-      }
-    }
-  },
-}
+	module: {
+		parser: {
+			javascript: {
+				exprContextCritical: true,
+				wrappedContextCritical: true
+			}
+		}
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/context-module/without-extension/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/context-module/without-extension/rspack.config.js
@@ -1,15 +1,12 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  plugins: [
-    function(compiler) {
-      compiler.hooks.contextModuleFactory.tap(
-        "test",
-        contextModuleFactory => {
-          contextModuleFactory.hooks.afterResolve.tap("test", resolveData => {
-            // do nothing
-          });
-        }
-      );
-    }
-  ]
-}
+	plugins: [
+		function (compiler) {
+			compiler.hooks.contextModuleFactory.tap("test", contextModuleFactory => {
+				contextModuleFactory.hooks.afterResolve.tap("test", resolveData => {
+					// do nothing
+				});
+			});
+		}
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/context-module/wrapped-context-reg-exp/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/context-module/wrapped-context-reg-exp/rspack.config.js
@@ -1,11 +1,10 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	module: {
-	  parser: {
-		javascript: {
-		  wrappedContextRegExp: /.*1/,
+		parser: {
+			javascript: {
+				wrappedContextRegExp: /.*1/
+			}
 		}
-	  }
-	},
-  }
-  
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/context/context-module-cjs-require-binary-expression/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/context/context-module-cjs-require-binary-expression/rspack.config.js
@@ -1,4 +1,2 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
-
-};
+module.exports = {};

--- a/packages/rspack-test-tools/tests/configCases/css-loader/css-modules-classname/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css-loader/css-modules-classname/rspack.config.js
@@ -15,7 +15,7 @@ module.exports = {
 							modules: {
 								namedExport: false,
 								localIdentName: "[name]__[local]--[contenthash]",
-								exportLocalsConvention: 'camel-case',
+								exportLocalsConvention: "camel-case"
 							}
 						}
 					}

--- a/packages/rspack-test-tools/tests/configCases/css/at-import-in-the-top/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/at-import-in-the-top/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	entry: {
 		main: "./index.js"
@@ -8,7 +8,7 @@ module.exports = {
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		}
 	},

--- a/packages/rspack-test-tools/tests/configCases/css/css-cross-origin-loading-use-credentials/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/css-cross-origin-loading-use-credentials/rspack.config.js
@@ -1,19 +1,19 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    crossOriginLoading: "use-credentials",
-  },
-  entry: "./index.js",
-  target: "web",
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        type: "css/module"
-      }
-    ]
-  },
-  experiments: {
-    css: true
-  },
+	output: {
+		crossOriginLoading: "use-credentials"
+	},
+	entry: "./index.js",
+	target: "web",
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				type: "css/module"
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/css/css-cross-origin-loading/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/css-cross-origin-loading/rspack.config.js
@@ -1,19 +1,19 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    crossOriginLoading: "anonymous",
-  },
-  entry: "./index.js",
-  target: "web",
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        type: "css/module"
-      }
-    ]
-  },
-  experiments: {
-    css: true
-  },
+	output: {
+		crossOriginLoading: "anonymous"
+	},
+	entry: "./index.js",
+	target: "web",
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				type: "css/module"
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/css/css-modules-animation/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/css-modules-animation/rspack.config.js
@@ -2,7 +2,7 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: {
 		__dirname: false,
 		__filename: false
@@ -16,11 +16,9 @@ module.exports = {
 	},
 	optimization: {
 		minimize: true,
-		minimizer: [
-			new rspack.LightningCssMinimizerRspackPlugin(),
-		],
+		minimizer: [new rspack.LightningCssMinimizerRspackPlugin()],
 		providedExports: true,
-		usedExports: true,
+		usedExports: true
 	},
 	experiments: {
 		css: true

--- a/packages/rspack-test-tools/tests/configCases/css/css-modules-animation/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/css-modules-animation/test.config.js
@@ -1,9 +1,6 @@
 module.exports = {
-	documentType: 'fake',
+	documentType: "fake",
 	findBundle() {
-		return [
-			'bundle0.css',
-			'bundle0.js',
-		]
+		return ["bundle0.css", "bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/css-modules-composes-same-ident/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/css-modules-composes-same-ident/rspack.config.js
@@ -8,6 +8,6 @@ module.exports = {
 		}
 	},
 	experiments: {
-		css: true,
+		css: true
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/css/deep-dir-local-path/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/deep-dir-local-path/rspack.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	module: {
 		generator: {
 			"css/auto": {
-				localIdentName: "[path][name]-[local]",
+				localIdentName: "[path][name]-[local]"
 			}
 		}
 	},

--- a/packages/rspack-test-tools/tests/configCases/css/escape-ident/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/escape-ident/rspack.config.js
@@ -5,10 +5,10 @@ module.exports = {
 	},
 	module: {
 		generator: {
-			'css/auto': {
+			"css/auto": {
 				exportsOnly: false,
-				localIdentName: '[local]-[path]'
+				localIdentName: "[local]-[path]"
 			}
 		}
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/css/escape-ident/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/escape-ident/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['bundle0.js']
+		return ["bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/export-selector/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/export-selector/rspack.config.js
@@ -1,16 +1,16 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
 	module: {
 		generator: {
-			'css/auto': {
-				exportsConvention: 'camel-case-only',
-				localIdentName: '[local]',
-				exportsOnly: false,
+			"css/auto": {
+				exportsConvention: "camel-case-only",
+				localIdentName: "[local]",
+				exportsOnly: false
 			}
 		}
 	},

--- a/packages/rspack-test-tools/tests/configCases/css/export-selector/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/export-selector/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	documentType: 'fake',
+	documentType: "fake",
 	moduleScope(scope) {
 		const link1 = scope.window.document.createElement("link");
 		link1.rel = "stylesheet";
@@ -16,4 +16,4 @@ module.exports = {
 		link3.href = "style_module_css.bundle0.css";
 		scope.window.document.head.appendChild(link3);
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/exports-convention-prod/webpack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/exports-convention-prod/webpack.config.js
@@ -6,9 +6,9 @@ const common = {
 	},
 	module: {
 		generator: {
-			'css/module': {
+			"css/module": {
 				exportsOnly: true,
-				esModule: false,
+				esModule: false
 			}
 		},
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/css/minify-lightning-css-remove-unused-local-idents/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/minify-lightning-css-remove-unused-local-idents/rspack.config.js
@@ -2,7 +2,7 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 const common = {
-	target: 'web',
+	target: "web",
 	node: {
 		__dirname: false,
 		__filename: false
@@ -11,15 +11,13 @@ const common = {
 		generator: {
 			"css/auto": {
 				localIdentName: "[path][name]-[local]",
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		}
 	},
 	optimization: {
 		minimize: true,
-		minimizer: [
-			new rspack.LightningCssMinimizerRspackPlugin(),
-		]
+		minimizer: [new rspack.LightningCssMinimizerRspackPlugin()]
 	},
 	experiments: {
 		css: true
@@ -46,16 +44,14 @@ module.exports = [
 			generator: {
 				"css/auto": {
 					localIdentName: "[path][name]-[local]",
-					exportsOnly: true,
+					exportsOnly: true
 				}
 			}
 		},
 		optimization: {
 			minimize: true,
 			concatenateModules: true,
-			minimizer: [
-				new rspack.LightningCssMinimizerRspackPlugin(),
-			]
-		},
+			minimizer: [new rspack.LightningCssMinimizerRspackPlugin()]
+		}
 	}
-]
+];

--- a/packages/rspack-test-tools/tests/configCases/css/minify-lightning-css-remove-unused-local-idents/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/minify-lightning-css-remove-unused-local-idents/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['bundle0.css', 'bundle0.js']
-	},
-}
+		return ["bundle0.css", "bundle0.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/override-exports/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/override-exports/rspack.config.js
@@ -1,10 +1,10 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	mode: "development",
-	target: 'web',
+	target: "web",
 	module: {
 		generator: {
-			'css/auto': {
+			"css/auto": {
 				exportsOnly: false
 			}
 		}

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-auto-public-path/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-auto-public-path/rspack.config.js
@@ -2,11 +2,11 @@ const { RawSource, ConcatSource } = require("webpack-sources");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
 	entry: {
 		main: "./index.js"
 	},
@@ -22,7 +22,7 @@ node: {
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-auto-public-path/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-auto-public-path/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['css/main.css', 'bundle0.js']
-	},
-}
+		return ["css/main.css", "bundle0.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-css-variables/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-css-variables/rspack.config.js
@@ -1,14 +1,14 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-css-variables/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-css-variables/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['bundle0.css', 'bundle0.js']
-	},
-}
+		return ["bundle0.css", "bundle0.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-rule-public-path/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-rule-public-path/rspack.config.js
@@ -1,17 +1,17 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
 	output: {
 		publicPath: "auto"
 	},
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-rule-public-path/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-rule-public-path/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['bundle0.css', 'bundle0.js']
-	},
-}
+		return ["bundle0.css", "bundle0.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-with-css-filename/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-with-css-filename/rspack.config.js
@@ -1,10 +1,10 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
 	output: {
 		publicPath: "/",
 		cssFilename: "css/[name].css"
@@ -17,7 +17,7 @@ node: {
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-with-css-filename/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-with-css-filename/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['css/main.css', 'bundle0.js']
-	},
-}
+		return ["css/main.css", "bundle0.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-with-data-url/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-with-data-url/rspack.config.js
@@ -1,10 +1,10 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
 	output: {
 		cssFilename: "css/[name].css"
 	},
@@ -12,7 +12,7 @@ node: {
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url-with-data-url/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url-with-data-url/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['css/main.css', 'bundle0.js']
-	},
-}
+		return ["css/main.css", "bundle0.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url/rspack.config.js
@@ -1,18 +1,18 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
+	target: "web",
 	node: {
 		__dirname: false,
-		__filename: false,
+		__filename: false
+	},
+	node: {
+		__dirname: false,
+		__filename: false
 	},
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/css/rewrite-url/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rewrite-url/test.config.js
@@ -1,9 +1,6 @@
 module.exports = {
-	documentType: 'fake',
+	documentType: "fake",
 	findBundle() {
-		return [
-			'bundle0.css',
-			'bundle0.js',
-		]
+		return ["bundle0.css", "bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/rspack-issue-4258/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rspack-issue-4258/rspack.config.js
@@ -1,14 +1,14 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		}
 	},

--- a/packages/rspack-test-tools/tests/configCases/css/rspack-issue-4258/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rspack-issue-4258/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['bundle0.css', 'bundle0.js']
-	},
-}
+		return ["bundle0.css", "bundle0.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/rspack-issue-4844/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rspack-issue-4844/rspack.config.js
@@ -11,11 +11,11 @@ module.exports = {
 		generator: {
 			"css/auto": {
 				exportsConvention: "camel-case",
-				exportsOnly: true,
+				exportsOnly: true
 			}
 		}
 	},
 	experiments: {
 		css: true
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/css/rspack-issue-6435-xxhash64/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rspack-issue-6435-xxhash64/rspack.config.js
@@ -2,45 +2,45 @@ const path = require("path");
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
-  mode: "development",
-  entry: "./index.js",
-  output: {
-    hashFunction: "xxhash64",
-    cssFilename: "main.css"
-  },
-  module: {
-    parser: {
-      "css/auto": {
-        namedExports: true,
-      },
-    },
-    generator: {
-      "css/auto": {
-        exportsConvention: "as-is",
-        localIdentName: "[hash]-[local]",
-      },
-    },
-    rules: [
-      {
-        include: path.resolve(__dirname, "legacy"),
-        test: /\.css$/,
-        type: "css/module",
-        parser: {
-          namedExports: false,
-        },
-        generator: {
-          exportsConvention: "camel-case",
-          localIdentName: "[hash]-[local]",
-        }
-      },
-    ]
-  },
-  experiments: {
-    css: true,
-  }
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	mode: "development",
+	entry: "./index.js",
+	output: {
+		hashFunction: "xxhash64",
+		cssFilename: "main.css"
+	},
+	module: {
+		parser: {
+			"css/auto": {
+				namedExports: true
+			}
+		},
+		generator: {
+			"css/auto": {
+				exportsConvention: "as-is",
+				localIdentName: "[hash]-[local]"
+			}
+		},
+		rules: [
+			{
+				include: path.resolve(__dirname, "legacy"),
+				test: /\.css$/,
+				type: "css/module",
+				parser: {
+					namedExports: false
+				},
+				generator: {
+					exportsConvention: "camel-case",
+					localIdentName: "[hash]-[local]"
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/css/rspack-issue-6435/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rspack-issue-6435/rspack.config.js
@@ -2,41 +2,41 @@ const path = require("path");
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
-  mode: "development",
-  entry: "./index.js",
-  output: {
-    hashFunction: "md4",
-    hashDigestLength: 20,
-  },
-  module: {
-    parser: {
-      "css/auto": {
-        namedExports: true,
-      },
-    },
-    generator: {
-      "css/auto": {
-        exportsConvention: "as-is",
-        localIdentName: "[hash]-[local]",
+	mode: "development",
+	entry: "./index.js",
+	output: {
+		hashFunction: "md4",
+		hashDigestLength: 20
+	},
+	module: {
+		parser: {
+			"css/auto": {
+				namedExports: true
+			}
+		},
+		generator: {
+			"css/auto": {
+				exportsConvention: "as-is",
+				localIdentName: "[hash]-[local]",
 				exportsOnly: true
-      },
-    },
-    rules: [
-      {
-        include: path.resolve(__dirname, "legacy"),
-        test: /\.css$/,
-        type: "css/module",
-        parser: {
-          namedExports: false,
-        },
-        generator: {
-          exportsConvention: "camel-case",
-          localIdentName: "[hash]-[local]",
-        }
-      },
-    ]
-  },
-  experiments: {
-    css: true,
-  }
+			}
+		},
+		rules: [
+			{
+				include: path.resolve(__dirname, "legacy"),
+				test: /\.css$/,
+				type: "css/module",
+				parser: {
+					namedExports: false
+				},
+				generator: {
+					exportsConvention: "camel-case",
+					localIdentName: "[hash]-[local]"
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/css/urls/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/urls/rspack.config.js
@@ -3,15 +3,15 @@ module.exports = {
 	output: {
 		cssChunkFilename: "bundle.css"
 	},
-	target: 'web',
-node: {
-  __dirname: false,
-  __filename: false
-},
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		}
 	}

--- a/packages/rspack-test-tools/tests/configCases/dependency/ids/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/dependency/ids/rspack.config.js
@@ -1,24 +1,24 @@
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.compilation.tap("Test", compilation => {
-            compilation.hooks.finishModules.tap("Test", () => {
-                const entry = compilation.entries.get("main");
-                const entryDependency = entry.dependencies[0];
-                const entryModule = compilation.moduleGraph.getModule(entryDependency);
-                const esmImportSpecifierDependency = entryModule.dependencies.find(d => d.type === "esm import specifier");
-                expect(esmImportSpecifierDependency.ids).toContain("foo");
-            });
-        });
-    }
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", compilation => {
+			compilation.hooks.finishModules.tap("Test", () => {
+				const entry = compilation.entries.get("main");
+				const entryDependency = entry.dependencies[0];
+				const entryModule = compilation.moduleGraph.getModule(entryDependency);
+				const esmImportSpecifierDependency = entryModule.dependencies.find(
+					d => d.type === "esm import specifier"
+				);
+				expect(esmImportSpecifierDependency.ids).toContain("foo");
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    entry: './index.js',
-    optimization: {
-        sideEffects: false,
-    },
-    plugins: [
-        new Plugin()
-    ]
+	entry: "./index.js",
+	optimization: {
+		sideEffects: false
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/dll/no-warning-for-cjs/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/dll/no-warning-for-cjs/rspack.config.js
@@ -1,37 +1,40 @@
 const rspack = require("@rspack/core");
 const path = require("path");
 
-const dllManifest = path.resolve(__dirname, "../../../js/config/dll/no-warning-for-cjs/manifest.json");
+const dllManifest = path.resolve(
+	__dirname,
+	"../../../js/config/dll/no-warning-for-cjs/manifest.json"
+);
 
 /** @type {import("@rspack/core").Configuration[]} */
 module.exports = [
-  {
-    name: "create-dll",
-    entry: "./lib.js",
-    output: {
-      filename: "lib-dll.js",
-      library: {
-        type: "commonjs2",
-      },
-    },
-    plugins: [
-      new rspack.DllPlugin({
-        path: dllManifest,
-        entryOnly: false,
-      })
-    ]
-  },
-  {
-    name: "use-dll",
-    dependencies: ["create-dll"],
-    entry: "./main.js",
-    plugins: [
-      new rspack.DllReferencePlugin({
-        manifest: dllManifest,
-        sourceType: "commonjs2",
-        scope: "dll",
-        name: "./lib-dll.js",
-      }),
-    ]
-  }
-]
+	{
+		name: "create-dll",
+		entry: "./lib.js",
+		output: {
+			filename: "lib-dll.js",
+			library: {
+				type: "commonjs2"
+			}
+		},
+		plugins: [
+			new rspack.DllPlugin({
+				path: dllManifest,
+				entryOnly: false
+			})
+		]
+	},
+	{
+		name: "use-dll",
+		dependencies: ["create-dll"],
+		entry: "./main.js",
+		plugins: [
+			new rspack.DllReferencePlugin({
+				manifest: dllManifest,
+				sourceType: "commonjs2",
+				scope: "dll",
+				name: "./lib-dll.js"
+			})
+		]
+	}
+];

--- a/packages/rspack-test-tools/tests/configCases/dll/numeric-module-id/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/dll/numeric-module-id/rspack.config.js
@@ -1,45 +1,48 @@
 const rspack = require("@rspack/core");
 const path = require("path");
 
-const dllManifest = path.resolve(__dirname, "../../../js/config/dll/numeric-module-id/manifest.json");
+const dllManifest = path.resolve(
+	__dirname,
+	"../../../js/config/dll/numeric-module-id/manifest.json"
+);
 
 /** @type {import("@rspack/core").Configuration[]} */
 module.exports = [
-  {
-    name: "create-dll",
-    entry: "./lib.js",
-    output: {
-      filename: "lib-dll.js",
-      library: {
-        type: "commonjs2",
-      },
-    },
-    optimization: {
-      moduleIds: 'deterministic',
-      chunkIds: 'deterministic',
-    },
-    plugins: [
-      new rspack.DllPlugin({
-        path: dllManifest,
-        entryOnly: false,
-      }),
-    ]
-  },
-  {
-    name: "use-dll",
-    dependencies: ["create-dll"],
-    entry: "./main.js",
-    plugins: [
-      function (compiler) {
-        compiler.hooks.beforeRun.tap('test', () => {
-          new rspack.DllReferencePlugin({
-            manifest: require(dllManifest),
-            sourceType: "commonjs2",
-            scope: "dll",
-            name: "./lib-dll.js",
-          }).apply(compiler)
-        })
-      }
-    ]
-  }
-]
+	{
+		name: "create-dll",
+		entry: "./lib.js",
+		output: {
+			filename: "lib-dll.js",
+			library: {
+				type: "commonjs2"
+			}
+		},
+		optimization: {
+			moduleIds: "deterministic",
+			chunkIds: "deterministic"
+		},
+		plugins: [
+			new rspack.DllPlugin({
+				path: dllManifest,
+				entryOnly: false
+			})
+		]
+	},
+	{
+		name: "use-dll",
+		dependencies: ["create-dll"],
+		entry: "./main.js",
+		plugins: [
+			function (compiler) {
+				compiler.hooks.beforeRun.tap("test", () => {
+					new rspack.DllReferencePlugin({
+						manifest: require(dllManifest),
+						sourceType: "commonjs2",
+						scope: "dll",
+						name: "./lib-dll.js"
+					}).apply(compiler);
+				});
+			}
+		]
+	}
+];

--- a/packages/rspack-test-tools/tests/configCases/entry/dynamic-entry-layer/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/entry/dynamic-entry-layer/rspack.config.js
@@ -4,11 +4,11 @@ module.exports = {
 		return Promise.resolve({
 			bundle0: {
 				import: "./index.js",
-				layer: "client",
+				layer: "client"
 			}
 		});
 	},
 	experiments: {
-		layers: true,
+		layers: true
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/errors/hide-stack/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/errors/hide-stack/rspack.config.js
@@ -1,32 +1,32 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: "./index",
-  plugins: [
-    {
-      apply(compiler) {
-        compiler.hooks.afterCompile.tap("TestPlugin", compilation => {
-          const errorHide = new Error("push message hide");
-          errorHide.hideStack = true;
-          errorHide.stack = "push stack hide";
-          compilation.errors.push(errorHide);
+	entry: "./index",
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.afterCompile.tap("TestPlugin", compilation => {
+					const errorHide = new Error("push message hide");
+					errorHide.hideStack = true;
+					errorHide.stack = "push stack hide";
+					compilation.errors.push(errorHide);
 
-          const error = new Error("push message");
-          error.stack = "push stack";
-          compilation.errors.push(error);
-        });
-        compiler.hooks.done.tap("TestPlugin", stats => {
-          const errors = stats.toJson({ errors: true }).errors;
-          for (let error of errors) {
-            if (error.message.includes("hide")) {
-              expect(typeof error.details).toBe("string");
-              expect(error.message.includes("stack")).toBeFalsy;
-            } else {
-              expect(typeof error.details).toBe("undefined");
-            }
-            expect(typeof error.stack).toBe("string");
-          }
-        });
-      }
-    }
-  ]
+					const error = new Error("push message");
+					error.stack = "push stack";
+					compilation.errors.push(error);
+				});
+				compiler.hooks.done.tap("TestPlugin", stats => {
+					const errors = stats.toJson({ errors: true }).errors;
+					for (let error of errors) {
+						if (error.message.includes("hide")) {
+							expect(typeof error.details).toBe("string");
+							expect(error.message.includes("stack")).toBeFalsy;
+						} else {
+							expect(typeof error.details).toBe("undefined");
+						}
+						expect(typeof error.stack).toBe("string");
+					}
+				});
+			}
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/errors/module-trace/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/errors/module-trace/rspack.config.js
@@ -1,21 +1,25 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: "./index",
-  plugins: [
-    {
-      apply(compiler) {
-        compiler.hooks.done.tap("TestPlugin", stats => {
-          const errors = stats.toJson({ errors: true, ids: true, moduleTrace: true }).errors;
-          expect(errors.length).toBe(1);
-          const moduleTrace = errors[0].moduleTrace;
-          expect(moduleTrace[0].moduleName).toBe('./c.js');
-          expect(moduleTrace[0].originName).toBe('./b.js');
-          expect(moduleTrace[1].moduleName).toBe('./b.js');
-          expect(moduleTrace[1].originName).toBe('./a.js');
-          expect(moduleTrace[2].moduleName).toBe('./a.js');
-          expect(moduleTrace[2].originName).toBe('./index.js');
-        });
-      }
-    }
-  ]
+	entry: "./index",
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.done.tap("TestPlugin", stats => {
+					const errors = stats.toJson({
+						errors: true,
+						ids: true,
+						moduleTrace: true
+					}).errors;
+					expect(errors.length).toBe(1);
+					const moduleTrace = errors[0].moduleTrace;
+					expect(moduleTrace[0].moduleName).toBe("./c.js");
+					expect(moduleTrace[0].originName).toBe("./b.js");
+					expect(moduleTrace[1].moduleName).toBe("./b.js");
+					expect(moduleTrace[1].originName).toBe("./a.js");
+					expect(moduleTrace[2].moduleName).toBe("./a.js");
+					expect(moduleTrace[2].originName).toBe("./index.js");
+				});
+			}
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/errors/module-trace/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/errors/module-trace/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  findBundle: function () {
-    return [];
-  }
+	findBundle: function () {
+		return [];
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/rspack.config.js
@@ -9,18 +9,18 @@ module.exports = {
 		chunkFormat: "module",
 		filename: "[name].mjs",
 		library: {
-			type: "modern-module",
+			type: "modern-module"
 		}
 	},
 	optimization: {
-		avoidEntryIife: true,
+		avoidEntryIife: true
 	},
 	experiments: {
 		outputModule: true
 	},
 	plugins: [
 		new rspack.CopyRspackPlugin({
-      patterns: ["./externals/**/*"],
-    }),
+			patterns: ["./externals/**/*"]
+		})
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/rspack.config.js
@@ -10,7 +10,10 @@ module.exports = (env, { testPath }) => {
 		},
 		resolve: {
 			alias: {
-				library: path.resolve(testPath, "../0-concatenation-tree-shaking/main.mjs")
+				library: path.resolve(
+					testPath,
+					"../0-concatenation-tree-shaking/main.mjs"
+				)
 			}
 		},
 		output: {
@@ -23,7 +26,7 @@ module.exports = (env, { testPath }) => {
 		},
 		optimization: {
 			minimize: true,
-			concatenateModules: true,
+			concatenateModules: true
 		},
 		plugins: [
 			new rspack.SwcJsMinimizerRspackPlugin({
@@ -33,6 +36,5 @@ module.exports = (env, { testPath }) => {
 				}
 			})
 		]
+	};
 };
-}
-

--- a/packages/rspack-test-tools/tests/configCases/externals/commonjs-import/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/commonjs-import/rspack.config.js
@@ -3,17 +3,17 @@ module.exports = [
 	{
 		target: "node",
 		entry: {
-			"index": "./index.js",
-			"case": "./case.js",
+			index: "./index.js",
+			case: "./case.js"
 		},
 		externalsType: "commonjs-import",
 		output: {
 			module: false,
-			filename: "[name].js",
+			filename: "[name].js"
 		},
 		externals: {
 			external1: "external1-alias",
-			external2: "external2-alias",
-		},
-	},
+			external2: "external2-alias"
+		}
+	}
 ];

--- a/packages/rspack-test-tools/tests/configCases/externals/context-info/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/context-info/rspack.config.js
@@ -5,7 +5,7 @@ module.exports = {
 		rules: [
 			{
 				test: /other-layer\.js$/,
-				layer: "other-layer",
+				layer: "other-layer"
 			}
 		]
 	},
@@ -17,10 +17,10 @@ module.exports = {
 				}
 				return callback(null, "var 1");
 			}
-			return callback()
+			return callback();
 		}
 	],
 	experiments: {
-		layers: true,
+		layers: true
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/externals/custom-url/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/custom-url/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	externals: [
 		function ({ request, dependencyType }, callback) {
@@ -16,7 +16,7 @@ module.exports = {
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		}
 	}

--- a/packages/rspack-test-tools/tests/configCases/externals/external-fn-datauri-context/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/external-fn-datauri-context/rspack.config.js
@@ -26,14 +26,14 @@ module.exports = {
 					paths: paths,
 					segments: segments
 				};
-			};
+			}
 			let { paths } = getPaths(context);
 			expect(paths).not.toContain(undefined);
 			if (request === "a") {
-				expect(paths).toEqual(["data:text/", "data:text/"])
-				return callback(null, "42")
+				expect(paths).toEqual(["data:text/", "data:text/"]);
+				return callback(null, "42");
 			}
-			return callback()
+			return callback();
 		}
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/externals/item-value-object/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/item-value-object/rspack.config.js
@@ -5,12 +5,12 @@ module.exports = {
 	entry: "./index.js",
 	output: {
 		library: {
-			type: "commonjs",
+			type: "commonjs"
 		}
 	},
 	externals: {
 		lodash: {
-			commonjs: "./lodash.js",
+			commonjs: "./lodash.js"
 		}
 	},
 	plugins: [

--- a/packages/rspack-test-tools/tests/configCases/externals/reexport-star/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/reexport-star/rspack.config.js
@@ -2,11 +2,11 @@
 module.exports = [
 	{
 		entry: {
-			"case1": "./case1.js",
-			"case2": "./case2.js",
-			"case3": "./case3/index.js",
-			"case4": "./case4.js",
-			"index": "./index.js",
+			case1: "./case1.js",
+			case2: "./case2.js",
+			case3: "./case3/index.js",
+			case4: "./case4.js",
+			index: "./index.js"
 		},
 		output: {
 			module: true,
@@ -14,17 +14,17 @@ module.exports = [
 			chunkFormat: "module",
 			library: {
 				type: "modern-module"
-			},
+			}
 		},
 		externals: {
 			external1: "module external1-alias",
-			external2: "module-import external2-alias",
+			external2: "module-import external2-alias"
 		},
 		experiments: {
 			outputModule: true
 		},
 		optimization: {
-			avoidEntryIife: true,
-		},
-	},
+			avoidEntryIife: true
+		}
+	}
 ];

--- a/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/rspack.config.js
@@ -3,7 +3,7 @@ const { rspack } = require("@rspack/core");
 /** @type {function(any, any): import("@rspack/core").Configuration[]} */
 module.exports = (env, { testPath }) => {
 	return {
-	  externals: [/.*foo.*/],
+		externals: [/.*foo.*/],
 		externalsType: "module",
 		output: {
 			module: true,
@@ -15,13 +15,12 @@ module.exports = (env, { testPath }) => {
 		},
 		optimization: {
 			minimize: true,
-			concatenateModules: true,
+			concatenateModules: true
 		},
-			plugins: [
-				new rspack.CopyRspackPlugin({
-					patterns: ["./a/**/*", "./_a/**/*"],
-				}),
-			]
+		plugins: [
+			new rspack.CopyRspackPlugin({
+				patterns: ["./a/**/*", "./_a/**/*"]
+			})
+		]
 	};
-}
-
+};

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/rspack.config.js
@@ -10,7 +10,7 @@ module.exports = {
 		lodash: {
 			root: "./lodash.js",
 			commonjs: "./lodash.js",
-			commonjs2: "./lodash.js",
+			commonjs2: "./lodash.js"
 		}
 	},
 	plugins: [

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/rspack.config.js
@@ -13,7 +13,7 @@ module.exports = {
 		lodash: {
 			root: "./lodash.js",
 			commonjs: "./lodash.js",
-			commonjs2: "./lodash.js",
+			commonjs2: "./lodash.js"
 		}
 	},
 	plugins: [

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-with-external-type/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-with-external-type/rspack.config.js
@@ -10,7 +10,7 @@ module.exports = {
 		lodash: {
 			root: "./lodash.js",
 			commonjs: "./lodash.js",
-			commonjs2: "./lodash.js",
+			commonjs2: "./lodash.js"
 		}
 	},
 	externalsType: "commonjs",

--- a/packages/rspack-test-tools/tests/configCases/hooks/additional-tree-runtime-requirements/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/additional-tree-runtime-requirements/rspack.config.js
@@ -1,19 +1,22 @@
 const { RuntimeGlobals } = require("@rspack/core");
 
 class Plugin {
-  apply(compiler) {
-    compiler.hooks.thisCompilation.tap("TestFakePlugin", compilation => {
-      compilation.hooks.additionalTreeRuntimeRequirements.tap("TestFakePlugin", (_, set) => {
-        expect(set.has(RuntimeGlobals.chunkName)).toBeFalsy();
-        expect(set.has(RuntimeGlobals.getFullHash)).toBeTruthy();
-        set.add(RuntimeGlobals.chunkName);
-        set.delete(RuntimeGlobals.getFullHash);
-      });
-    });
-  }
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap("TestFakePlugin", compilation => {
+			compilation.hooks.additionalTreeRuntimeRequirements.tap(
+				"TestFakePlugin",
+				(_, set) => {
+					expect(set.has(RuntimeGlobals.chunkName)).toBeFalsy();
+					expect(set.has(RuntimeGlobals.getFullHash)).toBeTruthy();
+					set.add(RuntimeGlobals.chunkName);
+					set.delete(RuntimeGlobals.getFullHash);
+				}
+			);
+		});
+	}
 }
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-  context: __dirname,
-  plugins: [new Plugin()]
+	context: __dirname,
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/after-environment/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/after-environment/rspack.config.js
@@ -3,10 +3,10 @@ module.exports = {
 	plugins: [
 		{
 			apply(compiler) {
-				compiler.hooks.afterEnvironment.tap('getResolver', () => {
+				compiler.hooks.afterEnvironment.tap("getResolver", () => {
 					expect(compiler.resolverFactory).toBeTruthy();
-				})
+				});
 			}
 		}
 	]
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/hooks/after-resolve-resource/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/after-resolve-resource/rspack.config.js
@@ -2,76 +2,97 @@ const pluginName = "plugin";
 
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = [
-  {
-    context: __dirname,
-    entry: "./resource.js",
-    output: {
-      filename: "resource.js"
-    },
-    optimization: {
-      moduleIds: "named",
+	{
+		context: __dirname,
+		entry: "./resource.js",
+		output: {
+			filename: "resource.js"
+		},
+		optimization: {
+			moduleIds: "named",
 			concatenateModules: false
-    },
-    plugins: [{
-      apply(compiler) {
-        compiler.hooks.compilation.tap(
-          pluginName,
-          (compilation, { normalModuleFactory }) => {
-            normalModuleFactory.hooks.afterResolve.tap(pluginName, resolveData => {
-              resolveData.createData.resource = resolveData.createData.resource.replace("b.js", "c.js");
-            });
-          }
-        );
-      }
-    }]
-  },
-  {
-    context: __dirname,
-    entry: "./request.js",
-    output: {
-      filename: "request.js"
-    },
-    optimization: {
-      moduleIds: "named",
-			concatenateModules: false,
-    },
-    plugins: [{
-      apply(compiler) {
-        compiler.hooks.compilation.tap(
-          pluginName,
-          (compilation, { normalModuleFactory }) => {
-            normalModuleFactory.hooks.afterResolve.tap(pluginName, resolveData => {
-              resolveData.createData.request = resolveData.createData.request.replace("b.js", "c.js");
-              resolveData.createData.userRequest = resolveData.createData.userRequest.replace("b.js", "c.js");
-            });
-          }
-        );
-      }
-    }]
-  },
-  {
-    context: __dirname,
-    entry: "./duplicate.js",
-    output: {
-      filename: "duplicate.js"
-    },
-    optimization: {
-      moduleIds: "named",
-			concatenateModules: false,
-    },
-    plugins: [{
-      apply(compiler) {
-        compiler.hooks.compilation.tap(
-          pluginName,
-          (compilation, { normalModuleFactory }) => {
-            normalModuleFactory.hooks.afterResolve.tap(pluginName, resolveData => {
-              resolveData.createData.request = resolveData.createData.request.replace("b.js", "c.js");
-              resolveData.createData.userRequest = resolveData.createData.userRequest.replace("b.js", "c.js");
-              resolveData.createData.resource = resolveData.createData.resource.replace("b.js", "c.js");
-            });
-          }
-        );
-      }
-    }]
-  },
+		},
+		plugins: [
+			{
+				apply(compiler) {
+					compiler.hooks.compilation.tap(
+						pluginName,
+						(compilation, { normalModuleFactory }) => {
+							normalModuleFactory.hooks.afterResolve.tap(
+								pluginName,
+								resolveData => {
+									resolveData.createData.resource =
+										resolveData.createData.resource.replace("b.js", "c.js");
+								}
+							);
+						}
+					);
+				}
+			}
+		]
+	},
+	{
+		context: __dirname,
+		entry: "./request.js",
+		output: {
+			filename: "request.js"
+		},
+		optimization: {
+			moduleIds: "named",
+			concatenateModules: false
+		},
+		plugins: [
+			{
+				apply(compiler) {
+					compiler.hooks.compilation.tap(
+						pluginName,
+						(compilation, { normalModuleFactory }) => {
+							normalModuleFactory.hooks.afterResolve.tap(
+								pluginName,
+								resolveData => {
+									resolveData.createData.request =
+										resolveData.createData.request.replace("b.js", "c.js");
+									resolveData.createData.userRequest =
+										resolveData.createData.userRequest.replace("b.js", "c.js");
+								}
+							);
+						}
+					);
+				}
+			}
+		]
+	},
+	{
+		context: __dirname,
+		entry: "./duplicate.js",
+		output: {
+			filename: "duplicate.js"
+		},
+		optimization: {
+			moduleIds: "named",
+			concatenateModules: false
+		},
+		plugins: [
+			{
+				apply(compiler) {
+					compiler.hooks.compilation.tap(
+						pluginName,
+						(compilation, { normalModuleFactory }) => {
+							normalModuleFactory.hooks.afterResolve.tap(
+								pluginName,
+								resolveData => {
+									resolveData.createData.request =
+										resolveData.createData.request.replace("b.js", "c.js");
+									resolveData.createData.userRequest =
+										resolveData.createData.userRequest.replace("b.js", "c.js");
+									resolveData.createData.resource =
+										resolveData.createData.resource.replace("b.js", "c.js");
+								}
+							);
+						}
+					);
+				}
+			}
+		]
+	}
 ];

--- a/packages/rspack-test-tools/tests/configCases/hooks/after-resolve-resource/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/after-resolve-resource/test.config.js
@@ -1,10 +1,13 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  findBundle(index) {
-    switch (index) {
-      case 0: return ['resource.js'];
-      case 1: return ['request.js'];
-      case 2: return ['duplicate.js'];
-    }
-  }
+	findBundle(index) {
+		switch (index) {
+			case 0:
+				return ["resource.js"];
+			case 1:
+				return ["request.js"];
+			case 2:
+				return ["duplicate.js"];
+		}
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/asset-emitted-buffer/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/asset-emitted-buffer/rspack.config.js
@@ -10,16 +10,17 @@ class Plugin {
 				const buffer = Buffer.from("i am content of emit asset");
 				contentLength = buffer.length;
 				const source = new RawSource(buffer, false);
-				compilation.emitAsset('emit-asset.js', source);
+				compilation.emitAsset("emit-asset.js", source);
 			});
 		});
-
 
 		compiler.hooks.assetEmitted.tap(pluginName, (filename, info) => {
 			if (filename === "emit-asset.js") {
 				expect(info.targetPath.includes("emit-asset.js")).toBeTruthy();
 				expect(info.content.length).toBe(contentLength);
-				expect(info.content.toString('utf-8').includes("i am content of emit asset")).toBeTruthy();
+				expect(
+					info.content.toString("utf-8").includes("i am content of emit asset")
+				).toBeTruthy();
 				hasEmittedAsset = true;
 			}
 		});

--- a/packages/rspack-test-tools/tests/configCases/hooks/check-asset/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/check-asset/rspack.config.js
@@ -6,7 +6,7 @@ class Plugin {
 		let called = 0;
 		compiler.hooks.compilation.tap(pluginName, compilation => {
 			compilation.hooks.chunkAsset.tap(pluginName, (chunk, name) => {
-				let files = [...chunk.files]
+				let files = [...chunk.files];
 				assert(files.includes("bundle0.js"));
 				called++;
 			});

--- a/packages/rspack-test-tools/tests/configCases/hooks/compat-path-data-chunk-contenthash/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/compat-path-data-chunk-contenthash/rspack.config.js
@@ -11,7 +11,7 @@ class Plugin {
 				}
 			});
 			called = true;
-			expect(p).toBe("xxx1")
+			expect(p).toBe("xxx1");
 		});
 		compiler.hooks.done.tap(pluginName, stats => {
 			let json = stats.toJson();

--- a/packages/rspack-test-tools/tests/configCases/hooks/compat-path-data-chunk-contenthash/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/compat-path-data-chunk-contenthash/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  noTests: true,
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/hooks/context-module-before-resolve/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/context-module-before-resolve/rspack.config.js
@@ -1,30 +1,33 @@
 const pluginName = "plugin";
 
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.contextModuleFactory.tap(
-            pluginName,
-            contextModuleFactory => {
-                contextModuleFactory.hooks.beforeResolve.tap(pluginName, resolveData => {
-                    if (resolveData.request.includes("./locale")) {
-                        resolveData.regExp = /[/\\](en(\.js)?|zh(\.js)?)$/;
-                        return resolveData;
-                    }
-                    for (const d of resolveData.dependencies) {
-                        if (d.critical) d.critical = false;
-                    }
-                });
-            }
-        );
-    }
+	apply(compiler) {
+		compiler.hooks.contextModuleFactory.tap(
+			pluginName,
+			contextModuleFactory => {
+				contextModuleFactory.hooks.beforeResolve.tap(
+					pluginName,
+					resolveData => {
+						if (resolveData.request.includes("./locale")) {
+							resolveData.regExp = /[/\\](en(\.js)?|zh(\.js)?)$/;
+							return resolveData;
+						}
+						for (const d of resolveData.dependencies) {
+							if (d.critical) d.critical = false;
+						}
+					}
+				);
+			}
+		);
+	}
 }
 
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-    context: __dirname,
-    entry: "./index.js",
-    module: {
-        rules: []
-    },
-    plugins: [new Plugin()]
+	context: __dirname,
+	entry: "./index.js",
+	module: {
+		rules: []
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/create-script/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/create-script/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'jsdom'
-}
+	documentType: "jsdom"
+};

--- a/packages/rspack-test-tools/tests/configCases/hooks/get-path-custom-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/get-path-custom-chunk/rspack.config.js
@@ -5,17 +5,19 @@ class Plugin {
 		let called = false;
 		compiler.hooks.compilation.tap(pluginName, compilation => {
 			called = true;
-			expect(compilation.getPath("[id]-[name]-[chunkhash]-[contenthash]", {
-				chunk: {
-					name: "chunkname",
-					id: "chunkid",
-					hash: "chunkhash",
-					contentHash: {
-						javascript: "contenthash"
-					}
-				},
-				contentHashType: "javascript"
-			})).toBe("chunkid-chunkname-chunkhash-contenthash");
+			expect(
+				compilation.getPath("[id]-[name]-[chunkhash]-[contenthash]", {
+					chunk: {
+						name: "chunkname",
+						id: "chunkid",
+						hash: "chunkhash",
+						contentHash: {
+							javascript: "contenthash"
+						}
+					},
+					contentHashType: "javascript"
+				})
+			).toBe("chunkid-chunkname-chunkhash-contenthash");
 		});
 		compiler.hooks.done.tap(pluginName, stats => {
 			let json = stats.toJson();

--- a/packages/rspack-test-tools/tests/configCases/hooks/get-path-custom-chunk/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/get-path-custom-chunk/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../../dist").TConfigCaseConfig} */
 module.exports = {
-  noTests: true,
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/hooks/get-path-existing-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/get-path-existing-chunk/rspack.config.js
@@ -6,11 +6,17 @@ class Plugin {
 		compiler.hooks.compilation.tap(pluginName, compilation => {
 			compilation.hooks.processAssets.tap(pluginName, () => {
 				called = true;
-				const mainChunk = Array.from(compilation.chunks).find(chunk => chunk.name === "main");
-				expect(compilation.getPath("[id]-[name]-[chunkhash]-[contenthash]", {
-					chunk: mainChunk,
-					contentHashType: "javascript",
-				})).toBe(`${mainChunk.id}-${mainChunk.name}-${mainChunk.renderedHash}-${mainChunk.contentHash["javascript"].slice(0, 20)}`);
+				const mainChunk = Array.from(compilation.chunks).find(
+					chunk => chunk.name === "main"
+				);
+				expect(
+					compilation.getPath("[id]-[name]-[chunkhash]-[contenthash]", {
+						chunk: mainChunk,
+						contentHashType: "javascript"
+					})
+				).toBe(
+					`${mainChunk.id}-${mainChunk.name}-${mainChunk.renderedHash}-${mainChunk.contentHash["javascript"].slice(0, 20)}`
+				);
 			});
 		});
 		compiler.hooks.done.tap(pluginName, stats => {

--- a/packages/rspack-test-tools/tests/configCases/hooks/get-path-existing-chunk/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/get-path-existing-chunk/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../../dist").TConfigCaseConfig} */
 module.exports = {
-  noTests: true,
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/hooks/interceptor/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/interceptor/rspack.config.js
@@ -5,30 +5,30 @@ class InterceptPlugin {
 		const content = [];
 		compiler.hooks.beforeCompile.intercept({
 			call() {
-				content.push("compiler.hooks.beforeCompile.intercept.call")
+				content.push("compiler.hooks.beforeCompile.intercept.call");
 			}
-		})
+		});
 		compiler.hooks.compile.intercept({
 			call() {
-				content.push("compiler.hooks.compile.intercept.call")
+				content.push("compiler.hooks.compile.intercept.call");
 			}
-		})
+		});
 		compiler.hooks.finishMake.intercept({
 			call() {
-				content.push("compiler.hooks.finishMake.intercept.call")
+				content.push("compiler.hooks.finishMake.intercept.call");
 			}
-		})
+		});
 		compiler.hooks.afterCompile.intercept({
 			call() {
-				content.push("compiler.hooks.afterCompile.intercept.call")
+				content.push("compiler.hooks.afterCompile.intercept.call");
 			}
-		})
+		});
 		compiler.hooks.done.tap(InterceptPlugin.name, () => {
 			deepEqual(content, [
 				"compiler.hooks.beforeCompile.intercept.call",
 				"compiler.hooks.compile.intercept.call",
 				"compiler.hooks.finishMake.intercept.call",
-				"compiler.hooks.afterCompile.intercept.call",
+				"compiler.hooks.afterCompile.intercept.call"
 			]);
 		});
 	}

--- a/packages/rspack-test-tools/tests/configCases/hooks/link-prefetch-preload/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/link-prefetch-preload/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'jsdom'
-}
+	documentType: "jsdom"
+};

--- a/packages/rspack-test-tools/tests/configCases/hooks/modify-extract-css-loading-runtime/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/modify-extract-css-loading-runtime/rspack.config.js
@@ -28,8 +28,5 @@ module.exports = {
 			}
 		]
 	},
-	plugins: [
-		new webpack.CssExtractRspackPlugin(),
-		new Plugin(),
-	]
+	plugins: [new webpack.CssExtractRspackPlugin(), new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/normal-module-factory/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/normal-module-factory/rspack.config.js
@@ -5,11 +5,11 @@ module.exports = {
 	plugins: [
 		{
 			apply(compiler) {
-				compiler.hooks.normalModuleFactory.tap('getResolver', (nmf) => {
-					const resolver = nmf.getResolver('normal');
+				compiler.hooks.normalModuleFactory.tap("getResolver", nmf => {
+					const resolver = nmf.getResolver("normal");
 					expect(resolver).toBeTruthy();
-				})
+				});
 			}
 		}
 	]
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/hooks/runtime-requirement-in-tree/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/runtime-requirement-in-tree/rspack.config.js
@@ -4,34 +4,37 @@ class Plugin {
 	/**
 	 * @param {import('@rspack/core').Compiler} compiler
 	 */
-  apply(compiler) {
-    compiler.hooks.thisCompilation.tap("TestFakePlugin", compilation => {
-			compilation.hooks.additionalTreeRuntimeRequirements.tap("TestFakePlugin", (_, set) => {
-				set.add(RuntimeGlobals.chunkName)
-				set.add(RuntimeGlobals.ensureChunk)
-				set.add(RuntimeGlobals.ensureChunkHandlers)
-			})
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap("TestFakePlugin", compilation => {
+			compilation.hooks.additionalTreeRuntimeRequirements.tap(
+				"TestFakePlugin",
+				(_, set) => {
+					set.add(RuntimeGlobals.chunkName);
+					set.add(RuntimeGlobals.ensureChunk);
+					set.add(RuntimeGlobals.ensureChunkHandlers);
+				}
+			);
 
-			compilation.hooks.runtimeRequirementInTree.for(
-				RuntimeGlobals.chunkName
-			).tap("TestFakePlugin", (chunk, set) => {
-        expect(chunk.name).toBe("main");
-				expect(set.has(RuntimeGlobals.chunkName)).toBeTruthy();
-				expect(set.has(RuntimeGlobals.ensureChunk)).toBeTruthy();
-				expect(set.has(RuntimeGlobals.ensureChunkHandlers)).toBeTruthy();
-			})
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.chunkName)
+				.tap("TestFakePlugin", (chunk, set) => {
+					expect(chunk.name).toBe("main");
+					expect(set.has(RuntimeGlobals.chunkName)).toBeTruthy();
+					expect(set.has(RuntimeGlobals.ensureChunk)).toBeTruthy();
+					expect(set.has(RuntimeGlobals.ensureChunkHandlers)).toBeTruthy();
+				});
 
-			compilation.hooks.runtimeRequirementInTree.for(
-				RuntimeGlobals.hasOwnProperty
-			).tap("TestFakePlugin", (chunk, set) => {
-        expect(chunk.name).toBe("main");
-				expect(set.has(RuntimeGlobals.hasOwnProperty)).toBeTruthy();
-      });
-    });
-  }
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.hasOwnProperty)
+				.tap("TestFakePlugin", (chunk, set) => {
+					expect(chunk.name).toBe("main");
+					expect(set.has(RuntimeGlobals.hasOwnProperty)).toBeTruthy();
+				});
+		});
+	}
 }
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-  context: __dirname,
-  plugins: [new Plugin()]
+	context: __dirname,
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/should-emit-1/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/should-emit-1/rspack.config.js
@@ -18,5 +18,5 @@ class Plugin {
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	context: __dirname,
-	plugins: [new Plugin()],
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/should-emit-2/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/should-emit-2/rspack.config.js
@@ -34,5 +34,5 @@ class Plugin {
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	plugins: [new Plugin()],
-	node: false,
+	node: false
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/should-emit-2/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/should-emit-2/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['bundle0.js']
+		return ["bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/hooks/stage-0-factorize/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/stage-0-factorize/rspack.config.js
@@ -2,12 +2,20 @@ const TestPlugin = require("../stage-compilation/plugin");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	externals: ['commonjs fs', 'commonjs path'],
-	plugins: [new TestPlugin((compiler, list) => {
-		compiler.hooks.compilation.tap(TestPlugin.name, (compilation, { normalModuleFactory }) => {
-			normalModuleFactory.hooks.factorize.tap(TestPlugin.name, (resolveData) => {
-				list.push(`/*: ${resolveData.request} :*/`);
-			})
-		});
-	})]
+	externals: ["commonjs fs", "commonjs path"],
+	plugins: [
+		new TestPlugin((compiler, list) => {
+			compiler.hooks.compilation.tap(
+				TestPlugin.name,
+				(compilation, { normalModuleFactory }) => {
+					normalModuleFactory.hooks.factorize.tap(
+						TestPlugin.name,
+						resolveData => {
+							list.push(`/*: ${resolveData.request} :*/`);
+						}
+					);
+				}
+			);
+		})
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/stage-compilation/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/stage-compilation/rspack.config.js
@@ -1,21 +1,23 @@
-const TestPlugin = require("./plugin")
+const TestPlugin = require("./plugin");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	plugins: [new TestPlugin((compiler, list) => {
-		const pushBanner = (compiler, banner, tapOptions) => {
-			compiler.hooks.compilation.tap(tapOptions, compilation => {
-				list.push(`/* ${banner} */`);
+	plugins: [
+		new TestPlugin((compiler, list) => {
+			const pushBanner = (compiler, banner, tapOptions) => {
+				compiler.hooks.compilation.tap(tapOptions, compilation => {
+					list.push(`/* ${banner} */`);
+				});
+			};
+			pushBanner(compiler, "banner1", { name: "banner1", stage: 100 });
+			pushBanner(compiler, "banner2", {
+				name: "banner2",
+				before: "banner1"
 			});
-		}
-		pushBanner(compiler, "banner1", { name: "banner1", stage: 100 });
-		pushBanner(compiler, "banner2", {
-			name: "banner2",
-			before: "banner1"
-		});
-		pushBanner(compiler, "banner3", { name: "banner3", stage: -100 });
-		pushBanner(compiler, "banner4", { name: "banner4" });
-		pushBanner(compiler, "banner5", { name: "banner5", stage: -Infinity });
-		pushBanner(compiler, "banner6", { name: "banner6", stage: Infinity });
-	})]
+			pushBanner(compiler, "banner3", { name: "banner3", stage: -100 });
+			pushBanner(compiler, "banner4", { name: "banner4" });
+			pushBanner(compiler, "banner5", { name: "banner5", stage: -Infinity });
+			pushBanner(compiler, "banner6", { name: "banner6", stage: Infinity });
+		})
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/stage-make/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/stage-make/rspack.config.js
@@ -2,27 +2,29 @@ const TestPlugin = require("../stage-compilation/plugin");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	plugins: [new TestPlugin((compiler, list) => {
-		const pushBanner = (compiler, banner, tapOptions) => {
-			compiler.hooks.make.tap(tapOptions, () => {
-				list.push(`/* sync ${banner} */`);
+	plugins: [
+		new TestPlugin((compiler, list) => {
+			const pushBanner = (compiler, banner, tapOptions) => {
+				compiler.hooks.make.tap(tapOptions, () => {
+					list.push(`/* sync ${banner} */`);
+				});
+				compiler.hooks.make.tapAsync(tapOptions, (compilation, callback) => {
+					list.push(`/* async ${banner} */`);
+					callback();
+				});
+				compiler.hooks.make.tapPromise(tapOptions, async () => {
+					list.push(`/* promise ${banner} */`);
+				});
+			};
+			pushBanner(compiler, "banner1", { name: "banner1", stage: 100 });
+			pushBanner(compiler, "banner2", {
+				name: "banner2",
+				before: "banner1"
 			});
-			compiler.hooks.make.tapAsync(tapOptions, (compilation, callback) => {
-				list.push(`/* async ${banner} */`);
-				callback()
-			});
-			compiler.hooks.make.tapPromise(tapOptions, async () => {
-				list.push(`/* promise ${banner} */`);
-			});
-		}
-		pushBanner(compiler, "banner1", { name: "banner1", stage: 100 });
-		pushBanner(compiler, "banner2", {
-			name: "banner2",
-			before: "banner1"
-		});
-		pushBanner(compiler, "banner3", { name: "banner3", stage: -100 });
-		pushBanner(compiler, "banner4", { name: "banner4" });
-		pushBanner(compiler, "banner5", { name: "banner5", stage: -Infinity });
-		pushBanner(compiler, "banner6", { name: "banner6", stage: Infinity });
-	})]
+			pushBanner(compiler, "banner3", { name: "banner3", stage: -100 });
+			pushBanner(compiler, "banner4", { name: "banner4" });
+			pushBanner(compiler, "banner5", { name: "banner5", stage: -Infinity });
+			pushBanner(compiler, "banner6", { name: "banner6", stage: Infinity });
+		})
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/stage-process-assets/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/stage-process-assets/rspack.config.js
@@ -2,7 +2,7 @@ function shuffle(arr) {
 	let m = arr.length;
 	while (m > 1) {
 		let index = Math.floor(Math.random() * m--);
-		[arr[m] , arr[index]] = [arr[index] , arr[m]]
+		[arr[m], arr[index]] = [arr[index], arr[m]];
 	}
 	return arr;
 }
@@ -17,13 +17,16 @@ module.exports = {
 		{
 			name: NAME,
 			apply(compiler) {
-				const { sources: { ConcatSource, RawSource }, Compilation } = compiler.webpack;
+				const {
+					sources: { ConcatSource, RawSource },
+					Compilation
+				} = compiler.webpack;
 				compiler.hooks.compilation.tap("compilation", compilation => {
 					function addStage(stage) {
 						compilation.hooks.processAssets.tapPromise(
 							{
 								name: NAME,
-								stage,
+								stage
 							},
 							async assets => {
 								for (const [key, value] of Object.entries(assets)) {
@@ -51,13 +54,13 @@ module.exports = {
 						Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
 						Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_TRANSFER,
 						Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
-						Compilation.PROCESS_ASSETS_STAGE_REPORT,
+						Compilation.PROCESS_ASSETS_STAGE_REPORT
 					].flatMap((s, i) => {
 						const r = i + 1;
-						return [s - r, s, s + r]
-					})
+						return [s - r, s, s + r];
+					});
 					shuffle(stages);
-					stages.forEach(s => addStage(s))
+					stages.forEach(s => addStage(s));
 				});
 			}
 		}

--- a/packages/rspack-test-tools/tests/configCases/hooks/update-asset-patch-asset-info/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/update-asset-patch-asset-info/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  noTests: true,
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/hooks/update-asset/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/update-asset/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  noTests: true,
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/issuer/empty-entry-layer/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/issuer/empty-entry-layer/rspack.config.js
@@ -1,17 +1,14 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    entry: "./index.js",
-    module: {
-        rules: [
-            {
-                issuer: /dark/,
-                resolve: {
-                    conditionNames: [
-                        'dark',
-                        '...'
-                    ]
-                }
-            }
-        ]
-    }
+	entry: "./index.js",
+	module: {
+		rules: [
+			{
+				issuer: /dark/,
+				resolve: {
+					conditionNames: ["dark", "..."]
+				}
+			}
+		]
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/layer/empty-entry-layer/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/layer/empty-entry-layer/rspack.config.js
@@ -1,17 +1,14 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    entry: "./index.js",
-    module: {
-        rules: [
-            {
-                issuerLayer: 'dark',
-                resolve: {
-                    conditionNames: [
-                        'dark',
-                        '...'
-                    ]
-                }
-            }
-        ]
-    }
+	entry: "./index.js",
+	module: {
+		rules: [
+			{
+				issuerLayer: "dark",
+				resolve: {
+					conditionNames: ["dark", "..."]
+				}
+			}
+		]
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/layer/rules/webpack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/layer/rules/webpack.config.js
@@ -54,10 +54,10 @@ module.exports = {
 	},
 	externals: [
 		{
-			external1: "var 42",
+			external1: "var 42"
 		},
 		{
-			external2: "var 42",
+			external2: "var 42"
 		}
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/less-loader/additional-data-async-fn/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/less-loader/additional-data-async-fn/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -31,7 +31,7 @@ module.exports = {
 				],
 				type: "css",
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/less-loader/additional-data-fn/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/less-loader/additional-data-fn/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -31,7 +31,7 @@ module.exports = {
 				],
 				type: "css",
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/less-loader/additional-data-string/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/less-loader/additional-data-string/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -16,7 +16,7 @@ module.exports = {
 				],
 				type: "css",
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/less-loader/with-source-map/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/less-loader/with-source-map/rspack.config.js
@@ -1,10 +1,10 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	devtool: "source-map",
 	output: {
-		publicPath: '/'
+		publicPath: "/"
 	},
 	module: {
 		rules: [
@@ -13,7 +13,7 @@ module.exports = {
 				use: [{ loader: "less-loader" }],
 				type: "css",
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			},
 			{

--- a/packages/rspack-test-tools/tests/configCases/library/0-create-library/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/0-create-library/rspack.config.js
@@ -4,22 +4,22 @@ const path = require("path");
 module.exports = (env, { testPath }) => [
 	{
 		entry: {
-			main: './modern-module-non-entry-module-export/index.js',
+			main: "./modern-module-non-entry-module-export/index.js"
 		},
 		output: {
 			module: true,
 			chunkFormat: "module",
 			filename: "modern-module-non-entry-module-export/[name].js",
 			library: {
-				type: 'modern-module',
-			},
+				type: "modern-module"
+			}
 		},
 		optimization: {
 			concatenateModules: true,
-			avoidEntryIife: true,
+			avoidEntryIife: true
 		},
 		experiments: {
-			outputModule: true,
-		},
+			outputModule: true
+		}
 	}
 ];

--- a/packages/rspack-test-tools/tests/configCases/library/1-use-library/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/1-use-library/rspack.config.js
@@ -6,7 +6,10 @@ module.exports = (env, { testPath }) => [
 		entry: "./default-test.js",
 		resolve: {
 			alias: {
-				library: path.resolve(testPath, "../0-create-library/modern-module-non-entry-module-export/main.js")
+				library: path.resolve(
+					testPath,
+					"../0-create-library/modern-module-non-entry-module-export/main.js"
+				)
 			}
 		},
 		plugins: [
@@ -14,5 +17,5 @@ module.exports = (env, { testPath }) => [
 				NAME: JSON.stringify("modern-module export from non-entry module")
 			})
 		]
-	},
+	}
 ];

--- a/packages/rspack-test-tools/tests/configCases/library/array-this/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/array-this/rspack.config.js
@@ -5,7 +5,7 @@ module.exports = {
 		library: ["a", "b"],
 		libraryTarget: "this",
 		environment: {
-			arrowFunction: false,
+			arrowFunction: false
 		}
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/library/duplicate-module-library/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/duplicate-module-library/rspack.config.js
@@ -2,12 +2,12 @@
 module.exports = {
 	output: {
 		library: {
-			type: "module",
+			type: "module"
 		},
-		enabledLibraryTypes: ["module", "module"],
+		enabledLibraryTypes: ["module", "module"]
 	},
 	target: ["es2022"],
 	experiments: {
-		outputModule: true,
+		outputModule: true
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/library/duplicate-module-library/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/duplicate-module-library/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  noTests: true
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/library/esm-external/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/esm-external/rspack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	},
 	node: false,
 	experiments: {
-		outputModule: true,
+		outputModule: true
 	},
 	target: "node"
 };

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-asset-entry/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-asset-entry/rspack.config.js
@@ -4,18 +4,18 @@ const assert = require("assert");
 module.exports = {
 	context: __dirname,
 	entry: {
-		index: './img.png'
+		index: "./img.png"
 	},
 	output: {
 		filename: `[name].js`,
-    chunkFilename: `async.js`,
+		chunkFilename: `async.js`,
 		module: true,
 		library: {
-			type: "modern-module",
+			type: "modern-module"
 		},
 		iife: false,
 		chunkFormat: "module",
-		chunkLoading: 'import',
+		chunkLoading: "import"
 	},
 	module: {
 		rules: [
@@ -23,7 +23,7 @@ module.exports = {
 				test: /\.png$/,
 				type: "asset/resource",
 				generator: {
-					filename: 'static/img/[name].png',
+					filename: "static/img/[name].png",
 					importMode: "preserve"
 				}
 			}
@@ -37,7 +37,7 @@ module.exports = {
 		avoidEntryIife: true,
 		minimize: false
 	},
-	plugins:[
+	plugins: [
 		new (class {
 			apply(compiler) {
 				compiler.hooks.compilation.tap("MyPlugin", compilation => {
@@ -46,11 +46,15 @@ module.exports = {
 						const js = list.find(item => item.endsWith("js"));
 						const jsContent = assets[js].source().toString();
 
-						const preseveImport = /import\simg_namespaceObject\sfrom ['"]\.\/static\/img\/img\.png['"]/.test(jsContent);
+						const preseveImport =
+							/import\simg_namespaceObject\sfrom ['"]\.\/static\/img\/img\.png['"]/.test(
+								jsContent
+							);
 						assert(preseveImport);
-						const hasExports = /export\s{\simg_namespaceObject\sas\sdefault\s}/.test(jsContent);
+						const hasExports =
+							/export\s{\simg_namespaceObject\sas\sdefault\s}/.test(jsContent);
 						assert(hasExports);
-					})
+					});
 				});
 			}
 		})()

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/rspack.config.js
@@ -1,42 +1,45 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = [{
-	entry: {
-		"main": "./main.js",
-	},
-	output: {
-		filename: `[name].js`,
-    chunkFilename: `async.js`,
-		module: true,
-		library: {
-			type: "modern-module",
+module.exports = [
+	{
+		entry: {
+			main: "./main.js"
 		},
-		iife: false,
-		chunkFormat: "module",
-		chunkLoading: 'import',
+		output: {
+			filename: `[name].js`,
+			chunkFilename: `async.js`,
+			module: true,
+			library: {
+				type: "modern-module"
+			},
+			iife: false,
+			chunkFormat: "module",
+			chunkLoading: "import"
+		},
+		externals: {
+			react: "react-alias",
+			vue: "vue-alias",
+			angular: "angular-alias",
+			svelte: "svelte-alias",
+			lit: "lit-alias",
+			solid: "solid-alias",
+			jquery: "jquery-alias"
+		},
+		externalsType: "module-import",
+		experiments: {
+			outputModule: true
+		},
+		optimization: {
+			concatenateModules: true,
+			avoidEntryIife: true,
+			minimize: false
+		}
 	},
-	externals: {
-		react: 'react-alias',
-		vue: 'vue-alias',
-		angular: 'angular-alias',
-		svelte: 'svelte-alias',
-		lit: 'lit-alias',
-		solid: 'solid-alias',
-		jquery: 'jquery-alias',
-	},
-	externalsType: 'module-import',
-	experiments: {
-		outputModule: true
-	},
-	optimization: {
-		concatenateModules: true,
-		avoidEntryIife: true,
-		minimize: false
-	},
-}, {
-	entry: {
-		"index": "./index.js",
-	},
-	output: {
-		filename: 'index.js',
-	},
-}]
+	{
+		entry: {
+			index: "./index.js"
+		},
+		output: {
+			filename: "index.js"
+		}
+	}
+];

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
@@ -1,16 +1,16 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: {
-		"index": "./index.js",
+		index: "./index.js"
 	},
 	output: {
 		filename: `[name].js`,
 		module: true,
 		libraryTarget: "modern-module",
 		iife: false,
-		chunkFormat: "module",
+		chunkFormat: "module"
 	},
-	externalsType: 'module-import',
+	externalsType: "module-import",
 	experiments: {
 		outputModule: true
 	},
@@ -28,10 +28,11 @@ module.exports = {
 			 */
 			const handler = compilation => {
 				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
-					const bundle = Object.values(assets)[0]._value
-					expect(bundle).toContain(`var __webpack_exports__cjsInterop = (foo_default());
+					const bundle = Object.values(assets)[0]._value;
+					expect(bundle)
+						.toContain(`var __webpack_exports__cjsInterop = (foo_default());
 var __webpack_exports__defaultImport = __WEBPACK_EXTERNAL_MODULE_external_module_43054e33__["default"];
-var __webpack_exports__namedImport = __WEBPACK_EXTERNAL_MODULE_external_module_43054e33__.namedImport;`)
+var __webpack_exports__namedImport = __WEBPACK_EXTERNAL_MODULE_external_module_43054e33__.namedImport;`);
 				});
 			};
 			this.hooks.compilation.tap("testcase", handler);

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/rspack.config.js
@@ -1,32 +1,32 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: {
-		"a": "./a.js",
-		"b": "./b.cjs",
-		"c": "./c.js",
-		"d": "./d.mjs",
-		"e": "./e/index.js",
-		"f": "./f/index.js",
-		"g": "./g/index.js",
-		"h": "./h/file.png",
+		a: "./a.js",
+		b: "./b.cjs",
+		c: "./c.js",
+		d: "./d.mjs",
+		e: "./e/index.js",
+		f: "./f/index.js",
+		g: "./g/index.js",
+		h: "./h/file.png"
 	},
 	module: {
 		rules: [
 			{
 				test: /\.png$/,
-				type: "asset/resource",
+				type: "asset/resource"
 			}
 		]
 	},
 	externals: {
-		path: 'node-commonjs path',
+		path: "node-commonjs path"
 	},
 	output: {
 		filename: `[name].js`,
 		module: true,
 		libraryTarget: "modern-module",
 		iife: false,
-		chunkFormat: "module",
+		chunkFormat: "module"
 	},
 	experiments: {
 		outputModule: true
@@ -44,14 +44,26 @@ module.exports = {
 			 */
 			const handler = compilation => {
 				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
-					expect(assets['a.js']._value).toMatchSnapshot("ESM export should concat");
-					expect(assets['b.js']._value).toMatchSnapshot(".cjs should bail out");
-					expect(assets['c.js']._value).toMatchSnapshot("unambiguous should bail out");
-					expect(assets['d.js']._value).toMatchSnapshot(".mjs should concat");
-					expect(assets['e.js']._value).toMatchSnapshot(".cjs should bail out when bundling");
-					expect(assets['f.js']._value).toMatchSnapshot("external module should bail out when bundling");
-					expect(assets['g.js']._value).toMatchSnapshot("harmony export should concat, even with bailout reason");
-					expect(assets['h.js']._value).toMatchSnapshot("asset as entry should not be concatenated");
+					expect(assets["a.js"]._value).toMatchSnapshot(
+						"ESM export should concat"
+					);
+					expect(assets["b.js"]._value).toMatchSnapshot(".cjs should bail out");
+					expect(assets["c.js"]._value).toMatchSnapshot(
+						"unambiguous should bail out"
+					);
+					expect(assets["d.js"]._value).toMatchSnapshot(".mjs should concat");
+					expect(assets["e.js"]._value).toMatchSnapshot(
+						".cjs should bail out when bundling"
+					);
+					expect(assets["f.js"]._value).toMatchSnapshot(
+						"external module should bail out when bundling"
+					);
+					expect(assets["g.js"]._value).toMatchSnapshot(
+						"harmony export should concat, even with bailout reason"
+					);
+					expect(assets["h.js"]._value).toMatchSnapshot(
+						"asset as entry should not be concatenated"
+					);
 				});
 			};
 			this.hooks.compilation.tap("testcase", handler);

--- a/packages/rspack-test-tools/tests/configCases/library/rspack-issue-8045/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/rspack-issue-8045/rspack.config.js
@@ -1,10 +1,10 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    output: {
-        library: {
+	output: {
+		library: {
 			name: "MyLibrary",
 			export: "default",
 			type: "window"
-		},
-    }
-}
+		}
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/library/system-runtime/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/system-runtime/rspack.config.js
@@ -1,20 +1,19 @@
-
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  target: "web",
-  mode: "development",
-  entry: {
-    main: "./index.js",
-  },
-  output: {
-    filename: "[name].js",
-    library: {
-      type: 'system',
-    },
-  },
-  optimization: {
-    runtimeChunk: {
-      name: "runtime"
-    },
-  },
+	target: "web",
+	mode: "development",
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].js",
+		library: {
+			type: "system"
+		}
+	},
+	optimization: {
+		runtimeChunk: {
+			name: "runtime"
+		}
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/library/system-runtime/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/system-runtime/test.config.js
@@ -2,17 +2,17 @@ const System = require("../../../../dist/helper/legacy/fakeSystem");
 
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  beforeExecute: () => {
-    System.init();
-  },
-  findBundle() {
-    return ["./main.js"];
-  },
-  moduleScope(scope) {
-    System.setRequire(scope.require);
-    scope.System = System;
-  },
-  afterExecute: () => {
-    System.execute("(anonym)");
-  }
+	beforeExecute: () => {
+		System.init();
+	},
+	findBundle() {
+		return ["./main.js"];
+	},
+	moduleScope(scope) {
+		System.setRequire(scope.require);
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/codegen-cache/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/codegen-cache/rspack.config.js
@@ -12,5 +12,5 @@ module.exports = {
 				options: {}
 			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/css/rspack.config.js
@@ -68,5 +68,5 @@ module.exports = {
 					throw e;
 				}
 			})
-	],
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/execute-failed/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/execute-failed/rspack.config.js
@@ -5,8 +5,8 @@ module.exports = {
 		rules: [
 			{
 				test: /index\.js/,
-				use: ['./import-loader.js', './import-loader-2.js'],
-			},
+				use: ["./import-loader.js", "./import-loader-2.js"]
+			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/nul-byte/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/nul-byte/rspack.config.js
@@ -8,8 +8,8 @@ module.exports = {
 		rules: [
 			{
 				test: /a.js/,
-				loader: './convert-loader.js'
-			},
+				loader: "./convert-loader.js"
+			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/recursive-import-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/recursive-import-module/rspack.config.js
@@ -8,8 +8,8 @@ module.exports = {
 		rules: [
 			{
 				test: /\.js/,
-				loader: './loader.js'
+				loader: "./loader.js"
 			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader/additional-data-no-passthrough/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/additional-data-no-passthrough/rspack.config.js
@@ -9,7 +9,11 @@ module.exports = {
 		rules: [
 			{
 				test: path.join(__dirname, "a.js"),
-				use: [{ loader: "./loader-2.js" }, { loader: "builtin:test-no-passthrough-loader" }, { loader: "./loader-1.js" }]
+				use: [
+					{ loader: "./loader-2.js" },
+					{ loader: "builtin:test-no-passthrough-loader" },
+					{ loader: "./loader-1.js" }
+				]
 			}
 		]
 	}

--- a/packages/rspack-test-tools/tests/configCases/loader/additional-data-passthrough/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/additional-data-passthrough/rspack.config.js
@@ -9,7 +9,11 @@ module.exports = {
 		rules: [
 			{
 				test: path.join(__dirname, "a.js"),
-				use: [{ loader: "./loader-2.js" }, { loader: "builtin:test-passthrough-loader" }, { loader: "./loader-1.js" }]
+				use: [
+					{ loader: "./loader-2.js" },
+					{ loader: "builtin:test-passthrough-loader" },
+					{ loader: "./loader-1.js" }
+				]
 			}
 		]
 	}

--- a/packages/rspack-test-tools/tests/configCases/loader/context-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/context-module/rspack.config.js
@@ -16,7 +16,7 @@ module.exports = {
 						loader: "./my-loader.js"
 					}
 				]
-			},
+			}
 		]
 	},
 	plugins: [
@@ -37,8 +37,8 @@ module.exports = {
 							}
 						}
 						assert(hasModule);
-					})
-				})
+					});
+				});
 			}
 		}
 	]

--- a/packages/rspack-test-tools/tests/configCases/loader/emit-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/emit-error/rspack.config.js
@@ -1,4 +1,4 @@
-const path = require("path")
+const path = require("path");
 module.exports = {
 	module: {
 		rules: [
@@ -7,5 +7,5 @@ module.exports = {
 				loader: "./loader"
 			}
 		]
-	},
-}
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/loader/inline-loader-options/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/inline-loader-options/rspack.config.js
@@ -14,4 +14,4 @@ module.exports = {
 			}
 		]
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/match-when-empty/rspack.config.js
@@ -13,8 +13,8 @@ module.exports = {
 				},
 				use: [
 					{
-						loader: "./loader.js", 
-					 }
+						loader: "./loader.js"
+					}
 				]
 			},
 			{

--- a/packages/rspack-test-tools/tests/configCases/loader/options/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/options/rspack.config.js
@@ -2,7 +2,7 @@
 module.exports = {
 	mode: "none",
 	optimization: {
-		moduleIds: 'named'
+		moduleIds: "named"
 	},
 	module: {
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/loader/rspack-issue-4297/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/rspack-issue-4297/rspack.config.js
@@ -5,7 +5,7 @@ module.exports = {
 		rules: [
 			{
 				test: /lib\.js$/,
-				resourceQuery: /source/,
+				resourceQuery: /source/
 			},
 			{
 				test: /lib\.js$/,
@@ -14,13 +14,13 @@ module.exports = {
 			},
 			{
 				test: /lib\.js$/,
-				resourceFragment: /source/,
+				resourceFragment: /source/
 			},
 			{
 				test: /lib\.js$/,
 				resourceFragment: { not: [/source/] },
 				loader: "./fragmentloader.js"
-			},
+			}
 		]
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader/rspack-issue-5600/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/rspack-issue-5600/rspack.config.js
@@ -5,11 +5,8 @@ module.exports = {
 		rules: [
 			{
 				test: /a\.js$/,
-				use: [
-					{ loader: './loader-b.js' },
-					{ loader: './loader-a.js' }
-				]
-			},
+				use: [{ loader: "./loader-b.js" }, { loader: "./loader-a.js" }]
+			}
 		]
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader/rspack-issue-6068/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/rspack-issue-6068/rspack.config.js
@@ -11,8 +11,8 @@ module.exports = {
 						{
 							loader: "./loader1"
 						}
-					]
-				},
+					];
+				}
 			},
 			{
 				test: /a\.js$/,
@@ -21,7 +21,7 @@ module.exports = {
 						{
 							loader: "./loader2"
 						}
-					]
+					];
 				},
 				enforce: "pre"
 			},
@@ -32,7 +32,7 @@ module.exports = {
 						{
 							loader: "./loader3"
 						}
-					]
+					];
 				},
 				enforce: "post"
 			}

--- a/packages/rspack-test-tools/tests/configCases/mangle-exports/skipping-mangle-css-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/mangle-exports/skipping-mangle-css-modules/rspack.config.js
@@ -1,7 +1,7 @@
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	experiments: {
-		css: true,
+		css: true
 	},
 	optimization: {
 		minimize: false,
@@ -13,10 +13,10 @@ module.exports = {
 				test: /\.module\.css$/,
 				type: "css/module",
 				generator: {
-					exportsOnly: true,
+					exportsOnly: true
 				},
 				parser: {
-					namedExports: false,
+					namedExports: false
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/module-graph/get-exports-info/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module-graph/get-exports-info/rspack.config.js
@@ -1,44 +1,50 @@
-const { normalize, join } = require('path');
+const { normalize, join } = require("path");
 
 const PLUGIN_NAME = "Test";
 
 class Plugin {
-    /**
-     * @param {import("@rspack/core").Compiler} compiler
-     */
-    apply(compiler) {
-        compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
-            compilation.hooks.optimizeModules.tap(PLUGIN_NAME, () => {
-                const moduleA = Array.from(compilation.modules).find(module => normalize(module.resource) === normalize(join(__dirname, "a.js")));
-                const exportsInfoA = compilation.moduleGraph.getExportsInfo(moduleA);
-                expect(exportsInfoA.isModuleUsed("main")).toBe(true);
-                expect(exportsInfoA.isUsed("main")).toBe(true);
-                expect(exportsInfoA.getUsed("good", "main")).toBe(4);
-                expect(exportsInfoA.getUsed("cool", "main")).toBe(0);
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.optimizeModules.tap(PLUGIN_NAME, () => {
+				const moduleA = Array.from(compilation.modules).find(
+					module =>
+						normalize(module.resource) === normalize(join(__dirname, "a.js"))
+				);
+				const exportsInfoA = compilation.moduleGraph.getExportsInfo(moduleA);
+				expect(exportsInfoA.isModuleUsed("main")).toBe(true);
+				expect(exportsInfoA.isUsed("main")).toBe(true);
+				expect(exportsInfoA.getUsed("good", "main")).toBe(4);
+				expect(exportsInfoA.getUsed("cool", "main")).toBe(0);
 
-                const moduleB = Array.from(compilation.modules).find(module => normalize(module.resource) === normalize(join(__dirname, "b.js")));
-                const exportsInfoB = compilation.moduleGraph.getExportsInfo(moduleB);
-                expect(exportsInfoB.isModuleUsed("main")).toBe(false);
-                expect(exportsInfoB.isUsed("main")).toBe(false);
+				const moduleB = Array.from(compilation.modules).find(
+					module =>
+						normalize(module.resource) === normalize(join(__dirname, "b.js"))
+				);
+				const exportsInfoB = compilation.moduleGraph.getExportsInfo(moduleB);
+				expect(exportsInfoB.isModuleUsed("main")).toBe(false);
+				expect(exportsInfoB.isUsed("main")).toBe(false);
 
-                const moduleC = Array.from(compilation.modules).find(module => normalize(module.resource) === normalize(join(__dirname, "c.js")));
-                const exportsInfoC = compilation.moduleGraph.getExportsInfo(moduleC);
-                expect(exportsInfoC.isModuleUsed("main")).toBe(true);
-                expect(exportsInfoC.isUsed("main")).toBe(false);
-            });
-        });
-
-    }
+				const moduleC = Array.from(compilation.modules).find(
+					module =>
+						normalize(module.resource) === normalize(join(__dirname, "c.js"))
+				);
+				const exportsInfoC = compilation.moduleGraph.getExportsInfo(moduleC);
+				expect(exportsInfoC.isModuleUsed("main")).toBe(true);
+				expect(exportsInfoC.isUsed("main")).toBe(false);
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: "web",
-    node: {
-        __dirname: false,
-        __filename: false,
-    },
-    plugins: [
-        new Plugin()
-    ]
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/module-graph/get-issuer/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module-graph/get-issuer/rspack.config.js
@@ -1,32 +1,33 @@
-const { normalize, join } = require('path');
+const { normalize, join } = require("path");
 
 const PLUGIN_NAME = "Test";
 
 class Plugin {
-    /**
-     * @param {import("@rspack/core").Compiler} compiler
-     */
-    apply(compiler) {
-        compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
-            compilation.hooks.finishModules.tap(PLUGIN_NAME, () => {
-                const fooModule = Array.from(compilation.modules.values())
-                    .find(module => normalize(module.request) === normalize(join(__dirname, 'foo.js')));
-                const issuer = compilation.moduleGraph.getIssuer(fooModule);
-                expect(normalize(issuer.request)).toBe(normalize(join(__dirname, 'index.js')));
-            });
-        });
-
-    }
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.finishModules.tap(PLUGIN_NAME, () => {
+				const fooModule = Array.from(compilation.modules.values()).find(
+					module =>
+						normalize(module.request) === normalize(join(__dirname, "foo.js"))
+				);
+				const issuer = compilation.moduleGraph.getIssuer(fooModule);
+				expect(normalize(issuer.request)).toBe(
+					normalize(join(__dirname, "index.js"))
+				);
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: "web",
-    node: {
-        __dirname: false,
-        __filename: false,
-    },
-    plugins: [
-        new Plugin()
-    ]
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/module-graph/get-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module-graph/get-module/rspack.config.js
@@ -1,39 +1,39 @@
-const { normalize, join } = require('path');
+const { normalize, join } = require("path");
 
 const PLUGIN_NAME = "Test";
 
 class Plugin {
-    /**
-     * @param {import("@rspack/core").Compiler} compiler
-     */
-    apply(compiler) {
-        compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
-            compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, () => {
-                const entry = Array.from(compilation.entries.values())[0];
-                const entryDependency = entry.dependencies[0];
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, () => {
+				const entry = Array.from(compilation.entries.values())[0];
+				const entryDependency = entry.dependencies[0];
 
-                const module = compilation.moduleGraph.getModule(entryDependency);
-                expect(module.modules.length).toBe(2);
+				const module = compilation.moduleGraph.getModule(entryDependency);
+				expect(module.modules.length).toBe(2);
 
-                const resolvedModule = compilation.moduleGraph.getResolvedModule(entryDependency);
-                expect(normalize(resolvedModule.request)).toBe(normalize(join(__dirname, 'index.js')));
-            });
-        });
-
-    }
+				const resolvedModule =
+					compilation.moduleGraph.getResolvedModule(entryDependency);
+				expect(normalize(resolvedModule.request)).toBe(
+					normalize(join(__dirname, "index.js"))
+				);
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: "web",
-    node: {
-        __dirname: false,
-        __filename: false,
-    },
-    plugins: [
-        new Plugin()
-    ],
-    optimization: {
-        concatenateModules: true
-    }
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [new Plugin()],
+	optimization: {
+		concatenateModules: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/module-graph/get-outgoing-connections/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module-graph/get-outgoing-connections/rspack.config.js
@@ -1,33 +1,34 @@
-const { normalize, join } = require('path');
+const { normalize, join } = require("path");
 
 const PLUGIN_NAME = "Test";
 
 class Plugin {
-    /**
-     * @param {import("@rspack/core").Compiler} compiler
-     */
-    apply(compiler) {
-        compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
-            compilation.hooks.finishModules.tap(PLUGIN_NAME, () => {
-                const entry = Array.from(compilation.entries.values())[0];
-                const entryDependency = entry.dependencies[0];
-                const connection = compilation.moduleGraph.getConnection(entryDependency);
-                const outgoingConnection = compilation.moduleGraph.getOutgoingConnections(connection.module)[0];
-                expect(normalize(outgoingConnection.module.request)).toBe(normalize(join(__dirname, 'foo.js')));
-            });
-        });
-
-    }
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.finishModules.tap(PLUGIN_NAME, () => {
+				const entry = Array.from(compilation.entries.values())[0];
+				const entryDependency = entry.dependencies[0];
+				const connection =
+					compilation.moduleGraph.getConnection(entryDependency);
+				const outgoingConnection =
+					compilation.moduleGraph.getOutgoingConnections(connection.module)[0];
+				expect(normalize(outgoingConnection.module.request)).toBe(
+					normalize(join(__dirname, "foo.js"))
+				);
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: "web",
-    node: {
-        __dirname: false,
-        __filename: false,
-    },
-    plugins: [
-        new Plugin()
-    ]
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/module-graph/get-parent-block-index/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module-graph/get-parent-block-index/rspack.config.js
@@ -1,29 +1,35 @@
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.compilation.tap("Test", compilation => {
-            compilation.hooks.processAssets.tap("Test", () => {
-                const entry = compilation.entries.get("main");
-                const entryDependency = entry.dependencies[0];
-                const entryModule = compilation.moduleGraph.getModule(entryDependency);
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", compilation => {
+			compilation.hooks.processAssets.tap("Test", () => {
+				const entry = compilation.entries.get("main");
+				const entryDependency = entry.dependencies[0];
+				const entryModule = compilation.moduleGraph.getModule(entryDependency);
 
-                const fooDependency = entryModule.dependencies.find(dep => dep.request === './foo');
-                expect(compilation.moduleGraph.getParentBlockIndex(fooDependency)).toBe(0);
+				const fooDependency = entryModule.dependencies.find(
+					dep => dep.request === "./foo"
+				);
+				expect(compilation.moduleGraph.getParentBlockIndex(fooDependency)).toBe(
+					0
+				);
 
-                const barDependency = entryModule.dependencies.find(dep => dep.request === './bar');
-                expect(compilation.moduleGraph.getParentBlockIndex(barDependency)).toBe(1);
-            });
-        });
-    }
+				const barDependency = entryModule.dependencies.find(
+					dep => dep.request === "./bar"
+				);
+				expect(compilation.moduleGraph.getParentBlockIndex(barDependency)).toBe(
+					1
+				);
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: "web",
-    node: false,
-    entry: {
-        main: "./index.js"
-    },
-    plugins: [
-        new Plugin()
-    ]
+	target: "web",
+	node: false,
+	entry: {
+		main: "./index.js"
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/module-graph/get-parent-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module-graph/get-parent-module/rspack.config.js
@@ -1,27 +1,27 @@
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.compilation.tap("Test", compilation => {
-            compilation.hooks.processAssets.tap("Test", () => {
-                const entry = compilation.entries.get("main");
-                const entryDependency = entry.dependencies[0];
-                const entryModule = compilation.moduleGraph.getModule(entryDependency);
-                expect(compilation.moduleGraph.getParentModule(entryModule.dependencies[0])).toBe(entryModule);
-            });
-        });
-    }
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", compilation => {
+			compilation.hooks.processAssets.tap("Test", () => {
+				const entry = compilation.entries.get("main");
+				const entryDependency = entry.dependencies[0];
+				const entryModule = compilation.moduleGraph.getModule(entryDependency);
+				expect(
+					compilation.moduleGraph.getParentModule(entryModule.dependencies[0])
+				).toBe(entryModule);
+			});
+		});
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: "web",
-    node: false,
-    entry: {
-        main: "./index.js"
-    },
-    optimization: {
-        sideEffects: false
-    },
-    plugins: [
-        new Plugin()
-    ]
+	target: "web",
+	node: false,
+	entry: {
+		main: "./index.js"
+	},
+	optimization: {
+		sideEffects: false
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/module/build-info/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/build-info/rspack.config.js
@@ -1,31 +1,27 @@
-const path = require('path');
+const path = require("path");
 
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.finishMake.tap('PLUGIN', compilation => {
-            const entry = compilation.entries.get("main");
-            const entryDependency = entry.dependencies[0];
-            const entryModule = compilation.moduleGraph.getModule(entryDependency);
-            expect(entryModule.buildInfo.loaded).toBe(true);
-        })
-    }
+	apply(compiler) {
+		compiler.hooks.finishMake.tap("PLUGIN", compilation => {
+			const entry = compilation.entries.get("main");
+			const entryDependency = entry.dependencies[0];
+			const entryModule = compilation.moduleGraph.getModule(entryDependency);
+			expect(entryModule.buildInfo.loaded).toBe(true);
+		});
+	}
 }
 
 /**
  * @type {import('@rspack/core').RspackOptions}
  */
 module.exports = {
-    module: {
-        rules: [
-            {
-                test: /\.js/,
-                use: [
-                    path.join(__dirname, "loader.js")
-                ]
-            }
-        ]
-    },
-    plugins: [
-        new Plugin()
-    ]
+	module: {
+		rules: [
+			{
+				test: /\.js/,
+				use: [path.join(__dirname, "loader.js")]
+			}
+		]
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/module/change-parser-in-child-compiler/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/change-parser-in-child-compiler/rspack.config.js
@@ -4,22 +4,30 @@
 module.exports = {
 	plugins: [
 		function (compiler) {
-			compiler.hooks.make.tapAsync('test', (compilation, callback) => {
-				const child = compilation.createChildCompiler("test", {
-					filename: '__child-[name].js',
-					publicPath: '',
-				}, [
-					new compiler.webpack.library.EnableLibraryPlugin('commonjs'),
-					new compiler.webpack.EntryPlugin(compilation.options.context, "./child-entry.js", {
-						name: "main",
-						library: {
-							type: "commonjs",
-						}
-					})
-				]);
+			compiler.hooks.make.tapAsync("test", (compilation, callback) => {
+				const child = compilation.createChildCompiler(
+					"test",
+					{
+						filename: "__child-[name].js",
+						publicPath: ""
+					},
+					[
+						new compiler.webpack.library.EnableLibraryPlugin("commonjs"),
+						new compiler.webpack.EntryPlugin(
+							compilation.options.context,
+							"./child-entry.js",
+							{
+								name: "main",
+								library: {
+									type: "commonjs"
+								}
+							}
+						)
+					]
+				);
 				child.options.module.parser.javascript.url = "relative";
 				child.runAsChild(callback);
-			})
+			});
 		}
-	],
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/module/function-use/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/function-use/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/module/generator-js/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/generator-js/rspack.config.js
@@ -5,7 +5,7 @@ module.exports = {
 	context: __dirname,
 	output: {
 		publicPath: "/",
-		filename: 'main.js'
+		filename: "main.js"
 	},
 	module: {
 		rules: [
@@ -15,7 +15,7 @@ module.exports = {
 				generator: {
 					filename: "custom/lib.js"
 				}
-			},
+			}
 		]
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/module/lib-ident/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/lib-ident/rspack.config.js
@@ -1,29 +1,29 @@
-const { normalize } = require('path');
+const { normalize } = require("path");
 
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.finishMake.tap('PLUGIN', compilation => {
-            const entry = compilation.entries.get("main");
-            const entryDependency = entry.dependencies[0];
-            const entryModule = compilation.moduleGraph.getModule(entryDependency);
-            expect(
-                normalize(entryModule.libIdent({
-                    context: __dirname
-                }))
-            ).toEqual("index.js");
-        })
-    }
+	apply(compiler) {
+		compiler.hooks.finishMake.tap("PLUGIN", compilation => {
+			const entry = compilation.entries.get("main");
+			const entryDependency = entry.dependencies[0];
+			const entryModule = compilation.moduleGraph.getModule(entryDependency);
+			expect(
+				normalize(
+					entryModule.libIdent({
+						context: __dirname
+					})
+				)
+			).toEqual("index.js");
+		});
+	}
 }
 
 /**
  * @type {import('@rspack/core').RspackOptions}
  */
 module.exports = {
-    context: __dirname,
-    entry: {
-        main: "./index.js"
-    },
-    plugins: [
-        new Plugin()
-    ]
+	context: __dirname,
+	entry: {
+		main: "./index.js"
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/module/match-resource-mimetype/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/match-resource-mimetype/rspack.config.js
@@ -7,19 +7,19 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				include: path.resolve(__dirname, 'a.js'),
+				include: path.resolve(__dirname, "a.js"),
 				use: [
-					'./get-source.js',
+					"./get-source.js",
 					{
 						loader: "builtin:swc-loader",
 						options: {
 							jsc: {
-								target: "es3",
+								target: "es3"
 							}
 						}
 					}
 				]
-			},
+			}
 		]
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/module/match-resource/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/match-resource/rspack.config.js
@@ -1,25 +1,25 @@
-const { resolve, normalize } = require('path');
+const { resolve, normalize } = require("path");
 
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.finishMake.tap('PLUGIN', compilation => {
-            const entry = compilation.entries.get("main");
-            const entryDependency = entry.dependencies[0];
-            const entryModule = compilation.moduleGraph.getModule(entryDependency);
-            expect(normalize(entryModule.matchResource)).toEqual(resolve(__dirname, "index.js"));
-        })
-    }
+	apply(compiler) {
+		compiler.hooks.finishMake.tap("PLUGIN", compilation => {
+			const entry = compilation.entries.get("main");
+			const entryDependency = entry.dependencies[0];
+			const entryModule = compilation.moduleGraph.getModule(entryDependency);
+			expect(normalize(entryModule.matchResource)).toEqual(
+				resolve(__dirname, "index.js")
+			);
+		});
+	}
 }
 
 /**
  * @type {import('@rspack/core').RspackOptions}
  */
 module.exports = {
-    context: __dirname,
-    entry: {
-        main: "./index.js!=!./loader"
-    },
-    plugins: [
-        new Plugin()
-    ]
+	context: __dirname,
+	entry: {
+		main: "./index.js!=!./loader"
+	},
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/module/merge-global-generator/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-global-generator/rspack.config.js
@@ -4,8 +4,8 @@
 module.exports = {
 	module: {
 		generator: {
-			"css": {
-				exportsOnly: true,
+			css: {
+				exportsOnly: true
 			}
 		},
 		rules: [
@@ -14,13 +14,13 @@ module.exports = {
 				type: "css/module",
 				generator: {
 					localIdentName: "[path][name][ext]-[local]",
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			},
 			{
 				test: /\.css$/,
-				type: "css",
-			},
+				type: "css"
+			}
 		]
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/rspack.config.js
@@ -5,17 +5,17 @@ module.exports = {
 			{
 				test: /\.js/,
 				resolve: {
-					conditionNames: ["server"],
+					conditionNames: ["server"]
 				}
 			},
 			{
 				test: /reexports\.js/,
 				resolve: {
 					alias: {
-						"server-lib": "lib2",
+						"server-lib": "lib2"
 					}
 				}
-			},
+			}
 		]
 	},
 	resolve: {

--- a/packages/rspack-test-tools/tests/configCases/module/resolve/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/resolve/rspack.config.js
@@ -1,11 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		},
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/module/resource-resolve-data/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/resource-resolve-data/rspack.config.js
@@ -1,22 +1,22 @@
-const { resolve, normalize } = require('path');
+const { resolve, normalize } = require("path");
 
 class Plugin {
-    apply(compiler) {
-        compiler.hooks.finishMake.tap('PLUGIN', compilation => {
-            const entry = compilation.entries.get("main");
-            const entryDependency = entry.dependencies[0];
-            const entryModule = compilation.moduleGraph.getModule(entryDependency);
-            expect(normalize(entryModule.resourceResolveData.resource)).toEqual(resolve(__dirname, "index.js"));
-        })
-    }
+	apply(compiler) {
+		compiler.hooks.finishMake.tap("PLUGIN", compilation => {
+			const entry = compilation.entries.get("main");
+			const entryDependency = entry.dependencies[0];
+			const entryModule = compilation.moduleGraph.getModule(entryDependency);
+			expect(normalize(entryModule.resourceResolveData.resource)).toEqual(
+				resolve(__dirname, "index.js")
+			);
+		});
+	}
 }
 
 /**
  * @type {import('@rspack/core').RspackOptions}
  */
 module.exports = {
-    context: __dirname,
-    plugins: [
-        new Plugin()
-    ]
+	context: __dirname,
+	plugins: [new Plugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/module/rspack-issue-5548/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/rspack-issue-5548/rspack.config.js
@@ -10,5 +10,5 @@ module.exports = {
 				dynamicImportMode: "eager"
 			}
 		}
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/module/rspack-issue-6739/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/rspack-issue-6739/rspack.config.js
@@ -1,4 +1,5 @@
-let foo = {}, bar = {}
+let foo = {},
+	bar = {};
 module.exports = {
 	module: {
 		rules: [
@@ -6,13 +7,13 @@ module.exports = {
 				test: require.resolve("foo"),
 				loader: "./loader",
 				descriptionData: {
-					"componentId": (componentIdData) => {
-						foo.componentIdData = componentIdData
-						return true
+					componentId: componentIdData => {
+						foo.componentIdData = componentIdData;
+						return true;
 					},
-					"componentId.scope": (scopeData) => {
-						foo.scopeData = scopeData
-						return true
+					"componentId.scope": scopeData => {
+						foo.scopeData = scopeData;
+						return true;
 					}
 				}
 			},
@@ -20,12 +21,12 @@ module.exports = {
 				test: require.resolve("bar"),
 				loader: "./empty-loader",
 				descriptionData: {
-					"_custom_key": (customKey) => {
-						bar.customKey = customKey
+					_custom_key: customKey => {
+						bar.customKey = customKey;
 						// return `true` causes error:
 						// `Error: didn't return a Buffer or String`
-						return false
-					},
+						return false;
+					}
 				}
 			}
 		]
@@ -35,14 +36,14 @@ module.exports = {
 			apply(compiler) {
 				compiler.hooks.done.tap("_", () => {
 					expect(foo.componentIdData).toMatchObject({
-							"scope": "react",
-							"name": "examples/button",
-							"version": "0.0.0"
-					})
-					expect(foo.scopeData).toBe("react")
-					expect(bar.customKey).toBe(true)
-				})
+						scope: "react",
+						name: "examples/button",
+						version: "0.0.0"
+					});
+					expect(foo.scopeData).toBe("react");
+					expect(bar.customKey).toBe(true);
+				});
 			}
 		}
 	]
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/module/rspack-issue-8785/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/rspack-issue-8785/rspack.config.js
@@ -4,11 +4,11 @@ module.exports = {
 		rules: [
 			{
 				test: /\.toml$/,
-				type: 'json',
+				type: "json",
 				parser: {
-					parse: () => ({ foo: 'bar' })
+					parse: () => ({ foo: "bar" })
 				}
 			}
 		]
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/rspack.config.js
@@ -5,4 +5,4 @@ module.exports = {
 	optimization: {
 		minimize: true
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/optimization/minimizer-swc-extract-comments/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/optimization/minimizer-swc-extract-comments/rspack.config.js
@@ -1,4 +1,4 @@
-const { SwcJsMinimizerRspackPlugin } = require("@rspack/core")
+const { SwcJsMinimizerRspackPlugin } = require("@rspack/core");
 
 /**
  * @type {import("@rspack/core").Configuration}
@@ -14,7 +14,7 @@ module.exports = {
 						comments: "all"
 					}
 				}
-			}),
+			})
 		]
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/optimization/module-ids-natural/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/optimization/module-ids-natural/rspack.config.js
@@ -2,5 +2,5 @@
 module.exports = {
 	optimization: {
 		moduleIds: "natural"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/output-module/only-non-webpack-require/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/only-non-webpack-require/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core")
+const webpack = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -32,7 +32,7 @@ module.exports = {
 							);
 						}
 					);
-				})
+				});
 			}
 		}
 	]

--- a/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-4784/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-4784/rspack.config.js
@@ -1,4 +1,4 @@
-const {RawSource} = require('webpack-sources')
+const { RawSource } = require("webpack-sources");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -18,20 +18,23 @@ module.exports = {
 		}
 	},
 	experiments: {
-		outputModule: true,
+		outputModule: true
 	},
 	plugins: [
 		{
 			apply(compiler) {
-				compiler.hooks.thisCompilation.tap('test', (compilation) => {
-					compilation.hooks.processAssets.tap('test', (assets) => {
-							compilation.updateAsset('m.mjs', new RawSource(`import { a, b } from './main.mjs';
+				compiler.hooks.thisCompilation.tap("test", compilation => {
+					compilation.hooks.processAssets.tap("test", assets => {
+						compilation.updateAsset(
+							"m.mjs",
+							new RawSource(`import { a, b } from './main.mjs';
 it('should get correctly exports', () => {
 	expect(a).toBe('a')
 	expect(b).toBe('b')
-})`))
-					})
-				})
+})`)
+						);
+					});
+				});
 			}
 		}
 	]

--- a/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-6572/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-6572/rspack.config.js
@@ -2,15 +2,15 @@
 module.exports = {
 	mode: "production",
 	optimization: {
-		minimize: false,
+		minimize: false
 	},
 	output: {
-    library: {
-      type: "module",
-    },
+		library: {
+			type: "module"
+		},
 		filename: "[name].mjs",
-    module: true,
-    chunkFormat: "module",
-    chunkLoading: "import",
+		module: true,
+		chunkFormat: "module",
+		chunkLoading: "import"
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/chunk-filename-win32/rspack.config.js
@@ -3,6 +3,6 @@ const path = require("path");
 module.exports = {
 	entry: "./index.js",
 	output: {
-		chunkFilename: path.win32.join('./', 'js/[name].[chunkhash:8].chunk.js'),
-	},
+		chunkFilename: path.win32.join("./", "js/[name].[chunkhash:8].chunk.js")
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/output/library-async-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/library-async-module/rspack.config.js
@@ -2,14 +2,14 @@
  * @type {import('@rspack/cli').Configuration}
  */
 module.exports = {
-  entry: "./index.js",
-  experiments: {
-    outputModule: true,
-  },
-  output: {
-    chunkFormat: "module",
-    library: {
-      type: "module",
-    },
-  },
+	entry: "./index.js",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		chunkFormat: "module",
+		library: {
+			type: "module"
+		}
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/output/library-truthy/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/library-truthy/rspack.config.js
@@ -1,11 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    output: {
-        library: {
-            type: 'modern-module'
-        }
-    },
-		optimization: {
-			avoidEntryIife: true,
-		},
-}
+	output: {
+		library: {
+			type: "modern-module"
+		}
+	},
+	optimization: {
+		avoidEntryIife: true
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/output/library-undefined/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/library-undefined/rspack.config.js
@@ -1,6 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    output: {
-        
-    }
-}
+	output: {}
+};

--- a/packages/rspack-test-tools/tests/configCases/parsing/class-method-parameters/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/class-method-parameters/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: {
-		main: "./index.js",
-	},
+		main: "./index.js"
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/parsing/default-export-const/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/default-export-const/rspack.config.js
@@ -4,7 +4,7 @@ module.exports = [
 		entry: "./not-supports-const.js",
 		output: {
 			environment: {
-				const: false,
+				const: false
 			}
 		}
 	},
@@ -12,7 +12,7 @@ module.exports = [
 		entry: "./supports-const.js",
 		output: {
 			environment: {
-				const: true,
+				const: true
 			}
 		}
 	}

--- a/packages/rspack-test-tools/tests/configCases/parsing/eval-cjs-typeof/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/eval-cjs-typeof/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	node: {
-		__filename: false,
+		__filename: false
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/parsing/eval-condition-inside-require/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/eval-condition-inside-require/rspack.config.js
@@ -2,6 +2,6 @@
 module.exports = {
 	mode: "development",
 	optimization: {
-		nodeEnv: "development",
+		nodeEnv: "development"
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/parsing/eval-exports-in-detection-harmony/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/eval-exports-in-detection-harmony/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	node: {
-		__filename: false,
+		__filename: false
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/rspack.config.js
@@ -2,14 +2,14 @@
  * @type {import('@rspack/core').Configuration}
  */
 module.exports = {
-  entry: "./index.js",
-  node: {
-    __dirname: false,
-    __filename: false
-  },
-  optimization: {
-    sideEffects: false,
-    concatenateModules: false,
-    innerGraph: false
-  }
-}
+	entry: "./index.js",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	optimization: {
+		sideEffects: false,
+		concatenateModules: false,
+		innerGraph: false
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/parsing/import-dynamic/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/import-dynamic/test.config.js
@@ -3,4 +3,3 @@ module.exports = {
 		return ["test.js"];
 	}
 };
-

--- a/packages/rspack-test-tools/tests/configCases/parsing/import-eager/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/import-eager/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	node: {
-		__dirname: false,
+		__dirname: false
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-exports/rspack.config.js
@@ -1,7 +1,7 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  mode: "production",
-  optimization: {
-    innerGraph: true,
-  }
-}
+	mode: "production",
+	optimization: {
+		innerGraph: true
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-require/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/nested-webpack-require/rspack.config.js
@@ -1,7 +1,7 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  mode: "development",
-  optimization: {
-    innerGraph: true,
-  }
-}
+	mode: "development",
+	optimization: {
+		innerGraph: true
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/parsing/preserve-all-comments-define/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/preserve-all-comments-define/rspack.config.js
@@ -1,4 +1,4 @@
-const { DefinePlugin } = require("@rspack/core")
+const { DefinePlugin } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -8,13 +8,15 @@ module.exports = {
 		}),
 		{
 			apply(compiler) {
-				compiler.hooks.compilation.tap("Test", (compilation) => {
-					compilation.hooks.processAssets.tap("Test", (assets) => {
+				compiler.hooks.compilation.tap("Test", compilation => {
+					compilation.hooks.processAssets.tap("Test", assets => {
 						let source = assets["bundle0.js"].source();
-						expect(source.match(/\/\* @__PURE__ \*\/ jsx/g) || []).toHaveLength(1);
-					})
-				})
+						expect(source.match(/\/\* @__PURE__ \*\/ jsx/g) || []).toHaveLength(
+							1
+						);
+					});
+				});
 			}
 		}
 	]
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/parsing/preserve-all-comments/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/preserve-all-comments/rspack.config.js
@@ -1,2 +1,2 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {}
+module.exports = {};

--- a/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-6934/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-6934/rspack.config.js
@@ -1,3 +1,3 @@
 module.exports = {
 	mode: "development"
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-7012/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-7012/rspack.config.js
@@ -1,3 +1,3 @@
 module.exports = {
 	mode: "production"
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/chunk-group-chunks/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/chunk-group-chunks/rspack.config.js
@@ -1,10 +1,10 @@
 function plugin(compiler) {
 	compiler.hooks.compilation.tap("plugin", compilation => {
 		compilation.hooks.processAssets.tap("plugin", () => {
-			const entryA = compilation.entrypoints.get('a');
-			expect(entryA.chunks.map(c => c.name)).toEqual(['a'])
-			const entryB = compilation.entrypoints.get('b');
-			expect(entryB.chunks.map(c => c.name)).toEqual(['b'])
+			const entryA = compilation.entrypoints.get("a");
+			expect(entryA.chunks.map(c => c.name)).toEqual(["a"]);
+			const entryB = compilation.entrypoints.get("b");
+			expect(entryB.chunks.map(c => c.name)).toEqual(["b"]);
 		});
 	});
 }
@@ -13,10 +13,10 @@ function plugin(compiler) {
 module.exports = {
 	entry: {
 		a: "./entry1.js",
-		b: "./entry2.js",
+		b: "./entry2.js"
 	},
 	output: {
-		filename: "[name].js",
+		filename: "[name].js"
 	},
 	plugins: [plugin]
 };

--- a/packages/rspack-test-tools/tests/configCases/plugins/chunk-group-chunks/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/chunk-group-chunks/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  noTests: true
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/compilation-chunk-groups/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/compilation-chunk-groups/rspack.config.js
@@ -3,14 +3,18 @@ function plugin(compiler) {
 		compilation.hooks.processAssets.tap("plugin", () => {
 			const chunkGroups = compilation.chunkGroups;
 			expect(chunkGroups.length).toBe(6);
-			expect(chunkGroups.find(i => i.name === 'a').getFiles()).toEqual(['a.js']);
-			expect(chunkGroups.find(i => i.name === 'b').getFiles()).toEqual(['b.js']);
+			expect(chunkGroups.find(i => i.name === "a").getFiles()).toEqual([
+				"a.js"
+			]);
+			expect(chunkGroups.find(i => i.name === "b").getFiles()).toEqual([
+				"b.js"
+			]);
 			expect(chunkGroups.filter(i => i.isInitial()).length).toEqual(2);
 
 			const namedChunkGroups = compilation.namedChunkGroups;
 			expect(Array.from(namedChunkGroups.keys()).length).toBe(2);
-			expect(namedChunkGroups.get("a").getFiles()).toEqual(['a.js']);
-			expect(namedChunkGroups.get("b").getFiles()).toEqual(['b.js']);
+			expect(namedChunkGroups.get("a").getFiles()).toEqual(["a.js"]);
+			expect(namedChunkGroups.get("b").getFiles()).toEqual(["b.js"]);
 
 			// for of
 			const result1 = [];
@@ -48,10 +52,10 @@ function plugin(compiler) {
 			}, []);
 			origins.sort();
 			expect(origins).toEqual([
-				'./entry1.js',
-				'./entry1.js',
-				'./entry2.js',
-				'./entry2.js'
+				"./entry1.js",
+				"./entry1.js",
+				"./entry2.js",
+				"./entry2.js"
 			]);
 		});
 	});
@@ -61,10 +65,10 @@ function plugin(compiler) {
 module.exports = {
 	entry: {
 		a: "./entry1.js",
-		b: "./entry2.js",
+		b: "./entry2.js"
 	},
 	output: {
-		filename: "[name].js",
+		filename: "[name].js"
 	},
 	plugins: [plugin]
 };

--- a/packages/rspack-test-tools/tests/configCases/plugins/compilation-chunk-groups/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/compilation-chunk-groups/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  noTests: true
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/eval-source-map-dev-tool-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/eval-source-map-dev-tool-plugin/rspack.config.js
@@ -5,19 +5,19 @@ const { rspack } = require("@rspack/core");
  * @type {import("@rspack/core").Configuration}
  */
 module.exports = {
-    node: {
-        __dirname: false,
-        __filename: false
-    },
-    output: {
-        filename: "[name].js"
-    },
-    plugins: [
-        new rspack.EvalSourceMapDevToolPlugin({
-            sourceRoot: path.join(__dirname, "folder") + "/"
-        }),
-        new rspack.DefinePlugin({
-            CONTEXT: JSON.stringify(__dirname)
-        })
-    ]
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		new rspack.EvalSourceMapDevToolPlugin({
+			sourceRoot: path.join(__dirname, "folder") + "/"
+		}),
+		new rspack.DefinePlugin({
+			CONTEXT: JSON.stringify(__dirname)
+		})
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/plugins/get-runtime-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/get-runtime-chunk/rspack.config.js
@@ -1,14 +1,14 @@
 const table = {
-	['main1']: 'main1',
-	['main2']: 'main2-runtime'
-}
+	["main1"]: "main1",
+	["main2"]: "main2-runtime"
+};
 
 function plugin(compiler) {
 	compiler.hooks.compilation.tap("plugin", compilation => {
 		compilation.hooks.processAssets.tap("plugin", () => {
 			for (let [name, entrypoint] of compilation.entrypoints.entries()) {
 				const runtimeChunk = entrypoint.getRuntimeChunk();
-				expect(runtimeChunk.name).toBe(table[name])
+				expect(runtimeChunk.name).toBe(table[name]);
 			}
 		});
 	});
@@ -16,22 +16,25 @@ function plugin(compiler) {
 
 const common = {
 	output: {
-		filename: "[name].js",
+		filename: "[name].js"
 	},
 	plugins: [plugin]
-}
+};
 
-module.exports = [{
-	...common,
-	entry: {
-		main1: "./entry1.js",
-	},
-}, {
-	...common,
-	entry: {
-		main2: {
-			import: "./entry2.js",
-			runtime: "main2-runtime"
+module.exports = [
+	{
+		...common,
+		entry: {
+			main1: "./entry1.js"
 		}
 	},
-}];
+	{
+		...common,
+		entry: {
+			main2: {
+				import: "./entry2.js",
+				runtime: "main2-runtime"
+			}
+		}
+	}
+];

--- a/packages/rspack-test-tools/tests/configCases/plugins/get-runtime-chunk/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/get-runtime-chunk/test.config.js
@@ -1,4 +1,4 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  noTests: true
-}
+	noTests: true
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-default-false/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-comment-default-false/rspack.config.js
@@ -13,7 +13,5 @@ module.exports = {
 	optimization: {
 		minimize: true
 	},
-	plugins: [
-		new rspack.SwcJsMinimizerRspackPlugin()
-	]
+	plugins: [new rspack.SwcJsMinimizerRspackPlugin()]
 };

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-disabled-on-empty-array/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-disabled-on-empty-array/rspack.config.js
@@ -1,11 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		}
 	},

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-extract-comments-with-query/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-extract-comments-with-query/rspack.config.js
@@ -3,7 +3,7 @@ const { rspack } = require("@rspack/core");
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	output: {
-		filename: 'bundle0.js?hash=[contenthash]'
+		filename: "bundle0.js?hash=[contenthash]"
 	},
 	optimization: {
 		minimize: true,

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-with-devtool-false/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-with-devtool-false/rspack.config.js
@@ -1,4 +1,4 @@
-const { SourceMapDevToolPlugin } = require('@rspack/core')
+const { SourceMapDevToolPlugin } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -8,10 +8,8 @@ module.exports = {
 		main: "./index.js"
 	},
 	optimization: {
-		minimize: true,
+		minimize: true
 	},
-	plugins: [
-		new SourceMapDevToolPlugin({})
-	],
-	devtool: false,
+	plugins: [new SourceMapDevToolPlugin({})],
+	devtool: false
 };

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-with-query/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-with-query/rspack.config.js
@@ -1,18 +1,18 @@
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		generator: {
 			"css/auto": {
-				exportsOnly: false,
+				exportsOnly: false
 			}
 		}
 	},
 	experiments: { css: true },
 	output: {
-		filename: 'bundle0.js?hash=[contenthash]',
-		cssFilename: 'bundle0.css?hash=[contenthash]'
+		filename: "bundle0.js?hash=[contenthash]",
+		cssFilename: "bundle0.css?hash=[contenthash]"
 	},
 	optimization: {
 		minimize: true

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-with-query/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-with-query/test.config.js
@@ -1,8 +1,5 @@
 module.exports = {
 	findBundle() {
-		return [
-			"bundle0.css",
-			"bundle0.js",
-		]
+		return ["bundle0.css", "bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/rspack-issue-7084/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/rspack-issue-7084/rspack.config.js
@@ -8,4 +8,4 @@ module.exports = {
 			"typeof window": JSON.stringify("undefined")
 		})
 	]
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-child-compiler/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-child-compiler/rspack.config.js
@@ -8,29 +8,36 @@ const CHILD_FILENAME = "./child";
  * @type {import("@rspack/core").Configuration}
  */
 module.exports = {
-    devtool: "source-map",
-    node: {
-        __dirname: false,
-        __filename: false
-    },
-    externals: {
-        CHILD_FILENAME: `commonjs ${CHILD_FILENAME}`
-    },
-    output: {
-        filename: "[name].js"
-    },
-    plugins: [
-        new rspack.DefinePlugin({
-            CONTEXT: JSON.stringify(__dirname)
-        }),
-        compiler => {
-            compiler.hooks.make.tapAsync('PLUGIN', (compilation, callback) => {
-                const outputOptions = {};
-                const childCompiler = compilation.createChildCompiler(CHILD_ID, outputOptions);
-                const SingleEntryPlugin = compiler.webpack.EntryPlugin;
-                new SingleEntryPlugin(compiler.context, path.join(__dirname, CHILD_FILENAME), CHILD_ID).apply(childCompiler);
-                childCompiler.runAsChild(err => callback(err));
-            });
-        }
-    ]
+	devtool: "source-map",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	externals: {
+		CHILD_FILENAME: `commonjs ${CHILD_FILENAME}`
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		new rspack.DefinePlugin({
+			CONTEXT: JSON.stringify(__dirname)
+		}),
+		compiler => {
+			compiler.hooks.make.tapAsync("PLUGIN", (compilation, callback) => {
+				const outputOptions = {};
+				const childCompiler = compilation.createChildCompiler(
+					CHILD_ID,
+					outputOptions
+				);
+				const SingleEntryPlugin = compiler.webpack.EntryPlugin;
+				new SingleEntryPlugin(
+					compiler.context,
+					path.join(__dirname, CHILD_FILENAME),
+					CHILD_ID
+				).apply(childCompiler);
+				childCompiler.runAsChild(err => callback(err));
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-child-compiler/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-child-compiler/test.config.js
@@ -1,6 +1,6 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-    findBundle: (i, options) => {
-        return ["main.js"];
-    }
+	findBundle: (i, options) => {
+		return ["main.js"];
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-file-context/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-file-context/rspack.config.js
@@ -2,18 +2,18 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    node: {
-        __dirname: false,
-        __filename: false
-    },
-    output: {
-        filename: "[name].js"
-    },
-    plugins: [
-        new rspack.SourceMapDevToolPlugin({
-            filename: "sourcemaps/[file].map",
-            fileContext: 'assets',
-            publicPath: 'http://localhost:50505/'
-        })
-    ]
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		new rspack.SourceMapDevToolPlugin({
+			filename: "sourcemaps/[file].map",
+			fileContext: "assets",
+			publicPath: "http://localhost:50505/"
+		})
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-file-context/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin-file-context/test.config.js
@@ -1,6 +1,6 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-    findBundle: (i, options) => {
-        return ["main.js"];
-    }
+	findBundle: (i, options) => {
+		return ["main.js"];
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/postcss-loader/pxtorem/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/postcss-loader/pxtorem/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [

--- a/packages/rspack-test-tools/tests/configCases/postcss-loader/pxtorem/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/postcss-loader/pxtorem/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['bundle0.css', 'bundle0.js']
+		return ["bundle0.css", "bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/postcss-loader/with-previous-source-map/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/postcss-loader/with-previous-source-map/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['bundle0.css', 'bundle0.js']
+		return ["bundle0.css", "bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/postcss-loader/with-source-map/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/postcss-loader/with-source-map/rspack.config.js
@@ -2,7 +2,7 @@ const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	devtool: "source-map",
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -20,7 +20,7 @@ module.exports = {
 				],
 				type: "css/auto",
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/postcss-loader/with-source-map/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/postcss-loader/with-source-map/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle() {
-		return ['bundle0.css', 'bundle0.js']
+		return ["bundle0.css", "bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/resolve/alias-order/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/alias-order/rspack.config.js
@@ -1,11 +1,11 @@
 const path = require("path");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: "./index.js",
-  resolve: {
-    alias: {
-      "@foo/index": path.resolve(__dirname, "./b"),
-      "@foo": path.resolve(__dirname, "./a"), // should not be used
-    }
-  },
+	entry: "./index.js",
+	resolve: {
+		alias: {
+			"@foo/index": path.resolve(__dirname, "./b"),
+			"@foo": path.resolve(__dirname, "./a") // should not be used
+		}
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/resolve/main-field-fallback/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/main-field-fallback/rspack.config.js
@@ -4,16 +4,16 @@ const path = require("path");
  * @type {import('webpack').Configuration | import('@rspack/cli').Configuration}
  */
 module.exports = {
-  devtool: false,
-  entry: {
-    main: {
-      import: "./index.js",
-    },
-  },
-  resolve: {
-    mainFields: ['module', 'main'],
-    extensionAlias: {
-      '.js': ['.ts', '.js']
-    }
-  },
+	devtool: false,
+	entry: {
+		main: {
+			import: "./index.js"
+		}
+	},
+	resolve: {
+		mainFields: ["module", "main"],
+		extensionAlias: {
+			".js": [".ts", ".js"]
+		}
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/resolve/matched-alias-not-found/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/matched-alias-not-found/rspack.config.js
@@ -4,7 +4,7 @@ const path = require("path");
 module.exports = {
 	resolve: {
 		alias: {
-			"m1": path.resolve(__dirname, "node_modules", "m2", "mod.js"),
+			m1: path.resolve(__dirname, "node_modules", "m2", "mod.js")
 		}
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/resolve/pnp-enable/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/pnp-enable/rspack.config.js
@@ -2,9 +2,9 @@
 module.exports = {
 	context: __dirname,
 	entry: {
-		main: './index.js'
+		main: "./index.js"
 	},
 	resolve: {
 		pnp: true
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/resolve/roots/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/roots/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  context: __dirname,
-}
+	context: __dirname
+};

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/assets/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/assets/test.config.js
@@ -1,7 +1,4 @@
 /** @type {import("../../../../dist").TDiffCaseConfig} */
 module.exports = {
-	files: [
-		'a.js',
-		'b.js',
-	],
+	files: ["a.js", "b.js"]
 };

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/chunkGraph/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/chunkGraph/rspack.config.js
@@ -1,14 +1,16 @@
-const { experiments: { RsdoctorPlugin } } = require("@rspack/core");
+const {
+	experiments: { RsdoctorPlugin }
+} = require("@rspack/core");
 const fs = require("fs");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: {
-		a: './a.js',
-		b: './b.js',
+		a: "./a.js",
+		b: "./b.js"
 	},
 	output: {
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	plugins: [
 		new RsdoctorPlugin({
@@ -17,16 +19,16 @@ module.exports = {
 		}),
 		{
 			apply(compiler) {
-				compiler.hooks.compilation.tap("TestPlugin::Chunks", (compilation) => {
+				compiler.hooks.compilation.tap("TestPlugin::Chunks", compilation => {
 					const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
-					hooks.chunkGraph.tap("TestPlugin::Chunks", (data) => {
+					hooks.chunkGraph.tap("TestPlugin::Chunks", data => {
 						const { chunks } = data;
 						expect(chunks.length).toBe(4);
 						expect(chunks.filter(c => c.entry).length).toBe(2);
 						expect(chunks.filter(c => c.initial).length).toBe(2);
 
-						const entryA = chunks.find(c => c.name === 'a');
-						const entryB = chunks.find(c => c.name === 'b');
+						const entryA = chunks.find(c => c.name === "a");
+						const entryB = chunks.find(c => c.name === "b");
 
 						expect(entryA.dependencies.length).toBe(1);
 						expect(entryB.dependencies.length).toBe(1);
@@ -41,19 +43,22 @@ module.exports = {
 		},
 		{
 			apply(compiler) {
-				compiler.hooks.compilation.tap("TestPlugin::Entrypoints", (compilation) => {
-					const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
-					hooks.chunkGraph.tap("TestPlugin::Entrypoints", (data) => {
-						const { entrypoints } = data;
-						expect(entrypoints.length).toBe(2);
+				compiler.hooks.compilation.tap(
+					"TestPlugin::Entrypoints",
+					compilation => {
+						const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
+						hooks.chunkGraph.tap("TestPlugin::Entrypoints", data => {
+							const { entrypoints } = data;
+							expect(entrypoints.length).toBe(2);
 
-						const entrypointA = entrypoints.find(e => e.name === 'a');
-						const entrypointB = entrypoints.find(e => e.name === 'b');
-						expect(entrypointA.chunks.length).toBe(1);
-						expect(entrypointB.chunks.length).toBe(1);
-					});
-				});
+							const entrypointA = entrypoints.find(e => e.name === "a");
+							const entrypointB = entrypoints.find(e => e.name === "b");
+							expect(entrypointA.chunks.length).toBe(1);
+							expect(entrypointB.chunks.length).toBe(1);
+						});
+					}
+				);
 			}
-		},
+		}
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/chunkGraph/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/chunkGraph/test.config.js
@@ -1,7 +1,4 @@
 /** @type {import("../../../../dist").TDiffCaseConfig} */
 module.exports = {
-	files: [
-		'a.js',
-		'b.js',
-	],
+	files: ["a.js", "b.js"]
 };

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
@@ -1,10 +1,12 @@
-const { experiments: { RsdoctorPlugin } } = require("@rspack/core");
+const {
+	experiments: { RsdoctorPlugin }
+} = require("@rspack/core");
 const path = require("path");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	optimization: {
-		concatenateModules: true,
+		concatenateModules: true
 	},
 	plugins: [
 		new RsdoctorPlugin({
@@ -13,56 +15,68 @@ module.exports = {
 		}),
 		{
 			apply(compiler) {
-				compiler.hooks.compilation.tap("TestPlugin::Modules", (compilation) => {
+				compiler.hooks.compilation.tap("TestPlugin::Modules", compilation => {
 					const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
-					hooks.moduleGraph.tap("TestPlugin::Modules", (moduleGraph) => {
+					hooks.moduleGraph.tap("TestPlugin::Modules", moduleGraph => {
 						const { modules } = moduleGraph;
 						expect(modules.length).toBe(5);
 
-						const concatenateModules = modules.filter(module => module.kind === "concatenated");
-						const normalModules = modules.filter(module => module.kind === "normal");
+						const concatenateModules = modules.filter(
+							module => module.kind === "concatenated"
+						);
+						const normalModules = modules.filter(
+							module => module.kind === "normal"
+						);
 						expect(concatenateModules.length).toBe(1);
 						expect(normalModules.length).toBe(4);
 
-						const entryModule = modules.find(module => module.isEntry && module.kind === "concatenated");
+						const entryModule = modules.find(
+							module => module.isEntry && module.kind === "concatenated"
+						);
 						expect(entryModule.chunks.length).toBe(1);
 						expect(entryModule.modules.length).toBe(3);
 						expect(entryModule.dependencies.length).toBe(1);
-						expect(entryModule.path).toBe(path.join(__dirname, './index.js'));
+						expect(entryModule.path).toBe(path.join(__dirname, "./index.js"));
 					});
 				});
 			}
 		},
 		{
 			apply(compiler) {
-				compiler.hooks.compilation.tap("TestPlugin::Dependencies", (compilation) => {
-					const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
-					hooks.moduleGraph.tap("TestPlugin::Dependencies", (moduleGraph) => {
-						const { dependencies } = moduleGraph;
-						const deps = dependencies.map(dep => ({
-							request: dep.request,
-							kind: dep.kind
-						}));
-						deps.sort((a, b) => a.request > b.request ? 1 : -1);
-						expect(deps).toEqual([
-							{ request: "./b", "kind": "esm export" },
-							{ request: "./c", "kind": "esm export" },
-							{ request: "./lib/a", "kind": "esm import" }
-						]);
-					});
-				});
+				compiler.hooks.compilation.tap(
+					"TestPlugin::Dependencies",
+					compilation => {
+						const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
+						hooks.moduleGraph.tap("TestPlugin::Dependencies", moduleGraph => {
+							const { dependencies } = moduleGraph;
+							const deps = dependencies.map(dep => ({
+								request: dep.request,
+								kind: dep.kind
+							}));
+							deps.sort((a, b) => (a.request > b.request ? 1 : -1));
+							expect(deps).toEqual([
+								{ request: "./b", kind: "esm export" },
+								{ request: "./c", kind: "esm export" },
+								{ request: "./lib/a", kind: "esm import" }
+							]);
+						});
+					}
+				);
 			}
 		},
 		{
 			apply(compiler) {
-				compiler.hooks.compilation.tap("TestPlugin::ChunkModules", (compilation) => {
-					const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
-					hooks.moduleGraph.tap("TestPlugin::ChunkModules", (moduleGraph) => {
-						const { chunkModules } = moduleGraph;
-						expect(chunkModules.length).toBe(1);
-						expect(chunkModules[0].modules.length).toBe(5);
-					});
-				});
+				compiler.hooks.compilation.tap(
+					"TestPlugin::ChunkModules",
+					compilation => {
+						const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
+						hooks.moduleGraph.tap("TestPlugin::ChunkModules", moduleGraph => {
+							const { chunkModules } = moduleGraph;
+							expect(chunkModules.length).toBe(1);
+							expect(chunkModules[0].modules.length).toBe(5);
+						});
+					}
+				);
 			}
 		}
 	]

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleIds/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleIds/rspack.config.js
@@ -1,9 +1,11 @@
-const { experiments: { RsdoctorPlugin } } = require("@rspack/core");
+const {
+	experiments: { RsdoctorPlugin }
+} = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	optimization: {
-		concatenateModules: true,
+		concatenateModules: true
 	},
 	plugins: [
 		new RsdoctorPlugin({
@@ -12,14 +14,14 @@ module.exports = {
 		}),
 		{
 			apply(compiler) {
-				compiler.hooks.compilation.tap("TestPlugin::ModuleIds", (compilation) => {
+				compiler.hooks.compilation.tap("TestPlugin::ModuleIds", compilation => {
 					const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
-					hooks.moduleIds.tap("TestPlugin::ModuleIds", (data) => {
+					hooks.moduleIds.tap("TestPlugin::ModuleIds", data => {
 						const { moduleIds } = data;
 						expect(moduleIds.length).toBe(2);
 					});
 				});
 			}
-		},
+		}
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleSources/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleSources/rspack.config.js
@@ -1,10 +1,12 @@
-const { experiments: { RsdoctorPlugin } } = require("@rspack/core");
+const {
+	experiments: { RsdoctorPlugin }
+} = require("@rspack/core");
 const fs = require("fs");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	optimization: {
-		concatenateModules: true,
+		concatenateModules: true
 	},
 	plugins: [
 		new RsdoctorPlugin({
@@ -13,22 +15,26 @@ module.exports = {
 		}),
 		{
 			apply(compiler) {
-				compiler.hooks.compilation.tap("TestPlugin::ModuleIds", (compilation) => {
+				compiler.hooks.compilation.tap("TestPlugin::ModuleIds", compilation => {
 					let modules = [];
 					const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
-					hooks.moduleGraph.tap("TestPlugin::ModuleIds", (data) => {
+					hooks.moduleGraph.tap("TestPlugin::ModuleIds", data => {
 						modules = data.modules;
 					});
-					hooks.moduleSources.tap("TestPlugin::ModuleIds", (data) => {
+					hooks.moduleSources.tap("TestPlugin::ModuleIds", data => {
 						const { moduleOriginalSources } = data;
 						expect(moduleOriginalSources.length).toBe(5);
 						for (const module of modules) {
-							const moduleSource = moduleOriginalSources.find(s => s.module === module.ukey);
-							expect(moduleSource.source).toBe(fs.readFileSync(module.path, "utf-8"));
+							const moduleSource = moduleOriginalSources.find(
+								s => s.module === module.ukey
+							);
+							expect(moduleSource.source).toBe(
+								fs.readFileSync(module.path, "utf-8")
+							);
 						}
 					});
 				});
 			}
-		},
+		}
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-isolate/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-isolate/rspack.config.js
@@ -1,65 +1,59 @@
 const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");
 
 class IsolateRuntimeModule extends RuntimeModule {
-  constructor(chunk) {
-    super("mock-isolate");
-  }
+	constructor(chunk) {
+		super("mock-isolate");
+	}
 
-  generate() {
-    return `
+	generate() {
+		return `
       __webpack_require__.mock = function() {
         return someGlobalValue;
       };
     `;
-  }
+	}
 }
 
 class NonIsolateRuntimeModule extends RuntimeModule {
-  constructor(chunk) {
-    super("mock-non-isolate");
-  }
+	constructor(chunk) {
+		super("mock-non-isolate");
+	}
 
-  shouldIsolate() {
-    return false;
-  }
+	shouldIsolate() {
+		return false;
+	}
 
-  generate() {
-    return `
+	generate() {
+		return `
       var someGlobalValue = "isolated";
     `;
-  }
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: "./index.js",
-  mode: "development",
-  devtool: false,
-  optimization: {
-    minimize: false,
-    sideEffects: false,
-    concatenateModules: false,
-    usedExports: false,
-    innerGraph: false,
-    providedExports: false
-  },
-  plugins: [
-    compiler => {
-      compiler.hooks.thisCompilation.tap(
-        "MockRuntimePlugin",
-        (compilation) => {
-          compilation.hooks.additionalTreeRuntimeRequirements.tap("MockRuntimePlugin", (chunk, set) => {
-            compilation.addRuntimeModule(
-              chunk,
-              new NonIsolateRuntimeModule()
-            );
-            compilation.addRuntimeModule(
-              chunk,
-              new IsolateRuntimeModule()
-            );
-          })
-        }
-      );
-    }
-  ],
+	entry: "./index.js",
+	mode: "development",
+	devtool: false,
+	optimization: {
+		minimize: false,
+		sideEffects: false,
+		concatenateModules: false,
+		usedExports: false,
+		innerGraph: false,
+		providedExports: false
+	},
+	plugins: [
+		compiler => {
+			compiler.hooks.thisCompilation.tap("MockRuntimePlugin", compilation => {
+				compilation.hooks.additionalTreeRuntimeRequirements.tap(
+					"MockRuntimePlugin",
+					(chunk, set) => {
+						compilation.addRuntimeModule(chunk, new NonIsolateRuntimeModule());
+						compilation.addRuntimeModule(chunk, new IsolateRuntimeModule());
+					}
+				);
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-stage/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-stage/rspack.config.js
@@ -1,60 +1,54 @@
 const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");
 
 class MockNormalRuntimeModule extends RuntimeModule {
-  constructor(chunk) {
-    super("mock-normal", RuntimeModule.STAGE_NORMAL);
-  }
+	constructor(chunk) {
+		super("mock-normal", RuntimeModule.STAGE_NORMAL);
+	}
 
-  generate() {
-    return `__webpack_require__.mockNormal = "normal";`;
-  }
+	generate() {
+		return `__webpack_require__.mockNormal = "normal";`;
+	}
 }
 
 class MockTriggerRuntimeModule extends RuntimeModule {
-  constructor(chunk) {
-    super("mock-trigger", RuntimeModule.STAGE_TRIGGER);
-  }
+	constructor(chunk) {
+		super("mock-trigger", RuntimeModule.STAGE_TRIGGER);
+	}
 
-  generate() {
-    return `__webpack_require__.mockTrigger = "trigger";`;
-  }
+	generate() {
+		return `__webpack_require__.mockTrigger = "trigger";`;
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: "./index.js",
-  mode: "development",
-  devtool: false,
-  optimization: {
-    minimize: false,
-    sideEffects: false,
-    concatenateModules: false,
-    usedExports: false,
-    innerGraph: false,
-    providedExports: false
-  },
-  plugins: [
+	entry: "./index.js",
+	mode: "development",
+	devtool: false,
+	optimization: {
+		minimize: false,
+		sideEffects: false,
+		concatenateModules: false,
+		usedExports: false,
+		innerGraph: false,
+		providedExports: false
+	},
+	plugins: [
 		/**
 		 * @param {import('@rspack/core').Compiler} compiler
 		 */
-    compiler => {
-      compiler.hooks.thisCompilation.tap(
-        "MockRuntimePlugin",
-        (compilation) => {
-          compilation.hooks.additionalTreeRuntimeRequirements.tap("MockRuntimePlugin", (chunk, set) => {
-            set.add(RuntimeGlobals.publicPath);
-            set.add(RuntimeGlobals.getChunkScriptFilename);
-            compilation.addRuntimeModule(
-              chunk,
-              new MockTriggerRuntimeModule()
-            );
-            compilation.addRuntimeModule(
-              chunk,
-              new MockNormalRuntimeModule()
-            );
-          })
-        }
-      );
-    }
-  ],
+		compiler => {
+			compiler.hooks.thisCompilation.tap("MockRuntimePlugin", compilation => {
+				compilation.hooks.additionalTreeRuntimeRequirements.tap(
+					"MockRuntimePlugin",
+					(chunk, set) => {
+						set.add(RuntimeGlobals.publicPath);
+						set.add(RuntimeGlobals.getChunkScriptFilename);
+						compilation.addRuntimeModule(chunk, new MockTriggerRuntimeModule());
+						compilation.addRuntimeModule(chunk, new MockNormalRuntimeModule());
+					}
+				);
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/rspack.config.js
@@ -1,65 +1,55 @@
 const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");
 
 class MockRuntimeModule extends RuntimeModule {
-  constructor() {
-    super("mock");
-  }
+	constructor() {
+		super("mock");
+	}
 
-  generate(compilation) {
-    const chunkIdToName = this.chunk.getChunkMaps(false).name;
-    const chunkNameToId = Object.fromEntries(
-      Object.entries(chunkIdToName).map(([chunkId, chunkName]) => [
-        chunkName,
-        chunkId,
-      ]),
-    );
+	generate(compilation) {
+		const chunkIdToName = this.chunk.getChunkMaps(false).name;
+		const chunkNameToId = Object.fromEntries(
+			Object.entries(chunkIdToName).map(([chunkId, chunkName]) => [
+				chunkName,
+				chunkId
+			])
+		);
 
-    return `
+		return `
       __webpack_require__.mock = function(chunkId) {
-        chunkId = (${JSON.stringify(
-      chunkNameToId,
-    )})[chunkId]||chunkId;
+        chunkId = (${JSON.stringify(chunkNameToId)})[chunkId]||chunkId;
         return ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);
       };
     `;
-  }
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: "./index.js",
-  mode: "development",
-  devtool: false,
+	entry: "./index.js",
+	mode: "development",
+	devtool: false,
 	module: {
-		rules: [
-			{ test: /imported-module\.js/, use: ['./loader']}
-		]
+		rules: [{ test: /imported-module\.js/, use: ["./loader"] }]
 	},
-  optimization: {
-    minimize: false,
-    sideEffects: false,
-    concatenateModules: false,
-    usedExports: false,
-    innerGraph: false,
-    providedExports: false
-  },
-  plugins: [
-    compiler => {
-      compiler.hooks.thisCompilation.tap(
-        "MockRuntimePlugin",
-        (compilation) => {
-          compilation.hooks.runtimeRequirementInTree
-						.for(RuntimeGlobals.ensureChunkHandlers)
-						.tap("MockRuntimePlugin", (chunk, set) => {
-							set.add(RuntimeGlobals.publicPath);
-							set.add(RuntimeGlobals.getChunkScriptFilename);
-							compilation.addRuntimeModule(
-								chunk,
-								new MockRuntimeModule(chunk)
-							);
-						})
-        }
-      );
-    }
-  ],
+	optimization: {
+		minimize: false,
+		sideEffects: false,
+		concatenateModules: false,
+		usedExports: false,
+		innerGraph: false,
+		providedExports: false
+	},
+	plugins: [
+		compiler => {
+			compiler.hooks.thisCompilation.tap("MockRuntimePlugin", compilation => {
+				compilation.hooks.runtimeRequirementInTree
+					.for(RuntimeGlobals.ensureChunkHandlers)
+					.tap("MockRuntimePlugin", (chunk, set) => {
+						set.add(RuntimeGlobals.publicPath);
+						set.add(RuntimeGlobals.getChunkScriptFilename);
+						compilation.addRuntimeModule(chunk, new MockRuntimeModule(chunk));
+					});
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/rspack.config.js
@@ -1,60 +1,52 @@
 const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");
 
 class MockRuntimeModule extends RuntimeModule {
-  constructor() {
-    super("mock");
-  }
+	constructor() {
+		super("mock");
+	}
 
-  generate() {
-    const chunkIdToName = this.chunk.getChunkMaps(false).name;
-    const chunkNameToId = Object.fromEntries(
-      Object.entries(chunkIdToName).map(([chunkId, chunkName]) => [
-        chunkName,
-        chunkId,
-      ]),
-    );
+	generate() {
+		const chunkIdToName = this.chunk.getChunkMaps(false).name;
+		const chunkNameToId = Object.fromEntries(
+			Object.entries(chunkIdToName).map(([chunkId, chunkName]) => [
+				chunkName,
+				chunkId
+			])
+		);
 
-    return `
+		return `
       __webpack_require__.mock = function(chunkId) {
-        chunkId = (${JSON.stringify(
-      chunkNameToId,
-    )})[chunkId]||chunkId;
+        chunkId = (${JSON.stringify(chunkNameToId)})[chunkId]||chunkId;
         return ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);
       };
     `;
-  }
+	}
 }
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: "./index.js",
-  mode: "development",
-  devtool: false,
-  optimization: {
-    minimize: false,
-    sideEffects: false,
-    concatenateModules: false,
-    usedExports: false,
-    innerGraph: false,
-    providedExports: false
-  },
-  plugins: [
-    compiler => {
-      compiler.hooks.thisCompilation.tap(
-        "MockRuntimePlugin",
-        (compilation) => {
-          compilation.hooks.runtimeRequirementInTree
-						.for(RuntimeGlobals.ensureChunkHandlers)
-						.tap("MockRuntimePlugin", (chunk, set) => {
-							set.add(RuntimeGlobals.publicPath);
-							set.add(RuntimeGlobals.getChunkScriptFilename);
-							compilation.addRuntimeModule(
-								chunk,
-								new MockRuntimeModule(chunk)
-							);
-						})
-        }
-      );
-    }
-  ],
+	entry: "./index.js",
+	mode: "development",
+	devtool: false,
+	optimization: {
+		minimize: false,
+		sideEffects: false,
+		concatenateModules: false,
+		usedExports: false,
+		innerGraph: false,
+		providedExports: false
+	},
+	plugins: [
+		compiler => {
+			compiler.hooks.thisCompilation.tap("MockRuntimePlugin", compilation => {
+				compilation.hooks.runtimeRequirementInTree
+					.for(RuntimeGlobals.ensureChunkHandlers)
+					.tap("MockRuntimePlugin", (chunk, set) => {
+						set.add(RuntimeGlobals.publicPath);
+						set.add(RuntimeGlobals.getChunkScriptFilename);
+						compilation.addRuntimeModule(chunk, new MockRuntimeModule(chunk));
+					});
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/dynamic-css-chunk-with-umd/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/dynamic-css-chunk-with-umd/rspack.config.js
@@ -2,33 +2,33 @@ module.exports = [
 	{
 		name: "lib",
 		entry: {
-			lib: "./lib.js",
+			lib: "./lib.js"
 		},
 		output: {
 			filename: "[name].js",
 			library: {
 				name: "lib",
-				type: "umd",
+				type: "umd"
 			}
 		},
 		target: "web",
 		optimization: {
 			chunkIds: "named",
 			moduleIds: "named",
-			runtimeChunk: true,
+			runtimeChunk: true
 		}
 	},
 	{
 		dependencies: ["lib"],
 		entry: {
-			main: "./index.js",
+			main: "./index.js"
 		},
 		output: {
-			filename: "[name].js",
+			filename: "[name].js"
 		},
 		target: "web",
 		experiments: {
-			css: true,
+			css: true
 		}
 	}
 ];

--- a/packages/rspack-test-tools/tests/configCases/runtime/dynamic-css-chunk-with-umd/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/dynamic-css-chunk-with-umd/test.config.js
@@ -1,6 +1,6 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-  findBundle() {
-    return ["main.js"]
-  }
-}
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/runtime/entry-runtime-false/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/entry-runtime-false/rspack.config.js
@@ -4,14 +4,14 @@ module.exports = {
 		e1: "./e1.js",
 		e2: {
 			import: "./e2.js",
-			runtime: false,
+			runtime: false
 		}
 	},
 	mode: "development",
 	output: {
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	optimization: {
-		runtimeChunk: "single",
+		runtimeChunk: "single"
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/entry-runtime/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/entry-runtime/rspack.config.js
@@ -7,6 +7,6 @@ module.exports = {
 		}
 	},
 	output: {
-		filename: '[name].js'
+		filename: "[name].js"
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/entry-runtime/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/entry-runtime/test.config.js
@@ -1,9 +1,6 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
 	findBundle: function (i, options) {
-		return [
-			"main.js",
-			"runtime.js",
-		];
+		return ["main.js", "runtime.js"];
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/issue-4019/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/issue-4019/rspack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 		}
 	},
 	output: {
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	optimization: {
 		runtimeChunk: "single",

--- a/packages/rspack-test-tools/tests/configCases/runtime/issue-4019/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/issue-4019/test.config.js
@@ -1,9 +1,6 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
 	findBundle: function (i, options) {
-		return [
-			"main.js",
-			"main2.js",
-		];
+		return ["main.js", "main2.js"];
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/runtime-condition/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/runtime-condition/rspack.config.js
@@ -3,18 +3,18 @@ module.exports = {
 	entry: {
 		"a-name": {
 			import: "./a",
-			runtime: "a-runtime",
+			runtime: "a-runtime"
 		},
 		"b-name": {
 			import: "./b",
-			runtime: "b-runtime",
+			runtime: "b-runtime"
 		},
 		"ax-name": "./ax.js",
 		"bx-name": "./bx.js"
 	},
 	target: "web",
 	output: {
-		filename: "[id].js",
+		filename: "[id].js"
 	},
 	node: false,
 	optimization: {
@@ -41,5 +41,5 @@ module.exports = {
 				sideEffects: false
 			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/runtime-condition/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/runtime-condition/test.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  findBundle: function (i, options) {
-    return [
-      "a-runtime.js",
-      "shared.js",
-      "a-name.js",
-    ];
-  }
+	findBundle: function (i, options) {
+		return ["a-runtime.js", "shared.js", "a-name.js"];
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/split-css-chunk-async/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/split-css-chunk-async/rspack.config.js
@@ -7,7 +7,7 @@ module.exports = {
 	},
 	output: {
 		chunkFilename: "[id].[contenthash].js",
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	optimization: {
 		splitChunks: {
@@ -27,6 +27,6 @@ module.exports = {
 			}
 		},
 		runtimeChunk: "single",
-		chunkIds: 'named'
+		chunkIds: "named"
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/split-css-chunk-async/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/split-css-chunk-async/test.config.js
@@ -1,10 +1,6 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
 	findBundle: function (i, options) {
-		return [
-			"main.js",
-			"main2.js",
-			"main3.js",
-		];
+		return ["main.js", "main2.js", "main3.js"];
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/runtime/split-css-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/split-css-chunk/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 	},
 	output: {
 		chunkFilename: "[id].[contenthash].js",
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	optimization: {
 		splitChunks: {

--- a/packages/rspack-test-tools/tests/configCases/runtime/split-css-chunk/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/split-css-chunk/test.config.js
@@ -1,9 +1,6 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
 	findBundle: function (i, options) {
-		return [
-			"main.js",
-			"main2.js",
-		];
+		return ["main.js", "main2.js"];
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/sass/additional-data/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/sass/additional-data/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -16,7 +16,7 @@ module.exports = {
 				],
 				type: "css",
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/sass/use-alias/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/sass/use-alias/rspack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -11,7 +11,7 @@ module.exports = {
 				use: [{ loader: "sass-loader" }],
 				type: "css",
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/schemes/data-imports/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/schemes/data-imports/rspack.config.js
@@ -16,11 +16,11 @@ class Plugin {
 }
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		generator: {
-			"css": {
+			css: {
 				exportsOnly: false
 			},
 			"css/auto": {
@@ -28,7 +28,7 @@ module.exports = {
 			},
 			"css/module": {
 				exportsOnly: false
-			},
+			}
 		},
 		rules: [
 			{
@@ -49,6 +49,6 @@ module.exports = {
 	},
 	plugins: [new Plugin()],
 	experiments: {
-		css: true,
+		css: true
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/schemes/nmf-update-resource/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/schemes/nmf-update-resource/rspack.config.js
@@ -3,9 +3,12 @@ module.exports = {
 	entry: 'data:text/javascript,import "./index.js";',
 	plugins: [
 		function (compiler) {
-			compiler.hooks.compilation.tap('test', (compilation, { normalModuleFactory }) => {
-				normalModuleFactory.hooks.afterResolve.tap('test', () => {})
-			})
+			compiler.hooks.compilation.tap(
+				"test",
+				(compilation, { normalModuleFactory }) => {
+					normalModuleFactory.hooks.afterResolve.tap("test", () => {});
+				}
+			);
 		}
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/source-map/auxiliary-files/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/auxiliary-files/rspack.config.js
@@ -1,20 +1,23 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    mode: "production",
-    devtool: 'source-map',
-    plugins: [
-        compiler => {
-            const { Compilation } = compiler.webpack;
-            compiler.hooks.thisCompilation.tap("test case", compilation => {
-                compilation.hooks.processAssets.tap({
-                    name: "test case",
-                    stage: Compilation.PROCESS_ASSETS_STAGE_REPORT
-                }, () => {
-										let chunks = [...compilation.chunks];
-										let auxiliaryFiles = [...chunks[0].auxiliaryFiles]
-                    expect(Array.from(auxiliaryFiles)).toEqual(["bundle0.js.map"]);
-                });
-            });
-        }
-    ]
+	mode: "production",
+	devtool: "source-map",
+	plugins: [
+		compiler => {
+			const { Compilation } = compiler.webpack;
+			compiler.hooks.thisCompilation.tap("test case", compilation => {
+				compilation.hooks.processAssets.tap(
+					{
+						name: "test case",
+						stage: Compilation.PROCESS_ASSETS_STAGE_REPORT
+					},
+					() => {
+						let chunks = [...compilation.chunks];
+						let auxiliaryFiles = [...chunks[0].auxiliaryFiles];
+						expect(Array.from(auxiliaryFiles)).toEqual(["bundle0.js.map"]);
+					}
+				);
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/source-map/cheap/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/cheap/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		rules: [
@@ -9,7 +9,7 @@ module.exports = {
 				use: [{ loader: "sass-loader" }],
 				type: "css",
 				generator: {
-					exportsOnly: false,
+					exportsOnly: false
 				}
 			}
 		]

--- a/packages/rspack-test-tools/tests/configCases/source-map/conflict/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/conflict/rspack.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
 	mode: "development",
-	devtool: "source-map", 
+	devtool: "source-map",
 	externals: ["source-map"],
-	entry: "./index.js",
+	entry: "./index.js"
 };

--- a/packages/rspack-test-tools/tests/configCases/source-map/empty-mapping/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/empty-mapping/rspack.config.js
@@ -3,23 +3,20 @@
  */
 module.exports = {
 	mode: "development",
-	target: 'web',
+	target: "web",
 	devtool: "source-map",
 	module: {
 		generator: {
-			'css/auto': {
-				exportsOnly: false,
+			"css/auto": {
+				exportsOnly: false
 			}
 		},
 		rules: [
 			{
 				test: /\.css$/,
-				use: [
-					'./loader.js',
-					'builtin:lightningcss-loader',
-				],
+				use: ["./loader.js", "builtin:lightningcss-loader"],
 				sideEffects: true,
-				type: 'css/auto'
+				type: "css/auto"
 			}
 		]
 	},

--- a/packages/rspack-test-tools/tests/configCases/source-map/eval-only/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/eval-only/rspack.config.js
@@ -12,6 +12,6 @@ module.exports = {
 		rules: [{ test: /\.scss$/, use: [{ loader: "sass-loader" }], type: "css" }]
 	},
 	experiments: {
-		css: true,
+		css: true
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/source-map/plugin-defaults/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/plugin-defaults/rspack.config.js
@@ -26,7 +26,7 @@ module.exports = {
 			CONTEXT: JSON.stringify(__dirname)
 		}),
 		new rspack.SourceMapDevToolPlugin({
-			filename: '[file].map[query]',
-		}),
+			filename: "[file].map[query]"
+		})
 	]
 };

--- a/packages/rspack-test-tools/tests/configCases/source-map/verify-bundle-css-minify-lightning/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/verify-bundle-css-minify-lightning/rspack.config.js
@@ -2,21 +2,19 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		generator: {
 			"css/auto": {
 				exportsOnly: false
-			},
-		},
+			}
+		}
 	},
 	devtool: "source-map",
 	optimization: {
 		minimize: true,
-		minimizer: [
-			new rspack.LightningCssMinimizerRspackPlugin()
-		]
+		minimizer: [new rspack.LightningCssMinimizerRspackPlugin()]
 	},
 	externals: ["source-map"],
 	externalsType: "commonjs"

--- a/packages/rspack-test-tools/tests/configCases/source-map/verify-bundle-css-minify-lightning/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/verify-bundle-css-minify-lightning/test.config.js
@@ -1,8 +1,5 @@
 module.exports = {
 	findBundle() {
-		return [
-			'bundle0.css',
-			'bundle0.js',
-		]
+		return ["bundle0.css", "bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/source-map/verify-bundle-css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/verify-bundle-css/rspack.config.js
@@ -1,13 +1,13 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	module: {
 		generator: {
 			"css/auto": {
 				exportsOnly: false
-			},
-		},
+			}
+		}
 	},
 	devtool: "source-map",
 	externals: ["source-map"],

--- a/packages/rspack-test-tools/tests/configCases/source-map/verify-bundle-css/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/verify-bundle-css/test.config.js
@@ -1,8 +1,5 @@
 module.exports = {
 	findBundle() {
-		return [
-			'bundle0.css',
-			'bundle0.js',
-		]
+		return ["bundle0.css", "bundle0.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/source-map/verify-css-js-mix/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/verify-css-js-mix/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	node: false,
 	devtool: "source-map",
 	externals: ["source-map"],

--- a/packages/rspack-test-tools/tests/configCases/source-map/verify-es6-minify/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/verify-es6-minify/rspack.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	devtool: "source-map",
 	optimization: {
 		minimize: true,
-		concatenateModules: false,
+		concatenateModules: false
 	},
 	externals: ["source-map"],
 	externalsType: "commonjs"

--- a/packages/rspack-test-tools/tests/configCases/split-chunks-common/rspack-issue-7509/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks-common/rspack-issue-7509/rspack.config.js
@@ -1,20 +1,20 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	optimization: {
-		chunkIds: 'named',
+		chunkIds: "named",
 		splitChunks: {
 			maxInitialRequests: 10,
 			cacheGroups: {
 				vendors: {
-					chunks: 'all',
+					chunks: "all",
 					test: /node_modules/,
 					minSize: 0,
-					filename: 'split-[name].js',
+					filename: "split-[name].js",
 
 					// should override the splitChunks.maxInitialRequests
-					maxInitialRequests: 1,
+					maxInitialRequests: 1
 				}
 			}
 		}
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-layer-function/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-layer-function/rspack.config.js
@@ -1,36 +1,36 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    target: "node",
-    entry: {
-        main: {
-            import: "./index",
-            layer: "foo"
-        }
-    },
-    output: {
-        filename: "[name].js"
-    },
-    experiments: {
-        layers: true
-    },
-    optimization: {
-        splitChunks: {
-            chunks: "all",
-            minSize: 0,
-            cacheGroups: {
-                bar: {
-                    name: "bar",
-                    layer(layer) {
-                        return layer === "bar";
-                    },
-                },
-                foo: {
-                    name: "foo",
-                    layer(layer) {
-                        return layer === "foo";
-                    },
-                }
-            }
-        }
-    }
+	target: "node",
+	entry: {
+		main: {
+			import: "./index",
+			layer: "foo"
+		}
+	},
+	output: {
+		filename: "[name].js"
+	},
+	experiments: {
+		layers: true
+	},
+	optimization: {
+		splitChunks: {
+			chunks: "all",
+			minSize: 0,
+			cacheGroups: {
+				bar: {
+					name: "bar",
+					layer(layer) {
+						return layer === "bar";
+					}
+				},
+				foo: {
+					name: "foo",
+					layer(layer) {
+						return layer === "foo";
+					}
+				}
+			}
+		}
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-layer-function/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-layer-function/test.config.js
@@ -1,6 +1,6 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
-    findBundle: function (i, options) {
-        return ["main.js"];
-    }
+	findBundle: function (i, options) {
+		return ["main.js"];
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-name-function-with-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-name-function-with-error/rspack.config.js
@@ -15,7 +15,7 @@ module.exports = {
 				foo: {
 					test: /\.js/,
 					name(module, chunks) {
-						throw new Error("CACHE_GROUP_NAME_FUNCTION_WITH_ERROR")
+						throw new Error("CACHE_GROUP_NAME_FUNCTION_WITH_ERROR");
 					}
 				}
 			}

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-test/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-test/rspack.config.js
@@ -1,21 +1,20 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    entry: "./index.js",
-    target: "node",
-    output: {
-        filename: "[name].js"
-    },
-    optimization: {
-        splitChunks: {
-            cacheGroups: {
-                common: {
-                    test(module) {
-                        expect(module.size()).toBe(5);
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-
+	entry: "./index.js",
+	target: "node",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				common: {
+					test(module) {
+						expect(module.size()).toBe(5);
+						return true;
+					}
+				}
+			}
+		}
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/chunks-function-with-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/chunks-function-with-error/rspack.config.js
@@ -14,9 +14,9 @@ module.exports = {
 			cacheGroups: {
 				splitLib2: {
 					chunks(chunk) {
-						throw new Error("CHUNKS_FUNCTION_WITH_ERROR")
+						throw new Error("CHUNKS_FUNCTION_WITH_ERROR");
 					},
-					test: /\.js/,
+					test: /\.js/
 				}
 			}
 		}

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/chunks-function/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/chunks-function/rspack.config.js
@@ -12,7 +12,7 @@ module.exports = {
 		lib2: {
 			import: "./lib2",
 			library: {
-				type: "commonjs2",
+				type: "commonjs2"
 			}
 		}
 	},

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/css-simple/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/css-simple/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'web',
+	target: "web",
 	entry: {
 		main: "./index"
 	},
@@ -8,7 +8,7 @@ module.exports = {
 		filename: "[name].js"
 	},
 	node: {
-		__dirname: false,
+		__dirname: false
 	},
 	optimization: {
 		chunkIds: "named"
@@ -17,7 +17,7 @@ module.exports = {
 		generator: {
 			"css/auto": {
 				exportsOnly: false
-			},
-		},
+			}
+		}
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/custom-filename-function/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/custom-filename-function/rspack.config.js
@@ -17,9 +17,9 @@ module.exports = {
 					chunks: "all",
 					test: /shared/,
 					filename: (pathData, assetInfo) => {
-						expect(pathData).toBeDefined()
-						expect(typeof assetInfo).toBe('object')
-						return "shared-[name].js"
+						expect(pathData).toBeDefined();
+						expect(typeof assetInfo).toBe("object");
+						return "shared-[name].js";
 					},
 					enforce: true
 				},

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/default-reuse-existing-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/default-reuse-existing-chunk/rspack.config.js
@@ -5,13 +5,13 @@ module.exports = {
 		filename: "[name].js"
 	},
 	optimization: {
-		chunkIds: 'named',
+		chunkIds: "named",
 		splitChunks: {
 			minSize: 1,
-      chunks: "all",
+			chunks: "all",
 			cacheGroups: {
 				foo: {
-					minSize: 0,
+					minSize: 0
 				}
 			}
 		}

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/external-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/external-modules/rspack.config.js
@@ -2,49 +2,49 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    entry: {
-        main: {
-            import: ["./index"],
-            library: {
-                type: "system"
-            },
-        }
-    },
-    node: {
-        __dirname: false,
-        __filename: false,
-    },
-    target: "web",
-    output: {
-        filename: "[name].js"
-    },
-    optimization: {
-        sideEffects: false,
-        concatenateModules: false,
-        splitChunks: {
-            cacheGroups: {
-                default: {
-                    chunks: "all",
-                    minSize: 0,
-                    maxSize: 0,
-                }
-            }
-        }
-    },
-    plugins: [
-        new rspack.ExternalsPlugin("system", ({ request }, callback) => {
-            if (request === './external') {
-                callback(null, "system " + request);
-                return;
-            }
-            callback();
-        }),
-        compiler => {
-            compiler.hooks.afterEmit.tap("PLUGIN", compilation => {
-                const stats = compilation.getStats().toJson();
-                const entryChunk = stats.chunks.find(chunk => chunk.entry);
-                expect(entryChunk.modules[0].name).toBe('external "./external"');
-            });
-        }
-    ]
+	entry: {
+		main: {
+			import: ["./index"],
+			library: {
+				type: "system"
+			}
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	target: "web",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		sideEffects: false,
+		concatenateModules: false,
+		splitChunks: {
+			cacheGroups: {
+				default: {
+					chunks: "all",
+					minSize: 0,
+					maxSize: 0
+				}
+			}
+		}
+	},
+	plugins: [
+		new rspack.ExternalsPlugin("system", ({ request }, callback) => {
+			if (request === "./external") {
+				callback(null, "system " + request);
+				return;
+			}
+			callback();
+		}),
+		compiler => {
+			compiler.hooks.afterEmit.tap("PLUGIN", compilation => {
+				const stats = compilation.getStats().toJson();
+				const entryChunk = stats.chunks.find(chunk => chunk.entry);
+				expect(entryChunk.modules[0].name).toBe('external "./external"');
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/extract-css-to-single-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/extract-css-to-single-chunk/rspack.config.js
@@ -7,7 +7,7 @@ module.exports = {
 	},
 	node: {
 		__dirname: false,
-		__filename: false,
+		__filename: false
 	},
 	target: "web",
 	output: {
@@ -17,8 +17,8 @@ module.exports = {
 		generator: {
 			"css/auto": {
 				exportsOnly: false
-			},
-		},
+			}
+		}
 	},
 	optimization: {
 		splitChunks: {

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-fit/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-fit/rspack.config.js
@@ -3,16 +3,16 @@ module.exports = {
 	target: "web",
 	entry: "./index.js",
 	output: {
-		filename: '[id].js',
+		filename: "[id].js"
 	},
 	ignoreWarnings: [/\.*/],
 	optimization: {
-		chunkIds:	'named',
-		moduleIds: 'named',
+		chunkIds: "named",
+		moduleIds: "named",
 		splitChunks: {
-			chunks: 'all',
+			chunks: "all",
 			minSize: 100 * 1024,
-			maxSize: 200 * 1024,
+			maxSize: 200 * 1024
 		}
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-split/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-split/rspack.config.js
@@ -1,22 +1,22 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: 'node',
+	target: "node",
 	entry: "./src/index.js",
 	output: {
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	optimization: {
-		chunkIds:	'named',
-		moduleIds: 'named',
+		chunkIds: "named",
+		moduleIds: "named",
 		splitChunks: {
-      chunks: "all",
-      cacheGroups: {
-        fragment: {
+			chunks: "all",
+			cacheGroups: {
+				fragment: {
 					minChunks: 1,
 					maxSize: 200 * 1024,
-					priority: 10,
+					priority: 10
 				}
-      }
+			}
 		}
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-split/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-split/test.config.js
@@ -2,6 +2,11 @@
 module.exports = {
 	findBundle: function (i, options) {
 		// should split based on their file path
-		return ["main.js", "fragment-src_aaa_sync_recursive_.js", "fragment-src_bbb_sync_recursive_.js", "fragment-src_index_js.js"];
+		return [
+			"main.js",
+			"fragment-src_aaa_sync_recursive_.js",
+			"fragment-src_bbb_sync_recursive_.js",
+			"fragment-src_index_js.js"
+		];
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/rspack-issue-4331/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/rspack-issue-4331/rspack.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	mode: "development",
 	target: "node",
 	entry: {
-		main: "./src/index.js",
+		main: "./src/index.js"
 	},
 	output: {
 		filename: "[name].js"

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/rspack-issue-5657/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/rspack-issue-5657/rspack.config.js
@@ -12,7 +12,7 @@ module.exports = {
 					test: /[\/\\]src\/lib[\/\\]/,
 					minSize: 0,
 					maxSize: 50,
-					minChunks: 1,
+					minChunks: 1
 				}
 			}
 		}

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/test-function-with-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/test-function-with-error/rspack.config.js
@@ -14,8 +14,8 @@ module.exports = {
 			cacheGroups: {
 				splitLib2: {
 					test() {
-						throw new Error("TEST_FUNCTION_WITH_ERROR")
-					},
+						throw new Error("TEST_FUNCTION_WITH_ERROR");
+					}
 				}
 			}
 		}

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/used-exports/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/used-exports/rspack.config.js
@@ -2,13 +2,13 @@
 module.exports = {
 	entry: {
 		foo: "./foo",
-		bar: "./bar",
+		bar: "./bar"
 	},
 	output: {
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	optimization: {
-		chunkIds: 'named',
+		chunkIds: "named",
 		usedExports: true,
 		splitChunks: {
 			chunks: "all",
@@ -16,7 +16,7 @@ module.exports = {
 			cacheGroups: {
 				shared: {
 					test: /shared/,
-					minSize: 0,
+					minSize: 0
 				}
 			}
 		}

--- a/packages/rspack-test-tools/tests/configCases/svg/different-module-by-loaders/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/svg/different-module-by-loaders/rspack.config.js
@@ -3,13 +3,13 @@ module.exports = {
 	target: "web",
 	node: {
 		__dirname: false,
-		__filename: false,
+		__filename: false
 	},
 	module: {
 		generator: {
 			"css/auto": {
 				exportsOnly: false
-			},
+			}
 		},
 		rules: [
 			{

--- a/packages/rspack-test-tools/tests/configCases/svg/different-module-by-loaders/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/svg/different-module-by-loaders/test.config.js
@@ -1,11 +1,15 @@
 module.exports = {
-	documentType: 'fake',
+	documentType: "fake",
 	moduleScope(scope) {
 		const link1 = scope.window.document.createElement("link");
 		link1.rel = "stylesheet";
 		link1.href = "bundle0.css";
 		scope.window.document.head.appendChild(link1);
 
-		console.log(scope.window.getComputedStyle(scope.document.head).getPropertyValue('--webpack--main'))
+		console.log(
+			scope.window
+				.getComputedStyle(scope.document.head)
+				.getPropertyValue("--webpack--main")
+		);
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/configCases/target/node-webkit/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/target/node-webkit/rspack.config.js
@@ -1,4 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	target: ["nwjs", "nwjs0", "nwjs0.80", "node-webkit", "node-webkit0", "node-webkit0.80"]
+	target: [
+		"nwjs",
+		"nwjs0",
+		"nwjs0.80",
+		"node-webkit",
+		"node-webkit0",
+		"node-webkit0.80"
+	]
 };

--- a/packages/rspack-test-tools/tests/configCases/tree-shaking/dynamic-import-unused/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/tree-shaking/dynamic-import-unused/rspack.config.js
@@ -10,5 +10,5 @@ module.exports = {
 		usedExports: true,
 		sideEffects: true,
 		innerGraph: true
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/tree-shaking/side-effects-consume-shared/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/tree-shaking/side-effects-consume-shared/rspack.config.js
@@ -1,16 +1,16 @@
-const { rspack } = require("@rspack/core")
+const { rspack } = require("@rspack/core");
 
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	optimization: {
-		sideEffects: true,
+		sideEffects: true
 	},
 	plugins: [
 		new rspack.sharing.ConsumeSharedPlugin({
 			consumes: {
 				"./lib/c.js": {
 					singleton: true,
-					eager: true,
+					eager: true
 				}
 			}
 		})

--- a/packages/rspack-test-tools/tests/configCases/tree-shaking/side-effects-disabled-active/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/tree-shaking/side-effects-disabled-active/rspack.config.js
@@ -4,11 +4,11 @@ module.exports = {
 		rules: [
 			{
 				test: /side-effect\.js/,
-				sideEffects: false,
+				sideEffects: false
 			}
 		]
 	},
 	optimization: {
-		sideEffects: false,
-	},
+		sideEffects: false
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/tree-shaking/side-effects-dynamic-cjs/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/tree-shaking/side-effects-dynamic-cjs/rspack.config.js
@@ -1,6 +1,6 @@
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	optimization: {
-		sideEffects: true,
-	},
+		sideEffects: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/tree-shaking/side-effects-same-target-export/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/tree-shaking/side-effects-same-target-export/rspack.config.js
@@ -1,6 +1,6 @@
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	optimization: {
-		sideEffects: true,
-	},
+		sideEffects: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/web/nonce/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/web/nonce/rspack.config.js
@@ -6,5 +6,5 @@ module.exports = {
 	},
 	experiments: {
 		css: true
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/web/nonce/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/web/nonce/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'jsdom'
-}
+	documentType: "jsdom"
+};

--- a/packages/rspack-test-tools/tests/configCases/worker/custom-worker-call-syntax/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/worker/custom-worker-call-syntax/test.config.js
@@ -1,8 +1,8 @@
 module.exports = {
-	findBundle: function(i, options) {
+	findBundle: function (i, options) {
 		return ["main.js"];
 	},
 	moduleScope(scope) {
 		scope["MyWorker"] = (...args) => new scope.Worker(...args);
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/worker/worker-webpack-chunk-name/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/worker/worker-webpack-chunk-name/rspack.config.js
@@ -1,9 +1,9 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  node: {
-    __dirname: false,
-  },
-  optimization: {
-    chunkIds: "named",
-  }
-}
+	node: {
+		__dirname: false
+	},
+	optimization: {
+		chunkIds: "named"
+	}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/builtins/html_syntax_error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/builtins/html_syntax_error/rspack.config.js
@@ -2,7 +2,5 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	plugins: [
-		new rspack.HtmlRspackPlugin({ template: "index.html" })
-	],
-}
+	plugins: [new rspack.HtmlRspackPlugin({ template: "index.html" })]
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/builtins/recoverable_syntax_error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/builtins/recoverable_syntax_error/rspack.config.js
@@ -6,8 +6,8 @@ module.exports = {
 			{
 				test: /\.tsx$/,
 				use: {
-					loader: "builtin:swc-loader",
-				},
+					loader: "builtin:swc-loader"
+				}
 			}
 		]
 	}

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/rspack.config.js
@@ -1,29 +1,29 @@
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
-   context: __dirname,
-   entry: {
-    main: './index.js'
-   },
-   experiments: {
-     css: true
-   },
-   module: {
-     rules: [
-        {
-            test: /\.css$/,
-            use: [
-                {
-                    loader: "builtin:lightningcss-loader",
-                    /** @type {import("@rspack/core").LightningcssLoaderOptions} */
-                    options: {
-                        unusedSymbols: ['unused'],
-                        targets: '> 0.2%',
-                        draft: 'xx'
-                    }
-                }
-            ],
-            type: "css/auto"
-        },
-     ]
-   }
+	context: __dirname,
+	entry: {
+		main: "./index.js"
+	},
+	experiments: {
+		css: true
+	},
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: "builtin:lightningcss-loader",
+						/** @type {import("@rspack/core").LightningcssLoaderOptions} */
+						options: {
+							unusedSymbols: ["unused"],
+							targets: "> 0.2%",
+							draft: "xx"
+						}
+					}
+				],
+				type: "css/auto"
+			}
+		]
+	}
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-swc-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-swc-loader/rspack.config.js
@@ -1,22 +1,22 @@
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
-   module: {
-     rules: [
-        {
-            test: /\.js$/,
-            use: [
-                {
-                    loader: "builtin:swc-loader",
-                    options: {
-                        jsc: {
-                            parser2: {
-                                syntax: "ecmascript"
-                            }
-                        },
-                    }
-                }
-            ]
-        }
-     ]
-   }
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								parser2: {
+									syntax: "ecmascript"
+								}
+							}
+						}
+					}
+				]
+			}
+		]
+	}
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/pnp-disable/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/pnp-disable/rspack.config.js
@@ -2,9 +2,9 @@
 module.exports = {
 	context: __dirname,
 	entry: {
-		main: './index.js'
+		main: "./index.js"
 	},
 	resolve: {
 		pnp: false
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/rspack.config.js
@@ -1,23 +1,23 @@
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
-  mode: "production",
-  entry: "./index.ts",
-  resolve: {
-    extensions: [".ts", ".js"],
-  },
-  optimization: {
-    concatenateModules: true,
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(j|t)s$/,
-        loader: "builtin:swc-loader",
-        options: {
-          target: "es5",
-        },
-        type: "javascript/auto",
-      },
-    ],
-  },
+	mode: "production",
+	entry: "./index.ts",
+	resolve: {
+		extensions: [".ts", ".js"]
+	},
+	optimization: {
+		concatenateModules: true
+	},
+	module: {
+		rules: [
+			{
+				test: /\.(j|t)s$/,
+				loader: "builtin:swc-loader",
+				options: {
+					target: "es5"
+				},
+				type: "javascript/auto"
+			}
+		]
+	}
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/rspack.config.js
@@ -1,23 +1,23 @@
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
-  mode: "production",
-  entry: "./index.ts",
-  resolve: {
-    extensions: [".ts", ".js"],
-  },
-  optimization: {
-    concatenateModules: true,
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(j|t)s$/,
-        loader: "builtin:swc-loader",
-        options: {
-          target: "es5",
-        },
-        type: "javascript/auto",
-      },
-    ],
-  },
+	mode: "production",
+	entry: "./index.ts",
+	resolve: {
+		extensions: [".ts", ".js"]
+	},
+	optimization: {
+		concatenateModules: true
+	},
+	module: {
+		rules: [
+			{
+				test: /\.(j|t)s$/,
+				loader: "builtin:swc-loader",
+				options: {
+					target: "es5"
+				},
+				type: "javascript/auto"
+			}
+		]
+	}
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-loader/rspack.config.js
@@ -8,4 +8,4 @@ module.exports = {
 			}
 		]
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/dynamic-import-non-exist-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/dynamic-import-non-exist-module/rspack.config.js
@@ -2,5 +2,5 @@
  * @type {import('@rspack/core').RspackOptions}
  */
 module.exports = {
-	context: __dirname,
+	context: __dirname
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/export_star_error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/export_star_error/rspack.config.js
@@ -5,5 +5,5 @@ module.exports = {
 		define: {
 			"process.env.NODE_ENV": "development"
 		}
-	},
-}
+	}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/fully-specified-resolve-suggestions/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/fully-specified-resolve-suggestions/rspack.config.js
@@ -11,4 +11,4 @@ module.exports = {
 			}
 		]
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/mismatched-module-type/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/mismatched-module-type/rspack.config.js
@@ -8,14 +8,14 @@ module.exports = {
 	context: __dirname,
 	module: {
 		rules: [
-      {
-        test: resolve("app.jsx"),
-        type: "javascript/auto"
-      },
-      {
-        test: resolve("app.tsx"),
-        type: "ts"
-      },
+			{
+				test: resolve("app.jsx"),
+				type: "javascript/auto"
+			},
+			{
+				test: resolve("app.tsx"),
+				type: "ts"
+			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-config-build-failed/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-config-build-failed/rspack.config.js
@@ -2,5 +2,5 @@
  * @type {import('@rspack/core').RspackOptions}
  */
 module.exports = {
-	context: __dirname,
+	context: __dirname
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/prefer-relative-resolve-suggestions/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/prefer-relative-resolve-suggestions/rspack.config.js
@@ -8,4 +8,4 @@ module.exports = {
 			}
 		]
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/resolve-extensions-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/resolve-extensions-error/rspack.config.js
@@ -1,3 +1,2 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
-}
+module.exports = {};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/minimize/lightning-css-invalid/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/minimize/lightning-css-invalid/rspack.config.js
@@ -6,11 +6,9 @@ module.exports = {
 	target: "web",
 	optimization: {
 		minimize: true,
-		minimizer: [
-			new rspack.LightningCssMinimizerRspackPlugin(),
-		]
+		minimizer: [new rspack.LightningCssMinimizerRspackPlugin()]
 	},
 	experiments: {
-		css: true,
+		css: true
 	}
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/asset-module-build-failed/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/asset-module-build-failed/rspack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 				test: /\.svg$/,
 				use: [
 					{
-						loader: "./my-loader.js",
+						loader: "./my-loader.js"
 					}
 				],
 				type: "asset"

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/rspack.config.js
@@ -9,5 +9,5 @@ module.exports = {
 				options: {}
 			}
 		]
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/rspack.config.js
@@ -1,13 +1,13 @@
-const { rspack } = require('@rspack/core')
+const { rspack } = require("@rspack/core");
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
 	plugins: [
 		new rspack.DefinePlugin({
-			DEFINE_VAR: '1 2 3'
+			DEFINE_VAR: "1 2 3"
 		})
 	],
 	optimization: {
 		concatenateModules: true
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/define_plugin_warning/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/define_plugin_warning/rspack.config.js
@@ -4,7 +4,7 @@ const { rspack } = require("@rspack/core");
 module.exports = {
 	plugins: [
 		new rspack.DefinePlugin({
-			"__DEV__": "😄"
+			__DEV__: "😄"
 		})
-	],
-}
+	]
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/empty-json/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/empty-json/rspack.config.js
@@ -2,10 +2,10 @@
  * @type {import('@rspack/core').RspackOptions}
  */
 module.exports = {
-  context: __dirname,
-  devtool: false,
-  optimization: {
-    concatenateModules: true,
-    minimize: false
-  }
+	context: __dirname,
+	devtool: false,
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	}
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/json/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/json/rspack.config.js
@@ -2,5 +2,5 @@
  * @type {import('@rspack/core').RspackOptions}
  */
 module.exports = {
-	context: __dirname,
+	context: __dirname
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/module-parse-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/module-parse-error/rspack.config.js
@@ -1,4 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	entry: "./index.js",
+	entry: "./index.js"
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/return-outside-function/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/return-outside-function/rspack.config.js
@@ -2,7 +2,7 @@ module.exports = {
 	entry: {
 		a: "./a",
 		b: "./b",
-		c: "./c",
+		c: "./c"
 	},
 	module: {
 		rules: [
@@ -20,5 +20,4 @@ module.exports = {
 			}
 		]
 	}
-}
-
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/tla_disable_error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/tla_disable_error/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  experiments: {
-    topLevelAwait: false
-  }
+	experiments: {
+		topLevelAwait: false
+	}
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/define-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/define-plugin/rspack.config.js
@@ -1,4 +1,4 @@
-const { rspack } = require("@rspack/core")
+const { rspack } = require("@rspack/core");
 
 module.exports = {
 	optimization: {
@@ -9,4 +9,4 @@ module.exports = {
 			"process.env.NODE_ENV": JSON.stringify("production")
 		})
 	]
-}
+};

--- a/packages/rspack-test-tools/tests/hashCases/depend-async-entrypoint/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hashCases/depend-async-entrypoint/rspack.config.js
@@ -5,19 +5,19 @@ function config(subpath, filename) {
 		entry: {
 			main: {
 				import: "./index.js",
-				filename: "[name].[chunkhash].js",
+				filename: "[name].[chunkhash].js"
 			}
 		},
 		output: {
 			path: path.resolve(__dirname, `dist/${subpath}`),
-			filename,
+			filename
 		},
 		target: "node",
 		optimization: {
 			realContentHash: false,
 			moduleIds: "named",
 			chunkIds: "named",
-			minimize: false,
+			minimize: false
 		}
 	};
 }
@@ -25,5 +25,5 @@ function config(subpath, filename) {
 /** @type {import("@rspack/core").Configuration} */
 module.exports = [
 	config("a", "[name].[chunkhash].js"),
-	config("b", "[name].[contenthash].js"),
+	config("b", "[name].[contenthash].js")
 ];

--- a/packages/rspack-test-tools/tests/hashCases/real-content-hash-fullhash/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hashCases/real-content-hash-fullhash/rspack.config.js
@@ -7,5 +7,5 @@ module.exports = {
 	},
 	output: {
 		filename: "[fullhash].js"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/hashCases/real-content-hash-md4/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hashCases/real-content-hash-md4/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 	output: {
 		filename: "main.js",
 		hashFunction: "md4",
-    hashDigestLength: 20,
+		hashDigestLength: 20,
 		assetModuleFilename: "[contenthash][ext]"
 	},
 	module: {

--- a/packages/rspack-test-tools/tests/hashCases/real-content-hash-md4/test.config.js
+++ b/packages/rspack-test-tools/tests/hashCases/real-content-hash-md4/test.config.js
@@ -6,6 +6,6 @@ module.exports = {
 		const assets = stats.stats[0].toJson().assets.map(i => i.name);
 		assets.sort();
 		// `afc10c70ed4ce2b33593` = md4 of src/file.svg
-		expect(assets).toEqual(['afc10c70ed4ce2b33593.svg', 'main.js']);
+		expect(assets).toEqual(["afc10c70ed4ce2b33593.svg", "main.js"]);
 	}
 };

--- a/packages/rspack-test-tools/tests/hashCases/real-content-hash-xxhash64/test.config.js
+++ b/packages/rspack-test-tools/tests/hashCases/real-content-hash-xxhash64/test.config.js
@@ -7,6 +7,6 @@ module.exports = {
 		assets.sort();
 
 		// `c30068f3cc748ce3` = xxhash64 of src/file.svg
-		expect(assets).toEqual(['c30068f3cc748ce3.svg', 'main.js']);
+		expect(assets).toEqual(["c30068f3cc748ce3.svg", "main.js"]);
 	}
 };

--- a/packages/rspack-test-tools/tests/hotCases/chunk/asset/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/chunk/asset/rspack.config.js
@@ -1,14 +1,14 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: { 
-    main: './index.js'
-  },
-  module: {
+	entry: {
+		main: "./index.js"
+	},
+	module: {
 		rules: [
 			{
 				test: /\.png/,
 				type: "asset/resource"
 			}
 		]
-	},
-}
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/chunk/ensure-chunk-change-to-promise-all/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/chunk/ensure-chunk-change-to-promise-all/rspack.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	target: "web",
 	optimization: {
 		splitChunks: {
-			minSize: 0,
+			minSize: 0
 		}
 	}
 };

--- a/packages/rspack-test-tools/tests/hotCases/chunk/multi-chunk-single-runtime/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/chunk/multi-chunk-single-runtime/rspack.config.js
@@ -1,15 +1,15 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: {
-		a: './a/index.js',
-		b: './b/index.js',
-		main: './main/index.js'
+		a: "./a/index.js",
+		b: "./b/index.js",
+		main: "./main/index.js"
 	},
 	output: {
-		filename: '[name].js',
-		chunkFilename: '[name].chunk.[fullhash].js',
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.[fullhash].js"
 	},
 	optimization: {
-		runtimeChunk: 'single'
+		runtimeChunk: "single"
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/hotCases/chunk/multi-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/chunk/multi-chunk/rspack.config.js
@@ -1,11 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: {
-		a: './a/index.js',
-		b: './b/index.js',
-		main: './main/index.js'
+		a: "./a/index.js",
+		b: "./b/index.js",
+		main: "./main/index.js"
 	},
 	output: {
-		filename: '[name].js',
-	},
-}
+		filename: "[name].js"
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/css/css-extract/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-extract/rspack.config.js
@@ -2,41 +2,41 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  cache: true,
-  mode: "development",
-  entry: "./index",
-  module: {
-    rules: [
-      {
-        test: /\.module.css$/,
-        use: [
-          {
-            loader: rspack.CssExtractRspackPlugin.loader,
+	cache: true,
+	mode: "development",
+	entry: "./index",
+	module: {
+		rules: [
+			{
+				test: /\.module.css$/,
+				use: [
+					{
+						loader: rspack.CssExtractRspackPlugin.loader,
 						options: {
 							emit: false,
-							esModule: true,
+							esModule: true
 						}
-          },
-          {
-            loader: "css-loader",
-            options: {
-              modules: {
-                namedExport: false,
-              }
-            }
-          },
+					},
+					{
+						loader: "css-loader",
+						options: {
+							modules: {
+								namedExport: false
+							}
+						}
+					},
 					"./loader.js"
-        ]
-      },
-    ]
-  },
-  experiments: {
-    css: false,
-  },
-  plugins: [
-    new rspack.CssExtractRspackPlugin({
-      filename: "[name].css",
-			runtime: false,
-    }),
-  ]
+				]
+			}
+		]
+	},
+	experiments: {
+		css: false
+	},
+	plugins: [
+		new rspack.CssExtractRspackPlugin({
+			filename: "[name].css",
+			runtime: false
+		})
+	]
 };

--- a/packages/rspack-test-tools/tests/hotCases/css/css-extract/test.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-extract/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'fake'
-}
+	documentType: "fake"
+};

--- a/packages/rspack-test-tools/tests/hotCases/css/css-loading-unique-name/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-loading-unique-name/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    uniqueName: 'css-test'
-  }
-}
+	output: {
+		uniqueName: "css-test"
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/css/css-loading-unique-name/test.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-loading-unique-name/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'jsdom'
-}
+	documentType: "jsdom"
+};

--- a/packages/rspack-test-tools/tests/hotCases/css/css-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-modules/rspack.config.js
@@ -1,22 +1,22 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: {
-    main: './index.js',
-  },
-  module: {
+	entry: {
+		main: "./index.js"
+	},
+	module: {
 		parser: {
-			'css/module': {
-				namedExports: false,
+			"css/module": {
+				namedExports: false
 			}
 		},
-    rules: [
-      {
-        test: /\.module\.css$/,
-        type: 'css/module',
-        generator: {
+		rules: [
+			{
+				test: /\.module\.css$/,
+				type: "css/module",
+				generator: {
 					exportsOnly: true
-        }
-      }
-    ]
-  }
-}
+				}
+			}
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/css/css-modules/test.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-modules/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'fake'
-}
+	documentType: "fake"
+};

--- a/packages/rspack-test-tools/tests/hotCases/css/parser-and-generator-states/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/parser-and-generator-states/rspack.config.js
@@ -1,12 +1,12 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: {
-    main: './index.js',
-  },
+		main: "./index.js"
+	},
 	module: {
 		parser: {
-			'css/module': {
-				namedExports: false,
+			"css/module": {
+				namedExports: false
 			}
 		},
 		rules: [
@@ -16,8 +16,8 @@ module.exports = {
 				generator: {
 					exportsConvention: "camel-case",
 					localIdentName: "[path][name][ext]__[local]",
-					exportsOnly: true,
-				},
+					exportsOnly: true
+				}
 			}
 		]
 	}

--- a/packages/rspack-test-tools/tests/hotCases/css/parser-and-generator-states/test.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/parser-and-generator-states/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'fake'
-}
+	documentType: "fake"
+};

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery-cacheable/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery-cacheable/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 	mode: "development",
 	devtool: false,
 	output: {
-		hotUpdateChunkFilename: '[id].hot-update.js'
+		hotUpdateChunkFilename: "[id].hot-update.js"
 	},
 	module: {
 		rules: [

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery-cacheable/test.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery-cacheable/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'fake'
-}
+	documentType: "fake"
+};

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 	mode: "development",
 	devtool: false,
 	output: {
-		hotUpdateChunkFilename: '[id].hot-update.js'
+		hotUpdateChunkFilename: "[id].hot-update.js"
 	},
 	module: {
 		rules: [

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/test.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'fake'
-}
+	documentType: "fake"
+};

--- a/packages/rspack-test-tools/tests/hotCases/module-graph/import-order-change/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/module-graph/import-order-change/rspack.config.js
@@ -1,28 +1,25 @@
-const { rspack } = require('@rspack/core')
+const { rspack } = require("@rspack/core");
 
 module.exports = {
 	node: {
-    __dirname: false,
-    __filename: false
-  },
+		__dirname: false,
+		__filename: false
+	},
 	module: {
 		rules: [
 			{
 				test: /\.css/,
-				type: 'javascript/auto',
-				use: [
-					rspack.CssExtractRspackPlugin.loader,
-					'css-loader'
-				]
+				type: "javascript/auto",
+				use: [rspack.CssExtractRspackPlugin.loader, "css-loader"]
 			}
 		]
 	},
 	plugins: [
 		new rspack.CssExtractRspackPlugin({
-			filename: 'bundle.css'
+			filename: "bundle.css"
 		})
 	],
 	experiments: {
 		css: false
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/hotCases/module-graph/import-order-change/test.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/module-graph/import-order-change/test.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	documentType: 'fake'
-}
+	documentType: "fake"
+};

--- a/packages/rspack-test-tools/tests/hotCases/newTreeshaking/auto-reexport/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/newTreeshaking/auto-reexport/rspack.config.js
@@ -1,5 +1,4 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	experiments: {
-	}
+	experiments: {}
 };

--- a/packages/rspack-test-tools/tests/hotCases/newTreeshaking/multi-chunk-single-runtime/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/newTreeshaking/multi-chunk-single-runtime/rspack.config.js
@@ -11,5 +11,5 @@ module.exports = {
 	},
 	optimization: {
 		runtimeChunk: "single"
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/hotCases/newTreeshaking/re-export-optimization/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/newTreeshaking/re-export-optimization/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	optimization: {
-		sideEffects: true,
+		sideEffects: true
 	}
 };

--- a/packages/rspack-test-tools/tests/hotCases/plugins/banner/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/plugins/banner/rspack.config.js
@@ -2,10 +2,11 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  plugins: [
-    new rspack.BannerPlugin({
-      banner: "global.bannerIndex = typeof global.bannerIndex === 'number' ? global.bannerIndex + 1 : 0;",
-      raw: true,
-    })
-  ]
+	plugins: [
+		new rspack.BannerPlugin({
+			banner:
+				"global.bannerIndex = typeof global.bannerIndex === 'number' ? global.bannerIndex + 1 : 0;",
+			raw: true
+		})
+	]
 };

--- a/packages/rspack-test-tools/tests/hotCases/plugins/html/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/plugins/html/rspack.config.js
@@ -2,14 +2,14 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: "./index.js",
-  plugins: [
-    new rspack.HtmlRspackPlugin({
-      template: "./index.html"
-    }),
-  ],
-  node: {
-    __dirname: false,
-    __filename: false
-  }
+	entry: "./index.js",
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	],
+	node: {
+		__dirname: false,
+		__filename: false
+	}
 };

--- a/packages/rspack-test-tools/tests/hotCases/runtime/dispose-removed-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/runtime/dispose-removed-chunk/rspack.config.js
@@ -1,7 +1,7 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    output: {
-        // TODO https://github.com/webpack/webpack/issues/16599
-        chunkFilename: "[id].[hash].js",
-    },
-}
+	output: {
+		// TODO https://github.com/webpack/webpack/issues/16599
+		chunkFilename: "[id].[hash].js"
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/runtime/import-after-download/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/runtime/import-after-download/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    output: {
-        chunkFilename: "[id].[hash].js",
-    },
-}
+	output: {
+		chunkFilename: "[id].[hash].js"
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/source-map/disable/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/source-map/disable/rspack.config.js
@@ -1,13 +1,13 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: { 
-    main: './index.js',
-  },
-  devtool: false,
-  externalsPresets: {
-    node: true,
-  },
-  node: {
-    __dirname: false,
-  }
-}
+	entry: {
+		main: "./index.js"
+	},
+	devtool: false,
+	externalsPresets: {
+		node: true
+	},
+	node: {
+		__dirname: false
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/source-map/enable/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/source-map/enable/rspack.config.js
@@ -1,13 +1,13 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: { 
-    main: './index.js',
-  },
-  devtool: 'cheap-source-map',
-  externalsPresets: {
-    node: true,
-  },
-  node: {
-    __dirname: false,
-  }
-}
+	entry: {
+		main: "./index.js"
+	},
+	devtool: "cheap-source-map",
+	externalsPresets: {
+		node: true
+	},
+	node: {
+		__dirname: false
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/stats/chunks/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/stats/chunks/rspack.config.js
@@ -1,18 +1,18 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-    plugins: [
-        compiler => {
-            compiler.hooks.afterCompile.tap("PLUGIN", compilation => {
-                const stats = compilation.getStats();
-                const { chunks } = stats.toJson({
-                    all: false,
-                    chunks: true
-                });
-                // Ensure that HotUpdateChunk is not added to chunks
-                expect(chunks.length).toBe(1);
-                expect(chunks[0].runtime[0]).toBe('main');
-                expect(chunks[0].files[0]).toBe('bundle.js');
-            })
-        }
-    ]
+	plugins: [
+		compiler => {
+			compiler.hooks.afterCompile.tap("PLUGIN", compilation => {
+				const stats = compilation.getStats();
+				const { chunks } = stats.toJson({
+					all: false,
+					chunks: true
+				});
+				// Ensure that HotUpdateChunk is not added to chunks
+				expect(chunks.length).toBe(1);
+				expect(chunks[0].runtime[0]).toBe("main");
+				expect(chunks[0].files[0]).toBe("bundle.js");
+			});
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/hotCases/worker/issue-5597/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/worker/issue-5597/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    filename: '[name].[fullhash].js'
-  }
-}
+	output: {
+		filename: "[name].[fullhash].js"
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/worker/move-between-runtime/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/worker/move-between-runtime/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    filename: '[name].[fullhash].js'
-  }
-}
+	output: {
+		filename: "[name].[fullhash].js"
+	}
+};

--- a/packages/rspack-test-tools/tests/legacy-test/MultiCompiler.test.js
+++ b/packages/rspack-test-tools/tests/legacy-test/MultiCompiler.test.js
@@ -69,7 +69,7 @@ describe.skip("Pressure test", function () {
 						context: path.join(__dirname, "fixtures"),
 						entry: "./a.js"
 					},
-					() => { }
+					() => {}
 				);
 			}
 

--- a/packages/rspack-test-tools/tests/legacy-test/Output.test.js
+++ b/packages/rspack-test-tools/tests/legacy-test/Output.test.js
@@ -52,7 +52,10 @@ describe("Output", () => {
 	});
 
 	it("should be cleared the build directory", done => {
-		const outputDist = path.resolve(__dirname, "../js/legacy-test/output-clear-build-directory");
+		const outputDist = path.resolve(
+			__dirname,
+			"../js/legacy-test/output-clear-build-directory"
+		);
 		compile(
 			"./a",
 			{

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/default-export-const/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/default-export-const/rspack.config.js
@@ -1,8 +1,8 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    environment: {
-      const: true,
-    }
-  }
-}
+	output: {
+		environment: {
+			const: true
+		}
+	}
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/default-export-const/webpack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/default-export-const/webpack.config.js
@@ -1,8 +1,8 @@
 /** @type {import("webpack").Configuration} */
 module.exports = {
-  output: {
-    environment: {
-      const: true,
-    }
-  }
-}
+	output: {
+		environment: {
+			const: true
+		}
+	}
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/esm-export/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/esm-export/rspack.config.js
@@ -3,5 +3,5 @@ module.exports = {
 	mode: "production",
 	optimization: {
 		minimize: false
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/esm-import/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/esm-import/rspack.config.js
@@ -3,5 +3,5 @@ module.exports = {
 	mode: "production",
 	optimization: {
 		minimize: false
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/esmodule-usage/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/esmodule-usage/rspack.config.js
@@ -4,5 +4,5 @@ module.exports = {
 	optimization: {
 		minimize: false,
 		usedExports: true
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/interop-test/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/interop-test/rspack.config.js
@@ -5,20 +5,17 @@ module.exports = {
 	mode: "development",
 	entry: {
 		js: "./src/index.js",
-		mjs: "./src/index.mjs",
+		mjs: "./src/index.mjs"
 	},
 	target: "async-node",
 	output: {
-		filename: "[name].js",
+		filename: "[name].js"
 	},
 	mode: "production",
 	optimization: {
 		minimize: false,
 		mangleExports: false,
-		concatenateModules: false,
+		concatenateModules: false
 	},
-	plugins: [
-		new Plugin(".js"),
-		new Plugin(".mjs"),
-	]
+	plugins: [new Plugin(".js"), new Plugin(".mjs")]
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/interop-test/test.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/interop-test/test.config.js
@@ -2,15 +2,12 @@
 module.exports = {
 	modules: true,
 	runtimeModules: false,
-	files: [
-		"js.js",
-		"mjs.js"
-	],
+	files: ["js.js", "mjs.js"],
 	errors: true,
 	replacements: [
 		{
 			from: /"[\s\S]*Module parse failed:[\s\S]*Top-level-await is only supported in EcmaScript Modules[\s\S]*"/g,
-			to: "\"Module parse failed: Top-level-await is only supported in EcmaScript Modules\"",
-		},
-	],
+			to: '"Module parse failed: Top-level-await is only supported in EcmaScript Modules"'
+		}
+	]
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/interop-test/webpack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/interop-test/webpack.config.js
@@ -5,20 +5,17 @@ module.exports = {
 	mode: "development",
 	entry: {
 		js: "./src/index.js",
-		mjs: "./src/index.mjs",
+		mjs: "./src/index.mjs"
 	},
 	target: "async-node",
 	output: {
-		filename: "[name].js",
+		filename: "[name].js"
 	},
 	mode: "production",
 	optimization: {
 		minimize: false,
 		mangleExports: false,
-		concatenateModules: false,
+		concatenateModules: false
 	},
-	plugins: [
-		new Plugin(".js"),
-		new Plugin(".mjs"),
-	]
+	plugins: [new Plugin(".js"), new Plugin(".mjs")]
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-concatenate-modules/test.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-concatenate-modules/test.config.js
@@ -15,8 +15,8 @@ module.exports = {
 		"d1.js",
 		"d2.js"
 	],
-	renameModule: (raw) => {
+	renameModule: raw => {
 		// remove hash for concated module identifier
-		return raw.split("|").slice(0, -1).join('|');
-	},
+		return raw.split("|").slice(0, -1).join("|");
+	}
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-optimized/test.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-optimized/test.config.js
@@ -15,8 +15,8 @@ module.exports = {
 		"d1.js",
 		"d2.js"
 	],
-	renameModule: (raw) => {
+	renameModule: raw => {
 		// remove hash for concated module identifier
-		return raw.split("|").slice(0, -1).join('|');
-	},
+		return raw.split("|").slice(0, -1).join("|");
+	}
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/runtime-module/create-script-url/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/runtime-module/create-script-url/rspack.config.js
@@ -3,14 +3,19 @@ module.exports = {
 	entry: {
 		other: "./src/index"
 	},
-	plugins: [{
-		apply(compiler) {
-			const { RuntimeGlobals } = compiler.webpack;
-			compiler.hooks.thisCompilation.tap("testPlugin", (compilation) => {
-				compilation.hooks.additionalTreeRuntimeRequirements.tap("testPlugin", (chunk, set) => {
-					set.add(RuntimeGlobals.createScriptUrl);
+	plugins: [
+		{
+			apply(compiler) {
+				const { RuntimeGlobals } = compiler.webpack;
+				compiler.hooks.thisCompilation.tap("testPlugin", compilation => {
+					compilation.hooks.additionalTreeRuntimeRequirements.tap(
+						"testPlugin",
+						(chunk, set) => {
+							set.add(RuntimeGlobals.createScriptUrl);
+						}
+					);
 				});
-			});
+			}
 		}
-	}]
+	]
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/runtime-module/create-script-url/webpack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/runtime-module/create-script-url/webpack.config.js
@@ -3,14 +3,19 @@ module.exports = {
 	entry: {
 		other: "./src/index"
 	},
-	plugins: [{
-		apply(compiler) {
-			const { RuntimeGlobals } = compiler.webpack;
-			compiler.hooks.thisCompilation.tap("testPlugin", (compilation) => {
-				compilation.hooks.additionalTreeRuntimeRequirements.tap("testPlugin", (chunk, set) => {
-					set.add(RuntimeGlobals.createScriptUrl);
+	plugins: [
+		{
+			apply(compiler) {
+				const { RuntimeGlobals } = compiler.webpack;
+				compiler.hooks.thisCompilation.tap("testPlugin", compilation => {
+					compilation.hooks.additionalTreeRuntimeRequirements.tap(
+						"testPlugin",
+						(chunk, set) => {
+							set.add(RuntimeGlobals.createScriptUrl);
+						}
+					);
 				});
-			});
+			}
 		}
-	}]
+	]
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/runtime-condition/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/runtime-condition/rspack.config.js
@@ -1,12 +1,12 @@
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-	mode: 'production',
+	mode: "production",
 	entry: {
-		a: './a.mjs',
-		b: './b.mjs',
+		a: "./a.mjs",
+		b: "./b.mjs"
 	},
 	output: {
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	module: {
 		rules: [
@@ -26,15 +26,15 @@ module.exports = {
 		usedExports: true,
 		innerGraph: true,
 		splitChunks: {
-			chunks: 'all',
+			chunks: "all",
 			minSize: 0,
 			cacheGroups: {
 				shared: {
 					test: /(shared|utils|value)/,
-					name: 'shared',
+					name: "shared",
 					enforce: true
 				}
 			}
 		}
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/runtime-condition/test.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/runtime-condition/test.config.js
@@ -1,13 +1,9 @@
 /** @type {import("../../../../dist").TDiffCaseConfig} */
 module.exports = {
-	renameModule: (raw) => {
+	renameModule: raw => {
 		// remove hash for concated module identifier
-		return raw.split("|").slice(0, -1).join('|');
+		return raw.split("|").slice(0, -1).join("|");
 	},
 	modules: true,
-	files: [
-		'shared.js',
-		'a.js',
-		'b.js',
-	],
+	files: ["shared.js", "a.js", "b.js"]
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/runtime-condition/webpack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/runtime-condition/webpack.config.js
@@ -1,12 +1,12 @@
 /** @type {import("webpack").Configuration} */
 module.exports = {
-	mode: 'production',
+	mode: "production",
 	entry: {
-		a: './a.mjs',
-		b: './b.mjs',
+		a: "./a.mjs",
+		b: "./b.mjs"
 	},
 	output: {
-		filename: '[name].js'
+		filename: "[name].js"
 	},
 	module: {
 		rules: [
@@ -26,15 +26,15 @@ module.exports = {
 		usedExports: true,
 		innerGraph: true,
 		splitChunks: {
-			chunks: 'all',
+			chunks: "all",
 			minSize: 0,
 			cacheGroups: {
 				shared: {
 					test: /(shared|utils|value)/,
-					name: 'shared',
+					name: "shared",
 					enforce: true
 				}
 			}
 		}
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/statsOutputCases/auxiliary-files-test/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/auxiliary-files-test/rspack.config.js
@@ -19,4 +19,4 @@ module.exports = {
 		builtAt: false,
 		version: false
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/statsOutputCases/builtin-swc-loader-parse-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/builtin-swc-loader-parse-error/rspack.config.js
@@ -20,4 +20,4 @@ module.exports = {
 			}
 		]
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/statsOutputCases/concatenated-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/concatenated-modules/rspack.config.js
@@ -4,5 +4,5 @@ module.exports = {
 	optimization: {
 		concatenateModules: true,
 		minimize: false
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/statsOutputCases/css-concat/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/css-concat/rspack.config.js
@@ -6,6 +6,6 @@ module.exports = {
 		minimize: false
 	},
 	experiments: {
-		css: true,
+		css: true
 	}
 };

--- a/packages/rspack-test-tools/tests/statsOutputCases/hot+production/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/hot+production/rspack.config.js
@@ -1,12 +1,10 @@
-const { rspack } = require("@rspack/core")
+const { rspack } = require("@rspack/core");
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
 	entry: {
 		main: "./index.js"
 	},
-	plugins: [
-		new rspack.HotModuleReplacementPlugin(),
-	],
+	plugins: [new rspack.HotModuleReplacementPlugin()],
 	mode: "production"
 };

--- a/packages/rspack-test-tools/tests/statsOutputCases/ignore-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/ignore-plugin/rspack.config.js
@@ -1,11 +1,11 @@
-const webpack = require('webpack')
+const webpack = require("webpack");
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
 	entry: "./index",
 	stats: {
 		all: false,
-		modules: true,
+		modules: true
 	},
 	plugins: [
 		new webpack.IgnorePlugin({

--- a/packages/rspack-test-tools/tests/statsOutputCases/limit-chunk-count-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/limit-chunk-count-plugin/rspack.config.js
@@ -19,6 +19,6 @@ module.exports = [1, 2, 3, 4].map(n => ({
 		// dependentModules: true,
 		chunkRelations: true,
 		modules: false,
-		chunks: true,
+		chunks: true
 	}
 }));

--- a/packages/rspack-test-tools/tests/statsOutputCases/match-resource-data-url/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/match-resource-data-url/rspack.config.js
@@ -6,6 +6,6 @@ module.exports = {
 	mode: "development",
 	stats: {
 		all: false,
-		modules: true,
+		modules: true
 	}
 };

--- a/packages/rspack-test-tools/tests/statsOutputCases/minify-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/minify-error/rspack.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	entry: "./index",
 	stats: "errors-warnings",
 	optimization: {
-		minimize: true,
+		minimize: true
 	},
 	plugins: [
 		{
@@ -20,16 +20,13 @@ module.exports = {
 							for (const [key, value] of Object.entries(assets)) {
 								compilation.updateAsset(
 									key,
-									new ConcatSource(
-										new RawSource("const a {}\n"),
-										value
-									)
+									new ConcatSource(new RawSource("const a {}\n"), value)
 								);
 							}
 						}
 					);
 				});
 			}
-		},
-	],
-}
+		}
+	]
+};

--- a/packages/rspack-test-tools/tests/statsOutputCases/named-chunk-group/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/named-chunk-group/rspack.config.js
@@ -4,6 +4,6 @@ module.exports = {
 	stats: {
 		all: false,
 		entrypoints: true,
-		chunkGroups: true,
+		chunkGroups: true
 	}
 };

--- a/packages/rspack-test-tools/tests/statsOutputCases/optimization-chunk-ids-natural/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/optimization-chunk-ids-natural/rspack.config.js
@@ -11,7 +11,7 @@ module.exports = {
 		chunks: true,
 		entrypoints: true,
 		chunkGroups: true,
-		errors: true,
+		errors: true
 	},
-	optimization: { chunkIds: 'natural' },
+	optimization: { chunkIds: "natural" }
 };

--- a/packages/rspack-test-tools/tests/statsOutputCases/optimization-runtime-chunk-multiple/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/optimization-runtime-chunk-multiple/rspack.config.js
@@ -14,7 +14,7 @@ module.exports = {
 		chunks: true,
 		entrypoints: true,
 		chunkGroups: true,
-		errors: true,
+		errors: true
 	},
 	optimization: {
 		runtimeChunk: "multiple"

--- a/packages/rspack-test-tools/tests/statsOutputCases/optimization-runtime-chunk-single/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/optimization-runtime-chunk-single/rspack.config.js
@@ -15,7 +15,7 @@ module.exports = {
 		chunks: true,
 		entrypoints: true,
 		chunkGroups: true,
-		errors: true,
+		errors: true
 	},
 	optimization: {
 		runtimeChunk: "single"

--- a/packages/rspack-test-tools/tests/statsOutputCases/optimization-runtime-chunk-true/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/optimization-runtime-chunk-true/rspack.config.js
@@ -14,7 +14,7 @@ module.exports = {
 		chunks: true,
 		entrypoints: true,
 		chunkGroups: true,
-		errors: true,
+		errors: true
 	},
 	optimization: {
 		runtimeChunk: true

--- a/packages/rspack-test-tools/tests/statsOutputCases/optimization-runtime-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/optimization-runtime-chunk/rspack.config.js
@@ -18,11 +18,11 @@ module.exports = {
 		chunks: true,
 		entrypoints: true,
 		chunkGroups: true,
-		errors: true,
+		errors: true
 	},
 	optimization: {
 		runtimeChunk: {
-			name: (entrypoint) => `${entrypoint.name}~runtime`
+			name: entrypoint => `${entrypoint.name}~runtime`
 		}
 	}
 };

--- a/packages/rspack-test-tools/tests/statsOutputCases/reasons/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/reasons/rspack.config.js
@@ -4,6 +4,6 @@ module.exports = {
 	stats: {
 		all: false,
 		modules: true,
-		reasons: true,
+		reasons: true
 	}
 };

--- a/packages/rspack-test-tools/tests/statsOutputCases/resolve-overflow-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/resolve-overflow-error/rspack.config.js
@@ -2,4 +2,4 @@
 module.exports = {
 	entry: "./index",
 	target: ["web"]
-}
+};

--- a/packages/rspack-test-tools/tests/statsOutputCases/runtime-specific-exports/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/runtime-specific-exports/rspack.config.js
@@ -1,14 +1,12 @@
-
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: "./example.js",
 	optimization: {
 		usedExports: true,
-		providedExports: true,
+		providedExports: true
 	},
 	stats: {
 		usedExports: true,
-		providedExports: true,
+		providedExports: true
 	}
 };
-

--- a/packages/rspack-test-tools/tests/statsOutputCases/side-effects-bailouts/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/side-effects-bailouts/rspack.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	entry: {
 		main: "./index.js"
 	},
-	mode: 'production',
+	mode: "production",
 	stats: {
 		chunks: true,
 		children: true,

--- a/packages/rspack-test-tools/tests/statsOutputCases/simple-module-source/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/simple-module-source/rspack.config.js
@@ -12,4 +12,4 @@ module.exports = {
 		source: true,
 		version: false
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/statsOutputCases/stats-hooks/rspack.config.js
+++ b/packages/rspack-test-tools/tests/statsOutputCases/stats-hooks/rspack.config.js
@@ -41,5 +41,5 @@ module.exports = {
 		timings: false,
 		version: false
 	},
-	plugins: [new StatsPrinterTestPlugin()],
+	plugins: [new StatsPrinterTestPlugin()]
 };

--- a/packages/rspack-test-tools/tests/treeShakingCases/array-side-effects/rspack.config.js
+++ b/packages/rspack-test-tools/tests/treeShakingCases/array-side-effects/rspack.config.js
@@ -2,7 +2,7 @@
 module.exports = {
 	optimization: {
 		sideEffects: true,
-		usedExports: true,
+		usedExports: true
 	},
 	builtins: {
 		define: {

--- a/packages/rspack-test-tools/tests/treeShakingCases/css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/treeShakingCases/css/rspack.config.js
@@ -2,8 +2,8 @@
 module.exports = {
 	module: {
 		parser: {
-			'css/auto': {
-				namedExports: false,
+			"css/auto": {
+				namedExports: false
 			}
 		},
 		rules: [

--- a/packages/rspack-test-tools/tests/treeShakingCases/issue-7016/rspack.config.js
+++ b/packages/rspack-test-tools/tests/treeShakingCases/issue-7016/rspack.config.js
@@ -1,3 +1,1 @@
-module.exports = {
-	
-}
+module.exports = {};

--- a/packages/rspack-test-tools/tests/treeShakingCases/issues_3198/rspack.config.js
+++ b/packages/rspack-test-tools/tests/treeShakingCases/issues_3198/rspack.config.js
@@ -1,4 +1,2 @@
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
-
-};
+module.exports = {};

--- a/packages/rspack-test-tools/tests/watchCases/async-modules/top-level-await/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/async-modules/top-level-await/rspack.config.js
@@ -5,7 +5,7 @@ module.exports = [
 			case1: "./case1/index.js"
 		},
 		output: {
-			filename: "case1.js",
+			filename: "case1.js"
 		}
 	},
 	{
@@ -13,7 +13,7 @@ module.exports = [
 			case2: "./case2/index.js"
 		},
 		output: {
-			filename: "case2.js",
+			filename: "case2.js"
 		}
 	},
 	{
@@ -21,7 +21,7 @@ module.exports = [
 			case3: "./case3/index.js"
 		},
 		output: {
-			filename: "case3.js",
+			filename: "case3.js"
 		}
 	}
 ];

--- a/packages/rspack-test-tools/tests/watchCases/async-modules/top-level-await/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/async-modules/top-level-await/test.config.js
@@ -2,11 +2,11 @@ module.exports = {
 	findBundle(i) {
 		switch (i) {
 			case 0:
-				return `case1.js`
+				return `case1.js`;
 			case 1:
-				return `case2.js`
+				return `case2.js`;
 			case 2:
-				return `case3.js`
+				return `case3.js`;
 		}
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/available-modules-change/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/available-modules-change/rspack.config.js
@@ -2,6 +2,6 @@
 module.exports = {
 	optimization: {
 		splitChunks: false,
-		sideEffects: false,
+		sideEffects: false
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/available-modules-change/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/available-modules-change/test.config.js
@@ -3,40 +3,24 @@ const { checkChunkModules } = require("@rspack/test-tools");
 module.exports = {
 	checkStats(stepName, stats) {
 		switch (stepName) {
-			case '0':
+			case "0":
 				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js'
-					],
-					'dyn-2': [
-						'dyn-2.js',
-					],
-					shared: [
-						'shared.js',
-						'm.js',
-					]
-				})
-				break
-			case '1':
+					"dyn-1": ["dyn-1.js", "m.js"],
+					"dyn-2": ["dyn-2.js"],
+					shared: ["shared.js", "m.js"]
+				});
+				break;
+			case "1":
 				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js'
-					],
-					'dyn-2': [
-						'dyn-2.js',
-						'm.js'
-					],
-					shared: [
-						'shared.js',
-					]
-				})
+					"dyn-1": ["dyn-1.js", "m.js"],
+					"dyn-2": ["dyn-2.js", "m.js"],
+					shared: ["shared.js"]
+				});
 				break;
 			default:
-				throw "no have more step"
+				throw "no have more step";
 		}
 
-		return true
+		return true;
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-add-then-change-ava-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-add-then-change-ava-module/rspack.config.js
@@ -2,6 +2,6 @@
 module.exports = {
 	optimization: {
 		splitChunks: false,
-		sideEffects: false,
+		sideEffects: false
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-add-then-change-ava-module/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-add-then-change-ava-module/test.config.js
@@ -3,51 +3,30 @@ const { checkChunkModules } = require("@rspack/test-tools");
 module.exports = {
 	checkStats(stepName, stats) {
 		switch (stepName) {
-			case '0':
+			case "0":
 				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js',
-					],
-					shared: [
-						'shared.js',
-					]
-				})
-				break
-			case '1':
-				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js'
-					],
-					'dyn-2': [
-						'dyn-2.js',
-					],
-					shared: [
-						'shared.js',
-						'm.js'
-					]
-				})
+					"dyn-1": ["dyn-1.js", "m.js"],
+					shared: ["shared.js"]
+				});
 				break;
-			case '2':
+			case "1":
 				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js'
-					],
-					'dyn-2': [
-						'dyn-2.js',
-						'm.js'
-					],
-					shared: [
-						'shared.js',
-					]
-				})
+					"dyn-1": ["dyn-1.js", "m.js"],
+					"dyn-2": ["dyn-2.js"],
+					shared: ["shared.js", "m.js"]
+				});
+				break;
+			case "2":
+				checkChunkModules(stats, {
+					"dyn-1": ["dyn-1.js", "m.js"],
+					"dyn-2": ["dyn-2.js", "m.js"],
+					shared: ["shared.js"]
+				});
 				break;
 			default:
-				throw "no have more step"
+				throw "no have more step";
 		}
 
-		return true
+		return true;
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-modify/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-modify/rspack.config.js
@@ -2,6 +2,6 @@
 module.exports = {
 	optimization: {
 		splitChunks: false,
-		sideEffects: false,
+		sideEffects: false
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-modify/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-modify/test.config.js
@@ -3,51 +3,30 @@ const { checkChunkModules } = require("@rspack/test-tools");
 module.exports = {
 	checkStats(stepName, stats) {
 		switch (stepName) {
-			case '0':
+			case "0":
 				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js'
-					],
-					'dyn-2': [
-						'dyn-2.js',
-					],
-					shared: [
-						'shared.js',
-						'm.js',
-					]
-				})
-				break
-			case '1':
-				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js'
-					],
-					shared: [
-						'shared.js',
-					]
-				})
+					"dyn-1": ["dyn-1.js", "m.js"],
+					"dyn-2": ["dyn-2.js"],
+					shared: ["shared.js", "m.js"]
+				});
 				break;
-			case '2':
+			case "1":
 				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js'
-					],
-					'dyn-2': [
-						'dyn-2.js',
-						'm.js'
-					],
-					shared: [
-						'shared.js',
-					]
-				})
+					"dyn-1": ["dyn-1.js", "m.js"],
+					shared: ["shared.js"]
+				});
+				break;
+			case "2":
+				checkChunkModules(stats, {
+					"dyn-1": ["dyn-1.js", "m.js"],
+					"dyn-2": ["dyn-2.js", "m.js"],
+					shared: ["shared.js"]
+				});
 				break;
 			default:
-				throw "no have more step"
+				throw "no have more step";
 		}
 
-		return true
+		return true;
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-remove/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-remove/rspack.config.js
@@ -2,6 +2,6 @@
 module.exports = {
 	optimization: {
 		splitChunks: false,
-		sideEffects: false,
+		sideEffects: false
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-remove/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-remove/test.config.js
@@ -3,36 +3,23 @@ const { checkChunkModules } = require("@rspack/test-tools");
 module.exports = {
 	checkStats(stepName, stats) {
 		switch (stepName) {
-			case '0':
+			case "0":
 				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js'
-					],
-					'dyn-2': [
-						'dyn-2.js',
-					],
-					shared: [
-						'shared.js',
-						'm.js',
-					]
-				})
-				break
-			case '1':
+					"dyn-1": ["dyn-1.js", "m.js"],
+					"dyn-2": ["dyn-2.js"],
+					shared: ["shared.js", "m.js"]
+				});
+				break;
+			case "1":
 				checkChunkModules(stats, {
-					'dyn-1': [
-						'dyn-1.js',
-						'm.js'
-					],
-					shared: [
-						'shared.js',
-					]
-				})
+					"dyn-1": ["dyn-1.js", "m.js"],
+					shared: ["shared.js"]
+				});
 				break;
 			default:
-				throw "no have more step"
+				throw "no have more step";
 		}
 
-		return true
+		return true;
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/keep-order-index/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/keep-order-index/rspack.config.js
@@ -2,34 +2,29 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("webpack").Configuration} */
 module.exports = {
-  plugins: [
-    new rspack.CssExtractRspackPlugin({ ignoreOrder: true }),
-  ],
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: [
-					rspack.CssExtractRspackPlugin.loader,
-					"css-loader"
-				],
-      },
-    ],
-  },
-  optimization: {
-    splitChunks: {
-      cacheGroups: {
-        styles: {
-          name: "styles",
-          chunks: "all",
-          test: /\.css$/,
-          enforce: true,
-        },
-      },
-    },
-  },
-  experiments: {
+	plugins: [new rspack.CssExtractRspackPlugin({ ignoreOrder: true })],
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [rspack.CssExtractRspackPlugin.loader, "css-loader"]
+			}
+		]
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				styles: {
+					name: "styles",
+					chunks: "all",
+					test: /\.css$/,
+					enforce: true
+				}
+			}
+		}
+	},
+	experiments: {
 		css: false,
-    incremental: true,
-  },
+		incremental: true
+	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/keep-order-index/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/keep-order-index/test.config.js
@@ -1,11 +1,11 @@
 module.exports = {
 	findBundle() {
 		return [
-			'bundle.js',
-			'ab_js.bundle.js',
-			'ba_js.bundle.js',
-			'styles.bundle.js',
+			"bundle.js",
+			"ab_js.bundle.js",
+			"ba_js.bundle.js",
+			"styles.bundle.js",
 			"styles.css"
-		]
+		];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/pre-order-index/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/pre-order-index/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	optimization: {
-		splitChunks: false,
-	},
+		splitChunks: false
+	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/runtime-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/runtime-chunk/rspack.config.js
@@ -1,9 +1,9 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    filename: "[name].js",
-  },
-  optimization: {
-    runtimeChunk: true,
-  }
-}
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		runtimeChunk: true
+	}
+};

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/runtime-chunk/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/runtime-chunk/test.config.js
@@ -2,4 +2,4 @@ module.exports = {
 	findBundle() {
 		return ["runtime~main.js", "main.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/watchCases/build-failed/watch-loader-failed-css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-failed/watch-loader-failed-css/rspack.config.js
@@ -1,38 +1,38 @@
 const path = require("path");
-const { rspack } = require('@rspack/core');
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  module: {
-    rules: [{
-      test: /.txt$/,
-      type: 'javascript/auto',
-      use: [
-        {
-          loader: rspack.CssExtractRspackPlugin.loader,
-        },
-        {
-          loader: "css-loader",
-          options: {
-            modules: {
-              namedExport: true,
-              exportLocalsConvention: 'camel-case-only'
-            }
-          }
-        },
-        {
-          loader: path.resolve(__dirname, './loader.js')
-        }
-      ]
-    }]
-  },
-  plugins: [
-    new rspack.CssExtractRspackPlugin(),
-  ],
-  experiments: {
-    css: false
-  },
-  resolve: {
-    extensions: ["...", ".txt"]
-  }
+	module: {
+		rules: [
+			{
+				test: /.txt$/,
+				type: "javascript/auto",
+				use: [
+					{
+						loader: rspack.CssExtractRspackPlugin.loader
+					},
+					{
+						loader: "css-loader",
+						options: {
+							modules: {
+								namedExport: true,
+								exportLocalsConvention: "camel-case-only"
+							}
+						}
+					},
+					{
+						loader: path.resolve(__dirname, "./loader.js")
+					}
+				]
+			}
+		]
+	},
+	plugins: [new rspack.CssExtractRspackPlugin()],
+	experiments: {
+		css: false
+	},
+	resolve: {
+		extensions: ["...", ".txt"]
+	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-failed/watch-loader-failed/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-failed/watch-loader-failed/rspack.config.js
@@ -2,13 +2,15 @@ const path = require("path");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  module: {
-    rules: [{
-      test: /.txt$/,
-      loader: path.resolve(__dirname, './loader.js')
-    }]
-  },
-  resolve: {
-    extensions: ["...", ".txt"]
-  }
+	module: {
+		rules: [
+			{
+				test: /.txt$/,
+				loader: path.resolve(__dirname, "./loader.js")
+			}
+		]
+	},
+	resolve: {
+		extensions: ["...", ".txt"]
+	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/chunks/split-chunks-add-chunks/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/split-chunks-add-chunks/rspack.config.js
@@ -1,7 +1,7 @@
 /** @type {import("webpack").Configuration} */
 module.exports = {
 	output: {
-		filename: "[name].js",
+		filename: "[name].js"
 	},
 	optimization: {
 		splitChunks: {
@@ -10,12 +10,12 @@ module.exports = {
 			cacheGroups: {
 				lib1: {
 					name: "lib1",
-					test: /lib1/,
+					test: /lib1/
 				},
 				lib2: {
 					name: "lib2",
-					test: /lib2/,
-				},
+					test: /lib2/
+				}
 			}
 		}
 	}

--- a/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/rspack.config.js
@@ -2,20 +2,24 @@ let firstRun = true;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	plugins: [{
-		apply(compiler) {
-			compiler.hooks.compilation.tap("test", (compilation) => {
-				compilation.hooks.seal.tap("test", () => {
-					const builtModules = Array.from(compilation.builtModules).map(m => m.rawRequest);
-					builtModules.sort();
-					if (firstRun) {
-						expect(builtModules).toEqual(["./foo", "./index.js"]);
-						firstRun = false;
-					} else {
-						expect(builtModules).toEqual(["./foo"]);
-					}
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("test", compilation => {
+					compilation.hooks.seal.tap("test", () => {
+						const builtModules = Array.from(compilation.builtModules).map(
+							m => m.rawRequest
+						);
+						builtModules.sort();
+						if (firstRun) {
+							expect(builtModules).toEqual(["./foo", "./index.js"]);
+							firstRun = false;
+						} else {
+							expect(builtModules).toEqual(["./foo"]);
+						}
+					});
 				});
-			});
+			}
 		}
-	}]
+	]
 };

--- a/packages/rspack-test-tools/tests/watchCases/compiler/multiply-compiler/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/compiler/multiply-compiler/rspack.config.js
@@ -5,7 +5,7 @@ module.exports = [
 			entry1: "./entry1.js"
 		},
 		output: {
-			filename: "./bundle1.js",
+			filename: "./bundle1.js"
 		}
 	},
 	{
@@ -13,7 +13,7 @@ module.exports = [
 			entry2: "./entry2.js"
 		},
 		output: {
-			filename: "./bundle2.js",
+			filename: "./bundle2.js"
 		}
 	}
 ];

--- a/packages/rspack-test-tools/tests/watchCases/compiler/multiply-compiler/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/compiler/multiply-compiler/test.config.js
@@ -2,9 +2,9 @@ module.exports = {
 	findBundle(i) {
 		switch (i) {
 			case 0:
-				return `bundle1.js`
+				return `bundle1.js`;
 			case 1:
-				return `bundle2.js`
+				return `bundle2.js`;
 		}
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/watchCases/context/out-of-context/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/context/out-of-context/rspack.config.js
@@ -1,10 +1,10 @@
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
 	entry: "./src/index",
-	target: 'web',
+	target: "web",
 	node: false,
 	output: {
-		publicPath: '/'
+		publicPath: "/"
 	},
 	module: {
 		rules: [

--- a/packages/rspack-test-tools/tests/watchCases/context/out-of-context/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/context/out-of-context/test.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-	documentType: 'fake',
+	documentType: "fake",
 	findBundle(i) {
-		return ["bundle.css", "bundle.js"]
+		return ["bundle.css", "bundle.js"];
 	}
-}
+};

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/rspack.config.js
@@ -2,41 +2,36 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: {
-    ab: './ab.js',
-    ba: './ba.js',
-  },
-  output: {
-    filename: '[name].js'
-  },
-  optimization: {
-    splitChunks: {
-      cacheGroups: {
-        styles: {
-          name: "styles",
-          chunks: "all",
-          test: /\.css$/,
-          enforce: true,
-        },
-      },
-    },
-  },
-  plugins: [
-    new rspack.CssExtractRspackPlugin({ ignoreOrder: false }),
-  ],
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: [
-          rspack.CssExtractRspackPlugin.loader,
-          "css-loader",
-        ],
-        type: "javascript/auto",
-      },
-    ],
-  },
-  experiments: {
-    css: false,
-  },
+	entry: {
+		ab: "./ab.js",
+		ba: "./ba.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				styles: {
+					name: "styles",
+					chunks: "all",
+					test: /\.css$/,
+					enforce: true
+				}
+			}
+		}
+	},
+	plugins: [new rspack.CssExtractRspackPlugin({ ignoreOrder: false })],
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [rspack.CssExtractRspackPlugin.loader, "css-loader"],
+				type: "javascript/auto"
+			}
+		]
+	},
+	experiments: {
+		css: false
+	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-css-extract/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle(i) {
 		return ["ab.js", "ba.js"];
-	},
-}
+	}
+};

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/rspack.config.js
@@ -2,27 +2,27 @@ const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  entry: {
-    ab: './ab.js',
-    ba: './ba.js',
-  },
-  output: {
-    filename: '[name].js'
-  },
-  target: "web",
-  optimization: {
-    splitChunks: {
-      cacheGroups: {
-        styles: {
-          name: "styles",
-          chunks: "all",
-          test: /\.css$/,
-          enforce: true,
-        },
-      },
-    },
-  },
-  experiments: {
-    css: true,
-  },
+	entry: {
+		ab: "./ab.js",
+		ba: "./ba.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	target: "web",
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				styles: {
+					name: "styles",
+					chunks: "all",
+					test: /\.css$/,
+					enforce: true
+				}
+			}
+		}
+	},
+	experiments: {
+		css: true
+	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/css/chunk-render-cache-experiments-css/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	findBundle(i) {
 		return ["ab.js", "ba.js"];
-	},
-}
+	}
+};

--- a/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/module-ids/activate-inactive-module/rspack.config.js
@@ -4,7 +4,7 @@ module.exports = {
 		rules: [
 			{
 				test: /a\.js/,
-				sideEffects: false,
+				sideEffects: false
 			}
 		]
 	}

--- a/packages/rspack-test-tools/tests/watchCases/module-ids/ignored-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/module-ids/ignored-module/rspack.config.js
@@ -2,7 +2,7 @@
 module.exports = {
 	resolve: {
 		alias: {
-			"ignored": false,
-		},
+			ignored: false
+		}
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/basic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/basic/rspack.config.js
@@ -2,6 +2,6 @@
 module.exports = {
 	optimization: {
 		sideEffects: true,
-		providedExports: true,
+		providedExports: true
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/side-effects/two-to-one/rspack.config.js
@@ -2,6 +2,6 @@
 module.exports = {
 	optimization: {
 		sideEffects: true,
-		providedExports: true,
+		providedExports: true
 	}
 };

--- a/website/.prettierignore
+++ b/website/.prettierignore
@@ -1,1 +1,0 @@
-pnpm-lock.yaml


### PR DESCRIPTION
## Summary

Allow prettier to format the following source files:

- packages/rspack-test-tools/tests/**/*.test.ts
- packages/rspack-test-tools/tests/**/*.test.js
- packages/rspack-test-tools/tests/**/*.config.js

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
