### PR TITLE
chore(workflow): no need to run pnpm cache in rust jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,9 +252,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Pnpm Cache # Required by some tests
-        uses: ./.github/actions/pnpm-cache
-
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           args: --all -- --check
 
       - name: Run toml format check
-        run: pnpm run format-ci:toml
+        run: npm run format-ci:toml
 
   rust_unused_dependencies:
     name: Check Rust Unused Dependencies
@@ -281,9 +281,6 @@ jobs:
     runs-on: ${{ fromJSON(needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Pnpm Cache # Required by some tests
-        uses: ./.github/actions/pnpm-cache
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,9 +212,6 @@ jobs:
           fmt: true
           shared-key: check
 
-      - name: Pnpm Cache # Required by some tests
-        uses: ./.github/actions/pnpm-cache
-
       - name: Run Cargo Check
         run: cargo check --workspace --all-targets --locked # Not using --release because it uses too much cache, and is also slow.
 


### PR DESCRIPTION
## Summary

It seems we do not need to run pnpm cache in some Rust jobs. Remove this step should make these workflows 30s faster.

For example:

![image](https://github.com/user-attachments/assets/f2c4e1df-3e06-4ac2-95a7-dd30c47187ae)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
