### PR TITLE
refactor: NormalModule.source remove diagnostic data

### DIFF
--- a/crates/rspack_binding_values/src/module.rs
+++ b/crates/rspack_binding_values/src/module.rs
@@ -86,7 +86,7 @@ impl JsModule {
   ) -> napi::Result<Either<JsCompatSource<'a>, ()>> {
     let module = self.as_ref()?;
 
-    Ok(match module.original_source() {
+    Ok(match module.source() {
       Some(source) => match source.to_js_compat_source(env).ok() {
         Some(s) => Either::A(s),
         None => Either::B(()),

--- a/crates/rspack_core/src/compiler/make/cutout/fix_build_meta.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/fix_build_meta.rs
@@ -1,7 +1,8 @@
 use rspack_collections::IdentifierMap;
+use rspack_error::Diagnosable;
 
 use super::super::MakeArtifact;
-use crate::{BuildMeta, Module, ModuleIdentifier, NormalModuleSource};
+use crate::{BuildMeta, Module, ModuleIdentifier};
 
 #[derive(Debug, Default)]
 pub struct FixBuildMeta {
@@ -28,7 +29,7 @@ impl FixBuildMeta {
     for (id, build_meta) in self.origin_module_build_meta {
       if let Some(module) = module_graph.module_by_identifier_mut(&id) {
         if let Some(module) = module.as_normal_module_mut() {
-          if matches!(module.source(), NormalModuleSource::BuiltFailed(_)) {
+          if module.first_error().is_some() {
             *module.build_meta_mut() = build_meta;
           }
         }

--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -147,7 +147,7 @@ mod t {
   use rspack_collections::Identifiable;
   use rspack_error::{impl_empty_diagnosable_trait, Result};
   use rspack_macros::impl_source_map_config;
-  use rspack_sources::Source;
+  use rspack_sources::BoxSource;
   use rspack_util::{atom::Atom, source_map::SourceMapKind};
 
   use crate::{
@@ -285,7 +285,7 @@ mod t {
       todo!()
     }
 
-    fn original_source(&self) -> Option<&dyn Source> {
+    fn source(&self) -> Option<&BoxSource> {
       todo!()
     }
 

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -118,7 +118,7 @@ pub async fn repair(
       let original_module_source = parent_module_identifier
         .and_then(|i| module_graph.module_by_identifier(&i))
         .and_then(|m| m.as_normal_module())
-        .and_then(|m| m.source().clone());
+        .and_then(|m| m.source().cloned());
       Box::new(factorize::FactorizeTask {
         compilation_id: compilation.id(),
         module_factory: compilation.get_dependency_factory(dependency),

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -16,7 +16,7 @@ use crate::{
   old_cache::Cache as OldCache,
   utils::task_loop::{run_task_loop, Task},
   BuildDependency, Compilation, CompilationId, CompilerOptions, DependencyType, Module,
-  ModuleFactory, ModuleProfile, NormalModuleSource, ResolverFactory, SharedPluginDriver,
+  ModuleFactory, ModuleProfile, ResolverFactory, SharedPluginDriver,
 };
 
 pub struct MakeTaskContext {
@@ -118,13 +118,7 @@ pub async fn repair(
       let original_module_source = parent_module_identifier
         .and_then(|i| module_graph.module_by_identifier(&i))
         .and_then(|m| m.as_normal_module())
-        .and_then(|m| {
-          if let NormalModuleSource::BuiltSucceed(s) = m.source() {
-            Some(s.clone())
-          } else {
-            None
-          }
-        });
+        .and_then(|m| m.source().clone());
       Box::new(factorize::FactorizeTask {
         compilation_id: compilation.id(),
         module_factory: compilation.get_dependency_factory(dependency),

--- a/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap as HashMap;
 use super::{factorize::FactorizeTask, MakeTaskContext};
 use crate::{
   utils::task_loop::{Task, TaskResult, TaskType},
-  ContextDependency, DependencyId, Module, ModuleIdentifier, ModuleProfile, NormalModuleSource,
+  ContextDependency, DependencyId, Module, ModuleIdentifier, ModuleProfile,
 };
 
 #[derive(Debug)]
@@ -74,13 +74,7 @@ impl Task<MakeTaskContext> for ProcessDependenciesTask {
       let original_module_source = module_graph
         .module_by_identifier(&original_module_identifier)
         .and_then(|m| m.as_normal_module())
-        .and_then(|m| {
-          if let NormalModuleSource::BuiltSucceed(s) = m.source() {
-            Some(s.clone())
-          } else {
-            None
-          }
-        });
+        .and_then(|m| m.source().clone());
       let dependency = &dependencies[0];
       let dependency_type = dependency.dependency_type();
       // TODO move module_factory calculate to dependency factories

--- a/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
@@ -74,7 +74,7 @@ impl Task<MakeTaskContext> for ProcessDependenciesTask {
       let original_module_source = module_graph
         .module_by_identifier(&original_module_identifier)
         .and_then(|m| m.as_normal_module())
-        .and_then(|m| m.source().clone());
+        .and_then(|m| m.source().cloned());
       let dependency = &dependencies[0];
       let dependency_type = dependency.dependency_type();
       // TODO move module_factory calculate to dependency factories

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -22,7 +22,7 @@ use rspack_error::{Diagnosable, Diagnostic, DiagnosticKind, Result, TraceableErr
 use rspack_hash::{HashDigest, HashFunction, RspackHash};
 use rspack_hook::define_hook;
 use rspack_sources::{
-  CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
+  BoxSource, CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
 };
 use rspack_util::{ext::DynHash, itoa, source_map::SourceMapKind, swc::join_atom};
 use rustc_hash::FxHasher;
@@ -526,7 +526,7 @@ impl Module for ConcatenatedModule {
     &[SourceType::JavaScript]
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -847,7 +847,7 @@ impl Module for ContextModule {
     &[SourceType::JavaScript]
   }
 
-  fn original_source(&self) -> Option<&dyn rspack_sources::Source> {
+  fn source(&self) -> Option<&rspack_sources::BoxSource> {
     None
   }
 

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 
 use crate::{
   extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
-  rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
+  rspack_sources::{BoxSource, RawStringSource, SourceExt},
   to_identifier, AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta,
   BuildMetaExportsType, BuildResult, ChunkInitFragments, ChunkUkey, CodeGenerationDataUrl,
   CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId,
@@ -510,7 +510,7 @@ impl Module for ExternalModule {
     )
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -15,7 +15,7 @@ use rspack_error::{Diagnosable, Result};
 use rspack_fs::ReadableFileSystem;
 use rspack_hash::RspackHashDigest;
 use rspack_paths::ArcPath;
-use rspack_sources::Source;
+use rspack_sources::BoxSource;
 use rspack_util::atom::Atom;
 use rspack_util::ext::{AsAny, DynHash};
 use rspack_util::source_map::ModuleSourceMapConfig;
@@ -221,9 +221,9 @@ pub trait Module:
   /// Defines what kind of code generation results this module can generate.
   fn source_types(&self) -> &[SourceType];
 
-  /// The original source of the module. This could be optional, modules like the `NormalModule` can have the corresponding original source.
-  /// However, modules that is created from "nowhere" (e.g. `ExternalModule` and `MissingModule`) does not have its original source.
-  fn original_source(&self) -> Option<&dyn Source>;
+  /// The source of the module. This could be optional, modules like the `NormalModule` can have the corresponding source.
+  /// However, modules that is created from "nowhere" (e.g. `ExternalModule` and `MissingModule`) does not have its source.
+  fn source(&self) -> Option<&BoxSource>;
 
   /// User readable identifier of the module.
   fn readable_identifier(&self, _context: &Context) -> Cow<str>;
@@ -609,7 +609,7 @@ mod test {
   use rspack_cacheable::cacheable;
   use rspack_collections::{Identifiable, Identifier};
   use rspack_error::{impl_empty_diagnosable_trait, Result};
-  use rspack_sources::Source;
+  use rspack_sources::BoxSource;
   use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 
   use super::Module;
@@ -670,7 +670,7 @@ mod test {
           unreachable!()
         }
 
-        fn original_source(&self) -> Option<&dyn Source> {
+        fn source(&self) -> Option<&BoxSource> {
           unreachable!()
         }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -21,8 +21,8 @@ use rspack_hook::define_hook;
 use rspack_loader_runner::{run_loaders, AdditionalData, Content, LoaderContext, ResourceData};
 use rspack_macros::impl_source_map_config;
 use rspack_sources::{
-  BoxSource, CachedSource, OriginalSource, RawBufferSource, RawStringSource, Source, SourceExt,
-  SourceMap, SourceMapSource, WithoutOriginalOptions,
+  BoxSource, CachedSource, OriginalSource, RawBufferSource, RawStringSource, SourceExt, SourceMap,
+  SourceMapSource, WithoutOriginalOptions,
 };
 use rspack_util::{
   ext::DynHash,
@@ -354,8 +354,8 @@ impl Module for NormalModule {
     self.parser_and_generator.source_types()
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
-    self.original_source.as_deref()
+  fn source(&self) -> Option<&BoxSource> {
+    self.source.as_ref()
   }
 
   fn readable_identifier(&self, context: &Context) -> Cow<str> {

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -129,7 +129,8 @@ pub struct NormalModule {
   #[cacheable(with=AsOption<AsPreset>)]
   original_source: Option<BoxSource>,
   /// Built source of this module (passed with loaders)
-  source: NormalModuleSource,
+  #[cacheable(with=AsOption<AsPreset>)]
+  source: Option<BoxSource>,
 
   /// Resolve options derived from [Rule.resolve]
   resolve_options: Option<Arc<Resolve>>,
@@ -152,27 +153,6 @@ pub struct NormalModule {
   build_info: BuildInfo,
   build_meta: BuildMeta,
   parsed: bool,
-}
-
-#[cacheable]
-#[derive(Debug, Clone)]
-pub enum NormalModuleSource {
-  Unbuild,
-  BuiltSucceed(#[cacheable(with=AsPreset)] BoxSource),
-  BuiltFailed(Diagnostic),
-}
-
-impl NormalModuleSource {
-  pub fn new_built(source: BoxSource, mut diagnostics: Vec<Diagnostic>) -> Self {
-    diagnostics.retain(|d| d.severity() == Severity::Error);
-    // Use the first error as diagnostic
-    // See: https://github.com/webpack/webpack/blob/6be4065ade1e252c1d8dcba4af0f43e32af1bdc1/lib/NormalModule.js#L878
-    if let Some(d) = diagnostics.into_iter().next() {
-      NormalModuleSource::BuiltFailed(d)
-    } else {
-      NormalModuleSource::BuiltSucceed(source)
-    }
-  }
 }
 
 static DEBUG_ID: AtomicUsize = AtomicUsize::new(1);
@@ -227,7 +207,7 @@ impl NormalModule {
       resolve_options,
       loaders,
       original_source: None,
-      source: NormalModuleSource::Unbuild,
+      source: None,
       debug_id: DEBUG_ID.fetch_add(1, Ordering::Relaxed),
 
       cached_source_sizes: DashMap::default(),
@@ -270,12 +250,8 @@ impl NormalModule {
     &self.raw_request
   }
 
-  pub fn source(&self) -> &NormalModuleSource {
+  pub fn source(&self) -> &Option<BoxSource> {
     &self.source
-  }
-
-  pub fn source_mut(&mut self) -> &mut NormalModuleSource {
-    &mut self.source
   }
 
   pub fn loaders(&self) -> &[BoxLoader] {
@@ -319,9 +295,12 @@ impl NormalModule {
     let mut hasher = RspackHash::from(output_options);
     "source".hash(&mut hasher);
     match &self.source {
-      NormalModuleSource::Unbuild => panic!("NormalModule should already build"),
-      NormalModuleSource::BuiltSucceed(s) => s.hash(&mut hasher),
-      NormalModuleSource::BuiltFailed(e) => e.message().hash(&mut hasher),
+      Some(s) => s.hash(&mut hasher),
+      None => self
+        .first_error()
+        .expect("should have error")
+        .message()
+        .hash(&mut hasher),
     }
     "meta".hash(&mut hasher);
     build_meta.hash(&mut hasher);
@@ -486,7 +465,7 @@ impl Module for NormalModule {
             .with_hide_stack(hide_stack)
         };
 
-        self.source = NormalModuleSource::BuiltFailed(diagnostic.clone());
+        self.source = None;
         self.add_diagnostic(diagnostic);
 
         self.build_info.hash =
@@ -538,7 +517,9 @@ impl Module for NormalModule {
     if no_parse {
       self.parsed = false;
       self.original_source = Some(original_source.clone());
-      self.source = NormalModuleSource::new_built(original_source, self.diagnostics.clone());
+      if self.first_error().is_none() {
+        self.source = Some(original_source);
+      }
       self.code_generation_dependencies = Some(Vec::new());
       self.presentational_dependencies = Some(Vec::new());
 
@@ -600,7 +581,11 @@ impl Module for NormalModule {
     // Only side effects used in code_generate can stay here
     // Other side effects should be set outside use_cache
     self.original_source = Some(source.clone());
-    self.source = NormalModuleSource::new_built(source, self.diagnostics.clone());
+    if self.first_error().is_some() {
+      self.source = None; // NormalModuleSource::BuiltFailed
+    } else {
+      self.source = Some(source);
+    };
     self.code_generation_dependencies = Some(code_generation_dependencies);
     self.presentational_dependencies = Some(presentational_dependencies);
 
@@ -621,56 +606,57 @@ impl Module for NormalModule {
     runtime: Option<&RuntimeSpec>,
     mut concatenation_scope: Option<ConcatenationScope>,
   ) -> Result<CodeGenerationResult> {
-    if let NormalModuleSource::BuiltSucceed(source) = &self.source {
-      let mut code_generation_result = CodeGenerationResult::default();
-      if !self.parsed {
-        code_generation_result
-          .runtime_requirements
-          .insert(RuntimeGlobals::MODULE);
-        code_generation_result
-          .runtime_requirements
-          .insert(RuntimeGlobals::EXPORTS);
-        code_generation_result
-          .runtime_requirements
-          .insert(RuntimeGlobals::THIS_AS_EXPORTS);
-      }
-      for source_type in self.source_types() {
-        let generation_result = self.parser_and_generator.generate(
-          source,
-          self,
-          &mut GenerateContext {
-            compilation,
-            runtime_requirements: &mut code_generation_result.runtime_requirements,
-            data: &mut code_generation_result.data,
-            requested_source_type: *source_type,
-            runtime,
-            concatenation_scope: concatenation_scope.as_mut(),
-          },
-        )?;
-        code_generation_result.add(*source_type, CachedSource::new(generation_result).boxed());
-      }
-      code_generation_result.concatenation_scope = concatenation_scope;
-      Ok(code_generation_result)
-    } else if let NormalModuleSource::BuiltFailed(error_message) = &self.source {
+    if let Some(error) = self.first_error() {
       let mut code_generation_result = CodeGenerationResult::default();
 
       // If the module build failed and the module is able to emit JavaScript source,
       // we should emit an error message to the runtime, otherwise we do nothing.
       if self.source_types().contains(&SourceType::JavaScript) {
-        let error = error_message.render_report(compilation.options.stats.colors)?;
+        let error = error.render_report(compilation.options.stats.colors)?;
         code_generation_result.add(
           SourceType::JavaScript,
           RawStringSource::from(format!("throw new Error({});\n", json!(error))).boxed(),
         );
         code_generation_result.concatenation_scope = concatenation_scope;
       }
-      Ok(code_generation_result)
-    } else {
-      Err(error!(
+      return Ok(code_generation_result);
+    }
+    let Some(source) = &self.source else {
+      return Err(error!(
         "Failed to generate code because ast or source is not set for module {}",
         self.request
-      ))
+      ));
+    };
+
+    let mut code_generation_result = CodeGenerationResult::default();
+    if !self.parsed {
+      code_generation_result
+        .runtime_requirements
+        .insert(RuntimeGlobals::MODULE);
+      code_generation_result
+        .runtime_requirements
+        .insert(RuntimeGlobals::EXPORTS);
+      code_generation_result
+        .runtime_requirements
+        .insert(RuntimeGlobals::THIS_AS_EXPORTS);
     }
+    for source_type in self.source_types() {
+      let generation_result = self.parser_and_generator.generate(
+        source,
+        self,
+        &mut GenerateContext {
+          compilation,
+          runtime_requirements: &mut code_generation_result.runtime_requirements,
+          data: &mut code_generation_result.data,
+          requested_source_type: *source_type,
+          runtime,
+          concatenation_scope: concatenation_scope.as_mut(),
+        },
+      )?;
+      code_generation_result.add(*source_type, CachedSource::new(generation_result).boxed());
+    }
+    code_generation_result.concatenation_scope = concatenation_scope;
+    Ok(code_generation_result)
   }
 
   fn update_hash(
@@ -681,7 +667,7 @@ impl Module for NormalModule {
   ) -> Result<()> {
     self.build_info.hash.dyn_hash(hasher);
     // For built failed NormalModule, hash will be calculated by build_info.hash, which contains error message
-    if matches!(&self.source, NormalModuleSource::BuiltSucceed(_)) {
+    if self.source.is_some() {
       self
         .parser_and_generator
         .update_hash(self, hasher, compilation, runtime)?;

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -100,8 +100,8 @@ impl Module for RawModule {
     RAW_MODULE_SOURCE_TYPES
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
-    Some(self.source.as_ref())
+  fn source(&self) -> Option<&BoxSource> {
+    Some(&self.source)
   }
 
   fn readable_identifier(&self, _context: &Context) -> Cow<str> {

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_macros::impl_source_map_config;
-use rspack_sources::Source;
+use rspack_sources::BoxSource;
 use rspack_util::source_map::SourceMapKind;
 
 use crate::{
@@ -91,7 +91,7 @@ impl Module for SelfModule {
     &[SourceType::JavaScript]
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -1040,7 +1040,7 @@ impl Stats<'_> {
     }
 
     if options.source {
-      stats.source = module.original_source();
+      stats.source = module.source();
     }
 
     Ok(stats)

--- a/crates/rspack_core/src/stats/struct.rs
+++ b/crates/rspack_core/src/stats/struct.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 
 use rspack_paths::Utf8PathBuf;
-use rspack_sources::Source;
+use rspack_sources::BoxSource;
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -156,7 +156,7 @@ pub struct StatsModule<'s> {
   pub reasons: Option<Vec<StatsModuleReason<'s>>>,
   pub assets: Option<Vec<String>>,
   pub modules: Option<Vec<StatsModule<'s>>>,
-  pub source: Option<&'s dyn Source>,
+  pub source: Option<&'s BoxSource>,
   pub profile: Option<StatsModuleProfile>,
   pub orphan: Option<bool>,
   pub provided_exports: Option<Vec<Atom>>,

--- a/crates/rspack_error/src/diagnostic.rs
+++ b/crates/rspack_error/src/diagnostic.rs
@@ -263,11 +263,17 @@ pub trait Diagnosable {
 
   fn diagnostics(&self) -> Cow<[Diagnostic]>;
 
-  fn has_error(&self) -> bool {
-    self
-      .diagnostics()
-      .iter()
-      .any(|d| d.severity() == Severity::Error)
+  fn first_error(&self) -> Option<Cow<Diagnostic>> {
+    match self.diagnostics() {
+      Cow::Borrowed(diagnostics) => diagnostics
+        .iter()
+        .find(|d| d.severity() == Severity::Error)
+        .map(Cow::Borrowed),
+      Cow::Owned(diagnostics) => diagnostics
+        .into_iter()
+        .find(|d| d.severity() == Severity::Error)
+        .map(Cow::Owned),
+    }
   }
 }
 

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -137,7 +137,7 @@ pub fn impl_runtime_module(
         self.name().as_str().into()
       }
 
-      fn original_source(&self) -> Option<&dyn ::rspack_core::rspack_sources::Source> {
+      fn source(&self) -> Option<&::rspack_core::rspack_sources::BoxSource> {
         None
       }
 

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -343,11 +343,11 @@ impl ParserAndGenerator for AssetParserAndGenerator {
   }
 
   fn size(&self, module: &dyn Module, source_type: Option<&SourceType>) -> f64 {
-    let original_source_size = module.original_source().map_or(0, |source| source.size()) as f64;
+    let original_source_size = module.source().map_or(0, |source| source.size()) as f64;
     match source_type.unwrap_or(&SourceType::Asset) {
       SourceType::Asset => original_source_size,
       SourceType::JavaScript => {
-        if module.original_source().is_none() {
+        if module.source().is_none() {
           return 0.0;
         }
 

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -104,7 +104,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
   fn size(&self, module: &dyn Module, source_type: Option<&SourceType>) -> f64 {
     match source_type.unwrap_or(&SourceType::Css) {
       SourceType::JavaScript => 42.0,
-      SourceType::Css => module.original_source().map_or(0, |source| source.size()) as f64,
+      SourceType::Css => module.source().map_or(0, |source| source.size()) as f64,
       _ => unreachable!(),
     }
   }

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -4,11 +4,11 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  impl_module_meta_info, impl_source_map_config, module_update_hash,
-  rspack_sources::RawStringSource, rspack_sources::Source, AsyncDependenciesBlockIdentifier,
-  BuildContext, BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Compilation,
-  ConcatenationScope, Context, DependenciesBlock, Dependency, DependencyId, EntryDependency,
-  FactoryMeta, Module, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  impl_module_meta_info, impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
+  rspack_sources::RawStringSource, AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo,
+  BuildMeta, BuildResult, CodeGenerationResult, Compilation, ConcatenationScope, Context,
+  DependenciesBlock, Dependency, DependencyId, EntryDependency, FactoryMeta, Module, ModuleType,
+  RuntimeGlobals, RuntimeSpec, SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 
@@ -67,7 +67,7 @@ impl Module for DllModule {
     &[SourceType::JavaScript]
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   impl_module_meta_info, impl_source_map_config, module_raw, module_update_hash,
-  rspack_sources::{BoxSource, OriginalSource, RawStringSource, Source},
+  rspack_sources::{BoxSource, OriginalSource, RawStringSource},
   throw_missing_module_error_block, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext,
   BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Compilation, ConcatenationScope,
   Context, DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleDependency,
@@ -74,7 +74,7 @@ impl Module for DelegatedModule {
     self.original_request.as_ref().map(|request| request.into())
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
-use rspack_core::rspack_sources::Source;
+use rspack_core::rspack_sources::BoxSource;
 use rspack_core::{
   impl_module_meta_info, impl_source_map_config, module_update_hash,
   AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta, BuildResult,
@@ -144,7 +144,7 @@ impl Module for CssModule {
     self.content.len() as f64
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -874,11 +874,11 @@ impl ESMExportImportedSpecifierDependency {
         .expect("should have parent module for dependency");
       let mut diagnostic = if let Some(span) = self.range()
         && let Some(parent_module) = module_graph.module_by_identifier(parent_module_identifier)
-        && let Some(source) = parent_module.original_source().map(|s| s.source())
+        && let Some(source) = parent_module.source()
       {
         Diagnostic::from(
           TraceableError::from_file(
-            source.into_owned(),
+            source.source().into_owned(),
             span.start as usize,
             span.end as usize,
             title.to_string(),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -252,11 +252,11 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       (Severity::Warning, "ESModulesLinkingWarning")
     };
     let mut diagnostic = if let Some(span) = module_dependency.range()
-      && let Some(source) = parent_module.original_source().map(|s| s.source())
+      && let Some(source) = parent_module.source()
     {
       Diagnostic::from(
         TraceableError::from_file(
-          source.into_owned(),
+          source.source().into_owned(),
           span.start as usize,
           span.end as usize,
           title.to_string(),

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -95,7 +95,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
   }
 
   fn size(&self, module: &dyn Module, _source_type: Option<&SourceType>) -> f64 {
-    module.original_source().map_or(0, |source| source.size()) as f64
+    module.source().map_or(0, |source| source.size()) as f64
   }
 
   #[tracing::instrument("JavaScriptParser:parse", skip_all)]

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -596,7 +596,7 @@ impl ModuleConcatenationPlugin {
             Some(&rspack_core::SourceType::JavaScript),
             Some(compilation),
           ),
-          original_source_hash: module.original_source().map(|source| {
+          original_source_hash: module.source().map(|source| {
             let mut hasher = DefaultHasher::default();
             source.dyn_hash(&mut hasher);
             hasher.finish()

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -44,7 +44,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
   }
 
   fn size(&self, module: &dyn Module, _source_type: Option<&SourceType>) -> f64 {
-    module.original_source().map_or(0, |source| source.size()) as f64
+    module.source().map_or(0, |source| source.size()) as f64
   }
 
   fn parse(

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn, with::Unsupported};
 use rspack_collections::Identifiable;
 use rspack_core::{
   impl_module_meta_info, module_namespace_promise, module_update_hash,
-  rspack_sources::{RawStringSource, Source},
+  rspack_sources::{BoxSource, RawStringSource},
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo,
   BuildMeta, BuildResult, ChunkGraph, CodeGenerationData, CodeGenerationResult, Compilation,
   ConcatenationScope, Context, DependenciesBlock, DependencyId, DependencyRange, FactoryMeta,
@@ -124,7 +124,7 @@ impl Module for LazyCompilationProxyModule {
     200f64
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -6,7 +6,7 @@ use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   basic_function, block_promise, impl_module_meta_info, impl_source_map_config, module_raw,
   module_update_hash, returning_function,
-  rspack_sources::{RawStringSource, Source, SourceExt},
+  rspack_sources::{BoxSource, RawStringSource, SourceExt},
   throw_missing_module_error_block, AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier,
   BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult,
   ChunkGroupOptions, CodeGenerationResult, Compilation, ConcatenationScope, Context,
@@ -119,7 +119,7 @@ impl Module for ContainerEntryModule {
     &[SourceType::JavaScript, SourceType::Expose]
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   impl_module_meta_info, impl_source_map_config, module_update_hash,
-  rspack_sources::{RawStringSource, Source, SourceExt},
+  rspack_sources::{BoxSource, RawStringSource, SourceExt},
   AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, ConcatenationScope, Context,
   DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleIdentifier,
@@ -105,7 +105,7 @@ impl Module for FallbackModule {
     &[SourceType::JavaScript]
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   impl_module_meta_info, impl_source_map_config, module_update_hash,
-  rspack_sources::{RawStringSource, Source, SourceExt},
+  rspack_sources::{BoxSource, RawStringSource, SourceExt},
   AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   ChunkGraph, CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock,
   DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeSpec,
@@ -123,7 +123,7 @@ impl Module for RemoteModule {
     &[SourceType::Remote, SourceType::ShareInit]
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  async_module_factory, impl_module_meta_info, impl_source_map_config, rspack_sources::Source,
+  async_module_factory, impl_module_meta_info, impl_source_map_config, rspack_sources::BoxSource,
   sync_module_factory, AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency,
   BuildContext, BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Compilation, Context,
   DependenciesBlock, DependencyId, LibIdentOptions, Module, ModuleIdentifier, ModuleType,
@@ -130,7 +130,7 @@ impl Module for ConsumeSharedModule {
     &[SourceType::ConsumeShared]
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   async_module_factory, impl_module_meta_info, impl_source_map_config, module_update_hash,
-  rspack_sources::Source, sync_module_factory, AsyncDependenciesBlock,
+  rspack_sources::BoxSource, sync_module_factory, AsyncDependenciesBlock,
   AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId,
   FactoryMeta, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec,
@@ -131,7 +131,7 @@ impl Module for ProvideSharedModule {
     &[SourceType::ShareInit]
   }
 
-  fn original_source(&self) -> Option<&dyn Source> {
+  fn source(&self) -> Option<&BoxSource> {
     None
   }
 

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -4,7 +4,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelBridge, ParallelIterator};
 use rspack_collections::{Identifier, IdentifierMap};
 use rspack_core::{
   rspack_sources::MapOptions, BoxModule, ChunkGraph, Compilation, Context, DependencyId,
-  DependencyType, Module, ModuleGraph, ModuleIdsArtifact,
+  DependencyType, ModuleGraph, ModuleIdsArtifact,
 };
 use rspack_paths::Utf8PathBuf;
 use rspack_util::fx_hash::FxDashMap;
@@ -137,7 +137,8 @@ pub fn collect_module_original_sources(
       let module_ukey = module_ukeys.get(module_id)?;
       let resource = module.resource_resolved_data().resource.clone();
       let source = module
-        .original_source()
+        .source()
+        .as_ref()
         .and_then(|s| s.map(&MapOptions::default()))
         .and_then(|s| {
           let idx = s.sources().iter().position(|s| s.eq(&resource))?;

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -4,7 +4,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelBridge, ParallelIterator};
 use rspack_collections::{Identifier, IdentifierMap};
 use rspack_core::{
   rspack_sources::MapOptions, BoxModule, ChunkGraph, Compilation, Context, DependencyId,
-  DependencyType, ModuleGraph, ModuleIdsArtifact,
+  DependencyType, Module, ModuleGraph, ModuleIdsArtifact,
 };
 use rspack_paths::Utf8PathBuf;
 use rspack_util::fx_hash::FxDashMap;
@@ -138,7 +138,6 @@ pub fn collect_module_original_sources(
       let resource = module.resource_resolved_data().resource.clone();
       let source = module
         .source()
-        .as_ref()
         .and_then(|s| s.map(&MapOptions::default()))
         .and_then(|s| {
           let idx = s.sources().iter().position(|s| s.eq(&resource))?;

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -116,7 +116,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
             .get_presentational_dependencies()
             .map_or(0.0, |i| i.len() as f64 * 10.0)
       }
-      SourceType::Wasm => module.original_source().map_or(0, |source| source.size()) as f64,
+      SourceType::Wasm => module.source().map_or(0, |source| source.size()) as f64,
       _ => 0.0,
     }
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. `Diagnosable` trait remove `has_error` and add `first_error` method.
``` diff
trait Diagnosable {
-  fn has_error(&self) -> bool;
+  fn first_error(&self) -> Option<Cow<Diagnostic>>;
}
```
2. update NormalModule.source to Option<BoxSource>, we should use Module.first_error to get the error information instead of getting it from Module.source.
``` diff
struct NormalModule {
-  source: NormalModuleSource,
+  source: Option<BoxSource>
}
```
3. remove NormalModule.original_source since it will always have the same value as NormalModule.source.
``` diff
struct NormalModule {
-  original_source: Option<BoxSource>
}
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
