### PR TITLE
ci: only install binding dependencies when building binary

### DIFF
--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -32,6 +32,9 @@ runs:
       if: ${{ inputs.node-version != '16' }}
       shell: bash
       run: |
+        echo "Corepack version: $(corepack --version)"
+        echo "Corepack version: $(corepack --version)"
+        echo "Corepack version: $(corepack --version)"
         if [[ "${{runner.os}}" == "Windows" ]]; then
           # add the npm prefix to PATH to ensure the installed corepack work properly
           NPM_PREFIX=$(cygpath -u "$(npm config get prefix)")

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -32,9 +32,6 @@ runs:
       if: ${{ inputs.node-version != '16' }}
       shell: bash
       run: |
-        echo "ttt1"
-        echo "ttt2"
-        echo "ttt3"
         if [[ "${{runner.os}}" == "Windows" ]]; then
           # add the npm prefix to PATH to ensure the installed corepack work properly
           NPM_PREFIX=$(cygpath -u "$(npm config get prefix)")
@@ -55,7 +52,7 @@ runs:
         standalone: true
 
     - name: Get pnpm store directory
-      if: ${{ inputs.run-install }}
+      if: ${{ inputs.run-install == 'true' }}
       id: pnpm-cache
       shell: bash
       run: |
@@ -70,7 +67,7 @@ runs:
 
     - name: Restore pnpm cache
       id: restore
-      if: ${{ inputs.run-install && startsWith(runner.name, 'GitHub Actions') }}
+      if: ${{ inputs.run-install == 'true' && startsWith(runner.name, 'GitHub Actions') }}
       uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -80,7 +77,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      if: ${{ inputs.run-install }}
+      if: ${{ inputs.run-install == 'true' }}
       run: |
         if [[ "${{ inputs.frozen-lockfile}}" == 'true' ]]; then
           pnpm install --frozen-lockfile --prefer-offline
@@ -90,7 +87,7 @@ runs:
 
     - name: Save pnpm cache
       uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4
-      if: ${{ inputs.run-install && startsWith(runner.name, 'GitHub Actions') && inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.run-install == 'true' && startsWith(runner.name, 'GitHub Actions') && inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -11,6 +11,10 @@ inputs:
     default: false
     required: false
     type: boolean
+  run-install:
+    default: true
+    required: false
+    type: boolean
   save-if:
     default: false
     required: false
@@ -49,6 +53,7 @@ runs:
 
     - name: Get pnpm store directory
       id: pnpm-cache
+      if: ${{ inputs.run-install }}
       shell: bash
       run: |
         # set store-dir to $(pnpm config get store-dir)/$(pnpm -v)
@@ -62,7 +67,7 @@ runs:
 
     - name: Restore pnpm cache
       id: restore
-      if: ${{ startsWith(runner.name, 'GitHub Actions') }}
+      if: ${{ startsWith(runner.name, 'GitHub Actions') && inputs.run-install }}
       uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -72,6 +77,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
+      if: ${{ inputs.run-install }}
       run: |
         if [[ "${{ inputs.frozen-lockfile}}" == 'true' ]]; then
           pnpm install --frozen-lockfile --prefer-offline
@@ -81,7 +87,7 @@ runs:
 
     - name: Save pnpm cache
       uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4
-      if: ${{ startsWith(runner.name, 'GitHub Actions') && inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
+      if: ${{ startsWith(runner.name, 'GitHub Actions') && inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' && inputs.run-install }}
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -44,16 +44,16 @@ runs:
     # https://pnpm.io/continuous-integration#github-actions
     # Uses `packageManagement` field from package.json
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
       if: ${{ inputs.node-version == '16' }}
+      uses: pnpm/action-setup@v4
       with:
         dest: ${{ runner.tool_cache }}/pnpm
         # Use `@pnpm/exe` for Node 16
         standalone: true
 
     - name: Get pnpm store directory
-      id: pnpm-cache
       if: ${{ inputs.run-install }}
+      id: pnpm-cache
       shell: bash
       run: |
         # set store-dir to $(pnpm config get store-dir)/$(pnpm -v)
@@ -67,7 +67,7 @@ runs:
 
     - name: Restore pnpm cache
       id: restore
-      if: ${{ startsWith(runner.name, 'GitHub Actions') && inputs.run-install }}
+      if: ${{ inputs.run-install && startsWith(runner.name, 'GitHub Actions') }}
       uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -87,7 +87,7 @@ runs:
 
     - name: Save pnpm cache
       uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4
-      if: ${{ startsWith(runner.name, 'GitHub Actions') && inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' && inputs.run-install }}
+      if: ${{ inputs.run-install && startsWith(runner.name, 'GitHub Actions') && inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -32,9 +32,9 @@ runs:
       if: ${{ inputs.node-version != '16' }}
       shell: bash
       run: |
-        echo "Corepack version: $(corepack --version)"
-        echo "Corepack version: $(corepack --version)"
-        echo "Corepack version: $(corepack --version)"
+        echo "ttt1"
+        echo "ttt2"
+        echo "ttt3"
         if [[ "${{runner.os}}" == "Windows" ]]; then
           # add the npm prefix to PATH to ensure the installed corepack work properly
           NPM_PREFIX=$(cygpath -u "$(npm config get prefix)")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,16 @@ jobs:
           fmt: true
           shared-key: check
 
+      - name: Pnpm Cache # Required by some tests
+        uses: ./.github/actions/pnpm-cache
+        with:
+          run-install: false
+      
+      - name: Install taplo cli
+        shell: bash
+        run: |
+          pnpm install -g @taplo/cli@0.7.0
+
       - name: Run Cargo Check
         run: cargo check --workspace --all-targets --locked # Not using --release because it uses too much cache, and is also slow.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
       skipable: ${{ needs.check-changed.outputs.changed != 'true' }}
       bench: true
+      full-install: false
 
   test-windows:
     name: Test Windows
@@ -78,6 +79,8 @@ jobs:
       profile: "dev"
       runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
       skipable: ${{ needs.check-changed.outputs.changed != 'true' }}
+      full-install: false
+
   test-mac:
     name: Test Mac
     needs: [get-runner-labels, check-changed]
@@ -88,6 +91,7 @@ jobs:
       profile: "ci"
       runner: ${{ needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS }}
       skipable: ${{ needs.check-changed.outputs.changed  != 'true' }}
+      full-install: false
 
   cargo-deny:
     name: Check license of dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,11 +221,6 @@ jobs:
         with:
           run-install: false
       
-      - name: Install taplo cli
-        shell: bash
-        run: |
-          pnpm install -g @taplo/cli@0.7.0
-
       - name: Run Cargo Check
         run: cargo check --workspace --all-targets --locked # Not using --release because it uses too much cache, and is also slow.
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -76,7 +76,7 @@ jobs:
         shell: bash
         run: |
           cd ./crates/node_binding
-          pnpm install --ignore-workspace
+          pnpm install --ignore-workspace --no-lockfile
           cd ../../
 
       - name: Install Rust Toolchain

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -10,6 +10,10 @@ on:
       target:
         required: true
         type: string
+      full-install:
+        default: true
+        required: false
+        type: boolean
       runner: # Runner labels
         required: true
         type: string
@@ -65,10 +69,10 @@ jobs:
         uses: ./.github/actions/pnpm-cache
         with:
           save-if: ${{ github.ref_name == 'main' }}
-          run-install: false
+          run-install: ${{ inputs.full-install == 'true' }}
 
-      - name: Install node dependencies
-        if: ${{ !inputs.skipable }}
+      - name: Install binding node dependencies
+        if: ${{ !inputs.skipable && inputs.full-install != 'true' }}
         shell: bash
         run: |
           cd ./crates/node_binding

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -60,11 +60,20 @@ jobs:
         with:
           target: ${{ inputs.target }}
 
-      - name: Pnpm Cache
+      - name: Pnpm Setup
         if: ${{ !inputs.skipable }}
         uses: ./.github/actions/pnpm-cache
         with:
           save-if: ${{ github.ref_name == 'main' }}
+          run-install: false
+
+      - name: Install node dependencies
+        if: ${{ !inputs.skipable }}
+        shell: bash
+        run: |
+          cd ./crates/node_binding
+          pnpm install --ignore-workspace
+          cd ../../
 
       - name: Install Rust Toolchain
         if: ${{ !inputs.skipable }}
@@ -99,6 +108,7 @@ jobs:
         uses: xc2/free-disk-space@fbe203b3788f2bebe2c835a15925da303eaa5efe # v1.0.0
         with:
           tool-cache: false
+
       # Linux
       - name: Build x86_64-unknown-linux-gnu in Docker
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' && steps.check_cache.outputs.exists != 'true' && !inputs.skipable }}
@@ -184,6 +194,7 @@ jobs:
           SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
           export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
           RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
+
       - name: Upload artifact
         id: upload-artifact
         uses: ./.github/actions/upload-artifact


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

There is no need to install the whole pnpm workspace dependencies when building binary

This pull request includes updates to the GitHub Actions workflows and custom actions to add more control over dependency installation and caching. The changes introduce a new input parameter to conditionally run the installation steps and update the workflows to use this new parameter.

Key changes:

### Updates to `.github/actions/pnpm-cache/action.yml`:

* Added `run-install` input parameter to control whether the installation steps should be executed.
* Modified the steps to conditionally run based on the `run-install` input parameter. [[1]](diffhunk://#diff-703261f283281b1446d87cf7f07bc488f0ce5f0d7fc9162b04baf83bce29f5c7L43-R55) [[2]](diffhunk://#diff-703261f283281b1446d87cf7f07bc488f0ce5f0d7fc9162b04baf83bce29f5c7L65-R70) [[3]](diffhunk://#diff-703261f283281b1446d87cf7f07bc488f0ce5f0d7fc9162b04baf83bce29f5c7R80) [[4]](diffhunk://#diff-703261f283281b1446d87cf7f07bc488f0ce5f0d7fc9162b04baf83bce29f5c7L84-R90)

### Updates to `.github/workflows/ci.yml`:

* Added `full-install` input parameter to several jobs to control whether the full installation should be performed. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR71) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR82-R83) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR94)
* Added a step to use the updated `pnpm-cache` action with the new `run-install` parameter.

### Updates to `.github/workflows/reusable-build.yml`:

* Added `full-install` input parameter to control the installation process.
* Updated the `Pnpm Cache` step to use the `run-install` parameter.
* Added a conditional step to install binding node dependencies if `full-install` is not set to true.
* Minor formatting changes for better readability. [[1]](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R115) [[2]](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R201)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
