### PR TITLE
refactor: move module_argument and exports_argument to BuildInfo struct

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -535,8 +535,6 @@ export interface JsBuildMeta {
   esm: boolean
   exportsType: 'unset' | 'default' | 'namespace' | 'flagged' | 'dynamic'
   defaultObject: 'false' | 'redirect' | JsBuildMetaDefaultObjectRedirectWarn
-  moduleArgument: 'module' | 'webpackModule'
-  exportsArgument: 'exports' | 'webpackExports'
   sideEffectFree?: boolean
   exportsFinalName?: Array<[string, string]> | undefined
 }

--- a/crates/rspack_binding_values/src/module.rs
+++ b/crates/rspack_binding_values/src/module.rs
@@ -5,8 +5,7 @@ use napi_derive::napi;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
   BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, Compilation, CompilationAsset,
-  CompilationId, ExportsArgument, LibIdentOptions, Module, ModuleArgument, ModuleIdentifier,
-  RuntimeModuleStage, SourceType,
+  CompilationId, LibIdentOptions, Module, ModuleIdentifier, RuntimeModuleStage, SourceType,
 };
 use rspack_napi::{napi::bindgen_prelude::*, threadsafe_function::ThreadsafeFunction, OneShotRef};
 use rspack_plugin_runtime::RuntimeModuleFromJs;
@@ -514,10 +513,6 @@ pub struct JsBuildMeta {
   pub exports_type: String,
   #[napi(ts_type = "'false' | 'redirect' | JsBuildMetaDefaultObjectRedirectWarn")]
   pub default_object: JsBuildMetaDefaultObject,
-  #[napi(ts_type = "'module' | 'webpackModule'")]
-  pub module_argument: String,
-  #[napi(ts_type = "'exports' | 'webpackExports'")]
-  pub exports_argument: String,
   pub side_effect_free: Option<bool>,
   #[napi(ts_type = "Array<[string, string]> | undefined")]
   pub exports_final_name: Option<Vec<Vec<String>>>,
@@ -529,9 +524,7 @@ impl From<JsBuildMeta> for BuildMeta {
       strict_esm_module,
       has_top_level_await,
       esm,
-      exports_argument: raw_exports_argument,
       default_object: raw_default_object,
-      module_argument: raw_module_argument,
       exports_final_name: raw_exports_final_name,
       side_effect_free,
       exports_type: raw_exports_type,
@@ -554,18 +547,6 @@ impl From<JsBuildMeta> for BuildMeta {
       "namespace" => BuildMetaExportsType::Namespace,
       "flagged" => BuildMetaExportsType::Flagged,
       "dynamic" => BuildMetaExportsType::Dynamic,
-      _ => unreachable!(),
-    };
-
-    let module_argument = match raw_module_argument.as_str() {
-      "module" => ModuleArgument::Module,
-      "webpackModule" => ModuleArgument::WebpackModule,
-      _ => unreachable!(),
-    };
-
-    let exports_argument = match raw_exports_argument.as_str() {
-      "exports" => ExportsArgument::Exports,
-      "webpackExports" => ExportsArgument::WebpackExports,
       _ => unreachable!(),
     };
 
@@ -592,8 +573,6 @@ impl From<JsBuildMeta> for BuildMeta {
       esm,
       exports_type,
       default_object,
-      module_argument,
-      exports_argument,
       side_effect_free,
       exports_final_name,
     }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -54,6 +54,8 @@ pub struct BuildInfo {
   pub cacheable: bool,
   pub hash: Option<RspackHashDigest>,
   pub strict: bool,
+  pub module_argument: ModuleArgument,
+  pub exports_argument: ExportsArgument,
   pub file_dependencies: HashSet<ArcPath>,
   pub context_dependencies: HashSet<ArcPath>,
   pub missing_dependencies: HashSet<ArcPath>,
@@ -77,6 +79,8 @@ impl Default for BuildInfo {
       cacheable: true,
       hash: None,
       strict: false,
+      module_argument: Default::default(),
+      exports_argument: Default::default(),
       file_dependencies: HashSet::default(),
       context_dependencies: HashSet::default(),
       missing_dependencies: HashSet::default(),
@@ -175,8 +179,6 @@ pub struct BuildMeta {
   pub esm: bool,
   pub exports_type: BuildMetaExportsType,
   pub default_object: BuildMetaDefaultObject,
-  pub module_argument: ModuleArgument,
-  pub exports_argument: ExportsArgument,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub side_effect_free: Option<bool>,
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -253,11 +255,11 @@ pub trait Module:
   fn build_meta_mut(&mut self) -> &mut BuildMeta;
 
   fn get_exports_argument(&self) -> ExportsArgument {
-    self.build_meta().exports_argument
+    self.build_info().exports_argument
   }
 
   fn get_module_argument(&self) -> ModuleArgument {
-    self.build_meta().module_argument
+    self.build_info().module_argument
   }
 
   fn get_exports_type(&self, module_graph: &ModuleGraph, strict: bool) -> ExportsType {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
@@ -62,12 +62,12 @@ impl JavascriptParserPlugin for ESMDetectionParserPlugin {
       parser.build_meta.esm = true;
       parser.build_meta.exports_type = BuildMetaExportsType::Namespace;
       parser.build_info.strict = true;
-      parser.build_meta.exports_argument = ExportsArgument::WebpackExports;
+      parser.build_info.exports_argument = ExportsArgument::WebpackExports;
     }
 
     if is_strict_esm {
       parser.build_meta.strict_esm_module = true;
-      parser.build_meta.module_argument = ModuleArgument::WebpackModule;
+      parser.build_info.module_argument = ModuleArgument::WebpackModule;
     }
 
     None

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -581,6 +581,8 @@ impl ModuleConcatenationPlugin {
         .get_side_effects_connection_state(&module_graph, &mut IdentifierSet::default()),
       factory_meta: box_module.factory_meta().cloned(),
       build_meta: box_module.build_meta().clone(),
+      module_argument: box_module.get_module_argument(),
+      exports_argument: box_module.get_exports_argument(),
     };
     let modules = modules_set
       .iter()


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
Background: https://github.com/web-infra-dev/rspack/issues/9094#issuecomment-2642106741
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
