### PR TITLE
chore: move modern module library finish_modules to finish_make

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1250,6 +1250,10 @@ impl Compilation {
     }
 
     let start = logger.time("finish modules");
+    // finish_modules means the module graph (modules, connections, dependencies) are
+    // frozen and start to optimize (provided exports, infer async, etc.) based on the
+    // module graph, so any kind of change that affect these should be done before the
+    // finish_modules
     plugin_driver
       .compilation_hooks
       .finish_modules

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -4,10 +4,10 @@ use rspack_collections::IdentifierMap;
 use rspack_core::rspack_sources::{ConcatSource, RawStringSource, SourceExt};
 use rspack_core::{
   merge_runtime, to_identifier, ApplyContext, BoxDependency, ChunkUkey,
-  CodeGenerationExportsFinalNames, Compilation, CompilationFinishModules,
-  CompilationOptimizeChunkModules, CompilationParams, CompilerCompilation, CompilerOptions,
-  ConcatenatedModule, ConcatenatedModuleExportsDefinitions, DependenciesBlock, Dependency,
-  DependencyId, LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, PluginContext,
+  CodeGenerationExportsFinalNames, Compilation, CompilationOptimizeChunkModules, CompilationParams,
+  CompilerCompilation, CompilerFinishMake, CompilerOptions, ConcatenatedModule,
+  ConcatenatedModuleExportsDefinitions, DependenciesBlock, Dependency, DependencyId,
+  LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, PluginContext,
 };
 use rspack_error::{error_bail, Result};
 use rspack_hash::RspackHash;
@@ -212,8 +212,8 @@ fn render_startup(
   Ok(())
 }
 
-#[plugin_hook(CompilationFinishModules for ModernModuleLibraryPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_ADDITIONS)]
-async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
+#[plugin_hook(CompilerFinishMake for ModernModuleLibraryPlugin)]
+async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
   let mut mg = compilation.get_module_graph_mut();
   let modules = mg.modules();
   let module_ids = modules.keys().cloned().collect::<Vec<_>>();
@@ -457,9 +457,9 @@ impl Plugin for ModernModuleLibraryPlugin {
       .tap(optimize_chunk_modules::new(self));
     ctx
       .context
-      .compilation_hooks
-      .finish_modules
-      .tap(finish_modules::new(self));
+      .compiler_hooks
+      .finish_make
+      .tap(finish_make::new(self));
 
     Ok(())
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

finish_modules means the module graph (modules, connections, dependencies) are frozen and start to optimize (provided exports, infer async, etc.) based on the module graph, so any kind of change that affect these should be done before the finish_modules.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
