### PR TITLE
docs: fix Chinese comment in English docs

### DIFF
--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -802,7 +802,7 @@ In the above example, we're passing a single entry file to `entry`, however, Rsp
    ```js title="rspack.config.mjs"
    export default {
      // …
-     entry: ['./src/a.js', './src/b.js'], // 只有在 b.js 中导出的内容才会被暴露
+     entry: ['./src/a.js', './src/b.js'], // only exports in b.js will be exposed
      output: {
        library: 'MyLibrary',
      },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fixes a line of Chinese in the English docs

From what I can tell, this was accidentally added in https://github.com/web-infra-dev/rspack/pull/7167

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
