### PR TITLE
ci: add option to test when releasing canary

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -7,6 +7,11 @@ on:
         required: true
         type: string
         description: "Commit SHA"
+      test:
+        required: false
+        type: boolean
+        default: false
+        description: "Run tests"
       profile:
         required: true
         type: choice
@@ -61,7 +66,7 @@ jobs:
       target: ${{ matrix.array.target }}
       runner: ${{ matrix.array.runner }}
       profile: ${{inputs.profile}}
-      test: false
+      test: ${{inputs.test}}
 
   release:
     name: Release Canary


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/release-canary.yml` file. The most important changes involve adding a new input parameter for running tests and modifying the job configuration to use this new parameter.

Updates to GitHub Actions workflow:

* [`.github/workflows/release-canary.yml`](diffhunk://#diff-9f4438d00ff0b9f13896fd034278896ec94153fc2a5733b1852cbfce7ecaff77R10-R14): Added a new input parameter `test` to optionally run tests, which is not required and defaults to `false`.
* [`.github/workflows/release-canary.yml`](diffhunk://#diff-9f4438d00ff0b9f13896fd034278896ec94153fc2a5733b1852cbfce7ecaff77L64-R69): Modified the `jobs` section to use the new `test` input parameter instead of hardcoding the value to `false`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
