### PR TITLE
fix: sort order incorrect

### DIFF
--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -141,9 +141,8 @@ impl PluginCssExtract {
       let a = compilation.chunk_group_by_ukey.expect_get(a);
       let b = compilation.chunk_group_by_ukey.expect_get(b);
       match a.index.cmp(&b.index) {
-        std::cmp::Ordering::Less => std::cmp::Ordering::Less,
-        std::cmp::Ordering::Equal => std::cmp::Ordering::Equal,
-        std::cmp::Ordering::Greater => a.ukey.cmp(&b.ukey),
+        std::cmp::Ordering::Equal => a.ukey.cmp(&b.ukey),
+        order_res => order_res,
       }
     });
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should fallback to ukey only when index is equal or missing

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
