### PR TITLE
refactor: remove duplicate static variable definitions

### DIFF
--- a/crates/rspack_core/src/utils/property_access.rs
+++ b/crates/rspack_core/src/utils/property_access.rs
@@ -1,55 +1,11 @@
-use std::sync::LazyLock;
-
-use regex::Regex;
-
-static SAFE_IDENTIFIER_REGEX: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"^[_a-zA-Z$][_a-zA-Z$0-9]*$").expect("should init regex"));
-const RESERVED_IDENTIFIER: [&str; 37] = [
-  "break",
-  "case",
-  "catch",
-  "class",
-  "const",
-  "continue",
-  "debugger",
-  "default",
-  "delete",
-  "do",
-  "else",
-  "enum",
-  "export",
-  "extends",
-  "false",
-  "finally",
-  "for",
-  "function",
-  "if",
-  "import",
-  "in",
-  "instanceof",
-  "new",
-  "null",
-  "package",
-  "return",
-  "super",
-  "switch",
-  "this",
-  "throw",
-  "true",
-  "try",
-  "typeof",
-  "var",
-  "void",
-  "while",
-  "with",
-];
+use crate::utils::property_name::{RESERVED_IDENTIFIER, SAFE_IDENTIFIER};
 
 pub fn property_access<S: AsRef<str>>(o: impl IntoIterator<Item = S>, start: usize) -> String {
   o.into_iter()
     .skip(start)
     .fold(String::default(), |mut str, property| {
       let property = property.as_ref();
-      if SAFE_IDENTIFIER_REGEX.is_match(property) && !RESERVED_IDENTIFIER.contains(&property) {
+      if SAFE_IDENTIFIER.is_match(property) && !RESERVED_IDENTIFIER.contains(property) {
         str.push_str(format!(".{property}").as_str());
       } else {
         str.push_str(

--- a/crates/rspack_core/src/utils/property_name.rs
+++ b/crates/rspack_core/src/utils/property_name.rs
@@ -52,7 +52,6 @@ pub static RESERVED_IDENTIFIER: LazyLock<HashSet<&str>> = LazyLock::new(|| {
     "public",
     "static",
     "yield",
-    "yield",
     // module code
     "await",
     // skip future reserved keywords defined under ES1 till ES3


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
They are redundantly defined in `property_name` and `property_access`, so one of them can be removed.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
