### PR TITLE
test: should not call stats toJson if not necessary

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -11,6 +11,8 @@ import type EventEmitter from 'node:events';
 import { IBasicGlobalContext as IBasicGlobalContext_2 } from '../../type';
 import { IBasicModuleScope as IBasicModuleScope_2 } from '../../type';
 import { ITestCompilerManager as ITestCompilerManager_2 } from '../type';
+import type { MultiStats } from '@rspack/core';
+import type { MultiStats as MultiStats_2 } from 'webpack';
 import type { RspackOptions } from '@rspack/core';
 import type { RspackOptionsNormalized } from '@rspack/core';
 import type { RspackPluginInstance } from '@rspack/core';
@@ -934,6 +936,8 @@ export interface IStatsAPIProcessorOptions<T extends ECompilerType> {
 export interface IStatsProcessorOptions<T extends ECompilerType> extends Omit<IMultiTaskProcessorOptions<T>, "runable"> {
     // (undocumented)
     snapshotName?: string;
+    // (undocumented)
+    writeStatsOuptut?: boolean;
 }
 
 // @public (undocumented)
@@ -957,7 +961,7 @@ export interface ITestCompilerManager<T extends ECompilerType> {
     // (undocumented)
     getOptions(): TCompilerOptions<T>;
     // (undocumented)
-    getStats(): TCompilerStats<T> | null;
+    getStats(): TCompilerStats<T> | TCompilerMultiStats<T> | null;
     // (undocumented)
     mergeOptions(newOptions: TCompilerOptions<T>): TCompilerOptions<T>;
     // (undocumented)
@@ -1367,6 +1371,9 @@ export type TCompilerFactories = Record<ECompilerType, TCompilerFactory<ECompile
 export type TCompilerFactory<T extends ECompilerType> = (options: TCompilerOptions<T> | TCompilerOptions<T>[]) => TCompiler<T>;
 
 // @public (undocumented)
+export type TCompilerMultiStats<T> = T extends ECompilerType.Rspack ? MultiStats : MultiStats_2;
+
+// @public (undocumented)
 export type TCompilerOptions<T> = T extends ECompilerType.Rspack ? RspackOptions : Configuration;
 
 // @public (undocumented)
@@ -1553,8 +1560,10 @@ export type TStatsAPICaseConfig = Omit<IStatsAPIProcessorOptions<ECompilerType.R
 // @public (undocumented)
 export type TTestConfig<T extends ECompilerType> = {
     documentType?: EDocumentType;
-    validate?: (stats: TCompilerStats<T>, stderr?: string) => void;
+    validate?: (stats: TCompilerStats<T> | TCompilerMultiStats<T>, stderr?: string) => void;
     noTest?: boolean;
+    writeStatsOuptut?: boolean;
+    writeStatsJson?: boolean;
     beforeExecute?: () => void;
     afterExecute?: () => void;
     moduleScope?: (ms: IBasicModuleScope, stats?: TCompilerStatsCompilation<T>) => IBasicModuleScope;

--- a/packages/rspack-test-tools/src/case/stats-output.ts
+++ b/packages/rspack-test-tools/src/case/stats-output.ts
@@ -8,6 +8,7 @@ const creator = new BasicCaseCreator({
 	steps: ({ name }) => [
 		new StatsProcessor({
 			name,
+			writeStatsOuptut: false,
 			compilerType: ECompilerType.Rspack,
 			configFiles: ["rspack.config.js", "webpack.config.js"]
 		})

--- a/packages/rspack-test-tools/src/processor/basic.ts
+++ b/packages/rspack-test-tools/src/processor/basic.ts
@@ -142,27 +142,41 @@ export class BasicProcessor<T extends ECompilerType> implements ITestProcessor {
 		const compiler = this.getCompiler(context);
 		const stats = compiler.getStats();
 		if (stats) {
-			fs.writeFileSync(
-				path.join(context.getDist(), "stats.txt"),
-				stats.toString({
-					preset: "verbose",
-					colors: false
-				}),
-				"utf-8"
-			);
-			const jsonStats = stats.toJson({
-				errorDetails: true
-			});
-			fs.writeFileSync(
-				path.join(context.getDist(), "stats.json"),
-				JSON.stringify(jsonStats, null, 2),
-				"utf-8"
-			);
-			if (jsonStats.errors) {
-				errors.push(...jsonStats.errors);
+			if (testConfig.writeStatsOuptut) {
+				fs.writeFileSync(
+					path.join(context.getDist(), "stats.txt"),
+					stats.toString({
+						preset: "verbose",
+						colors: false
+					}),
+					"utf-8"
+				);
 			}
-			if (jsonStats.warnings) {
-				warnings.push(...jsonStats.warnings);
+
+			if (testConfig.writeStatsJson) {
+				const jsonStats = stats.toJson({
+					errorDetails: true
+				});
+				fs.writeFileSync(
+					path.join(context.getDist(), "stats.json"),
+					JSON.stringify(jsonStats, null, 2),
+					"utf-8"
+				);
+			}
+
+			if (
+				fs.existsSync(context.getSource("errors.js")) ||
+				fs.existsSync(context.getSource("warnings.js"))
+			) {
+				const statsJson = stats.toJson({
+					errorDetails: true
+				});
+				if (statsJson.errors) {
+					errors.push(...statsJson.errors);
+				}
+				if (statsJson.warnings) {
+					warnings.push(...statsJson.warnings);
+				}
 			}
 		}
 		await checkArrayExpectation(

--- a/packages/rspack-test-tools/src/processor/hash.ts
+++ b/packages/rspack-test-tools/src/processor/hash.ts
@@ -31,11 +31,10 @@ export class HashProcessor<
 			env.expect(false);
 			return;
 		}
-		const statsJson = stats.toJson({ assets: true });
 		if (REG_ERROR_CASE.test(this._options.name)) {
-			env.expect((statsJson.errors || []).length > 0);
+			env.expect(stats.hasErrors());
 		} else {
-			env.expect((statsJson.errors || []).length === 0);
+			env.expect(!stats.hasErrors());
 		}
 
 		if (typeof testConfig.validate === "function") {

--- a/packages/rspack-test-tools/src/processor/hot-step.ts
+++ b/packages/rspack-test-tools/src/processor/hot-step.ts
@@ -137,7 +137,7 @@ export class HotSnapshotProcessor<
 
 	async check(env: ITestEnv, context: ITestContext) {
 		const compiler = this.getCompiler(context);
-		const stats = compiler.getStats();
+		const stats = compiler.getStats() as TCompilerStats<T>;
 		if (!stats || !stats.hash) {
 			env.expect(false);
 			return;

--- a/packages/rspack-test-tools/src/processor/simple.ts
+++ b/packages/rspack-test-tools/src/processor/simple.ts
@@ -54,9 +54,9 @@ export class SimpleTaskProcessor<T extends ECompilerType>
 
 	async check(env: ITestEnv, context: ITestContext) {
 		const compiler = this.getCompiler(context);
-		const stats = compiler.getStats();
+		const stats = compiler.getStats() as TCompilerStats<T>;
 		if (typeof this._options.check === "function") {
-			await this._options.check(context, compiler.getCompiler()!, stats!);
+			await this._options.check(context, compiler.getCompiler()!, stats);
 		}
 	}
 

--- a/packages/rspack-test-tools/src/processor/stats-api.ts
+++ b/packages/rspack-test-tools/src/processor/stats-api.ts
@@ -58,7 +58,7 @@ export class StatsAPIProcessor<
 
 	async check(env: ITestEnv, context: ITestContext) {
 		const compiler = this.getCompiler(context);
-		const stats = compiler.getStats();
+		const stats = compiler.getStats() as TCompilerStats<T>;
 		env.expect(typeof stats).toBe("object");
 		await this._statsAPIOptions.check?.(stats!, compiler.getCompiler()!);
 	}

--- a/packages/rspack-test-tools/src/processor/stats.ts
+++ b/packages/rspack-test-tools/src/processor/stats.ts
@@ -15,6 +15,7 @@ import { type IMultiTaskProcessorOptions, MultiTaskProcessor } from "./multi";
 export interface IStatsProcessorOptions<T extends ECompilerType>
 	extends Omit<IMultiTaskProcessorOptions<T>, "runable"> {
 	snapshotName?: string;
+	writeStatsOuptut?: boolean;
 }
 
 const REG_ERROR_CASE = /error$/;
@@ -28,6 +29,7 @@ export class StatsProcessor<
 > extends MultiTaskProcessor<T> {
 	private stderr: any;
 	private snapshotName?: string;
+	private writeStatsOuptut?: boolean;
 	constructor(_statsOptions: IStatsProcessorOptions<T>) {
 		super({
 			defaultOptions: StatsProcessor.defaultOptions<T>,
@@ -36,6 +38,7 @@ export class StatsProcessor<
 			..._statsOptions
 		});
 		this.snapshotName = _statsOptions.snapshotName;
+		this.writeStatsOuptut = _statsOptions.writeStatsOuptut;
 	}
 
 	async before(context: ITestContext) {
@@ -114,7 +117,7 @@ export class StatsProcessor<
 					// errorDetails: true
 				})
 			);
-		} else {
+		} else if (this.writeStatsOuptut) {
 			fs.writeFileSync(
 				path.join(context.getDist(), "stats.txt"),
 				stats.toString({

--- a/packages/rspack-test-tools/src/processor/watch.ts
+++ b/packages/rspack-test-tools/src/processor/watch.ts
@@ -10,7 +10,8 @@ import type {
 	ECompilerType,
 	ITestContext,
 	ITestEnv,
-	TCompilerOptions
+	TCompilerOptions,
+	TCompilerStatsCompilation
 } from "../type";
 import { type IMultiTaskProcessorOptions, MultiTaskProcessor } from "./multi";
 
@@ -102,31 +103,62 @@ export class WatchProcessor<
 		const checkStats = testConfig.checkStats || (() => true);
 
 		if (stats) {
-			fs.writeFileSync(
-				path.join(context.getDist(), "stats.txt"),
-				stats.toString({
-					preset: "verbose",
-					colors: false
-				}),
-				"utf-8"
-			);
-			const jsonStats = stats.toJson({
-				errorDetails: true
-			});
+			if (testConfig.writeStatsOuptut) {
+				fs.writeFileSync(
+					path.join(context.getDist(), "stats.txt"),
+					stats.toString({
+						preset: "verbose",
+						colors: false
+					}),
+					"utf-8"
+				);
+			}
 
-			if (!checkStats(this._watchOptions.stepName, jsonStats)) {
-				throw new Error("stats check failed");
+			const getJsonStats = (() => {
+				let cached: TCompilerStatsCompilation<T> | null = null;
+				return () => {
+					if (!cached) {
+						cached = stats.toJson({
+							errorDetails: true
+						});
+					}
+					return cached;
+				};
+			})();
+			if (checkStats.length > 1) {
+				if (!checkStats(this._watchOptions.stepName, getJsonStats())) {
+					throw new Error("stats check failed");
+				}
+			} else {
+				// @ts-expect-error only one param
+				if (!checkStats(this._watchOptions.stepName)) {
+					throw new Error("stats check failed");
+				}
 			}
-			fs.writeFileSync(
-				path.join(context.getDist(), "stats.json"),
-				JSON.stringify(jsonStats, null, 2),
-				"utf-8"
-			);
-			if (jsonStats.errors) {
-				errors.push(...jsonStats.errors);
+			if (testConfig.writeStatsJson) {
+				fs.writeFileSync(
+					path.join(context.getDist(), "stats.json"),
+					JSON.stringify(getJsonStats(), null, 2),
+					"utf-8"
+				);
 			}
-			if (jsonStats.warnings) {
-				warnings.push(...jsonStats.warnings);
+			if (
+				fs.existsSync(
+					context.getSource(`${this._watchOptions.stepName}/errors.js`)
+				) ||
+				fs.existsSync(
+					context.getSource(`${this._watchOptions.stepName}/warnings.js`)
+				)
+			) {
+				const statsJson = stats.toJson({
+					errorDetails: true
+				});
+				if (statsJson.errors) {
+					errors.push(...statsJson.errors);
+				}
+				if (statsJson.warnings) {
+					warnings.push(...statsJson.warnings);
+				}
 			}
 		}
 		await checkArrayExpectation(
@@ -151,14 +183,21 @@ export class WatchProcessor<
 		}
 
 		// check hash
-		fs.renameSync(
-			path.join(context.getDist(), "stats.txt"),
-			path.join(context.getDist(), `stats.${this._watchOptions.stepName}.txt`)
-		);
-		fs.renameSync(
-			path.join(context.getDist(), "stats.json"),
-			path.join(context.getDist(), `stats.${this._watchOptions.stepName}.json`)
-		);
+		if (testConfig.writeStatsOuptut) {
+			fs.renameSync(
+				path.join(context.getDist(), "stats.txt"),
+				path.join(context.getDist(), `stats.${this._watchOptions.stepName}.txt`)
+			);
+		}
+		if (testConfig.writeStatsJson) {
+			fs.renameSync(
+				path.join(context.getDist(), "stats.json"),
+				path.join(
+					context.getDist(),
+					`stats.${this._watchOptions.stepName}.json`
+				)
+			);
+		}
 	}
 
 	async config(context: ITestContext) {

--- a/packages/rspack-test-tools/src/type.ts
+++ b/packages/rspack-test-tools/src/type.ts
@@ -3,12 +3,14 @@
 import type EventEmitter from "node:events";
 import type {
 	Compiler as RspackCompiler,
+	MultiStats as RspackMultiStats,
 	RspackOptions,
 	Stats as RspackStats,
 	StatsCompilation as RspackStatsCompilation
 } from "@rspack/core";
 import type {
 	Compiler as WebpackCompiler,
+	MultiStats as WebpackMultiStats,
 	Configuration as WebpackOptions,
 	Stats as WebpackStats,
 	StatsCompilation as WebpackStatsCompilation
@@ -57,6 +59,9 @@ export type TCompiler<T> = T extends ECompilerType.Rspack
 export type TCompilerStats<T> = T extends ECompilerType.Rspack
 	? RspackStats
 	: WebpackStats;
+export type TCompilerMultiStats<T> = T extends ECompilerType.Rspack
+	? RspackMultiStats
+	: WebpackMultiStats;
 
 export type TCompilerStatsCompilation<T> = T extends ECompilerType.Rspack
 	? RspackStatsCompilation
@@ -70,7 +75,7 @@ export interface ITestCompilerManager<T extends ECompilerType> {
 	createCompiler(): TCompiler<T>;
 	build(): Promise<TCompilerStats<T>>;
 	watch(timeout?: number): void;
-	getStats(): TCompilerStats<T> | null;
+	getStats(): TCompilerStats<T> | TCompilerMultiStats<T> | null;
 	getEmitter(): EventEmitter;
 	close(): Promise<void>;
 }
@@ -187,8 +192,13 @@ export enum EDocumentType {
 
 export type TTestConfig<T extends ECompilerType> = {
 	documentType?: EDocumentType;
-	validate?: (stats: TCompilerStats<T>, stderr?: string) => void;
+	validate?: (
+		stats: TCompilerStats<T> | TCompilerMultiStats<T>,
+		stderr?: string
+	) => void;
 	noTest?: boolean;
+	writeStatsOuptut?: boolean;
+	writeStatsJson?: boolean;
 	beforeExecute?: () => void;
 	afterExecute?: () => void;
 	moduleScope?: (

--- a/packages/rspack-test-tools/tests/configCases/module/rspack-issue-1652/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/rspack-issue-1652/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	writeStatsOuptut: true,
+	writeStatsJson: true
+};

--- a/packages/rspack-test-tools/tests/configCases/module/rspack-issue-5548/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/rspack-issue-5548/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	writeStatsOuptut: true,
+	writeStatsJson: true
+};

--- a/packages/rspack-test-tools/tests/configCases/output/rspack-issue-4338/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/rspack-issue-4338/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	writeStatsOuptut: true,
+	writeStatsJson: true
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/swc-js-minifier/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/swc-js-minifier/test.config.js
@@ -1,5 +1,7 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
+	writeStatsOuptut: true,
+	writeStatsJson: true,
 	findBundle: function (i) {
 		return ["main.js"];
 	}

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-fit/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-fit/test.config.js
@@ -1,5 +1,6 @@
 /** @type {import("../../../..").TConfigCaseConfig} */
 module.exports = {
+	writeStatsJson: true,
 	findBundle: function (i, options) {
 		return ["main~1.js", "main~2.js", "main~3.js", "main~400f55e3.js"];
 	}

--- a/packages/rspack-test-tools/tests/watchCases/chunk-ids/id-equals-name/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunk-ids/id-equals-name/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	writeStatsOuptut: true
+};

--- a/packages/rspack-test-tools/tests/watchCases/chunk-ids/update-module/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunk-ids/update-module/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	writeStatsOuptut: true
+};

--- a/packages/rspack-test-tools/tests/watchCases/module-ids/ignored-module/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/module-ids/ignored-module/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	writeStatsOuptut: true
+};

--- a/packages/rspack-test-tools/tests/watchCases/module-ids/update-module/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/module-ids/update-module/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	writeStatsOuptut: true
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Not to call `stats.toJson` if it is not necessary. This may improve the performance of CI on windows. The following comparison is just a sample. It may also be affected by machine fluctuations.  

Before:
![image](https://github.com/user-attachments/assets/0918b47e-0109-41ab-9230-362eceeecfcc)

After:
![image](https://github.com/user-attachments/assets/f37c9e14-eeab-47e8-aa42-adc2b55a8e96)

---

This pull request introduces several enhancements and fixes to the `rspack-test-tools` package, focusing on improved handling and output of compiler statistics. The most important changes include the addition of new types for multi-stats, updates to various processors to handle these types, and the introduction of new configuration options for writing stats output and JSON files.

### Enhancements to Compiler Statistics Handling:

* Added new types `TCompilerMultiStats` to handle multi-stats for both `Rspack` and `Webpack` compilers. (`packages/rspack-test-tools/etc/test-tools.api.md` [[1]](diffhunk://#diff-ffb09cc036242173fb7f1876bb2276893e09c2e1d812e781042b064941d2bd4cR1373-R1375) `packages/rspack-test-tools/src/type.ts` [[2]](diffhunk://#diff-1b475f687d68c1a972ca3fc3886e9b75221574cfe5ad230f8e936d9bc10e686fR62-R64)

* Updated `ITestCompilerManager` interface to return `TCompilerStats` or `TCompilerMultiStats` in the `getStats` method. (`packages/rspack-test-tools/etc/test-tools.api.md` [[1]](diffhunk://#diff-ffb09cc036242173fb7f1876bb2276893e09c2e1d812e781042b064941d2bd4cL960-R964) `packages/rspack-test-tools/src/type.ts` [[2]](diffhunk://#diff-1b475f687d68c1a972ca3fc3886e9b75221574cfe5ad230f8e936d9bc10e686fL73-R78)

### Processor Updates:

* Modified `BasicProcessor`, `HashProcessor`, `HotSnapshotProcessor`, `SimpleTaskProcessor`, `SnapshotProcessor`, `StatsAPIProcessor`, `StatsProcessor`, and `WatchProcessor` to handle the new multi-stats types and write stats output and JSON files based on the new configuration options. (`packages/rspack-test-tools/src/processor/basic.ts` [[1]](diffhunk://#diff-d2fa1a709cac9449aaee19691860e7289a833799390d4dcd493cb735796b2feaR145) [[2]](diffhunk://#diff-d2fa1a709cac9449aaee19691860e7289a833799390d4dcd493cb735796b2feaR154-R156) [[3]](diffhunk://#diff-d2fa1a709cac9449aaee19691860e7289a833799390d4dcd493cb735796b2feaL161-R179) `packages/rspack-test-tools/src/processor/hash.ts` [[4]](diffhunk://#diff-e880a2ee8f3bf3f0af5cd671ac56bbe7ffd17175fc82862adcaa18726a383b13L34-R37) `packages/rspack-test-tools/src/processor/hot-step.ts` [[5]](diffhunk://#diff-3a4f6b46a89474869b3ae4588d2ab8b6e1d1611ba41a9ac7c23a1d0a235afe47L140-R140) `packages/rspack-test-tools/src/processor/simple.ts` [[6]](diffhunk://#diff-a0a0c52af90357e69ba639385e7528e5cd6ba6fbf8f841ad78ad633a0cd697caL57-R59) `packages/rspack-test-tools/src/processor/snapshot.ts` [[7]](diffhunk://#diff-a4719a7d4ecabd145c747c08ce520231e8ec58dca53b78f6c9bf971ade7ed007R42-R56) `packages/rspack-test-tools/src/processor/stats-api.ts` [[8]](diffhunk://#diff-82a81e31043a9ef3ddbf1c6d1582d91239199a116529071057eef5765824c629L61-R61) `packages/rspack-test-tools/src/processor/stats.ts` [[9]](diffhunk://#diff-8f44f60fcd912bb97f31f3e4879f394fc66224a876dd5c215ffd412c85924b68R32) [[10]](diffhunk://#diff-8f44f60fcd912bb97f31f3e4879f394fc66224a876dd5c215ffd412c85924b68R41) [[11]](diffhunk://#diff-8f44f60fcd912bb97f31f3e4879f394fc66224a876dd5c215ffd412c85924b68L117-R120) `packages/rspack-test-tools/src/processor/watch.ts` [[12]](diffhunk://#diff-1ede92d3b44d2acd8ed0bb05f79ade41bf3d1537d5c330940f415d9c8acd11a6R106) [[13]](diffhunk://#diff-1ede92d3b44d2acd8ed0bb05f79ade41bf3d1537d5c330940f415d9c8acd11a6L113-R161) [[14]](diffhunk://#diff-1ede92d3b44d2acd8ed0bb05f79ade41bf3d1537d5c330940f415d9c8acd11a6R186-R201)

### Configuration Updates:

* Introduced new configuration options `writeStatsOuptut` and `writeStatsJson` to control the writing of stats output and JSON files. (`packages/rspack-test-tools/etc/test-tools.api.md` [[1]](diffhunk://#diff-ffb09cc036242173fb7f1876bb2276893e09c2e1d812e781042b064941d2bd4cR939-R940) `packages/rspack-test-tools/src/type.ts` [[2]](diffhunk://#diff-1b475f687d68c1a972ca3fc3886e9b75221574cfe5ad230f8e936d9bc10e686fL190-R201)

### Test Configurations:

* Updated test configurations to use the new `writeStatsOuptut` and `writeStatsJson` options. (`packages/rspack-test-tools/tests/configCases/module/rspack-issue-1652/test.config.js` [[1]](diffhunk://#diff-d88ae1ab9e76bc5d16d94c788523c0e3b19832615d991ad98546f7ce96fe8547R1-R4) `packages/rspack-test-tools/tests/configCases/module/rspack-issue-5548/test.config.js` [[2]](diffhunk://#diff-d88ae1ab9e76bc5d16d94c788523c0e3b19832615d991ad98546f7ce96fe8547R1-R4) `packages/rspack-test-tools/tests/configCases/output/rspack-issue-4338/test.config.js` [[3]](diffhunk://#diff-d88ae1ab9e76bc5d16d94c788523c0e3b19832615d991ad98546f7ce96fe8547R1-R4) `packages/rspack-test-tools/tests/configCases/plugins/swc-js-minifier/test.config.js` [[4]](diffhunk://#diff-ef85a3151813119f22b754b1ef476c001752feccf910cf4709234677a0c78c61R3-R4) `packages/rspack-test-tools/tests/configCases/split-chunks/max-size-fit/test.config.js` [[5]](diffhunk://#diff-a0e9066ddd5847eae7d2a3a66996ca6483d496d84402a1f9ca33f007b8d6953aR3) `packages/rspack-test-tools/tests/watchCases/chunk-ids/id-equals-name/test.config.js` [[6]](diffhunk://#diff-2c312c96346443c5c77aabd102492be127f3b2fb76f182da8b5fd2b5954bc162R1-R3)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
