### PR TITLE
chore(codeowners): removing deprecated package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,7 +71,6 @@ pnpm-lock.yaml
 /packages/postcss-loader
 /packages/rspack
 /packages/rspack-cli
-/packages/rspack-dev-middleware
 /packages/rspack-plugin-html
 /packages/rspack-plugin-minify
 /packages/rspack-plugin-node-polyfill


### PR DESCRIPTION
The rspack-dev-middleware package was deprecated, this reference was missed.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
Was helping someone debug an issue and was looking for this package. Was not able to find it in the codebase even though it looked like it was being published still. After verifying on NPM the package is deprecated. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
