### PR TITLE
refactor: build info save module asset

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -112,7 +112,6 @@ export declare class JsCompilation {
   deleteAssetSource(name: string): void
   getAssetFilenames(): Array<string>
   hasAsset(name: string): boolean
-  emitAssetFromLoader(filename: string, source: JsCompatSource, assetInfo: JsAssetInfo, module: string): void
   emitAsset(filename: string, source: JsCompatSource, assetInfo: JsAssetInfo): void
   deleteAsset(filename: string): void
   renameAsset(filename: string, newName: string): void
@@ -242,6 +241,7 @@ export declare class JsModule {
   libIdent(options: JsLibIdentOptions): string | null
   get resourceResolveData(): JsResourceData | undefined
   get matchResource(): string | undefined
+  emitFile(filename: string, source: JsCompatSource, assetInfo: JsAssetInfo): void
 }
 
 export declare class JsModuleGraph {
@@ -672,7 +672,6 @@ export interface JsExecuteModuleResult {
   buildDependencies: Array<string>
   missingDependencies: Array<string>
   cacheable: boolean
-  assets: Array<string>
   id: number
   error?: string
 }

--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -14,7 +14,6 @@ use rspack_core::rspack_sources::BoxSource;
 use rspack_core::AssetInfo;
 use rspack_core::BoxDependency;
 use rspack_core::Compilation;
-use rspack_core::CompilationAsset;
 use rspack_core::CompilationId;
 use rspack_core::EntryDependency;
 use rspack_core::EntryOptions;
@@ -321,29 +320,6 @@ impl JsCompilation {
     let compilation = self.as_ref()?;
 
     Ok(compilation.assets().contains_key(&name))
-  }
-
-  #[napi]
-  pub fn emit_asset_from_loader(
-    &mut self,
-    filename: String,
-    source: JsCompatSource,
-    asset_info: JsAssetInfo,
-    module: String,
-  ) -> Result<()> {
-    let compilation = self.as_mut()?;
-
-    compilation.emit_asset(
-      filename.clone(),
-      CompilationAsset::new(Some(source.into()), asset_info.into()),
-    );
-
-    compilation
-      .module_assets
-      .entry(ModuleIdentifier::from(module))
-      .or_default()
-      .insert(filename);
-    Ok(())
   }
 
   #[napi]
@@ -676,7 +652,6 @@ impl JsCompilation {
           .into_iter()
           .map(|d| d.to_string_lossy().to_string())
           .collect(),
-        assets: res.assets.into_iter().collect(),
         id: res.id,
         error: res.error,
       };
@@ -884,7 +859,6 @@ pub struct JsExecuteModuleResult {
   pub build_dependencies: Vec<String>,
   pub missing_dependencies: Vec<String>,
   pub cacheable: bool,
-  pub assets: Vec<String>,
   pub id: u32,
   pub error: Option<String>,
 }

--- a/crates/rspack_binding_values/src/module.rs
+++ b/crates/rspack_binding_values/src/module.rs
@@ -4,9 +4,9 @@ use napi::JsString;
 use napi_derive::napi;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
-  BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, Compilation, CompilationId,
-  ExportsArgument, LibIdentOptions, Module, ModuleArgument, ModuleIdentifier, RuntimeModuleStage,
-  SourceType,
+  BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, Compilation, CompilationAsset,
+  CompilationId, ExportsArgument, LibIdentOptions, Module, ModuleArgument, ModuleIdentifier,
+  RuntimeModuleStage, SourceType,
 };
 use rspack_napi::{napi::bindgen_prelude::*, threadsafe_function::ThreadsafeFunction, OneShotRef};
 use rspack_plugin_runtime::RuntimeModuleFromJs;
@@ -15,7 +15,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use super::JsCompatSourceOwned;
 use crate::{
-  JsChunkWrapper, JsCodegenerationResults, JsCompatSource, JsDependenciesBlockWrapper,
+  JsAssetInfo, JsChunkWrapper, JsCodegenerationResults, JsCompatSource, JsDependenciesBlockWrapper,
   JsDependencyWrapper, JsResourceData, ToJsCompatSource,
 };
 
@@ -324,6 +324,22 @@ impl JsModule {
       },
       None => Either::B(()),
     })
+  }
+
+  #[napi]
+  pub fn emit_file(
+    &mut self,
+    filename: String,
+    source: JsCompatSource,
+    asset_info: JsAssetInfo,
+  ) -> napi::Result<()> {
+    let module = self.as_mut()?;
+
+    module.build_info_mut().assets.insert(
+      filename,
+      CompilationAsset::new(Some(source.into()), asset_info.into()),
+    );
+    Ok(())
   }
 }
 

--- a/crates/rspack_cacheable/src/with/as_preset/serde_json.rs
+++ b/crates/rspack_cacheable/src/with/as_preset/serde_json.rs
@@ -5,7 +5,7 @@ use rkyv::{
   with::{ArchiveWith, DeserializeWith, SerializeWith},
   Place,
 };
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use super::AsPreset;
 use crate::{DeserializeError, SerializeError};
@@ -15,6 +15,7 @@ pub struct SerdeJsonResolver {
   value: String,
 }
 
+// for Value
 impl ArchiveWith<Value> for AsPreset {
   type Archived = ArchivedString;
   type Resolver = SerdeJsonResolver;
@@ -45,6 +46,52 @@ where
 {
   #[inline]
   fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<Value, DeserializeError> {
+    serde_json::from_str(field)
+      .map_err(|_| DeserializeError::MessageError("deserialize serde_json value failed"))
+  }
+}
+
+// for Map<String, Value>
+impl ArchiveWith<Map<String, Value>> for AsPreset {
+  type Archived = ArchivedString;
+  type Resolver = SerdeJsonResolver;
+
+  #[inline]
+  fn resolve_with(
+    _field: &Map<String, Value>,
+    resolver: Self::Resolver,
+    out: Place<Self::Archived>,
+  ) {
+    let SerdeJsonResolver { inner, value } = resolver;
+    ArchivedString::resolve_from_str(&value, inner, out);
+  }
+}
+
+impl<S> SerializeWith<Map<String, Value>, S> for AsPreset
+where
+  S: Fallible<Error = SerializeError> + Writer,
+{
+  #[inline]
+  fn serialize_with(
+    field: &Map<String, Value>,
+    serializer: &mut S,
+  ) -> Result<Self::Resolver, SerializeError> {
+    let value = serde_json::to_string(field)
+      .map_err(|_| SerializeError::MessageError("serialize serde_json value failed"))?;
+    let inner = ArchivedString::serialize_from_str(&value, serializer)?;
+    Ok(SerdeJsonResolver { value, inner })
+  }
+}
+
+impl<D> DeserializeWith<ArchivedString, Map<String, Value>, D> for AsPreset
+where
+  D: Fallible<Error = DeserializeError>,
+{
+  #[inline]
+  fn deserialize_with(
+    field: &ArchivedString,
+    _: &mut D,
+  ) -> Result<Map<String, Value>, DeserializeError> {
     serde_json::from_str(field)
       .map_err(|_| DeserializeError::MessageError("deserialize serde_json value failed"))
   }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -12,7 +12,10 @@ use dashmap::DashSet;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use rayon::prelude::*;
-use rspack_cacheable::cacheable;
+use rspack_cacheable::{
+  cacheable,
+  with::{AsOption, AsPreset},
+};
 use rspack_collections::{
   DatabaseItem, Identifiable, IdentifierDashMap, IdentifierMap, IdentifierSet, UkeyMap, UkeySet,
 };
@@ -173,7 +176,6 @@ pub struct Compilation {
   pub entrypoints: IndexMap<String, ChunkGroupUkey>,
   pub async_entrypoints: Vec<ChunkGroupUkey>,
   assets: CompilationAssets,
-  pub module_assets: IdentifierMap<HashSet<String>>,
   pub emitted_assets: DashSet<String, BuildHasherDefault<FxHasher>>,
   diagnostics: Vec<Diagnostic>,
   logging: CompilationLogging,
@@ -296,7 +298,6 @@ impl Compilation {
       entrypoints: Default::default(),
       async_entrypoints: Default::default(),
       assets: Default::default(),
-      module_assets: Default::default(),
       emitted_assets: Default::default(),
       diagnostics: Default::default(),
       logging: Default::default(),
@@ -618,7 +619,6 @@ impl Compilation {
     filename: &str,
     updater: impl FnOnce(BoxSource, AssetInfo) -> Result<(BoxSource, AssetInfo)>,
   ) -> Result<()> {
-    // Safety: we don't move anything from compilation
     let assets = &mut self.assets;
 
     let (new_source, new_info) = match assets.remove(filename) {
@@ -996,29 +996,39 @@ impl Compilation {
 
   #[instrument("Compilation:create_module_assets", skip_all)]
   async fn create_module_assets(&mut self, _plugin_driver: SharedPluginDriver) {
-    let mut temp = vec![];
-    for (module_identifier, assets) in self.module_assets.iter() {
+    let mut chunk_asset_map = vec![];
+    let mut module_assets = vec![];
+    let mg = self.get_module_graph();
+    for (identifier, module) in mg.modules() {
+      let assets = &module.build_info().assets;
+      if assets.is_empty() {
+        continue;
+      }
+
+      for (name, asset) in assets {
+        module_assets.push((name.clone(), asset.clone()));
+      }
       // assets of executed modules are not in this compilation
       if self
         .chunk_graph
         .chunk_graph_module_by_module_identifier
-        .contains_key(module_identifier)
+        .contains_key(&identifier)
       {
-        for chunk in self
-          .chunk_graph
-          .get_module_chunks(*module_identifier)
-          .iter()
-        {
-          for asset in assets {
-            temp.push((*chunk, asset.clone()))
+        for chunk in self.chunk_graph.get_module_chunks(identifier).iter() {
+          for (name, _) in assets {
+            chunk_asset_map.push((*chunk, name.clone()))
           }
         }
       }
     }
 
-    for (chunk, asset) in temp {
+    for (name, asset) in module_assets {
+      self.emit_asset(name, asset);
+    }
+
+    for (chunk, asset_name) in chunk_asset_map {
       let chunk = self.chunk_by_ukey.expect_get_mut(&chunk);
-      chunk.add_auxiliary_file(asset);
+      chunk.add_auxiliary_file(asset_name);
     }
   }
 
@@ -2260,8 +2270,10 @@ impl Compilation {
 
 pub type CompilationAssets = HashMap<String, CompilationAsset>;
 
+#[cacheable]
 #[derive(Debug, Clone)]
 pub struct CompilationAsset {
+  #[cacheable(with=AsOption<AsPreset>)]
   pub source: Option<BoxSource>,
   pub info: AssetInfo,
 }
@@ -2302,6 +2314,7 @@ impl CompilationAsset {
   }
 }
 
+#[cacheable]
 #[derive(Debug, Default, Clone)]
 pub struct AssetInfo {
   /// if the asset can be long term cached forever (contains a hash)
@@ -2339,6 +2352,7 @@ pub struct AssetInfo {
   /// But Napi.rs does not support Intersectiont types. This is a hack to store the additional fields
   /// in the rust struct and have the Js side to reshape and align with webpack.
   /// Related: packages/rspack/src/Compilation.ts
+  #[cacheable(with=AsPreset)]
   pub extras: serde_json::Map<String, serde_json::Value>,
   /// whether this asset is over the size limit
   pub is_over_size_limit: Option<bool>,
@@ -2437,6 +2451,7 @@ impl AssetInfo {
   }
 }
 
+#[cacheable]
 #[derive(Debug, Default, Clone)]
 pub struct AssetInfoRelated {
   pub source_map: Option<String>,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1015,7 +1015,7 @@ impl Compilation {
         .contains_key(&identifier)
       {
         for chunk in self.chunk_graph.get_module_chunks(identifier).iter() {
-          for (name, _) in assets {
+          for name in assets.keys() {
             chunk_asset_map.push((*chunk, name.clone()))
           }
         }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -608,6 +608,12 @@ impl Module for ConcatenatedModule {
       } else {
         self.build_info.top_level_declarations = None;
       }
+
+      // populate assets
+      self
+        .build_info
+        .assets
+        .extend(module_build_info.assets.clone());
     }
     // return a dummy result is enough, since we don't build the ConcatenatedModule in make phase
     Ok(BuildResult::default())

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -19,17 +19,17 @@ use rspack_sources::Source;
 use rspack_util::atom::Atom;
 use rspack_util::ext::{AsAny, DynHash};
 use rspack_util::source_map::ModuleSourceMapConfig;
-use rustc_hash::FxHashSet as HashSet;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use serde::Serialize;
 
 use crate::concatenated_module::ConcatenatedModule;
 use crate::dependencies_block::dependencies_block_update_hash;
 use crate::{
   AsyncDependenciesBlock, BoxDependency, ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation,
-  CompilationId, CompilerOptions, ConcatenationScope, ConnectionState, Context, ContextModule,
-  DependenciesBlock, DependencyId, DependencyTemplate, ExportInfoProvided, ExternalModule,
-  ModuleDependency, ModuleGraph, ModuleLayer, ModuleType, NormalModule, RawModule, Resolve,
-  ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver, SourceType,
+  CompilationAsset, CompilationId, CompilerOptions, ConcatenationScope, ConnectionState, Context,
+  ContextModule, DependenciesBlock, DependencyId, DependencyTemplate, ExportInfoProvided,
+  ExternalModule, ModuleDependency, ModuleGraph, ModuleLayer, ModuleType, NormalModule, RawModule,
+  Resolve, ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver, SourceType,
 };
 
 pub struct BuildContext {
@@ -67,6 +67,7 @@ pub struct BuildInfo {
   #[cacheable(with=AsOption<AsVec<AsPreset>>)]
   pub top_level_declarations: Option<HashSet<Atom>>,
   pub module_concatenation_bailout: Option<String>,
+  pub assets: HashMap<String, CompilationAsset>,
 }
 
 impl Default for BuildInfo {
@@ -85,6 +86,7 @@ impl Default for BuildInfo {
       json_data: None,
       top_level_declarations: None,
       module_concatenation_bailout: None,
+      assets: Default::default(),
     }
   }
 }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -767,7 +767,7 @@ impl<'a> ModuleGraph<'a> {
     if let Some(res) = active_partial.modules.get_mut(identifier) {
       res.as_mut()
     } else {
-      panic!("can not find module in active_partial")
+      None
     }
   }
 

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -891,12 +891,11 @@ impl Stats<'_> {
       stats.assets = if executed {
         None
       } else {
-        let mut assets = self
-          .compilation
-          .module_assets
-          .get(&identifier)
-          .map(|files| files.iter().map(|i| i.to_string()).collect_vec())
-          .unwrap_or_default();
+        let mg = self.compilation.get_module_graph();
+        let module = mg
+          .module_by_identifier(&identifier)
+          .expect("should have module");
+        let mut assets = module.build_info().assets.keys().cloned().collect_vec();
         assets.sort();
         Some(assets)
       };

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -613,17 +613,6 @@ impl ModuleConcatenationPlugin {
       config.runtime.clone(),
       compilation,
     );
-    let new_module_assets: HashSet<String> =
-      modules_set.iter().fold(HashSet::default(), |mut acc, id| {
-        acc.extend(
-          compilation
-            .module_assets
-            .get(id)
-            .cloned()
-            .unwrap_or_default(),
-        );
-        acc
-      });
     new_module
       .build(
         rspack_core::BuildContext {
@@ -716,11 +705,8 @@ impl ModuleConcatenationPlugin {
         };
       !inner_connection
     });
-    let id = new_module.id();
     module_graph.add_module(new_module.boxed());
     compilation.chunk_graph = chunk_graph;
-    compilation.module_assets.insert(id, new_module_assets);
-
     Ok(())
   }
 

--- a/packages/rspack-test-tools/tests/cacheCases/common/module-asset/file.js
+++ b/packages/rspack-test-tools/tests/cacheCases/common/module-asset/file.js
@@ -1,0 +1,7 @@
+export default 1;
+---
+export default 2;
+---
+export default 3;
+---
+export default 4;

--- a/packages/rspack-test-tools/tests/cacheCases/common/module-asset/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/common/module-asset/index.js
@@ -1,0 +1,15 @@
+import value from "./file";
+
+it("should basic test work", async () => {
+	if (COMPILER_INDEX == 0) {
+		expect(value).toBe(1);
+		await NEXT_HMR();
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(value).toBe(3);
+		await NEXT_HMR();
+		expect(value).toBe(4);
+	}
+});

--- a/packages/rspack-test-tools/tests/cacheCases/common/module-asset/loader.js
+++ b/packages/rspack-test-tools/tests/cacheCases/common/module-asset/loader.js
@@ -1,0 +1,4 @@
+module.exports = function (content) {
+	this.emitFile("a.txt", "123");
+	return content;
+};

--- a/packages/rspack-test-tools/tests/cacheCases/common/module-asset/rspack.config.js
+++ b/packages/rspack-test-tools/tests/cacheCases/common/module-asset/rspack.config.js
@@ -1,0 +1,30 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	entry: "./index.js",
+	module: {
+		rules: [
+			{
+				test: /index\.js$/,
+				loader: "./loader.js"
+			}
+		]
+	},
+	experiments: {
+		cache: {
+			type: "persistent"
+		}
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.done.tap("Test", function (stats) {
+					let s = stats.toJson({
+						assets: true
+					});
+					expect(s.assets.some(item => item.name === "a.txt")).toBeTruthy();
+				});
+			}
+		}
+	]
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/interop-test/plugin.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/interop-test/plugin.js
@@ -130,6 +130,10 @@ module.exports = class GenerateCasesPlugin {
       )
       .sort(comparator);
     compiler.hooks.beforeCompile.tapPromise(GenerateCasesPlugin.name, async () => {
+      // clean
+      await fs.promises.rm(extEntryFile, { force: true });
+      await fs.promises.rm(extDir, { recursive: true, force: true });
+      // init
       await fs.promises.mkdir(extDir);
       await Promise.all(modules.map(moduleName => fs.promises.mkdir(path.resolve(extDir, moduleName))));
       const imports = await Promise.all(

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -626,8 +626,6 @@ export class Compilation {
     // @internal
     __internal__deleteAssetSource(filename: string): void;
     // @internal
-    __internal__emit_asset_from_loader(filename: string, source: Source, assetInfo: AssetInfo, module: string): void;
-    // @internal
     __internal__getAssetFilenames(): string[];
     // @internal
     __internal__getAssetSource(filename: string): Source | void;
@@ -3749,6 +3747,8 @@ export class Module {
     readonly context?: string;
     // (undocumented)
     readonly dependencies: Dependency[];
+    // (undocumented)
+    emitFile(filename: string, source: Source, assetInfo: AssetInfo): void;
     // (undocumented)
     readonly factoryMeta?: JsFactoryMeta;
     // (undocumented)

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -622,25 +622,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		);
 	}
 
-	/**
-	 * Note: This is not a webpack public API, maybe removed in future.
-	 *
-	 * @internal
-	 */
-	__internal__emit_asset_from_loader(
-		filename: string,
-		source: Source,
-		assetInfo: AssetInfo,
-		module: string
-	) {
-		this.#inner.emitAssetFromLoader(
-			filename,
-			JsSource.__to_binding(source),
-			JsAssetInfo.__to_binding(assetInfo),
-			module
-		);
-	}
-
 	deleteAsset(filename: string) {
 		this.#inner.deleteAsset(filename);
 	}

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -12,6 +12,7 @@ import type { Source } from "webpack-sources";
 import { DependenciesBlock } from "./DependenciesBlock";
 import { Dependency } from "./Dependency";
 import { JsSource } from "./util/source";
+import { type AssetInfo, JsAssetInfo } from "./util/AssetInfo";
 
 export type ResourceData = {
 	resource: string;
@@ -360,6 +361,14 @@ export class Module {
 
 	libIdent(options: JsLibIdentOptions): string | null {
 		return this.#inner.libIdent(options);
+	}
+
+	emitFile(filename: string, source: Source, assetInfo: AssetInfo) {
+		return this.#inner.emitFile(
+			filename,
+			JsSource.__to_binding(source),
+			JsAssetInfo.__to_binding(assetInfo)
+		);
 	}
 }
 

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -11,8 +11,8 @@ import type { Source } from "webpack-sources";
 
 import { DependenciesBlock } from "./DependenciesBlock";
 import { Dependency } from "./Dependency";
-import { JsSource } from "./util/source";
 import { type AssetInfo, JsAssetInfo } from "./util/AssetInfo";
+import { JsSource } from "./util/source";
 
 export type ResourceData = {
 	resource: string;

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -730,12 +730,7 @@ export async function runLoaders(
 				content
 			);
 		}
-		compiler._lastCompilation!.__internal__emit_asset_from_loader(
-			name,
-			source!,
-			assetInfo!,
-			context._moduleIdentifier
-		);
+		loaderContext._module.emitFile(name, source!, assetInfo!);
 	};
 	loaderContext.fs = compiler.inputFileSystem;
 	loaderContext.experiments = {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. move module assets to module.build_info.
``` rust
struct BuildInfo {
  ..
  assets: HashMap<String, CompilationAsset>
}
```

2. compilaiton.create_module_assets emit module asset to compilation.assets
``` rust
impl Compilation {
  fn create_module_assets(&mut self) {
    for (mid, m) in mg.modules() {
       for (filename, asset) in m.build_info().assets {
         self.emit_asset(filename.clone(), asset.clone())
       }
    }
  }
}
```


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
