### PR TITLE
refactor: module diagnostic action move to `Diagnosable` trait

### DIFF
--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -145,7 +145,7 @@ mod t {
 
   use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
   use rspack_collections::Identifiable;
-  use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+  use rspack_error::{impl_empty_diagnosable_trait, Result};
   use rspack_macros::impl_source_map_config;
   use rspack_sources::Source;
   use rspack_util::{atom::Atom, source_map::SourceMapKind};
@@ -282,10 +282,6 @@ mod t {
     }
 
     fn source_types(&self) -> &[SourceType] {
-      todo!()
-    }
-
-    fn get_diagnostics(&self) -> Vec<Diagnostic> {
       todo!()
     }
 

--- a/crates/rspack_core/src/compiler/make/repair/build.rs
+++ b/crates/rspack_core/src/compiler/make/repair/build.rs
@@ -61,8 +61,9 @@ impl Task<MakeTaskContext> for BuildTask {
 
     let build_result = result.map(|t| {
       let diagnostics = module
-        .clone_diagnostics()
-        .into_iter()
+        .diagnostics()
+        .iter()
+        .cloned()
         .map(|d| d.with_module_identifier(Some(module.identifier())))
         .collect();
       t.with_diagnostic(diagnostics)

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -490,10 +490,6 @@ impl Module for ConcatenatedModule {
     &ModuleType::JsEsm
   }
 
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    self.diagnostics.clone()
-  }
-
   fn factory_meta(&self) -> Option<&FactoryMeta> {
     self.root_module_ctxt.factory_meta.as_ref()
   }
@@ -589,7 +585,7 @@ impl Module for ConcatenatedModule {
         self.blocks.push(*b);
       }
       // populate diagnostic
-      self.diagnostics.extend(module.get_diagnostics());
+      self.diagnostics.extend(module.diagnostics().into_owned());
 
       // populate topLevelDeclarations
       let module_build_info = module.build_info();
@@ -1411,8 +1407,8 @@ impl Diagnosable for ConcatenatedModule {
     self.diagnostics.append(&mut diagnostics);
   }
 
-  fn clone_diagnostics(&self) -> Vec<Diagnostic> {
-    self.diagnostics.clone()
+  fn diagnostics(&self) -> Cow<[Diagnostic]> {
+    Cow::Borrowed(&self.diagnostics)
   }
 }
 

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -3,7 +3,7 @@ use std::{
   collections::hash_map::Entry,
   fmt::Debug,
   hash::{BuildHasherDefault, Hasher},
-  sync::{Arc, LazyLock, Mutex},
+  sync::{Arc, LazyLock},
 };
 
 use dashmap::DashMap;
@@ -372,7 +372,7 @@ pub struct ConcatenatedModule {
   #[cacheable(with=AsMap)]
   cached_source_sizes: DashMap<SourceType, f64, BuildHasherDefault<FxHasher>>,
   #[cacheable(with=Skip)]
-  diagnostics: Mutex<Vec<Diagnostic>>,
+  diagnostics: Vec<Diagnostic>,
   build_info: BuildInfo,
 }
 
@@ -394,7 +394,7 @@ impl ConcatenatedModule {
       dependencies: vec![],
       blocks: vec![],
       cached_source_sizes: DashMap::default(),
-      diagnostics: Mutex::new(vec![]),
+      diagnostics: vec![],
       build_info: BuildInfo {
         cacheable: true,
         hash: None,
@@ -491,8 +491,7 @@ impl Module for ConcatenatedModule {
   }
 
   fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    let guard = self.diagnostics.lock().expect("should have diagnostics");
-    guard.clone()
+    self.diagnostics.clone()
   }
 
   fn factory_meta(&self) -> Option<&FactoryMeta> {
@@ -556,9 +555,6 @@ impl Module for ConcatenatedModule {
     compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
     let compilation = compilation.expect("should pass compilation");
-    // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L774-L784
-    // Some fields does not exists in rspack
-    self.clear_diagnostics();
 
     let module_graph = compilation.get_module_graph();
     let modules = self
@@ -592,12 +588,8 @@ impl Module for ConcatenatedModule {
       for b in module.get_blocks() {
         self.blocks.push(*b);
       }
-      let mut diagnostics_guard = self.diagnostics.lock().expect("should have diagnostics");
       // populate diagnostic
-      diagnostics_guard.extend(module.get_diagnostics());
-
-      // release guard ASAP
-      drop(diagnostics_guard);
+      self.diagnostics.extend(module.get_diagnostics());
 
       // populate topLevelDeclarations
       let module_build_info = module.build_info();
@@ -1411,42 +1403,20 @@ impl Module for ConcatenatedModule {
 }
 
 impl Diagnosable for ConcatenatedModule {
-  fn add_diagnostic(&self, diagnostic: Diagnostic) {
-    self
-      .diagnostics
-      .lock()
-      .expect("should be able to lock diagnostics")
-      .push(diagnostic);
+  fn add_diagnostic(&mut self, diagnostic: Diagnostic) {
+    self.diagnostics.push(diagnostic);
   }
 
-  fn add_diagnostics(&self, mut diagnostics: Vec<Diagnostic>) {
-    self
-      .diagnostics
-      .lock()
-      .expect("should be able to lock diagnostics")
-      .append(&mut diagnostics);
+  fn add_diagnostics(&mut self, mut diagnostics: Vec<Diagnostic>) {
+    self.diagnostics.append(&mut diagnostics);
   }
 
   fn clone_diagnostics(&self) -> Vec<Diagnostic> {
-    self
-      .diagnostics
-      .lock()
-      .expect("should be able to lock diagnostics")
-      .iter()
-      .cloned()
-      .collect()
+    self.diagnostics.clone()
   }
 }
 
 impl ConcatenatedModule {
-  fn clear_diagnostics(&mut self) {
-    self
-      .diagnostics
-      .lock()
-      .expect("should be able to lock diagnostics")
-      .clear()
-  }
-
   // TODO: replace self.modules with indexmap or linkedhashset
   fn get_modules_with_info(
     &self,

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -10,7 +10,7 @@ use rspack_cacheable::{
   with::{AsOption, AsPreset, AsVec, Unsupported},
 };
 use rspack_collections::{Identifiable, Identifier};
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_macros::impl_source_map_config;
 use rspack_paths::{ArcPath, Utf8PathBuf};
 use rspack_regex::RspackRegex;
@@ -845,10 +845,6 @@ impl Module for ContextModule {
 
   fn source_types(&self) -> &[SourceType] {
     &[SourceType::JavaScript]
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   fn original_source(&self) -> Option<&dyn rspack_sources::Source> {

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, hash::Hash, iter};
 
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
-use rspack_error::{error, impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{error, impl_empty_diagnosable_trait, Result};
 use rspack_hash::RspackHash;
 use rspack_macros::impl_source_map_config;
 use rspack_util::{ext::DynHash, json_stringify, source_map::SourceMapKind};
@@ -488,10 +488,6 @@ impl Module for ExternalModule {
 
   fn module_type(&self) -> &ModuleType {
     &ModuleType::JsAuto
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   fn source_types(&self) -> &[SourceType] {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -11,7 +11,7 @@ use rspack_cacheable::{
   with::{AsOption, AsVec},
 };
 use rspack_collections::{Identifiable, Identifier, IdentifierSet};
-use rspack_error::{Diagnosable, Diagnostic, Result};
+use rspack_error::{Diagnosable, Result};
 use rspack_fs::ReadableFileSystem;
 use rspack_hash::RspackHashDigest;
 use rspack_paths::ArcPath;
@@ -215,7 +215,7 @@ pub trait Module:
 
   /// Defines what kind of code generation results this module can generate.
   fn source_types(&self) -> &[SourceType];
-  fn get_diagnostics(&self) -> Vec<Diagnostic>;
+
   /// The original source of the module. This could be optional, modules like the `NormalModule` can have the corresponding original source.
   /// However, modules that is created from "nowhere" (e.g. `ExternalModule` and `MissingModule`) does not have its original source.
   fn original_source(&self) -> Option<&dyn Source>;
@@ -603,7 +603,7 @@ mod test {
 
   use rspack_cacheable::cacheable;
   use rspack_collections::{Identifiable, Identifier};
-  use rspack_error::{Diagnosable, Diagnostic, Result};
+  use rspack_error::{impl_empty_diagnosable_trait, Result};
   use rspack_sources::Source;
   use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 
@@ -630,7 +630,7 @@ mod test {
         }
       }
 
-      impl Diagnosable for $ident {}
+      impl_empty_diagnosable_trait!($ident);
 
       impl DependenciesBlock for $ident {
         fn add_block_id(&mut self, _: AsyncDependenciesBlockIdentifier) {
@@ -687,10 +687,6 @@ mod test {
           _compilation: Option<&Compilation>,
         ) -> Result<BuildResult> {
           unreachable!()
-        }
-
-        fn get_diagnostics(&self) -> Vec<Diagnostic> {
-          vec![]
         }
 
         fn update_hash(

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -371,10 +371,6 @@ impl Module for NormalModule {
     &self.module_type
   }
 
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    self.diagnostics.clone()
-  }
-
   fn source_types(&self) -> &[SourceType] {
     self.parser_and_generator.source_types()
   }
@@ -542,7 +538,7 @@ impl Module for NormalModule {
     if no_parse {
       self.parsed = false;
       self.original_source = Some(original_source.clone());
-      self.source = NormalModuleSource::new_built(original_source, self.clone_diagnostics());
+      self.source = NormalModuleSource::new_built(original_source, self.diagnostics.clone());
       self.code_generation_dependencies = Some(Vec::new());
       self.presentational_dependencies = Some(Vec::new());
 
@@ -604,7 +600,7 @@ impl Module for NormalModule {
     // Only side effects used in code_generate can stay here
     // Other side effects should be set outside use_cache
     self.original_source = Some(source.clone());
-    self.source = NormalModuleSource::new_built(source, self.clone_diagnostics());
+    self.source = NormalModuleSource::new_built(source, self.diagnostics.clone());
     self.code_generation_dependencies = Some(code_generation_dependencies);
     self.presentational_dependencies = Some(presentational_dependencies);
 
@@ -803,8 +799,8 @@ impl Diagnosable for NormalModule {
     self.diagnostics.append(&mut diagnostics);
   }
 
-  fn clone_diagnostics(&self) -> Vec<Diagnostic> {
-    self.diagnostics.clone()
+  fn diagnostics(&self) -> Cow<[Diagnostic]> {
+    Cow::Borrowed(&self.diagnostics)
   }
 }
 

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_collections::Identifiable;
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_macros::impl_source_map_config;
 use rspack_sources::{BoxSource, RawStringSource, Source, SourceExt};
 use rspack_util::source_map::SourceMapKind;
@@ -91,10 +91,6 @@ impl DependenciesBlock for RawModule {
 #[async_trait::async_trait]
 impl Module for RawModule {
   impl_module_meta_info!();
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
-  }
 
   fn module_type(&self) -> &ModuleType {
     &ModuleType::JsAuto

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_macros::impl_source_map_config;
 use rspack_sources::Source;
 use rspack_util::source_map::SourceMapKind;
@@ -78,10 +78,6 @@ impl DependenciesBlock for SelfModule {
 #[async_trait]
 impl Module for SelfModule {
   impl_module_meta_info!();
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
-  }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     self.identifier.len() as f64

--- a/crates/rspack_error/src/diagnostic.rs
+++ b/crates/rspack_error/src/diagnostic.rs
@@ -257,10 +257,10 @@ impl Diagnostic {
 }
 
 pub trait Diagnosable {
-  fn add_diagnostic(&self, _diagnostic: Diagnostic) {
+  fn add_diagnostic(&mut self, _diagnostic: Diagnostic) {
     unimplemented!("`<T as Diagnosable>::add_diagnostic` is not implemented")
   }
-  fn add_diagnostics(&self, _diagnostics: Vec<Diagnostic>) {
+  fn add_diagnostics(&mut self, _diagnostics: Vec<Diagnostic>) {
     unimplemented!("`<T as Diagnosable>::add_diagnostics` is not implemented")
   }
   /// Clone diagnostics from current [Diagnosable].
@@ -268,29 +268,19 @@ pub trait Diagnosable {
   fn clone_diagnostics(&self) -> Vec<Diagnostic> {
     vec![]
   }
-  /// Take diagnostics from current [Diagnosable].
-  /// This drains every diagnostic from the current one.
-  fn take_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
-  }
-  /// Pipe diagnostics from the current [Diagnosable] to the target one.
-  /// This drains every diagnostic from current, and pipe into the target one.
-  fn pipe_diagnostics(&self, target: &dyn Diagnosable) {
-    target.add_diagnostics(self.take_diagnostics())
-  }
 }
 
 #[macro_export]
 macro_rules! impl_empty_diagnosable_trait {
   ($ty:ty) => {
     impl $crate::Diagnosable for $ty {
-      fn add_diagnostic(&self, _diagnostic: $crate::Diagnostic) {
+      fn add_diagnostic(&mut self, _diagnostic: $crate::Diagnostic) {
         unimplemented!(
           "`<{ty} as Diagnosable>::add_diagnostic` is not implemented",
           ty = stringify!($ty)
         )
       }
-      fn add_diagnostics(&self, _diagnostics: Vec<$crate::Diagnostic>) {
+      fn add_diagnostics(&mut self, _diagnostics: Vec<$crate::Diagnostic>) {
         unimplemented!(
           "`<{ty} as Diagnosable>::add_diagnostics` is not implemented",
           ty = stringify!($ty)

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -163,10 +163,6 @@ pub fn impl_runtime_module(
         unreachable!()
       }
 
-      fn get_diagnostics(&self) -> Vec<::rspack_error::Diagnostic> {
-        vec![]
-      }
-
       fn code_generation(
         &self,
         compilation: &::rspack_core::Compilation,
@@ -196,7 +192,17 @@ pub fn impl_runtime_module(
       }
     }
 
-    impl #impl_generics rspack_error::Diagnosable for #name  #ty_generics #where_clause {}
+    impl #impl_generics rspack_error::Diagnosable for #name  #ty_generics #where_clause {
+      fn add_diagnostic(&mut self, _diagnostic: rspack_error::Diagnostic) {
+        unreachable!()
+      }
+      fn add_diagnostics(&mut self, _diagnostics: Vec<rspack_error::Diagnostic>) {
+        unreachable!()
+      }
+      fn diagnostics(&self) -> std::borrow::Cow<[rspack_error::Diagnostic]> {
+        std::borrow::Cow::Owned(vec![])
+      }
+    }
 
     impl #impl_generics ::rspack_util::source_map::ModuleSourceMapConfig for #name #ty_generics #where_clause {
       fn get_source_map_kind(&self) -> &::rspack_util::source_map::SourceMapKind {

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   ConcatenationScope, Context, DependenciesBlock, Dependency, DependencyId, EntryDependency,
   FactoryMeta, Module, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
 };
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 
 use super::dll_entry_dependency::DllEntryDependency;
 
@@ -65,10 +65,6 @@ impl Module for DllModule {
 
   fn source_types(&self) -> &[SourceType] {
     &[SourceType::JavaScript]
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   fn original_source(&self) -> Option<&dyn Source> {

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   ModuleId, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency,
   StaticExportsSpec,
 };
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_util::{json_stringify, source_map::ModuleSourceMapConfig};
 
 use super::delegated_source_dependency::DelegatedSourceDependency;
@@ -88,10 +88,6 @@ impl Module for DelegatedModule {
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   async fn build(

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -10,8 +10,8 @@ use rspack_core::{
   DependencyId, FactoryMeta, Module, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult,
   RuntimeSpec, SourceType,
 };
+use rspack_error::impl_empty_diagnosable_trait;
 use rspack_error::Result;
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_util::ext::DynHash;
 use rspack_util::itoa;
@@ -177,10 +177,6 @@ impl Module for CssModule {
     _concatenation_scope: Option<ConcatenationScope>,
   ) -> Result<CodeGenerationResult> {
     Ok(CodeGenerationResult::default())
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   fn update_hash(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -234,7 +234,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
   should_error: bool,
 ) -> Option<Diagnostic> {
   let imported_module = module_graph.get_module_by_dependency_id(module_dependency.id())?;
-  if !imported_module.get_diagnostics().is_empty() {
+  if !imported_module.diagnostics().is_empty() {
     return None;
   }
   let parent_module_identifier = module_graph

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   LibIdentOptions, Module, ModuleFactoryCreateData, ModuleIdentifier, ModuleLayer, ModuleType,
   RuntimeGlobals, RuntimeSpec, SourceType, TemplateContext,
 };
-use rspack_error::{Diagnosable, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_plugin_javascript::dependency::CommonJsRequireDependency;
 use rspack_util::{
   ext::DynHash,
@@ -101,14 +101,7 @@ impl LazyCompilationProxyModule {
   }
 }
 
-impl Diagnosable for LazyCompilationProxyModule {
-  fn add_diagnostic(&mut self, _diagnostic: Diagnostic) {
-    unimplemented!()
-  }
-  fn add_diagnostics(&mut self, _diagnostics: Vec<Diagnostic>) {
-    unimplemented!()
-  }
-}
+impl_empty_diagnosable_trait!(LazyCompilationProxyModule);
 
 #[cacheable_dyn]
 #[async_trait::async_trait]
@@ -141,10 +134,6 @@ impl Module for LazyCompilationProxyModule {
 
   fn lib_ident(&self, _options: LibIdentOptions) -> Option<Cow<str>> {
     self.lib_ident.as_ref().map(|s| Cow::Borrowed(s.as_str()))
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   async fn build(

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -102,10 +102,10 @@ impl LazyCompilationProxyModule {
 }
 
 impl Diagnosable for LazyCompilationProxyModule {
-  fn add_diagnostic(&self, _diagnostic: Diagnostic) {
+  fn add_diagnostic(&mut self, _diagnostic: Diagnostic) {
     unimplemented!()
   }
-  fn add_diagnostics(&self, _diagnostics: Vec<Diagnostic>) {
+  fn add_diagnostics(&mut self, _diagnostics: Vec<Diagnostic>) {
     unimplemented!()
   }
 }

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -14,7 +14,7 @@ use rspack_core::{
   ModuleDependency, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
   StaticExportsDependency, StaticExportsSpec,
 };
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_util::source_map::SourceMapKind;
 use rustc_hash::FxHashSet;
 
@@ -130,9 +130,7 @@ impl Module for ContainerEntryModule {
   fn lib_ident(&self, _options: LibIdentOptions) -> Option<Cow<str>> {
     Some(self.lib_ident.as_str().into())
   }
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
-  }
+
   async fn build(
     &mut self,
     _build_context: BuildContext,

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleIdentifier,
   ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
 };
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_util::{itoa, source_map::SourceMapKind};
 
 use super::fallback_item_dependency::FallbackItemDependency;
@@ -99,10 +99,6 @@ impl Module for FallbackModule {
 
   fn module_type(&self) -> &ModuleType {
     &ModuleType::Fallback
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   fn source_types(&self) -> &[SourceType] {

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeSpec,
   SourceType,
 };
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_util::source_map::SourceMapKind;
 
 use super::{
@@ -117,10 +117,6 @@ impl Module for RemoteModule {
 
   fn module_type(&self) -> &ModuleType {
     &ModuleType::Remote
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   fn source_types(&self) -> &[SourceType] {

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   RuntimeGlobals, RuntimeSpec, SourceType,
 };
 use rspack_core::{module_update_hash, ConcatenationScope, FactoryMeta};
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_util::ext::DynHash;
 use rspack_util::source_map::SourceMapKind;
 
@@ -120,10 +120,6 @@ impl Module for ConsumeSharedModule {
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   fn module_type(&self) -> &ModuleType {

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   FactoryMeta, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec,
   SourceType,
 };
-use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_util::source_map::SourceMapKind;
 
 use super::{
@@ -121,10 +121,6 @@ impl Module for ProvideSharedModule {
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0
-  }
-
-  fn get_diagnostics(&self) -> Vec<Diagnostic> {
-    vec![]
   }
 
   fn module_type(&self) -> &ModuleType {

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module_factory.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module_factory.rs
@@ -1,5 +1,3 @@
-use std::sync::Mutex;
-
 use async_trait::async_trait;
 use rspack_core::{ModuleDependency, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult};
 use rspack_error::{Diagnosable, Diagnostic, Result};
@@ -10,7 +8,7 @@ use super::{
 
 #[derive(Debug, Default)]
 pub struct ProvideSharedModuleFactory {
-  diagnostics: Mutex<Vec<Diagnostic>>,
+  diagnostics: Vec<Diagnostic>,
 }
 
 #[async_trait]
@@ -35,29 +33,15 @@ impl ModuleFactory for ProvideSharedModuleFactory {
 }
 
 impl Diagnosable for ProvideSharedModuleFactory {
-  fn add_diagnostic(&self, diagnostic: Diagnostic) {
-    self
-      .diagnostics
-      .lock()
-      .expect("should be able to lock diagnostics")
-      .push(diagnostic);
+  fn add_diagnostic(&mut self, diagnostic: Diagnostic) {
+    self.diagnostics.push(diagnostic);
   }
 
-  fn add_diagnostics(&self, mut diagnostics: Vec<Diagnostic>) {
-    self
-      .diagnostics
-      .lock()
-      .expect("should be able to lock diagnostics")
-      .append(&mut diagnostics);
+  fn add_diagnostics(&mut self, mut diagnostics: Vec<Diagnostic>) {
+    self.diagnostics.append(&mut diagnostics);
   }
 
   fn clone_diagnostics(&self) -> Vec<Diagnostic> {
-    self
-      .diagnostics
-      .lock()
-      .expect("should be able to lock diagnostics")
-      .iter()
-      .cloned()
-      .collect()
+    self.diagnostics.clone()
   }
 }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module_factory.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module_factory.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use async_trait::async_trait;
 use rspack_core::{ModuleDependency, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult};
 use rspack_error::{Diagnosable, Diagnostic, Result};
@@ -41,7 +43,7 @@ impl Diagnosable for ProvideSharedModuleFactory {
     self.diagnostics.append(&mut diagnostics);
   }
 
-  fn clone_diagnostics(&self) -> Vec<Diagnostic> {
-    self.diagnostics.clone()
+  fn diagnostics(&self) -> Cow<[Diagnostic]> {
+    Cow::Borrowed(&self.diagnostics)
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. use &mut self for add_* method in Diagnosable trait, and remove useless method
``` diff
trait Diagnosable {
-  fn add_diagnostic(&self, _diagnostic: Diagnostic);
+ fn add_diagnostic(&mut self, _diagnostic: Diagnostic);
-  fn add_diagnostics(&self, _diagnostics: Vec<Diagnostic>);
+ fn add_diagnostics(&mut self, _diagnostics: Vec<Diagnostic>);

-  fn clone_diagnostics(&self) -> Vec<Diagnostic>;
-  fn take_diagnostics(&self) -> Vec<Diagnostic>;
-  fn pipe_diagnostics(&self, target: &dyn Diagnosable);
}
```
2. move diagnostics action from Module trait to Diagnosable trait
``` diff
trait Module {
-  fn get_diagnostics(&self) -> Vec<Diagnostic>;
}
trait Diagnosable {
+  fn diagnostics(&self) -> Cow<[Diagnostic]>;
}
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
