### PR TITLE
fix: initialize lazy compilation backend earlier

### DIFF
--- a/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
@@ -69,7 +69,7 @@ const getBackend =
 	(
 		compiler: Compiler,
 		callback: (
-			err: any,
+			err: Error | null,
 			obj?: {
 				dispose: (callback: (err: any) => void) => void;
 				module: (args: { module: string; path: string }) => {
@@ -166,7 +166,8 @@ const getBackend =
 			});
 			if (isClosing) socket.destroy();
 		});
-		server.on("listening", (err: any) => {
+
+		server.on("listening", err => {
 			if (err) return callback(err);
 			const addr = server.address() as AddressInfo;
 			if (typeof addr === "string")
@@ -216,6 +217,7 @@ const getBackend =
 			state.dispose = result.dispose;
 			callback(null, result);
 		});
+
 		listen(server);
 	};
 


### PR DESCRIPTION
## Summary

The lazy compilation backend needs to listen to the server's "listening" event, and we need to ensure that the backend is initialized before the `listen()` call.

There are two cases:

1. When using Rspack's default lazy compilation server, we can ensure this.
2. When users configured `backend.server`, the `listen()` method is called by the user, which is usually earlier than `compiler.hooks.beforeCompile` hook.

This PR moves up the timing of the backend initialization to avoid the second case.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
