### PR TITLE
perf: migrate all blocking call to async call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4619,6 +4619,7 @@ dependencies = [
 name = "rspack_macros_test"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -4809,6 +4810,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "simd-json",
  "sugar_path",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4975,6 +4975,7 @@ dependencies = [
  "dashmap 6.1.0",
  "either",
  "fast-glob",
+ "futures",
  "indexmap 2.7.0",
  "indoc",
  "itertools 0.14.0",

--- a/crates/node_binding/src/plugins/interceptor.rs
+++ b/crates/node_binding/src/plugins/interceptor.rs
@@ -710,7 +710,7 @@ define_register!(
   RegisterCompilationExecuteModuleTaps,
   tap = CompilationExecuteModuleTap<JsExecuteModuleArg, ()> @ CompilationExecuteModuleHook,
   cache = false,
-  sync = true,
+  sync = false,
   kind = RegisterJsTapKind::CompilationExecuteModule,
   skip = true,
 );
@@ -1153,7 +1153,7 @@ impl CompilationSucceedModule for CompilationSucceedModuleTap {
 
 #[async_trait]
 impl CompilationExecuteModule for CompilationExecuteModuleTap {
-  fn run(
+  async fn run(
     &self,
     entry: &ModuleIdentifier,
     runtime_modules: &IdentifierSet,

--- a/crates/node_binding/src/plugins/interceptor.rs
+++ b/crates/node_binding/src/plugins/interceptor.rs
@@ -1160,12 +1160,15 @@ impl CompilationExecuteModule for CompilationExecuteModuleTap {
     codegen_results: &CodeGenerationResults,
     id: &ExecuteModuleId,
   ) -> rspack_error::Result<()> {
-    self.function.blocking_call_with_sync(JsExecuteModuleArg {
-      entry: entry.to_string(),
-      runtime_modules: runtime_modules.iter().map(|id| id.to_string()).collect(),
-      codegen_results: codegen_results.clone().into(),
-      id: *id,
-    })
+    self
+      .function
+      .call_with_sync(JsExecuteModuleArg {
+        entry: entry.to_string(),
+        runtime_modules: runtime_modules.iter().map(|id| id.to_string()).collect(),
+        codegen_results: codegen_results.clone().into(),
+        id: *id,
+      })
+      .await
   }
 
   fn stage(&self) -> i32 {

--- a/crates/node_binding/src/plugins/interceptor.rs
+++ b/crates/node_binding/src/plugins/interceptor.rs
@@ -1300,7 +1300,8 @@ impl CompilationRuntimeModule for CompilationRuntimeModuleTap {
       module: JsRuntimeModule {
         source: Some(
           module
-            .generate(compilation)?
+            .generate(compilation)
+            .await?
             .to_js_compat_source_owned()
             .unwrap_or_else(|err| panic!("Failed to generate runtime module source: {err}")),
         ),

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -117,7 +117,7 @@ impl Cache for PersistentCache {
       .add(modified_paths.iter().map(|item| item.as_ref()))
       .await;
 
-    let rx = self.storage.trigger_save()?;
+    let rx = self.storage.trigger_save().await?;
     if self.async_mode {
       tokio::spawn(async {
         if let Err(err) = rx.await.expect("should receive message") {

--- a/crates/rspack_core/src/cache/persistent/storage/memory.rs
+++ b/crates/rspack_core/src/cache/persistent/storage/memory.rs
@@ -37,7 +37,7 @@ impl Storage for MemoryStorage {
     let mut map = self.inner.lock().expect("should get lock");
     map.get_mut(scope).map(|map| map.remove(key));
   }
-  fn trigger_save(&self) -> Result<Receiver<Result<()>>> {
+  async fn trigger_save(&self) -> Result<Receiver<Result<()>>> {
     let (rs, rx) = channel::<Result<()>>();
     let _ = rs.send(Ok(()));
     Ok(rx)

--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -143,6 +143,7 @@ impl HasModuleGraphChange {
 mod t {
   use std::borrow::Cow;
 
+  use async_trait::async_trait;
   use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
   use rspack_collections::Identifiable;
   use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
@@ -276,6 +277,7 @@ mod t {
   impl_empty_diagnosable_trait!(TestModule);
 
   #[cacheable_dyn]
+  #[async_trait]
   impl Module for TestModule {
     fn module_type(&self) -> &ModuleType {
       todo!()
@@ -325,7 +327,7 @@ mod t {
       todo!()
     }
 
-    fn code_generation(
+    async fn code_generation(
       &self,
       _compilation: &Compilation,
       _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -153,7 +153,7 @@ impl Task<MakeTaskContext> for ExecuteTask {
     // replace code_generation_results is the same reason
     compilation.chunk_graph = chunk_graph;
 
-    compilation.create_module_hashes(modules.clone())?;
+    compilation.create_module_hashes(modules.clone()).await?;
 
     compilation
       .code_generation_modules(&mut None, modules.clone())
@@ -186,7 +186,7 @@ impl Task<MakeTaskContext> for ExecuteTask {
         .get(runtime_id)
         .expect("runtime module exist");
 
-      let runtime_module_source = runtime_module.generate(&compilation)?;
+      let runtime_module_source = runtime_module.generate(&compilation).await?;
       runtime_module_size.insert(
         runtime_module.identifier(),
         runtime_module_source.size() as f64,

--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -155,7 +155,9 @@ impl Task<MakeTaskContext> for ExecuteTask {
 
     compilation.create_module_hashes(modules.clone())?;
 
-    compilation.code_generation_modules(&mut None, modules.clone())?;
+    compilation
+      .code_generation_modules(&mut None, modules.clone())
+      .await?;
     compilation
       .process_modules_runtime_requirements(modules.clone(), compilation.plugin_driver.clone())
       .await?;
@@ -210,7 +212,8 @@ impl Task<MakeTaskContext> for ExecuteTask {
         &runtime_modules,
         &codegen_results,
         &id,
-      );
+      )
+      .await;
 
     let module_graph = compilation.get_module_graph();
     let mut execute_result = modules.iter().fold(

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use dashmap::DashMap;
+use futures::future::join_all;
 use indexmap::IndexMap;
-use rayon::prelude::*;
 use regex::Regex;
 use rspack_ast::javascript::Ast;
 use rspack_cacheable::{
@@ -56,7 +56,7 @@ use crate::{
 };
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
-define_hook!(ConcatenatedModuleExportsDefinitions: SyncSeriesBail(exports_definitions: &mut ExportsDefinitionArgs, is_entry_module: bool) -> bool);
+define_hook!(ConcatenatedModuleExportsDefinitions: AsyncSeriesBail(exports_definitions: &mut ExportsDefinitionArgs, is_entry_module: bool) -> bool);
 
 #[derive(Debug, Default)]
 pub struct ConcatenatedModuleHooks {
@@ -621,7 +621,7 @@ impl Module for ConcatenatedModule {
   }
 
   // #[tracing::instrument("ConcatenatedModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     generation_runtime: Option<&RuntimeSpec>,
@@ -653,14 +653,14 @@ impl Module for ConcatenatedModule {
     // Prepare a ReplaceSource for the final source
     //
     let arc_map = Arc::new(module_to_info_map);
-    let tmp: Vec<rspack_error::Result<(rspack_collections::Identifier, ModuleInfo)>> = arc_map
-      .par_iter()
-      .map(|(id, info)| {
-        let updated_module_info =
-          self.analyze_module(compilation, Arc::clone(&arc_map), info.clone(), runtime)?;
+    let tmp: Vec<rspack_error::Result<(rspack_collections::Identifier, ModuleInfo)>> =
+      join_all(arc_map.iter().map(|(id, info)| async {
+        let updated_module_info = self
+          .analyze_module(compilation, Arc::clone(&arc_map), info.clone(), runtime)
+          .await?;
         Ok((*id, updated_module_info))
-      })
-      .collect::<Vec<_>>();
+      }))
+      .await;
 
     let mut updated_pairs = vec![];
     for item in tmp {
@@ -1034,7 +1034,8 @@ impl Module for ConcatenatedModule {
         .call(
           &mut exports_final_names,
           compilation.chunk_graph.is_entry_module(&self.id),
-        )?;
+        )
+        .await?;
 
       if !matches!(should_skip_render_definitions, Some(true)) {
         runtime_requirements.insert(RuntimeGlobals::EXPORTS);
@@ -1701,7 +1702,7 @@ impl ConcatenatedModule {
   }
 
   /// Using `ModuleIdentifier` instead of `ModuleInfo` to work around rustc borrow checker
-  fn analyze_module(
+  async fn analyze_module(
     &self,
     compilation: &Compilation,
     module_info_map: Arc<IdentifierIndexMap<ModuleInfo>>,
@@ -1716,7 +1717,9 @@ impl ConcatenatedModule {
       let module = module_graph
         .module_by_identifier(&module_id)
         .unwrap_or_else(|| panic!("should have module {module_id}"));
-      let codegen_res = module.code_generation(compilation, runtime, Some(concatenation_scope))?;
+      let codegen_res = module
+        .code_generation(compilation, runtime, Some(concatenation_scope))
+        .await?;
 
       let CodeGenerationResult {
         mut inner,

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -994,7 +994,7 @@ impl Module for ContextModule {
   }
 
   // #[tracing::instrument("ContextModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -568,7 +568,7 @@ impl Module for ExternalModule {
   }
 
   // #[tracing::instrument("ExternalModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -97,6 +97,7 @@ pub use resolver::*;
 pub mod concatenated_module;
 pub mod reserved_names;
 
+pub use futures::executor::block_on;
 use rspack_cacheable::{cacheable, with::AsPreset};
 pub use rspack_loader_runner::{
   get_scheme, parse_resource, AdditionalData, ResourceData, ResourceParsedData, Scheme,

--- a/crates/rspack_core/src/loader/rspack_loader.rs
+++ b/crates/rspack_core/src/loader/rspack_loader.rs
@@ -18,8 +18,13 @@ impl LoaderRunnerPlugin for RspackLoaderRunnerPlugin {
     "rspack-loader-runner"
   }
 
-  fn before_all(&self, context: &mut LoaderContext<Self::Context>) -> Result<()> {
-    self.plugin_driver.normal_module_hooks.loader.call(context)
+  async fn before_all(&self, context: &mut LoaderContext<Self::Context>) -> Result<()> {
+    self
+      .plugin_driver
+      .normal_module_hooks
+      .loader
+      .call(context)
+      .await
   }
 
   async fn process_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -288,7 +288,7 @@ pub trait Module:
   ///
   /// Code generation will often iterate through every `source_types` given by the module
   /// to provide multiple code generation results for different `source_type`s.
-  fn code_generation(
+  async fn code_generation(
     &self,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
@@ -733,7 +733,7 @@ mod test {
           unreachable!()
         }
 
-        fn code_generation(
+        async fn code_generation(
           &self,
           _compilation: &Compilation,
           _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -79,10 +79,10 @@ impl ModuleIssuer {
 }
 
 define_hook!(NormalModuleReadResource: AsyncSeriesBail(resource_data: &ResourceData) -> Content);
-define_hook!(NormalModuleLoader: SyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
+define_hook!(NormalModuleLoader: AsyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
 define_hook!(NormalModuleLoaderShouldYield: SyncSeriesBail(loader_context: &LoaderContext<RunnerContext>) -> bool);
 define_hook!(NormalModuleLoaderStartYielding: AsyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
-define_hook!(NormalModuleBeforeLoaders: SyncSeries(module: &mut NormalModule));
+define_hook!(NormalModuleBeforeLoaders: AsyncSeries(module: &mut NormalModule));
 define_hook!(NormalModuleAdditionalData: AsyncSeries(additional_data: &mut Option<&mut AdditionalData>));
 
 #[derive(Debug, Default)]
@@ -426,7 +426,8 @@ impl Module for NormalModule {
       .plugin_driver
       .normal_module_hooks
       .before_loaders
-      .call(self)?;
+      .call(self)
+      .await?;
 
     let plugin = Arc::new(RspackLoaderRunnerPlugin {
       plugin_driver: build_context.plugin_driver.clone(),
@@ -631,7 +632,7 @@ impl Module for NormalModule {
   }
 
   // #[tracing::instrument("NormalModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -31,7 +31,7 @@ define_hook!(NormalModuleFactoryResolveInScheme: AsyncSeriesBail(data: &mut Modu
 define_hook!(NormalModuleFactoryAfterResolve: AsyncSeriesBail(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData) -> bool);
 define_hook!(NormalModuleFactoryCreateModule: AsyncSeriesBail(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData) -> BoxModule);
 define_hook!(NormalModuleFactoryModule: AsyncSeries(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData, module: &mut BoxModule));
-define_hook!(NormalModuleFactoryParser: SyncSeries(module_type: &ModuleType, parser: &mut dyn ParserAndGenerator, parser_options: Option<&ParserOptions>));
+define_hook!(NormalModuleFactoryParser: AsyncSeries(module_type: &ModuleType, parser: &mut dyn ParserAndGenerator, parser_options: Option<&ParserOptions>));
 define_hook!(NormalModuleFactoryResolveLoader: AsyncSeriesBail(context: &Context, resolver: &Resolver, l: &ModuleRuleUseLoader) -> BoxLoader);
 
 pub enum NormalModuleFactoryResolveResult {
@@ -547,11 +547,16 @@ impl NormalModuleFactory {
       resolved_parser_options.as_ref(),
       resolved_generator_options.as_ref(),
     );
-    self.plugin_driver.normal_module_factory_hooks.parser.call(
-      &resolved_module_type,
-      resolved_parser_and_generator.as_mut(),
-      resolved_parser_options.as_ref(),
-    )?;
+    self
+      .plugin_driver
+      .normal_module_factory_hooks
+      .parser
+      .call(
+        &resolved_module_type,
+        resolved_parser_and_generator.as_mut(),
+        resolved_parser_options.as_ref(),
+      )
+      .await?;
 
     let mut create_data = {
       let mut create_data = NormalModuleCreateData {

--- a/crates/rspack_core/src/old_cache/occasion/code_generate.rs
+++ b/crates/rspack_core/src/old_cache/occasion/code_generate.rs
@@ -1,8 +1,10 @@
+use futures::future::BoxFuture;
 use rspack_collections::Identifier;
 use rspack_error::Result;
+use rspack_hash::RspackHashDigest;
 
 use crate::{old_cache::storage, CodeGenerationResult};
-use crate::{CodeGenerationJob, ModuleIdentifier, RuntimeSpec};
+use crate::{ModuleIdentifier, RuntimeSpec};
 
 type Storage = dyn storage::Storage<CodeGenerationResult>;
 
@@ -17,28 +19,30 @@ impl CodeGenerateOccasion {
   }
 
   // #[tracing::instrument(skip_all, fields(module = ?job.module))]
-  pub fn use_cache(
+  pub async fn use_cache(
     &self,
-    job: CodeGenerationJob,
-    provide: impl Fn(ModuleIdentifier, &RuntimeSpec) -> Result<CodeGenerationResult>,
+    module: ModuleIdentifier,
+    hash: RspackHashDigest,
+    runtimes: Vec<RuntimeSpec>,
+    provide: BoxFuture<'_, Result<CodeGenerationResult>>,
   ) -> (Result<CodeGenerationResult>, Vec<RuntimeSpec>, bool) {
     let storage = match &self.storage {
       Some(s) => s,
       None => {
-        let res = provide(job.module, &job.runtime);
-        return (res, job.runtimes, false);
+        let res = provide.await;
+        return (res, runtimes, false);
       }
     };
-    let cache_key = Identifier::from(format!("{}|{}", job.module, job.hash.encoded()));
+    let cache_key = Identifier::from(format!("{}|{}", module, hash.encoded()));
     if let Some(value) = storage.get(&cache_key) {
-      (Ok(value), job.runtimes, true)
+      (Ok(value), runtimes, true)
     } else {
-      match provide(job.module, &job.runtime) {
+      match provide.await {
         Ok(res) => {
           storage.set(cache_key, res.clone());
-          (Ok(res), job.runtimes, false)
+          (Ok(res), runtimes, false)
         }
-        Err(err) => (Err(err), job.runtimes, false),
+        Err(err) => (Err(err), runtimes, false),
       }
     }
   }

--- a/crates/rspack_core/src/old_cache/occasion/process_runtime_requirements.rs
+++ b/crates/rspack_core/src/old_cache/occasion/process_runtime_requirements.rs
@@ -1,3 +1,4 @@
+use futures::future::BoxFuture;
 use rspack_collections::Identifier;
 use rspack_error::Result;
 
@@ -19,17 +20,17 @@ impl ProcessRuntimeRequirementsOccasion {
   }
 
   // #[tracing::instrument(skip_all, fields(module = ?module))]
-  pub fn use_cache(
+  pub async fn use_cache(
     &self,
     module: ModuleIdentifier,
     runtime: &RuntimeSpec,
     compilation: &Compilation,
-    provide: impl Fn(ModuleIdentifier, &RuntimeSpec) -> Result<RuntimeGlobals>,
+    provide: BoxFuture<'_, Result<RuntimeGlobals>>,
   ) -> Result<RuntimeGlobals> {
     let storage = match &self.storage {
       Some(s) => s,
       None => {
-        let res = provide(module, runtime)?;
+        let res = provide.await?;
         return Ok(res);
       }
     };
@@ -44,7 +45,7 @@ impl ProcessRuntimeRequirementsOccasion {
     if let Some(value) = storage.get(&cache_key) {
       Ok(value)
     } else {
-      let res = provide(module, runtime)?;
+      let res = provide.await?;
       storage.set(cache_key, res);
       Ok(res)
     }

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -129,7 +129,7 @@ impl Module for RawModule {
   }
 
   // #[tracing::instrument("RawModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     _compilation: &crate::Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -1,14 +1,16 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use rspack_cacheable::cacheable;
 use rspack_collections::Identifier;
 use rspack_sources::{BoxSource, Source};
 
 use crate::{ChunkUkey, Compilation, Module};
 
+#[async_trait]
 pub trait RuntimeModule: Module + CustomSourceRuntimeModule {
   fn name(&self) -> Identifier;
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource>;
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource>;
   fn attach(&mut self, _chunk: ChunkUkey) {}
   fn stage(&self) -> RuntimeModuleStage {
     RuntimeModuleStage::Normal
@@ -26,14 +28,14 @@ pub trait RuntimeModule: Module + CustomSourceRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![]
   }
-  fn generate_with_custom(
+  async fn generate_with_custom(
     &self,
     compilation: &Compilation,
   ) -> rspack_error::Result<Arc<dyn Source>> {
     if let Some(custom_source) = self.get_custom_source() {
       Ok(custom_source as Arc<dyn Source>)
     } else {
-      self.generate(compilation)
+      self.generate(compilation).await
     }
   }
 }

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -129,7 +129,7 @@ impl Module for SelfModule {
   }
 
   // #[tracing::instrument("SelfModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -22,7 +22,7 @@ impl DeterministicChunkIdsPlugin {
 }
 
 #[plugin_hook(CompilationChunkIds for DeterministicChunkIdsPlugin)]
-fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
+async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
   let mut used_ids = get_used_chunk_ids(compilation);
   let used_ids_len = used_ids.len();
 

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -15,7 +15,7 @@ use crate::id_helpers::{
 pub struct DeterministicModuleIdsPlugin;
 
 #[plugin_hook(CompilationModuleIds for DeterministicModuleIdsPlugin)]
-fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
+async fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
   let (mut used_ids, modules) = get_used_module_ids_and_modules(compilation, None);
 
   let mut module_ids = std::mem::take(&mut compilation.module_ids_artifact);

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -157,7 +157,7 @@ impl NamedChunkIdsPlugin {
 }
 
 #[plugin_hook(CompilationChunkIds for NamedChunkIdsPlugin)]
-fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
+async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
   let more_chunks = if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::CHUNK_IDS)

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -122,7 +122,7 @@ fn assign_named_module_ids(
 pub struct NamedModuleIdsPlugin;
 
 #[plugin_hook(CompilationModuleIds for NamedModuleIdsPlugin)]
-fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<()> {
+async fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<()> {
   let mut module_ids = std::mem::take(&mut compilation.module_ids_artifact);
   let mut used_ids: FxHashMap<ModuleId, ModuleIdentifier> = module_ids
     .iter()

--- a/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
@@ -12,7 +12,7 @@ use crate::id_helpers::{assign_ascending_chunk_ids, compare_chunks_natural};
 pub struct NaturalChunkIdsPlugin;
 
 #[plugin_hook(CompilationChunkIds for NaturalChunkIdsPlugin)]
-fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
+async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
   let module_ids = &compilation.module_ids_artifact;
   let chunk_graph = &compilation.chunk_graph;
   let module_graph = &compilation.get_module_graph();

--- a/crates/rspack_ids/src/natural_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_module_ids_plugin.rs
@@ -12,7 +12,7 @@ use crate::id_helpers::{assign_ascending_module_ids, get_used_module_ids_and_mod
 pub struct NaturalModuleIdsPlugin;
 
 #[plugin_hook(CompilationModuleIds for NaturalModuleIdsPlugin)]
-fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<()> {
+async fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<()> {
   let (used_ids, mut modules_in_natural_order) = get_used_module_ids_and_modules(compilation, None);
 
   let mut module_ids = std::mem::take(&mut compilation.module_ids_artifact);

--- a/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
@@ -28,7 +28,7 @@ impl OccurrenceChunkIdsPlugin {
 }
 
 #[plugin_hook(CompilationChunkIds for OccurrenceChunkIdsPlugin)]
-fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<()> {
+async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<()> {
   let chunk_graph = &compilation.chunk_graph;
   let module_graph = &compilation.get_module_graph();
   let chunk_group_by_ukey = &compilation.chunk_group_by_ukey;

--- a/crates/rspack_loader_runner/src/plugin.rs
+++ b/crates/rspack_loader_runner/src/plugin.rs
@@ -13,7 +13,7 @@ pub trait LoaderRunnerPlugin: Send + Sync {
     "unknown"
   }
 
-  fn before_all(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
+  async fn before_all(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -102,7 +102,7 @@ async fn create_loader_context<Context>(
   };
 
   if let Some(plugin) = loader_context.plugin.clone() {
-    plugin.before_all(&mut loader_context)?;
+    plugin.before_all(&mut loader_context).await?;
   }
 
   Ok(loader_context)
@@ -263,7 +263,7 @@ mod test {
       "test-content"
     }
 
-    fn before_all(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
+    async fn before_all(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
       Ok(())
     }
 

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -116,6 +116,7 @@ pub fn impl_runtime_module(
       }
     }
 
+    #[async_trait::async_trait]
     #[rspack_cacheable::cacheable_dyn]
     impl #impl_generics ::rspack_core::Module for #name #ty_generics #where_clause {
       fn module_type(&self) -> &::rspack_core::ModuleType {
@@ -163,7 +164,7 @@ pub fn impl_runtime_module(
         vec![]
       }
 
-      fn code_generation(
+      async fn code_generation(
         &self,
         compilation: &::rspack_core::Compilation,
         _runtime: Option<&::rspack_core::RuntimeSpec>,

--- a/crates/rspack_macros_test/Cargo.toml
+++ b/crates/rspack_macros_test/Cargo.toml
@@ -7,6 +7,7 @@ name        = "rspack_macros_test"
 repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.2.0"
 [dev-dependencies]
+async-trait        = { workspace = true }
 rspack_cacheable   = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_core        = { workspace = true }

--- a/crates/rspack_macros_test/tests/runtime_module.rs
+++ b/crates/rspack_macros_test/tests/runtime_module.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{rspack_sources::Source, Compilation, RuntimeModule};
 use rspack_macros::impl_runtime_module;
@@ -13,12 +14,13 @@ fn with_generic() {
     marker: PhantomData<T>,
   }
 
+  #[async_trait]
   impl<T: std::fmt::Debug + Send + Sync + Eq + 'static> RuntimeModule for Foo<T> {
     fn name(&self) -> Identifier {
       todo!()
     }
 
-    fn generate(
+    async fn generate(
       &self,
       _: &Compilation,
     ) -> rspack_error::Result<rspack_core::rspack_sources::BoxSource> {

--- a/crates/rspack_plugin_css/src/runtime/mod.rs
+++ b/crates/rspack_plugin_css/src/runtime/mod.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -24,12 +25,13 @@ impl Default for CssLoadingRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for CssLoadingRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     if let Some(chunk_ukey) = self.chunk {
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
       let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -26,8 +26,9 @@ rspack_plugin_javascript = { workspace = true }
 rspack_util              = { workspace = true }
 rustc-hash               = { workspace = true }
 simd-json                = { workspace = true }
+sugar_path               = { workspace = true }
+tokio                    = { workspace = true }
 tracing                  = { workspace = true }
-sugar_path                  = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -90,7 +90,7 @@ async fn eval_devtool_plugin_compilation(
 }
 
 #[plugin_hook(JavascriptModulesRenderModuleContent for EvalDevToolModulePlugin)]
-fn eval_devtool_plugin_render_module_content(
+async fn eval_devtool_plugin_render_module_content(
   &self,
   compilation: &Compilation,
   module: &BoxModule,
@@ -169,7 +169,7 @@ async fn eval_devtool_plugin_js_chunk_hash(
 }
 
 #[plugin_hook(JavascriptModulesInlineInRuntimeBailout for EvalDevToolModulePlugin)]
-fn eval_devtool_plugin_inline_in_runtime_bailout(
+async fn eval_devtool_plugin_inline_in_runtime_bailout(
   &self,
   _compilation: &Compilation,
 ) -> Result<Option<String>> {
@@ -197,7 +197,7 @@ impl Plugin for EvalDevToolModulePlugin {
 }
 
 #[plugin_hook(CompilationAdditionalModuleRuntimeRequirements for EvalDevToolModulePlugin)]
-fn eval_devtool_plugin_additional_module_runtime_requirements(
+async fn eval_devtool_plugin_additional_module_runtime_requirements(
   &self,
   compilation: &Compilation,
   _module: &ModuleIdentifier,

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -115,13 +115,14 @@ async fn eval_devtool_plugin_render_module_content(
       &self.namespace,
     ),
     ModuleFilenameTemplate::Fn(f) => {
-      futures::executor::block_on(ModuleFilenameHelpers::create_filename_of_fn_template(
+      ModuleFilenameHelpers::create_filename_of_fn_template(
         &ModuleOrSource::Module(module.identifier()),
         compilation,
         f,
         output_options,
         &self.namespace,
-      ))?
+      )
+      .await?
     }
   };
   let source = {

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -81,7 +81,7 @@ async fn eval_source_map_devtool_plugin_compilation(
 }
 
 #[plugin_hook(JavascriptModulesRenderModuleContent for EvalSourceMapDevToolPlugin)]
-fn eval_source_map_devtool_plugin_render_module_content(
+async fn eval_source_map_devtool_plugin_render_module_content(
   &self,
   compilation: &Compilation,
   module: &BoxModule,
@@ -194,7 +194,7 @@ async fn eval_source_map_devtool_plugin_js_chunk_hash(
 }
 
 #[plugin_hook(JavascriptModulesInlineInRuntimeBailout for EvalSourceMapDevToolPlugin)]
-fn eval_source_map_devtool_plugin_inline_in_runtime_bailout(
+async fn eval_source_map_devtool_plugin_inline_in_runtime_bailout(
   &self,
   _compilation: &Compilation,
 ) -> Result<Option<String>> {
@@ -202,7 +202,7 @@ fn eval_source_map_devtool_plugin_inline_in_runtime_bailout(
 }
 
 #[plugin_hook(CompilationAdditionalModuleRuntimeRequirements for EvalSourceMapDevToolPlugin)]
-fn eval_source_map_devtool_plugin_additional_module_runtime_requirements(
+async fn eval_source_map_devtool_plugin_additional_module_runtime_requirements(
   &self,
   compilation: &Compilation,
   _module: &ModuleIdentifier,

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -98,7 +98,7 @@ impl Module for DllModule {
     })
   }
 
-  fn code_generation(
+  async fn code_generation(
     &self,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -119,7 +119,7 @@ impl Module for DelegatedModule {
     })
   }
 
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
+++ b/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
@@ -42,7 +42,7 @@ impl Plugin for FlagAllModulesAsUsedPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeDependencies for FlagAllModulesAsUsedPlugin)]
-fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let entries = &compilation.entries;
 
   let runtime = compilation

--- a/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
+++ b/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
@@ -8,7 +8,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 pub struct EnsureChunkConditionsPlugin;
 
 #[plugin_hook(CompilationOptimizeChunks for EnsureChunkConditionsPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_BASIC)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let logger = compilation.get_logger(self.name());
   let start = logger.time("ensure chunk conditions");
 

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -185,7 +185,7 @@ impl Module for CssModule {
   }
 
   // #[tracing::instrument("ExtractCssModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -672,7 +672,7 @@ async fn render_manifest(
 }
 
 #[plugin_hook(NormalModuleFactoryParser for PluginCssExtract)]
-fn nmf_parser(
+async fn nmf_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut dyn ParserAndGenerator,

--- a/crates/rspack_plugin_extract_css/src/runtime.rs
+++ b/crates/rspack_plugin_extract_css/src/runtime.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::UkeySet;
 use rspack_core::{
@@ -56,6 +57,7 @@ impl CssLoadingRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for CssLoadingRuntimeModule {
   fn name(&self) -> rspack_collections::Identifier {
     "webpack/runtime/css loading".into()
@@ -65,7 +67,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
     RuntimeModuleStage::Attach
   }
 
-  fn generate(
+  async fn generate(
     &self,
     compilation: &rspack_core::Compilation,
   ) -> Result<rspack_core::rspack_sources::BoxSource> {

--- a/crates/rspack_plugin_hmr/src/hot_module_replacement.rs
+++ b/crates/rspack_plugin_hmr/src/hot_module_replacement.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -18,13 +19,13 @@ impl Default for HotModuleReplacementRuntimeModule {
     Self::with_default(Identifier::from("webpack/runtime/hot_module_replacement"))
   }
 }
-
+#[async_trait]
 impl RuntimeModule for HotModuleReplacementRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(
         include_str!("runtime/hot_module_replacement.js")

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -85,7 +85,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     return Ok(());
   }
 
-  let (now_all_modules, now_runtime_modules) = collect_changed_modules(compilation)?;
+  let (now_all_modules, now_runtime_modules) = collect_changed_modules(compilation).await?;
 
   let mut updated_modules: IdentifierSet = Default::default();
   let mut updated_runtime_modules: IdentifierSet = Default::default();

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -366,13 +366,13 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 }
 
 #[plugin_hook(NormalModuleLoader for HotModuleReplacementPlugin)]
-fn normal_module_loader(&self, context: &mut LoaderContext<RunnerContext>) -> Result<()> {
+async fn normal_module_loader(&self, context: &mut LoaderContext<RunnerContext>) -> Result<()> {
   context.hot = true;
   Ok(())
 }
 
 #[plugin_hook(NormalModuleFactoryParser for HotModuleReplacementPlugin)]
-fn normal_module_factory_parser(
+async fn normal_module_factory_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut dyn ParserAndGenerator,

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -13,6 +13,7 @@ cow-utils = { workspace = true }
 dashmap = { workspace = true }
 either = { workspace = true }
 fast-glob = "0.4.3"
+futures = { workspace = true }
 indexmap = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/mod.rs
@@ -85,7 +85,7 @@ async fn compilation(
 }
 
 #[plugin_hook(NormalModuleFactoryParser for DefinePlugin)]
-fn nmf_parser(
+async fn nmf_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut dyn ParserAndGenerator,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
@@ -144,7 +144,7 @@ impl JavascriptParserPlugin for ProvidePlugin {
 }
 
 #[plugin_hook(NormalModuleFactoryParser for ProvidePlugin)]
-fn nmf_parser(
+async fn nmf_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut dyn ParserAndGenerator,

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -26,7 +26,7 @@ async fn compilation(
 }
 
 #[plugin_hook(JavascriptModulesRenderModuleContent for APIPlugin)]
-fn render_module_content(
+async fn render_module_content(
   &self,
   compilation: &Compilation,
   module: &BoxModule,

--- a/crates/rspack_plugin_javascript/src/plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/drive.rs
@@ -5,14 +5,14 @@ use rspack_core::{
 use rspack_hash::RspackHash;
 use rspack_hook::define_hook;
 
-define_hook!(JavascriptModulesRenderChunk: SyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource));
-define_hook!(JavascriptModulesRender: SyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource));
-define_hook!(JavascriptModulesRenderStartup: SyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &ModuleIdentifier, source: &mut RenderSource));
-define_hook!(JavascriptModulesRenderModuleContent: SyncSeries(compilation: &Compilation, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
+define_hook!(JavascriptModulesRenderChunk: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource));
+define_hook!(JavascriptModulesRender: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource));
+define_hook!(JavascriptModulesRenderStartup: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &ModuleIdentifier, source: &mut RenderSource));
+define_hook!(JavascriptModulesRenderModuleContent: AsyncSeries(compilation: &Compilation, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
 define_hook!(JavascriptModulesChunkHash: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash));
-define_hook!(JavascriptModulesInlineInRuntimeBailout: SyncSeriesBail(compilation: &Compilation) -> String);
-define_hook!(JavascriptModulesEmbedInRuntimeBailout: SyncSeriesBail(compilation: &Compilation, module: &BoxModule, chunk: &Chunk) -> String);
-define_hook!(JavascriptModulesStrictRuntimeBailout: SyncSeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> String);
+define_hook!(JavascriptModulesInlineInRuntimeBailout: AsyncSeriesBail(compilation: &Compilation) -> String);
+define_hook!(JavascriptModulesEmbedInRuntimeBailout: AsyncSeriesBail(compilation: &Compilation, module: &BoxModule, chunk: &Chunk) -> String);
+define_hook!(JavascriptModulesStrictRuntimeBailout: AsyncSeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> String);
 
 #[derive(Debug, Default)]
 pub struct JavascriptModulesPluginHooks {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -414,7 +414,7 @@ impl FlagDependencyUsagePlugin {
 }
 
 #[plugin_hook(CompilationOptimizeDependencies for FlagDependencyUsagePlugin)]
-fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let mut proxy = FlagDependencyUsagePluginProxy::new(self.global, compilation);
   proxy.apply();
   Ok(None)

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -164,7 +164,9 @@ async fn chunk_hash(
     .expect_get(chunk_ukey)
     .has_runtime(&compilation.chunk_group_by_ukey)
   {
-    self.update_hash_with_bootstrap(chunk_ukey, compilation, hasher)?;
+    self
+      .update_hash_with_bootstrap(chunk_ukey, compilation, hasher)
+      .await?;
   }
   Ok(())
 }
@@ -182,7 +184,9 @@ async fn content_hash(
     .or_insert_with(|| RspackHash::from(&compilation.options.output));
 
   if chunk.has_runtime(&compilation.chunk_group_by_ukey) {
-    self.update_hash_with_bootstrap(chunk_ukey, compilation, hasher)?;
+    self
+      .update_hash_with_bootstrap(chunk_ukey, compilation, hasher)
+      .await?;
   } else {
     chunk.id(&compilation.chunk_ids_artifact).hash(&mut hasher);
   }

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -42,7 +42,7 @@ impl MangleExportsPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeCodeGeneration for MangleExportsPlugin)]
-fn optimize_code_generation(&self, compilation: &mut Compilation) -> Result<()> {
+async fn optimize_code_generation(&self, compilation: &mut Compilation) -> Result<()> {
   // TODO: should bailout if compilation.moduleMemCache is enable, https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/MangleExportsPlugin.js#L160-L164
   // We don't do that cause we don't have this option
   let mut mg = compilation.get_module_graph_mut();

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -628,7 +628,7 @@ impl JsPlugin {
       .chunk_graph
       .has_chunk_runtime_modules(chunk_ukey)
     {
-      sources.add(render_runtime_modules(compilation, chunk_ukey)?);
+      sources.add(render_runtime_modules(compilation, chunk_ukey).await?);
       sources.add(RawStringSource::from(
         "/************************************************************************/\n",
       ));

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -665,7 +665,7 @@ async fn nmf_module(
 }
 
 #[plugin_hook(CompilationOptimizeDependencies for SideEffectsFlagPlugin)]
-fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let logger = compilation.get_logger("rspack.SideEffectsFlagPlugin");
   let start = logger.time("update connections");
 

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -220,11 +220,11 @@ pub async fn render_module(
   )))
 }
 
-pub fn render_chunk_runtime_modules(
+pub async fn render_chunk_runtime_modules(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
 ) -> Result<BoxSource> {
-  let runtime_modules_sources = render_runtime_modules(compilation, chunk_ukey)?;
+  let runtime_modules_sources = render_runtime_modules(compilation, chunk_ukey).await?;
   if runtime_modules_sources.source().is_empty() {
     return Ok(runtime_modules_sources);
   }
@@ -239,12 +239,12 @@ pub fn render_chunk_runtime_modules(
   Ok(sources.boxed())
 }
 
-pub fn render_runtime_modules(
+pub async fn render_runtime_modules(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
 ) -> Result<BoxSource> {
   let mut sources = ConcatSource::default();
-  compilation
+  let modules = compilation
     .chunk_graph
     .get_chunk_runtime_modules_in_order(chunk_ukey, compilation)
     .map(|(identifier, runtime_module)| {
@@ -255,54 +255,53 @@ pub fn render_runtime_modules(
           .expect("should have runtime module result"),
         runtime_module,
       )
-    })
-    .try_for_each(|(source, module)| -> Result<()> {
-      if source.size() == 0 {
-        return Ok(());
-      }
-      if is_diff_mode() {
-        sources.add(RawStringSource::from(format!(
-          "/* start::{} */\n",
-          module.identifier()
-        )));
+    });
+  for (source, module) in modules {
+    if source.size() == 0 {
+      continue;
+    }
+    if is_diff_mode() {
+      sources.add(RawStringSource::from(format!(
+        "/* start::{} */\n",
+        module.identifier()
+      )));
+    } else {
+      sources.add(RawStringSource::from(format!(
+        "// {}\n",
+        module.identifier()
+      )));
+    }
+    let supports_arrow_function = compilation
+      .options
+      .output
+      .environment
+      .supports_arrow_function();
+    if module.should_isolate() {
+      sources.add(RawStringSource::from(if supports_arrow_function {
+        "(() => {\n"
       } else {
-        sources.add(RawStringSource::from(format!(
-          "// {}\n",
-          module.identifier()
-        )));
-      }
-      let supports_arrow_function = compilation
-        .options
-        .output
-        .environment
-        .supports_arrow_function();
-      if module.should_isolate() {
-        sources.add(RawStringSource::from(if supports_arrow_function {
-          "(() => {\n"
-        } else {
-          "!function() {\n"
-        }));
-      }
-      if !(module.full_hash() || module.dependent_hash()) {
-        sources.add(source.clone());
+        "!function() {\n"
+      }));
+    }
+    if !(module.full_hash() || module.dependent_hash()) {
+      sources.add(source.clone());
+    } else {
+      sources.add(module.generate_with_custom(compilation).await?);
+    }
+    if module.should_isolate() {
+      sources.add(RawStringSource::from(if supports_arrow_function {
+        "\n})();\n"
       } else {
-        sources.add(module.generate_with_custom(compilation)?);
-      }
-      if module.should_isolate() {
-        sources.add(RawStringSource::from(if supports_arrow_function {
-          "\n})();\n"
-        } else {
-          "\n}();\n"
-        }));
-      }
-      if is_diff_mode() {
-        sources.add(RawStringSource::from(format!(
-          "/* end::{} */\n",
-          module.identifier()
-        )));
-      }
-      Ok(())
-    })?;
+        "\n}();\n"
+      }));
+    }
+    if is_diff_mode() {
+      sources.add(RawStringSource::from(format!(
+        "/* end::{} */\n",
+        module.identifier()
+      )));
+    }
+  }
   Ok(sources.boxed())
 }
 

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -184,7 +184,7 @@ impl Module for LazyCompilationProxyModule {
   }
 
   // #[tracing::instrument("LazyCompilationProxyModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -88,7 +88,7 @@ async fn compilation(
 }
 
 #[plugin_hook(JavascriptModulesRender for AmdLibraryPlugin)]
-fn render(
+async fn render(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -192,7 +192,7 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for AmdLibraryPlugin)]
-fn additional_chunk_runtime_requirements(
+async fn additional_chunk_runtime_requirements(
   &self,
   compilation: &mut Compilation,
   chunk_ukey: &ChunkUkey,

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -210,7 +210,7 @@ async fn compilation(
 }
 
 #[plugin_hook(JavascriptModulesRender for AssignLibraryPlugin)]
-fn render(
+async fn render(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -238,7 +238,7 @@ fn render(
 }
 
 #[plugin_hook(JavascriptModulesRenderStartup for AssignLibraryPlugin)]
-fn render_startup(
+async fn render_startup(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -316,7 +316,7 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(JavascriptModulesEmbedInRuntimeBailout for AssignLibraryPlugin)]
-fn embed_in_runtime_bailout(
+async fn embed_in_runtime_bailout(
   &self,
   compilation: &Compilation,
   module: &BoxModule,
@@ -354,7 +354,7 @@ fn embed_in_runtime_bailout(
 }
 
 #[plugin_hook(JavascriptModulesStrictRuntimeBailout for AssignLibraryPlugin)]
-fn strict_runtime_bailout(
+async fn strict_runtime_bailout(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -454,7 +454,7 @@ impl Plugin for AssignLibraryPlugin {
 }
 
 #[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for AssignLibraryPlugin)]
-fn additional_chunk_runtime_requirements(
+async fn additional_chunk_runtime_requirements(
   &self,
   compilation: &mut Compilation,
   chunk_ukey: &ChunkUkey,

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -70,7 +70,7 @@ async fn compilation(
 }
 
 #[plugin_hook(JavascriptModulesRenderStartup for ExportPropertyLibraryPlugin)]
-fn render_startup(
+async fn render_startup(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -194,7 +194,7 @@ impl Plugin for ExportPropertyLibraryPlugin {
 }
 
 #[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for ExportPropertyLibraryPlugin)]
-fn additional_chunk_runtime_requirements(
+async fn additional_chunk_runtime_requirements(
   &self,
   compilation: &mut Compilation,
   chunk_ukey: &ChunkUkey,

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -137,7 +137,7 @@ impl ModernModuleLibraryPlugin {
 }
 
 #[plugin_hook(JavascriptModulesRenderStartup for ModernModuleLibraryPlugin)]
-fn render_startup(
+async fn render_startup(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -420,7 +420,7 @@ async fn compilation(
 }
 
 #[plugin_hook(ConcatenatedModuleExportsDefinitions for ModernModuleLibraryPlugin)]
-fn exports_definitions(
+async fn exports_definitions(
   &self,
   _exports_definitions: &mut Vec<(String, String)>,
   is_entry_module: bool,

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -54,7 +54,7 @@ async fn compilation(
 }
 
 #[plugin_hook(JavascriptModulesRenderStartup for ModuleLibraryPlugin)]
-fn render_startup(
+async fn render_startup(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -78,7 +78,7 @@ async fn compilation(
 }
 
 #[plugin_hook(JavascriptModulesRender for SystemLibraryPlugin)]
-fn render(
+async fn render(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -183,7 +183,7 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for SystemLibraryPlugin)]
-fn additional_chunk_runtime_requirements(
+async fn additional_chunk_runtime_requirements(
   &self,
   compilation: &mut Compilation,
   chunk_ukey: &ChunkUkey,

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -93,7 +93,7 @@ async fn compilation(
 }
 
 #[plugin_hook(JavascriptModulesRender for UmdLibraryPlugin)]
-fn render(
+async fn render(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -261,7 +261,7 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for UmdLibraryPlugin)]
-fn additional_chunk_runtime_requirements(
+async fn additional_chunk_runtime_requirements(
   &self,
   compilation: &mut Compilation,
   chunk_ukey: &ChunkUkey,

--- a/crates/rspack_plugin_limit_chunk_count/src/lib.rs
+++ b/crates/rspack_plugin_limit_chunk_count/src/lib.rs
@@ -57,7 +57,7 @@ impl LimitChunkCountPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for LimitChunkCountPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let max_chunks = self.options.max_chunks;
   if max_chunks < 1 {
     return Ok(None);

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashSet as HashSet;
 pub struct MergeDuplicateChunksPlugin;
 
 #[plugin_hook(CompilationOptimizeChunks for MergeDuplicateChunksPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_BASIC)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let mut not_duplicates = HashSet::default();
 
   let mut chunk_ukeys = compilation

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -177,7 +177,7 @@ impl Module for ContainerEntryModule {
   }
 
   // #[tracing::instrument("ContainerEntryModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -48,6 +49,7 @@ impl ExposeRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ExposeRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
@@ -57,7 +59,7 @@ impl RuntimeModule for ExposeRuntimeModule {
     RuntimeModuleStage::Attach
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk_ukey = self
       .chunk
       .expect("should have chunk in <ExposeRuntimeModule as RuntimeModule>::generate");

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -147,7 +147,7 @@ impl Module for FallbackModule {
   }
 
   // #[tracing::instrument("FallbackModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
@@ -24,6 +24,7 @@ impl Default for FederationRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for FederationRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
@@ -37,7 +38,7 @@ impl RuntimeModule for FederationRuntimeModule {
     RuntimeModuleStage::Normal
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk = compilation
       .chunk_by_ukey
       .expect_get(&self.chunk.expect("The chunk should be attached."));

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -169,7 +169,7 @@ impl Module for RemoteModule {
   }
 
   // #[tracing::instrument("RemoteModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   impl_runtime_module,
@@ -29,6 +30,7 @@ impl RemoteRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for RemoteRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
@@ -38,7 +40,7 @@ impl RuntimeModule for RemoteRuntimeModule {
     RuntimeModuleStage::Attach
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk_ukey = self
       .chunk
       .expect("should have chunk in <RemoteRuntimeModule as RuntimeModule>::generate");

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -177,7 +177,7 @@ impl Module for ConsumeSharedModule {
   }
 
   // #[tracing::instrument("ConsumeSharedModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -28,6 +29,7 @@ impl ConsumeSharedRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ConsumeSharedRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
@@ -37,7 +39,7 @@ impl RuntimeModule for ConsumeSharedRuntimeModule {
     RuntimeModuleStage::Attach
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk_ukey = self
       .chunk
       .expect("should have chunk in <ConsumeSharedRuntimeModule as RuntimeModule>::generate");

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -172,7 +172,7 @@ impl Module for ProvideSharedModule {
   }
 
   // #[tracing::instrument("ProvideSharedModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
-  fn code_generation(
+  async fn code_generation(
     &self,
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use hashlink::{LinkedHashMap, LinkedHashSet};
 use itertools::Itertools;
 use rspack_collections::Identifier;
@@ -25,12 +26,13 @@ impl ShareRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ShareRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk_ukey = self
       .chunk
       .expect("should have chunk in <ShareRuntimeModule as RuntimeModule>::generate");

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -404,7 +404,7 @@ async fn seal(&self, _compilation: &mut Compilation) -> Result<()> {
 }
 
 #[plugin_hook(CompilationOptimizeDependencies for ProgressPlugin)]
-fn optimize_dependencies(&self, _compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_dependencies(&self, _compilation: &mut Compilation) -> Result<Option<bool>> {
   self.sealing_hooks_report("dependencies", 2)?;
   Ok(None)
 }
@@ -421,7 +421,7 @@ async fn after_optimize_modules(&self, _compilation: &mut Compilation) -> Result
 }
 
 #[plugin_hook(CompilationOptimizeChunks for ProgressPlugin)]
-fn optimize_chunks(&self, _compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, _compilation: &mut Compilation) -> Result<Option<bool>> {
   self.sealing_hooks_report("chunk optimization", 9)?;
   Ok(None)
 }
@@ -438,12 +438,12 @@ async fn optimize_chunk_modules(&self, _compilation: &mut Compilation) -> Result
 }
 
 #[plugin_hook(CompilationModuleIds for ProgressPlugin)]
-fn module_ids(&self, _modules: &mut Compilation) -> Result<()> {
+async fn module_ids(&self, _modules: &mut Compilation) -> Result<()> {
   self.sealing_hooks_report("module ids", 16)
 }
 
 #[plugin_hook(CompilationChunkIds for ProgressPlugin)]
-fn chunk_ids(&self, _compilation: &mut Compilation) -> Result<()> {
+async fn chunk_ids(&self, _compilation: &mut Compilation) -> Result<()> {
   self.sealing_hooks_report("chunk ids", 21)
 }
 

--- a/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
+++ b/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
@@ -21,7 +21,7 @@ impl std::default::Default for RemoveDuplicateModulesPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for RemoveDuplicateModulesPlugin)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let module_graph = compilation.get_module_graph();
   let chunk_graph = &compilation.chunk_graph;
 

--- a/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
+++ b/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
@@ -40,7 +40,7 @@ impl RemoveEmptyChunksPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for RemoveEmptyChunksPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   self.remove_empty_chunks(compilation);
   Ok(None)
 }

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -35,7 +35,7 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for ArrayPushCallbackChunkFormatPlugin)]
-fn additional_chunk_runtime_requirements(
+async fn additional_chunk_runtime_requirements(
   &self,
   compilation: &mut Compilation,
   chunk_ukey: &ChunkUkey,
@@ -92,7 +92,7 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(JavascriptModulesRenderChunk for ArrayPushCallbackChunkFormatPlugin)]
-fn render_chunk(
+async fn render_chunk(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -155,12 +155,15 @@ fn render_chunk(
         let mut render_source = RenderSource {
           source: start_up_source,
         };
-        hooks.render_startup.call(
-          compilation,
-          chunk_ukey,
-          last_entry_module,
-          &mut render_source,
-        )?;
+        hooks
+          .render_startup
+          .call(
+            compilation,
+            chunk_ukey,
+            last_entry_module,
+            &mut render_source,
+          )
+          .await?;
         source.add(render_source.source);
         let runtime_requirements =
           ChunkGraph::get_tree_runtime_requirements(compilation, chunk_ukey);

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -117,7 +117,7 @@ async fn render_chunk(
     source.add(render_source.source.clone());
     if has_runtime_modules {
       source.add(RawStringSource::from_static(","));
-      source.add(render_chunk_runtime_modules(compilation, chunk_ukey)?);
+      source.add(render_chunk_runtime_modules(compilation, chunk_ukey).await?);
     }
     source.add(RawStringSource::from_static(")"));
   } else {
@@ -141,7 +141,7 @@ async fn render_chunk(
         RuntimeGlobals::REQUIRE
       )));
       if has_runtime_modules {
-        source.add(render_runtime_modules(compilation, chunk_ukey)?);
+        source.add(render_runtime_modules(compilation, chunk_ukey).await?);
       }
       if has_entry {
         let entries = compilation

--- a/crates/rspack_plugin_runtime/src/chunk_prefetch_preload.rs
+++ b/crates/rspack_plugin_runtime/src/chunk_prefetch_preload.rs
@@ -15,7 +15,7 @@ use crate::runtime_module::{
 pub struct ChunkPrefetchPreloadPlugin;
 
 #[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for ChunkPrefetchPreloadPlugin)]
-fn additional_chunk_runtime_requirements(
+async fn additional_chunk_runtime_requirements(
   &self,
   compilation: &mut Compilation,
   chunk_ukey: &ChunkUkey,

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -38,7 +38,7 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for CommonJsChunkFormatPlugin)]
-fn additional_chunk_runtime_requirements(
+async fn additional_chunk_runtime_requirements(
   &self,
   compilation: &mut Compilation,
   chunk_ukey: &ChunkUkey,
@@ -90,7 +90,7 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(JavascriptModulesRenderChunk for CommonJsChunkFormatPlugin)]
-fn render_chunk(
+async fn render_chunk(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -142,12 +142,15 @@ fn render_chunk(
     let mut startup_render_source = RenderSource {
       source: start_up_source,
     };
-    hooks.render_startup.call(
-      compilation,
-      chunk_ukey,
-      last_entry_module,
-      &mut startup_render_source,
-    )?;
+    hooks
+      .render_startup
+      .call(
+        compilation,
+        chunk_ukey,
+        last_entry_module,
+        &mut startup_render_source,
+      )
+      .await?;
     sources.add(startup_render_source.source);
     render_source.source = ConcatSource::new([
       RawStringSource::from_static("(function() {\n").boxed(),

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -112,7 +112,7 @@ async fn render_chunk(
     .has_chunk_runtime_modules(chunk_ukey)
   {
     sources.add(RawStringSource::from_static("exports.runtime = "));
-    sources.add(render_chunk_runtime_modules(compilation, chunk_ukey)?);
+    sources.add(render_chunk_runtime_modules(compilation, chunk_ukey).await?);
     sources.add(RawStringSource::from_static(";\n"));
   }
 

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -120,7 +120,7 @@ async fn render_chunk(
     .has_chunk_runtime_modules(chunk_ukey)
   {
     sources.add(RawStringSource::from_static("export const runtime = "));
-    sources.add(render_chunk_runtime_modules(compilation, chunk_ukey)?);
+    sources.add(render_chunk_runtime_modules(compilation, chunk_ukey).await?);
     sources.add(RawStringSource::from_static(";\n"));
   }
 

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -41,7 +41,7 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for ModuleChunkFormatPlugin)]
-fn additional_chunk_runtime_requirements(
+async fn additional_chunk_runtime_requirements(
   &self,
   compilation: &mut Compilation,
   chunk_ukey: &ChunkUkey,
@@ -93,7 +93,7 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(JavascriptModulesRenderChunk for ModuleChunkFormatPlugin)]
-fn render_chunk(
+async fn render_chunk(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
@@ -196,12 +196,15 @@ fn render_chunk(
     let mut render_source = RenderSource {
       source: RawStringSource::from(startup_source.join("\n")).boxed(),
     };
-    hooks.render_startup.call(
-      compilation,
-      chunk_ukey,
-      last_entry_module,
-      &mut render_source,
-    )?;
+    hooks
+      .render_startup
+      .call(
+        compilation,
+        chunk_ukey,
+        last_entry_module,
+        &mut render_source,
+      )
+      .await?;
     sources.add(render_source.source);
   }
   render_source.source = sources.boxed();

--- a/crates/rspack_plugin_runtime/src/runtime_module/amd_define.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/amd_define.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for AmdDefineRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for AmdDefineRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(format!(
         "{} = function () {{ throw new Error('define cannot be used indirect'); }}",

--- a/crates/rspack_plugin_runtime/src/runtime_module/amd_options.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/amd_options.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -18,12 +19,13 @@ impl AmdOptionsRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for AmdOptionsRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(format!(
         "{} = {}",

--- a/crates/rspack_plugin_runtime/src/runtime_module/async_module.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/async_module.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -16,8 +17,9 @@ impl Default for AsyncRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for AsyncRuntimeModule {
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let source = compilation.runtime_template.render(&self.id, None)?;
 
     Ok(RawStringSource::from(source).boxed())

--- a/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   get_js_chunk_filename_template, impl_runtime_module,
@@ -21,6 +22,7 @@ impl Default for AutoPublicPathRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for AutoPublicPathRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
@@ -34,7 +36,7 @@ impl RuntimeModule for AutoPublicPathRuntimeModule {
     RuntimeModuleStage::Attach
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk = self.chunk.expect("The chunk should be attached");
     let chunk = compilation.chunk_by_ukey.expect_get(&chunk);
     let filename = get_js_chunk_filename_template(

--- a/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,8 +18,9 @@ impl Default for BaseUriRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for BaseUriRuntimeModule {
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let base_uri = self
       .chunk
       .and_then(|ukey| compilation.chunk_by_ukey.get(&ukey))

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -18,6 +19,7 @@ impl Default for ChunkNameRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ChunkNameRuntimeModule {
   fn attach(&mut self, chunk: ChunkUkey) {
     self.chunk = Some(chunk);
@@ -27,7 +29,7 @@ impl RuntimeModule for ChunkNameRuntimeModule {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     if let Some(chunk_ukey) = self.chunk {
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
       Ok(

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_preload_function.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_preload_function.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -31,12 +32,13 @@ impl ChunkPrefetchPreloadFunctionRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ChunkPrefetchPreloadFunctionRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(
         include_str!("runtime/chunk_prefetch_preload_function.js")

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use itertools::Itertools;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -24,6 +25,7 @@ impl ChunkPrefetchStartupRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
@@ -33,7 +35,7 @@ impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
     self.chunk = Some(chunk);
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk_ukey = self.chunk.expect("chunk do not attached");
     Ok(
       RawStringSource::from(

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_trigger.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_trigger.rs
@@ -1,5 +1,6 @@
 use std::hash::BuildHasherDefault;
 
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use indexmap::IndexMap;
 use rspack_cacheable::with::AsMap;
@@ -29,12 +30,13 @@ impl ChunkPrefetchTriggerRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ChunkPrefetchTriggerRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(
         include_str!("runtime/chunk_prefetch_trigger.js")

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_preload_trigger.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_preload_trigger.rs
@@ -1,5 +1,6 @@
 use std::hash::BuildHasherDefault;
 
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use indexmap::IndexMap;
 use rspack_cacheable::with::AsMap;
@@ -29,12 +30,13 @@ impl ChunkPreloadTriggerRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ChunkPreloadTriggerRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(
         include_str!("runtime/chunk_preload_trigger.js")

--- a/crates/rspack_plugin_runtime/src/runtime_module/compat_get_default_export.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/compat_get_default_export.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -19,12 +20,13 @@ impl Default for CompatGetDefaultExportRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for CompatGetDefaultExportRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static(include_str!("runtime/compat_get_default_export.js")).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_fake_namespace_object.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_fake_namespace_object.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -19,12 +20,13 @@ impl Default for CreateFakeNamespaceObjectRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for CreateFakeNamespaceObjectRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from_static(include_str!("runtime/create_fake_namespace_object.js")).boxed(),
     )

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_script.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for CreateScriptRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for CreateScriptRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(format!(
         r#"

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_script_url.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_script_url.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for CreateScriptUrlRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for CreateScriptUrlRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(format!(
         r#"

--- a/crates/rspack_plugin_runtime/src/runtime_module/define_property_getters.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/define_property_getters.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for DefinePropertyGettersRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for DefinePropertyGettersRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static(include_str!("runtime/define_property_getters.js")).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -21,12 +22,13 @@ impl Default for EnsureChunkRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for EnsureChunkRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk_ukey = self.chunk.expect("should have chunk");
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
     Ok(

--- a/crates/rspack_plugin_runtime/src/runtime_module/esm_module_decorator.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/esm_module_decorator.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for ESMModuleDecoratorRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ESMModuleDecoratorRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static(include_str!("runtime/esm_module_decorator.js")).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/export_webpack_require.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/export_webpack_require.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl ExportWebpackRequireRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ExportWebpackRequireRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static("export default __webpack_require__;").boxed())
   }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -1,5 +1,6 @@
 use std::{cmp::Ordering, fmt};
 
+use async_trait::async_trait;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rspack_cacheable::with::Unsupported;
@@ -73,6 +74,7 @@ impl GetChunkFilenameRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for GetChunkFilenameRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
@@ -82,7 +84,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
     true
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunks = self
       .chunk
       .and_then(|chunk_ukey| compilation.chunk_by_ukey.get(&chunk_ukey))

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -23,11 +24,12 @@ impl Default for GetChunkUpdateFilenameRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     if let Some(chunk_ukey) = self.chunk {
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
       let filename = compilation

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_full_hash.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_full_hash.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -18,12 +19,13 @@ impl Default for GetFullHashRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for GetFullHashRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(
         include_str!("runtime/get_full_hash.js")

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -25,12 +26,13 @@ impl GetMainFilenameRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for GetMainFilenameRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     if let Some(chunk_ukey) = self.chunk {
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
       let filename = compilation.get_path(

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -24,12 +25,13 @@ impl Default for GetTrustedTypesPolicyRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for GetTrustedTypesPolicyRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let trusted_types = compilation
       .options
       .output

--- a/crates/rspack_plugin_runtime/src/runtime_module/global.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/global.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for GlobalRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for GlobalRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static(include_str!("runtime/global.js")).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for HasOwnPropertyRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for HasOwnPropertyRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static(include_str!("runtime/has_own_property.js")).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::{DatabaseItem, Identifier};
 use rspack_core::{
@@ -59,12 +60,13 @@ impl ImportScriptsChunkLoadingRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk = compilation
       .chunk_by_ukey
       .expect_get(&self.chunk.expect("The chunk should be attached."));

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_namespace_object.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_namespace_object.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for MakeNamespaceObjectRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for MakeNamespaceObjectRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static(include_str!("runtime/make_namespace_object.js")).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::{DatabaseItem, Identifier};
 use rspack_core::{
@@ -50,12 +51,13 @@ impl ModuleChunkLoadingRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk = compilation
       .chunk_by_ukey
       .expect_get(&self.chunk.expect("The chunk should be attached."));

--- a/crates/rspack_plugin_runtime/src/runtime_module/node_module_decorator.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/node_module_decorator.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for NodeModuleDecoratorRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for NodeModuleDecoratorRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static(include_str!("runtime/node_module_decorator.js")).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/nonce.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/nonce.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for NonceRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for NonceRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from(format!("{} = undefined;", RuntimeGlobals::SCRIPT_NONCE)).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for OnChunkLoadedRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for OnChunkLoadedRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static(include_str!("runtime/on_chunk_loaded.js")).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -19,12 +20,13 @@ impl PublicPathRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for PublicPathRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(
         include_str!("runtime/public_path.js")

--- a/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::{DatabaseItem, Identifier};
 use rspack_core::{
@@ -60,11 +61,12 @@ impl ReadFileChunkLoadingRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk = compilation
       .chunk_by_ukey
       .expect_get(&self.chunk.expect("The chunk should be attached."));

--- a/crates/rspack_plugin_runtime/src/runtime_module/relative_url.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/relative_url.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for RelativeUrlRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for RelativeUrlRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(RawStringSource::from_static(include_str!("runtime/relative_url.js")).boxed())
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::{DatabaseItem, Identifier};
 use rspack_core::{
@@ -60,12 +61,13 @@ impl RequireChunkLoadingRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for RequireChunkLoadingRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let chunk = compilation
       .chunk_by_ukey
       .expect_get(&self.chunk.expect("The chunk should be attached."));

--- a/crates/rspack_plugin_runtime/src/runtime_module/rspack_unique_id.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/rspack_unique_id.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -24,6 +25,7 @@ impl RspackUniqueIdRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for RspackUniqueIdRuntimeModule {
   fn stage(&self) -> RuntimeModuleStage {
     RuntimeModuleStage::Attach
@@ -32,7 +34,7 @@ impl RuntimeModule for RspackUniqueIdRuntimeModule {
     self.id
   }
 
-  fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(
         include_str!("runtime/get_unique_id.js")

--- a/crates/rspack_plugin_runtime/src/runtime_module/rspack_version.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/rspack_version.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -19,12 +20,13 @@ impl RspackVersionRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for RspackVersionRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(
         include_str!("runtime/get_version.js")

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use itertools::Itertools;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -19,6 +20,7 @@ impl Default for RuntimeIdRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for RuntimeIdRuntimeModule {
   fn attach(&mut self, chunk: ChunkUkey) {
     self.chunk = Some(chunk);
@@ -28,7 +30,7 @@ impl RuntimeModule for RuntimeIdRuntimeModule {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     if let Some(chunk_ukey) = self.chunk {
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
@@ -1,5 +1,6 @@
 use std::iter;
 
+use async_trait::async_trait;
 use itertools::Itertools;
 use rspack_collections::Identifier;
 use rspack_core::{
@@ -26,12 +27,13 @@ impl StartupChunkDependenciesRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     if let Some(chunk_ukey) = self.chunk {
       let chunk_ids = compilation
         .chunk_graph

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_entry_point.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_entry_point.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -21,12 +22,13 @@ impl StartupEntrypointRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for StartupEntrypointRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let source = if self.async_chunk_loading {
       include_str!("runtime/startup_entrypoint_with_async.js")
     } else {

--- a/crates/rspack_plugin_runtime/src/runtime_module/system_context.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/system_context.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -17,12 +18,13 @@ impl Default for SystemContextRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for SystemContextRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
 
-  fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     Ok(
       RawStringSource::from(format!(
         "{} = __system_context__",

--- a/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use derive_more::Debug;
 use rspack_cacheable::with::Unsupported;
 use rspack_collections::Identifier;
@@ -24,12 +25,13 @@ pub struct RuntimeModuleFromJs {
   pub stage: RuntimeModuleStage,
 }
 
+#[async_trait]
 impl RuntimeModule for RuntimeModuleFromJs {
   fn name(&self) -> Identifier {
     Identifier::from(format!("webpack/runtime/{}", self.name))
   }
 
-  fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
     let res = (self.generator)()?;
     Ok(RawStringSource::from(res).boxed())
   }

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -162,7 +162,7 @@ impl Debug for SplitChunksPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for SplitChunksPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-pub fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+pub async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   self.inner_impl(compilation)?;
   Ok(None)
 }

--- a/crates/rspack_plugin_wasm/src/runtime.rs
+++ b/crates/rspack_plugin_wasm/src/runtime.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use cow_utils::CowUtils;
 use rspack_collections::Identifier;
 use rspack_core::rspack_sources::{BoxSource, RawStringSource, SourceExt};
@@ -32,11 +33,12 @@ impl AsyncWasmLoadingRuntimeModule {
   }
 }
 
+#[async_trait]
 impl RuntimeModule for AsyncWasmLoadingRuntimeModule {
   fn name(&self) -> Identifier {
     self.id
   }
-  fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
+  async fn generate(&self, compilation: &Compilation) -> rspack_error::Result<BoxSource> {
     let (fake_filename, hash_len_map) =
       get_filename_without_hash_length(&compilation.options.output.webassembly_module_filename);
 

--- a/crates/rspack_storage/src/lib.rs
+++ b/crates/rspack_storage/src/lib.rs
@@ -18,7 +18,7 @@ pub trait Storage: std::fmt::Debug + Sync + Send {
   async fn load(&self, scope: &'static str) -> Result<Vec<(Arc<Vec<u8>>, Arc<Vec<u8>>)>>;
   fn set(&self, scope: &'static str, key: Vec<u8>, value: Vec<u8>);
   fn remove(&self, scope: &'static str, key: &[u8]);
-  fn trigger_save(&self) -> Result<Receiver<Result<()>>>;
+  async fn trigger_save(&self) -> Result<Receiver<Result<()>>>;
 }
 
 pub type ArcStorage = Arc<dyn Storage>;

--- a/crates/rspack_storage/src/pack/mod.rs
+++ b/crates/rspack_storage/src/pack/mod.rs
@@ -77,9 +77,8 @@ impl Storage for PackStorage {
     let scope_update = updates.entry(scope).or_default();
     scope_update.insert(key.to_vec(), None);
   }
-  fn trigger_save(&self) -> Result<Receiver<Result<()>>> {
-    self.manager.save(std::mem::take(
-      &mut *self.updates.lock().expect("should get lock"),
-    ))
+  async fn trigger_save(&self) -> Result<Receiver<Result<()>>> {
+    let updates = std::mem::take(&mut *self.updates.lock().expect("should get lock"));
+    self.manager.save(updates).await
   }
 }

--- a/crates/rspack_storage/tests/build.rs
+++ b/crates/rspack_storage/tests/build.rs
@@ -55,7 +55,7 @@ mod test_storage_build {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
     rx.await.expect("should save")?;
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())
@@ -75,7 +75,7 @@ mod test_storage_build {
       format!("new_{:0>3}", 222).as_bytes().to_vec(),
     );
     storage.remove("test_scope", format!("key_{:0>3}", 333).as_bytes().as_ref());
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
     rx.await.expect("should save")?;
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())

--- a/crates/rspack_storage/tests/dev.rs
+++ b/crates/rspack_storage/tests/dev.rs
@@ -55,7 +55,7 @@ mod test_storage_dev {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?.await.expect("should save")?;
+    storage.trigger_save().await?.await.expect("should save")?;
 
     assert_eq!(storage.load("test_scope").await?.len(), 300);
     for i in 300..700 {
@@ -65,7 +65,7 @@ mod test_storage_dev {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?;
+    storage.trigger_save().await?;
 
     assert_eq!(storage.load("test_scope").await?.len(), 700);
     for i in 700..1000 {
@@ -75,7 +75,7 @@ mod test_storage_dev {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
 
     assert_eq!(storage.load("test_scope").await?.len(), 1000);
     rx.await.expect("should save")?;
@@ -98,7 +98,7 @@ mod test_storage_dev {
       format!("new_{:0>3}", 100).as_bytes().to_vec(),
     );
     storage.remove("test_scope", format!("key_{:0>3}", 200).as_bytes().as_ref());
-    storage.trigger_save()?;
+    storage.trigger_save().await?;
     assert_eq!(storage.load("test_scope").await?.len(), 999);
 
     storage.set(
@@ -107,7 +107,7 @@ mod test_storage_dev {
       format!("new_{:0>3}", 300).as_bytes().to_vec(),
     );
     storage.remove("test_scope", format!("key_{:0>3}", 400).as_bytes().as_ref());
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
     assert_eq!(storage.load("test_scope").await?.len(), 998);
 
     rx.await.expect("should save")?;

--- a/crates/rspack_storage/tests/error.rs
+++ b/crates/rspack_storage/tests/error.rs
@@ -55,7 +55,7 @@ mod test_storage_error {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
     assert_eq!(storage.load("test_scope").await?.len(), 1000);
 
     rx.await.expect("should save")?;

--- a/crates/rspack_storage/tests/expire.rs
+++ b/crates/rspack_storage/tests/expire.rs
@@ -47,7 +47,7 @@ mod test_storage_expire {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
     assert_eq!(storage.load("test_scope").await?.len(), 100);
 
     rx.await.expect("should save")?;
@@ -110,7 +110,7 @@ mod test_storage_expire {
       format!("key_{:0>3}", 0).as_bytes().to_vec(),
       format!("val_{:0>3}", 0).as_bytes().to_vec(),
     );
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
 
     rx.await.expect("should save")?;
     assert!(

--- a/crates/rspack_storage/tests/lock.rs
+++ b/crates/rspack_storage/tests/lock.rs
@@ -110,7 +110,7 @@ mod test_storage_lock {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
     assert_eq!(storage.load("test_scope").await?.len(), 100);
 
     assert!(rx

--- a/crates/rspack_storage/tests/multi.rs
+++ b/crates/rspack_storage/tests/multi.rs
@@ -62,7 +62,7 @@ mod test_storage_multi {
         format!("scope_2_val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
     rx.await.expect("should save")?;
     assert!(fs.exists(&root.join("scope_1/scope_meta")).await?);
     assert!(fs.exists(&root.join("scope_2/scope_meta")).await?);
@@ -98,7 +98,7 @@ mod test_storage_multi {
       "scope_2",
       format!("scope_2_key_{:0>3}", 444).as_bytes().as_ref(),
     );
-    let rx = storage.trigger_save()?;
+    let rx = storage.trigger_save().await?;
     rx.await.expect("should save")?;
     assert!(fs.exists(&root.join("scope_1/scope_meta")).await?);
     assert!(fs.exists(&root.join("scope_2/scope_meta")).await?);

--- a/crates/rspack_storage/tests/release.rs
+++ b/crates/rspack_storage/tests/release.rs
@@ -84,7 +84,7 @@ mod test_storage_release {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?.await.expect("should save")?;
+    storage.trigger_save().await?.await.expect("should save")?;
 
     assert_eq!(
       get_scope_generations(&storage, scope_name).await?,
@@ -99,7 +99,7 @@ mod test_storage_release {
         format!("new_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?.await.expect("should save")?;
+    storage.trigger_save().await?.await.expect("should save")?;
 
     assert_eq!(
       get_scope_generations(&storage, scope_name).await?,
@@ -114,7 +114,7 @@ mod test_storage_release {
         format!("new_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?.await.expect("should save")?;
+    storage.trigger_save().await?.await.expect("should save")?;
 
     assert_eq!(
       get_scope_generations(&storage, scope_name).await?,
@@ -129,7 +129,7 @@ mod test_storage_release {
         format!("new_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?.await.expect("should save")?;
+    storage.trigger_save().await?.await.expect("should save")?;
 
     assert_eq!(
       get_scope_generations(&storage, scope_name).await?,
@@ -144,7 +144,7 @@ mod test_storage_release {
         format!("new_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?.await.expect("should save")?;
+    storage.trigger_save().await?.await.expect("should save")?;
 
     assert_eq!(
       get_scope_generations(&storage, scope_name).await?,
@@ -159,7 +159,7 @@ mod test_storage_release {
         format!("new_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?.await.expect("should save")?;
+    storage.trigger_save().await?.await.expect("should save")?;
 
     assert_eq!(
       get_scope_generations(&storage, scope_name).await?,
@@ -174,7 +174,7 @@ mod test_storage_release {
         format!("new_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?.await.expect("should save")?;
+    storage.trigger_save().await?.await.expect("should save")?;
 
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     assert_eq!(


### PR DESCRIPTION
## Summary

Related: https://github.com/web-infra-dev/rspack/issues/8312

Help me start benchmarking. **I will try to polish the code further if performance improves** (and split the pr).

There are still undo tasks:
1. Many `block_on`s and `blocking_call`s are called in `impl From<RawXX> for XX`s, which is hard to be converted into `async`. Maybe we should create our own `AsyncFrom`.
2. Some hooks are hard to migrate:
    - `NormalModuleLoaderShouldYield`: `module: NonNull<dyn Module>` is not `Send` in RunnerContext: https://github.com/CPunisher/rspack/blob/87945e092d42741490ae4b36d405ce400a375149/crates/rspack_core/src/loader/rspack_loader.rs#L49
    - `CompilationRuntimeRequirementInModule`, `CompilationRuntimeRequirementInChunk`, `CompilationRuntimeRequirementInTree`: It's hard to migrate the related code in https://github.com/CPunisher/rspack/blob/87945e092d42741490ae4b36d405ce400a375149/crates/rspack_core/src/compiler/compilation.rs#L1700
3. `block_on` in Module trait functions: https://github.com/CPunisher/rspack/blob/87945e092d42741490ae4b36d405ce400a375149/crates/rspack_macros/src/runtime_module.rs#L189, https://github.com/CPunisher/rspack/blob/87945e092d42741490ae4b36d405ce400a375149/crates/rspack_macros/src/runtime_module.rs#L131

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
