### PR TITLE
docs: update Rspack roadmap

### DIFF
--- a/website/docs/en/api/javascript-api/index.mdx
+++ b/website/docs/en/api/javascript-api/index.mdx
@@ -1,6 +1,6 @@
 import WebpackLicense from '@components/WebpackLicense';
 import { Collapse, CollapsePanel } from '@components/Collapse';
-import { PackageManagerTabs } from '@theme';
+import { Tab, Tabs, PackageManagerTabs } from '@theme';
 import { Stability } from '@components/ApiMeta';
 import CompilerType from '../../types/compiler.mdx';
 import WatchingType from '../../types/watching.mdx';
@@ -24,11 +24,24 @@ To start using the Rspack JavaScript API, first install `@rspack/core` if you ha
 
 <PackageManagerTabs command="add @rspack/core -D" />
 
-Then require the `@rspack/core` module in your JavaScript file:
+Then introduce the `@rspack/core` module in your JavaScript file:
 
-```js title="build.js"
+<Tabs>
+  <Tab label="ESM">
+
+```js title="build.mjs"
 import { rspack } from '@rspack/core';
 ```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="build.cjs"
+const { rspack } = require('@rspack/core');
+```
+
+  </Tab>
+</Tabs>
 
 ## rspack()
 

--- a/website/docs/en/guide/start/introduction.mdx
+++ b/website/docs/en/guide/start/introduction.mdx
@@ -59,31 +59,18 @@ Rspack was initially created to solve performance problems encountered at ByteDa
 
 As of August 2024, we have released [Rspack 1.0](/blog/announcing-1-0), which is now what we consider production-ready as it covers most of webpack's APIs and features.
 
-Rspack is currently compatible with almost all loaders in the community. For the 50 most downloaded [webpack plugins](/guide/compatibility/plugin), more than 80% can be used in Rspack or have an alternative.
+Rspack is currently compatible with almost all loaders in the community. For the 50 most downloaded [webpack plugins](/guide/compatibility/plugin), more than 85% can be used in Rspack or have an alternative.
 
-Please refer to the [Rspack blog](/blog/index) for the latest updates on Rspack.
+:::tip Learn more
 
-## The future of Rspack
+- See [Rspack blogs](/blog/index) for the latest updates on Rspack.
+- See [Roadmap](/misc/planning/roadmap) for the future plans of Rspack.
 
-Although Rspack already meets the needs of many projects, there are still some gaps to reach the full capabilities of webpack. Prioritization will be based on community feedback, so please tell us about your needs!
+:::
 
-### Collaboration with community partners
+## Comparisons with other tools
 
-We are very willing to provide support to framework teams and toolchains within the community to unleash the true performance advantages of Rspack. If your framework or toolchain has a demand for high-performance build engines, let us know!
-
-### Enhancing plugin capabilities
-
-Rspack already implements the full `Loader` interface and most of the webpack plugin APIs. Although our goal is not to achieve 100% compatibility for plugin APIs, we will try our best to implement the mainstream requirements based on community feedback. At the same time, we are also exploring higher-performance plugin communication solutions to reduce the cost of plugin communication, thereby ensuring more plugin APIs can be implemented.
-
-### Continuously improving performance
-
-Performance is the core selling point and focus of Rspack development. In the future we'll explore higher-performance concurrent/multi-core-friendly algorithms, higher-performance caching solutions, higher-performance plugin communication solutions, etc.
-
-### Expanding the test suite
-
-Today Rspack is primarily tested using a subset of webpack's test cases. In the future, we'll cover more of these tests, while also expanding the test suite and including community projects to ensure compatibility across Rspack releases.
-
-## Compared with webpack
+### Compared with webpack
 
 [webpack](https://webpack.js.org/) is perhaps the most mature modern bundler, with an active ecosystem, flexible configuration, and rich features.
 
@@ -95,23 +82,23 @@ Today Rspack is primarily tested using a subset of webpack's test cases. In the 
 
 - **Optimized hot module replacement (HMR):** No matter how large your project is, ensuring a great experience for HMR places even steeper demands for build times than ordinary bundling. Rspack incorporates a specialized incremental compilation strategy to address this requirement.
 
-## Compared with Vite
+### Compared with Vite
 
 [Vite](https://vitejs.dev/) offers a great developer experience, but its reliance on [Rollup](https://rollupjs.org/) for production builds faces similar performance costs as other JavaScript-based algorithms. The same tradeoffs of webpack versus Rollup also apply, for example missing flexibility of the [optimization.splitChunks](/config/optimization#optimizationsplitchunks) feature.
 
-## Compared with esbuild
+### Compared with esbuild
 
 [esbuild](https://esbuild.github.io/) achieves very good performance by implementing nearly all operations in Golang except for some JavaScript plugins. However, esbuild's feature set is not as complete as webpack, for example missing HMR and [optimization.splitChunks](/config/optimization#optimizationsplitchunks) features.
 
-## Compared with Turbopack
+### Compared with Turbopack
 
 [Turbopack](https://turbo.build/) is implemented in Rust like Rspack, but Turbopack started over with a redesigned architecture and configuration. This brings some benefits, but presents a steeper migration cost for projects that rely on webpack and its extensive ecosystem.
 
-## Compared with Rollup
+### Compared with Rollup
 
 Rspack and Rollup are both bundling tools, but they focus on different areas. Rollup is more suitable for bundling libraries, while Rspack is more suitable for bundling applications. Therefore, Rspack has optimized many features for bundling applications, such as HMR and Bundle splitting. Rollup produces ESM outputs that are more friendly to libraries than Rspack. There are also many tools in the community that encapsulate Rollup to some extent and provide more friendly support for bundling applications, such as vite and wmr. Currently, Rspack has better production build performance than rollup.
 
-## Compared with Parcel
+### Compared with Parcel
 
 The overall architecture of Rspack shares many similarities with [Parcel](https://parceljs.org/). For example, both treat CSS assets as first-class citizens and both support filter-based transformers. However, Parcel focuses more on out-of-the-box usability, while Rspack focuses more on providing flexible configuration for higher-level frameworks and tools. Parcel innovatively designed features like the Unified Graph and making HTML a first-class citizen. Rspack also plans to support these features in the future.
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -107,13 +107,14 @@ See [Configure Rspack](/config/index) to learn about how to configure Rspack.
 
 ## Migrating from existing projects
 
-If you need to migrate from an existing project to Rspack or Rsbuild, you can refer to the following guides:
+If you need to migrate from an existing project to Rspack stack, you can refer to the following guides:
 
 - [Migrating from webpack to Rspack](/guide/migration/webpack)
 - [Migrating from webpack to Rsbuild](https://rsbuild.dev/guide/migration/webpack)
 - [Migrating from Create React App to Rsbuild](https://rsbuild.dev/guide/migration/cra)
 - [Migrating from Vue CLI to Rsbuild](https://rsbuild.dev/guide/migration/vue-cli)
 - [Migrating from Vite to Rsbuild](https://rsbuild.dev/guide/migration/vite)
+- [Migrating from Tsup to Rslib](https://lib.rsbuild.dev/guide/migration/tsup)
 - [Migrating from Storybook](/guide/migration/storybook)
 
 ## Ecosystem
@@ -155,6 +156,12 @@ Docusaurus v3.6 supports Rspack as the bundler, see [Docusaurus Faster](https://
 [Nuxt](https://nuxt.com/) is a free and open-source framework with an intuitive and extendable way to create type-safe, performant and production-grade full-stack web applications and websites with Vue.js.
 
 Nuxt v3.14 introduces a new first-class Nuxt builder for Rspack, see [Nuxt 3.14](https://nuxt.com/blog/v3-14) for details.
+
+### Re.pack
+
+[Re.pack](https://github.com/callstack/repack) is a toolkit for building your React Native application.
+
+Re.Pack v5 uses Rspack and React Native community CLI's plugin system to allow you to bundle your application using Rspack and easily switch from Metro.
 
 ### More
 

--- a/website/docs/en/misc/planning/roadmap.mdx
+++ b/website/docs/en/misc/planning/roadmap.mdx
@@ -2,23 +2,37 @@
 
 The current document lists some important features that Rspack will support, some of which are already in progress, while others will be implemented in future versions of Rspack.
 
-> Last updated: 2024-10
+> Last updated: February 2025
 
 ## Rspack 1.x iteration
 
-Rspack will release a minor version every 2-3 months, each containing significant new features and improvements.
+Rspack will release a minor version every 2-3 months, each containing significant new features and performance improvements.
 
-## Faster HMR
+See [Rspack blogs](/blog/index) to learn about the latest minor versions of Rspack.
 
-We are developing a new incremental build implementation that will significantly enhance Rspack's HMR performance.
+## Wasm build
 
-Rspack v1.1 will support this feature experimentally, and will continue to optimize it in future versions until it is enabled by default.
+We plan to compile Rspack's Rust code into WebAssembly format, allowing Rspack to run in the browser.
+
+You can see the current progress in this PR: [#9134](https://github.com/web-infra-dev/rspack/pull/9134).
+
+## Introduce Rstest
+
+We are implementing [Rstest](https://github.com/rspack/rstest), a testing framework based on Rspack. It can seamlessly integrate with Rspack's ecosystem and provide out-of-the-box testing capabilities.
+
+We plan to release the first version of Rstest in the second half of 2025.
+
+## Incremental build
+
+Rspack v1.1 introduces experimental support for [incremental build](/config/experiments#experimentsincremental), which significantly enhances Rspack's HMR performance.
+
+We will continue to optimize this feature in future versions until it is enabled by default.
 
 ## Persistent cache
 
-Persistent Cache can cache the build artifacts during multiple builds, significantly reducing the time for subsequent builds, especially providing a substantial performance boost for large projects.
+Persistent cache can cache the build artifacts during multiple builds, significantly reducing the time for subsequent builds, especially providing a substantial performance boost for large projects.
 
-We are implementing the Persistent Cache feature for Rspack and plan to release experimental support in Rspack v1.2.
+Rspack v1.2 introduces experimental support for [persistent cache](/config/experiments#experimentscache). We will continue to optimize it in the future to further improve cache performance and coverage.
 
 ## Portable cache
 
@@ -28,15 +42,15 @@ After that, we plan to continue implementing portable cache. This means that Rsp
 
 ## Webpack API alignment
 
-As webpack contains a large number of APIs, we will be working to support the most frequently used loaders and plugins based on feedback from the community first.
+As webpack has a rich API interface, we are taking a progressive approach to support them. We will closely follow community feedback and prioritize support for commonly used loaders and plugins.
 
-## Stable Rust API
+## Stabilize Rust API
 
-Currently, higher-level tools can use the JS API to integrate Rspack, which provides good extensibility. However, the communication overhead between Rust and JavaScript that limits the performance of Rspack. We also provide the [SWC Wasm plugin](/guide/features/builtin-swc-loader#jscexperimentalplugins) to support extensions, but its performance is still slower than native languages.To provide higher-level tools with more flexible integration options and better performance, we plan to expose Rspack's Rust API for integration.
+Currently, higher-level tools can use the [JS API](/api/javascript-api/index) to integrate Rspack, which provides good extensibility. However, the communication overhead between Rust and JavaScript that limits the performance of Rspack. We also provide the [SWC Wasm plugin](/guide/features/builtin-swc-loader#jscexperimentalplugins) to support extensions, but its performance is still slower than native languages.To provide higher-level tools with more flexible integration options and better performance, we plan to expose Rspack's Rust API for integration.
 
 ## Improved ESM output
 
-ESM is the standard for JavaScript modules. We are currently improving Rspack and webpack's support for ESM output and creating a library build tool based on Rspack called Rslib. This will allow developers to make better use of ESM's static analysis and tree-shaking when building npm packages.
+ESM is the standard for JavaScript modules. We are currently improving Rspack and webpack's support for ESM output and creating a library build tool based on Rspack called [Rslib](https://github.com/web-infra-dev/rslib). This will allow developers to make better use of ESM's static analysis and tree-shaking when building npm packages.
 
 ## React Server Components support
 
@@ -45,3 +59,15 @@ At ByteDance, we have experimentally supported RSC ([React Server Components](ht
 ## TypeScript-based optimization
 
 Currently, when Rspack processes TypeScript modules, it first converts them to JavaScript through a loader before further processing. This provides flexibility but also hinders further optimization of the build output. For example, developers need to use `enum` instead of `const enum`, but `enum` is difficult to optimize as a constant. In the future, we plan to treat TypeScript as a first-class citizen in Rspack, leveraging TypeScript's static information to provide more advanced compile-time optimization of the build output (such as [type-based property renaming](https://github.com/google/closure-compiler/wiki/Type-Based-Property-Renaming)).
+
+### Continuously improving performance
+
+Performance is the core selling point and focus of Rspack development. In the future we'll explore higher-performance concurrent/multi-core-friendly algorithms, higher-performance caching solutions, higher-performance plugin communication solutions, etc.
+
+### Expanding the test suite
+
+Today Rspack is primarily tested using a subset of webpack's test cases. In the future, we'll cover more of these tests, while also expanding the test suite and including community projects to ensure compatibility across Rspack releases.
+
+### Collaboration with community partners
+
+We are very willing to provide support to framework teams and toolchains within the community to unleash the true performance advantages of Rspack. If your framework or toolchain has a demand for high-performance build engines, let us know!

--- a/website/docs/zh/api/javascript-api/index.mdx
+++ b/website/docs/zh/api/javascript-api/index.mdx
@@ -1,6 +1,6 @@
 import WebpackLicense from '@components/WebpackLicense';
 import { Collapse, CollapsePanel } from '@components/Collapse';
-import { PackageManagerTabs } from '@theme';
+import { Tab, Tabs, PackageManagerTabs } from '@theme';
 import { Stability } from '@components/ApiMeta';
 import CompilerType from '../../types/compiler.mdx';
 import WatchingType from '../../types/watching.mdx';
@@ -26,9 +26,22 @@ Rspack 提供了一组 JavaScript API，可在 Node.js、Deno、Bun 等 JavaScri
 
 在 JavaScript 文件中，引入 `@rspack/core` 模块：
 
-```js title="build.js"
+<Tabs>
+  <Tab label="ESM">
+
+```js title="build.mjs"
 import { rspack } from '@rspack/core';
 ```
+
+  </Tab>
+  <Tab label="CJS">
+
+```js title="build.cjs"
+const { rspack } = require('@rspack/core');
+```
+
+  </Tab>
+</Tabs>
 
 ## rspack()
 

--- a/website/docs/zh/guide/start/introduction.mdx
+++ b/website/docs/zh/guide/start/introduction.mdx
@@ -66,29 +66,14 @@ import rspackAudio from '../../../public/rspack.mp3';
 
 我们在 2024 年 8 月发布了 [Rspack 1.0 版本](/blog/announcing-1-0)，覆盖了 webpack 绝大多数的 API 和功能，并达到生产稳定。
 
-目前，Rspack 已经兼容了社区几乎所有的 webpack loader。在下载量最高的 50 个 [webpack 插件](/guide/compatibility/plugin) 中，80% 以上都可以在 Rspack 中使用，或是找到替代方案。
+目前，Rspack 已经兼容了社区几乎所有的 webpack loader。在下载量最高的 50 个 [webpack 插件](/guide/compatibility/plugin) 中，85% 以上都可以在 Rspack 中使用，或是找到替代方案。
 
-请参考 [Rspack 博客](/blog/index) 来了解 Rspack 的最新动态。
+:::tip 了解更多
 
-## Rspack 的未来
+- 请参考 [Rspack 博客](/blog/index) 来了解 Rspack 的最新动态。
+- 请参考 [功能规划](/misc/planning/roadmap) 来了解 Rspack 的未来规划。
 
-虽然 Rspack 目前提供的能力已经能够满足大多数项目的使用，但是相比于 webpack 提供的完整能力，Rspack 仍然存在一些差距。因此，我们会根据社区的反馈，持续丰富 Rspack 的能力，从而满足更多构建场景的需求。
-
-### 和社区的伙伴合作
-
-Rspack 作为一个底层依赖，解决了我们在工作中遇到的很多问题，相信它也可以帮助社区解决一些问题。我们非常期待能与社区内的框架团队深入合作，让大家发挥出 Rspack 真正的性能优势。如果你的框架或者工具链对高性能构建引擎有需求，欢迎联系我们来获得更好的支持。
-
-### 提升插件化能力
-
-目前 Rspack 已经支持了完整的 Loader API 和大部分的 webpack plugin API。webpack 有着海量的 plugin API，虽然我们的目标**不是**实现 plugin API 的 100% 兼容，但是我们会尽可能地实现社区主流需要的 plugin API，以满足社区的需求。同时我们也在探索更高性能的插件通信方案，减小插件通信成本，以保证可以实现更多的插件 API。
-
-### 持续提升性能
-
-性能是 Rspack 的核心卖点，所以在未来我们会持续地对 Rspack 进行性能优化，提升 Rspack 的性能。如探索更高性能的并发/多核友好的算法，探索更高性能的缓存方案，探索更高性能的插件通信方案等等。
-
-### 建设完善的质量保障体系
-
-Rspack 复用了 webpack 的测试用例，未来我们会覆盖更多的 webpack 的测试用例，同时建设完善的 CI 体系，持续提升测试覆盖率，与社区项目共建 Ecosystem CI，避免 Rspack 的升级对上游项目造成 break，保障项目长期健康发展。
+:::
 
 ## 和其他构建工具的对比
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -112,13 +112,14 @@ npm init -y
 
 ## 从现有项目迁移
 
-如果你需要从一个现有项目迁移迁移到 Rspack 或 Rsbuild，可以参考以下指南：
+如果你需要从一个现有项目迁移迁移到 Rspack 技术栈，可以参考以下指南：
 
 - [从 webpack 迁移到 Rspack](/guide/migration/webpack)
 - [从 webpack 迁移到 Rsbuild](https://rsbuild.dev/zh/guide/migration/webpack)
 - [从 Create React App 迁移到 Rsbuild](https://rsbuild.dev/zh/guide/migration/cra)
 - [从 Vue CLI 迁移到 Rsbuild](https://rsbuild.dev/zh/guide/migration/vue-cli)
 - [从 Vite 迁移到 Rsbuild](https://rsbuild.dev/zh/guide/migration/vite)
+- [从 Tsup 迁移到 Rslib](https://lib.rsbuild.dev/zh/guide/migration/tsup)
 - [从 Storybook 迁移](/guide/migration/storybook)
 
 ## 生态
@@ -160,6 +161,12 @@ Docusaurus v3.6 支持使用 Rspack 作为打包工具，详见 [Docusaurus Fast
 [Nuxt](https://nuxt.com/) 是一个开源框架，提供了直观且可扩展的方式来使用 Vue.js 创建类型安全、高性能和生产级的全栈 Web 应用程序和网站。
 
 Nuxt v3.14 引入了对 Rspack 的官方支持，详见 [Nuxt 3.14](https://nuxt.com/blog/v3-14)。
+
+### Re.pack
+
+[Re.pack](https://github.com/callstack/repack) 是一个用于构建 React Native 应用的工具集。
+
+Re.Pack v5 使用 Rspack 和 React Native 社区 CLI 的插件系统，允许你使用 Rspack 打包你的应用，并轻松切换到 Metro。
 
 ### 更多
 

--- a/website/docs/zh/misc/planning/roadmap.mdx
+++ b/website/docs/zh/misc/planning/roadmap.mdx
@@ -2,23 +2,37 @@
 
 当前文档列出了 Rspack 正在支持的一些重要功能，其中一部分功能已经在实现过程中，一部分将在 Rspack 未来的版本中实现。
 
-> 更新时间：2024-10
+> 更新时间：2025-02
 
 ## Rspack 1.x 迭代
 
-Rspack 将每隔 2～3 个月发布一个 minor 版本，minor 版本将包含一些重要的新功能和改进。
+Rspack 将每隔 2～3 个月发布一个 minor 版本，minor 版本将包含一些重要的新功能和性能改进。
 
-## 更快的 HMR
+查看 [Rspack 博客](/blog/index) 来了解 Rspack 最新发布的 minor 版本。
 
-我们正在开发新版的 incremental build 实现，它将显著提升 Rspack 的 HMR 性能。
+## Wasm 产物
 
-Rspack v1.1 版本将支持实验性启用该功能，并将在未来的版本中持续优化，直到默认启用。
+我们正在将 Rspack 的 Rust 代码编译为 WebAssembly 格式，从而允许 Rspack 在浏览器中运行。
+
+你可以在这个 PR 中看到当前的进展：[#9134](https://github.com/web-infra-dev/rspack/pull/9134)。
+
+## 发布 Rstest
+
+我们正在实现 [Rstest](https://github.com/rspack/rstest)，一个基于 Rspack 的测试框架。它能够与 Rspack 生态中的工具和框架无缝集成，提供开箱即用的测试能力。
+
+我们计划于 2025 年下半年发布 Rstest 的首个版本。
+
+## 增量构建
+
+Rspack v1.1 引入了开发实验性的 [incremental build](/config/experiments#experimentsincremental) 实现，它可以显著提升 Rspack 的 HMR 性能。
+
+我们将在未来的版本中持续优化这项特性，直到默认启用它。
 
 ## 持久化缓存
 
-Persistent Cache 能够在多次构建中缓存构建的中间产物，显著减少二次构建的耗时，尤其是能够为大型项目带来很大的性能提升。
+持久化缓存能够在多次构建中缓存构建的中间产物，显著减少二次构建的耗时，尤其是能够为大型项目带来很大的性能提升。
 
-我们正在实现 Rspack 的 Persistent Cache 功能，并计划在 Rspack v1.2 版本中发布实验性支持。
+Rspack v1.2 引入了实验性的 [persistent cache](/config/experiments#experimentscache) 功能，未来我们将持续优化，进一步提升缓存的性能和覆盖范围。
 
 ## 可移植的缓存
 
@@ -28,15 +42,15 @@ Rspack 缓存能力的演进路线，是依次实现 memory cache、persistent c
 
 ## webpack API 对齐
 
-由于 webpack 包含了大量的 API，我们需要逐步地进行支持。我们将根据社区的反馈，优先支持一些高频使用的 loaders 和 plugins。
+由于 webpack 包含了丰富的 API，我们采取渐进式的方式进行支持。我们会密切关注社区反馈，优先支持一些高频使用的 loaders 和 plugins。
 
 ## 稳定的 Rust API
 
-目前，上层工具可以使用 JS API 来集成 Rspack，这提供了良好的扩展性。但是 Rust 和 JavaScript 存在通信开销，这在一定程度上限制了 Rspack 的性能。我们也提供了 [SWC Wasm plugin](/guide/features/builtin-swc-loader#jscexperimentalplugins) 以支持扩展，但是 Wasm 的性能相比 native 语言仍然有一定差距，为了给上层工具提供更灵活的接入方式和更好的性能，我们计划开放 Rspack 的 Rust API 用于集成。
+目前，上层工具可以使用 [JS API](/api/javascript-api/index) 来集成 Rspack，这提供了良好的扩展性。但是 Rust 和 JavaScript 存在通信开销，这在一定程度上限制了 Rspack 的性能。我们也提供了 [SWC Wasm plugin](/guide/features/builtin-swc-loader#jscexperimentalplugins) 以支持扩展，但是 Wasm 的性能相比 native 语言仍然有一定差距，为了给上层工具提供更灵活的接入方式和更好的性能，我们计划开放 Rspack 的 Rust API 用于集成。
 
 ## 改进 ESM 产物
 
-ESM 是 JavaScript 模块的标准，目前，我们正在改进 Rspack 和 webpack 对 ESM 产物的支持，并实现基于 Rspack 的 library 构建工具—— Rslib。这将帮助开发者更好地使用 Rspack 来构建 npm 包，并享受 ESM 带来的静态分析能力和 tree shaking 支持。
+ESM 是 JavaScript 模块的标准，目前，我们正在改进 Rspack 和 webpack 对 ESM 产物的支持，并实现基于 Rspack 的 library 构建工具—— [Rslib](https://github.com/web-infra-dev/rslib)。这将帮助开发者更好地使用 Rspack 来构建 npm 包，并享受 ESM 带来的静态分析能力和 tree shaking 支持。
 
 ## RSC 支持
 
@@ -45,3 +59,15 @@ ESM 是 JavaScript 模块的标准，目前，我们正在改进 Rspack 和 webp
 ## 基于 TypeScript 的优化
 
 目前 Rspack 在处理 TypeScript 模块时，会先通过 loader 将其转换为 JavaScript 再处理。这虽然提供了充足的灵活性，但是也阻碍了进一步的产物优化。 例如，开发者需要使用 `enum` 替代 `const enum`，但是 `enum` 本身难以进行常量优化，未来我们考虑重新将 TypeScript 作为 Rspack 的一等公民，充分利用 TypeScript 的静态信息，提供更高级的编译产物优化（如 [基于 type 的 property renaming](https://github.com/google/closure-compiler/wiki/Type-Based-Property-Renaming)）。
+
+### 持续提升性能
+
+性能是 Rspack 的核心卖点，所以在未来我们会持续地对 Rspack 进行性能优化，提升 Rspack 的性能。如探索更高性能的并发/多核友好的算法，探索更高性能的缓存方案，探索更高性能的插件通信方案等等。
+
+### 建设完善的质量保障体系
+
+Rspack 复用了 webpack 的测试用例，未来我们会覆盖更多的 webpack 的测试用例，同时建设完善的 CI 体系，持续提升测试覆盖率，与社区项目共建 Ecosystem CI，避免 Rspack 的升级对上游项目造成 break，保障项目长期健康发展。
+
+### 和社区的伙伴合作
+
+Rspack 作为一个底层依赖，解决了我们在工作中遇到的很多问题，相信它也可以帮助社区解决一些问题。我们非常期待能与社区内的框架团队深入合作，让大家发挥出 Rspack 真正的性能优势。如果你的框架或者工具链对高性能构建引擎有需求，欢迎联系我们来获得更好的支持。

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -24,9 +24,9 @@ chakra
 chapple
 chenjiahan
 codeva
+Colum
 commmonjs
 cpuprofile
-Colum
 CRACO
 cssextractrspackplugin
 dail
@@ -152,6 +152,7 @@ rspackplugin
 rspress
 Rspress
 rstack
+Rstest
 ruid
 ruleoneof
 ruleparserdataurlcondition


### PR DESCRIPTION
## Summary

- Updated Rspack roadmap to include Wasm build, Rstest and more.
- Updated the introduction page to link to the roadmap.
- Add [Re.pack](https://github.com/callstack/repack) to ecosystem.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
