### PR TITLE
chore: release v1.2.6

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "binding.js",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-x64-msvc",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-x64-msvc.node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "description": "The fast Rust-based web bundler with webpack-compatible API",
   "private": true,

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "CLI for rspack",
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/test-tools",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "description": "Test tools for rspack",
   "main": "dist/index.js",

--- a/packages/rspack-tracing/package.json
+++ b/packages/rspack-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/tracing",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "description": "Internal tracing package for rspack",
   "homepage": "https://rspack.dev",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "The fast Rust-based web bundler with webpack-compatible API",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at release/v1.2.6 -->

## What's Changed
### Performance Improvements ⚡
* perf(loader-runner): memoize resolver creation for improved performance by @inottn in https://github.com/web-infra-dev/rspack/pull/9403
* perf: remove blocking for execute module hook by @ahabhgk in https://github.com/web-infra-dev/rspack/pull/9406
* perf: use partition_map to avoid clone by @JSerFeng in https://github.com/web-infra-dev/rspack/pull/9427
### Exciting New Features 🎉
* feat: render chunk runtime template with dojang by @GiveMe-A-Name in https://github.com/web-infra-dev/rspack/pull/9407
* feat: using dojang to render runtime_template by @GiveMe-A-Name in https://github.com/web-infra-dev/rspack/pull/9422
### Bug Fixes 🐞
* fix(incremental): enable incremental for full hash test by @ahabhgk in https://github.com/web-infra-dev/rspack/pull/9377
* fix: sort group by group index by @JSerFeng in https://github.com/web-infra-dev/rspack/pull/9394
* fix: sort order incorrect by @JSerFeng in https://github.com/web-infra-dev/rspack/pull/9404
* fix: strip `blob:` protocol when public path is auto by @stormslowly in https://github.com/web-infra-dev/rspack/pull/9303
* fix(type): Change the module in the LazyCompilationOptions from any to Module by @gaoachao in https://github.com/web-infra-dev/rspack/pull/9387
* fix: clean up deps at the beginning of compilation.finish by @jerrykingxyz in https://github.com/web-infra-dev/rspack/pull/9414
* fix(json): correctly escape unicode characters by @inottn in https://github.com/web-infra-dev/rspack/pull/9419
* fix: remove dynamic entry should re-build chunk graph by @ahabhgk in https://github.com/web-infra-dev/rspack/pull/9425
* fix: build error with reserved keywords in CSS modules by @inottn in https://github.com/web-infra-dev/rspack/pull/9439
* fix: update CLI flags to use camelCase consistently by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/9442
* fix: use persistent cache with module federation by @jerrykingxyz in https://github.com/web-infra-dev/rspack/pull/9445
### Other Changes
* chore(codeowners): removing deprecated package by @zackarychapple in https://github.com/web-infra-dev/rspack/pull/9395
* test: replace content hashes and full hashes to placeholders in css extract plugin cases by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9398
* test(incremental): enable more webpack watch tests by @ahabhgk in https://github.com/web-infra-dev/rspack/pull/9392
* refactor: incremental rebuild make failed modules and dependencies by @jerrykingxyz in https://github.com/web-infra-dev/rspack/pull/9393
* chore: enable renovate webpack by @stormslowly in https://github.com/web-infra-dev/rspack/pull/9420
* chore(deps): update rspress to v1.42.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/9417
* ci: use different shared key between normal build and codspeed build by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9421
* test: do not snapshot the whole main file in css extract test cases by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9408
* chore(codeowners): update code ownership to match repository structure by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/9410
* ci: run codspeed build in parallel by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9401
* chore: move modern module library finish_modules to finish_make by @ahabhgk in https://github.com/web-infra-dev/rspack/pull/9426
* chore(deps): update dependency @rslib/core to v0.5.1 by @renovate in https://github.com/web-infra-dev/rspack/pull/9416
* chore(workflow): no need to run pnpm cache in rust jobs by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/9430
* ci: only install binding dependencies when building binary by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9429
* chore(deps): update dependency postcss-loader to v8 by @renovate in https://github.com/web-infra-dev/rspack/pull/9418
* chore(deps): update npm dependencies by @renovate in https://github.com/web-infra-dev/rspack/pull/9366
* chore(deps): update dependency @swc/plugin-remove-console to ^6.3.2 by @renovate in https://github.com/web-infra-dev/rspack/pull/9435
* chore(deps): update dependency less-loader to v12 by @renovate in https://github.com/web-infra-dev/rspack/pull/9436
* chore(deps): update dependency typescript to v5 by @renovate in https://github.com/web-infra-dev/rspack/pull/9437
* chore(deps): update npm dev dependencies by @renovate in https://github.com/web-infra-dev/rspack/pull/9367
* chore(deps): bump `fast-glob` to v0.4.4 by @shulaoda in https://github.com/web-infra-dev/rspack/pull/9438
* test: should not call stats toJson if not necessary by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9434
* test: remove hash test in sri plugin cases by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9440
* refactor: remove duplicate static variable definitions by @inottn in https://github.com/web-infra-dev/rspack/pull/9443


**Full Changelog**: https://github.com/web-infra-dev/rspack/compare/v1.2.5...v1.2.6