### PR TITLE
fix(type): Change the module in the LazyCompilationOptions from any to Module

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3237,7 +3237,7 @@ export type LazyCompilationOptions = {
     backend?: LazyCompilationDefaultBackendOptions;
     imports?: boolean;
     entries?: boolean;
-    test?: RegExp | ((module: any) => boolean);
+    test?: RegExp | ((module: Module) => boolean);
 };
 
 // @public

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2465,7 +2465,7 @@ export type LazyCompilationOptions = {
 	/**
 	 * Test function or regex to determine which modules to include.
 	 */
-	test?: RegExp | ((module: any) => boolean);
+	test?: RegExp | ((module: Module) => boolean);
 };
 
 /**


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

Change the `module` in the `LazyCompilationOptions` from `any` to `Module`.

```typescript
export type LazyCompilationOptions = {
    // other properties
    test?: RegExp | ((module: Module) => boolean);
};
```

Documentation has been updated: 
- https://rspack.dev/config/experiments#experimentslazycompilation
- https://github.com/web-infra-dev/rspack/blob/main/website/docs/en/config/experiments.mdx

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
