### PR TITLE
docs: fix import SRI statement

### DIFF
--- a/website/docs/en/plugins/rspack/subresource-integrity-plugin.mdx
+++ b/website/docs/en/plugins/rspack/subresource-integrity-plugin.mdx
@@ -46,11 +46,12 @@ const {
 The [output.crossOriginLoading](/config/output#outputcrossoriginloading) option is required for SRI to work:
 
 ```js title="rspack.config.mjs"
-import { experiments: { SubresourceIntegrityPlugin } } from "@rspack/core";
+import { experiments } from '@rspack/core';
+const { SubresourceIntegrityPlugin } = experiments;
 
 export default {
   output: {
-    crossOriginLoading: "anonymous",
+    crossOriginLoading: 'anonymous',
   },
   plugins: [new SubresourceIntegrityPlugin()],
 };
@@ -63,29 +64,28 @@ When the HTML plugin([`HtmlRspackPlugin`](/plugins/rspack/html-rspack-plugin.mdx
 The SubresourceIntegrityPlugin will interact with [`HtmlRspackPlugin`](/plugins/rspack/html-rspack-plugin.mdx) by default:
 
 ```js title="rspack.config.mjs"
-import { experiments: { SubresourceIntegrityPlugin }, HtmlRspackPlugin } from "@rspack/core";
+import { experiments, HtmlRspackPlugin } from '@rspack/core';
+const { SubresourceIntegrityPlugin } = experiments;
 
 export default {
-  plugins: [
-    new SubresourceIntegrityPlugin(),
-    new HtmlRspackPlugin()
-  ],
+  plugins: [new SubresourceIntegrityPlugin(), new HtmlRspackPlugin()],
 };
 ```
 
 If [`html-webpack-plugin`](https://github.com/jantimon/html-webpack-plugin) is used, the `htmlPlugin` option should be specified to the path of it:
 
 ```js title="rspack.config.mjs"
-import { experiments: { SubresourceIntegrityPlugin } } from "@rspack/core";
-import HtmlWebpackPlugin from "html-webpack-plugin";
+import { experiments } from '@rspack/core';
+const { SubresourceIntegrityPlugin } = experiments;
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 export default {
   plugins: [
     new SubresourceIntegrityPlugin({
       // the path to the html-webpack-plugin
-      htmlPlugin: import.meta.resolve("html-webpack-plugin"),
+      htmlPlugin: import.meta.resolve('html-webpack-plugin'),
     }),
-    new HtmlWebpackPlugin()
+    new HtmlWebpackPlugin(),
   ],
 };
 ```

--- a/website/docs/en/plugins/rspack/subresource-integrity-plugin.mdx
+++ b/website/docs/en/plugins/rspack/subresource-integrity-plugin.mdx
@@ -75,9 +75,9 @@ export default {
 If [`html-webpack-plugin`](https://github.com/jantimon/html-webpack-plugin) is used, the `htmlPlugin` option should be specified to the path of it:
 
 ```js title="rspack.config.mjs"
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { experiments } from '@rspack/core';
 const { SubresourceIntegrityPlugin } = experiments;
-import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 export default {
   plugins: [

--- a/website/docs/zh/plugins/rspack/subresource-integrity-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/subresource-integrity-plugin.mdx
@@ -75,9 +75,9 @@ export default {
 如果使用 [`html-webpack-plugin`](https://github.com/jantimon/html-webpack-plugin)，需要在 `htmlPlugin` 选项中指定其路径：
 
 ```js title="rspack.config.mjs"
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { experiments } from '@rspack/core';
 const { SubresourceIntegrityPlugin } = experiments;
-import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 export default {
   plugins: [

--- a/website/docs/zh/plugins/rspack/subresource-integrity-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/subresource-integrity-plugin.mdx
@@ -46,11 +46,12 @@ const {
 为了确保 SRI 正常工作，需要配置 [output.crossOriginLoading](/config/output#outputcrossoriginloading) 选项：
 
 ```js title="rspack.config.mjs"
-import { experiments: { SubresourceIntegrityPlugin } } from "@rspack/core";
+import { experiments } from '@rspack/core';
+const { SubresourceIntegrityPlugin } = experiments;
 
 export default {
   output: {
-    crossOriginLoading: "anonymous",
+    crossOriginLoading: 'anonymous',
   },
   plugins: [new SubresourceIntegrityPlugin()],
 };
@@ -63,29 +64,28 @@ export default {
 SubresourceIntegrityPlugin 默认会与 [`HtmlRspackPlugin`](/plugins/rspack/html-rspack-plugin.mdx) 交互：
 
 ```js title="rspack.config.mjs"
-import { experiments: { SubresourceIntegrityPlugin }, HtmlRspackPlugin } from "@rspack/core";
+import { experiments, HtmlRspackPlugin } from '@rspack/core';
+const { SubresourceIntegrityPlugin } = experiments;
 
 export default {
-  plugins: [
-    new SubresourceIntegrityPlugin(),
-    new HtmlRspackPlugin()
-  ],
+  plugins: [new SubresourceIntegrityPlugin(), new HtmlRspackPlugin()],
 };
 ```
 
 如果使用 [`html-webpack-plugin`](https://github.com/jantimon/html-webpack-plugin)，需要在 `htmlPlugin` 选项中指定其路径：
 
 ```js title="rspack.config.mjs"
-import { experiments: { SubresourceIntegrityPlugin } } from "@rspack/core";
-import HtmlWebpackPlugin from "html-webpack-plugin";
+import { experiments } from '@rspack/core';
+const { SubresourceIntegrityPlugin } = experiments;
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 export default {
   plugins: [
     new SubresourceIntegrityPlugin({
       // html-webpack-plugin 的路径
-      htmlPlugin: import.meta.resolve("html-webpack-plugin"),
+      htmlPlugin: import.meta.resolve('html-webpack-plugin'),
     }),
-    new HtmlWebpackPlugin()
+    new HtmlWebpackPlugin(),
   ],
 };
 ```


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This pull request includes updates to the `SubresourceIntegrityPlugin` usage examples in both the English and Chinese documentation files for the `rspack` plugin. The changes primarily involve refactoring the import statements and updating code formatting for consistency.

Refactoring and formatting updates:

* [`website/docs/en/plugins/rspack/subresource-integrity-plugin.mdx`](diffhunk://#diff-55abaab5f1ba6905f2b665c40bf48109c1ae41cca197fdff822514df0e81997aL49-R54): Updated import statements to use destructuring assignment for `experiments` and adjusted code formatting for consistency. [[1]](diffhunk://#diff-55abaab5f1ba6905f2b665c40bf48109c1ae41cca197fdff822514df0e81997aL49-R54) [[2]](diffhunk://#diff-55abaab5f1ba6905f2b665c40bf48109c1ae41cca197fdff822514df0e81997aL66-R88)
* [`website/docs/zh/plugins/rspack/subresource-integrity-plugin.mdx`](diffhunk://#diff-aea840d68fed1c5cef3b284b81c54dd41151ba0e25a29d8613a85e38cb8bce1eL49-R54): Applied similar refactoring to the import statements and formatting adjustments in the Chinese documentation. [[1]](diffhunk://#diff-aea840d68fed1c5cef3b284b81c54dd41151ba0e25a29d8613a85e38cb8bce1eL49-R54) [[2]](diffhunk://#diff-aea840d68fed1c5cef3b284b81c54dd41151ba0e25a29d8613a85e38cb8bce1eL66-R88)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
