### PR TITLE
refactor: get plugin hooks by compilation id

### DIFF
--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -443,7 +443,7 @@ async fn js_hooks_adapter_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> rspack_error::Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks
     .chunk_hash
     .intercept(self.register_javascript_modules_chunk_hash_taps.clone());
@@ -457,7 +457,7 @@ async fn html_hooks_adapter_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> rspack_error::Result<()> {
-  let mut hooks = HtmlRspackPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = HtmlRspackPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.before_asset_tag_generation.intercept(
     self
       .register_html_plugin_before_asset_tag_generation_taps
@@ -492,7 +492,7 @@ async fn runtime_hooks_adapter_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> rspack_error::Result<()> {
-  let mut hooks = RuntimePlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = RuntimePlugin::get_compilation_hooks_mut(compilation.id());
   hooks
     .create_script
     .intercept(self.register_runtime_plugin_create_script_taps.clone());
@@ -511,7 +511,7 @@ async fn rsdoctor_hooks_adapter_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> rspack_error::Result<()> {
-  let mut hooks = RsdoctorPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = RsdoctorPlugin::get_compilation_hooks_mut(compilation.id());
   hooks
     .module_graph
     .intercept(self.register_rsdoctor_plugin_module_graph_taps.clone());

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -75,7 +75,7 @@ async fn eval_devtool_plugin_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks
     .render_module_content
     .tap(eval_devtool_plugin_render_module_content::new(self));

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -65,7 +65,7 @@ async fn eval_source_map_devtool_plugin_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks
     .render_module_content
     .tap(eval_source_map_devtool_plugin_render_module_content::new(

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -46,9 +46,9 @@ impl HtmlRspackPlugin {
   }
 
   pub fn get_compilation_hooks_mut(
-    compilation: &Compilation,
-  ) -> dashmap::mapref::one::RefMut<'_, CompilationId, Box<HtmlPluginHooks>> {
-    COMPILATION_HOOKS_MAP.entry(compilation.id()).or_default()
+    id: CompilationId,
+  ) -> dashmap::mapref::one::RefMut<'static, CompilationId, Box<HtmlPluginHooks>> {
+    COMPILATION_HOOKS_MAP.entry(id).or_default()
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -18,7 +18,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks
     .render_module_content
     .tap(render_module_content::new(self));

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -89,7 +89,7 @@ pub fn render_module(
     return Ok(None);
   };
 
-  let hooks = JsPlugin::get_compilation_hooks(compilation);
+  let hooks = JsPlugin::get_compilation_hooks(compilation.id());
   let mut module_chunk_init_fragments = match code_gen_result.data.get::<ChunkInitFragments>() {
     Some(fragments) => fragments.clone(),
     None => ChunkInitFragments::default(),

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -81,7 +81,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.render.tap(render::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -196,7 +196,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.render.tap(render::new(self));
   hooks.render_startup.tap(render_startup::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -63,7 +63,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.render_startup.tap(render_startup::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -413,7 +413,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.render_startup.tap(render_startup::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -47,7 +47,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.render_startup.tap(render_startup::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -71,7 +71,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.render.tap(render::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -86,7 +86,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.render.tap(render::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -161,9 +161,9 @@ impl RsdoctorPlugin {
   }
 
   pub fn get_compilation_hooks_mut(
-    compilation: &Compilation,
-  ) -> dashmap::mapref::one::RefMut<'_, CompilationId, Box<RsdoctorPluginHooks>> {
-    COMPILATION_HOOKS_MAP.entry(compilation.id()).or_default()
+    id: CompilationId,
+  ) -> dashmap::mapref::one::RefMut<'static, CompilationId, Box<RsdoctorPluginHooks>> {
+    COMPILATION_HOOKS_MAP.entry(id).or_default()
   }
 }
 

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -28,7 +28,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   hooks.render_chunk.tap(render_chunk::new(self));
   Ok(())
@@ -98,7 +98,7 @@ fn render_chunk(
   chunk_ukey: &ChunkUkey,
   render_source: &mut RenderSource,
 ) -> Result<()> {
-  let hooks = JsPlugin::get_compilation_hooks(compilation);
+  let hooks = JsPlugin::get_compilation_hooks(compilation.id());
   let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
   let has_runtime_modules = compilation
     .chunk_graph

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -31,7 +31,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   hooks.render_chunk.tap(render_chunk::new(self));
   Ok(())
@@ -96,7 +96,7 @@ fn render_chunk(
   chunk_ukey: &ChunkUkey,
   render_source: &mut RenderSource,
 ) -> Result<()> {
-  let hooks = JsPlugin::get_compilation_hooks(compilation);
+  let hooks = JsPlugin::get_compilation_hooks(compilation.id());
   let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
   let base_chunk_output_name = get_chunk_output_name(chunk, compilation)?;
   let mut sources = ConcatSource::default();

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -34,7 +34,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.render_chunk.tap(render_chunk::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())
@@ -99,7 +99,7 @@ fn render_chunk(
   chunk_ukey: &ChunkUkey,
   render_source: &mut RenderSource,
 ) -> Result<()> {
-  let hooks = JsPlugin::get_compilation_hooks(compilation);
+  let hooks = JsPlugin::get_compilation_hooks(compilation.id());
   let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
   let base_chunk_output_name = get_chunk_output_name(chunk, compilation)?;
   if matches!(chunk.kind(), ChunkKind::HotUpdate) {

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -171,9 +171,9 @@ impl RuntimePlugin {
   }
 
   pub fn get_compilation_hooks_mut(
-    compilation: &Compilation,
-  ) -> dashmap::mapref::one::RefMut<'_, CompilationId, Box<RuntimePluginHooks>> {
-    COMPILATION_HOOKS_MAP.entry(compilation.id()).or_default()
+    id: CompilationId,
+  ) -> dashmap::mapref::one::RefMut<'static, CompilationId, Box<RuntimePluginHooks>> {
+    COMPILATION_HOOKS_MAP.entry(id).or_default()
   }
 }
 
@@ -183,7 +183,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())
 }

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -132,7 +132,7 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation);
+  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Get plugin hooks by compilation id. Some hooks may not pass the whole compilation through its arguments

---
This pull request includes several changes to the `get_compilation_hooks_mut` and `get_compilation_hooks` methods across multiple plugins to use `compilation.id()` instead of passing the entire `compilation` object. This change aims to standardize how compilation hooks are retrieved by using the compilation ID directly.

Changes to `get_compilation_hooks_mut` and `get_compilation_hooks` methods:

* [`crates/node_binding/src/plugins/mod.rs`](diffhunk://#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L446-R446): Updated `js_hooks_adapter_compilation`, `html_hooks_adapter_compilation`, `runtime_hooks_adapter_compilation`, and `rsdoctor_hooks_adapter_compilation` functions to use `compilation.id()` for retrieving hooks. [[1]](diffhunk://#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L446-R446) [[2]](diffhunk://#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L460-R460) [[3]](diffhunk://#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L495-R495) [[4]](diffhunk://#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L514-R514)
* [`crates/rspack_plugin_javascript/src/plugin/mod.rs`](diffhunk://#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L108-R109): Updated multiple methods in `JsPlugin` to use `compilation.id()` instead of the entire `compilation` object. [[1]](diffhunk://#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L108-R109) [[2]](diffhunk://#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L120-R121) [[3]](diffhunk://#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L356-R355) [[4]](diffhunk://#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L518-R517) [[5]](diffhunk://#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L1110-R1109) [[6]](diffhunk://#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L1169-R1168)
* [`crates/rspack_plugin_html/src/plugin.rs`](diffhunk://#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcL49-R51): Updated `get_compilation_hooks_mut` method in `HtmlRspackPlugin` to use `compilation.id()`.
* [`crates/rspack_plugin_rsdoctor/src/plugin.rs`](diffhunk://#diff-bbbaef80d0e831527745f700440d57ac04632271530457983a6cd401196c9637L164-R166): Updated `get_compilation_hooks_mut` method in `RsdoctorPlugin` to use `compilation.id()`.
* [`crates/rspack_plugin_runtime/src/runtime_plugin.rs`](diffhunk://#diff-6923fbd704173451f38e3af15185bc087c2edf9e5775352e1484838f3837635dL174-R176): Updated `get_compilation_hooks_mut` method in `RuntimePlugin` to use `compilation.id()`.

Updates to various plugin compilation functions:

* [`crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs`](diffhunk://#diff-ed666c4275a27d0e7cee5db53f8722d80d854929e5f127369358e08beb88fef9L78-R78): Updated `eval_devtool_plugin_compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs`](diffhunk://#diff-ccde728cd055b2cf9ea38fbd58d787377431f4dea993fc5b285da1aefbd39261L68-R68): Updated `eval_source_map_devtool_plugin_compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_javascript/src/plugin/api_plugin.rs`](diffhunk://#diff-3c6c89f1db30aae2914fceda7ab35824ee543d7343a66c17a9689f352f951f25L21-R21): Updated `compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_library/src/amd_library_plugin.rs`](diffhunk://#diff-99b8865986eb7a60594bf91fdaf4ff519f350372c4318137019e1c7915c70e7cL84-R84): Updated `compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_library/src/assign_library_plugin.rs`](diffhunk://#diff-979eac2d1174f1315fb43b75c93c8613baa58826742117730314ac01e9265f05L199-R199): Updated `compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_library/src/export_property_library_plugin.rs`](diffhunk://#diff-b1372288cff4a077916dd97d5274853b7b258ab3e07ffaa87fea2f57ceae67d9L66-R66): Updated `compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_library/src/modern_module_library_plugin.rs`](diffhunk://#diff-71a146dfb31b7dc1b762f9dc18faaddaf21cf2f5d98536133f31db61c4479ccaL416-R416): Updated `compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_library/src/module_library_plugin.rs`](diffhunk://#diff-32658f3059223914bd10474ae269827489a13ca9c2f616e7597579f6b2041a8fL50-R50): Updated `compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_library/src/system_library_plugin.rs`](diffhunk://#diff-b8f548abfda2e14e8e8ffe240f3bb243d2c7b62ea2c88d6f11f48dcc8e190a28L74-R74): Updated `compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_library/src/umd_library_plugin.rs`](diffhunk://#diff-15f899e00c44305afdd562b8e6d9c61bc236fac141eb98752007537da9ab55cdL89-R89): Updated `compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs`](diffhunk://#diff-642bde562c4bac7d3a7e5f2a4036a9e7deac1c97428d86cdf4be20a2edad82adL31-R31): Updated `compilation` and `render_chunk` functions to use `compilation.id()` for retrieving hooks. [[1]](diffhunk://#diff-642bde562c4bac7d3a7e5f2a4036a9e7deac1c97428d86cdf4be20a2edad82adL31-R31) [[2]](diffhunk://#diff-642bde562c4bac7d3a7e5f2a4036a9e7deac1c97428d86cdf4be20a2edad82adL101-R101)
* [`crates/rspack_plugin_runtime/src/common_js_chunk_format.rs`](diffhunk://#diff-cf0b5d37badeb43c872afa010841db383fe16a3ece6adc5462f371e8c237d907L34-R34): Updated `compilation` and `render_chunk` functions to use `compilation.id()` for retrieving hooks. [[1]](diffhunk://#diff-cf0b5d37badeb43c872afa010841db383fe16a3ece6adc5462f371e8c237d907L34-R34) [[2]](diffhunk://#diff-cf0b5d37badeb43c872afa010841db383fe16a3ece6adc5462f371e8c237d907L99-R99)
* [`crates/rspack_plugin_runtime/src/module_chunk_format.rs`](diffhunk://#diff-4af6c3c9405524865903fa3308ef47dcde8e02e128b709df74433c29314ceb7bL37-R37): Updated `compilation` and `render_chunk` functions to use `compilation.id()` for retrieving hooks. [[1]](diffhunk://#diff-4af6c3c9405524865903fa3308ef47dcde8e02e128b709df74433c29314ceb7bL37-R37) [[2]](diffhunk://#diff-4af6c3c9405524865903fa3308ef47dcde8e02e128b709df74433c29314ceb7bL102-R102)
* [`crates/rspack_plugin_runtime/src/runtime_plugin.rs`](diffhunk://#diff-6923fbd704173451f38e3af15185bc087c2edf9e5775352e1484838f3837635dL186-R186): Updated `compilation` function to use `compilation.id()` for retrieving hooks.
* [`crates/rspack_plugin_swc_js_minimizer/src/lib.rs`](diffhunk://#diff-df5d31ca74393f8512c81cd6fbda52ba9329fe64fc3d550b8cc4bc840fa7a00eL135-R135): Updated `compilation` function to use `compilation.id()` for retrieving hooks.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
