### PR TITLE
test: remove hash test in sri plugin cases

### DIFF
--- a/tests/plugin-test/sri-plugin/examples/issue-152/webpack.config.js
+++ b/tests/plugin-test/sri-plugin/examples/issue-152/webpack.config.js
@@ -3,7 +3,7 @@ const { createIntegrityPlugin, getDist } = require("../wsi-test-helper");
 module.exports = {
   entry: "./index.js",
   output: {
-    filename: "[contenthash].js",
+    filename: "[name].js",
     chunkFilename: "[contenthash].chunk.js",
     crossOriginLoading: "anonymous",
     path: getDist(__dirname),
@@ -23,9 +23,8 @@ module.exports = {
     {
       apply: (compiler) => {
         compiler.hooks.done.tap("wsi-test", (stats) => {
-          expect(Object.keys(stats.compilation.assets)).toContain(
-            "85e3f6d0198e353b.js"
-          );
+          const mainAsset = stats.compilation.assets["main.js"];
+          expect(mainAsset.source()).toContain(`JSON.parse('{"key":"value","key2":"value2","key3":"value","key4":"value2","key5":"value","key6":"value2","key7":"value","key8":"value2","key9":"value","key10":"value2","key11":"value","key12":"value2","key13":"value","key14":"value2","key15":"value","key16":"value2","key17":"value","key18":"value2","key19":"value","key20":"value2","key21":"value","key22":"value2"}')`);
         });
       },
     },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This pull request includes changes to the `webpack.config.js` file in the `tests/plugin-test/sri-plugin/examples/issue-152` directory. The changes focus on modifying the output filename configuration and updating the test expectations for the generated assets.

### Changes to output filename configuration:

* Modified the `filename` property in the `output` configuration from using `[contenthash].js` to `[name].js`.

### Updates to test expectations:

* Changed the test to check for the presence of `main.js` and verify its content instead of checking for a specific hashed filename. The new expectation checks that `main.js` contains a specific JSON string.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
