### PR TITLE
perf: speedup ci by skip codegen-units = 1

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -37,23 +37,7 @@ jobs:
       matrix:
         array:
           - target: x86_64-unknown-linux-gnu
-            runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
-          - target: aarch64-unknown-linux-gnu
-            runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
-          - target: x86_64-unknown-linux-musl
-            runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
-          - target: aarch64-unknown-linux-musl
-            runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
-          - target: i686-pc-windows-msvc
-            runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
-          - target: x86_64-pc-windows-msvc
-            runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
-          - target: aarch64-pc-windows-msvc
-            runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
-          - target: x86_64-apple-darwin
-            runner: ${{ needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS }}
-          - target: aarch64-apple-darwin
-            runner: ${{ needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS }}
+            runner: '"ubuntu-22.04"'
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{inputs.commit}}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -44,6 +44,7 @@ jobs:
       target: ${{ matrix.array.target }}
       runner: ${{ matrix.array.runner }}
       profile: ${{inputs.profile}}
+      native: true
       test: false
 
   release:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ incremental   = true
 panic         = "abort"
 
 [profile.release]
-codegen-units = 1
+codegen-units = 64
 debug         = false
 # Performs “thin” LTO. This is similar to “fat”, but takes substantially less time to run while still achieving performance gains similar to “fat”.
 lto       = "thin"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
`codegen-units` = 1 doesn't bring too much performance gain but will slow build a lot, so only enable it for release-prod
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
