### PR TITLE
feat: add `--config-loader` CLI option

### DIFF
--- a/packages/rspack-cli/src/types.ts
+++ b/packages/rspack-cli/src/types.ts
@@ -24,7 +24,7 @@ export interface RspackCLIOptions {
 	config?: string;
 	argv?: Record<string, any>;
 	configName?: string[];
-	"disable-interpret"?: boolean;
+	"config-loader"?: string;
 }
 
 export interface RspackBuildCLIOptions extends RspackCLIOptions {

--- a/packages/rspack-cli/src/types.ts
+++ b/packages/rspack-cli/src/types.ts
@@ -24,6 +24,7 @@ export interface RspackCLIOptions {
 	config?: string;
 	argv?: Record<string, any>;
 	configName?: string[];
+	"disable-interpret"?: boolean;
 }
 
 export interface RspackBuildCLIOptions extends RspackCLIOptions {

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -61,7 +61,7 @@ export async function loadRspackConfig(
 		if (!fs.existsSync(configPath)) {
 			throw new Error(`config file "${configPath}" not found.`);
 		}
-		if (isTsFile(configPath)) {
+		if (isTsFile(configPath) && !options["disable-interpret"]) {
 			await registerLoader(configPath);
 		}
 		return crossImport(configPath, cwd);
@@ -69,7 +69,7 @@ export async function loadRspackConfig(
 
 	const defaultConfig = findConfig(path.resolve(cwd, DEFAULT_CONFIG_NAME));
 	if (defaultConfig) {
-		if (isTsFile(defaultConfig)) {
+		if (isTsFile(defaultConfig) && !options["disable-interpret"]) {
 			await registerLoader(defaultConfig);
 		}
 		return crossImport(defaultConfig, cwd);

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -61,7 +61,7 @@ export async function loadRspackConfig(
 		if (!fs.existsSync(configPath)) {
 			throw new Error(`config file "${configPath}" not found.`);
 		}
-		if (isTsFile(configPath) && options['config-loader'] === 'register') {
+		if (isTsFile(configPath) && options["config-loader"] === "register") {
 			await registerLoader(configPath);
 		}
 		return crossImport(configPath, cwd);
@@ -69,7 +69,7 @@ export async function loadRspackConfig(
 
 	const defaultConfig = findConfig(path.resolve(cwd, DEFAULT_CONFIG_NAME));
 	if (defaultConfig) {
-		if (isTsFile(defaultConfig) && options['config-loader'] === 'register') {
+		if (isTsFile(defaultConfig) && options["config-loader"] === "register") {
 			await registerLoader(defaultConfig);
 		}
 		return crossImport(defaultConfig, cwd);

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -61,7 +61,7 @@ export async function loadRspackConfig(
 		if (!fs.existsSync(configPath)) {
 			throw new Error(`config file "${configPath}" not found.`);
 		}
-		if (isTsFile(configPath) && !options["disable-interpret"]) {
+		if (isTsFile(configPath) && options['config-loader'] === 'native') {
 			await registerLoader(configPath);
 		}
 		return crossImport(configPath, cwd);
@@ -69,7 +69,7 @@ export async function loadRspackConfig(
 
 	const defaultConfig = findConfig(path.resolve(cwd, DEFAULT_CONFIG_NAME));
 	if (defaultConfig) {
-		if (isTsFile(defaultConfig) && !options["disable-interpret"]) {
+		if (isTsFile(defaultConfig) && options['config-loader'] === 'native') {
 			await registerLoader(defaultConfig);
 		}
 		return crossImport(defaultConfig, cwd);

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -61,7 +61,7 @@ export async function loadRspackConfig(
 		if (!fs.existsSync(configPath)) {
 			throw new Error(`config file "${configPath}" not found.`);
 		}
-		if (isTsFile(configPath) && options['config-loader'] === 'native') {
+		if (isTsFile(configPath) && options['config-loader'] === 'register') {
 			await registerLoader(configPath);
 		}
 		return crossImport(configPath, cwd);
@@ -69,7 +69,7 @@ export async function loadRspackConfig(
 
 	const defaultConfig = findConfig(path.resolve(cwd, DEFAULT_CONFIG_NAME));
 	if (defaultConfig) {
-		if (isTsFile(defaultConfig) && options['config-loader'] === 'native') {
+		if (isTsFile(defaultConfig) && options['config-loader'] === 'register') {
 			await registerLoader(defaultConfig);
 		}
 		return crossImport(defaultConfig, cwd);

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -47,8 +47,8 @@ export const commonOptions = (yargs: yargs.Argv) => {
 			},
 			'config-loader': {
 				type: "string",
-				default: "native",
-				describe: "Specify the loader to load the config file, can be `none` or `native`.",
+				default: "register",
+				describe: "Specify the loader to load the config file, can be `native` or `register`.",
 			},
 		})
 		.alias({ v: "version", h: "help" });

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -45,11 +45,12 @@ export const commonOptions = (yargs: yargs.Argv) => {
 				string: true,
 				describe: "Name of the configuration to use."
 			},
-			'config-loader': {
+			"config-loader": {
 				type: "string",
 				default: "register",
-				describe: "Specify the loader to load the config file, can be `native` or `register`.",
-			},
+				describe:
+					"Specify the loader to load the config file, can be `native` or `register`."
+			}
 		})
 		.alias({ v: "version", h: "help" });
 };

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -45,11 +45,10 @@ export const commonOptions = (yargs: yargs.Argv) => {
 				string: true,
 				describe: "Name of the configuration to use."
 			},
-			'disable-interpret': {
-				type: "boolean",
-				default: false,
-				describe: "Disable interpret for loading the config file.",
-				alias: "d"
+			'config-loader': {
+				type: "string",
+				default: "native",
+				describe: "Specify the loader to load the config file, can be `none` or `native`.",
 			},
 		})
 		.alias({ v: "version", h: "help" });

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -44,7 +44,13 @@ export const commonOptions = (yargs: yargs.Argv) => {
 				type: "array",
 				string: true,
 				describe: "Name of the configuration to use."
-			}
+			},
+			'disable-interpret': {
+				type: "boolean",
+				default: false,
+				describe: "Disable interpret for loading the config file.",
+				alias: "d"
+			},
 		})
 		.alias({ v: "version", h: "help" });
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

According to my issue #9176 I prepare PR with implementation of `--disable-interpret` CLI option. 

This CLI option is analogue of same option in Webpack.

For myself this option is wery helpful because in my projects I use tsimp as main loader for TS.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
