### PR TITLE
feat(lazy-compilation): support module id for LazyCompilationProxyModule

### DIFF
--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -3,8 +3,9 @@ use std::{fmt::Debug, sync::Arc};
 
 use rspack_core::{
   ApplyContext, BoxModule, Compilation, CompilationId, CompilationParams, CompilerCompilation,
-  CompilerOptions, DependencyType, EntryDependency, Module, ModuleFactory, ModuleFactoryCreateData,
-  NormalModuleCreateData, NormalModuleFactoryModule, Plugin, PluginContext,
+  CompilerOptions, DependencyType, EntryDependency, LibIdentOptions, Module, ModuleFactory,
+  ModuleFactoryCreateData, NormalModuleCreateData, NormalModuleFactoryModule, Plugin,
+  PluginContext,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -156,6 +157,10 @@ async fn normal_module_factory_module(
 
   let mut backend = self.backend.lock().await;
   let module_identifier = module.identifier();
+
+  let lib_ident = module.lib_ident(LibIdentOptions {
+    context: module_factory_create_data.options.context.as_str(),
+  });
   let info = backend
     .module(
       module_identifier,
@@ -165,6 +170,7 @@ async fn normal_module_factory_module(
 
   *module = Box::new(LazyCompilationProxyModule::new(
     module_identifier,
+    lib_ident.map(|ident| ident.into_owned()),
     module_factory_create_data.clone(),
     create_data.resource_resolve_data.resource.clone(),
     self.cacheable,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Support more readable infomation when using lazy-compilation.

Before, the id of module that is lazy compiled is unreadable, eg: `?45ab`, now is module's `lib_ident` plus `!lazy-compilation-proxy`

![image](https://github.com/user-attachments/assets/fc9adf02-6821-4f72-99e8-b9127f29899d)


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
