### PR TITLE
chore(deps): bump `fast-glob` to v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "fast-glob"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eca69ef247d19faa15ac0156968637440824e5ff22baa5ee0cd35b2f7ea6a0f"
+checksum = "a43e28342e6608e53d694e6a12f56ebd1c9228df61b8edbe6a9a882cab5f4a93"
 dependencies = [
  "arrayvec",
 ]

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -12,7 +12,7 @@ bitflags = { workspace = true }
 cow-utils = { workspace = true }
 dashmap = { workspace = true }
 either = { workspace = true }
-fast-glob = "0.4.3"
+fast-glob = "0.4.4"
 indexmap = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
## Summary

Related to https://github.com/shulaoda/fast-glob/pull/10

Fixed some matching issues.

## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
