### PR TITLE
fix: detect module graph change right before build_chunk_graph

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/build_chunk_graph/mod.rs
@@ -42,9 +42,7 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
     compilation.chunk_graph.add_module(module_identifier)
   }
 
-  if enable_incremental {
-    compilation.code_splitting_cache.code_splitter = splitter;
-  }
+  compilation.code_splitting_cache.code_splitter = splitter;
 
   Ok(())
 }

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -38,7 +38,6 @@ impl MakeOccasion {
       missing_dependencies: _,
       build_dependencies: _,
       state: _,
-      has_module_graph_change: _,
       make_failed_dependencies: _,
       make_failed_module: _,
     } = artifact;
@@ -68,9 +67,6 @@ impl MakeOccasion {
       module_graph::recovery_module_graph(&self.storage, &self.context).await?;
     artifact.module_graph_partial = partial;
     artifact.state = MakeArtifactState::Uninitialized(force_build_dependencies);
-
-    // TODO remove it after code splitting support incremental rebuild
-    artifact.has_module_graph_change = true;
 
     // regenerate statistical data
     // TODO remove set make_failed_module after all of module are cacheable

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1360,11 +1360,13 @@ impl Compilation {
 
     let start = logger.time("create chunks");
     use_code_splitting_cache(self, |compilation| async {
+      let start = logger.time("rebuild chunk graph");
       if compilation.options.experiments.parallel_code_splitting {
         build_chunk_graph_new(compilation)?;
       } else {
         build_chunk_graph(compilation)?;
       }
+      logger.time_end(start);
       Ok(compilation)
     })
     .await?;
@@ -2284,11 +2286,6 @@ impl Compilation {
         )
       })
       .clone()
-  }
-
-  // TODO remove it after code splitting support incremental rebuild
-  pub fn has_module_import_export_change(&self) -> bool {
-    self.make_artifact.has_module_graph_change
   }
 
   pub fn built_modules(&self) -> &IdentifierSet {

--- a/crates/rspack_core/src/compiler/make/cutout/mod.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/mod.rs
@@ -1,14 +1,12 @@
 mod clean_isolated_module;
 mod fix_build_meta;
 mod fix_issuers;
-mod has_module_graph_change;
 
 use rspack_collections::IdentifierSet;
 use rustc_hash::FxHashSet as HashSet;
 
 use self::{
-  clean_isolated_module::CleanIsolatedModule, fix_build_meta::FixBuildMeta,
-  fix_issuers::FixIssuers, has_module_graph_change::HasModuleGraphChange,
+  clean_isolated_module::CleanIsolatedModule, fix_build_meta::FixBuildMeta, fix_issuers::FixIssuers,
 };
 use super::{MakeArtifact, MakeParam};
 use crate::{BuildDependency, FactorizeInfo};
@@ -18,7 +16,6 @@ pub struct Cutout {
   fix_issuers: FixIssuers,
   fix_build_meta: FixBuildMeta,
   clean_isolated_module: CleanIsolatedModule,
-  has_module_graph_change: HasModuleGraphChange,
 }
 
 impl Cutout {
@@ -113,9 +110,6 @@ impl Cutout {
       self
         .clean_isolated_module
         .analyze_force_build_module(artifact, module_identifier);
-      self
-        .has_module_graph_change
-        .analyze_force_build_module(artifact, module_identifier);
     }
 
     let mut build_deps = HashSet::default();
@@ -162,8 +156,6 @@ impl Cutout {
     }
     artifact.entry_dependencies = entry_dependencies;
 
-    self.has_module_graph_change.analyze_artifact(artifact);
-
     // only return available build_deps
     let module_graph = artifact.get_module_graph();
     build_deps
@@ -182,11 +174,9 @@ impl Cutout {
       fix_issuers,
       fix_build_meta,
       clean_isolated_module,
-      has_module_graph_change,
     } = self;
     fix_issuers.fix_artifact(artifact);
     fix_build_meta.fix_artifact(artifact);
     clean_isolated_module.fix_artifact(artifact);
-    has_module_graph_change.fix_artifact(artifact);
   }
 }

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -28,7 +28,6 @@ impl Default for MakeArtifactState {
 pub struct MakeArtifact {
   // temporary data, used by subsequent steps of make
   // should be reset when rebuild
-  pub has_module_graph_change: bool,
   pub built_modules: IdentifierSet,
   pub revoked_modules: IdentifierSet,
   // Field to mark whether artifact has been initialized.
@@ -221,10 +220,6 @@ pub async fn make_module_graph(
   // reset temporary data
   artifact.built_modules = Default::default();
   artifact.revoked_modules = Default::default();
-  if matches!(artifact.state, MakeArtifactState::Initialized) {
-    artifact.has_module_graph_change = false;
-  }
-
   artifact = update_module_graph(compilation, artifact, params).await?;
   Ok(artifact)
 }

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -63,7 +63,6 @@ impl ModuleExecutor {
     }
     make_artifact.built_modules = Default::default();
     make_artifact.revoked_modules = Default::default();
-    make_artifact.has_module_graph_change = false;
 
     // Modules imported by `importModule` are passively loaded.
     let mut build_dependencies = self.cutout.cutout_artifact(&mut make_artifact, params);

--- a/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
@@ -1,12 +1,15 @@
 use futures::Future;
 use indexmap::IndexMap;
+use rspack_collections::{IdentifierIndexMap, IdentifierSet};
 use rspack_error::Result;
 use rustc_hash::FxHashMap as HashMap;
 use tracing::instrument;
 
 use crate::{
-  build_chunk_graph::code_splitter::CodeSplitter, incremental::IncrementalPasses, ChunkByUkey,
-  ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation, ModuleIdentifier,
+  build_chunk_graph::code_splitter::{CodeSplitter, DependenciesBlockIdentifier},
+  incremental::{IncrementalPasses, Mutation},
+  ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation, Logger,
+  ModuleIdentifier,
 };
 
 #[derive(Debug, Default)]
@@ -20,6 +23,115 @@ pub struct CodeSplittingCache {
   named_chunks: HashMap<String, ChunkUkey>,
   pub(crate) code_splitter: CodeSplitter,
   pub(crate) module_idx: HashMap<ModuleIdentifier, (u32, u32)>,
+}
+
+impl CodeSplittingCache {
+  // we can skip rebuilding chunk graph if none of modules
+  // has changed its outgoings
+  // we don't need to check if module has changed its incomings
+  // if it changes, the incoming module changes its outgoings as well
+  fn can_skip_rebuilding(&self, this_compilation: &Compilation) -> bool {
+    let logger = this_compilation.get_logger("rspack.Compilation.codeSplittingCache");
+
+    let Some(mutations) = this_compilation
+      .incremental
+      .mutations_read(IncrementalPasses::MAKE)
+    else {
+      logger.log("incremental for make disabled, rebuilding chunk graph");
+      // if disable incremental for make phase, we can't skip rebuilding
+      return false;
+    };
+
+    // if we have module removal, we can't skip rebuilding
+    if mutations
+      .iter()
+      .any(|mutation| matches!(mutation, Mutation::ModuleRemove { .. }))
+    {
+      logger.log("module removal detected, rebuilding chunk graph");
+      return false;
+    }
+
+    let module_graph = this_compilation.get_module_graph();
+    let affected_modules = mutations.get_affected_modules_with_module_graph(&module_graph);
+    let previous_modules_map = &self.code_splitter.block_modules_runtime_map;
+
+    if previous_modules_map.is_empty() {
+      logger.log("no cache detected, rebuilding chunk graph");
+      return false;
+    }
+
+    for module in affected_modules {
+      let outgoings: Vec<ModuleIdentifier> = {
+        let mut res = vec![];
+        let mut visited = IdentifierSet::default();
+        let mut active_modules = IdentifierSet::default();
+        module_graph
+          .get_ordered_outgoing_connections(&module)
+          .filter_map(|dep| module_graph.connection_by_dependency_id(dep))
+          .map(|conn| {
+            let m = *conn.module_identifier();
+            if conn.active_state(&module_graph, None).is_not_false() {
+              active_modules.insert(m);
+            }
+            m
+          })
+          .collect::<Vec<_>>()
+          .into_iter()
+          .for_each(|m| {
+            if active_modules.contains(&m) && visited.insert(m) {
+              res.push(m);
+            }
+          });
+
+        res
+      };
+
+      // get outgoings from all runtimes in the previous compilation
+      let mut previous_modules = IdentifierIndexMap::default();
+      let all_runtimes = previous_modules_map.values();
+      let mut miss_in_previous = true;
+
+      all_runtimes.for_each(|modules| {
+        let Some(outgoings) = modules.get(&DependenciesBlockIdentifier::Module(module)) else {
+          return;
+        };
+        miss_in_previous = false;
+
+        for (outgoing, state, _) in outgoings {
+          // we must insert module even if state is false
+          // because we need to keep the import order
+          previous_modules
+            .entry(*outgoing)
+            .and_modify(|v| {
+              if state.is_not_false() {
+                *v = state;
+              }
+            })
+            .or_insert(state);
+        }
+      });
+
+      if miss_in_previous {
+        logger.log("new module detected, rebuilding chunk graph");
+        return false;
+      }
+
+      if previous_modules
+        .iter()
+        .filter(|(_, conn_state)| conn_state.is_not_false())
+        .map(|(m, _)| *m)
+        .collect::<Vec<_>>()
+        != outgoings.clone()
+      {
+        // we find one module's outgoings has changed
+        // we cannot skip rebuilding
+        logger.log("module outgoings change detected");
+        return false;
+      }
+    }
+
+    true
+  }
 }
 
 #[instrument(skip_all)]
@@ -45,7 +157,9 @@ where
     && compilation
       .incremental
       .can_read_mutations(IncrementalPasses::BUILD_CHUNK_GRAPH);
-  let no_change = !compilation.has_module_import_export_change();
+  let no_change = compilation
+    .code_splitting_cache
+    .can_skip_rebuilding(compilation);
 
   if incremental_code_splitting || no_change {
     let cache = &mut compilation.code_splitting_cache;

--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -1567,7 +1567,7 @@ export type TTestConfig<T extends ECompilerType> = {
     beforeExecute?: () => void;
     afterExecute?: () => void;
     moduleScope?: (ms: IBasicModuleScope, stats?: TCompilerStatsCompilation<T>) => IBasicModuleScope;
-    checkStats?: (stepName: string, stats: TCompilerStatsCompilation<T>) => boolean;
+    checkStats?: (stepName: string, jsonStats: TCompilerStatsCompilation<T>, stringStats: String) => boolean;
     findBundle?: (index: number, options: TCompilerOptions<T>, stepName?: string) => string | string[];
     bundlePath?: string[];
     nonEsmThis?: (p: string | string[]) => Object;

--- a/packages/rspack-test-tools/src/processor/watch.ts
+++ b/packages/rspack-test-tools/src/processor/watch.ts
@@ -125,8 +125,25 @@ export class WatchProcessor<
 					return cached;
 				};
 			})();
+			const getStringStats = (() => {
+				let cached: string | null = null;
+				return () => {
+					if (!cached) {
+						cached = stats.toString({
+							logging: "verbose"
+						});
+					}
+					return cached;
+				};
+			})();
 			if (checkStats.length > 1) {
-				if (!checkStats(this._watchOptions.stepName, getJsonStats())) {
+				if (
+					!checkStats(
+						this._watchOptions.stepName,
+						getJsonStats(),
+						getStringStats()
+					)
+				) {
 					throw new Error("stats check failed");
 				}
 			} else {

--- a/packages/rspack-test-tools/src/type.ts
+++ b/packages/rspack-test-tools/src/type.ts
@@ -207,7 +207,8 @@ export type TTestConfig<T extends ECompilerType> = {
 	) => IBasicModuleScope;
 	checkStats?: (
 		stepName: string,
-		stats: TCompilerStatsCompilation<T>
+		jsonStats: TCompilerStatsCompilation<T>,
+		stringStats: String
 	) => boolean;
 	findBundle?: (
 		index: number,

--- a/packages/rspack-test-tools/tests/statsAPICases/verbose-time.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/verbose-time.js
@@ -16,6 +16,7 @@ module.exports = {
 		LOG from rspack.Compilation
 		<t> finish modules: X ms
 		<t> optimize dependencies: X ms
+		<t> rebuild chunk graph: X ms
 		<t> create chunks: X ms
 		<t> optimize: X ms
 		<t> module ids: X ms

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/deep.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/deep.js
@@ -1,0 +1,2 @@
+export const v1 = 42;
+export const v2 = 42

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/index.js
@@ -1,0 +1,9 @@
+import lib from "./lib"
+import value from './value'
+import { v1 } from './re-exports'
+
+it("should have correct result", () => {
+  expect(lib).toBe(42);
+  expect(value).toBe(42);
+	expect(v1).toBe(42);
+});

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/lib.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/lib.js
@@ -1,0 +1,3 @@
+// use eval to add sideEffects to current module
+eval('')
+export default 42;

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/re-exports.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/re-exports.js
@@ -1,0 +1,2 @@
+export * from "./deep"
+export const direct = 42

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/value.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/0/value.js
@@ -1,0 +1,3 @@
+// use eval to add sideEffects to current module
+eval('')
+export default 42;

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/1/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/1/index.js
@@ -1,0 +1,11 @@
+import lib from "./lib"
+import value from './value'
+import { v1 } from './re-exports'
+
+it("should have correct result", () => {
+	// add specifier dependency should not rebuild chunk graph
+  expect(lib).toBe(42);
+  expect(lib).toBe(42);
+  expect(value).toBe(42);
+	expect(v1).toBe(42);
+});

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/2/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/2/index.js
@@ -1,0 +1,10 @@
+// change import order should rebuild chunk graph
+import value from './value'
+import lib from "./lib"
+import { v1 } from './re-exports'
+
+it("should have correct result", () => {
+  expect(lib).toBe(42);
+  expect(value).toBe(42);
+	expect(v1).toBe(42);
+});

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/3/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/3/index.js
@@ -1,0 +1,11 @@
+import value from './value'
+import lib from "./lib"
+// import member from same modules should not rebuild chunk graph
+import { v1, v2 } from './re-exports'
+
+it("should have correct result", () => {
+  expect(lib).toBe(42);
+  expect(value).toBe(42);
+	expect(v1).toBe(42);
+	expect(v2).toBe(42);
+});

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/4/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/4/index.js
@@ -1,0 +1,12 @@
+import value from './value'
+import lib from "./lib"
+// import member from different modules should rebuild chunk graph
+import { v1, v2, direct } from './re-exports'
+
+it("should have correct result", () => {
+  expect(lib).toBe(42);
+  expect(value).toBe(42);
+  expect(direct).toBe(42);
+	expect(v1).toBe(42);
+	expect(v2).toBe(42);
+});

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/rspack.config.js
@@ -1,0 +1,21 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		sideEffects: true,
+		usedExports: true,
+		innerGraph: true
+	},
+	experiments: {
+		incremental: {
+			buildChunkGraph: false
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /re-exports\.js$/,
+				sideEffects: false
+			}
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/skip-building-chunk-graph/test.config.js
@@ -1,0 +1,35 @@
+function assert(condition) {
+	if (!condition) {
+		throw new Error("Assertion failed for");
+	}
+}
+
+function should_rebuild(stats) {
+	return stats.includes("<t> rebuild chunk graph");
+}
+
+module.exports = {
+	checkStats(stepName, _, stats) {
+		switch (stepName) {
+			case "0":
+				assert(should_rebuild(stats));
+				break;
+			case "1":
+				assert(!should_rebuild(stats));
+				break;
+			case "2":
+				assert(should_rebuild(stats));
+				break;
+			case "3":
+				assert(!should_rebuild(stats));
+				break;
+			case "4":
+				assert(should_rebuild(stats));
+				break;
+			default:
+				throw "not have more step";
+		}
+
+		return true;
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

### Background

We have a way to skip re-building chunk graph, that is, when module graph has no change, no incoming outgoing changes, we can skip creating chunks for current compilation.

We detect module graph change in make phase before, which is not exactly accurate.

### Issue

Many optimizations are applied **after** make phase, for example, `innerGraph`, `sideEffects` and `usedExports`, they can change module graph as well. To solve this, we did a lot of hack to detect change according to many aspects, even `dependency.ids`, as it can affect how `sideEffects` optimized.

### Current solution

Now I move this detection later right before `build_chunk_graph`, and compare current outgoings with last compilation, in this stage, all optimizations are already applied.

### Long term solution

When incremental for `build_chunk_graph` is stable, we no longer need to detect the changes and skip creating chunks, as incremental build chunks is performant enough

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
