### PR TITLE
docs: rewrite configure Rspack section

### DIFF
--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -588,7 +588,7 @@ jq('.my-element').animate(/* ... */);
 ```
 
 ```js
-module.export = {
+module.exports = {
   experiments: {
     outputModule: true,
   },

--- a/website/docs/en/config/index.mdx
+++ b/website/docs/en/config/index.mdx
@@ -1,4 +1,5 @@
 import { PackageManagerTabs } from '@theme';
+import { Tabs, Tab } from '@theme';
 
 # Configure Rspack
 
@@ -10,42 +11,110 @@ When you run the Rspack CLI, Rspack automatically reads the `rspack.config.*` fi
 
 A basic Rspack configuration file looks like this:
 
+<Tabs>
+  <Tab label="ESM">
+
 ```js title="rspack.config.mjs"
-export default {
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
   entry: {
     main: './src/index.js',
   },
-};
+});
 ```
 
-### Configuration file formats
+  </Tab>
+  <Tab label="CJS">
 
-Rspack supports four types of configuration files, `.js`, `.ts`, `.cjs` and `.mjs` formats.
+```js title="rspack.config.js"
+const { defineConfig } = require('@rspack/cli');
 
-- `rspack.config.js`: defaults to `CommonJS` format, or `ES modules` format if the type of the package.json is module.
-- `rspack.config.ts`: `TypeScript` format, see [TypeScript Configuration File](#typescript-configuration-file) for more details.
+module.exports = defineConfig({
+  entry: {
+    main: './src/index.js',
+  },
+});
+```
+
+  </Tab>
+  <Tab label="TypeScript">
+
+```ts title="rspack.config.ts"
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
+  entry: {
+    main: './src/index.js',
+  },
+});
+```
+
+  </Tab>
+</Tabs>
+
+## Configuration file formats
+
+Rspack supports these configuration file formats:
+
+- `rspack.config.js`: defaults to `CommonJS` format, or `ES modules` format if the type of the package.json is "module".
+- `rspack.config.ts`: `TypeScript` format, see [TypeScript configuration file](#typescript-configuration-file) for more details.
 - `rspack.config.cjs`: Forced to `CommonJS` format.
 - `rspack.config.mjs`: Forced to `ES modules` format.
 
+Note that Rspack will first search JS configuration file and then TS configuration file.
+
 > See [ES modules](https://nodejs.org/api/esm.html#modules-ecmascript-modules) and [CommonJS](https://nodejs.org/api/modules.html) for the difference between `CommonJS` and `ES modules`.
 
-### TypeScript configuration file
+## TypeScript configuration file
 
-When using `rspack.config.ts`, you need to install additional dependencies to resolve TypeScript files. You can choose one of the following:
+When using `rspack.config.ts`, you need to use a runtime that supports TypeScript, or install additional dependencies to resolve TypeScript files. You can choose one of the following:
 
-#### Using esbuild
+### Native support
+
+If your JavaScript runtime already natively supports TypeScript, you can use the built-in TS transformation to load the configuration file without needing to install additional dependencies.
+
+For example, Node.js already natively supports TypeScript, you can use the following command to use the Node.js native loader to load the configuration file:
+
+- For Node.js v22.7.0 to v23.5.0, you need to enable the `--experimental-transform-types` flag:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "NODE_OPTIONS='--experimental-transform-types' rspack build"
+  }
+}
+```
+
+- For Node.js v23.6.0+, the `--experimental-transform-types` flag is no longer required:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "rspack build"
+  }
+}
+```
+
+See [Node.js - Running TypeScript Natively](https://nodejs.org/en/learn/typescript/run-natively#running-typescript-natively) for more details.
+
+### Using esbuild
+
+For lower Node.js versions, you can use `esbuild-register` to load the configuration file.
 
 Install [esbuild](https://npmjs.com/package/esbuild) and [esbuild-register](https://npmjs.com/package/esbuild-register), no additional configuration is needed.
 
 <PackageManagerTabs command="add esbuild esbuild-register -D" />
 
-#### Using ts-node
+### Using ts-node
 
-Install [ts-node](https://npmjs.com/package/ts-node):
+You can also use [ts-node](https://npmjs.com/package/ts-node) to load the configuration file.
+
+1. Install `ts-node`:
 
 <PackageManagerTabs command="add ts-node -D" />
 
-Then configure `ts-node` to use `CommonJS` modules in `tsconfig.json`:
+2. Then configure `ts-node` to use `CommonJS` modules in `tsconfig.json`:
 
 ```json title="tsconfig.json"
 {
@@ -57,74 +126,56 @@ Then configure `ts-node` to use `CommonJS` modules in `tsconfig.json`:
 }
 ```
 
-### Type checking
+## Type checking
 
-`rspack.config.js` is a JavaScript file, you can use JSDoc to enable the IDE's Intellisense and TypeScript type checking.
+Use the `defineConfig` helper to enable auto-completion. For JavaScript configuration files, you can use the `// @ts-check` comment to enable type checking.
 
-```js title="rspack.config.js"
+<Tabs>
+  <Tab label="TypeScript">
+
+```ts title="rspack.config.ts"
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
+  entry: {
+    main: './src/index.js',
+  },
+});
+```
+
+  </Tab>
+  <Tab label="JavaScript">
+
+```js title="rspack.config.mjs"
 // @ts-check
+import { defineConfig } from '@rspack/cli';
 
+export default defineConfig({
+  entry: {
+    main: './src/index.js',
+  },
+});
+```
+
+  </Tab>
+</Tabs>
+
+Alternatively, you can use [JSDoc](https://jsdoc.app/) for type checking.
+
+```js title="rspack.config.mjs"
+// @ts-check
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {
     main: './src/index.js',
   },
 };
-module.exports = config;
+export default config;
 ```
-
-Alternatively, you can use the `defineConfig` helper, which provides auto-completion of the configuration:
-
-```js title="rspack.config.js"
-// @ts-check
-
-const { defineConfig } = require('@rspack/cli');
-
-const config = defineConfig({
-  entry: {
-    main: './src/index.js',
-  },
-});
-module.exports = config;
-```
-
-Alternatively, you can use TypeScript as configuration file. The default TypeScript configuration file name is `rspack.config.ts`.
-
-```ts title="rspack.config.ts"
-import { Configuration } from '@rspack/cli';
-
-const config: Configuration = {
-  entry: {
-    main: './src/index.js',
-  },
-};
-
-export = config;
-```
-
-You need to install `ts-node` as `devDependencies` so that Rspack can resolve the `ts` extension.
-
-```json title="package.json"
-{
-  "devDependencies": {
-    "ts-node": "^10.9.2"
-  }
-}
-```
-
-If the version of Node.js you are using supports the [--experimental-transform-types](https://nodejs.org/api/cli.html#--experimental-transform-types) flag, you can use the built-in TS transformation of Node.js without needing to install `ts-node`.
-
-```json title="package.json"
-{
-  "build": "NODE_OPTIONS=--experimental-transform-types rspack build"
-}
-```
-
-Note that Rspack will first search JavaScript and then TypeScript if the JS file does not exist.
 
 ## Specify the configuration file
 
-You can specify the name of the configuration file using the `--config` option.
+Specify the name of the configuration file using the `--config` option.
 
 For example, if you need to use the `rspack.prod.config.js` file when running build, you can add the following scripts to `package.json`:
 
@@ -137,7 +188,7 @@ For example, if you need to use the `rspack.prod.config.js` file when running bu
 }
 ```
 
-You can also abbreviate the `--config` option to `-c`:
+Abbreviate the `--config` option to `-c`:
 
 ```bash
 $ rspack build -c rspack.prod.config.js
@@ -175,7 +226,7 @@ module.exports = function (env, argv) {
 
 ## Merge configurations
 
-You can use the `merge` function exported by `webpack-merge` to merge multiple configurations.
+Use the `merge` function exported by `webpack-merge` to merge multiple configurations.
 
 ```js title="rspack.config.js"
 const { merge } = require('webpack-merge');

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -586,7 +586,7 @@ jq('.my-element').animate(/* ... */);
 ```
 
 ```js title=rspack.config.js
-module.export = {
+module.exports = {
   externalsType: 'node-commonjs',
   externals: {
     jquery: 'jquery',

--- a/website/docs/zh/config/index.mdx
+++ b/website/docs/zh/config/index.mdx
@@ -1,4 +1,5 @@
 import { PackageManagerTabs } from '@theme';
+import { Tabs, Tab } from '@theme';
 
 # 配置 Rspack
 
@@ -10,42 +11,110 @@ Rspack 提供了与 webpack 相似的配置项，通过本章节，你可以了�
 
 一个基础的 Rspack 配置文件如下所示：
 
+<Tabs>
+  <Tab label="ESM">
+
 ```js title="rspack.config.mjs"
-export default {
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
   entry: {
     main: './src/index.js',
   },
-};
+});
 ```
 
-### 配置文件格式
+  </Tab>
+  <Tab label="CJS">
 
-Rspack 支持四种配置文件，支持`.js`，`.ts`，`.cjs` 和 `.mjs` 格式:
+```js title="rspack.config.js"
+const { defineConfig } = require('@rspack/cli');
 
-- `rspack.config.js`: 默认为 `CommonJS` 格式，如果所在 package.json 的 type 为 module 则变成 `ES modules` 格式。
+module.exports = defineConfig({
+  entry: {
+    main: './src/index.js',
+  },
+});
+```
+
+  </Tab>
+  <Tab label="TypeScript">
+
+```ts title="rspack.config.ts"
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
+  entry: {
+    main: './src/index.js',
+  },
+});
+```
+
+  </Tab>
+</Tabs>
+
+## 配置文件格式
+
+Rspack 支持以下配置文件格式：
+
+- `rspack.config.js`: 默认为 `CommonJS` 格式，如果所在 package.json 的 type 为 "module" 则变成 `ES modules` 格式。
 - `rspack.config.ts`: `TypeScript` 格式，参考 [TypeScript 配置文件](#typescript-配置文件) 了解更多。
 - `rspack.config.cjs`: 强制为 `CommonJS` 格式。
 - `rspack.config.mjs`: 强制为 `ES modules` 格式。
 
+注意，Rspack 将首先搜索 JS 配置文件，然后才是 TS 配置文件。
+
 > `CommonJS` 和 `ES modules`的区别请参考 [ES modules](https://nodejs.org/api/esm.html#modules-ecmascript-modules) 和 [CommonJS](https://nodejs.org/api/modules.html)。
 
-### TypeScript 配置文件
+## TypeScript 配置文件
 
-在使用 `rspack.config.ts` 时，你需要安装额外的依赖来解析 TypeScript 文件，你可以选择以下任意一种：
+在使用 `rspack.config.ts` 时，你需要使用支持 TypeScript 的运行时，或者安装额外的依赖来解析 TypeScript 文件，你可以选择以下任意一种：
 
-#### 使用 esbuild
+### 原生支持
+
+如果你使用的 JavaScript 运行时已经原生支持 TypeScript，你可以使用内置的 TS 转换来加载配置文件，而无需安装额外的依赖。
+
+例如，Node.js 已经原生支持 TypeScript，你可以使用以下命令来使用 Node.js 原生加载器来加载配置文件：
+
+- 对于 Node.js v22.7.0 到 v23.5.0，你需要启用 `--experimental-transform-types` 选项：
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "NODE_OPTIONS='--experimental-transform-types' rspack build"
+  }
+}
+```
+
+- 对于 Node.js v23.6.0+，不再需要 `--experimental-transform-types` 选项：
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "rspack build"
+  }
+}
+```
+
+详见 [Node.js - Running TypeScript Natively](https://nodejs.org/en/learn/typescript/run-natively#running-typescript-natively)。
+
+### 使用 esbuild
+
+对于低于 Node.js v22.7.0 的版本，你可以使用 `esbuild-register` 来加载配置文件。
 
 安装 [esbuild](https://npmjs.com/package/esbuild) 和 [esbuild-register](https://npmjs.com/package/esbuild-register) 即可，不需要任何配置。
 
 <PackageManagerTabs command="add esbuild esbuild-register -D" />
 
-#### 使用 ts-node
+### 使用 ts-node
 
-安装 [ts-node](https://npmjs.com/package/ts-node)：
+你也可以使用 [ts-node](https://npmjs.com/package/ts-node) 来加载配置文件。
+
+1. 安装 `ts-node`：
 
 <PackageManagerTabs command="add ts-node -D" />
 
-然后在 `tsconfig.json` 中配置 `ts-node` 使用 `CommonJS` 模块：
+2. 然后在 `tsconfig.json` 中配置 `ts-node` 使用 `CommonJS` 模块：
 
 ```json title="tsconfig.json"
 {
@@ -59,66 +128,50 @@ Rspack 支持四种配置文件，支持`.js`，`.ts`，`.cjs` 和 `.mjs` 格式
 
 ### 配置类型检查
 
-`rspack.config.js` 是一个 JavaScript 文件，你可以通过 JSDoc 来启用 IDE 的智能补全和 TypeScript 类型检查。
+使用 `defineConfig` 工具函数来启用智能补全。对于 JavaScript 配置文件，你可以使用 `// @ts-check` 注释来启用类型检查。
 
-```js title="rspack.config.js"
+<Tabs>
+  <Tab label="TypeScript">
+
+```ts title="rspack.config.ts"
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
+  entry: {
+    main: './src/index.js',
+  },
+});
+```
+
+  </Tab>
+  <Tab label="JavaScript">
+
+```js title="rspack.config.mjs"
 // @ts-check
+import { defineConfig } from '@rspack/cli';
 
+export default defineConfig({
+  entry: {
+    main: './src/index.js',
+  },
+});
+```
+
+  </Tab>
+</Tabs>
+
+你也可以使用 [JSDoc](https://jsdoc.app/) 来启用类型检查。
+
+```js title="rspack.config.mjs"
+// @ts-check
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {
     main: './src/index.js',
   },
 };
-module.exports = config;
+export default config;
 ```
-
-你也可以使用 `defineConfig` 工具函数，它提供了针对配置的自动补全：
-
-```js title="rspack.config.js"
-// @ts-check
-
-const { defineConfig } = require('@rspack/cli');
-
-const config = defineConfig({
-  entry: {
-    main: './src/index.js',
-  },
-});
-module.exports = config;
-```
-
-另外，你也可以使用 TypeScript 作为配置文件。默认的 TypeScript 配置文件名称是 `rspack.config.ts`。
-
-```ts title="rspack.config.ts"
-import { Configuration } from '@rspack/cli';
-const config: Configuration = {
-  entry: {
-    main: './src/index.js',
-  },
-};
-export = config;
-```
-
-你需要把 `ts-node` 安装为 `devDependencies`，这样 Rspack 才能解析 `ts` 扩展。
-
-```json title="package.json"
-{
-  "devDependencies": {
-    "ts-node": "^10.9.2"
-  }
-}
-```
-
-如果你使用的 Node.js 版本支持 [--experimental-transform-types](https://nodejs.org/api/cli.html#--experimental-transform-types) 功能，那么可以使用 Node.js 内置的 TS 解析功能,而不需要安装 `ts-node`
-
-```json title="package.json"
-{
-  "build": "NODE_OPTIONS=--experimental-transform-types rspack build"
-}
-```
-
-注意，如果 JS 文件不存在，Rspack 将首先搜索 JavaScript，然后才是 TypeScript。
 
 ## 指定配置文件
 
@@ -135,7 +188,7 @@ Rspack 命令行支持通过 `--config` 选项来指定配置文件的名称。
 }
 ```
 
-你也可以将 `--config` 选项缩写为 `-c`：
+也可以将 `--config` 选项缩写为 `-c`：
 
 ```bash
 $ rspack build -c rspack.prod.config.js
@@ -173,7 +226,7 @@ module.exports = function (env, argv) {
 
 ## 合并配置
 
-你可以使用 `webpack-merge` 导出的 `merge` 函数来合并多个配置。
+使用 `webpack-merge` 导出的 `merge` 函数来合并多个配置。
 
 ```js title="rspack.config.js"
 const { merge } = require('webpack-merge');


### PR DESCRIPTION
## Summary

Rewrite configure Rspack section, major changes:

1. Add guide for Node.js v23.6.0+, the `--experimental-transform-types` flag is no longer required.
2. Use `<Tabs>` to better display different configuration formats.
3. Improve "Type checking" guide.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
