### PR TITLE
ci: run codspeed build in parallel

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -260,6 +260,7 @@ jobs:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
       # TODO: use puppeteer to test SRI Plugin, maybe find a better performance way
       # PUPPETEER_SKIP_DOWNLOAD: true
+      
     steps:
       - name: Checkout
         if: ${{ !inputs.skipable }}
@@ -358,9 +359,8 @@ jobs:
 
   bench:
     name: Bench
-    needs: build
     if: ${{ inputs.bench && !inputs.skipable }}
-    runs-on: ${{ fromJSON(needs.build.outputs.runner-labels) }}
+    runs-on: ${{ fromJSON(inputs.runner) }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -374,6 +374,30 @@ jobs:
         with:
           target: ${{ inputs.target }}
 
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          save-cache: ${{ github.ref_name == 'main' }} # This should be safe because we have nightly building the cache every day
+          shared-key: build-bench-${{ inputs.target }}-${{ inputs.profile }}
+      
+      - name: Install cargo-codspeed binary
+        uses: taiki-e/install-action@54b836426b3fa9aef432e760885ea0419ab50dab # v2
+        with:
+          tool: cargo-codspeed@2.7.2
+
+      - name: Build Benchmark
+        env:
+          RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
+        run: cargo codspeed build -p rspack_benchmark --features codspeed
+
+      - name: Wait for build job
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          check-name: 'Test Linux / Build'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+      
       - name: Download bindings
         uses: ./.github/actions/download-artifact
         with:
@@ -386,27 +410,11 @@ jobs:
         shell: bash
         run: ls -lah crates/node_binding/*.node
 
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
-        with:
-          save-cache: ${{ github.ref_name == 'main' }} # This should be safe because we have nightly building the cache every day
-          shared-key: build-bench-${{ inputs.target }}-${{ inputs.profile }}
-
       - name: Pnpm Cache
         uses: ./.github/actions/pnpm-cache
 
       - name: Build JS
         run: pnpm run build:js
-
-      - name: Install cargo-codspeed binary
-        uses: taiki-e/install-action@54b836426b3fa9aef432e760885ea0419ab50dab # v2
-        with:
-          tool: cargo-codspeed@2.7.2
-
-      - name: Build Benchmark
-        env:
-          RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
-        run: cargo codspeed build -p rspack_benchmark --features codspeed
 
       - name: Run benchmark
         uses: CodSpeedHQ/action@1015f4f828ff74b7a950909897fe581d6ba868cc # v3


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Start building codspeed in parallel
- Use `wait-on-check-action` to make sure the binary of build task is ready before running codspeed task

![image](https://github.com/user-attachments/assets/22b3e6a5-ef3a-461a-928a-d9627443de19)


---

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This pull request includes several updates to the `jobs` section in the `.github/workflows/reusable-build.yml` file. The key changes involve modifying the conditions and steps for the bench job, specifically around the installation of tools and the build process.

### Updates to the `jobs` section:

* **Modification of job dependencies and conditions:**
  - Changed the `runs-on` condition for the `bench` job to use the `inputs.runner` instead of the output from the `build` job.

* **Addition of new steps for the `bench` job:**
  - Added steps to install the Rust toolchain, install the `cargo-codspeed` binary, build the benchmark, and wait for the build job to complete.

* **Removal of redundant steps:**
  - Removed previously existing steps for installing the Rust toolchain, installing the `cargo-codspeed` binary, and building the benchmark, as these have been restructured and added earlier in the workflow.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
