### PR TITLE
fix: persistent cache skip calc modified_files when rebuild

### DIFF
--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -78,12 +78,12 @@ impl PersistentCache {
 #[async_trait::async_trait]
 impl Cache for PersistentCache {
   async fn before_compile(&self, compilation: &mut Compilation) -> Result<()> {
-    if compilation.modified_files.is_empty() && compilation.removed_files.is_empty() {
+    if !compilation.is_rebuild {
       // inject modified_files and removed_files
       let (modified_paths, removed_paths) = self.snapshot.calc_modified_paths().await?;
       tracing::info!("cache::snapshot recovery {modified_paths:?} {removed_paths:?}",);
-      compilation.modified_files = modified_paths;
-      compilation.removed_files = removed_paths;
+      compilation.modified_files.extend(modified_paths);
+      compilation.removed_files.extend(removed_paths);
     }
     Ok(())
   }
@@ -136,6 +136,7 @@ impl Cache for PersistentCache {
   }
 
   async fn before_make(&self, make_artifact: &mut MakeArtifact) -> Result<()> {
+    // TODO When does not need to pass variables through make_artifact.state, use compilation.is_rebuild to check
     if matches!(make_artifact.state, MakeArtifactState::Uninitialized(..)) {
       *make_artifact = self.make_occasion.recovery().await?;
     }

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -78,8 +78,9 @@ impl PersistentCache {
 #[async_trait::async_trait]
 impl Cache for PersistentCache {
   async fn before_compile(&self, compilation: &mut Compilation) -> Result<()> {
+    // rebuild will pass modified_files and removed_files from js side,
+    // so only calculate them when build.
     if !compilation.is_rebuild {
-      // inject modified_files and removed_files
       let (modified_paths, removed_paths) = self.snapshot.calc_modified_paths().await?;
       tracing::info!("cache::snapshot recovery {modified_paths:?} {removed_paths:?}",);
       compilation.modified_files.extend(modified_paths);

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -238,6 +238,11 @@ pub struct Compilation {
 
   pub intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
   pub output_filesystem: Arc<dyn WritableFileSystem>,
+
+  /// A flag indicating whether the current compilation is being rebuilt.
+  ///
+  /// Rebuild will include previous compilation data, so persistent cache will not recovery anything
+  pub is_rebuild: bool,
 }
 
 impl Compilation {
@@ -278,6 +283,7 @@ impl Compilation {
     input_filesystem: Arc<dyn ReadableFileSystem>,
     intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
     output_filesystem: Arc<dyn WritableFileSystem>,
+    is_rebuild: bool,
   ) -> Self {
     let incremental = Incremental::new(options.experiments.incremental);
     Self {
@@ -349,6 +355,7 @@ impl Compilation {
 
       intermediate_filesystem,
       output_filesystem,
+      is_rebuild,
     }
   }
 

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -86,6 +86,8 @@ impl MakeTaskContext {
       self.fs.clone(),
       self.intermediate_fs.clone(),
       self.output_fs.clone(),
+      // used at module executor which not support persistent cache, set as false
+      false,
     );
     compilation.dependency_factories = self.dependency_factories.clone();
     compilation.swap_make_artifact(&mut self.artifact);

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -170,6 +170,7 @@ impl Compiler {
         input_filesystem.clone(),
         intermediate_filesystem.clone(),
         output_filesystem.clone(),
+        false,
       ),
       output_filesystem,
       intermediate_filesystem,
@@ -218,6 +219,7 @@ impl Compiler {
         self.input_filesystem.clone(),
         self.intermediate_filesystem.clone(),
         self.output_filesystem.clone(),
+        false,
       ),
     );
     if let Err(err) = self.cache.before_compile(&mut self.compilation).await {

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -57,6 +57,7 @@ impl Compiler {
         self.input_filesystem.clone(),
         self.intermediate_filesystem.clone(),
         self.output_filesystem.clone(),
+        true,
       );
 
       new_compilation.hot_index = self.compilation.hot_index + 1;

--- a/tasks/benchmark/benches/build_chunk_graph.rs
+++ b/tasks/benchmark/benches/build_chunk_graph.rs
@@ -137,6 +137,7 @@ pub fn build_chunk_graph_benchmark(c: &mut Criterion) {
       compiler.input_filesystem.clone(),
       compiler.intermediate_filesystem.clone(),
       compiler.output_filesystem.clone(),
+      false,
     ),
   );
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Persistent cache calculation of modified_files should only be run in `compilation.build`. This PR will add a field at compilation to mark whether it is in a rebuild.

``` rust
struct Compilation {
  // A flag indicating whether the current compilation is being rebuilt.
  is_rebuild: bool
}
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
