### PR TITLE
fix: ignore generator options for `asset/source` module type

### DIFF
--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -666,6 +666,7 @@ function getRawGeneratorOptions(
 
 	if (
 		[
+			"asset/source",
 			"javascript",
 			"javascript/auto",
 			"javascript/dynamic",

--- a/tests/webpack-test/configCases/contenthash/assets/test.filter.js
+++ b/tests/webpack-test/configCases/contenthash/assets/test.filter.js
@@ -1,2 +1,0 @@
-// blocked by https://github.com/web-infra-dev/rspack/issues/3465
-module.exports = () => { return 'https://github.com/web-infra-dev/rspack/issues/8604' }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fixes #8604 

For the `asset/source` module type, the generator options will not used and therefore can be safely ignored in the config adapter.

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
