### PR TITLE
fix: use persistent cache with module foundation

### DIFF
--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use async_trait::async_trait;
+use rspack_cacheable::with::Unsupported;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
@@ -25,6 +26,7 @@ use crate::{utils::json_stringify, ConsumeOptions};
 #[cacheable]
 #[derive(Debug)]
 pub struct ConsumeSharedModule {
+  #[cacheable(with=Unsupported)]
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
   identifier: ModuleIdentifier,

--- a/packages/rspack-test-tools/src/helper/loaders/hot-update.ts
+++ b/packages/rspack-test-tools/src/helper/loaders/hot-update.ts
@@ -6,14 +6,17 @@ export default function (this: any, c: string) {
 		content = `
 			${content}
 			let __hmr_children__ = [...module.children];
-			let __hmr_used_exports__ = __hmr_children__.reduce((res, child) => {
-				res[child] = __webpack_module_cache__[child].exports;
+      let __hmr_used_exports__ = __hmr_children__.reduce((res, child) => {
+        if (__webpack_module_cache__[child]) {
+          res[child] = __webpack_module_cache__[child].exports;
+        }
 				return res;
 			}, {});
 			module.hot.accept(__hmr_children__, () => {
 				__hmr_children__.forEach((child) => {
 					const reexports = __webpack_require__(child);
-					for (let key in reexports) {
+          for (let key in reexports) {
+            if (!__hmr_used_exports__[child]) { continue; }
 						Object.defineProperty(__hmr_used_exports__[child], key, {
 							configurable: true,
 							enumerable: true,

--- a/packages/rspack-test-tools/tests/cacheCases/mf/issue-9150/file.js
+++ b/packages/rspack-test-tools/tests/cacheCases/mf/issue-9150/file.js
@@ -1,0 +1,7 @@
+export default 1;
+---
+export default 2;
+---
+export default 3;
+---
+export default 4;

--- a/packages/rspack-test-tools/tests/cacheCases/mf/issue-9150/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/mf/issue-9150/index.js
@@ -1,0 +1,18 @@
+import react from "react";
+import value from "./file";
+
+it("should basic test work", async () => {
+	if (COMPILER_INDEX == 0) {
+		expect(value).toBe(1);
+		await NEXT_HMR();
+		expect(value).toBe(2);
+		expect(typeof react).toBe("object");
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(value).toBe(3);
+		await NEXT_HMR();
+		expect(value).toBe(4);
+		expect(typeof react).toBe("object");
+	}
+});

--- a/packages/rspack-test-tools/tests/cacheCases/mf/issue-9150/rspack.config.js
+++ b/packages/rspack-test-tools/tests/cacheCases/mf/issue-9150/rspack.config.js
@@ -1,0 +1,26 @@
+const rspack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	optimization: {
+		minimize: false
+	},
+	experiments: {
+		cache: {
+			type: "persistent"
+		}
+	},
+	plugins: [
+		new rspack.container.ModuleFederationPlugin({
+			shared: {
+				react: {
+					requiredVersion: "^19.0.0",
+					version: "19.0.0",
+					singleton: true,
+					eager: true
+				}
+			}
+		})
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The Module foundation plugin collects the consumption location and use `compilation.add_includes` to generate them as entry, but the plugin state cannot be saved to the persistent cache, which will cause bug when hot start.
https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_plugin_mf/src/sharing/provide_shared_plugin.rs#L85

This PR will make the ConsumeSharedModule non-cacheable so that it is always regenerated on hot start to restore plugin state.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
