### PR TITLE
fix(cli): failed to run preview with TS config file

### DIFF
--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -5,6 +5,7 @@ import type { RspackCLI } from "../cli";
 import type { RspackCommand } from "../types";
 import {
 	commonOptions,
+	commonOptionsForBuildAndServe,
 	ensureEnvObject,
 	setBuiltinEnvArg
 } from "../utils/options";
@@ -14,8 +15,8 @@ export class BuildCommand implements RspackCommand {
 		cli.program.command(
 			["build", "$0", "bundle", "b"],
 			"run the rspack build",
-			yargs =>
-				commonOptions(yargs).options({
+			yargs => {
+				commonOptionsForBuildAndServe(commonOptions(yargs)).options({
 					analyze: {
 						type: "boolean",
 						default: false,
@@ -29,7 +30,8 @@ export class BuildCommand implements RspackCommand {
 						default: false,
 						describe: "capture timing information for each module"
 					}
-				}),
+				});
+			},
 			async options => {
 				const env = ensureEnvObject(options);
 				if (options.watch) {

--- a/packages/rspack-cli/src/commands/preview.ts
+++ b/packages/rspack-cli/src/commands/preview.ts
@@ -5,10 +5,41 @@ import {
 	type RspackOptions,
 	rspack
 } from "@rspack/core";
+import type yargs from "yargs";
 
 import type { RspackCLI } from "../cli";
 import type { RspackCommand, RspackPreviewCLIOptions } from "../types";
-import { previewOptions } from "../utils/options";
+import { commonOptions } from "../utils/options";
+
+const previewOptions = (yargs: yargs.Argv) => {
+	yargs.positional("dir", {
+		type: "string",
+		describe: "directory want to preview"
+	});
+	return commonOptions(yargs).options({
+		publicPath: {
+			type: "string",
+			describe: "static resource server path"
+		},
+		port: {
+			type: "number",
+			describe: "preview server port"
+		},
+		host: {
+			type: "string",
+			describe: "preview server host"
+		},
+		open: {
+			type: "boolean",
+			describe: "open browser"
+		},
+		// same as devServer.server
+		server: {
+			type: "string",
+			describe: "Configuration items for the server."
+		}
+	});
+};
 
 const defaultRoot = "dist";
 export class PreviewCommand implements RspackCommand {
@@ -18,14 +49,7 @@ export class PreviewCommand implements RspackCommand {
 			"run the rspack server for build output",
 			previewOptions,
 			async options => {
-				// config、configName are necessary for loadConfig
-				const rspackOptions = {
-					config: options.config,
-					configName: options.configName,
-					argv: {
-						...options
-					}
-				};
+				const rspackOptions = { ...options, argv: { ...options } };
 				const { RspackDevServer } = await import("@rspack/dev-server");
 
 				let config = await cli.loadConfig(rspackOptions);

--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -5,6 +5,7 @@ import type { RspackCLI } from "../cli";
 import type { RspackCommand } from "../types";
 import {
 	commonOptions,
+	commonOptionsForBuildAndServe,
 	ensureEnvObject,
 	setBuiltinEnvArg
 } from "../utils/options";
@@ -15,7 +16,7 @@ export class ServeCommand implements RspackCommand {
 			["serve", "server", "s", "dev"],
 			"run the rspack dev server.",
 			yargs =>
-				commonOptions(yargs).options({
+				commonOptionsForBuildAndServe(commonOptions(yargs)).options({
 					hot: {
 						coerce: arg => {
 							if (typeof arg === "boolean" || arg === "only") {

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -1,13 +1,36 @@
 import type yargs from "yargs";
+
+/**
+ * Apply common options for all commands
+ */
 export const commonOptions = (yargs: yargs.Argv) => {
+	return yargs.options({
+		config: {
+			g: true,
+			type: "string",
+			describe: "config file",
+			alias: "c"
+		},
+		configName: {
+			type: "array",
+			string: true,
+			describe: "Name of the configuration to use."
+		},
+		configLoader: {
+			type: "string",
+			default: "register",
+			describe:
+				"Specify the loader to load the config file, can be `native` or `register`."
+		}
+	});
+};
+
+/**
+ * Apply common options for `build` and `serve` commands
+ */
+export const commonOptionsForBuildAndServe = (yargs: yargs.Argv) => {
 	return yargs
 		.options({
-			config: {
-				g: true,
-				type: "string",
-				describe: "config file",
-				alias: "c"
-			},
 			entry: {
 				type: "array",
 				string: true,
@@ -39,62 +62,9 @@ export const commonOptions = (yargs: yargs.Argv) => {
 				default: false,
 				describe: "devtool",
 				alias: "d"
-			},
-			configName: {
-				type: "array",
-				string: true,
-				describe: "Name of the configuration to use."
-			},
-			configLoader: {
-				type: "string",
-				default: "register",
-				describe:
-					"Specify the loader to load the config file, can be `native` or `register`."
 			}
 		})
 		.alias({ v: "version", h: "help" });
-};
-
-export const previewOptions = (yargs: yargs.Argv) => {
-	return yargs
-		.positional("dir", {
-			type: "string",
-			describe: "directory want to preview"
-		})
-		.options({
-			publicPath: {
-				type: "string",
-				describe: "static resource server path"
-			},
-			config: {
-				g: true,
-				type: "string",
-				describe: "config file",
-				alias: "c"
-			},
-			port: {
-				type: "number",
-				describe: "preview server port"
-			},
-			host: {
-				type: "string",
-				describe: "preview server host"
-			},
-			open: {
-				type: "boolean",
-				describe: "open browser"
-			},
-			// same as devServer.server
-			server: {
-				type: "string",
-				describe: "Configuration items for the server."
-			},
-			configName: {
-				type: "array",
-				string: true,
-				describe: "Name of the configuration to use."
-			}
-		});
 };
 
 export function normalizeEnv(argv: yargs.Arguments) {

--- a/packages/rspack-cli/tests/preview/basic/index.test.ts
+++ b/packages/rspack-cli/tests/preview/basic/index.test.ts
@@ -1,10 +1,19 @@
-import { normalizeStderr, runWatch } from "../../utils/test-utils";
+import {
+	getRandomPort,
+	normalizeStderr,
+	runWatch
+} from "../../utils/test-utils";
 
 describe("should run preview command as expected", () => {
 	it("should work", async () => {
-		const { stderr } = await runWatch(__dirname, ["preview"], {
-			killString: /localhost/
-		});
+		const port = await getRandomPort();
+		const { stderr } = await runWatch(
+			__dirname,
+			["preview", "--port", port.toString()],
+			{
+				killString: /localhost/
+			}
+		);
 
 		expect(normalizeStderr(stderr)).toContain("Project is running at");
 	});

--- a/packages/rspack-cli/tests/preview/basic/index.test.ts
+++ b/packages/rspack-cli/tests/preview/basic/index.test.ts
@@ -1,0 +1,11 @@
+import { normalizeStderr, runWatch } from "../../utils/test-utils";
+
+describe("should run preview command as expected", () => {
+	it("should work", async () => {
+		const { stderr } = await runWatch(__dirname, ["preview"], {
+			killString: /localhost/
+		});
+
+		expect(normalizeStderr(stderr)).toContain("Project is running at");
+	});
+});

--- a/packages/rspack-cli/tests/preview/basic/rspack.config.js
+++ b/packages/rspack-cli/tests/preview/basic/rspack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	mode: "production"
+};

--- a/packages/rspack-cli/tests/preview/basic/src/index.js
+++ b/packages/rspack-cli/tests/preview/basic/src/index.js
@@ -1,0 +1,1 @@
+console.log("hello world");

--- a/packages/rspack-cli/tests/preview/ts-config-file/index.test.ts
+++ b/packages/rspack-cli/tests/preview/ts-config-file/index.test.ts
@@ -1,0 +1,11 @@
+import { normalizeStderr, runWatch } from "../../utils/test-utils";
+
+describe("should run preview command with ts config file as expected", () => {
+	it("should work", async () => {
+		const { stderr } = await runWatch(__dirname, ["preview"], {
+			killString: /localhost/
+		});
+
+		expect(normalizeStderr(stderr)).toContain("Project is running at");
+	});
+});

--- a/packages/rspack-cli/tests/preview/ts-config-file/index.test.ts
+++ b/packages/rspack-cli/tests/preview/ts-config-file/index.test.ts
@@ -1,10 +1,19 @@
-import { normalizeStderr, runWatch } from "../../utils/test-utils";
+import {
+	getRandomPort,
+	normalizeStderr,
+	runWatch
+} from "../../utils/test-utils";
 
 describe("should run preview command with ts config file as expected", () => {
 	it("should work", async () => {
-		const { stderr } = await runWatch(__dirname, ["preview"], {
-			killString: /localhost/
-		});
+		const port = await getRandomPort();
+		const { stderr } = await runWatch(
+			__dirname,
+			["preview", "--port", port.toString()],
+			{
+				killString: /localhost/
+			}
+		);
 
 		expect(normalizeStderr(stderr)).toContain("Project is running at");
 	});

--- a/packages/rspack-cli/tests/preview/ts-config-file/rspack.config.ts
+++ b/packages/rspack-cli/tests/preview/ts-config-file/rspack.config.ts
@@ -1,0 +1,3 @@
+export default {
+	mode: "production"
+};

--- a/packages/rspack-cli/tests/preview/ts-config-file/src/index.js
+++ b/packages/rspack-cli/tests/preview/ts-config-file/src/index.js
@@ -1,0 +1,1 @@
+console.log("hello world");


### PR DESCRIPTION
## Summary

This PR fixes the failure of `rspack preview' to run with `rspack.config.ts'.

The preview command should inherit all common CLI flags to have the default value of `--configLoader`.

fix https://github.com/web-infra-dev/rspack/issues/9460

related https://github.com/web-infra-dev/rspack/pull/9210

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
