### PR TITLE
fix: clear module_execution_results every compilation

### DIFF
--- a/packages/rspack/src/ExecuteModulePlugin.ts
+++ b/packages/rspack/src/ExecuteModulePlugin.ts
@@ -5,7 +5,11 @@ import type { Compiler } from "./Compiler";
 
 export default class ExecuteModulePlugin {
 	apply(compiler: Compiler) {
-		compiler.hooks.compilation.tap("executeModule", compilation => {
+		compiler.hooks.thisCompilation.tap("executeModule", compilation => {
+			// remove execution results every new compilation
+			const map = compiler.__internal__get_module_execution_results_map();
+			map.clear();
+
 			compilation.hooks.executeModule.tap(
 				"executeModule",
 				(options, context) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Remove execution results cache when there is a new compilation to avoid mem leak

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
