### PR TITLE
docs: migrate all configuration examples to ESM or dual format

### DIFF
--- a/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
@@ -7,8 +7,8 @@ import ChunkType from '../../types/chunk.mdx';
 
 You can obtain these hooks like below:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   plugins: [
     {

--- a/website/docs/en/api/runtime-api/hmr.mdx
+++ b/website/docs/en/api/runtime-api/hmr.mdx
@@ -180,7 +180,7 @@ module.hot.accept('./dep', () => {
 
 A module can self-accept itself, but can invalidate itself when the change is not handleable:
 
-```javascript
+```js
 const VALUE = 'constant';
 
 export default VALUE;
@@ -201,7 +201,7 @@ if (
 
 **Triggering custom HMR updates**
 
-```javascript
+```js
 const moduleId = chooseAModule();
 const code = __webpack_modules__[moduleId].toString();
 __webpack_modules__[moduleId] = eval(`(${makeChanges(code)})`);

--- a/website/docs/en/blog/announcing-0-3.mdx
+++ b/website/docs/en/blog/announcing-0-3.mdx
@@ -17,8 +17,8 @@ Before Rspack fully supported `postcss-loader`, Rspack implemented `@rspack/post
 
 • Before:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   builtins: {
     postcss: {
       pxtorem: {
@@ -31,8 +31,8 @@ module.exports = {
 
 • After:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -64,8 +64,8 @@ module.exports = {
 
 To align better with webpack's CSS handling, Rspack removes the built-in autoprefixer functionality in 0.3. You can use `postcss-loader` to achieve `autoprefixer`.
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-You can refer to the [examples/postcss-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/postcss-loader/rspack.config.js) for a complete example.
+You can refer to the [examples/postcss-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/postcss-loader) for a complete example.
 
 ### Access to internal modules restricted
 

--- a/website/docs/en/blog/announcing-0-4.mdx
+++ b/website/docs/en/blog/announcing-0-4.mdx
@@ -32,8 +32,8 @@ This feature primarily addresses three categories of problems: [builtins](https:
 - [builtins.decorator](https://v0.rspack.dev/config/builtins#builtinsdecorator): moved to `jsc.parser.decorators`
 - [builtins.presetEnv](https://v0.rspack.dev/config/builtins#builtinspresetenv): moved to `jsc.env`
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -69,8 +69,8 @@ module.exports = {
 
 2. [target](/config/target) will not downgrade user-side code(including `node_modules`)
 
-```diff
-module.exports = {
+```diff title="rspack.config.mjs"
+export default {
   target: ["web", "es5"],
   module: {
     rules: [
@@ -118,11 +118,12 @@ Check out our previous discussion [here](https://github.com/web-infra-dev/rspack
 
 With `experiments.rspackFuture.disableTransformByDefault` is enabled by default in v0.4.0, `builtin.react.refresh` has also been deprecated. Now we recommend using `@rspack/plugin-react-refresh` to enable react fast refresh.
 
-```diff
-+ const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
+```diff title="rspack.config.mjs"
++ import ReactRefreshPlugin from '@rspack/plugin-react-refresh';
+
 const isDev = process.env.NODE_ENV === 'development';
 
-module.exports = {
+export default {
   // ...
   mode: isDev ? 'development' : 'production',
   module: {
@@ -156,7 +157,7 @@ module.exports = {
 -  },
   plugins: [
 +    isDev && new ReactRefreshPlugin()
-  ].filter(Boolean),
+  ],
 };
 ```
 
@@ -246,9 +247,10 @@ Currently, Rspack's internal plugins are divided into two categories:
 
 The original `builtins.define` can be migrated as follows:
 
-```diff
-+ const { rspack } = require("@rspack/core")
-module.exports = {
+```diff title="rspack.config.mjs"
++ import { rspack } from '@rspack/core';
+
+export default {
 -  builtins: {
 -    define: { process.env.NODE_ENV: JSON.stringify(process.env.NODE_ENV) }
 -  },
@@ -260,9 +262,10 @@ module.exports = {
 
 For `builtins.html`, it can be directly migrated to [HtmlRspackPlugin](/plugins/rspack/html-rspack-plugin):
 
-```diff
-+ const { rspack } = require("@rspack/core")
-module.exports = {
+```diff title="rspack.config.mjs"
++ import { rspack } from '@rspack/core';
+
+export default {
 -  builtins: {
 -    html: [{ template: "./index.html" }]
 -  },
@@ -274,9 +277,10 @@ module.exports = {
 
 When there are multiple configurations in `builtins.html`, multiple plugin instances can be created:
 
-```js
-const { rspack } = require('@rspack/core');
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   plugins: [
     new rspack.HtmlRspackPlugin({ template: './index.html' }),
     new rspack.HtmlRspackPlugin({ template: './foo.html' }),
@@ -288,9 +292,10 @@ For `builtins.copy`, it can be directly migrated to [CopyRspackPlugin](/plugins/
 
 For the original `builtins.minifyOptions`, we provide [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin):
 
-```js
-const { rspack } = require('@rspack/core');
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   optimization: {
     minimizer: [
       new rspack.SwcJsMinimizerRspackPlugin({

--- a/website/docs/en/blog/announcing-0-5.mdx
+++ b/website/docs/en/blog/announcing-0-5.mdx
@@ -37,8 +37,8 @@ In order to achieve old behavior, please remove `rule.type` or change it to `"ja
 
 To transform a `.jsx` file:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -61,8 +61,8 @@ module.exports = {
 
 To transform a `.tsx` file:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -85,8 +85,8 @@ module.exports = {
 
 To transform a `.ts` file:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -110,8 +110,8 @@ module.exports = {
 
 Rspack aligns [target](/config/target) with webpack. Instead of transforming arbitrary user code, Rspack now lets loaders control the transformation of user land code. To transform user land code to which your target environment(s) needed, add `env` to `builtin:swc-loader`:
 
-```diff
-module.exports = {
+```diff title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -140,8 +140,8 @@ module.exports = {
 
 In order to get the same behavior, change `resolve.extensions` to this:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   resolve: {
     extensions: ['...', '.tsx', '.ts', '.jsx'], // "..." means to extend from the default extensions
   },

--- a/website/docs/en/blog/announcing-0-6.mdx
+++ b/website/docs/en/blog/announcing-0-6.mdx
@@ -19,9 +19,10 @@ This is very useful in some scenarios, for example when the built-in CSS parser 
 
 For more details, please see [CssExtractRspackPlugin](/plugins/rspack/css-extract-rspack-plugin#cssextractrspackplugin).
 
-```js
-const { rspack } = require('@rspack/core');
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   plugins: [new rspack.CssExtractRspackPlugin()],
   module: {
     rules: [
@@ -114,8 +115,8 @@ WARNING in ⚠ chunk src_a_css-src_b_-5c8c53 [css-extract-rspack-plugin]
 
 If you are sure that their order inconsistency does not matter, you can ignore this error by configuring `ignoreWarnings`.
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   ignoreWarnings: [/Conflicting order/],
 };
 ```
@@ -126,11 +127,12 @@ module.exports = {
 
 If you have used `mini-css-extract-plugin` and webpack before, you can simply replace `mini-css-extract-plugin` by `rspack.CssExtractPlugin`.
 
-```diff
-+ const CssExtract = require('@rspack/core').CssExtractRspackPlugin;
-- const CssExtract = require('mini-css-extract-plugin');
-module.exports = {
-  plugins: [new CssExtract()],
+```diff title="rspack.config.mjs"
++ import { rspack } from '@rspack/core';
+- import CssExtract from 'mini-css-extract-plugin';
+
+export default {
+  plugins: [new rspack.CssExtractRspackPlugin()],
   module: {
     rules: [
       {
@@ -153,8 +155,8 @@ The above occurrences of `"css/auto"` are the default module type for CSS, which
 
 Add the following configuration to maintain the original default behavior of `builtins.css`, which can be modified as needed based on the following setup:
 
-```diff
-module.exports = {
+```diff title="rspack.config.mjs"
+export default {
    // ...
 +  module: {
 +    generator: {

--- a/website/docs/en/blog/announcing-1-1.mdx
+++ b/website/docs/en/blog/announcing-1-1.mdx
@@ -60,10 +60,10 @@ In a case of 10000 React components, the HMR becomes 38% faster:
 
 In Rspack v1.1 you can enable this feature in development mode by:
 
-```js title=rspack.config.js
+```js title="rspack.config.mjs"
 const isDev = process.env.NODE_ENV === 'development';
 
-module.exports = {
+export default {
   mode: isDev ? 'development' : 'production',
   experiments: {
     incremental: isDev,
@@ -83,7 +83,7 @@ In earlier versions of Rspack, the built-in [HtmlRspackPlugin](/plugins/rspack/h
 
 Therefore, we refactored `HtmlRspackPlugin`. While supporting most of the configuration options of `HtmlWebpackPlugin`, we also completed the alignment of `hooks`. Now you can get these hooks through `HtmlRspackPlugin.getCompilationHooks` and use them to modify the content of the HTML assets like below:
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const DeferPlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('DeferPlugin', compilation => {
@@ -100,7 +100,7 @@ const DeferPlugin = {
   },
 };
 
-module.exports = {
+export default {
   plugins: [new HtmlRspackPlugin(), DeferPlugin],
 };
 ```

--- a/website/docs/en/config/context.mdx
+++ b/website/docs/en/config/context.mdx
@@ -41,7 +41,7 @@ export default {
   </Tab>
   <Tab label="CJS">
 
-```js title="rspack.config.js"
+```js title="rspack.config.cjs"
 module.exports = {
   context: __dirname,
   entry: {

--- a/website/docs/en/config/dev-server.mdx
+++ b/website/docs/en/config/dev-server.mdx
@@ -916,9 +916,9 @@ export default {
   </Tab>
   <Tab label="CJS">
 
-```js title="rspack.config.js"
+```js title="rspack.config.cjs"
 const fs = require('fs');
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
   //...

--- a/website/docs/en/config/dev-server.mdx
+++ b/website/docs/en/config/dev-server.mdx
@@ -1,4 +1,5 @@
 import WebpackLicense from '@components/WebpackLicense';
+import { Tabs, Tab } from '@theme';
 
 <WebpackLicense from="https://webpack.js.org/configuration/dev-server/" />
 
@@ -257,8 +258,12 @@ To create a custom client implementation, create a class that extends BaseClient
 
 Using path to `CustomClient.js`, a custom WebSocket client implementation, along with the compatible `'ws'` server:
 
-```js title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export default {
   //...
   devServer: {
     client: {
@@ -271,8 +276,12 @@ module.exports = {
 
 Using custom, compatible WebSocket client and server implementations:
 
-```js title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export default {
   //...
   devServer: {
     client: {
@@ -819,7 +828,7 @@ export default {
 - **Type:** `'http' | 'https' | 'spdy' | string | object`
 - **Default:** `'http'`
 
-Allows to set server and options (by default 'http').
+Allows to set server and options (by default `'http'`).
 
 ```js title="rspack.config.mjs"
 export default {
@@ -875,7 +884,39 @@ export default {
 
 It also allows you to set additional [TLS options](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) like `minVersion` and you can directly pass the contents of respective files:
 
-```javascript title="rspack.config.js"
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
+  //...
+  devServer: {
+    server: {
+      type: 'https',
+      options: {
+        minVersion: 'TLSv1.1',
+        key: fs.readFileSync(path.join(__dirname, './server.key')),
+        pfx: fs.readFileSync(path.join(__dirname, './server.pfx')),
+        cert: fs.readFileSync(path.join(__dirname, './server.crt')),
+        ca: fs.readFileSync(path.join(__dirname, './ca.pem')),
+        passphrase: '@rspack/dev-server',
+        requestCert: true,
+      },
+    },
+  },
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.js"
 const fs = require('fs');
 const path = require('path');
 
@@ -897,6 +938,9 @@ module.exports = {
   },
 };
 ```
+
+  </Tab>
+</Tabs>
 
 ## devServer.setupMiddlewares
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -189,8 +189,8 @@ type ServerOptions =
   | (() => Server);
 ```
 
-```js title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   experiments: {
     lazyCompilation: {
       backend: {
@@ -712,7 +712,7 @@ export default {
 
 Sample migration code:
 
-```javascript
+```js
 function transform(webpackConfig, rspackConfig) {
   rspackConfig.experiments = rspackConfig.experiments || {};
   if (webpackConfig.cache === undefined) {

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -42,7 +42,7 @@ import $ from 'jquery';
 $('.my-element').animate(/* ... */);
 ```
 
-The property name `jquery` specified under `externals` in the above `rspack.config.js` indicates that the module `jquery` in `import $ from 'jquery'` should be excluded from bundling. In order to replace this module, the value `jQuery` will be used to retrieve a global `jQuery` variable, as the default external library type is `var`, see [externalsType](#externalstype).
+The property name `jquery` specified under `externals` in the above Rspack configuration indicates that the module `jquery` in `import $ from 'jquery'` should be excluded from bundling. In order to replace this module, the value `jQuery` will be used to retrieve a global `jQuery` variable, as the default external library type is `var`, see [externalsType](#externalstype).
 
 While we showed an example consuming external global variable above, the external can actually be available in any of these forms: global variable, CommonJS, AMD, ES2015 Module, see more in [externalsType](#externalstype).
 
@@ -587,8 +587,8 @@ import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   experiments: {
     outputModule: true,
   },

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -36,7 +36,7 @@ export default {
 
 This leaves any dependent modules unchanged, i.e. the code shown below will still work:
 
-```javascript
+```js
 import $ from 'jquery';
 
 $('.my-element').animate(/* ... */);
@@ -318,7 +318,7 @@ Specify the default type of externals as `'commonjs'`. Rspack will generate code
 
 **Example**
 
-```javascript
+```js
 import fs from 'fs-extra';
 ```
 
@@ -334,7 +334,7 @@ export default {
 
 Will generate into something like:
 
-```javascript
+```js
 const fs = require('fs-extra');
 ```
 
@@ -346,7 +346,7 @@ Specify the default type of externals as `'global'`. Rspack will read the extern
 
 **Example**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -366,7 +366,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 const jq = global['$'];
 jq('.my-element').animate(/* ... */);
 ```
@@ -379,7 +379,7 @@ Make sure to enable [`experiments.outputModule`](/config/experiments#experiments
 
 **Example**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -398,7 +398,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 import * as __WEBPACK_EXTERNAL_MODULE_jquery__ from 'jquery';
 
 const jq = __WEBPACK_EXTERNAL_MODULE_jquery__['default'];
@@ -413,7 +413,7 @@ Specify the default type of externals as `'import'`. Rspack will generate code l
 
 **Example**
 
-```javascript
+```js
 async function foo() {
   const jq = await import('jquery');
   jq('.my-element').animate(/* ... */);
@@ -431,7 +431,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 var __webpack_modules__ = {
   jquery: module => {
     module.exports = import('jquery');
@@ -458,7 +458,7 @@ Make sure to enable [`experiments.outputModule`](/config/#experimentsoutputmodul
 
 **Example**
 
-```javascript
+```js
 import { attempt } from 'lodash';
 
 async function foo() {
@@ -479,7 +479,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from 'lodash';
 const lodash = __WEBPACK_EXTERNAL_MODULE_jquery__;
 
@@ -531,7 +531,7 @@ This is useful when building a Node.js application that target Node.js version h
 
 **Example**
 
-```javascript
+```js
 import { attempt } from 'lodash';
 
 async function foo() {
@@ -552,7 +552,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 var __webpack_modules__ = {
   lodash: function (module) {
     module.exports = require('lodash');
@@ -582,7 +582,7 @@ Specify the default type of externals as `'node-commonjs'`. Rspack will import [
 
 **Example**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -601,7 +601,7 @@ module.exports = {
 
 Will generate into something like
 
-```javascript
+```js
 import { createRequire } from 'module';
 
 const jq = createRequire(import.meta.url)('jquery');
@@ -616,7 +616,7 @@ Specify the default type of externals as `'promise'`. Rspack will read the exter
 
 **Example**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -633,7 +633,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 const jq = await $;
 jq('.my-element').animate(/* ... */);
 ```
@@ -644,7 +644,7 @@ Specify the default type of externals as `'self'`. Rspack will read the external
 
 **Example**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -661,7 +661,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 const jq = self['$'];
 jq('.my-element').animate(/* ... */);
 ```
@@ -756,7 +756,7 @@ Specify the default type of externals as `'this'`. Rspack will read the external
 
 **Example**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -773,7 +773,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 const jq = this['$'];
 jq('.my-element').animate(/* ... */);
 ```
@@ -784,7 +784,7 @@ Specify the default type of externals as `'var'`. Rspack will read the external 
 
 **Example**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -801,7 +801,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 const jq = $;
 jq('.my-element').animate(/* ... */);
 ```
@@ -812,7 +812,7 @@ Specify the default type of externals as `'window'`. Rspack will read the extern
 
 **Example**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -829,7 +829,7 @@ export default {
 
 Will generate into something like
 
-```javascript
+```js
 const jq = window['$'];
 jq('.my-element').animate(/* ... */);
 ```

--- a/website/docs/en/config/index.mdx
+++ b/website/docs/en/config/index.mdx
@@ -27,7 +27,7 @@ export default defineConfig({
   </Tab>
   <Tab label="CJS">
 
-```js title="rspack.config.js"
+```js title="rspack.config.cjs"
 const { defineConfig } = require('@rspack/cli');
 
 module.exports = defineConfig({
@@ -196,14 +196,14 @@ $ rspack build -c rspack.prod.config.js
 
 ## Exporting a configuration function
 
-Rspack supports exporting a function in `rspack.config.js`, you can dynamically compute the configuration in the function and return it to Rspack.
+Rspack supports exporting a function in Rspack configuration file, you can dynamically compute the configuration in the function and return it to Rspack.
 
-```js title="rspack.config.js"
-module.exports = function (env, argv) {
+```js title="rspack.config.mjs"
+export default function (env, argv) {
   return {
     devtool: env.production ? 'source-map' : 'eval',
   };
-};
+}
 ```
 
 As you can see from the example above, the function takes two input parameters:
@@ -215,21 +215,21 @@ As you can see from the example above, the function takes two input parameters:
 
 In addition to passing the `env` parameter, it is more common to use `process.env.NODE_ENV` to determine the current environment:
 
-```js title="rspack.config.js"
-module.exports = function (env, argv) {
+```js title="rspack.config.mjs"
+export default function (env, argv) {
   const isProduction = process.env.NODE_ENV === 'production';
   return {
     devtool: isProduction ? 'source-map' : 'eval',
   };
-};
+}
 ```
 
 ## Merge configurations
 
 Use the `merge` function exported by `webpack-merge` to merge multiple configurations.
 
-```js title="rspack.config.js"
-const { merge } = require('webpack-merge');
+```js title="rspack.config.mjs"
+import { merge } from 'webpack-merge';
 
 const base = {};
 
@@ -237,8 +237,7 @@ const dev = {
   plugins: [new DevelopmentSpecifiedPlugin()],
 };
 
-module.exports =
-  process.env.NODE_ENV === 'development' ? merge(base, dev) : base;
+export default process.env.NODE_ENV === 'development' ? merge(base, dev) : base;
 ```
 
 For more information of `merge`, please refer to [webpack-merge documentation](https://npmjs.com/package/webpack-merge).

--- a/website/docs/en/config/mode.mdx
+++ b/website/docs/en/config/mode.mdx
@@ -39,7 +39,7 @@ rspack --mode=production
 ```
 
 :::info
-`--mode` option on the CLI has a higher priority than `mode` in `rspack.config.js`.
+`--mode` option on the CLI has a higher priority than `mode` in Rspack config.
 :::
 
 ## Optional values

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -1715,8 +1715,8 @@ import('./data', { with: { type: 'url' } });
 
 It should be noted that in order for Rspack to properly match the `with` syntax, when you use [builtin:swc-loader](/guide/features/builtin-swc-loader), you need to manually enable the `keepImportAttributes` configuration to preserve import attributes:
 
-```diff title=rspack.config.js
-module.exports = {
+```diff title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {

--- a/website/docs/en/config/optimization.mdx
+++ b/website/docs/en/config/optimization.mdx
@@ -349,8 +349,8 @@ export default {
 
 To opt-out from used exports analysis per runtime:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   optimization: {
     usedExports: 'global',

--- a/website/docs/en/config/optimization.mdx
+++ b/website/docs/en/config/optimization.mdx
@@ -119,10 +119,10 @@ Customize the minimizer. By default, [`rspack.SwcJsMinimizerRspackPlugin`](/plug
 
 When `optimization.minimizer` is specified, the default minimizers will be disabled.
 
-```js title=rspack.config.js
-const TerserPlugin = require('terser-webpack-plugin');
+```js title="rspack.config.mjs"
+import TerserPlugin from 'terser-webpack-plugin';
 
-module.exports = {
+export default {
   optimization: {
     minimizer: [new TerserPlugin()],
   },
@@ -131,10 +131,10 @@ module.exports = {
 
 Use Rspack's built-in minimizer with custom options:
 
-```js title=rspack.config.js
-const { rspack } = require('@rspack/core');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   optimization: {
     // when `optimization.minimizer` is specified, the default minimizers are disabled by default
     // but you can use '...', it represents the default minimizers

--- a/website/docs/en/config/other-options.mdx
+++ b/website/docs/en/config/other-options.mdx
@@ -52,8 +52,8 @@ In watch mode dependencies will invalidate the compiler when:
 
 Remember that current configuration will not compile until its dependencies are done.
 
-```js title="rspack.config.js"
-module.exports = [
+```js title="rspack.config.mjs"
+export default [
   {
     name: 'client',
     target: 'web',

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1,5 +1,6 @@
 import WebpackLicense from '@components/WebpackLicense';
 import { ApiMeta, Stability } from '../../../components/ApiMeta';
+import { Tabs, Tab } from '@theme';
 
 <WebpackLicense from="https://webpack.js.org/configuration/output/" />
 
@@ -218,10 +219,10 @@ If `target` is `'web'`, Rspack will dynamically create `<script>` and `<link>` t
 
 For example, set `output.publicPath` to `https://example.com/` and `output.crossOriginLoading` to `'anonymous'`:
 
-```js title="rspack.config.js"
-const path = require('path');
+```js title="rspack.config.mjs"
+import path from 'node:path';
 
-module.exports = {
+export default {
   output: {
     publicPath: 'https://example.com/',
     crossOriginLoading: 'anonymous',
@@ -1548,8 +1549,27 @@ export default {
 
 The output directory as an **absolute** path.
 
-```js title="rspack.config.js"
-const path = require('path');
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
+  output: {
+    path: path.resolve(__dirname, 'dist/assets'),
+  },
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
+const path = require('node:path');
 
 module.exports = {
   output: {
@@ -1557,6 +1577,9 @@ module.exports = {
   },
 };
 ```
+
+  </Tab>
+</Tabs>
 
 Note that `[fullhash]` in this parameter will be replaced with a hash of the compilation.
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -910,7 +910,7 @@ export default {
 
 When your library is loaded, the **return value of your entry point** will be assigned to a variable:
 
-```javascript
+```js
 var MyLibrary = _entry_return_;
 
 // In a separate script with `MyLibrary` loaded…
@@ -933,7 +933,7 @@ module.exports = {
 
 This will generate an implied global which has the potential to reassign an existing value (use with caution):
 
-```javascript
+```js
 MyLibrary = _entry_return_;
 ```
 
@@ -991,7 +991,7 @@ module.exports = {
 
 The **return value of your entry point** will be assigned to `this` under the property named by `output.library.name`. The meaning of `this` is up to you:
 
-```javascript
+```js
 this['MyLibrary'] = _entry_return_;
 
 // In a separate script
@@ -1015,7 +1015,7 @@ module.exports = {
 
 The **return value of your entry point** will be assigned to the `window` object using the `output.library.name` value.
 
-```javascript
+```js
 window['MyLibrary'] = _entry_return_;
 
 window.MyLibrary.doSomething();
@@ -1037,7 +1037,7 @@ module.exports = {
 
 The **return value of your entry point** will be assigned to the global object using the `output.library.name` value. Depending on the [`target`](/config/target) value, the global object could change respectively, e.g., `self`, `global` or `globalThis`.
 
-```javascript
+```js
 global['MyLibrary'] = _entry_return_;
 
 global.MyLibrary.doSomething();
@@ -1059,7 +1059,7 @@ module.exports = {
 
 The **return value of your entry point** will be assigned to the `exports` object using the `output.library.name` value. As the name implies, this is used in CommonJS environments.
 
-```javascript
+```js
 exports['MyLibrary'] = _entry_return_;
 
 require('MyLibrary').doSomething();
@@ -1110,7 +1110,7 @@ module.exports = {
 
 The **return value of your entry point** will be assigned to the `module.exports`. As the name implies, this is used in Node.js (CommonJS) environments:
 
-```javascript
+```js
 module.exports = _entry_return_;
 
 require('MyLibrary').doSomething();
@@ -1140,13 +1140,13 @@ Individual exports will be set as properties on `module.exports`. The "static" i
 
 Input:
 
-```javascript
+```js
 export function doSomething() {}
 ```
 
 Output:
 
-```javascript
+```js
 function doSomething() {}
 
 // …
@@ -1156,13 +1156,13 @@ exports.doSomething = __webpack_exports__.doSomething;
 
 Consumption (CommonJS):
 
-```javascript
+```js
 const { doSomething } = require('./output.cjs'); // doSomething => [Function: doSomething]
 ```
 
 Consumption (ESM):
 
-```javascript
+```js
 import { doSomething } from './output.cjs'; // doSomething => [Function: doSomething]
 ```
 
@@ -1242,7 +1242,7 @@ This exposes your library under all the module definitions, allowing it to work 
 
 In this case, you need the `library.name` property to name your module:
 
-```javascript
+```js
 module.exports = {
   //...
   output: {
@@ -1256,7 +1256,7 @@ module.exports = {
 
 And finally the output is:
 
-```javascript
+```js
 (function webpackUniversalModuleDefinition(root, factory) {
   if (typeof exports === 'object' && typeof module === 'object')
     module.exports = factory();
@@ -1270,7 +1270,7 @@ And finally the output is:
 
 Note that omitting `library.name` will result in the assignment of all properties returned by the entry point be assigned directly to the root object, as documented under the [object assignment section](#expose-via-object-assignment). Example:
 
-```javascript
+```js
 module.exports = {
   //...
   output: {
@@ -1281,7 +1281,7 @@ module.exports = {
 
 The output will be:
 
-```javascript
+```js
 (function webpackUniversalModuleDefinition(root, factory) {
   if (typeof exports === 'object' && typeof module === 'object')
     module.exports = factory();
@@ -1297,7 +1297,7 @@ The output will be:
 
 You may specify an object for `library.name` for differing names per targets:
 
-```javascript
+```js
 module.exports = {
   //...
   output: {
@@ -1319,7 +1319,7 @@ This will expose your library as a [`System.register`](https://github.com/system
 
 System modules require that a global variable `System` is present in the browser when the Rspack bundle is executed. Compiling to `System.register` format allows you to `System.import('/bundle.js')` without additional configuration and has your Rspack bundle loaded into the System module registry.
 
-```javascript
+```js
 module.exports = {
   //...
   output: {
@@ -1332,7 +1332,7 @@ module.exports = {
 
 Output:
 
-```javascript
+```js
 System.register([], function (__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
   return {
     execute: function () {
@@ -1344,7 +1344,7 @@ System.register([], function (__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
 
 By adding `output.library.name` to configuration in addition to having `output.library.type` set to `system`, the output bundle will have the library name as an argument to `System.register`:
 
-```javascript
+```js
 System.register(
   'MyLibrary',
   [],
@@ -1499,7 +1499,7 @@ module.exports = {
 
 When using `output.library.type: "umd"`, setting `output.library.umdNamedDefine` to `true` will name the AMD module of the UMD build. Otherwise, an anonymous `define` is used.
 
-```javascript
+```js
 module.exports = {
   //...
   output: {

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -799,8 +799,8 @@ In the above example, we're passing a single entry file to `entry`, however, Rsp
 
 1. If you provide an `array` as the `entry` point, only the last one in the array will be exposed.
 
-   ```js
-   module.exports = {
+   ```js title="rspack.config.mjs"
+   export default {
      // …
      entry: ['./src/a.js', './src/b.js'], // 只有在 b.js 中导出的内容才会被暴露
      output: {
@@ -811,8 +811,8 @@ In the above example, we're passing a single entry file to `entry`, however, Rsp
 
 2. If an `object` is provided as the `entry` point, all entries can be exposed using the `array` syntax of `library`:
 
-   ```js
-   module.exports = {
+   ```js title="rspack.config.mjs"
+   export default {
      // …
      entry: {
        a: './src/a.js',
@@ -870,8 +870,8 @@ Specify a name for the library.
 
 - **Type:** `string | string[] | {amd?: string, commonjs?: string, root?: string | string[]}`
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -920,8 +920,8 @@ MyLibrary.doSomething();
 
 ##### type: 'assign'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -942,8 +942,8 @@ Be aware that if `MyLibrary` isn't defined earlier your library will be set in g
 
 ##### type: 'assign-properties'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -978,8 +978,8 @@ These options assign the return value of the entry point (e.g. whatever the entr
 
 ##### type: 'this'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1002,8 +1002,8 @@ MyLibrary.doSomething(); // if `this` is window
 
 ##### type: 'window'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1024,8 +1024,8 @@ window.MyLibrary.doSomething();
 
 ##### type: 'global'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1046,8 +1046,8 @@ global.MyLibrary.doSomething();
 
 ##### type: 'commonjs'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1097,8 +1097,8 @@ However this feature is still experimental and not fully supported yet, so make 
 
 ##### type: 'commonjs2'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1125,8 +1125,8 @@ Wondering the difference between CommonJS and CommonJS2 is? While they are simil
 
 ##### type: 'commonjs-static'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1243,8 +1243,8 @@ This exposes your library under all the module definitions, allowing it to work 
 
 In this case, you need the `library.name` property to name your module:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   output: {
     library: {
@@ -1271,8 +1271,8 @@ And finally the output is:
 
 Note that omitting `library.name` will result in the assignment of all properties returned by the entry point be assigned directly to the root object, as documented under the [object assignment section](#expose-via-object-assignment). Example:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   output: {
     libraryTarget: 'umd',
@@ -1298,8 +1298,8 @@ The output will be:
 
 You may specify an object for `library.name` for differing names per targets:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   output: {
     library: {
@@ -1320,8 +1320,8 @@ This will expose your library as a [`System.register`](https://github.com/system
 
 System modules require that a global variable `System` is present in the browser when the Rspack bundle is executed. Compiling to `System.register` format allows you to `System.import('/bundle.js')` without additional configuration and has your Rspack bundle loaded into the System module registry.
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   output: {
     library: {
@@ -1440,8 +1440,8 @@ Add a comment in the UMD wrapper.
 
 To insert the same comment for each `umd` type, set `auxiliaryComment` to a string:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   mode: 'development',
   output: {
@@ -1474,8 +1474,8 @@ which will yield the following:
 
 For fine-grained control, pass an object:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   mode: 'development',
   output: {
@@ -1500,8 +1500,8 @@ module.exports = {
 
 When using `output.library.type: "umd"`, setting `output.library.umdNamedDefine` to `true` will name the AMD module of the UMD build. Otherwise, an anonymous `define` is used.
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   output: {
     library: {

--- a/website/docs/en/config/resolve-loader.mdx
+++ b/website/docs/en/config/resolve-loader.mdx
@@ -1,3 +1,5 @@
+import { Tabs, Tab } from '@theme';
+
 # ResolveLoader
 
 This configuration item is consistent in type with [`resolve`](/config/resolve), but this setting only affects the resolution of [loaders](/guide/features/loader).
@@ -17,9 +19,29 @@ This configuration item is consistent in type with [`resolve`](/config/resolve),
 
 ## Example
 
-For instance, if you are developing a loader and want to showcase its usage from a user's perspective in an example, you can write:
+For example, if you are developing a loader and want to showcase its usage from a user's perspective in an example, you can write:
 
-```js title="rspack.config.js"
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+export default {
+  resolveLoader: {
+    alias: {
+      'amazing-loader': require.resolve('path-to-your-amazing-loader'),
+    },
+  },
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
 module.exports = {
   resolveLoader: {
     alias: {
@@ -28,6 +50,9 @@ module.exports = {
   },
 };
 ```
+
+  </Tab>
+</Tabs>
 
 Then, in the example code, you can write:
 

--- a/website/docs/en/config/stats.mdx
+++ b/website/docs/en/config/stats.mdx
@@ -573,8 +573,8 @@ If you want to use the preset output behavior but want to output more or less of
 
 For example, only the error and the reason why the module was introduced are output.
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // ...
   stats: {
     preset: 'errors-only',

--- a/website/docs/en/contribute/development/testing-rspack.mdx
+++ b/website/docs/en/contribute/development/testing-rspack.mdx
@@ -79,7 +79,7 @@ The writing of the case is the same as a regular rspack project, but it does not
 
 This test case is similar to a regular rspack project. You can specify the build configuration by adding a `rspack.config.js` and control various behaviors during testing by adding a `test.config.js`. The structure of the `test.config.js` file is as follows:
 
-```typescript {16-20} title="test.config.js"
+```ts {16-20} title="test.config.js"
 type TConfigCaseConfig = {
   noTest?: boolean; // Do not run the test output and end the test
   beforeExecute?: () => void; // Callback before running the output
@@ -254,7 +254,7 @@ This test case is similar to a typical rspack project and can specify build conf
 
 This test case is similar to a typical rspack project, but it will add a `test.config.js` file in the case directory and specify a `validate()` method to check the hash information in the `stats` object after the build is complete:
 
-```javascript {5-8} title="test.config.js"
+```js {5-8} title="test.config.js"
 type THashCaseConfig = {
   validate?: (stats: TCompilerStats<T>) => void,
 };
@@ -276,7 +276,7 @@ module.exports = {
 
 This test uses `rspack-test-tools/tests/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
 
-```javascript {9-12} title="{case.js}"
+```js {9-12} title="{case.js}"
 interface TCompilerCaseConfig {
   description: string; // Description of the test case
   options?: (context: ITestContext) => TCompilerOptions<T>; // Test case build configuration
@@ -308,7 +308,7 @@ This test does not execute real builds; it only generates build configurations a
 
 This test uses `rspack-test-tools/tests/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
 
-```javascript {8-11} title="{case}.js"
+```js {8-11} title="{case}.js"
 interface TDefaultsCaseConfig {
   description: string; // Description of the test case
   cwd?: string; // process.cwd for generating the build configuration of the test case, default is the `rspack-test-tools` directory
@@ -338,7 +338,7 @@ The details for the Error test are as follows:
 
 This test uses `rspack-test-tools/tests/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
 
-```javascript {8-11} title="{case}.js"
+```js {8-11} title="{case}.js"
 interface TErrorCaseConfig {
   description: string; // Description of the test case
   options?: (
@@ -368,7 +368,7 @@ This test records the input and output of the hook and stores it in the snapshot
 
 This test uses `rspack-test-tools/tests/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
 
-```javascript {8-11} title="{case}/test.js"
+```js {8-11} title="{case}/test.js"
 interface THookCaseConfig {
   description: string; // Description of the test case
   options?: (

--- a/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
@@ -10,10 +10,10 @@ The `builtin:lightningcss-loader` uses the builtin [lightningcss](https://github
 
 To use `builtin:lightningcss-loader` in your project, you need to configure it as follows.
 
-```js
-const { rspack } = require('@rspack/core');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   module: {
     rules: [
       {
@@ -37,10 +37,8 @@ module.exports = {
 
 You can use the `LightningcssLoaderOptions` type exported by `@rspack/core` to enable type hints:
 
-- `rspack.config.js`:
-
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {

--- a/website/docs/en/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/features/builtin-swc-loader.mdx
@@ -12,8 +12,8 @@ If you need to use `builtin:swc-loader` in your project, configure it as follows
 
 To transpile `.ts` files:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -38,8 +38,8 @@ module.exports = {
 
 To transpile React's `.jsx` files:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -79,8 +79,8 @@ SWC provides [jsc.target](https://swc.rs/docs/configuration/compilation#jsctarge
 
 [jsc.target](https://swc.rs/docs/configuration/compilation#jsctarget) is used to specify the ECMA version, such as `es5`, `es2015`, `es2016`, etc.
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -104,8 +104,8 @@ module.exports = {
 
 [env.targets](https://swc.rs/docs/configuration/compilation#envtargets) uses the [browserslist](https://github.com/browserslist/browserslist) syntax to specify browser range, for example:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -140,8 +140,8 @@ When using higher versions of JavaScript syntax and APIs in your project, to ens
 
 SWC supports injecting [core-js](https://github.com/zloirock/core-js) as an API polyfill, which can be configured using [env.mode](https://swc.rs/docs/configuration/compilation#envmode) and [env.coreJs](https://swc.rs/docs/configuration/compilation#envcorejs):
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -179,10 +179,8 @@ Note:
 
 You can enable type hints using the `SwcLoaderOptions` type exported by `@rspack/core`:
 
-- `rspack.config.js`:
-
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -238,8 +236,8 @@ See [FAQ - SWC Plugin Version Unmatched](/errors/swc-plugin-version) for more de
 
 Rspack supports load Wasm plugin in `builtin:swc-loader`, you can specify the plugin name like
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -273,10 +271,13 @@ this is an [example](https://github.com/rspack-contrib/rspack-examples/blob/d4b8
 
 When you use SWC's Wasm plugin, SWC will generate cache files in the `.swc` directory of the current project by default. If you want to adjust this directory, you can modify the `cacheRoot` configuration, such as:
 
-```js
-const path = require('path');
+```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
   module: {
     rules: [
       {

--- a/website/docs/en/guide/features/dev-server.mdx
+++ b/website/docs/en/guide/features/dev-server.mdx
@@ -13,10 +13,10 @@ Rspack CLI comes with a built-in `@rspack/dev-server` for development and debugg
 
 ### HMR
 
-By default, Rspack enables HMR in dev mode. You can disable HMR by configuring the `devServer.hot` option in `rspack.config.js`.
+By default, Rspack enables HMR in dev mode. You can disable HMR by configuring the `devServer.hot` option in Rspack configuration.
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   devServer: {
     hot: false,
   },
@@ -24,15 +24,15 @@ module.exports = {
 ```
 
 :::warning
-HMR is not working for CSS when `output.cssFilename` contains `[hash]` or `[contenthash]`
+Do not include `[hash]` or `[contenthash]` in [output.cssFilename](/config/output#outputcssfilename), otherwise CSS HMR may not work.
 :::
 
 ### Proxy
 
-Rspack has a built-in simple proxy server. You can enable the proxy server by configuring the `devServer.proxy` option in `rspack.config.js`. The devServer internally uses [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) to implement the proxy function. For example, you can proxy `/api` to `http://localhost:3000` as follows:
+Rspack has a built-in simple proxy server. You can enable the proxy server by configuring the `devServer.proxy` option in Rspack configuration. The devServer internally uses [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) to implement the proxy function. For example, you can proxy `/api` to `http://localhost:3000` as follows:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   devServer: {
     proxy: [
       {

--- a/website/docs/en/guide/features/loader.mdx
+++ b/website/docs/en/guide/features/loader.mdx
@@ -126,13 +126,13 @@ The first input to this loader is the content of the file, allowing us to proces
 
 For example, to add a banner to all `*.js` files, the configuration might look like this:
 
-```js title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
         test: /\.js$/,
-        loader: require.resolve('./banner-loader.js'),
+        loader: './banner-loader.js',
       },
     ],
   },

--- a/website/docs/en/guide/features/module-federation.mdx
+++ b/website/docs/en/guide/features/module-federation.mdx
@@ -37,12 +37,10 @@ Here are the characteristics of several versions:
 
 You need to install the additional `@module-federation/enhanced` plugin to use Module Federation v2.0.
 
-```js title="rspack.config.js"
-const {
-  ModuleFederationPlugin,
-} = require('@module-federation/enhanced/rspack');
+```js title="rspack.config.mjs"
+import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
 
-module.exports = {
+export default {
   plugins: [
     new ModuleFederationPlugin({
       // options

--- a/website/docs/en/guide/features/plugin.mdx
+++ b/website/docs/en/guide/features/plugin.mdx
@@ -1,3 +1,5 @@
+import { Tabs, Tab } from '@theme';
+
 # Plugins
 
 If [loaders](/guide/features/loader) are the workhorse for file transformations (preprocessing), then plugins are the workhorse for the overall Rspack build process. Most of Rspack's native implementations rely on the Rust side of the plugin system.
@@ -8,9 +10,27 @@ For Node.js users, you don't need to worry about interoperability issues with No
 
 Rspack provides the [plugins](/config/plugins) configuration, which is used to register a set of Rspack or webpack plugins to customize the build process.
 
-Here is an example of using the [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) in `rspack.config.js`:
+Here is an example of using the [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) in Rspack configuration:
 
-```js title="rspack.config.js"
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+
+export default {
+  plugins: [
+    new BundleAnalyzerPlugin({
+      // options
+    }),
+  ],
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 module.exports = {
@@ -21,6 +41,9 @@ module.exports = {
   ],
 };
 ```
+
+  </Tab>
+</Tabs>
 
 If you're looking for more Rspack plugins, have a look at the great list of [supported plugins](/plugins/index).
 
@@ -34,7 +57,25 @@ You can also refer to [Plugin compat](/guide/compatibility/plugin) for the list 
 
 Here is an example of using [unplugin-vue-components](https://www.npmjs.com/package/unplugin-vue-components):
 
-```js title=rspack.config.js
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import Components from 'unplugin-vue-components/rspack';
+
+export default {
+  plugins: [
+    Components({
+      // options
+    }),
+  ],
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
 const Components = require('unplugin-vue-components/rspack');
 
 module.exports = {
@@ -45,6 +86,9 @@ module.exports = {
   ],
 };
 ```
+
+  </Tab>
+</Tabs>
 
 ### SWC plugins
 
@@ -71,7 +115,25 @@ Here is a comparison table for the plugins that can be used in Rspack and Rsbuil
 
 As a plugin author, the structure of a plugin is very simple: just implement an `apply` method that accepts a `Compiler` instance. It will be called when the Rspack plugin is initialized. The detailed API can be found in the [Plugin API](/api/plugin-api/index).
 
-```js
+<Tabs>
+  <Tab label="ESM">
+
+```js title="MyPlugin.mjs"
+const PLUGIN_NAME = 'MyPlugin';
+
+export class MyPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+      console.log('The Rspack build process is starting!');
+    });
+  }
+}
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="MyPlugin.cjs"
 const PLUGIN_NAME = 'MyPlugin';
 
 class MyPlugin {
@@ -85,18 +147,19 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
-We use CommonJS style module exports so that plugins can be imported directly using `require` in `rspack.config.js`.
+  </Tab>
+</Tabs>
 
 ### Write with TypeScript
 
 If you use TypeScript to write Rspack plugins, you can import `Compiler` and `RspackPluginInstance` to declare the types of your plugins:
 
-```ts
+```ts title="MyPlugin.ts"
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
 
 const PLUGIN_NAME = 'MyPlugin';
 
-class MyPlugin implements RspackPluginInstance {
+export class MyPlugin implements RspackPluginInstance {
   apply(compiler: Compiler) {
     compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
       console.log('The Rspack build process is starting!');

--- a/website/docs/en/guide/features/web-workers.mdx
+++ b/website/docs/en/guide/features/web-workers.mdx
@@ -1,5 +1,6 @@
 import WebpackLicense from '@components/WebpackLicense';
 import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
+import { Tabs, Tab } from '@theme';
 
 <WebpackLicense from="https://webpack.js.org/guides/web-workers/" />
 
@@ -64,7 +65,26 @@ Rspack also supports worker-loader. However, since [worker-loader](https://githu
 
 Use [resolveLoader](/config/resolve-loader) to replace worker-loader with worker-rspack-loader:
 
-```js
+<Tabs>
+  <Tab label="ESM">
+```js title="rspack.config.mjs"
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+export default {
+  resolveLoader: {
+    alias: {
+      'worker-loader': require.resolve('worker-rspack-loader'),
+    },
+  },
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
 module.exports = {
   resolveLoader: {
     alias: {
@@ -73,3 +93,6 @@ module.exports = {
   },
 };
 ```
+
+  </Tab>
+</Tabs>

--- a/website/docs/en/guide/migration/rspack_0.x.mdx
+++ b/website/docs/en/guide/migration/rspack_0.x.mdx
@@ -75,7 +75,7 @@ The default value of [optimization.chunkIds](/config/optimization#optimizationch
 Please use [resolve.tsConfig](/config/resolve#resolvetsconfig) instead.
 
 ```diff
-module.exports = {
+export default {
   resolve: {
 -   tsConfigPath: path.resolve(__dirname, './tsconfig.json'),
 +   tsConfig: path.resolve(__dirname, './tsconfig.json'),
@@ -209,7 +209,9 @@ Now, we have removed it and replaced it with [rspack.LightningCssMinimizerRspack
 If you previously manually registered and configured `rspack.SwcCssMinimizerRspackPlugin`, you should to switch to `rspack.LightningCssMinimizerRspackPlugin`:
 
 ```diff
-module.exports = {
+import { rspack } from '@rspack/core';
+
+export default {
   optimization: {
     minimizer: [
 -     new rspack.SwcCssMinimizerRspackPlugin({

--- a/website/docs/en/guide/optimization/code-splitting.mdx
+++ b/website/docs/en/guide/optimization/code-splitting.mdx
@@ -43,11 +43,8 @@ Though `shared.js` exist in 2 chunks, but it is executed only once, you don't ha
 
 This is the simplest and most intuitive way to split the code. However, this approach requires us to manually configure the Rspack. Let's start by looking at how to split multiple Chunks from multiple entry points.
 
-```js title=rspack.config.js
-/**
- * @type {import('@rspack/core').Configuration}
- */
-const config = {
+```js title="rspack.config.mjs"
+export default {
   mode: 'development',
   entry: {
     index: './src/index.js',
@@ -55,8 +52,6 @@ const config = {
   },
   stats: 'normal',
 };
-
-module.exports = config;
 ```
 
 ```js title=index.js
@@ -92,11 +87,8 @@ Rspack defaults to splitting files in the `node_modules` directory and duplicate
 
 We can configure the minimum split size to 0 to allow `shared.js` to be extracted on its own.
 
-```diff title=rspack.config.js
-/**
- * @type {import('@rspack/core').Configuration}
- */
-const config = {
+```diff title="rspack.config.mjs"
+export default {
   entry: {
     index: './src/index.js',
   },
@@ -106,8 +98,6 @@ const config = {
 +    }
 +  }
 };
-
-module.exports = config;
 ```
 
 When rebuild, you will find that `shared.js` has been extracted separately, and there is an additional Chunk in the product that contains `shared.js`.

--- a/website/docs/en/guide/optimization/use-rsdoctor.mdx
+++ b/website/docs/en/guide/optimization/use-rsdoctor.mdx
@@ -56,19 +56,19 @@ import { PackageManagerTabs } from '@theme';
 
 :::
 
-Initialize the RsdoctorRspackPlugin plugin in the [plugins](/config/plugins.html#plugins) section of `rspack.config.js`, as shown below:
+Initialize the RsdoctorRspackPlugin plugin in the [plugins](/config/plugins.html#plugins) field of Rspack configuration, as shown below:
 
-```ts title="rspack.config.js"
-const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
+```ts title="rspack.config.mjs"
+import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 
-module.exports = {
+export default {
   // ...
   plugins: [
     process.env.RSDOCTOR &&
       new RsdoctorRspackPlugin({
         // plugin options
       }),
-  ].filter(Boolean),
+  ],
 };
 ```
 

--- a/website/docs/en/guide/tech/css.mdx
+++ b/website/docs/en/guide/tech/css.mdx
@@ -131,7 +131,7 @@ import { red } from './index.module.css';
 document.getElementById('element').className = red;
 ```
 
-To enable default imports in Rspack, you need to set `namedExports` to `false` in your `rspack.config.js` file. This allows you, when using CSS Modules, to import the entire style module by default import, in addition to namespace imports and named imports:
+To enable default imports in Rspack, you need to set `namedExports` to `false` in your Rspack configuration file. This allows you, when using CSS Modules, to import the entire style module by default import, in addition to namespace imports and named imports:
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/guide/tech/html.mdx
+++ b/website/docs/en/guide/tech/html.mdx
@@ -7,11 +7,11 @@ This is particularly useful for Rspack bundles that contain filename hashes, as 
 
 Rspack fully supports [HtmlWebpackPlugin](https://github.com/jantimon/html-webpack-plugin).
 
-```js title="rspack.config.js"
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const path = require('path');
+```js title="rspack.config.mjs"
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'node:path';
 
-module.exports = {
+export default {
   entry: 'index.js',
   output: {
     path: path.resolve(__dirname, './dist'),

--- a/website/docs/en/guide/tech/preact.mdx
+++ b/website/docs/en/guide/tech/preact.mdx
@@ -57,7 +57,7 @@ export default {
 
 Refer to [Builtin swc-loader](guide/features/builtin-swc-loader) for detailed configurations.
 
-Refer to [examples/preact](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact/rspack.config.js) for the full example.
+Refer to [examples/preact](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact) for the full example.
 
 ## Preact Refresh
 
@@ -87,11 +87,12 @@ In versions below 1.0.0, Rspack did not support preact refresh with `swc-loader`
 Please use `builtin:swc-loader` and enable preact specific transformation with `rspackExperiments.preact: {}`
 :::
 
-```js title=rspack.config.js
-const PreactRefreshPlugin = require('@rspack/plugin-preact-refresh');
+```js title="rspack.config.mjs"
+import PreactRefreshPlugin from '@rspack/plugin-preact-refresh';
+
 const isDev = process.env.NODE_ENV === 'development';
 
-module.exports = {
+export default {
   // ...
   mode: isDev ? 'development' : 'production',
   module: {
@@ -131,8 +132,8 @@ module.exports = {
   plugins: [
     isDev && new PreactRefreshPlugin(),
     isDev && new rspack.HotModuleReplacementPlugin(),
-  ].filter(Boolean),
+  ],
 };
 ```
 
-Refer to [examples/preact-refresh](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact-refresh/rspack.config.js) for the full example.
+Refer to [examples/preact-refresh](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact-refresh) for the full example.

--- a/website/docs/en/guide/tech/react.mdx
+++ b/website/docs/en/guide/tech/react.mdx
@@ -106,14 +106,14 @@ export default {
   plugins: [
     isDev && new ReactRefreshPlugin(),
     isDev && new rspack.HotModuleReplacementPlugin(),
-  ].filter(Boolean),
+  ],
 };
 ```
 
 Compared to the previous approach, this method decouples the React Fast Refresh code injection logic from the transformation logic. The code injection logic is handled uniformly by the @rspack/plugin-react-refresh plugin, while the code transformation is handled by loaders. This means that this plugin can be used in conjunction with `builtin:swc-loader`, `swc-loader`, or `babel-loader`:
 
-- For usage with `builtin:swc-loader`, you can refer to the example at [examples/react-refresh](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh/rspack.config.js), When using with `swc-loader`, simply replace `builtin:swc-loader` with `swc-loader`.
-- For usage with `babel-loader`, you can refer to the example at [examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh-babel-loader/rspack.config.js)
+- For usage with `builtin:swc-loader`, you can refer to the example at [examples/react-refresh](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh), When using with `swc-loader`, simply replace `builtin:swc-loader` with `swc-loader`.
+- For usage with `babel-loader`, you can refer to the example at [examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh-babel-loader)
 
 ## React Compiler
 

--- a/website/docs/en/guide/tech/typescript.mdx
+++ b/website/docs/en/guide/tech/typescript.mdx
@@ -4,8 +4,8 @@
 
 Enabling TypeScript support can be done through [`builtin:swc-loader`](/guide/features/builtin-swc-loader).
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -60,8 +60,8 @@ Remember to evaluate the trade-off between build speed and the accuracy of type 
 
 Enabling TSX|JSX support can be done through [`builtin:swc-loader`](/guide/features/builtin-swc-loader).
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {

--- a/website/docs/en/guide/tech/vue.mdx
+++ b/website/docs/en/guide/tech/vue.mdx
@@ -38,8 +38,8 @@ export default defineConfig({
 
 As Rspack natively supports the compilation of CSS modules, you do not need to configure loaders related to CSS. In addition, when you try to use a CSS preprocessor (such as: less), you only need to add the following configuration:
 
-```diff
-const config = {
+```diff title="rspack.config.mjs"
+export default {
   module: {
     rules: [
 +      {
@@ -50,7 +50,6 @@ const config = {
     ],
   },
 };
-module.exports = config;
 ```
 
 At this time, Rspack will use the built-in CSS processor for post-processing.

--- a/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
@@ -18,10 +18,10 @@ new rspack.CopyRspackPlugin(options);
 
 - Copy a single file. If the file does not exist, the plugin will throw an error.
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -34,10 +34,10 @@ module.exports = {
 
 - `patterns` can be a string, or an array of objects.
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -50,10 +50,10 @@ module.exports = {
 
 - Copy a directory. If there are no files in the directory, the plugin will throw an error.
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -67,11 +67,14 @@ module.exports = {
 
 - Use glob pattern to match and copy files.
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
-const path = require('node:path');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -90,10 +93,10 @@ module.exports = {
 
 - Use `to` to specify the destination path.
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -114,10 +117,14 @@ module.exports = {
 
 The source path of the copy operation, which can be an absolute path, a relative path, or a glob pattern. It can refer to a file or a directory. If a relative path is passed, it is relative to the [context](#context) option.
 
-```js title="rspack.config.js"
-const path = require('node:path');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
   plugins: [
     new rspack.CopyRspackPlugin({
       patterns: [
@@ -187,10 +194,14 @@ export default {
 
 `context` is a path to be prepended to `from` and removed from the start of the result paths.
 
-```js
-const path = require('node:path');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
   plugins: [
     new rspack.CopyRspackPlugin({
       // `./src/*.json` -> `./dist/*.json`

--- a/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
@@ -13,10 +13,10 @@ Rspack is currently incompatible with [mini-css-extract-plugin](https://github.c
 
 When using CssExtractRspackPlugin, you need to register the plugin in the `plugins` section and register `CssExtractRspackPlugin.loader` in [module.rules](/config/module#modulerules).
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   plugins: [new rspack.CssExtractRspackPlugin({})],
   module: {
     rules: [
@@ -201,10 +201,10 @@ Please note when enabling the built-in CSS support (`experiments.css`), Files en
 
 For example:
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   plugins: [new rspack.CssExtractRspackPlugin({})],
   module: {
     rules: [

--- a/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
@@ -518,7 +518,7 @@ If `base` is set, HtmlRspackPlugin will inject the `<base>` tag.
 
 The `<base>` tag can be generated through the following configuration:
 
-```js title="rspack.config.js"
+```js
 new HtmlWebpackPlugin({
   // Will generate: <base href="http://example.com/some/page.html">
   base: 'http://example.com/some/page.html',
@@ -567,9 +567,9 @@ export default {
 
 HtmlRspackPlugin provides some hooks that allow you to modify tags or generated HTML code. The hooks object can be obtained through `rspack.HtmlRspackPlugin.getCompilationHooks`:
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const HtmlModifyPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('HtmlModifyPlugin', compilation => {
       const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
       // hooks.beforeAssetTagGeneration.tapPromise()
@@ -582,7 +582,7 @@ const HtmlModifyPlugin = {
   },
 };
 
-module.exports = {
+export default {
   //...
   plugins: [new HtmlRspackPlugin(), HtmlModifyPlugin],
 };
@@ -617,9 +617,9 @@ Only `assets.js`, `assets.css`, and `assets.favicon` can be modified. Modificati
 
 The following code adds an additional `extra-script.js` and generates a `<script defer src="extra-script.js"></script>` tag in the final html content.
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const AddScriptPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('AddScriptPlugin', compilation => {
       HtmlRspackPlugin.getCompilationHooks(
         compilation,
@@ -630,7 +630,7 @@ const AddScriptPlugin = {
   },
 };
 
-module.exports = {
+export default {
   //...
   plugins: [new HtmlRspackPlugin(), AddScriptPlugin],
 };
@@ -677,9 +677,9 @@ Only `assetTags` can be modified. Modifications to other items will not take eff
 
 The following code adds the `specialAttribute` property to all `script` type tags:
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const AddAttributePlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('AddAttributePlugin', compilation => {
       HtmlRspackPlugin.getCompilationHooks(
         compilation,
@@ -695,7 +695,7 @@ const AddAttributePlugin = {
   },
 };
 
-module.exports = {
+export default {
   //...
   plugins: [new HtmlRspackPlugin(), AddAttributePlugin],
 };
@@ -726,9 +726,9 @@ Only `headTags` and `bodyTags` can be modified. Modifications to other items wil
 
 The following code moves the `async` `script` tags from `body` to `head`:
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const MoveTagsPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('MoveTagsPlugin', compilation => {
       HtmlWebpackPlugin.getCompilationHooks(
         compilation,
@@ -740,7 +740,7 @@ const MoveTagsPlugin = {
   },
 };
 
-module.exports = {
+export default {
   //...
   plugins: [
     new HtmlRspackPlugin({
@@ -779,9 +779,9 @@ The HTML content and the tags to be injected can be modified here.
 
 The following code adds `Injected by plugin` at the end of the body. Then the tags will be injected after this text. Therefore, it will be `<Injected by plugin<script defer src="main.js"></script></body>` in the final HTML content:
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const InjectContentPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('InjectContentPlugin', compilation => {
       HtmlWebpackPlugin.getCompilationHooks(
         compilation,
@@ -792,7 +792,7 @@ const InjectContentPlugin = {
   },
 };
 
-module.exports = {
+export default {
   //...
   plugins: [
     new HtmlRspackPlugin({
@@ -825,9 +825,9 @@ Only `html` can be modified. Modifications to other items will not take effect.
 
 The following code adds `Injected by plugin` at the end of the body. It will be `<script defer src="main.js"></script>Injected by plugin</body>` in the final HTML content:
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const InjectContentPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('InjectContentPlugin', compilation => {
       HtmlWebpackPlugin.getCompilationHooks(compilation).beforeEmit.tapPromise(
         'InjectContentPlugin',
@@ -839,7 +839,7 @@ const InjectContentPlugin = {
   },
 };
 
-module.exports = {
+export default {
   //...
   plugins: [
     new HtmlRspackPlugin({

--- a/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
@@ -6,8 +6,10 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 
 This plugin uses [lightningcss](https://lightningcss.dev/) to minify CSS assets. See [optimization.minimizer](/config/optimization#optimizationminimizer).
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   // ...
   optimization: {
     minimizer: [new rspack.LightningCssMinimizerRspackPlugin(options)],

--- a/website/docs/en/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
@@ -10,8 +10,10 @@ This plugin is used to minify JavaScript files using [SWC](https://swc.rs/).
 
 Use this plugin via [optimization.minimizer](/config/optimization#optimizationminimizer):
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   // ...
   optimization: {
     minimizer: [

--- a/website/docs/en/plugins/webpack/eval-source-map-dev-tool-plugin.mdx
+++ b/website/docs/en/plugins/webpack/eval-source-map-dev-tool-plugin.mdx
@@ -36,8 +36,10 @@ Indicates whether column mappings should be used (defaults to `true`).
 
 You can use the following code to replace the configuration option `devtool: eval-source-map` with an equivalent custom plugin configuration:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   // ...
   devtool: false,
   plugins: [new rspack.EvalSourceMapDevToolPlugin({})],

--- a/website/docs/en/plugins/webpack/hot-module-replacement-plugin.mdx
+++ b/website/docs/en/plugins/webpack/hot-module-replacement-plugin.mdx
@@ -12,11 +12,11 @@ Enabling HMR is straightforward and in most cases no options are necessary.
 
 Note that HMR can not be used in production build. You can use `process.env.NODE_ENV` to determine if it is a development environment.
 
-```js title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 const isDev = process.env.NODE_ENV === 'development';
 
-module.exports = {
+export default {
   plugins: [isDev && new rspack.HotModuleReplacementPlugin()],
 };
 ```

--- a/website/docs/en/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/en/plugins/webpack/module-federation-plugin.mdx
@@ -6,10 +6,10 @@ This plugin implements [Module Federation 1.5](https://github.com/module-federat
 
 ## Example
 
-```js
-const { rspack } = require('@rspack/core');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   output: {
     // set uniqueName explicitly to make HMR works
     uniqueName: 'app',
@@ -160,8 +160,8 @@ The SharedConfig can include the following sub-options:
 
   If you need to be compatible with legacy browsers, please add [builtin:swc-loader](/guide/features/builtin-swc-loader) for syntax downgrade, and make sure it matches `@module-federation/runtime` and `@module-federation/sdk`. Here is an example:
 
-  ```js
-  module.exports = {
+  ```js title="rspack.config.mjs"
+  export default {
     module: {
       rules: [
         {

--- a/website/docs/en/plugins/webpack/normal-module-replacement-plugin.mdx
+++ b/website/docs/en/plugins/webpack/normal-module-replacement-plugin.mdx
@@ -30,7 +30,7 @@ Say you have a configuration file `some/path/config.development.js` and a specia
 
 Add the following plugin when building for production:
 
-```javascript
+```js
 new rspack.NormalModuleReplacementPlugin(
   /some\/path\/config\.development\.js/,
   './config.production.js',
@@ -43,7 +43,7 @@ Conditional build depending on a specified environment.
 
 Say you want a configuration with specific values for different build targets.
 
-```javascript
+```js
 module.exports = function getRspackConfig(env) {
   const appTarget = env.APP_TARGET || 'VERSION_A';
   return {
@@ -78,7 +78,7 @@ export const config = {
 
 Then import that configuration using the keyword you're looking for in the regexp:
 
-```javascript
+```js
 import { config } from './app/config-APP_TARGET';
 console.log(config.title);
 ```

--- a/website/docs/en/plugins/webpack/provide-plugin.mdx
+++ b/website/docs/en/plugins/webpack/provide-plugin.mdx
@@ -27,7 +27,7 @@ By default, module resolution path is current folder (`./**`) and `node_modules`
 It is also possible to specify full path:
 
 ```js
-const path = require('path');
+const path = require('node:path');
 
 new rspack.ProvidePlugin({
   identifier: path.resolve(path.join(__dirname, 'src/module1')),

--- a/website/docs/en/plugins/webpack/source-map-dev-tool-plugin.mdx
+++ b/website/docs/en/plugins/webpack/source-map-dev-tool-plugin.mdx
@@ -117,8 +117,10 @@ The following examples demonstrate some common use cases for this plugin.
 
 You can use the following code to replace the configuration option devtool: inline-source-map with an equivalent custom plugin configuration:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   // ...
   devtool: false,
   plugins: [new rspack.SourceMapDevToolPlugin({})],

--- a/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
@@ -7,8 +7,8 @@ import ChunkType from '../../types/chunk.mdx';
 
 你可以通过参考如下代码获取这些钩子：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // ...
   plugins: [
     {

--- a/website/docs/zh/api/runtime-api/hmr.mdx
+++ b/website/docs/zh/api/runtime-api/hmr.mdx
@@ -180,7 +180,7 @@ module.hot.accept('./dep', () => {
 
 模块可以自我接受，但是当更改无法处理时可以使自身失效：
 
-```javascript
+```js
 const VALUE = 'constant';
 
 export default VALUE;
@@ -201,7 +201,7 @@ if (
 
 **Triggering custom HMR updates**
 
-```javascript
+```js
 const moduleId = chooseAModule();
 const code = __webpack_modules__[moduleId].toString();
 __webpack_modules__[moduleId] = eval(`(${makeChanges(code)})`);

--- a/website/docs/zh/blog/announcing-0-3.mdx
+++ b/website/docs/zh/blog/announcing-0-3.mdx
@@ -15,10 +15,10 @@ Rspack 在 0.3 版本将 `experiments.css = true` 的情况下的 CSS 默认处�
 
 在 Rspack 完全支持 `postcss-loader` 之前，Rspack fork 实现了 `@rspack/postcss-loader` 和内置实现了 `builtins.postcss` 以满足功能，目前 Rspack 已经完全支持了 `postcss-loader`，因此我们决定废弃掉 `@rspack/postcss-loader` 和 `builtins.postcss`，使用 `@rspack/postcss-loader` 的用户可以无缝迁移到 `postcss-loader` 上，而之前 Rspack 的 `builtins.postcss` 只实现了 `px2rem` 的转换功能，使用该功能的用户可以迁移到 `postcss-loader` 和 `postcss-plugin-px2rem` 上，如下是迁移方式。
 
-- before
+- before:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   builtins: {
     postcss: {
       pxtorem: {
@@ -29,10 +29,10 @@ module.exports = {
 };
 ```
 
-- after
+- after:
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -64,8 +64,8 @@ module.exports = {
 
 为了更好的对齐 webpack 的 CSS 处理， Rspack 从 0.3 移除了内置的 autoprefixer 功能，你可以使用 postcss-loader 来实现 autoprefixer。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {

--- a/website/docs/zh/blog/announcing-0-4.mdx
+++ b/website/docs/zh/blog/announcing-0-4.mdx
@@ -32,7 +32,7 @@ Rspack 不再支持 Node.js 14，现在需要 Node.js 16+。
 - [builtins.decorator](https://v0.rspack.dev/config/builtins#builtinsdecorator)：移动到 `jsc.parser.decorators`
 - [builtins.presetEnv](https://v0.rspack.dev/config/builtins#builtinspresetenv)：移动到 `jsc.env`
 
-```javascript
+```js
 module.exports = {
   module: {
     rules: [

--- a/website/docs/zh/blog/announcing-0-4.mdx
+++ b/website/docs/zh/blog/announcing-0-4.mdx
@@ -32,8 +32,8 @@ Rspack 不再支持 Node.js 14，现在需要 Node.js 16+。
 - [builtins.decorator](https://v0.rspack.dev/config/builtins#builtinsdecorator)：移动到 `jsc.parser.decorators`
 - [builtins.presetEnv](https://v0.rspack.dev/config/builtins#builtinspresetenv)：移动到 `jsc.env`
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -69,8 +69,8 @@ module.exports = {
 
 2. [target](/config/target) 不再降级用户端代码（包含 node_modules）
 
-```diff
-module.exports = {
+```diff title="rspack.config.mjs"
+export default {
   target: ["web", "es5"],
   module: {
     rules: [
@@ -102,11 +102,12 @@ module.exports = {
 
 由于在 v0.4.0 中默认启用了 `experiments.rspackFuture.disableTransformByDefault`，`builtin.react.refresh` 也已被废弃。现在我们建议使用 `@rspack/plugin-react-refresh` 来启用 React Fast Refresh。你需要手动安装 [@rspack/plugin-react-refresh](https://www.npmjs.com/package/@rspack/plugin-react-refresh) 和 [react-refresh](https://www.npmjs.com/package/react-refresh)。
 
-```diff
-+ const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
+```diff title="rspack.config.mjs"
++ import ReactRefreshPlugin from '@rspack/plugin-react-refresh';
+
 const isDev = process.env.NODE_ENV === 'development';
 
-module.exports = {
+export default {
   // ...
   mode: isDev ? 'development' : 'production',
   module: {
@@ -140,7 +141,7 @@ module.exports = {
 -  },
   plugins: [
 +    isDev && new ReactRefreshPlugin()
-  ].filter(Boolean),
+  ],
 };
 ```
 
@@ -230,9 +231,10 @@ Rspack 在 v0.4.0 中废弃了部分 builtin options 并迁移至 Rspack [内部
 
 原有的 `builtins.define` 可以这样迁移：
 
-```diff
-+ const { rspack } = require("@rspack/core")
-module.exports = {
+```diff title="rspack.config.mjs"
++ import { rspack } from '@rspack/core';
+
+export default {
 -  builtins: {
 -    define: { process.env.NODE_ENV: JSON.stringify(process.env.NODE_ENV) }
 -  },
@@ -244,9 +246,10 @@ module.exports = {
 
 对于 `builtins.html` 可以直接迁移到 [HtmlRspackPlugin](/plugins/rspack/html-rspack-plugin)：
 
-```diff
-+ const { rspack } = require("@rspack/core")
-module.exports = {
+```diff title="rspack.config.mjs"
++ import { rspack } from '@rspack/core';
+
+export default {
 -  builtins: {
 -    html: [{ template: "./index.html" }]
 -  },
@@ -258,9 +261,10 @@ module.exports = {
 
 当 `builtins.html` 中存在多个配置，可以创建多个插件实例：
 
-```js
-const { rspack } = require('@rspack/core');
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   plugins: [
     new rspack.HtmlRspackPlugin({ template: './index.html' }),
     new rspack.HtmlRspackPlugin({ template: './foo.html' }),
@@ -272,9 +276,10 @@ module.exports = {
 
 原先的 `builtins.minifyOptions` 我们提供了 [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin)：
 
-```js
-const { rspack } = require('@rspack/core');
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   optimization: {
     minimizer: [
       new rspack.SwcJsMinimizerRspackPlugin({

--- a/website/docs/zh/blog/announcing-0-5.mdx
+++ b/website/docs/zh/blog/announcing-0-5.mdx
@@ -37,8 +37,8 @@ import { PackageManagerTabs } from '@theme';
 
 转译 `.jsx` 文件：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -61,8 +61,8 @@ module.exports = {
 
 转译 `.tsx` 文件：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -85,8 +85,8 @@ module.exports = {
 
 转译 `.ts` 文件：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -110,8 +110,8 @@ module.exports = {
 
 Rspack 将 [target](/config/target) 与 webpack 对齐。Rspack 不再转换任意用户代码，而是让 loader 来控制用户代码的转换。要将用户代码转换为目标环境所需的代码，请将 `env` 添加到 `builtin:swc-loader` 中：
 
-```diff
-module.exports = {
+```diff title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -140,8 +140,8 @@ module.exports = {
 
 为了获得与原来相同的行为，请将 `resolve.extensions` 更改为以下内容：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   resolve: {
     extensions: ['...', '.tsx', '.ts', '.jsx'], // "..." 代表着默认的文件扩展名。
   },

--- a/website/docs/zh/blog/announcing-0-6.mdx
+++ b/website/docs/zh/blog/announcing-0-6.mdx
@@ -19,9 +19,10 @@ import { PackageManagerTabs } from '@theme';
 
 详细配置见 [CssExtractRspackPlugin](/plugins/rspack/css-extract-rspack-plugin#cssextractrspackplugin)。
 
-```js
-const { rspack } = require('@rspack/core');
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   plugins: [new rspack.CssExtractRspackPlugin()],
   module: {
     rules: [
@@ -113,8 +114,8 @@ WARNING in ⚠ chunk src_a_css-src_b_-5c8c53 [css-extract-rspack-plugin]
 
 如果你确定他们的顺序不一致没有关系，可以通过配置 `ignoreWarnings` 来忽略这种错误。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   ignoreWarnings: [/Conflicting order/],
 };
 ```
@@ -125,11 +126,12 @@ module.exports = {
 
 如果你曾经使用 webpack 和 `mini-css-extract-plugin`，只需要将 `mini-css-extract-plugin` 换成 `rspack.CssExtractPlugin` 即可。
 
-```diff
-+ const CssExtract = require('@rspack/core').CssExtractRspackPlugin;
-- const CssExtract = require('mini-css-extract-plugin');
-module.exports = {
-  plugins: [new CssExtract()],
+```diff title="rspack.config.mjs"
++ import { rspack } from '@rspack/core';
+- import CssExtract from 'mini-css-extract-plugin';
+
+export default {
+  plugins: [new rspack.CssExtractRspackPlugin()],
   module: {
     rules: [
       {
@@ -152,8 +154,8 @@ module.exports = {
 
 添加以下配置将保持原有 `builtins.css` 默认行为，可根据以下配置根据需要进行修改：
 
-```diff
-module.exports = {
+```diff title="rspack.config.mjs"
+export default {
    // ...
 +  module: {
 +    generator: {

--- a/website/docs/zh/blog/announcing-1-1.mdx
+++ b/website/docs/zh/blog/announcing-1-1.mdx
@@ -60,10 +60,10 @@ Rspack v1.1 和 Rsbuild v1.1 已经正式发布！
 
 在 Rspack v1.1 中，你可以在 `dev` 模式下通过以下方式启用此功能：
 
-```js title=rspack.config.js
+```js title="rspack.config.mjs"
 const isDev = process.env.NODE_ENV === 'development';
 
-module.exports = {
+export default {
   mode: isDev ? 'development' : 'production',
   experiments: {
     incremental: isDev,
@@ -83,7 +83,7 @@ module.exports = {
 
 因此，我们大幅重构了 `HtmlRspackPlugin`，在对齐了更多 `HtmlWebpackPlugin` 配置项的同时，也完成了 `hooks` 对齐。现在你可以通过 `HtmlRspackPlugin.getCompilationHooks` 来获取它们，并使用其修改 HTML 产物的内容：
 
-```js
+```js title="rspack.config.mjs"
 const AddAttributePlugin = {
   apply: function (compiler) {
     compiler.hooks.compilation.tap('AddAttributePlugin', compilation => {
@@ -101,7 +101,7 @@ const AddAttributePlugin = {
   },
 };
 
-module.exports = {
+export default {
   plugins: [new HtmlRspackPlugin(), AddAttributePlugin],
 };
 ```

--- a/website/docs/zh/blog/announcing-1-1.mdx
+++ b/website/docs/zh/blog/announcing-1-1.mdx
@@ -85,7 +85,7 @@ export default {
 
 ```js title="rspack.config.mjs"
 const AddAttributePlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('AddAttributePlugin', compilation => {
       HtmlRspackPlugin.getCompilationHooks(
         compilation,

--- a/website/docs/zh/config/context.mdx
+++ b/website/docs/zh/config/context.mdx
@@ -41,7 +41,7 @@ export default {
   </Tab>
   <Tab label="CJS">
 
-```js title="rspack.config.js"
+```js title="rspack.config.cjs"
 module.exports = {
   context: __dirname,
   entry: {

--- a/website/docs/zh/config/dev-server.mdx
+++ b/website/docs/zh/config/dev-server.mdx
@@ -906,9 +906,9 @@ export default {
   </Tab>
   <Tab label="CJS">
 
-```js title="rspack.config.js"
+```js title="rspack.config.cjs"
 const fs = require('fs');
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
   //...

--- a/website/docs/zh/config/dev-server.mdx
+++ b/website/docs/zh/config/dev-server.mdx
@@ -1,4 +1,5 @@
 import WebpackLicense from '@components/WebpackLicense';
+import { Tabs, Tab } from '@theme';
 
 <WebpackLicense from="https://webpack.docschina.org/configuration/dev-server/" />
 
@@ -257,8 +258,12 @@ export default {
 
 使用路径引用 `CustomClient.js`，一个自定义的 WebSocket 客户端实现，以及与之兼容的 `'ws'` 服务器：
 
-```js title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export default {
   //...
   devServer: {
     client: {
@@ -271,8 +276,12 @@ module.exports = {
 
 使用自定义、兼容的 WebSocket 客户端和服务器实现：
 
-```js title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export default {
   //...
   devServer: {
     client: {
@@ -809,7 +818,7 @@ export default {
 - **类型：** `'http' | 'https' | 'spdy' | string | object`
 - **默认值：** `'http'`
 
-用于设置服务器（默认为“http”）：
+用于设置服务器（默认为 `"http"`）：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -865,6 +874,38 @@ export default {
 
 它还允许你设置其他 [TLS 选项](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options)，如 `minVersion`，并且你可以直接传递相应文件的内容：
 
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
+  //...
+  devServer: {
+    server: {
+      type: 'https',
+      options: {
+        minVersion: 'TLSv1.1',
+        key: fs.readFileSync(path.join(__dirname, './server.key')),
+        pfx: fs.readFileSync(path.join(__dirname, './server.pfx')),
+        cert: fs.readFileSync(path.join(__dirname, './server.crt')),
+        ca: fs.readFileSync(path.join(__dirname, './ca.pem')),
+        passphrase: '@rspack/dev-server',
+        requestCert: true,
+      },
+    },
+  },
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
 ```js title="rspack.config.js"
 const fs = require('fs');
 const path = require('path');
@@ -887,6 +928,9 @@ module.exports = {
   },
 };
 ```
+
+  </Tab>
+</Tabs>
 
 ## devServer.setupMiddlewares
 

--- a/website/docs/zh/config/dev-server.mdx
+++ b/website/docs/zh/config/dev-server.mdx
@@ -353,8 +353,8 @@ export default {
 
 提供选项给 [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware)，它用于处理 Rspack 的静态资源。
 
-```ts
-module.exports = {
+```ts title="rspack.config.mjs"
+export default {
   devServer: {
     devMiddleware: {
       index: true,

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -189,8 +189,8 @@ type ServerOptions =
   | (() => Server);
 ```
 
-```js title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   experiments: {
     lazyCompilation: {
       backend: {
@@ -716,7 +716,7 @@ export default {
 
 示例代码:
 
-```javascript
+```js
 function transform(webpackConfig, rspackConfig) {
   rspackConfig.experiments = rspackConfig.experiments || {};
   if (webpackConfig.cache === undefined) {

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -36,7 +36,7 @@ export default {
 
 这样就剥离了那些不需要改动的依赖模块，换句话，下面展示的代码还可以正常运行：
 
-```javascript
+```js
 import $ from 'jquery';
 
 $('.my-element').animate(/* ... */);
@@ -319,7 +319,7 @@ export default {
 
 **示例**
 
-```javascript
+```js
 import fs from 'fs-extra';
 ```
 
@@ -335,7 +335,7 @@ export default {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 const fs = require('fs-extra');
 ```
 
@@ -347,7 +347,7 @@ const fs = require('fs-extra');
 
 **示例**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -367,7 +367,7 @@ export default {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 const jq = global['$'];
 jq('.my-element').animate(/* ... */);
 ```
@@ -414,7 +414,7 @@ jq('.my-element').animate(/* ... */);
 
 **示例**
 
-```javascript
+```js
 async function foo() {
   const jq = await import('jquery');
   jq('.my-element').animate(/* ... */);
@@ -432,7 +432,7 @@ export default {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 var __webpack_modules__ = {
   jquery: module => {
     module.exports = import('jquery');
@@ -457,7 +457,7 @@ async function foo() {
 
 **示例**
 
-```javascript
+```js
 import { attempt } from 'lodash';
 
 async function foo() {
@@ -477,7 +477,7 @@ export default {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from 'lodash';
 const lodash = __WEBPACK_EXTERNAL_MODULE_jquery__;
 
@@ -529,7 +529,7 @@ export default {
 
 **示例**
 
-```javascript
+```js
 import { attempt } from 'lodash';
 
 async function foo() {
@@ -550,7 +550,7 @@ export default {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 var __webpack_modules__ = {
   lodash: function (module) {
     module.exports = require('lodash');
@@ -580,7 +580,7 @@ async function foo() {
 
 **示例**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -596,7 +596,7 @@ module.exports = {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 import { createRequire } from 'module';
 
 const jq = createRequire(import.meta.url)('jquery');
@@ -637,7 +637,7 @@ jq('.my-element').animate(/* ... */);
 
 将外部的默认类型指定为 `'self'`。 Rspack 会将 external 作为 `self` 对象上的全局变量读取。
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -654,7 +654,7 @@ export default {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 const jq = self['$'];
 jq('.my-element').animate(/* ... */);
 ```
@@ -747,7 +747,7 @@ console.log(window._.head(['a', 'b'])); // logs a here
 
 **示例**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -764,7 +764,7 @@ export default {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 const jq = this['$'];
 jq('.my-element').animate(/* ... */);
 ```
@@ -775,7 +775,7 @@ jq('.my-element').animate(/* ... */);
 
 **示例**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -792,7 +792,7 @@ export default {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 const jq = $;
 jq('.my-element').animate(/* ... */);
 ```
@@ -803,7 +803,7 @@ jq('.my-element').animate(/* ... */);
 
 **示例**
 
-```javascript
+```js
 import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
@@ -820,7 +820,7 @@ export default {
 
 将会转换为类似下面的代码：
 
-```javascript
+```js
 const jq = window['$'];
 jq('.my-element').animate(/* ... */);
 ```

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -42,7 +42,7 @@ import $ from 'jquery';
 $('.my-element').animate(/* ... */);
 ```
 
-上面 `rspack.config.js` 中 `externals` 下指定的属性名称 `jquery` 表示 `import $ from 'jquery'` 中的模块 `jquery` 应该从打包产物中排除。为了替换这个模块，`jQuery` 值将用于检索全局 `jQuery` 变量，因为默认的外部库类型是 `var`，请参阅 [externalsType](#externalstype)。
+在上面 Rspack 配置中，`externals` 下指定的属性名称 `jquery` 表示 `import $ from 'jquery'` 中的模块 `jquery` 应该从打包产物中排除。为了替换这个模块，`jQuery` 值将用于检索全局 `jQuery` 变量，因为默认的外部库类型是 `var`，请参阅 [externalsType](#externalstype)。
 
 虽然我们在上面展示了一个使用外部全局变量的示例，但实际上可以以以下任何形式使用外部变量：全局变量、CommonJS、AMD、ES2015 模块，在 [externalsType](#externalstype) 中查看更多信息。
 
@@ -585,8 +585,8 @@ import jq from 'jquery';
 jq('.my-element').animate(/* ... */);
 ```
 
-```js title=rspack.config.js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   externalsType: 'node-commonjs',
   externals: {
     jquery: 'jquery',

--- a/website/docs/zh/config/index.mdx
+++ b/website/docs/zh/config/index.mdx
@@ -27,7 +27,7 @@ export default defineConfig({
   </Tab>
   <Tab label="CJS">
 
-```js title="rspack.config.js"
+```js title="rspack.config.cjs"
 const { defineConfig } = require('@rspack/cli');
 
 module.exports = defineConfig({
@@ -196,14 +196,14 @@ $ rspack build -c rspack.prod.config.js
 
 ## 导出配置函数
 
-Rspack 支持在 `rspack.config.js` 中导出一个函数，你可以在函数中动态计算配置，并返回给 Rspack。
+Rspack 支持在 Rspack 配置文件中导出一个函数，你可以在函数中动态计算配置，并返回给 Rspack。
 
-```js title="rspack.config.js"
-module.exports = function (env, argv) {
+```js title="rspack.config.mjs"
+export default function (env, argv) {
   return {
     devtool: env.production ? 'source-map' : 'eval',
   };
-};
+}
 ```
 
 从上述示例中可以看到，该函数接受两个入参：
@@ -215,21 +215,21 @@ module.exports = function (env, argv) {
 
 除了通过 `env` 参数，通过 `process.env.NODE_ENV` 来判断当前环境是更常见的方式：
 
-```js title="rspack.config.js"
-module.exports = function (env, argv) {
+```js title="rspack.config.mjs"
+export default function (env, argv) {
   const isProduction = process.env.NODE_ENV === 'production';
   return {
     devtool: isProduction ? 'source-map' : 'eval',
   };
-};
+}
 ```
 
 ## 合并配置
 
 使用 `webpack-merge` 导出的 `merge` 函数来合并多个配置。
 
-```js title="rspack.config.js"
-const { merge } = require('webpack-merge');
+```js title="rspack.config.mjs"
+import { merge } from 'webpack-merge';
 
 const base = {};
 
@@ -237,8 +237,7 @@ const dev = {
   plugins: [new DevelopmentSpecifiedPlugin()],
 };
 
-module.exports =
-  process.env.NODE_ENV === 'development' ? merge(base, dev) : base;
+export default process.env.NODE_ENV === 'development' ? merge(base, dev) : base;
 ```
 
 关于 `merge` 的更多信息请查看 [webpack-merge 文档](https://npmjs.com/package/webpack-merge)。

--- a/website/docs/zh/config/mode.mdx
+++ b/website/docs/zh/config/mode.mdx
@@ -39,7 +39,7 @@ rspack --mode=production
 ```
 
 :::info
-命令行中的 `--mode` 选项优先级高于 `rspack.config.js` 中的 `mode`。
+命令行中的 `--mode` 选项优先级高于 Rspack 配置中的 `mode`。
 :::
 
 ## 可选值

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -1713,8 +1713,8 @@ import('./data', { with: { type: 'url' } });
 
 需要注意的是，为了让 Rspack 能够正常匹配 `with` 语法，当你在使用 [builtin:swc-loader](/guide/features/builtin-swc-loader) 时，需要手动开启 `keepImportAttributes` 配置以保留 `import attributes`：
 
-```diff title=rspack.config.js
-module.exports = {
+```diff title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {

--- a/website/docs/zh/config/optimization.mdx
+++ b/website/docs/zh/config/optimization.mdx
@@ -117,10 +117,10 @@ export default {
 
 当设置了 `optimization.minimizer` 时，默认的压缩器会被禁用。
 
-```js title=rspack.config.js
-const TerserPlugin = require('terser-webpack-plugin');
+```js title="rspack.config.mjs"
+import TerserPlugin from 'terser-webpack-plugin';
 
-module.exports = {
+export default {
   optimization: {
     minimizer: [new TerserPlugin()],
   },
@@ -129,10 +129,10 @@ module.exports = {
 
 使用 Rspack 内置的压缩器，并自定义压缩选项：
 
-```js title=rspack.config.js
-const { rspack } = require('@rspack/core');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   optimization: {
     // 当声明了 `optimization.minimizer`，默认压缩器会被禁用
     // 但你可以配合使用 '...'，它代表默认压缩器

--- a/website/docs/zh/config/optimization.mdx
+++ b/website/docs/zh/config/optimization.mdx
@@ -342,8 +342,8 @@ export default {
 
 如果需要在运行时取消使用的导出分析：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   optimization: {
     usedExports: 'global',

--- a/website/docs/zh/config/other-options.mdx
+++ b/website/docs/zh/config/other-options.mdx
@@ -51,8 +51,8 @@ export default {
 
 请记住，当前配置在其依赖项完成之前不会编译。
 
-```js title="rspack.config.js"
-module.exports = [
+```js title="rspack.config.mjs"
+export default [
   {
     name: 'client',
     target: 'web',

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -791,8 +791,8 @@ export function hello(name) {
 
 1. 如果你将 `entry` 设置为一个 `array`，那么只有数组中的最后一个会被暴露。
 
-   ```js
-   module.exports = {
+   ```js title="rspack.config.mjs"
+   export default {
      // …
      entry: ['./src/a.js', './src/b.js'], // 只有在 b.js 中导出的内容才会被暴露
      output: {
@@ -803,8 +803,8 @@ export function hello(name) {
 
 2. 如果你将 `entry` 设置为一个 `object`，所以入口都可以通过 `library` 的 `array` 语法暴露：
 
-   ```js
-   module.exports = {
+   ```js title="rspack.config.mjs"
+   export default {
      // …
      entry: {
        a: './src/a.js',
@@ -862,8 +862,8 @@ window['clientContainer'].define(/*define args*/); // or 'amd-require' window['c
 
 - **类型：**`string | string[] | {amd?: string, commonjs?: string, root?: string | string[]}`
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -912,8 +912,8 @@ MyLibrary.doSomething();
 
 ##### type: 'assign'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -934,8 +934,8 @@ MyLibrary = _entry_return_;
 
 ##### type: 'assign-properties'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -970,8 +970,8 @@ MyLibrary.hello('World');
 
 ##### type: 'this'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -994,8 +994,8 @@ MyLibrary.doSomething(); // 如果 `this` 为 window 对象
 
 ##### type: 'window'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1016,8 +1016,8 @@ window.MyLibrary.doSomething();
 
 ##### type: 'global'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1038,8 +1038,8 @@ global.MyLibrary.doSomething();
 
 ##### type: 'commonjs'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1089,8 +1089,8 @@ export default {
 
 ##### type: 'commonjs2'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1117,8 +1117,8 @@ require('MyLibrary').doSomething();
 
 ##### type: 'commonjs-static'
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   output: {
     library: {
@@ -1235,8 +1235,8 @@ export default {
 
 在这种情况下，你需要使用 `library.name` 属性命名你的模块：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   output: {
     library: {
@@ -1263,8 +1263,8 @@ module.exports = {
 
 请注意，根据[对象赋值部分](#expose-via-object-assignment)，省略 `library.name` 将导致入口起点返回的所有属性直接赋值给根对象。示例：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   output: {
     libraryTarget: 'umd',
@@ -1290,8 +1290,8 @@ module.exports = {
 
 你可以为 `library.name` 指定一个对象，每个目标的名称不同：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   output: {
     library: {
@@ -1312,8 +1312,8 @@ module.exports = {
 
 System 模块要求当 bundle 执行时，全局变量 `System` 出现在浏览器中。编译的 `System.register` 格式允许你在没有额外配置的情况下使用 `System.import('/bundle.js')`，并将你的 bundle 加载到系统模块注册表中。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   //...
   output: {
     library: {
@@ -1432,8 +1432,8 @@ var MyLibrary = _entry_return_.default.subModule;
 
 为每个 `umd` 类型插入相同的注释，将 `auxiliaryComment` 设置为 string。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   mode: 'development',
   output: {
@@ -1466,8 +1466,8 @@ module.exports = {
 
 对于细粒度控制，可以传递一个对象：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   // …
   mode: 'development',
   output: {

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -902,7 +902,7 @@ export default {
 
 让你的库加载之后，**入口起点的返回值** 将会被赋值给一个变量：
 
-```javascript
+```js
 var MyLibrary = _entry_return_;
 
 // 在加载了 `MyLibrary` 的单独脚本中
@@ -925,7 +925,7 @@ module.exports = {
 
 这将生成一个隐含的全局变量，它有可能重新分配一个现有的值（请谨慎使用）：
 
-```javascript
+```js
 MyLibrary = _entry_return_;
 ```
 
@@ -983,7 +983,7 @@ module.exports = {
 
 **入口起点的返回值** 将会被赋值给 this 对象下的 `output.library.name` 属性。`this` 的含义取决于你：
 
-```javascript
+```js
 this['MyLibrary'] = _entry_return_;
 
 // 在一个单独的脚本中
@@ -1007,7 +1007,7 @@ module.exports = {
 
 **入口起点的返回值** 将会被赋值给 `window` 对象下的 `output.library.name`。
 
-```javascript
+```js
 window['MyLibrary'] = _entry_return_;
 
 window.MyLibrary.doSomething();
@@ -1029,7 +1029,7 @@ module.exports = {
 
 **入口起点的返回值** 将会被复制给全局对象下的 `output.library.name`。取决于 [`target`](/config/target) 值，全局对象可以分别改变,例如，`self`、`global` 或者 `globalThis`。
 
-```javascript
+```js
 global['MyLibrary'] = _entry_return_;
 
 global.MyLibrary.doSomething();
@@ -1051,7 +1051,7 @@ module.exports = {
 
 **入口起点的返回值** 将使用 `output.library.name` 赋值给 `exports` 对象。顾名思义，这是在 CommonJS 环境中使用。
 
-```javascript
+```js
 exports['MyLibrary'] = _entry_return_;
 
 require('MyLibrary').doSomething();
@@ -1102,7 +1102,7 @@ module.exports = {
 
 **入口起点的返回值** 将会被赋值给 `module.exports`。顾名思义，这是在 Node.js（CommonJS）环境中使用的：
 
-```javascript
+```js
 module.exports = _entry_return_;
 
 require('MyLibrary').doSomething();
@@ -1132,13 +1132,13 @@ module.exports = {
 
 输入：
 
-```javascript
+```js
 export function doSomething() {}
 ```
 
 输出：
 
-```javascript
+```js
 function doSomething() {}
 
 // …
@@ -1148,13 +1148,13 @@ exports.doSomething = __webpack_exports__.doSomething;
 
 消费（CommonJS）:
 
-```javascript
+```js
 const { doSomething } = require('./output.cjs'); // doSomething => [Function: doSomething]
 ```
 
 消费（ESM）:
 
-```javascript
+```js
 import { doSomething } from './output.cjs'; // doSomething => [Function: doSomething]
 ```
 
@@ -1234,7 +1234,7 @@ export default {
 
 在这种情况下，你需要使用 `library.name` 属性命名你的模块：
 
-```javascript
+```js
 module.exports = {
   //...
   output: {
@@ -1248,7 +1248,7 @@ module.exports = {
 
 最终的输出为：
 
-```javascript
+```js
 (function webpackUniversalModuleDefinition(root, factory) {
   if (typeof exports === 'object' && typeof module === 'object')
     module.exports = factory();
@@ -1262,7 +1262,7 @@ module.exports = {
 
 请注意，根据[对象赋值部分](#expose-via-object-assignment)，省略 `library.name` 将导致入口起点返回的所有属性直接赋值给根对象。示例：
 
-```javascript
+```js
 module.exports = {
   //...
   output: {
@@ -1273,7 +1273,7 @@ module.exports = {
 
 输出将会是：
 
-```javascript
+```js
 (function webpackUniversalModuleDefinition(root, factory) {
   if (typeof exports === 'object' && typeof module === 'object')
     module.exports = factory();
@@ -1289,7 +1289,7 @@ module.exports = {
 
 你可以为 `library.name` 指定一个对象，每个目标的名称不同：
 
-```javascript
+```js
 module.exports = {
   //...
   output: {
@@ -1311,7 +1311,7 @@ module.exports = {
 
 System 模块要求当 bundle 执行时，全局变量 `System` 出现在浏览器中。编译的 `System.register` 格式允许你在没有额外配置的情况下使用 `System.import('/bundle.js')`，并将你的 bundle 加载到系统模块注册表中。
 
-```javascript
+```js
 module.exports = {
   //...
   output: {
@@ -1324,7 +1324,7 @@ module.exports = {
 
 输出：
 
-```javascript
+```js
 System.register([], function (__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
   return {
     execute: function () {
@@ -1336,7 +1336,7 @@ System.register([], function (__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
 
 除了设置 `output.library.type` 为 `system`，还要将 `output.library.name` 添加到配置中，输出的 bundle 将以库名作为 `System.register` 的参数：
 
-```javascript
+```js
 System.register(
   'MyLibrary',
   [],
@@ -1491,7 +1491,7 @@ module.exports = {
 
 当使用 `output.library.type: "umd"` 时，将 `output.library.umdNamedDefine` 设置为 `true` 将会把 AMD 模块命名为 UMD 构建。否则使用匿名 `define`。
 
-```javascript
+```js
 module.exports = {
   //...
   output: {

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1,5 +1,6 @@
 import WebpackLicense from '@components/WebpackLicense';
 import { ApiMeta, Stability } from '../../../components/ApiMeta';
+import { Tabs, Tab } from '@theme';
 
 <WebpackLicense from="https://webpack.docschina.org/configuration/output/" />
 
@@ -214,10 +215,10 @@ export default {
 
 比如将 `output.publicPath` 设置为 `https://example.com/`，并将 `output.crossOriginLoading` 设置为 `'anonymous'`：
 
-```js title="rspack.config.js"
-const path = require('path');
+```js title="rspack.config.mjs"
+import path from 'node:path';
 
-module.exports = {
+export default {
   output: {
     publicPath: 'https://example.com/',
     crossOriginLoading: 'anonymous',
@@ -1540,8 +1541,27 @@ export default {
 
 输出文件目录的绝对路径。
 
-```js title="rspack.config.js"
-const path = require('path');
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
+  output: {
+    path: path.resolve(__dirname, 'dist/assets'),
+  },
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
+const path = require('node:path');
 
 module.exports = {
   output: {
@@ -1549,6 +1569,9 @@ module.exports = {
   },
 };
 ```
+
+  </Tab>
+</Tabs>
 
 注意 `[fullhash]` 将会被替换为构建过程中的 hash 值。
 

--- a/website/docs/zh/config/resolve-loader.mdx
+++ b/website/docs/zh/config/resolve-loader.mdx
@@ -1,3 +1,5 @@
+import { Tabs, Tab } from '@theme';
+
 # ResolveLoader
 
 该配置项和 [`resolve`](/config/resolve) 的类型保持一致，但这个配置仅会对 [loader](/guide/features/loader) 的解析生效。
@@ -19,7 +21,27 @@
 
 比如，你在进行 loader 的开发，但又希望能在 loader 的使用示例中以用户视角展示使用方式，你可以这样写：
 
-```js title="rspack.config.js"
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+export default {
+  resolveLoader: {
+    alias: {
+      'amazing-loader': require.resolve('path-to-your-amazing-loader'),
+    },
+  },
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
 module.exports = {
   resolveLoader: {
     alias: {
@@ -28,6 +50,9 @@ module.exports = {
   },
 };
 ```
+
+  </Tab>
+</Tabs>
 
 然后，在 example 的代码中这么写：
 

--- a/website/docs/zh/contribute/development/testing-rspack.mdx
+++ b/website/docs/zh/contribute/development/testing-rspack.mdx
@@ -77,7 +77,7 @@ Rspack 的测试用例包括如下：
 
 此测试用例与常规的 rspack 项目相同，可通过添加 `rspack.config.js` 来指定构建配置，并可通过添加 `test.config.js` 来控制测试运行时的各种行为，其结构如下：
 
-```typescript {16-20} title="test.config.js"
+```ts {16-20} title="test.config.js"
 type TConfigCaseConfig = {
   noTest?: boolean; // 不运行测试产物并结束测试
   beforeExecute?: () => void; // 运行产物前回调

--- a/website/docs/zh/contribute/development/testing-webpack.mdx
+++ b/website/docs/zh/contribute/development/testing-webpack.mdx
@@ -14,7 +14,7 @@
 
 例如：
 
-```javascript title="test.filter.js"
+```js title="test.filter.js"
 module.exports = () => {
   return false; // false 表示当前测试用例暂时被跳过，但也许我们将来会支持它；-1 表示我们不希望兼容这个测试用例，这与 `willNotSupportTest` 相关。
 };
@@ -22,7 +22,7 @@ module.exports = () => {
 
 如果你发现测试用例已可以通过，那么将 `test.filter.js` 更改为：
 
-```javascript title="test.filter.js"
+```js title="test.filter.js"
 module.exports = () => {
   return true;
 };

--- a/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
@@ -10,10 +10,10 @@ import { ApiMeta, Stability } from '@components/ApiMeta';
 
 如果需要在项目中使用 `builtin:lightningcss-loader`，需进行如下配置。
 
-```js
-const { rspack } = require('@rspack/core');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   module: {
     rules: [
       {
@@ -37,10 +37,8 @@ module.exports = {
 
 你可以使用 `@rspack/core` 导出的 `LightningcssLoaderOptions` 类型来开启类型提示：
 
-- `rspack.config.js`:
-
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {

--- a/website/docs/zh/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-swc-loader.mdx
@@ -12,8 +12,8 @@ import { ApiMeta, Stability } from '@components/ApiMeta';
 
 比如对 `.ts` 文件进行转译：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -38,8 +38,8 @@ module.exports = {
 
 对 React 的 `.jsx` 文件进行转译：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -79,8 +79,8 @@ SWC 提供了 [jsc.target](https://swc.rs/docs/configuration/compilation#jsctarg
 
 [jsc.target](https://swc.rs/docs/configuration/compilation#jsctarget) 用于指定 ECMA 版本，例如 `es5`，`es2015`，`es2016` 等。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -104,8 +104,8 @@ module.exports = {
 
 [env.targets](https://swc.rs/docs/configuration/compilation#envtargets) 使用 [browserslist](https://github.com/browserslist/browserslist) 的语法来指定浏览器范围，例如：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -140,8 +140,8 @@ module.exports = {
 
 SWC 支持注入 [core-js](https://github.com/zloirock/core-js) 作为 API polyfill，可以通过 [env.mode](https://swc.rs/docs/configuration/compilation#envmode) 和 [env.coreJs](https://swc.rs/docs/configuration/compilation#envcorejs) 来配置：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -179,10 +179,8 @@ module.exports = {
 
 你可以使用 `@rspack/core` 导出的 `SwcLoaderOptions` 类型来开启类型提示：
 
-- `rspack.config.js`:
-
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -273,10 +271,13 @@ Rspack 支持在 `builtin:swc-loader` 里加载 SWC 的 Wasm 插件, 你可以�
 
 当你使用 SWC 的 Wasm 插件时，SWC 默认会生成缓存文件在当前项目的 `.swc` 目录下，如果你希望调整该目录，可以修改 `cacheRoot` 配置，如：
 
-```js
-const path = require('path');
+```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
   module: {
     rules: [
       {

--- a/website/docs/zh/guide/features/dev-server.mdx
+++ b/website/docs/zh/guide/features/dev-server.mdx
@@ -13,10 +13,10 @@ Rspack CLI 内置了 `@rspack/dev-server` 用于开发调试，它的能力与 `
 
 ### HMR
 
-Rspack 在 dev 模式下默认开启了 HMR，你也可以在 `rspack.config.js` 中配置 `devServer.hot` 选项来关闭 HMR。
+Rspack 在 dev 模式下默认开启了 HMR，你也可以在 Rspack 配置中设置 `devServer.hot` 选项来关闭 HMR。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   devServer: {
     hot: false,
   },
@@ -24,15 +24,15 @@ module.exports = {
 ```
 
 :::warning
-不要在 `output.cssFilename` 包含 `[hash]` 或者 `[contenthash]`，否则 CSS 的 HMR 可能会不生效。
+不要在 [output.cssFilename](/config/output#outputcssfilename) 中包含 `[hash]` 或者 `[contenthash]`，否则 CSS 的 HMR 可能会不生效。
 :::
 
 ### Proxy
 
-Rspack 内置了一个简单的代理服务器，你可以在 `rspack.config.js` 中配置 `devServer.proxy` 选项来开启代理服务器。devServer 内部使用了 [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) 来实现代理功能。例如我们可以通过如下方式将 `/api` 代理到 `http://localhost:3000`。
+Rspack 内置了一个简单的代理服务器，你可以在 Rspack 配置中添加 `devServer.proxy` 选项来开启代理服务器。devServer 内部使用了 [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) 来实现代理功能。例如我们可以通过如下方式将 `/api` 代理到 `http://localhost:3000`。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   devServer: {
     proxy: [
       {

--- a/website/docs/zh/guide/features/loader.mdx
+++ b/website/docs/zh/guide/features/loader.mdx
@@ -128,13 +128,13 @@ Loader 的第一个入参为文件的内容，我们可以在这里对文件内�
 
 上述示例中，我们会在所有匹配的文件的头部添加一个 banner 注释，如果我们希望将这个行为匹配所有以 `js` 结尾的文件，我们可以这样配置：
 
-```js title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
         test: /\.js$/,
-        loader: require.resolve('./banner-loader.js'),
+        loader: './banner-loader.js',
       },
     ],
   },

--- a/website/docs/zh/guide/features/module-federation.mdx
+++ b/website/docs/zh/guide/features/module-federation.mdx
@@ -39,12 +39,10 @@ Module Federation（MF） 目前有多个主要版本，你可以根据你的需
 
 你需要安装额外的 `@module-federation/enhanced` 插件，才能使用 Module Federation v2.0。
 
-```js title="rspack.config.js"
-const {
-  ModuleFederationPlugin,
-} = require('@module-federation/enhanced/rspack');
+```js title="rspack.config.mjs"
+import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
 
-module.exports = {
+export default {
   plugins: [
     new ModuleFederationPlugin({
       // options

--- a/website/docs/zh/guide/features/plugin.mdx
+++ b/website/docs/zh/guide/features/plugin.mdx
@@ -1,3 +1,5 @@
+import { Tabs, Tab } from '@theme';
+
 # 插件
 
 如果说 [loader](/guide/features/loader) 是文件转换（预处理）的核心，那么插件（plugin）则是 Rspack 整体构建流程的核心组成部分，Rspack 大部分的原生实现都依赖于 Rust 侧的插件系统。
@@ -8,9 +10,27 @@
 
 Rspack 提供了 [plugins](/config/plugins) 配置项，用于注册一组 Rspack 或 webpack 插件来自定义构建过程。
 
-下面是一个例子，在 `rspack.config.js` 中使用 [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) 插件：
+下面是一个例子，在 Rspack 配置中使用 [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) 插件：
 
-```js title="rspack.config.js"
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+
+export default {
+  plugins: [
+    new BundleAnalyzerPlugin({
+      // options
+    }),
+  ],
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 module.exports = {
@@ -21,6 +41,9 @@ module.exports = {
   ],
 };
 ```
+
+  </Tab>
+</Tabs>
 
 如果你正在寻找更多的 Rspack 插件，请查看 [插件](/plugins/index) 列表。
 
@@ -34,7 +57,25 @@ module.exports = {
 
 下面是使用 [unplugin-vue-components](https://www.npmjs.com/package/unplugin-vue-components) 的示例：
 
-```js title=rspack.config.js
+<Tabs>
+  <Tab label="ESM">
+
+```js title="rspack.config.mjs"
+import Components from 'unplugin-vue-components/rspack';
+
+export default {
+  plugins: [
+    Components({
+      // options
+    }),
+  ],
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
 const Components = require('unplugin-vue-components/rspack');
 
 module.exports = {
@@ -45,6 +86,9 @@ module.exports = {
   ],
 };
 ```
+
+  </Tab>
+</Tabs>
 
 ### SWC 插件
 
@@ -71,7 +115,25 @@ module.exports = {
 
 作为插件的作者，插件的结构非常简单：只需要实现一个 `apply` 方法，这个方法接受一个 `Compiler` 实例，并会在 Rspack 插件初始化时被调用。详细的 API 可以参考 [Plugin API](/api/plugin-api/index)。
 
-```js
+<Tabs>
+  <Tab label="ESM">
+
+```js title="MyPlugin.mjs"
+const PLUGIN_NAME = 'MyPlugin';
+
+export class MyPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+      console.log('The Rspack build process is starting!');
+    });
+  }
+}
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="MyPlugin.cjs"
 const PLUGIN_NAME = 'MyPlugin';
 
 class MyPlugin {
@@ -85,18 +147,19 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
-我们使用 CommonJS 风格的模块导出，这样在 `rspack.config.js` 中就可以直接使用 `require` 导入。
+  </Tab>
+</Tabs>
 
 ### 使用 TypeScript 编写
 
 如果你使用 TypeScript 来编写 Rspack 插件，可以引入 `Compiler` 和 `RspackPluginInstance` 来声明插件的类型：
 
-```ts
+```ts title="MyPlugin.ts"
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
 
 const PLUGIN_NAME = 'MyPlugin';
 
-class MyPlugin implements RspackPluginInstance {
+export class MyPlugin implements RspackPluginInstance {
   apply(compiler: Compiler) {
     compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
       console.log('The Rspack build process is starting!');

--- a/website/docs/zh/guide/features/web-workers.mdx
+++ b/website/docs/zh/guide/features/web-workers.mdx
@@ -1,5 +1,6 @@
 import WebpackLicense from '@components/WebpackLicense';
 import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
+import { Tabs, Tab } from '@theme';
 
 <WebpackLicense from="https://webpack.docschina.org/guides/web-workers/" />
 
@@ -64,7 +65,26 @@ Rspack 也支持了 worker-loader，不过由于 [worker-loader](https://github.
 
 使用 [resolveLoader](/config/resolve-loader) 替换 worker-loader 为 worker-rspack-loader：
 
-```js
+<Tabs>
+  <Tab label="ESM">
+```js title="rspack.config.mjs"
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+export default {
+  resolveLoader: {
+    alias: {
+      'worker-loader': require.resolve('worker-rspack-loader'),
+    },
+  },
+};
+```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="rspack.config.cjs"
 module.exports = {
   resolveLoader: {
     alias: {
@@ -73,3 +93,6 @@ module.exports = {
   },
 };
 ```
+
+  </Tab>
+</Tabs>

--- a/website/docs/zh/guide/migration/rspack_0.x.mdx
+++ b/website/docs/zh/guide/migration/rspack_0.x.mdx
@@ -75,7 +75,7 @@ export default {
 请使用 [resolve.tsConfig](/config/resolve#resolvetsconfig) 代替。
 
 ```diff
-module.exports = {
+export default {
   resolve: {
 -   tsConfigPath: path.resolve(__dirname, './tsconfig.json'),
 +   tsConfig: path.resolve(__dirname, './tsconfig.json'),
@@ -208,7 +208,9 @@ export default {
 如果你之前手动注册并配置 `rspack.SwcCssMinimizerRspackPlugin`，现在需要使用 `rspack.LightningCssMinimizerRspackPlugin`：
 
 ```diff
-module.exports = {
+import { rspack } from '@rspack/core';
+
+export default {
   optimization: {
     minimizer: [
 -     new rspack.SwcCssMinimizerRspackPlugin({

--- a/website/docs/zh/guide/optimization/code-splitting.mdx
+++ b/website/docs/zh/guide/optimization/code-splitting.mdx
@@ -43,11 +43,8 @@ console.log('bar.js');
 
 这是最简单直观分离代码的方式。但这种方式需要我们手动对 Rspack 进行配置。我们来看看如何从通过多个入口起点分割出多个 Chunk 。
 
-```js title=rspack.config.js
-/**
- * @type {import('@rspack/core').Configuration}
- */
-const config = {
+```js title="rspack.config.mjs"
+export default {
   mode: 'development',
   entry: {
     index: './src/index.js',
@@ -55,8 +52,6 @@ const config = {
   },
   stats: 'normal',
 };
-
-module.exports = config;
 ```
 
 ```js title=index.js
@@ -92,11 +87,8 @@ Rspack 默认会对 `node_modules` 目录下的文件以及重复模块进行拆
 
 我们可以配置最小拆分体积为 0 ，来让 `shared.js` 被单独抽离。
 
-```diff title=rspack.config.js
-/**
- * @type {import('@rspack/core').Configuration}
- */
-const config = {
+```diff title="rspack.config.mjs"
+export default {
   entry: {
     index: './src/index.js',
   },
@@ -106,8 +98,6 @@ const config = {
 +    }
 +  }
 };
-
-module.exports = config;
 ```
 
 重新打包会发现 `shared.js` 被单独抽离出去，产物中多了一个包含有 `shared.js` 的 Chunk。

--- a/website/docs/zh/guide/optimization/use-rsdoctor.mdx
+++ b/website/docs/zh/guide/optimization/use-rsdoctor.mdx
@@ -54,12 +54,12 @@ import { PackageManagerTabs } from '@theme';
 
 :::
 
-在 `rspack.config.js` 的 [plugins](/config/plugins.html#plugins) 中初始化 RsdoctorRspackPlugin 插件，参考：
+在 Rspack 配置的 [plugins](/config/plugins.html#plugins) 中初始化 RsdoctorRspackPlugin 插件，参考：
 
-```ts title="rspack.config.js"
-const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
+```ts title="rspack.config.mjs"
+import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 
-module.exports = {
+export default {
   // ...
   plugins: [
     // 仅在 RSDOCTOR 为 true 时注册插件，因为插件会增加构建耗时
@@ -67,7 +67,7 @@ module.exports = {
       new RsdoctorRspackPlugin({
         // 插件选项
       }),
-  ].filter(Boolean),
+  ],
 };
 ```
 

--- a/website/docs/zh/guide/tech/css.mdx
+++ b/website/docs/zh/guide/tech/css.mdx
@@ -131,7 +131,7 @@ import { red } from './index.module.css';
 document.getElementById('element').className = red;
 ```
 
-要在 Rspack 中启用默认导入方式，你需要在 `rspack.config.js` 文件中将 `namedExports` 配置为 `false`。这允许你在用到 CSS Modules 时，除了命名空间导入和具名导入，也能通过默认导入整个样式模块：
+要在 Rspack 中启用默认导入方式，你需要在 Rspack 配置中将 `namedExports` 配置为 `false`。这允许你在用到 CSS Modules 时，除了命名空间导入和具名导入，也能通过默认导入整个样式模块：
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/guide/tech/html.mdx
+++ b/website/docs/zh/guide/tech/html.mdx
@@ -6,11 +6,11 @@ Rspack 支持通过以下插件来生成 HTML 文件，并自动将生成的 CSS
 
 Rspack 完全支持 [HtmlWebpackPlugin](https://github.com/jantimon/html-webpack-plugin)。
 
-```js title="rspack.config.js"
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const path = require('path');
+```js title="rspack.config.mjs"
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'node:path';
 
-module.exports = {
+export default {
   entry: 'index.js',
   output: {
     path: path.resolve(__dirname, './dist'),

--- a/website/docs/zh/guide/tech/preact.mdx
+++ b/website/docs/zh/guide/tech/preact.mdx
@@ -57,7 +57,7 @@ export default {
 
 关于配置项的更多信息请参考 [内置 swc-loader](guide/features/builtin-swc-loader)。
 
-完整示例可参考：[examples/preact](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact/rspack.config.js)
+完整示例可参考：[examples/preact](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact)
 
 ## Preact Refresh
 
@@ -87,11 +87,12 @@ export default {
 请使用 `builtin:swc-loader` 并在配置中添加 `rspackExperiments.preact: {}` 以开启 preact 特有转换。
 :::
 
-```js title=rspack.config.js
-const PreactRefreshPlugin = require('@rspack/plugin-preact-refresh');
+```js title="rspack.config.mjs"
+import PreactRefreshPlugin from '@rspack/plugin-preact-refresh';
+
 const isDev = process.env.NODE_ENV === 'development';
 
-module.exports = {
+export default {
   // ...
   mode: isDev ? 'development' : 'production',
   module: {
@@ -131,8 +132,8 @@ module.exports = {
   plugins: [
     isDev && new PreactRefreshPlugin(),
     isDev && new rspack.HotModuleReplacementPlugin(),
-  ].filter(Boolean),
+  ],
 };
 ```
 
-完整示例可参考：[examples/preact-refresh](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact-refresh/rspack.config.js)
+完整示例可参考：[examples/preact-refresh](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact-refresh)

--- a/website/docs/zh/guide/tech/react.mdx
+++ b/website/docs/zh/guide/tech/react.mdx
@@ -104,14 +104,14 @@ export default {
   plugins: [
     isDev && new ReactRefreshPlugin(),
     isDev && new rspack.HotModuleReplacementPlugin(),
-  ].filter(Boolean),
+  ],
 };
 ```
 
 这种实现方式将代码注入逻辑和转换逻辑解耦，代码注入逻辑统一通过 `@rspack/plugin-react-refresh` 插件完成，代码转换通过 loader 完成。这意味着该插件可以配合 `builtin:swc-loader`、`swc-loader` 或 `babel-loader` 使用：
 
-- 配合 `builtin:swc-loader` 使用方式可参考：[examples/react-refresh](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh/rspack.config.js)，使用 `swc-loader` 只需将 `builtin:swc-loader` 换为 `swc-loader` 即可。
-- 配合 `babel-loader` 的使用方式可参考：[examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh-babel-loader/rspack.config.js)
+- 配合 `builtin:swc-loader` 使用方式可参考：[examples/react-refresh](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh)，使用 `swc-loader` 只需将 `builtin:swc-loader` 换为 `swc-loader` 即可。
+- 配合 `babel-loader` 的使用方式可参考：[examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh-babel-loader)
 
 ## React Compiler
 
@@ -135,7 +135,7 @@ React Compiler 目前仅支持 Babel 编译，这会导致构建时间变慢。
 - [babel-plugin-react-compiler](https://www.npmjs.com/package/babel-plugin-react-compiler)
 - [@babel/plugin-syntax-jsx](https://www.npmjs.com/package/@babel/plugin-syntax-jsx)
 
-3. 在你的 Rspack 配置文件中注册 `babel-loader`：
+3. 在你的 Rspack 配置中注册 `babel-loader`：
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/guide/tech/typescript.mdx
+++ b/website/docs/zh/guide/tech/typescript.mdx
@@ -4,8 +4,8 @@
 
 通过 [`builtin:swc-loader`](/guide/features/builtin-swc-loader) 可以开启对 TypeScript 的支持。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {
@@ -61,8 +61,8 @@ module.exports = {
 
 通过 [`builtin:swc-loader`](/guide/features/builtin-swc-loader) 可以开启对 JSX 和 TSX 的支持。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   module: {
     rules: [
       {

--- a/website/docs/zh/guide/tech/vue.mdx
+++ b/website/docs/zh/guide/tech/vue.mdx
@@ -38,8 +38,8 @@ export default defineConfig({
 
 由于 Rspack 原生支持了 CSS 模块的编译，因此你无需配置与 CSS 相关的 loader。另外，当你尝试使用 CSS 预处理器（如：less）时，你只需要添加如下配置即可：
 
-```diff
-const config = {
+```diff title="rspack.config.mjs"
+export default {
   module: {
     rules: [
 +      {
@@ -50,7 +50,6 @@ const config = {
     ]
   }
 }
-module.exports = config;
 ```
 
 此时，Rspack 将会使用内置的 CSS 处理器进行后处理。

--- a/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
@@ -18,10 +18,10 @@ new rspack.CopyRspackPlugin(options);
 
 - 拷贝一个文件。如果文件不存在，则插件会抛出错误。
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -34,10 +34,10 @@ module.exports = {
 
 - `patterns` 配置可以是一个字符串，或是一个包含多个对象的数组。
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -50,10 +50,10 @@ module.exports = {
 
 - 拷贝一个目录。如果目录中没有文件，则插件会抛出错误。
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -67,11 +67,14 @@ module.exports = {
 
 - 使用 glob pattern 来匹配并拷贝文件。
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
-const path = require('node:path');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -90,10 +93,10 @@ module.exports = {
 
 - 使用 `to` 指定目标路径。
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: './src/index.js',
   plugins: [
     new rspack.CopyRspackPlugin({
@@ -114,10 +117,13 @@ module.exports = {
 
 拷贝的源路径，可以是绝对路径、相对路径、glob pattern，可以是文件或目录。若传入相对路径，则是相对于 [context](#context) 选项。
 
-```js title="rspack.config.js"
-const path = require('node:path');
+```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
   plugins: [
     new rspack.CopyRspackPlugin({
       patterns: [
@@ -187,10 +193,14 @@ export default {
 
 `context` 是一个路径，它会被添加到 `from` 路径的前面，并从结果路径中移除。
 
-```js
-const path = require('node:path');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
   plugins: [
     new rspack.CopyRspackPlugin({
       // `./src/*.json` -> `./dist/*.json`
@@ -284,6 +294,11 @@ export default {
 当没有找到对应的文件或目录时，是否忽略错误。
 
 ```js title="rspack.config.mjs"
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 export default {
   plugins: [
     new rspack.CopyRspackPlugin({

--- a/website/docs/zh/plugins/rspack/css-extract-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/css-extract-rspack-plugin.mdx
@@ -13,10 +13,10 @@ Rspack 目前不兼容 [mini-css-extract-plugin](https://github.com/webpack-cont
 
 使用 CssExtractRspackPlugin 时，需要在 `plugins` 中注册插件，并在 [module.rules](/config/module#modulerules) 中注册 `CssExtractRspackPlugin.loader`。
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   plugins: [new rspack.CssExtractRspackPlugin({})],
   module: {
     rules: [
@@ -198,10 +198,10 @@ interface LoaderOptions {
 
 例如：
 
-```ts title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   plugins: [new rspack.CssExtractRspackPlugin({})],
   module: {
     rules: [

--- a/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
@@ -516,7 +516,7 @@ export default {
 
 可以通过如下配置生成 `<base>` 标签：
 
-```js title="rspack.config.js"
+```js
 new HtmlWebpackPlugin({
   // 将会生成: <base href="http://example.com/some/page.html">
   base: 'http://example.com/some/page.html',
@@ -540,10 +540,10 @@ new HtmlWebpackPlugin({
 
 比如以下配置，会生成 foo.html 和 bar.html，其中 foo.html 仅会包含 foo.js 生成的 JS 产物。
 
-```js
-const { rspack } = require('@rspack/core');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: {
     foo: './foo.js',
     bar: './bar.js',
@@ -565,9 +565,9 @@ module.exports = {
 
 HtmlRspackPlugin 提供了一些 hooks，可以让你在构建过程中修改标签或 HTML 产物代码。可通过 `rspack.HtmlRspackPlugin.getCompilationHooks` 来获取 hooks 对象：
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const HtmlModifyPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('HtmlModifyPlugin', compilation => {
       const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
       // hooks.beforeAssetTagGeneration.tapPromise()
@@ -580,7 +580,7 @@ const HtmlModifyPlugin = {
   },
 };
 
-module.exports = {
+export default {
   // ...
   plugins: [new HtmlRspackPlugin(), HtmlModifyPlugin],
 };
@@ -615,9 +615,9 @@ module.exports = {
 
 如下代码将添加了一个额外的 `extra-script.js` 并在最终产物中生成对应的 `<script defer src="extra-script.js"></script>` 标签
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const AddScriptPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('AddScriptPlugin', compilation => {
       HtmlRspackPlugin.getCompilationHooks(
         compilation,
@@ -628,7 +628,7 @@ const AddScriptPlugin = {
   },
 };
 
-module.exports = {
+export default {
   // ...
   plugins: [new HtmlRspackPlugin(), AddScriptPlugin],
 };
@@ -673,9 +673,9 @@ module.exports = {
 
 如下代码将给所有 `script` 类型的标签添加 `specialAttribute` 属性:
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const AddAttributePlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('AddAttributePlugin', compilation => {
       HtmlRspackPlugin.getCompilationHooks(
         compilation,
@@ -691,7 +691,7 @@ const AddAttributePlugin = {
   },
 };
 
-module.exports = {
+export default {
   // ...
   plugins: [new HtmlRspackPlugin(), AddAttributePlugin],
 };
@@ -720,9 +720,9 @@ module.exports = {
 
 如下代码将把 `async` 的 `script` 标签从 `body` 调整到 `head` 中:
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const MoveTagsPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('MoveTagsPlugin', compilation => {
       HtmlWebpackPlugin.getCompilationHooks(
         compilation,
@@ -736,7 +736,7 @@ const MoveTagsPlugin = {
   },
 };
 
-module.exports = {
+export default {
   // ...
   plugins: [
     new HtmlRspackPlugin({
@@ -773,9 +773,9 @@ module.exports = {
 
 如下代码将在 body 结尾添加 `Injected by plugin`，之后标签才会注入并添加到该文本之后，因此产物中为 ，产物中为 `Injected by plugin<script defer src="main.js"></script></body>`：
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const InjectContentPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('InjectContentPlugin', compilation => {
       HtmlWebpackPlugin.getCompilationHooks(
         compilation,
@@ -792,7 +792,7 @@ const InjectContentPlugin = {
   },
 };
 
-module.exports = {
+export default {
   // ...
   plugins: [
     new HtmlRspackPlugin({
@@ -825,9 +825,9 @@ module.exports = {
 
 如下代码将在 body 结尾添加 `Injected by plugin`，产物中为 `<script defer src="main.js"></script>Injected by plugin</body>`：
 
-```js title="rspack.config.js"
+```js title="rspack.config.mjs"
 const InjectContentPlugin = {
-  apply: function (compiler) {
+  apply(compiler) {
     compiler.hooks.compilation.tap('InjectContentPlugin', compilation => {
       HtmlWebpackPlugin.getCompilationHooks(compilation).beforeEmit.tapPromise(
         'InjectContentPlugin',
@@ -842,7 +842,7 @@ const InjectContentPlugin = {
   },
 };
 
-module.exports = {
+export default {
   // ...
   plugins: [
     new HtmlRspackPlugin({

--- a/website/docs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
@@ -6,8 +6,10 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 
 此插件使用 [lightningcss](https://lightningcss.dev/) 来压缩 CSS 产物。参见 [optimization.minimizer](/config/optimization#optimizationminimizer)。
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   // ...
   optimization: {
     minimizer: [new rspack.LightningCssMinimizerRspackPlugin()],

--- a/website/docs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
@@ -10,8 +10,10 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 
 通过 [optimization.minimizer](/config/optimization#optimizationminimizer) 使用此插件：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   // ...
   optimization: {
     minimizer: [

--- a/website/docs/zh/plugins/webpack/eval-source-map-dev-tool-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/eval-source-map-dev-tool-plugin.mdx
@@ -36,8 +36,10 @@ new webpack.EvalSourceMapDevToolPlugin(options);
 
 你可以使用以下代码来替换配置选项 `devtool: eval-source-map`，使用等效的自定义插件配置：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   // ...
   devtool: false,
   plugins: [new rspack.EvalSourceMapDevToolPlugin({})],

--- a/website/docs/zh/plugins/webpack/hot-module-replacement-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/hot-module-replacement-plugin.mdx
@@ -12,11 +12,11 @@ new rspack.HotModuleReplacementPlugin();
 
 注意 HMR 不能被用于生产构建，因此你需要通过 `process.env.NODE_ENV` 来判断当前是否是开发环境。
 
-```js title="rspack.config.js"
-const { rspack } = require('@rspack/core');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 const isDev = process.env.NODE_ENV === 'development';
 
-module.exports = {
+export default {
   plugins: [isDev && new rspack.HotModuleReplacementPlugin()],
 };
 ```

--- a/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
@@ -6,10 +6,10 @@ import { Stability } from '@components/ApiMeta';
 
 ## 示例
 
-```js
-const { rspack } = require('@rspack/core');
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   output: {
     // set uniqueName explicitly to make HMR works
     uniqueName: 'app',
@@ -160,8 +160,8 @@ module.exports = {
 
   如果你需要兼容低版本浏览器，请添加 [builtin:swc-loader](/guide/features/builtin-swc-loader) 进行语法降级，需要匹配 `@module-federation/runtime` 和 `@module-federation/sdk`。示例如下：
 
-  ```js
-  module.exports = {
+  ```js title="rspack.config.mjs"
+  export default {
     module: {
       rules: [
         {

--- a/website/docs/zh/plugins/webpack/normal-module-replacement-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/normal-module-replacement-plugin.mdx
@@ -31,7 +31,7 @@ new rspack.NormalModuleReplacementPlugin(resourceRegExp, newResource);
 
 可以在生产构建时这样配置该插件：
 
-```javascript
+```js
 new rspack.NormalModuleReplacementPlugin(
   /some\/path\/config\.development\.js/,
   './config.production.js',
@@ -44,7 +44,7 @@ new rspack.NormalModuleReplacementPlugin(
 
 假设你希望为不同的构建目标使用不同的配置：
 
-```javascript
+```js
 module.exports = function getRspackConfig(env) {
   const appTarget = env.APP_TARGET || 'VERSION_A';
   return {

--- a/website/docs/zh/plugins/webpack/provide-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/provide-plugin.mdx
@@ -27,7 +27,7 @@ new rspack.ProvidePlugin({
 也可以指定完整路径：
 
 ```js
-const path = require('path');
+const path = require('node:path');
 
 new rspack.ProvidePlugin({
   identifier: path.resolve(path.join(__dirname, 'src/module1')),

--- a/website/docs/zh/plugins/webpack/source-map-dev-tool-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/source-map-dev-tool-plugin.mdx
@@ -119,8 +119,10 @@ new rspack.SourceMapDevToolPlugin(options);
 
 你可以使用以下代码将配置项 devtool: inline-source-map 替换为等效的自定义插件配置：
 
-```js
-module.exports = {
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
   // ...
   devtool: false,
   plugins: [new rspack.SourceMapDevToolPlugin({})],


### PR DESCRIPTION
## Summary

Migrate all the configuration examples to ESM or dual format.

Related:

- https://github.com/web-infra-dev/rspack/pull/9190
- https://github.com/web-infra-dev/rspack/pull/9186

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
