### PR TITLE
fix(core): add sourceURL when devtool set to 'eval-source-map'

### DIFF
--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -162,9 +162,9 @@ fn eval_source_map_devtool_plugin_render_module_content(
       // align with https://github.com/webpack/webpack/blob/3919c844eca394d73ca930e4fc5506fb86e2b094/lib/EvalSourceMapDevToolPlugin.js#L171
       let module_id =
         if let Some(module_id) = ChunkGraph::get_module_id(module_ids, module.identifier()) {
-          module_id.to_string()
+          module_id.as_str()
         } else {
-          "unknown".to_string()
+          "unknown"
         };
       map
         .to_writer(&mut map_buffer)

--- a/packages/rspack-test-tools/tests/configCases/source-map/eval-source-map/index.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/eval-source-map/index.js
@@ -4,7 +4,7 @@ it("basic", () => {
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename, "utf-8");
 	const base64 =
-		/sourceMappingURL\s*=\s*data:application\/json;charset=utf-8;base64,(.*)\"\);/.exec(
+		/sourceMappingURL\s*=\s*data:application\/json;charset=utf-8;base64,(.*)\\n\/\/#/.exec(
 			source
 		)[1];
 	const map = JSON.parse(Buffer.from(base64, "base64").toString("utf-8"));

--- a/packages/rspack-test-tools/tests/configCases/source-map/eval-source-map/index.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/eval-source-map/index.js
@@ -8,6 +8,7 @@ it("basic", () => {
 			source
 		)[1];
 	const map = JSON.parse(Buffer.from(base64, "base64").toString("utf-8"));
+	expect(source.includes('//# sourceURL=webpack-internal:///./index.js'))
 	expect(map.sources[0]).toMatch(/webpack:\/\/\/\.\/index.js?[a-zA-Z0-9]+/);
 	expect(map.file).toBe(path.join(CONTEXT, "index.js"));
 });

--- a/packages/rspack-test-tools/tests/configCases/source-map/eval-source-map/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/eval-source-map/rspack.config.js
@@ -9,6 +9,9 @@ module.exports = {
 	devtool: "eval-source-map",
 	externals: ["source-map"],
 	externalsType: "commonjs",
+	optimization: {
+		moduleIds: 'named'
+	},
 	plugins: [
 		new rspack.DefinePlugin({
 			CONTEXT: JSON.stringify(__dirname)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
fix missing sourceURL field when devtool equals to `eval-source-map`, related to https://github.com/vercel/next.js/pull/75981#discussion_r1953463762
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
