### PR TITLE
refactor: add compilation id to html hook data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ rspack_sources     = { version = "0.4.4" }
 rustc-hash         = { version = "2.1.0" }
 serde              = { version = "1.0.217" }
 serde_json         = { version = "1.0.134" }
+sha2               = { version = "0.10.8" }
 simd-json          = { version = "0.14.3" }
 smol_str           = { version = "0.3.0" }
 stacker            = { version = "0.1.17" }

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -412,6 +412,7 @@ export interface JsAdditionalTreeRuntimeRequirementsResult {
 
 export interface JsAfterEmitData {
   outputName: string
+  compilationId: number
 }
 
 export interface JsAfterResolveData {
@@ -429,6 +430,7 @@ export interface JsAfterTemplateExecutionData {
   headTags: Array<JsHtmlPluginTag>
   bodyTags: Array<JsHtmlPluginTag>
   outputName: string
+  compilationId: number
 }
 
 export interface JsAlterAssetTagGroupsData {
@@ -436,12 +438,14 @@ export interface JsAlterAssetTagGroupsData {
   bodyTags: Array<JsHtmlPluginTag>
   publicPath: string
   outputName: string
+  compilationId: number
 }
 
 export interface JsAlterAssetTagsData {
   assetTags: JsHtmlPluginAssetTags
   outputName: string
   publicPath: string
+  compilationId: number
 }
 
 export interface JsAsset {
@@ -509,11 +513,13 @@ export interface JsBannerContentFnCtx {
 export interface JsBeforeAssetTagGenerationData {
   assets: JsHtmlPluginAssets
   outputName: string
+  compilationId: number
 }
 
 export interface JsBeforeEmitData {
   html: string
   outputName: string
+  compilationId: number
 }
 
 export interface JsBeforeResolveArgs {
@@ -692,6 +698,8 @@ export interface JsHtmlPluginAssets {
   js: Array<string>
   css: Array<string>
   favicon?: string
+  jsIntegrity?: Array<string | undefined | null>
+  cssIntegrity?: Array<string | undefined | null>
 }
 
 export interface JsHtmlPluginAssetTags {

--- a/crates/rspack_binding_values/src/html.rs
+++ b/crates/rspack_binding_values/src/html.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use cow_utils::CowUtils;
 use napi::Either;
 use napi_derive::napi;
+use rspack_core::CompilationId;
 use rspack_plugin_html::{
   asset::{HtmlPluginAssetTags, HtmlPluginAssets},
   tag::{HtmlPluginAttribute, HtmlPluginTag},
@@ -85,6 +86,8 @@ pub struct JsHtmlPluginAssets {
   pub css: Vec<String>,
   pub favicon: Option<String>,
   // manifest: Option<String>,
+  pub js_integrity: Option<Vec<Option<String>>>,
+  pub css_integrity: Option<Vec<Option<String>>>,
 }
 
 impl From<HtmlPluginAssets> for JsHtmlPluginAssets {
@@ -94,6 +97,8 @@ impl From<HtmlPluginAssets> for JsHtmlPluginAssets {
       js: value.js,
       css: value.css,
       favicon: value.favicon,
+      js_integrity: value.js_integrity,
+      css_integrity: value.css_integrity,
     }
   }
 }
@@ -105,6 +110,8 @@ impl From<JsHtmlPluginAssets> for HtmlPluginAssets {
       js: value.js,
       css: value.css,
       favicon: value.favicon,
+      js_integrity: value.js_integrity,
+      css_integrity: value.css_integrity,
     }
   }
 }
@@ -113,6 +120,7 @@ impl From<JsHtmlPluginAssets> for HtmlPluginAssets {
 pub struct JsBeforeAssetTagGenerationData {
   pub assets: JsHtmlPluginAssets,
   pub output_name: String,
+  pub compilation_id: u32,
 }
 
 impl From<JsBeforeAssetTagGenerationData> for BeforeAssetTagGenerationData {
@@ -120,6 +128,7 @@ impl From<JsBeforeAssetTagGenerationData> for BeforeAssetTagGenerationData {
     Self {
       assets: value.assets.into(),
       output_name: value.output_name,
+      compilation_id: CompilationId(value.compilation_id),
     }
   }
 }
@@ -129,6 +138,7 @@ impl From<BeforeAssetTagGenerationData> for JsBeforeAssetTagGenerationData {
     Self {
       assets: value.assets.into(),
       output_name: value.output_name,
+      compilation_id: value.compilation_id.0,
     }
   }
 }
@@ -189,6 +199,7 @@ pub struct JsAlterAssetTagsData {
   pub asset_tags: JsHtmlPluginAssetTags,
   pub output_name: String,
   pub public_path: String,
+  pub compilation_id: u32,
 }
 
 impl From<AlterAssetTagsData> for JsAlterAssetTagsData {
@@ -197,6 +208,7 @@ impl From<AlterAssetTagsData> for JsAlterAssetTagsData {
       asset_tags: value.asset_tags.into(),
       output_name: value.output_name,
       public_path: value.public_path,
+      compilation_id: value.compilation_id.0,
     }
   }
 }
@@ -207,6 +219,7 @@ impl From<JsAlterAssetTagsData> for AlterAssetTagsData {
       asset_tags: value.asset_tags.into(),
       output_name: value.output_name,
       public_path: value.public_path,
+      compilation_id: CompilationId(value.compilation_id),
     }
   }
 }
@@ -217,6 +230,7 @@ pub struct JsAlterAssetTagGroupsData {
   pub body_tags: Vec<JsHtmlPluginTag>,
   pub public_path: String,
   pub output_name: String,
+  pub compilation_id: u32,
 }
 
 impl From<AlterAssetTagGroupsData> for JsAlterAssetTagGroupsData {
@@ -234,6 +248,7 @@ impl From<AlterAssetTagGroupsData> for JsAlterAssetTagGroupsData {
         .collect::<Vec<_>>(),
       public_path: value.public_path,
       output_name: value.output_name,
+      compilation_id: value.compilation_id.0,
     }
   }
 }
@@ -253,6 +268,7 @@ impl From<JsAlterAssetTagGroupsData> for AlterAssetTagGroupsData {
         .collect::<Vec<_>>(),
       public_path: value.public_path,
       output_name: value.output_name,
+      compilation_id: CompilationId(value.compilation_id),
     }
   }
 }
@@ -263,6 +279,7 @@ pub struct JsAfterTemplateExecutionData {
   pub head_tags: Vec<JsHtmlPluginTag>,
   pub body_tags: Vec<JsHtmlPluginTag>,
   pub output_name: String,
+  pub compilation_id: u32,
 }
 
 impl From<AfterTemplateExecutionData> for JsAfterTemplateExecutionData {
@@ -280,6 +297,7 @@ impl From<AfterTemplateExecutionData> for JsAfterTemplateExecutionData {
         .map(JsHtmlPluginTag::from)
         .collect::<Vec<_>>(),
       output_name: value.output_name,
+      compilation_id: value.compilation_id.0,
     }
   }
 }
@@ -299,6 +317,7 @@ impl From<JsAfterTemplateExecutionData> for AfterTemplateExecutionData {
         .map(HtmlPluginTag::from)
         .collect::<Vec<_>>(),
       output_name: value.output_name,
+      compilation_id: CompilationId(value.compilation_id),
     }
   }
 }
@@ -307,6 +326,7 @@ impl From<JsAfterTemplateExecutionData> for AfterTemplateExecutionData {
 pub struct JsBeforeEmitData {
   pub html: String,
   pub output_name: String,
+  pub compilation_id: u32,
 }
 
 impl From<BeforeEmitData> for JsBeforeEmitData {
@@ -314,6 +334,7 @@ impl From<BeforeEmitData> for JsBeforeEmitData {
     Self {
       html: value.html,
       output_name: value.output_name,
+      compilation_id: value.compilation_id.0,
     }
   }
 }
@@ -323,6 +344,7 @@ impl From<JsBeforeEmitData> for BeforeEmitData {
     Self {
       html: value.html,
       output_name: value.output_name,
+      compilation_id: CompilationId(value.compilation_id),
     }
   }
 }
@@ -330,12 +352,14 @@ impl From<JsBeforeEmitData> for BeforeEmitData {
 #[napi(object)]
 pub struct JsAfterEmitData {
   pub output_name: String,
+  pub compilation_id: u32,
 }
 
 impl From<AfterEmitData> for JsAfterEmitData {
   fn from(value: AfterEmitData) -> Self {
     Self {
       output_name: value.output_name,
+      compilation_id: value.compilation_id.0,
     }
   }
 }
@@ -344,6 +368,7 @@ impl From<JsAfterEmitData> for AfterEmitData {
   fn from(value: JsAfterEmitData) -> Self {
     Self {
       output_name: value.output_name,
+      compilation_id: CompilationId(value.compilation_id),
     }
   }
 }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -130,7 +130,7 @@ pub struct CompilationHooks {
 
 #[cacheable]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct CompilationId(u32);
+pub struct CompilationId(pub u32);
 
 impl CompilationId {
   pub fn new() -> Self {

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -195,7 +195,7 @@ impl From<&str> for WasmLoadingType {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CrossOriginLoading {
   Disable,
   Enable(String),

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -25,7 +25,7 @@ rspack_paths      = { workspace = true }
 rspack_util       = { workspace = true }
 serde             = { workspace = true, features = ["derive"] }
 serde_json        = { workspace = true }
-sha2              = "0.10.8"
+sha2              = { workspace = true }
 sugar_path        = { workspace = true }
 swc_core          = { workspace = true }
 swc_html          = { workspace = true }

--- a/crates/rspack_plugin_html/src/asset.rs
+++ b/crates/rspack_plugin_html/src/asset.rs
@@ -35,6 +35,8 @@ pub struct HtmlPluginAssets {
   pub css: Vec<String>,
   pub favicon: Option<String>,
   // manifest: Option<String>,
+  pub js_integrity: Option<Vec<Option<String>>>,
+  pub css_integrity: Option<Vec<Option<String>>>,
 }
 
 impl HtmlPluginAssets {
@@ -45,7 +47,7 @@ impl HtmlPluginAssets {
     output_path: &Utf8PathBuf,
     html_file_name: &Filename<NoFilenameFn>,
   ) -> (HtmlPluginAssets, HashMap<String, &'a CompilationAsset>) {
-    let mut assets = HtmlPluginAssets::default();
+    let mut assets: HtmlPluginAssets = HtmlPluginAssets::default();
     let mut asset_map = HashMap::new();
     assets.public_path = public_path.to_string();
 

--- a/crates/rspack_plugin_html/src/drive.rs
+++ b/crates/rspack_plugin_html/src/drive.rs
@@ -1,3 +1,4 @@
+use rspack_core::CompilationId;
 use rspack_hook::define_hook;
 
 use crate::{
@@ -9,6 +10,7 @@ use crate::{
 pub struct BeforeAssetTagGenerationData {
   pub assets: HtmlPluginAssets,
   pub output_name: String,
+  pub compilation_id: CompilationId,
 }
 
 #[derive(Clone, Debug)]
@@ -16,6 +18,7 @@ pub struct AlterAssetTagsData {
   pub asset_tags: HtmlPluginAssetTags,
   pub output_name: String,
   pub public_path: String,
+  pub compilation_id: CompilationId,
 }
 
 #[derive(Clone, Debug)]
@@ -24,6 +27,7 @@ pub struct AlterAssetTagGroupsData {
   pub body_tags: Vec<HtmlPluginTag>,
   pub public_path: String,
   pub output_name: String,
+  pub compilation_id: CompilationId,
 }
 
 #[derive(Clone, Debug)]
@@ -32,17 +36,20 @@ pub struct AfterTemplateExecutionData {
   pub head_tags: Vec<HtmlPluginTag>,
   pub body_tags: Vec<HtmlPluginTag>,
   pub output_name: String,
+  pub compilation_id: CompilationId,
 }
 
 #[derive(Clone, Debug)]
 pub struct BeforeEmitData {
   pub html: String,
   pub output_name: String,
+  pub compilation_id: CompilationId,
 }
 
 #[derive(Clone, Debug)]
 pub struct AfterEmitData {
   pub output_name: String,
+  pub compilation_id: CompilationId,
 }
 
 define_hook!(HtmlPluginBeforeAssetTagGeneration: AsyncSeriesWaterfall(data: BeforeAssetTagGenerationData) -> BeforeAssetTagGenerationData);

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -87,6 +87,7 @@ async fn generate_html(
     .call(BeforeAssetTagGenerationData {
       assets: assets_info.0,
       output_name: html_file_name.as_str().to_string(),
+      compilation_id: compilation.id(),
     })
     .await?;
 
@@ -99,6 +100,7 @@ async fn generate_html(
       asset_tags,
       public_path: public_path.clone(),
       output_name: html_file_name.as_str().to_string(),
+      compilation_id: compilation.id(),
     })
     .await?;
 
@@ -112,6 +114,7 @@ async fn generate_html(
       body_tags,
       public_path: public_path.clone(),
       output_name: html_file_name.as_str().to_string(),
+      compilation_id: compilation.id(),
     })
     .await?;
 
@@ -135,6 +138,7 @@ async fn generate_html(
       head_tags: alter_asset_tag_groups_data.head_tags,
       body_tags: alter_asset_tag_groups_data.body_tags,
       output_name: html_file_name.as_str().to_string(),
+      compilation_id: compilation.id(),
     })
     .await?;
 
@@ -234,6 +238,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       .call(BeforeEmitData {
         html,
         output_name: output_file_name.as_str().to_string(),
+        compilation_id: compilation.id(),
       })
       .await?;
 
@@ -261,6 +266,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       .after_emit
       .call(AfterEmitData {
         output_name: html_asset.0.to_string(),
+        compilation_id: compilation.id(),
       })
       .await?;
   }

--- a/packages/rspack/src/builtin-plugin/html-plugin/taps.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/taps.ts
@@ -15,7 +15,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsBeforeAssetTagGenerationData) {
-					return await queried.promise({
+					const compilationId = data.compilationId;
+					const res = await queried.promise({
 						...data,
 						plugin: {
 							options:
@@ -24,6 +25,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 								) || {}
 						}
 					});
+					res.compilationId = compilationId;
+					return res;
 				};
 			}
 		),
@@ -36,7 +39,10 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsAlterAssetTagsData) {
-					return await queried.promise(data);
+					const compilationId = data.compilationId;
+					const res = await queried.promise(data);
+					res.compilationId = compilationId;
+					return res;
 				};
 			}
 		),
@@ -49,7 +55,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsAlterAssetTagGroupsData) {
-					return await queried.promise({
+					const compilationId = data.compilationId;
+					const res = await queried.promise({
 						...data,
 						plugin: {
 							options:
@@ -58,6 +65,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 								) || {}
 						}
 					});
+					res.compilationId = compilationId;
+					return res;
 				};
 			}
 		),
@@ -70,7 +79,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsAfterTemplateExecutionData) {
-					return await queried.promise({
+					const compilationId = data.compilationId;
+					const res = await queried.promise({
 						...data,
 						plugin: {
 							options:
@@ -79,6 +89,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 								) || {}
 						}
 					});
+					res.compilationId = compilationId;
+					return res;
 				};
 			}
 		),
@@ -91,7 +103,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsBeforeEmitData) {
-					return await queried.promise({
+					const compilationId = data.compilationId;
+					const res = await queried.promise({
 						...data,
 						plugin: {
 							options:
@@ -100,6 +113,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 								) || {}
 						}
 					});
+					res.compilationId = compilationId;
+					return res;
 				};
 			}
 		),
@@ -112,7 +127,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsAfterEmitData) {
-					return await queried.promise({
+					const compilationId = data.compilationId;
+					const res = await queried.promise({
 						...data,
 						plugin: {
 							options:
@@ -121,6 +137,8 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 								) || {}
 						}
 					});
+					res.compilationId = compilationId;
+					return res;
 				};
 			}
 		)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Relate to https://github.com/web-infra-dev/rspack/issues/4381

Add compilation id to data structures of html plugin hooks.

---

This pull request includes several changes to the `rspack` project, primarily focusing on adding support for integrity attributes and incorporating `CompilationId` in various structures. The most important changes are summarized below:

### Dependency Updates:
* Added the `sha2` crate to the `Cargo.toml` file. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R74) [[2]](diffhunk://#diff-ff5d3405535927b7df3b3d04126df21b25ff5576d92e57440a7c91b0b112810cL28-R28)

### Code Enhancements:
* Introduced `CompilationId` in the `rspack_core` crate and updated its visibility to `pub`. [[1]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR6) [[2]](diffhunk://#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L133-R133)
* Updated various structures in the `rspack_binding_values` crate to include `compilation_id` and integrity attributes for assets. [[1]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR89-R90) [[2]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR100-R101) [[3]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR113-R114) [[4]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR123-R131) [[5]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR141) [[6]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR202) [[7]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR211) [[8]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR222) [[9]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR233) [[10]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR251) [[11]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR271) [[12]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR282) [[13]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR300) [[14]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR320) [[15]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR329-R337) [[16]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR347-R362) [[17]](diffhunk://#diff-d63651f60ea732097aa6b9c63bf329e9c4b1bda6ef71e7ceec7d87ba5ece14aeR371)

### Plugin Enhancements:
* Updated the `rspack_plugin_html` crate to integrate `CompilationId` in its data structures and functions. [[1]](diffhunk://#diff-6897473554428c6090db13d1ec17bc1f347bebd0795b49abd67c691693ac1e45R1) [[2]](diffhunk://#diff-6897473554428c6090db13d1ec17bc1f347bebd0795b49abd67c691693ac1e45R13-R21) [[3]](diffhunk://#diff-6897473554428c6090db13d1ec17bc1f347bebd0795b49abd67c691693ac1e45R30) [[4]](diffhunk://#diff-6897473554428c6090db13d1ec17bc1f347bebd0795b49abd67c691693ac1e45R39-R52) [[5]](diffhunk://#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcR90) [[6]](diffhunk://#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcR103) [[7]](diffhunk://#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcR117) [[8]](diffhunk://#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcR141) [[9]](diffhunk://#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcR241) [[10]](diffhunk://#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcR269)

### TypeScript Adjustments:
* Modified the `createHtmlPluginHooksRegisters` function in the `taps.ts` file to handle `compilationId` correctly. [[1]](diffhunk://#diff-21988f40eccade9de737cef5b34b86d85b762976c441575e39313f91f768bd05L18-R19) [[2]](diffhunk://#diff-21988f40eccade9de737cef5b34b86d85b762976c441575e39313f91f768bd05R28-R29) [[3]](diffhunk://#diff-21988f40eccade9de737cef5b34b86d85b762976c441575e39313f91f768bd05L39-R45)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
