### PR TITLE
fix: introduce AsyncTask, make rebuildModule safer

### DIFF
--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -590,7 +590,6 @@ impl JsCompilation {
         )
         .await
         .map_err(|e| Error::new(napi::Status::GenericFailure, format!("{e}")))?;
-
       modules
         .iter_mut()
         .for_each(|module| module.attach(compilation));

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1201,13 +1201,6 @@ impl Compilation {
 
     self.in_finish_make.store(false, Ordering::Release);
 
-    // sync assets to compilation from module_executor
-    if let Some(module_executor) = &mut self.module_executor {
-      let mut module_executor = std::mem::take(module_executor);
-      module_executor.hook_after_finish_modules(self).await;
-      self.module_executor = Some(module_executor);
-    }
-
     // take built_modules
     if let Some(mutations) = self.incremental.mutations_write() {
       mutations.extend(
@@ -1239,6 +1232,14 @@ impl Compilation {
       .finish_modules
       .call(self)
       .await?;
+
+    // sync assets to compilation from module_executor
+    if let Some(module_executor) = &mut self.module_executor {
+      let mut module_executor = std::mem::take(module_executor);
+      module_executor.hook_after_finish_modules(self).await;
+      self.module_executor = Some(module_executor);
+    }
+
     logger.time_end(start);
     // Collect dependencies diagnostics at here to make sure:
     // 1. after finish_modules: has provide exports info

--- a/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module-multi-times/a.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module-multi-times/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module-multi-times/index.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module-multi-times/index.js
@@ -1,0 +1,7 @@
+import { a as a1 } from "./a?1";
+import { a as a2 } from "./a?2";
+import { a as a3 } from "./a?3";
+
+it("compilation rebuild module should works", () => {
+	expect(a1 + a2 + a3).toBe(15)
+});

--- a/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module-multi-times/loader.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module-multi-times/loader.js
@@ -1,0 +1,5 @@
+let times = 0;
+module.exports = function loader(content) {
+	times++;
+	return content.replace("1", times);
+};

--- a/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module-multi-times/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/rebuild-module-multi-times/rspack.config.js
@@ -1,0 +1,49 @@
+const pluginName = "plugin";
+
+class Plugin {
+	apply(compiler) {
+		let initial = true;
+		compiler.hooks.compilation.tap(pluginName, compilation => {
+			compilation.hooks.finishModules.tapPromise(pluginName, async modules => {
+				modules = [...modules];
+				if (initial) {
+					initial = false;
+
+					const results = await Promise.all(
+						modules.map(m => {
+							return new Promise((resolve, reject) => {
+								compilation.rebuildModule(m, (err, module) => {
+									if (err) {
+										reject(err);
+									} else {
+										resolve(module);
+									}
+								});
+							});
+						})
+					);
+
+					// should compile success
+					expect(results.length).toBe(4);
+				}
+			});
+		});
+	}
+}
+
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /a\.js$/,
+				use: [
+					{
+						loader: "./loader"
+					}
+				]
+			}
+		]
+	},
+	plugins: [new Plugin()]
+};

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -838,7 +838,7 @@ export class Compilation {
     // (undocumented)
     static PROCESS_ASSETS_STAGE_SUMMARIZE: number;
     // (undocumented)
-    rebuildModule(m: Module, f: (err: Error, m: Module) => void): void;
+    rebuildModule(m: Module, f: (err: Error | null, m: Module | null) => void): void;
     // (undocumented)
     renameAsset(filename: string, newFilename: string): void;
     // (undocumented)

--- a/packages/rspack/src/util/AsyncTask.ts
+++ b/packages/rspack/src/util/AsyncTask.ts
@@ -1,0 +1,52 @@
+type TaskCallback<Ret> = (err: Error | null, ret: Ret | null) => void;
+
+export class AsyncTask<Param, Ret> {
+	#isRunning = false;
+	#params: Param[] = [];
+	#callbacks: TaskCallback<Ret>[] = [];
+
+	#task: (
+		param: Param[],
+		callback: (results: [Error | null, Ret | null][]) => void
+	) => void;
+
+	constructor(
+		task: (
+			param: Param[],
+			callback: (results: [Error | null, Ret | null][]) => void
+		) => void
+	) {
+		this.#task = task;
+	}
+
+	#exec_internal() {
+		const params = this.#params;
+		const callbacks = this.#callbacks;
+		this.#params = [];
+		this.#callbacks = [];
+
+		this.#task(params, results => {
+			this.#isRunning = false;
+			if (this.#params.length) {
+				this.#isRunning = true;
+				queueMicrotask(() => this.#exec_internal());
+			}
+
+			for (let i = 0; i < results.length; i++) {
+				const [err, result] = results[i];
+				const callback = callbacks[i];
+				callback(err, result);
+			}
+		});
+	}
+
+	exec(param: Param, callback: TaskCallback<Ret>) {
+		if (!this.#isRunning) {
+			queueMicrotask(() => this.#exec_internal());
+			this.#isRunning = true;
+		}
+
+		this.#params.push(param);
+		this.#callbacks.push(callback);
+	}
+}

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -479,7 +479,7 @@ Triggers a re-build of the module.
 ```ts
 rebuildModule(
   m: Module, // module to be rebuilt
-  f: (err: Error, m: Module) => void //  function to be invoked when the module finishes rebuilding
+  f: (err: Error | null, m: Module | null) => void //  function to be invoked when the module finishes rebuilding
 ): void;
 ```
 

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -477,7 +477,7 @@ export default {
 重新构建指定模块。
 
 ```ts
-rebuildModule(m: Module, f: (err: Error, m: Module) => void): void;
+rebuildModule(m: Module, f: (err: Error | null, m: Module | null) => void): void;
 ```
 
 以下示例将重新构建结尾为 `a.js` 模块：


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close #9058

Introduce AsyncTask to replace MergeCaller, which is more robust. Make rebuildModule safe to use.

ModuleExecutor's `hook_after_make` should be called **after** `finish_modules` done

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
