### PR TITLE
fix(deps): ⬆️ rspack_resolver 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5384,9 +5384,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0fac1113e5d3c710cac34ddac23a58d7615cd5f7098f7b553ddb3a20dfedc6"
+checksum = "fa7be13888a4d57ed3992c6c17438f284643b69cc67e3a36cbdd61e3f6a6fe38"
 dependencies = [
  "cfg-if",
  "dashmap 6.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ quote              = { version = "1.0.38" }
 rayon              = { version = "1.10.0" }
 regex              = { version = "1.11.1" }
 ropey              = "1.6.1"
-rspack_resolver    = { features = ["package_json_raw_json_api"], version = "0.5.0" }
+rspack_resolver    = { features = ["package_json_raw_json_api"], version = "0.5.1" }
 rspack_sources     = { version = "0.4.4" }
 rustc-hash         = { version = "2.1.0" }
 serde              = { version = "1.0.217" }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
close https://github.com/web-infra-dev/rspack/issues/9224
close https://github.com/web-infra-dev/rspack/issues/9183
close https://github.com/web-infra-dev/rspack/issues/9135

The root cause is that rspack resolver unexpectedly enables yarn's pnp mode by default; if there is a `.pnp.cjs` file in the parent folder (or parent of parent folder),  resolving will fail.

In rspack_resolver@0.5.1 the pnp feature is enabled by respecting `options.enable_pnp`, thus disabled by default in rspack.


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).

