### PR TITLE
fix: persistent cache remove non-existent modules from make_failed_module

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -90,6 +90,12 @@ impl MakeOccasion {
     artifact.build_dependencies = build_dep;
     artifact.reset_dependencies_incremental_info();
 
+    // TODO remove it after all of module are cacheable
+    let mut make_failed_module = std::mem::take(&mut artifact.make_failed_module);
+    let mg = artifact.get_module_graph_mut();
+    make_failed_module.retain(|module_id| mg.module_by_identifier(module_id).is_some());
+    artifact.make_failed_module = make_failed_module;
+
     Ok(artifact)
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The ModuleGraph generated from the persistent cache only contains modules that support serialization. Therefore, we need to filter make_failed_module to keep only the existing ones.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
