### PR TITLE
fix: update CLI flags to use camelCase consistently

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -136,8 +136,8 @@ export class RspackCLI {
 			}
 			// to set output.path
 			item.output = item.output || {};
-			if (options["output-path"]) {
-				item.output.path = path.resolve(process.cwd(), options["output-path"]);
+			if (options.outputPath) {
+				item.output.path = path.resolve(process.cwd(), options.outputPath);
 			}
 			if (options.analyze) {
 				const { BundleAnalyzerPlugin } = await import(

--- a/packages/rspack-cli/src/types.ts
+++ b/packages/rspack-cli/src/types.ts
@@ -24,7 +24,7 @@ export interface RspackCLIOptions {
 	config?: string;
 	argv?: Record<string, any>;
 	configName?: string[];
-	"config-loader"?: string;
+	configLoader?: string;
 }
 
 export interface RspackBuildCLIOptions extends RspackCLIOptions {
@@ -36,7 +36,7 @@ export interface RspackBuildCLIOptions extends RspackCLIOptions {
 	profile?: boolean;
 	env?: Record<string, any>;
 	nodeEnv?: string;
-	"output-path"?: string;
+	outputPath?: string;
 }
 
 export interface RspackPreviewCLIOptions extends RspackCLIOptions {

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -61,7 +61,7 @@ export async function loadRspackConfig(
 		if (!fs.existsSync(configPath)) {
 			throw new Error(`config file "${configPath}" not found.`);
 		}
-		if (isTsFile(configPath) && options["config-loader"] === "register") {
+		if (isTsFile(configPath) && options.configLoader === "register") {
 			await registerLoader(configPath);
 		}
 		return crossImport(configPath, cwd);
@@ -69,7 +69,7 @@ export async function loadRspackConfig(
 
 	const defaultConfig = findConfig(path.resolve(cwd, DEFAULT_CONFIG_NAME));
 	if (defaultConfig) {
-		if (isTsFile(defaultConfig) && options["config-loader"] === "register") {
+		if (isTsFile(defaultConfig) && options.configLoader === "register") {
 			await registerLoader(defaultConfig);
 		}
 		return crossImport(defaultConfig, cwd);

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -13,7 +13,7 @@ export const commonOptions = (yargs: yargs.Argv) => {
 				string: true,
 				describe: "entry file"
 			},
-			"output-path": {
+			outputPath: {
 				type: "string",
 				describe: "output path dir",
 				alias: "o"
@@ -30,7 +30,7 @@ export const commonOptions = (yargs: yargs.Argv) => {
 				string: true,
 				describe: "env passed to config function"
 			},
-			"node-env": {
+			nodeEnv: {
 				string: true,
 				describe: "sets process.env.NODE_ENV to be specified value"
 			},
@@ -45,7 +45,7 @@ export const commonOptions = (yargs: yargs.Argv) => {
 				string: true,
 				describe: "Name of the configuration to use."
 			},
-			"config-loader": {
+			configLoader: {
 				type: "string",
 				default: "register",
 				describe:

--- a/packages/rspack-cli/tests/build/basic/basic.test.ts
+++ b/packages/rspack-cli/tests/build/basic/basic.test.ts
@@ -80,7 +80,8 @@ describe("build command", () => {
 		expect(mainJs).toContain("other");
 		expect(mainJs).not.toContain("CONFIG");
 	});
-	it.each(["-o", "--output-path"])(
+
+	it.each(["-o", "--output-path", "--outputPath"])(
 		"output-path option %p should have higher priority than config",
 		async command => {
 			const { exitCode, stderr, stdout } = await run(__dirname, [

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -9,6 +9,30 @@
 `@rspack/cli` is not compatible with `webpack-cli`, so there will be some differences between the two.
 :::
 
+## All commands
+
+To view all available CLI commands, run the following command in the project directory:
+
+```bash
+npx rspack -h
+```
+
+## Common flags
+
+Rspack CLI provides several common flags that can be used with all commands:
+
+| Flag                 | Description                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| -c, --config [value] | Specify the path to the configuration file, see [Specify the configuration file](/config/index#specify-the-configuration-file) |
+| --configLoader       | Specify the loader to load the config file, can be `native` or `register`, defaults to `register`                              |
+| --configName         | Specify the name of the configuration to use.                                                                                  |
+| -h, --help           | Show help information                                                                                                          |
+| -v, --version        | Show version number                                                                                                            |
+
+:::tip
+All flags in Rspack CLI support the `camelCase` and `kebab-case`, for example, both `--configLoader` and `--config-loader` are valid.
+:::
+
 ## rspack build
 
 `rspack build` is used to run Rspack build, which will generate the output files in the [output.path](/config/output#outputpath) directory.
@@ -35,17 +59,13 @@ The complete flags are as follows:
 rspack build
 
 Options:
-  -c, --config         config file                                      [string]
       --entry          entry file                                        [array]
-  -o, --output-path    output path dir                                  [string]
+  -o, --outputPath     output path dir                                  [string]
   -m, --mode           mode                                             [string]
   -w, --watch          watch                          [boolean] [default: false]
       --env            env passed to config function                     [array]
-      --node-env       sets process.env.NODE_ENV to be specified value  [string]
+      --nodeEnv        sets process.env.NODE_ENV to be specified value  [string]
   -d, --devtool        devtool                        [boolean] [default: false]
-      --configName     Name of the configuration to use.                 [array]
-      --config-loader  Specify the loader to load the config file, can be
-                       `native` or `register`.    [string] [default: "register"]
       --analyze        analyze                        [boolean] [default: false]
       --json           emit stats json
       --profile        capture timing information for each module
@@ -79,22 +99,16 @@ The complete flags are as follows:
 rspack dev
 
 Options:
-  -c, --config         config file                                      [string]
       --entry          entry file                                        [array]
-  -o, --output-path    output path dir                                  [string]
+  -o, --outputPath     output path dir                                  [string]
   -m, --mode           mode                                             [string]
   -w, --watch          watch                          [boolean] [default: false]
       --env            env passed to config function                     [array]
-      --node-env       sets process.env.NODE_ENV to be specified value  [string]
+      --nodeEnv        sets process.env.NODE_ENV to be specified value  [string]
   -d, --devtool        devtool                        [boolean] [default: false]
-      --configName     Name of the configuration to use.                 [array]
-      --config-loader  Specify the loader to load the config file, can be
-                       `native` or `register`.    [string] [default: "register"]
       --hot            enables hot module replacement
       --port           allows to specify a port to use                  [number]
       --host           allows to specify a hostname to use              [string]
-  -v, --version        Show version number                             [boolean]
-  -h, --help           Show help                                       [boolean]
 ```
 
 ## rspack preview
@@ -116,23 +130,9 @@ Positionals:
   dir  directory want to preview                                        [string]
 
 Options:
-      --help        Show help                                          [boolean]
-      --version     Show version number                                [boolean]
       --publicPath  static resource server path                         [string]
-  -c, --config      config file                                         [string]
       --port        preview server port                                 [number]
       --host        preview server host                                 [string]
       --open        open browser                                       [boolean]
       --server      Configuration items for the server.                 [string]
-      --configName  Name of the configuration to use.                    [array]
 ```
-
-## Common flags
-
-Here are some common flags that are supported by all Rspack commands:
-
-| Flags                | Usage                                      |
-| -------------------- | ------------------------------------------ |
-| -c, --config [value] | Specify the path to the configuration file |
-| -h, --help           | Show help information                      |
-| -v, --version        | Show version number                        |

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -9,6 +9,30 @@
 `@rspack/cli` 与 `webpack-cli` 并不是完全兼容的，它们会有一些使用方式的差异。
 :::
 
+## 查看所有命令
+
+如果你需要查看所有可用的 CLI 命令，请在项目目录中运行以下命令：
+
+```bash
+npx rspack -h
+```
+
+## 公共选项
+
+Rspack CLI 提供了一些公共选项，可以用于所有命令：
+
+| 选项                 | 描述                                                                 |
+| -------------------- | -------------------------------------------------------------------- |
+| -c, --config [value] | 指定配置文件路径，详见 [指定配置文件](/config/index#指定配置文件)    |
+| --configLoader       | 指定配置文件加载器，可以是 `native` 或 `register`，默认是 `register` |
+| --configName         | 指定配置文件名称                                                     |
+| -h, --help           | 显示帮助信息                                                         |
+| -v, --version        | 显示版本号                                                           |
+
+:::tip
+Rspack CLI 的所有选项都支持使用 `camelCase`（驼峰命名）和 `kebab-case`（短横线命名），例如 `--configLoader` 和 `--config-loader` 都是有效的。
+:::
+
 ## rspack build
 
 `rspack build` 用于运行 Rspack 构建，将会在 [output.path](/config/output#outputpath) 目录下生成构建后的文件。
@@ -36,13 +60,12 @@ rspack build
 
 Options:
       --entry        entry file                                          [array]
-  -o, --output-path  output path dir                                    [string]
+  -o, --outputPath   output path dir                                    [string]
   -m, --mode         mode                                               [string]
   -w, --watch        watch                            [boolean] [default: false]
       --env          env passed to config function                       [array]
-      --node-env     sets process.env.NODE_ENV to be specified value    [string]
+      --nodeEnv     sets process.env.NODE_ENV to be specified value    [string]
   -d, --devtool      devtool                          [boolean] [default: false]
-      --configName   Name of the configuration to use.                   [array]
       --analyze      analyze                          [boolean] [default: false]
       --json         emit stats json
       --profile      capture timing information for each module
@@ -77,13 +100,12 @@ rspack dev
 
 Options:
       --entry        entry file                                          [array]
-  -o, --output-path  output path dir                                    [string]
+  -o, --outputPath   output path dir                                    [string]
   -m, --mode         mode                                               [string]
   -w, --watch        watch                            [boolean] [default: false]
       --env          env passed to config function                       [array]
-      --node-env     sets process.env.NODE_ENV to be specified value    [string]
+      --nodeEnv      sets process.env.NODE_ENV to be specified value    [string]
   -d, --devtool      devtool                          [boolean] [default: false]
-      --configName   Name of the configuration to use.                   [array]
       --hot          enables hot module replacement
       --port         allows to specify a port to use                    [number]
       --host         allows to specify a hostname to use                [string]
@@ -111,15 +133,4 @@ Options:
       --host        preview server host                                 [string]
       --open        open browser                                       [boolean]
       --server      Configuration items for the server.                 [string]
-      --configName  Name of the configuration to use.                    [array]
 ```
-
-## 公共选项
-
-下面是一些公共的选项，所有 Rspack 命令都支持这些选项：
-
-| 选项                 | 作用             |
-| -------------------- | ---------------- |
-| -c, --config [value] | 指定配置文件路径 |
-| -h, --help           | 显示帮助信息     |
-| -v, --version        | 显示版本号       |


### PR DESCRIPTION
## Summary

This PR updates the Rspack CLI flags to use camelCase consistently.

The [yargs](https://www.npmjs.com/package/yargs) package will convert camelCase to kebab-case, so both the two cases are supported:

<img width="793" alt="Screenshot 2025-02-24 at 16 57 50" src="https://github.com/user-attachments/assets/2c4363db-7ba2-4e81-b92c-a8a29d7e3070" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
