### PR TITLE
docs: link to Tailwind CSS v4 documentation

### DIFF
--- a/website/docs/en/guide/tech/css.mdx
+++ b/website/docs/en/guide/tech/css.mdx
@@ -251,48 +251,9 @@ The above configuration runs all `*.less` files through the [less-loader](https:
 
 ## Tailwind CSS
 
-[Tailwind CSS](https://tailwindcss.com/) is a utility-first CSS framework packed with classes that can be composed to build any design, directly in your markup.
+[Tailwind CSS](https://tailwindcss.com/) is a CSS framework and design system based on utility class, which can quickly add common styles to components, and support flexible extension of theme styles.
 
-Installing Tailwind CSS as a PostCSS plugin is the most seamless way to integrate it with Rspack.
+Tailwind CSS documentation provides integration guides for Rspack, please refer to:
 
-### Install Tailwind CSS
-
-Please install [tailwindcss](https://tailwindcss.com/),[autoprefixer](https://github.com/postcss/autoprefixer),[postcss](https://postcss.org/) and [postcss-loader](https://www.npmjs.com/package/) in your project.
-
-<PackageManagerTabs command="add tailwindcss autoprefixer postcss postcss-loader -D" />
-
-### Configure Tailwind CSS
-
-Once installed, you need to configure `postcss-loader` in `rspack.config.js` to handle CSS files, and then add `tailwindcss` to `postcssOptions.plugins`.
-
-Here is an example configuration for handling `.css` files, if you need to handle `.scss` or `.less` files, you can refer to this example for modifications.
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: [
-          {
-            loader: 'postcss-loader',
-            options: {
-              postcssOptions: {
-                plugins: {
-                  tailwindcss: {},
-                  autoprefixer: {},
-                },
-              },
-            },
-          },
-        ],
-        type: 'css',
-      },
-    ],
-  },
-};
-```
-
-At this point, you have completed the build configuration required to use Tailwind CSS in Rspack.
-
-Next you can follow the steps in the [Tailwind CSS Documentation](https://tailwindcss.com/docs/installation/using-postcss) to add the required configuration and code for Tailwind CSS and start using it.
+- [Install Tailwind CSS v4 with Rspack](https://tailwindcss.com/docs/installation/framework-guides/rspack/react)
+- [Install Tailwind CSS v3 with Rspack](https://v3.tailwindcss.com/docs/guides/rspack)

--- a/website/docs/zh/guide/tech/css.mdx
+++ b/website/docs/zh/guide/tech/css.mdx
@@ -251,48 +251,9 @@ export default {
 
 ## Tailwind CSS
 
-[Tailwind CSS](https://tailwindcss.com/) 是一个功能类优先的 CSS 框架，它集成了一系列样式类，它们能直接在脚本标记语言中组合起来，构建出任何设计。
+[Tailwind CSS](https://tailwindcss.com/) 是一个以 Utility Class 为基础的 CSS 框架和设计系统，可以快速地为组件添加常用样式，同时支持主题样式的灵活扩展。
 
-将 Tailwind CSS 作为 PostCSS 插件安装，是将其与 Rspack 整合的最佳方式。
+Tailwind CSS 官网提供了集成 Rspack 的指南，请参考：
 
-### 安装 Tailwind CSS
-
-在你的项目中安装 [tailwindcss](https://tailwindcss.com/)、[autoprefixer](https://github.com/postcss/autoprefixer)、[postcss](https://postcss.org/) 和 [postcss-loader](https://www.npmjs.com/package/postcss-loader) 这些依赖：
-
-<PackageManagerTabs command="add tailwindcss autoprefixer postcss postcss-loader -D" />
-
-### 配置 Tailwind CSS
-
-安装完成后，你需要在 `rspack.config.js` 中配置 `postcss-loader` 来处理 CSS 文件，然后在 `postcssOptions.plugins` 中添加 `tailwindcss`。
-
-下面是一个处理 `.css` 文件的配置示例，如果你需要处理 `.scss` 或 `.less` 文件，可以参考该示例进行修改。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: [
-          {
-            loader: 'postcss-loader',
-            options: {
-              postcssOptions: {
-                plugins: {
-                  tailwindcss: {},
-                  autoprefixer: {},
-                },
-              },
-            },
-          },
-        ],
-        type: 'css',
-      },
-    ],
-  },
-};
-```
-
-到此为止，你已经完成了在 Rspack 中使用 Tailwind CSS 所需的构建配置。
-
-接下来你可以按照 [Tailwind CSS 官方文档](https://tailwindcss.com/docs/installation/using-postcss)中的步骤，添加 Tailwind CSS 所需的配置和代码，即可开始使用。
+- [Install Tailwind CSS v4 with Rspack](https://tailwindcss.com/docs/installation/framework-guides/rspack/react)
+- [Install Tailwind CSS v3 with Rspack](https://v3.tailwindcss.com/docs/guides/rspack)


### PR DESCRIPTION
## Summary

Tailwind CSS v4 has been released and Rspack's Tailwind CSS guide is out of date.

This PR adds links to the official Tailwind CSS guide for both v3 and v4, so we no longer need to maintain the guides.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
