### PR TITLE
feat: rebuild without modifiedFiles and removedFiles show warning

### DIFF
--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -702,16 +702,21 @@ class Compiler {
 				return callback?.(error);
 			}
 			if (!this.#initial) {
-				instance!.rebuild(
-					Array.from(this.modifiedFiles || []),
-					Array.from(this.removedFiles || []),
-					error => {
-						if (error) {
-							return callback?.(error);
-						}
-						callback?.(null);
+				const modifiedFiles = Array.from(this.modifiedFiles || []);
+				const removedFiles = Array.from(this.removedFiles || []);
+				if (!modifiedFiles.length && !removedFiles.length) {
+					// both not exist modified file and remove files show warnings
+					const logger = this.getInfrastructureLogger("Compiler");
+					logger.warn(
+						"Neither modifiedFiles nor removedFiles are included when running the build. This is an unexpected behavior and the memory cache will not be invalidated correctly. Please set them manually."
+					);
+				}
+				instance!.rebuild(modifiedFiles, removedFiles, error => {
+					if (error) {
+						return callback?.(error);
 					}
-				);
+					callback?.(null);
+				});
 				return;
 			}
 			this.#initial = false;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

User can trigger rspack rebuild via `compiler.watch` or manually call `compiler.run`. 

The watcher automatically adds `compiler.modifiedFiles` and `compiler.removedFiles`, but manually call `compiler.run` can sometimes forget to set them, which causes the rspack memory cache to not be invalidated correctly. This PR will add a warning for this situation.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
