### PR TITLE
feat: support enabling builtin loaders in compiler builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,10 @@ jobs:
 
       - name: Run test
         # reason for excluding https://github.com/napi-rs/napi-rs/issues/2200
-        run: cargo test --workspace --exclude rspack_node -- --nocapture
+        run: cargo test --workspace --exclude rspack_node --exclude rspack -- --nocapture
+
+      - name: Run rspack test
+        run: cargo test --package rspack --all-features -- --nocapture
 
   rust_test_miri:
     name: Rust test miri

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4522,7 +4522,6 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_loader_runner",
- "rspack_macros",
  "serde",
  "serde_json",
  "tokio",
@@ -4538,7 +4537,6 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_loader_runner",
- "rspack_macros",
 ]
 
 [[package]]
@@ -4551,7 +4549,6 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_loader_runner",
- "rspack_macros",
 ]
 
 [[package]]
@@ -4593,7 +4590,6 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_loader_runner",
- "rspack_macros",
  "rspack_plugin_javascript",
  "rspack_swc_plugin_import",
  "rspack_util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4150,6 +4150,10 @@ dependencies = [
  "rspack_fs",
  "rspack_hash",
  "rspack_ids",
+ "rspack_loader_lightningcss",
+ "rspack_loader_preact_refresh",
+ "rspack_loader_react_refresh",
+ "rspack_loader_swc",
  "rspack_paths",
  "rspack_plugin_asset",
  "rspack_plugin_css",
@@ -4516,8 +4520,11 @@ dependencies = [
  "rspack_cacheable",
  "rspack_core",
  "rspack_error",
+ "rspack_hook",
  "rspack_loader_runner",
+ "rspack_macros",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -4529,7 +4536,9 @@ dependencies = [
  "rspack_cacheable",
  "rspack_core",
  "rspack_error",
+ "rspack_hook",
  "rspack_loader_runner",
+ "rspack_macros",
 ]
 
 [[package]]
@@ -4540,7 +4549,9 @@ dependencies = [
  "rspack_cacheable",
  "rspack_core",
  "rspack_error",
+ "rspack_hook",
  "rspack_loader_runner",
+ "rspack_macros",
 ]
 
 [[package]]
@@ -4580,7 +4591,9 @@ dependencies = [
  "rspack_cacheable",
  "rspack_core",
  "rspack_error",
+ "rspack_hook",
  "rspack_loader_runner",
+ "rspack_macros",
  "rspack_plugin_javascript",
  "rspack_swc_plugin_import",
  "rspack_util",
@@ -4591,6 +4604,7 @@ dependencies = [
  "swc",
  "swc_config",
  "swc_core",
+ "tokio",
  "tracing",
  "url",
 ]

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -6,6 +6,15 @@ name        = "rspack"
 repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.2.0"
 
+[features]
+full = ["loaders"]
+
+loader_lightningcss   = ["rspack_loader_lightningcss"]
+loader_preact_refresh = ["rspack_loader_preact_refresh"]
+loader_react_refresh  = ["rspack_loader_react_refresh"]
+loader_swc            = ["rspack_loader_swc"]
+loaders               = ["loader_lightningcss", "loader_preact_refresh", "loader_react_refresh", "loader_swc"]
+
 [dependencies]
 bitflags     = { workspace = true }
 enum-tag     = { workspace = true }
@@ -20,6 +29,7 @@ rspack_regex = { workspace = true }
 rustc-hash   = { workspace = true }
 serde_json   = { workspace = true }
 
+# Plugins
 rspack_plugin_asset                   = { workspace = true }
 rspack_plugin_css                     = { workspace = true }
 rspack_plugin_devtool                 = { workspace = true }
@@ -39,6 +49,12 @@ rspack_plugin_schemes                 = { workspace = true }
 rspack_plugin_swc_js_minimizer        = { workspace = true }
 rspack_plugin_wasm                    = { workspace = true }
 rspack_plugin_worker                  = { workspace = true }
+
+# Loaders
+rspack_loader_lightningcss   = { workspace = true, optional = true }
+rspack_loader_preact_refresh = { workspace = true, optional = true }
+rspack_loader_react_refresh  = { workspace = true, optional = true }
+rspack_loader_swc            = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["filters"] }

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -431,6 +431,7 @@ impl CompilerBuilder {
   }
 
   /// Build [`Compiler`] from options and plugins.
+  #[must_use]
   pub fn build(&mut self) -> Compiler {
     let mut builder_context = BuilderContext::default();
     let compiler_options = self.options_builder.build(&mut builder_context);
@@ -452,6 +453,44 @@ impl CompilerBuilder {
       None,
       None,
     )
+  }
+}
+
+#[cfg(feature = "loader_lightningcss")]
+impl CompilerBuilder {
+  /// Enable support for builtin:lightningcss-loader.
+  pub fn enable_loader_lightningcss(&mut self) -> &mut Self {
+    self.plugin(Box::new(
+      rspack_loader_lightningcss::LightningcssLoaderPlugin::new(),
+    ))
+  }
+}
+
+#[cfg(feature = "loader_swc")]
+impl CompilerBuilder {
+  /// Enable support for builtin:swc-loader.
+  pub fn enable_loader_swc(&mut self) -> &mut Self {
+    self.plugin(Box::new(rspack_loader_swc::SwcLoaderPlugin::new()))
+  }
+}
+
+#[cfg(feature = "loader_react_refresh")]
+impl CompilerBuilder {
+  /// Enable support for builtin:react-refresh-loader.
+  pub fn enable_loader_react_refresh(&mut self) -> &mut Self {
+    self.plugin(Box::new(
+      rspack_loader_react_refresh::ReactRefreshLoaderPlugin::new(),
+    ))
+  }
+}
+
+#[cfg(feature = "loader_preact_refresh")]
+impl CompilerBuilder {
+  /// Enable support for builtin:preact-refresh-loader.
+  pub fn enable_loader_preact_refresh(&mut self) -> &mut Self {
+    self.plugin(Box::new(
+      rspack_loader_preact_refresh::PreactRefreshLoaderPlugin::new(),
+    ))
   }
 }
 
@@ -838,6 +877,7 @@ impl CompilerOptionsBuilder {
   ///
   /// [`BuilderContext`]: crate::builder::BuilderContext
   /// [`CompilerOptions`]: rspack_core::options::CompilerOptions
+  #[must_use]
   pub fn build(&mut self, builder_context: &mut BuilderContext) -> CompilerOptions {
     let name = self.name.take();
     let context = f!(self.context.take(), || {
@@ -1480,6 +1520,7 @@ impl NodeOptionBuilder {
   /// Build [`NodeOption`] from options.
   ///
   /// [`NodeOption`]: rspack_core::options::NodeOption
+  #[must_use]
   fn build(
     &mut self,
     target_properties: &TargetProperties,
@@ -1606,6 +1647,7 @@ impl ModuleOptionsBuilder {
   /// Normally, you don't need to call this function, it's used internally by [`CompilerBuilder::build`].
   ///
   /// [`ModuleOptions`]: rspack_core::options::ModuleOptions
+  #[must_use]
   fn build(
     &mut self,
     _builder_context: &mut BuilderContext,
@@ -2566,6 +2608,7 @@ impl OutputOptionsBuilder {
   ///
   /// [`OutputOptions`]: rspack_core::options::OutputOptions
   #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+  #[must_use]
   fn build(
     &mut self,
     builder_context: &mut BuilderContext,
@@ -3322,6 +3365,7 @@ impl OptimizationOptionsBuilder {
   /// Build [`Optimization`] from options.
   ///
   /// [`Optimization`]: rspack_core::options::Optimization
+  #[must_use]
   fn build(
     &mut self,
     builder_context: &mut BuilderContext,
@@ -3668,6 +3712,7 @@ impl ExperimentsBuilder {
   /// Build [`Experiments`] from options.
   ///
   /// [`Experiments`]: rspack_core::options::Experiments
+  #[must_use]
   fn build(
     &mut self,
     _builder_context: &mut BuilderContext,
@@ -3758,7 +3803,7 @@ mod test {
 
   #[test]
   fn mutable_builder_into_owned_builder() {
-    CompilerOptions::builder()
+    let _ = CompilerOptions::builder()
       .optimization(OptimizationOptionsBuilder::default().node_env("development".to_string()))
       .output(OutputOptionsBuilder::default().charset(true))
       .experiments(ExperimentsBuilder::default().future_defaults(true))

--- a/crates/rspack/tests/fixtures/lightningcss/src/index.css
+++ b/crates/rspack/tests/fixtures/lightningcss/src/index.css
@@ -1,0 +1,9 @@
+body {
+  .a {
+    color: blue
+  }
+
+  .b {
+    color: red
+  }
+}

--- a/crates/rspack/tests/fixtures/lightningcss/src/index.js
+++ b/crates/rspack/tests/fixtures/lightningcss/src/index.js
@@ -1,0 +1,1 @@
+import "./index.css";

--- a/crates/rspack/tests/fixtures/preact-refresh/src/index.jsx
+++ b/crates/rspack/tests/fixtures/preact-refresh/src/index.jsx
@@ -1,0 +1,5 @@
+function Foo() {
+  return <div>Foo</div>;
+}
+
+eval(Foo);

--- a/crates/rspack/tests/fixtures/react-refresh/src/index.jsx
+++ b/crates/rspack/tests/fixtures/react-refresh/src/index.jsx
@@ -1,0 +1,5 @@
+function Foo() {
+  return <div>Foo</div>;
+}
+
+eval(Foo);

--- a/crates/rspack/tests/fixtures/swc/src/index.jsx
+++ b/crates/rspack/tests/fixtures/swc/src/index.jsx
@@ -1,0 +1,5 @@
+function Foo() {
+  return <div>Foo</div>;
+}
+
+eval(Foo);

--- a/crates/rspack/tests/loader.rs
+++ b/crates/rspack/tests/loader.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use rspack::builder::Builder as _;
 use rspack_core::{
   Compiler, Experiments, ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleRuleUse,
@@ -7,6 +9,7 @@ use rspack_paths::Utf8Path;
 use rspack_regex::RspackRegex;
 use serde_json::json;
 
+#[cfg(feature = "loader_lightningcss")]
 #[tokio::test(flavor = "multi_thread")]
 async fn lightningcss() {
   let mut compiler = Compiler::builder()
@@ -37,6 +40,7 @@ async fn lightningcss() {
   assert!(errors.is_empty());
 }
 
+#[cfg(feature = "loader_swc")]
 #[tokio::test(flavor = "multi_thread")]
 async fn swc() {
   let mut compiler = Compiler::builder()
@@ -81,6 +85,7 @@ async fn swc() {
   assert!(errors.is_empty());
 }
 
+#[cfg(feature = "loader_react_refresh")]
 #[tokio::test(flavor = "multi_thread")]
 async fn react_refresh() {
   let mut compiler = Compiler::builder()
@@ -131,6 +136,7 @@ async fn react_refresh() {
   assert!(errors.is_empty());
 }
 
+#[cfg(feature = "loader_preact_refresh")]
 #[tokio::test(flavor = "multi_thread")]
 async fn preact_refresh() {
   let mut compiler = Compiler::builder()

--- a/crates/rspack/tests/loader.rs
+++ b/crates/rspack/tests/loader.rs
@@ -1,0 +1,182 @@
+use rspack::builder::Builder as _;
+use rspack_core::{
+  Compiler, Experiments, ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleRuleUse,
+  ModuleRuleUseLoader, RuleSetCondition,
+};
+use rspack_paths::Utf8Path;
+use rspack_regex::RspackRegex;
+use serde_json::json;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lightningcss() {
+  let mut compiler = Compiler::builder()
+    .context(Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/lightningcss"))
+    .entry("main", "./src/index.js")
+    .module(ModuleOptions::builder().rule(ModuleRule {
+      test: Some(RuleSetCondition::Regexp(
+        RspackRegex::new("\\.css$").unwrap(),
+      )),
+      effect: ModuleRuleEffect {
+        r#use: ModuleRuleUse::Array(vec![ModuleRuleUseLoader {
+          loader: "builtin:lightningcss-loader".to_string(),
+          options: Some(json!({
+            "include": 1 // lower nesting syntax
+          }).to_string()),
+        }]),
+        ..Default::default()
+      },
+      ..Default::default()
+    }))
+    .experiments(Experiments::builder().css(true))
+    .enable_loader_lightningcss()
+    .build();
+
+  compiler.build().await.unwrap();
+
+  let errors: Vec<_> = compiler.compilation.get_errors().collect();
+  assert!(errors.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn swc() {
+  let mut compiler = Compiler::builder()
+    .context(Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/swc"))
+    .entry("main", "./src/index.jsx")
+    .module(ModuleOptions::builder().rule(ModuleRule {
+      test: Some(RuleSetCondition::Regexp(
+        RspackRegex::new("\\.jsx$").unwrap(),
+      )),
+      effect: ModuleRuleEffect {
+        r#use: ModuleRuleUse::Array(vec![ModuleRuleUseLoader {
+          loader: "builtin:swc-loader".to_string(),
+          options: Some(json!({
+            "jsc": {
+              "parser": {
+                "syntax": "ecmascript",
+                "jsx": true,
+              },
+              "transform": {
+                "react": {
+                  "runtime": "classic",
+                  "pragma": "React.createElement",
+                  "pragmaFrag": "React.Fragment",
+                  "throwIfNamespace": true,
+                  "useBuiltins": false
+                }
+              }
+            }
+          }).to_string()),
+        }]),
+        ..Default::default()
+      },
+      ..Default::default()
+    }))
+    .experiments(Experiments::builder().css(true))
+    .enable_loader_swc()
+    .build();
+
+  compiler.build().await.unwrap();
+
+  let errors: Vec<_> = compiler.compilation.get_errors().collect();
+  assert!(errors.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn react_refresh() {
+  let mut compiler = Compiler::builder()
+    .context(Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/react-refresh"))
+    .entry("main", "./src/index.jsx")
+    .module(ModuleOptions::builder().rule(ModuleRule {
+      test: Some(RuleSetCondition::Regexp(
+        RspackRegex::new("\\.jsx$").unwrap(),
+      )),
+      effect: ModuleRuleEffect {
+        r#use: ModuleRuleUse::Array(vec![
+          ModuleRuleUseLoader {
+            loader: "builtin:react-refresh-loader".to_string(),
+            options: None
+          },
+          ModuleRuleUseLoader {
+          loader: "builtin:swc-loader".to_string(),
+          options: Some(json!({
+            "jsc": {
+              "parser": {
+                "syntax": "ecmascript",
+                "jsx": true,
+              },
+              "transform": {
+                "react": {
+                  "runtime": "classic",
+                  "pragma": "React.createElement",
+                  "pragmaFrag": "React.Fragment",
+                  "throwIfNamespace": true,
+                  "useBuiltins": false
+                }
+              }
+            }
+          }).to_string()),
+        }]),
+        ..Default::default()
+      },
+      ..Default::default()
+    }))
+    .experiments(Experiments::builder().css(true))
+    .enable_loader_swc()
+    .enable_loader_react_refresh()
+    .build();
+
+  compiler.build().await.unwrap();
+
+  let errors: Vec<_> = compiler.compilation.get_errors().collect();
+  assert!(errors.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn preact_refresh() {
+  let mut compiler = Compiler::builder()
+    .context(Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/preact-refresh"))
+    .entry("main", "./src/index.jsx")
+    .module(ModuleOptions::builder().rule(ModuleRule {
+      test: Some(RuleSetCondition::Regexp(
+        RspackRegex::new("\\.jsx$").unwrap(),
+      )),
+      effect: ModuleRuleEffect {
+        r#use: ModuleRuleUse::Array(vec![
+          ModuleRuleUseLoader {
+            loader: "builtin:preact-refresh-loader".to_string(),
+            options: None
+          },
+          ModuleRuleUseLoader {
+          loader: "builtin:swc-loader".to_string(),
+          options: Some(json!({
+            "jsc": {
+              "parser": {
+                "syntax": "ecmascript",
+                "jsx": true,
+              },
+              "transform": {
+                "react": {
+                  "runtime": "classic",
+                  "pragma": "Preact.h",
+                  "pragmaFrag": "Preact.Fragment",
+                  "throwIfNamespace": true,
+                  "useBuiltins": false
+                }
+              }
+            }
+          }).to_string()),
+        }]),
+        ..Default::default()
+      },
+      ..Default::default()
+    }))
+    .experiments(Experiments::builder().css(true))
+    .enable_loader_swc()
+    .enable_loader_preact_refresh()
+    .build();
+
+  compiler.build().await.unwrap();
+
+  let errors: Vec<_> = compiler.compilation.get_errors().collect();
+  assert!(errors.is_empty());
+}

--- a/crates/rspack_loader_lightningcss/Cargo.toml
+++ b/crates/rspack_loader_lightningcss/Cargo.toml
@@ -15,6 +15,9 @@ parcel_sourcemap     = { workspace = true }
 rspack_cacheable     = { workspace = true }
 rspack_core          = { workspace = true }
 rspack_error         = { workspace = true }
+rspack_hook          = { workspace = true }
 rspack_loader_runner = { workspace = true }
+rspack_macros        = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
+serde_json           = { workspace = true }
 tokio                = { workspace = true }

--- a/crates/rspack_loader_lightningcss/Cargo.toml
+++ b/crates/rspack_loader_lightningcss/Cargo.toml
@@ -17,7 +17,6 @@ rspack_core          = { workspace = true }
 rspack_error         = { workspace = true }
 rspack_hook          = { workspace = true }
 rspack_loader_runner = { workspace = true }
-rspack_macros        = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }
 tokio                = { workspace = true }

--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -19,6 +19,9 @@ use rspack_loader_runner::{Identifiable, Identifier};
 use tokio::sync::Mutex;
 
 pub mod config;
+mod plugin;
+
+pub use plugin::LightningcssLoaderPlugin;
 
 pub const LIGHTNINGCSS_LOADER_IDENTIFIER: &str = "builtin:lightningcss-loader";
 

--- a/crates/rspack_loader_lightningcss/src/plugin.rs
+++ b/crates/rspack_loader_lightningcss/src/plugin.rs
@@ -22,6 +22,12 @@ impl LightningcssLoaderPlugin {
   }
 }
 
+impl Default for LightningcssLoaderPlugin {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl Plugin for LightningcssLoaderPlugin {
   fn name(&self) -> &'static str {
     "LightningcssLoaderPlugin"
@@ -48,7 +54,7 @@ pub(crate) async fn resolve_loader(
   let options = l.options.as_deref().unwrap_or("{}");
 
   if loader_request.starts_with(LIGHTNINGCSS_LOADER_IDENTIFIER) {
-    let config: crate::config::RawConfig = serde_json::from_str(options.as_ref()).map_err(|e| {
+    let config: crate::config::RawConfig = serde_json::from_str(options).map_err(|e| {
       serde_error_to_miette(
         e,
         options,
@@ -63,7 +69,7 @@ pub(crate) async fn resolve_loader(
     ))));
   }
 
-  return Ok(None);
+  Ok(None)
 }
 
 // convert serde_error to miette report for pretty error

--- a/crates/rspack_loader_lightningcss/src/plugin.rs
+++ b/crates/rspack_loader_lightningcss/src/plugin.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use rspack_core::{
+  ApplyContext, BoxLoader, CompilerOptions, Context, ModuleRuleUseLoader,
+  NormalModuleFactoryResolveLoader, Plugin, PluginContext, Resolver,
+};
+use rspack_error::{
+  miette::{miette, LabeledSpan, SourceOffset},
+  Result,
+};
+use rspack_hook::{plugin, plugin_hook};
+
+use crate::{config::Config, LIGHTNINGCSS_LOADER_IDENTIFIER};
+
+#[plugin]
+#[derive(Debug)]
+pub struct LightningcssLoaderPlugin;
+
+impl LightningcssLoaderPlugin {
+  pub fn new() -> Self {
+    Self::new_inner()
+  }
+}
+
+impl Plugin for LightningcssLoaderPlugin {
+  fn name(&self) -> &'static str {
+    "LightningcssLoaderPlugin"
+  }
+
+  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+    ctx
+      .context
+      .normal_module_factory_hooks
+      .resolve_loader
+      .tap(resolve_loader::new(self));
+    Ok(())
+  }
+}
+
+#[plugin_hook(NormalModuleFactoryResolveLoader for LightningcssLoaderPlugin)]
+pub(crate) async fn resolve_loader(
+  &self,
+  _context: &Context,
+  _resolver: &Resolver,
+  l: &ModuleRuleUseLoader,
+) -> Result<Option<BoxLoader>> {
+  let loader_request = &l.loader;
+  let options = l.options.as_deref().unwrap_or("{}");
+
+  if loader_request.starts_with(LIGHTNINGCSS_LOADER_IDENTIFIER) {
+    let config: crate::config::RawConfig = serde_json::from_str(options.as_ref()).map_err(|e| {
+      serde_error_to_miette(
+        e,
+        options,
+        "Could not parse builtin:lightningcss-loader options",
+      )
+    })?;
+    // TODO: builtin-loader supports function
+    return Ok(Some(Arc::new(crate::LightningCssLoader::new(
+      None,
+      Config::try_from(config)?,
+      loader_request,
+    ))));
+  }
+
+  return Ok(None);
+}
+
+// convert serde_error to miette report for pretty error
+pub fn serde_error_to_miette(
+  e: serde_json::Error,
+  content: &str,
+  msg: &str,
+) -> rspack_error::miette::Report {
+  let offset = SourceOffset::from_location(content, e.line(), e.column());
+  let span = LabeledSpan::at_offset(offset.offset(), e.to_string());
+  miette!(labels = vec![span], "{msg}").with_source_code(content.to_owned())
+}

--- a/crates/rspack_loader_preact_refresh/Cargo.toml
+++ b/crates/rspack_loader_preact_refresh/Cargo.toml
@@ -12,4 +12,6 @@ async-trait          = { workspace = true }
 rspack_cacheable     = { workspace = true }
 rspack_core          = { workspace = true }
 rspack_error         = { workspace = true }
+rspack_hook          = { workspace = true }
 rspack_loader_runner = { workspace = true }
+rspack_macros        = { workspace = true }

--- a/crates/rspack_loader_preact_refresh/Cargo.toml
+++ b/crates/rspack_loader_preact_refresh/Cargo.toml
@@ -14,4 +14,3 @@ rspack_core          = { workspace = true }
 rspack_error         = { workspace = true }
 rspack_hook          = { workspace = true }
 rspack_loader_runner = { workspace = true }
-rspack_macros        = { workspace = true }

--- a/crates/rspack_loader_preact_refresh/src/lib.rs
+++ b/crates/rspack_loader_preact_refresh/src/lib.rs
@@ -1,3 +1,6 @@
+mod plugin;
+
+pub use plugin::PreactRefreshLoaderPlugin;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::RunnerContext;
 use rspack_error::Result;

--- a/crates/rspack_loader_preact_refresh/src/plugin.rs
+++ b/crates/rspack_loader_preact_refresh/src/plugin.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use rspack_core::{
+  ApplyContext, BoxLoader, CompilerOptions, Context, ModuleRuleUseLoader,
+  NormalModuleFactoryResolveLoader, Plugin, PluginContext, Resolver,
+};
+use rspack_error::Result;
+use rspack_hook::{plugin, plugin_hook};
+
+use crate::PREACT_REFRESH_LOADER_IDENTIFIER;
+
+#[plugin]
+#[derive(Debug)]
+pub struct PreactRefreshLoaderPlugin;
+
+impl PreactRefreshLoaderPlugin {
+  pub fn new() -> Self {
+    Self::new_inner()
+  }
+}
+
+impl Plugin for PreactRefreshLoaderPlugin {
+  fn name(&self) -> &'static str {
+    "PreactRefreshLoaderPlugin"
+  }
+
+  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+    ctx
+      .context
+      .normal_module_factory_hooks
+      .resolve_loader
+      .tap(resolve_loader::new(self));
+    Ok(())
+  }
+}
+
+#[plugin_hook(NormalModuleFactoryResolveLoader for PreactRefreshLoaderPlugin)]
+pub(crate) async fn resolve_loader(
+  &self,
+  _context: &Context,
+  _resolver: &Resolver,
+  l: &ModuleRuleUseLoader,
+) -> Result<Option<BoxLoader>> {
+  let loader_request = &l.loader;
+
+  if loader_request.starts_with(PREACT_REFRESH_LOADER_IDENTIFIER) {
+    return Ok(Some(Arc::new(
+      crate::PreactRefreshLoader::default().with_identifier(loader_request.as_str().into()),
+    )));
+  }
+
+  return Ok(None);
+}

--- a/crates/rspack_loader_preact_refresh/src/plugin.rs
+++ b/crates/rspack_loader_preact_refresh/src/plugin.rs
@@ -19,6 +19,12 @@ impl PreactRefreshLoaderPlugin {
   }
 }
 
+impl Default for PreactRefreshLoaderPlugin {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl Plugin for PreactRefreshLoaderPlugin {
   fn name(&self) -> &'static str {
     "PreactRefreshLoaderPlugin"
@@ -49,5 +55,5 @@ pub(crate) async fn resolve_loader(
     )));
   }
 
-  return Ok(None);
+  Ok(None)
 }

--- a/crates/rspack_loader_react_refresh/Cargo.toml
+++ b/crates/rspack_loader_react_refresh/Cargo.toml
@@ -12,4 +12,6 @@ async-trait          = { workspace = true }
 rspack_cacheable     = { workspace = true }
 rspack_core          = { workspace = true }
 rspack_error         = { workspace = true }
+rspack_hook          = { workspace = true }
 rspack_loader_runner = { workspace = true }
+rspack_macros        = { workspace = true }

--- a/crates/rspack_loader_react_refresh/Cargo.toml
+++ b/crates/rspack_loader_react_refresh/Cargo.toml
@@ -14,4 +14,3 @@ rspack_core          = { workspace = true }
 rspack_error         = { workspace = true }
 rspack_hook          = { workspace = true }
 rspack_loader_runner = { workspace = true }
-rspack_macros        = { workspace = true }

--- a/crates/rspack_loader_react_refresh/src/lib.rs
+++ b/crates/rspack_loader_react_refresh/src/lib.rs
@@ -1,3 +1,6 @@
+mod plugin;
+
+pub use plugin::ReactRefreshLoaderPlugin;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::RunnerContext;
 use rspack_error::Result;

--- a/crates/rspack_loader_react_refresh/src/plugin.rs
+++ b/crates/rspack_loader_react_refresh/src/plugin.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use rspack_core::{
+  ApplyContext, BoxLoader, CompilerOptions, Context, ModuleRuleUseLoader,
+  NormalModuleFactoryResolveLoader, Plugin, PluginContext, Resolver,
+};
+use rspack_error::Result;
+use rspack_hook::{plugin, plugin_hook};
+
+use crate::REACT_REFRESH_LOADER_IDENTIFIER;
+
+#[plugin]
+#[derive(Debug)]
+pub struct ReactRefreshLoaderPlugin;
+
+impl ReactRefreshLoaderPlugin {
+  pub fn new() -> Self {
+    Self::new_inner()
+  }
+}
+
+impl Plugin for ReactRefreshLoaderPlugin {
+  fn name(&self) -> &'static str {
+    "ReactRefreshLoaderPlugin"
+  }
+
+  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+    ctx
+      .context
+      .normal_module_factory_hooks
+      .resolve_loader
+      .tap(resolve_loader::new(self));
+    Ok(())
+  }
+}
+
+#[plugin_hook(NormalModuleFactoryResolveLoader for ReactRefreshLoaderPlugin)]
+pub(crate) async fn resolve_loader(
+  &self,
+  _context: &Context,
+  _resolver: &Resolver,
+  l: &ModuleRuleUseLoader,
+) -> Result<Option<BoxLoader>> {
+  let loader_request = &l.loader;
+
+  if loader_request.starts_with(REACT_REFRESH_LOADER_IDENTIFIER) {
+    return Ok(Some(Arc::new(
+      crate::ReactRefreshLoader::default().with_identifier(loader_request.as_str().into()),
+    )));
+  }
+
+  return Ok(None);
+}

--- a/crates/rspack_loader_react_refresh/src/plugin.rs
+++ b/crates/rspack_loader_react_refresh/src/plugin.rs
@@ -19,6 +19,12 @@ impl ReactRefreshLoaderPlugin {
   }
 }
 
+impl Default for ReactRefreshLoaderPlugin {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl Plugin for ReactRefreshLoaderPlugin {
   fn name(&self) -> &'static str {
     "ReactRefreshLoaderPlugin"
@@ -49,5 +55,5 @@ pub(crate) async fn resolve_loader(
     )));
   }
 
-  return Ok(None);
+  Ok(None)
 }

--- a/crates/rspack_loader_swc/Cargo.toml
+++ b/crates/rspack_loader_swc/Cargo.toml
@@ -27,7 +27,9 @@ rspack_ast               = { workspace = true }
 rspack_cacheable         = { workspace = true }
 rspack_core              = { workspace = true }
 rspack_error             = { workspace = true }
+rspack_hook              = { workspace = true }
 rspack_loader_runner     = { workspace = true }
+rspack_macros            = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
 rspack_swc_plugin_import = { workspace = true }
 rspack_util              = { workspace = true }
@@ -38,6 +40,7 @@ stacker                  = { workspace = true }
 swc                      = { workspace = true, features = ["manual-tokio-runtime"] }
 swc_config               = { workspace = true }
 swc_core                 = { workspace = true, features = ["base", "ecma_ast", "common"] }
+tokio                    = { workspace = true }
 tracing                  = { workspace = true }
 url                      = "2.5.0"
 

--- a/crates/rspack_loader_swc/Cargo.toml
+++ b/crates/rspack_loader_swc/Cargo.toml
@@ -29,7 +29,6 @@ rspack_core              = { workspace = true }
 rspack_error             = { workspace = true }
 rspack_hook              = { workspace = true }
 rspack_loader_runner     = { workspace = true }
-rspack_macros            = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
 rspack_swc_plugin_import = { workspace = true }
 rspack_util              = { workspace = true }

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod compiler;
 mod options;
+mod plugin;
 mod transformer;
 
 use std::default::Default;
@@ -9,6 +10,7 @@ use std::default::Default;
 use compiler::{IntoJsAst, SwcCompiler};
 use options::SwcCompilerOptionsWithAdditional;
 pub use options::SwcLoaderJsOptions;
+pub use plugin::SwcLoaderPlugin;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{Mode, RunnerContext};
 use rspack_error::{error, AnyhowError, Diagnostic, Result};

--- a/crates/rspack_loader_swc/src/plugin.rs
+++ b/crates/rspack_loader_swc/src/plugin.rs
@@ -1,0 +1,97 @@
+use std::{
+  borrow::Cow,
+  sync::{Arc, LazyLock},
+};
+
+use rspack_core::{
+  ApplyContext, BoxLoader, CompilerOptions, Context, ModuleRuleUseLoader,
+  NormalModuleFactoryResolveLoader, Plugin, PluginContext, Resolver,
+};
+use rspack_error::{
+  miette::{miette, LabeledSpan, SourceOffset},
+  Result,
+};
+use rspack_hook::{plugin, plugin_hook};
+use rustc_hash::FxHashMap;
+use tokio::sync::RwLock;
+
+use crate::{SwcLoader, SWC_LOADER_IDENTIFIER};
+
+#[plugin]
+#[derive(Debug)]
+pub struct SwcLoaderPlugin;
+
+impl SwcLoaderPlugin {
+  pub fn new() -> Self {
+    Self::new_inner()
+  }
+}
+
+impl Plugin for SwcLoaderPlugin {
+  fn name(&self) -> &'static str {
+    "SwcLoaderPlugin"
+  }
+
+  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+    ctx
+      .context
+      .normal_module_factory_hooks
+      .resolve_loader
+      .tap(resolve_loader::new(self));
+    Ok(())
+  }
+}
+
+type SwcLoaderCache<'a> = LazyLock<RwLock<FxHashMap<(Cow<'a, str>, Cow<'a, str>), Arc<SwcLoader>>>>;
+static SWC_LOADER_CACHE: SwcLoaderCache = LazyLock::new(|| RwLock::new(FxHashMap::default()));
+
+#[plugin_hook(NormalModuleFactoryResolveLoader for SwcLoaderPlugin)]
+pub(crate) async fn resolve_loader(
+  &self,
+  _context: &Context,
+  _resolver: &Resolver,
+  l: &ModuleRuleUseLoader,
+) -> Result<Option<BoxLoader>> {
+  let loader_request = &l.loader;
+  let options = l.options.as_deref().unwrap_or("{}");
+
+  if loader_request.starts_with(SWC_LOADER_IDENTIFIER) {
+    if let Some(loader) = SWC_LOADER_CACHE
+      .read()
+      .await
+      .get(&(Cow::Borrowed(loader_request), Cow::Borrowed(options)))
+    {
+      return Ok(Some(loader.clone()));
+    }
+
+    let loader = Arc::new(
+      SwcLoader::new(options.as_ref())
+        .map_err(|e| {
+          serde_error_to_miette(e, options, "failed to parse builtin:swc-loader options")
+        })?
+        .with_identifier(loader_request.as_str().into()),
+    );
+
+    SWC_LOADER_CACHE.write().await.insert(
+      (
+        Cow::Owned(loader_request.to_owned()),
+        Cow::Owned(options.to_owned()),
+      ),
+      loader.clone(),
+    );
+    return Ok(Some(loader));
+  }
+
+  return Ok(None);
+}
+
+// convert serde_error to miette report for pretty error
+pub fn serde_error_to_miette(
+  e: serde_json::Error,
+  content: &str,
+  msg: &str,
+) -> rspack_error::miette::Report {
+  let offset = SourceOffset::from_location(content, e.line(), e.column());
+  let span = LabeledSpan::at_offset(offset.offset(), e.to_string());
+  miette!(labels = vec![span], "{msg}").with_source_code(content.to_owned())
+}

--- a/crates/rspack_loader_swc/src/plugin.rs
+++ b/crates/rspack_loader_swc/src/plugin.rs
@@ -27,6 +27,12 @@ impl SwcLoaderPlugin {
   }
 }
 
+impl Default for SwcLoaderPlugin {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl Plugin for SwcLoaderPlugin {
   fn name(&self) -> &'static str {
     "SwcLoaderPlugin"
@@ -65,7 +71,7 @@ pub(crate) async fn resolve_loader(
     }
 
     let loader = Arc::new(
-      SwcLoader::new(options.as_ref())
+      SwcLoader::new(options)
         .map_err(|e| {
           serde_error_to_miette(e, options, "failed to parse builtin:swc-loader options")
         })?
@@ -82,7 +88,7 @@ pub(crate) async fn resolve_loader(
     return Ok(Some(loader));
   }
 
-  return Ok(None);
+  Ok(None)
 }
 
 // convert serde_error to miette report for pretty error


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Support enabling builtin loaders in compiler builder. 

Under the hood, rspack registers enabled loader plugins for loader resolving. 
Otherwise, an failed to resolve error will be reported.

Check out tests to see examples: https://github.com/web-infra-dev/rspack/blob/605d8ac816b4142492c239ac04e65bd59a746e6b/crates/rspack/tests/loader.rs

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
