### PR TITLE
ci: use different shared key between normal build and codspeed build

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -390,7 +390,7 @@ jobs:
         uses: ./.github/actions/rustup
         with:
           save-cache: ${{ github.ref_name == 'main' }} # This should be safe because we have nightly building the cache every day
-          shared-key: build-${{ inputs.target }}-${{ inputs.profile }}
+          shared-key: build-bench-${{ inputs.target }}-${{ inputs.profile }}
 
       - name: Pnpm Cache
         uses: ./.github/actions/pnpm-cache


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This pull request includes a minor change to the `.github/workflows/reusable-build.yml` file. The change modifies the `shared-key` parameter to include the prefix `build-bench` instead of `build`.

* [`.github/workflows/reusable-build.yml`](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L393-R393): Changed `shared-key` from `build-${{ inputs.target }}-${{ inputs.profile }}` to `build-bench-${{ inputs.target }}-${{ inputs.profile }}`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
