### PR TITLE
test: lazy create stats in runner

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -115,7 +115,9 @@ export class BasicRunnerFactory<T extends ECompilerType> implements TRunnerFacto
     // (undocumented)
     create(file: string, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
     // (undocumented)
-    protected createRunner(file: string, stats: TCompilerStatsCompilation<T>, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
+    protected createRunner(file: string, stats: () => TCompilerStatsCompilation<T>, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
+    // (undocumented)
+    protected createStatsGetter(): () => TCompilerStatsCompilation<T>;
     // (undocumented)
     protected getRunnerKey(file: string): string;
     // (undocumented)
@@ -653,7 +655,7 @@ export interface IBasicRunnerOptions<T extends ECompilerType> {
     // (undocumented)
     source: string;
     // (undocumented)
-    stats?: TCompilerStatsCompilation<T>;
+    stats?: () => TCompilerStatsCompilation<T>;
     // (undocumented)
     testConfig: TTestConfig<T>;
 }
@@ -1172,7 +1174,7 @@ export class JSDOMWebRunner<T extends ECompilerType = ECompilerType.Rspack> exte
 // @public (undocumented)
 export class MultipleRunnerFactory<T extends ECompilerType> extends BasicRunnerFactory<T> {
     // (undocumented)
-    protected createRunner(file: string, stats: TCompilerStatsCompilation<T>, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
+    protected createRunner(file: string, stats: () => TCompilerStatsCompilation<T>, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
     // (undocumented)
     protected getFileIndexHandler(file: string): {
         getIndex: () => number[];
@@ -1217,7 +1219,7 @@ export class NormalRunner<T extends ECompilerType = ECompilerType.Rspack> extend
 // @public (undocumented)
 export class NormalRunnerFactory<T extends ECompilerType> extends BasicRunnerFactory<T> {
     // (undocumented)
-    protected createRunner(file: string, stats: TCompilerStatsCompilation<T>, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
+    protected createRunner(file: string, stats: () => TCompilerStatsCompilation<T>, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
 }
 
 // @public (undocumented)
@@ -1636,7 +1638,9 @@ export class WatchRunner<T extends ECompilerType = ECompilerType.Rspack> extends
 // @public (undocumented)
 export class WatchRunnerFactory<T extends ECompilerType> extends BasicRunnerFactory<T> {
     // (undocumented)
-    protected createRunner(file: string, stats: TCompilerStatsCompilation<T>, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
+    protected createRunner(file: string, stats: () => TCompilerStatsCompilation<T>, compilerOptions: TCompilerOptions<T>, env: ITestEnv): ITestRunner;
+    // (undocumented)
+    protected createStatsGetter(): () => TCompilerStatsCompilation<T>;
     // (undocumented)
     protected getRunnerKey(file: string): string;
 }

--- a/packages/rspack-test-tools/src/runner/basic.ts
+++ b/packages/rspack-test-tools/src/runner/basic.ts
@@ -19,6 +19,23 @@ export class BasicRunnerFactory<T extends ECompilerType>
 		protected context: ITestContext
 	) {}
 
+	protected createStatsGetter() {
+		const compiler = this.context.getCompiler<T>(this.name);
+		const statsGetter = (() => {
+			let cached: TCompilerStatsCompilation<T> | null = null;
+			return () => {
+				if (cached) {
+					return cached;
+				}
+				cached = compiler.getStats()!.toJson({
+					errorDetails: true
+				});
+				return cached;
+			};
+		})();
+		return statsGetter;
+	}
+
 	create(
 		file: string,
 		compilerOptions: TCompilerOptions<T>,
@@ -29,11 +46,12 @@ export class BasicRunnerFactory<T extends ECompilerType>
 		if (exists) {
 			return exists;
 		}
-		const compiler = this.context.getCompiler<T>(this.name);
-		const stats = compiler.getStats()!.toJson({
-			errorDetails: true
-		});
-		const runner = this.createRunner(file, stats, compilerOptions, env);
+		const runner = this.createRunner(
+			file,
+			this.createStatsGetter(),
+			compilerOptions,
+			env
+		);
 		this.context.setRunner(key, runner);
 		return runner;
 	}
@@ -44,7 +62,7 @@ export class BasicRunnerFactory<T extends ECompilerType>
 
 	protected createRunner(
 		file: string,
-		stats: TCompilerStatsCompilation<T>,
+		stats: () => TCompilerStatsCompilation<T>,
 		compilerOptions: TCompilerOptions<T>,
 		env: ITestEnv
 	): ITestRunner {

--- a/packages/rspack-test-tools/src/runner/cache.ts
+++ b/packages/rspack-test-tools/src/runner/cache.ts
@@ -40,7 +40,7 @@ export class CacheRunnerFactory<
 					this.context.getValue(this.name, "documentType") ||
 					EDocumentType.JSDOM,
 				env,
-				stats,
+				stats: this.createStatsGetter(),
 				cachable: false,
 				name: this.name,
 				runInNewContext: false,

--- a/packages/rspack-test-tools/src/runner/hot-step.ts
+++ b/packages/rspack-test-tools/src/runner/hot-step.ts
@@ -112,7 +112,7 @@ export class HotStepRunnerFactory<
 			dom:
 				this.context.getValue(this.name, "documentType") || EDocumentType.JSDOM,
 			env,
-			stats,
+			stats: this.createStatsGetter(),
 			name: this.name,
 			runInNewContext: false,
 			testConfig: {

--- a/packages/rspack-test-tools/src/runner/hot.ts
+++ b/packages/rspack-test-tools/src/runner/hot.ts
@@ -95,7 +95,7 @@ export class HotRunnerFactory<
 			dom:
 				this.context.getValue(this.name, "documentType") || EDocumentType.JSDOM,
 			env,
-			stats,
+			stats: this.createStatsGetter(),
 			name: this.name,
 			runInNewContext: false,
 			testConfig: {

--- a/packages/rspack-test-tools/src/runner/multiple.ts
+++ b/packages/rspack-test-tools/src/runner/multiple.ts
@@ -19,7 +19,7 @@ export class MultipleRunnerFactory<
 
 	protected createRunner(
 		file: string,
-		stats: TCompilerStatsCompilation<T>,
+		stats: () => TCompilerStatsCompilation<T>,
 		compilerOptions: TCompilerOptions<T>,
 		env: ITestEnv
 	): ITestRunner {
@@ -29,7 +29,7 @@ export class MultipleRunnerFactory<
 		const [index] = getIndex();
 		const runner = super.createRunner(
 			file,
-			stats.children![index],
+			() => stats().children![index],
 			multiCompilerOptions[index],
 			env
 		);

--- a/packages/rspack-test-tools/src/runner/normal.ts
+++ b/packages/rspack-test-tools/src/runner/normal.ts
@@ -13,7 +13,7 @@ export class NormalRunnerFactory<
 > extends BasicRunnerFactory<T> {
 	protected createRunner(
 		file: string,
-		stats: TCompilerStatsCompilation<T>,
+		stats: () => TCompilerStatsCompilation<T>,
 		compilerOptions: TCompilerOptions<T>,
 		env: ITestEnv
 	): ITestRunner {

--- a/packages/rspack-test-tools/src/runner/runner/basic.ts
+++ b/packages/rspack-test-tools/src/runner/runner/basic.ts
@@ -43,7 +43,7 @@ const cached = new Map<string, TBasicRunnerFile>();
 
 export interface IBasicRunnerOptions<T extends ECompilerType> {
 	env: ITestEnv;
-	stats?: TCompilerStatsCompilation<T>;
+	stats?: () => TCompilerStatsCompilation<T>;
 	name: string;
 	runInNewContext?: boolean;
 	testConfig: TTestConfig<T>;

--- a/packages/rspack-test-tools/src/runner/runner/cjs.ts
+++ b/packages/rspack-test-tools/src/runner/runner/cjs.ts
@@ -48,9 +48,6 @@ export class CommonJsRunner<
 			},
 			...this._options.env
 		};
-		if (this._options.stats) {
-			baseModuleScope.__STATS__ = this._options.stats;
-		}
 		return baseModuleScope;
 	}
 
@@ -120,15 +117,16 @@ export class CommonJsRunner<
 			);
 
 			if (this._options.testConfig.moduleScope) {
-				this._options.testConfig.moduleScope(
-					currentModuleScope,
-					this._options.stats
-				);
+				this._options.testConfig.moduleScope(currentModuleScope);
 			}
 
 			if (!this._options.runInNewContext) {
 				file.content = `Object.assign(global, _globalAssign);\n ${file.content}`;
 			}
+			if (file.content.includes("__STATS__") && this._options.stats) {
+				currentModuleScope.__STATS__ = this._options.stats();
+			}
+
 			const args = Object.keys(currentModuleScope);
 			const argValues = args.map(arg => currentModuleScope[arg]);
 			const code = `(function(${args.join(", ")}) {

--- a/packages/rspack-test-tools/src/runner/runner/watch.ts
+++ b/packages/rspack-test-tools/src/runner/runner/watch.ts
@@ -33,7 +33,7 @@ export class WatchRunner<
 		moduleScope.document = this.globalContext!.document;
 		moduleScope.STATE = this._watchOptions.state;
 		moduleScope.WATCH_STEP = this._watchOptions.stepName;
-		moduleScope.STATS_JSON = this._options.stats;
+		moduleScope.__STATS__ = this._options.stats;
 		return moduleScope;
 	}
 

--- a/packages/rspack-test-tools/src/runner/runner/web/jsdom.ts
+++ b/packages/rspack-test-tools/src/runner/runner/web/jsdom.ts
@@ -154,7 +154,6 @@ export class JSDOMWebRunner<
 				}
 			};
 		};
-		moduleScope.STATS = moduleScope.__STATS__;
 		return moduleScope;
 	}
 

--- a/packages/rspack-test-tools/src/runner/watch.ts
+++ b/packages/rspack-test-tools/src/runner/watch.ts
@@ -18,9 +18,28 @@ export class WatchRunnerFactory<
 		);
 		return `${this.name}-${stepName}`;
 	}
+
+	protected createStatsGetter() {
+		const compiler = this.context.getCompiler<T>(this.name);
+		const stepName: string = this.context.getValue(this.name, "watchStepName")!;
+		const statsGetter = (() => {
+			const cached: Record<string, TCompilerStatsCompilation<T>> = {};
+			return () => {
+				if (cached[stepName]) {
+					return cached[stepName];
+				}
+				cached[stepName] = compiler.getStats()!.toJson({
+					errorDetails: true
+				});
+				return cached[stepName];
+			};
+		})();
+		return statsGetter;
+	}
+
 	protected createRunner(
 		file: string,
-		stats: TCompilerStatsCompilation<T>,
+		stats: () => TCompilerStatsCompilation<T>,
 		compilerOptions: TCompilerOptions<T>,
 		env: ITestEnv
 	): ITestRunner {

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/pre-order-index/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/pre-order-index/0/index.js
@@ -11,5 +11,5 @@ function checkStats(stats) {
 
 it('should compile', () => {
 	expect(v).toBe(1)
-	expect(checkStats(STATS_JSON)).toBe(true)
+	expect(checkStats(__STATS__)).toBe(true)
 })

--- a/tests/webpack-test/WatchTestCases.template.js
+++ b/tests/webpack-test/WatchTestCases.template.js
@@ -299,7 +299,7 @@ const describeCases = config => {
 														options.target === "webworker"
 													) {
 														fn = vm.runInNewContext(
-															"(function(require, module, exports, __dirname, __filename, it, WATCH_STEP, STATS_JSON, STATE, expect, window, self) {" +
+															"(function(require, module, exports, __dirname, __filename, it, WATCH_STEP, __STATS__, STATE, expect, window, self) {" +
 															'function nsObj(m) { Object.defineProperty(m, Symbol.toStringTag, { value: "Module" }); return m; }' +
 															content +
 															"\n})",
@@ -308,7 +308,7 @@ const describeCases = config => {
 														);
 													} else {
 														fn = vm.runInThisContext(
-															"(function(require, module, exports, __dirname, __filename, it, WATCH_STEP, STATS_JSON, STATE, expect) {" +
+															"(function(require, module, exports, __dirname, __filename, it, WATCH_STEP, __STATS__, STATE, expect) {" +
 															"global.expect = expect;" +
 															'function nsObj(m) { Object.defineProperty(m, Symbol.toStringTag, { value: "Module" }); return m; }' +
 															content +

--- a/tests/webpack-test/watchCases/cache/asset-modules/0/index.js
+++ b/tests/webpack-test/watchCases/cache/asset-modules/0/index.js
@@ -14,6 +14,6 @@ it("should return a valid url when modified", async () => {
 });
 
 it("should not emit undefined files", () => {
-	expect(STATS_JSON.assets.map(a => a.name)).not.toContain(undefined);
-	expect(STATS_JSON.assets.map(a => a.name)).not.toContain("undefined");
+	expect(__STATS__.assets.map(a => a.name)).not.toContain(undefined);
+	expect(__STATS__.assets.map(a => a.name)).not.toContain("undefined");
 });

--- a/tests/webpack-test/watchCases/cache/asset-modules/2/index.js
+++ b/tests/webpack-test/watchCases/cache/asset-modules/2/index.js
@@ -1,5 +1,5 @@
 it("should not emit files", () => {
-	expect(STATS_JSON.assets.map(a => a.name)).not.toContainEqual(
+	expect(__STATS__.assets.map(a => a.name)).not.toContainEqual(
 		expect.stringMatching(/\.txt$/)
 	);
 });

--- a/tests/webpack-test/watchCases/cache/asset-modules/3/index.js
+++ b/tests/webpack-test/watchCases/cache/asset-modules/3/index.js
@@ -14,6 +14,6 @@ it("should return a valid url when modified", async () => {
 });
 
 it("should not emit undefined files", () => {
-	expect(STATS_JSON.assets.map(a => a.name)).not.toContain(undefined);
-	expect(STATS_JSON.assets.map(a => a.name)).not.toContain("undefined");
+	expect(__STATS__.assets.map(a => a.name)).not.toContain(undefined);
+	expect(__STATS__.assets.map(a => a.name)).not.toContain("undefined");
 });

--- a/tests/webpack-test/watchCases/cache/emit-when-clean/2/index.js
+++ b/tests/webpack-test/watchCases/cache/emit-when-clean/2/index.js
@@ -1,5 +1,5 @@
 it("should not emit files", () => {
-	expect(STATS_JSON.assets.map(a => a.name)).not.toContainEqual(
+	expect(__STATS__.assets.map(a => a.name)).not.toContainEqual(
 		expect.stringMatching(/\.txt$/)
 	);
 });

--- a/tests/webpack-test/watchCases/cache/emit-when-clean/3/index.js
+++ b/tests/webpack-test/watchCases/cache/emit-when-clean/3/index.js
@@ -14,7 +14,7 @@ it("should return a valid url when modified", async () => {
 });
 
 it("should not rewrite files and only compare them", () => {
-	for (const asset of STATS_JSON.assets) {
+	for (const asset of __STATS__.assets) {
 		if (asset.name.endsWith(".txt")) {
 			expect(asset).toHaveProperty("emitted", true);
 		}

--- a/tests/webpack-test/watchCases/cache/emit-without-clean/2/index.js
+++ b/tests/webpack-test/watchCases/cache/emit-without-clean/2/index.js
@@ -1,5 +1,5 @@
 it("should not emit files", () => {
-	expect(STATS_JSON.assets.map(a => a.name)).not.toContainEqual(
+	expect(__STATS__.assets.map(a => a.name)).not.toContainEqual(
 		expect.stringMatching(/\.txt$/)
 	);
 });

--- a/tests/webpack-test/watchCases/cache/emit-without-clean/3/index.js
+++ b/tests/webpack-test/watchCases/cache/emit-without-clean/3/index.js
@@ -14,7 +14,7 @@ it("should return a valid url when modified", async () => {
 });
 
 it("should not rewrite files and only compare them", () => {
-	for (const asset of STATS_JSON.assets) {
+	for (const asset of __STATS__.assets) {
 		if (asset.name.endsWith(".txt")) {
 			expect(asset).toHaveProperty("cached", true);
 		}

--- a/tests/webpack-test/watchCases/cache/new-split-chunk-entry-node/0/index.js
+++ b/tests/webpack-test/watchCases/cache/new-split-chunk-entry-node/0/index.js
@@ -3,17 +3,17 @@ import path from "path";
 
 it("should include the correct split chunk ids in entry", async () => {
 	await import("./module");
-	const runtimeId = STATS_JSON.chunks.find(c => c.names.includes("runtime")).id;
+	const runtimeId = __STATS__.chunks.find(c => c.names.includes("runtime")).id;
 	const entryCode = fs.readFileSync(
 		path.resolve(__dirname, "entry.js"),
 		"utf-8"
 	);
 	STATE.allIds = new Set([
 		...(STATE.allIds || []),
-		...STATS_JSON.entrypoints.entry.chunks
+		...__STATS__.entrypoints.entry.chunks
 	]);
 	const expectedIds = Array.from(STATE.allIds).filter(
-		id => STATS_JSON.entrypoints.entry.chunks.includes(id) && id !== runtimeId
+		id => __STATS__.entrypoints.entry.chunks.includes(id) && id !== runtimeId
 	);
 	try {
 		for (const id of STATE.allIds) {

--- a/tests/webpack-test/watchCases/cache/new-split-chunk-entry-web/0/index.js
+++ b/tests/webpack-test/watchCases/cache/new-split-chunk-entry-web/0/index.js
@@ -3,17 +3,17 @@ import path from "path";
 
 it("should include the correct split chunk ids in entry", async () => {
 	if (Math.random() < 0) import("./module");
-	const runtimeId = STATS_JSON.chunks.find(c => c.names.includes("runtime")).id;
+	const runtimeId = __STATS__.chunks.find(c => c.names.includes("runtime")).id;
 	const entryCode = fs.readFileSync(
 		path.resolve(__dirname, "entry.js"),
 		"utf-8"
 	);
 	STATE.allIds = new Set([
 		...(STATE.allIds || []),
-		...STATS_JSON.entrypoints.entry.chunks
+		...__STATS__.entrypoints.entry.chunks
 	]);
 	const expectedIds = Array.from(STATE.allIds).filter(
-		id => STATS_JSON.entrypoints.entry.chunks.includes(id) && id !== runtimeId
+		id => __STATS__.entrypoints.entry.chunks.includes(id) && id !== runtimeId
 	);
 	try {
 		for (const id of STATE.allIds) {

--- a/tests/webpack-test/watchCases/long-term-caching/issue-8766-with-cache/0/index.js
+++ b/tests/webpack-test/watchCases/long-term-caching/issue-8766-with-cache/0/index.js
@@ -2,7 +2,7 @@ import { foo } from "./shared";
 
 it("should compile fine", () => {
 	expect(foo).toBe("foo");
-	STATE.hash = STATS_JSON.assetsByChunkName.async[0];
+	STATE.hash = __STATS__.assetsByChunkName.async[0];
 });
 
 it("should load the async chunk", () => {

--- a/tests/webpack-test/watchCases/long-term-caching/issue-8766-with-cache/1/index.js
+++ b/tests/webpack-test/watchCases/long-term-caching/issue-8766-with-cache/1/index.js
@@ -2,7 +2,7 @@ import { bar } from "./shared";
 
 it("should compile fine", () => {
 	expect(bar).toBe("bar");
-	const hash = STATS_JSON.assetsByChunkName.async[0];
+	const hash = __STATS__.assetsByChunkName.async[0];
 	expect(hash).toBe(STATE.hash);
 });
 

--- a/tests/webpack-test/watchCases/long-term-caching/issue-8766/0/index.js
+++ b/tests/webpack-test/watchCases/long-term-caching/issue-8766/0/index.js
@@ -2,7 +2,7 @@ import { foo } from "./shared";
 
 it("should compile fine", () => {
 	expect(foo).toBe("foo");
-	STATE.hash = STATS_JSON.assetsByChunkName.async[0];
+	STATE.hash = __STATS__.assetsByChunkName.async[0];
 });
 
 it("should load the async chunk", () => {

--- a/tests/webpack-test/watchCases/long-term-caching/issue-8766/1/index.js
+++ b/tests/webpack-test/watchCases/long-term-caching/issue-8766/1/index.js
@@ -2,7 +2,7 @@ import { bar } from "./shared";
 
 it("should compile fine", () => {
 	expect(bar).toBe("bar");
-	const hash = STATS_JSON.assetsByChunkName.async[0];
+	const hash = __STATS__.assetsByChunkName.async[0];
 	expect(hash).toBe(STATE.hash);
 });
 

--- a/tests/webpack-test/watchCases/plugins/automatic-prefetch-plugin-9485/0/index.js
+++ b/tests/webpack-test/watchCases/plugins/automatic-prefetch-plugin-9485/0/index.js
@@ -2,7 +2,7 @@ it("should watch for changes", function () {
 	if (+WATCH_STEP !== 3) expect(require("./delayed")).toBe(WATCH_STEP);
 	else expect(require("./delayed")).toBe("This is only a test." + WATCH_STEP);
 	if (+WATCH_STEP > 0) {
-		for (var m of STATS_JSON.modules.filter(m =>
+		for (var m of __STATS__.modules.filter(m =>
 			/(a|b|c)\.js$/.test(m.identifier)
 		))
 			expect(m.issuer).toBe(null);

--- a/tests/webpack-test/watchCases/plugins/automatic-prefetch-plugin/0/index.js
+++ b/tests/webpack-test/watchCases/plugins/automatic-prefetch-plugin/0/index.js
@@ -4,7 +4,7 @@ it("should watch for changes", function() {
 	else
 		expect(require("./delayed!./delayed")).toBe('This is only a test.' + WATCH_STEP);
 	if(+WATCH_STEP > 0) {
-		for(var m of STATS_JSON.modules.filter(m => /(a|b|c)\.js$/.test(m.identifier)))
+		for(var m of __STATS__.modules.filter(m => /(a|b|c)\.js$/.test(m.identifier)))
 			expect(m.issuer).toBe(null);
 	}
 });

--- a/tests/webpack-test/watchCases/plugins/mini-css-extract-plugin/1/index.js
+++ b/tests/webpack-test/watchCases/plugins/mini-css-extract-plugin/1/index.js
@@ -59,7 +59,7 @@ it("should generate correct css", () => {
 if (WATCH_STEP !== "1") {
 	it("should not emit javascript again", () => {
 		expect(
-			STATS_JSON.assets.filter(a => a.name.endsWith(".js"))
+			__STATS__.assets.filter(a => a.name.endsWith(".js"))
 		).not.toContainEqual(
 			expect.objectContaining({
 				cached: false

--- a/tests/webpack-test/watchCases/plugins/module-concatenation-plugin/0/index.js
+++ b/tests/webpack-test/watchCases/plugins/module-concatenation-plugin/0/index.js
@@ -14,7 +14,7 @@ it("should watch for changes", function () {
 	}
 
 	const realModule = m => m.moduleType !== "runtime" && !m.orphan;
-	expect(STATS_JSON.modules.filter(realModule).length).toBe(
+	expect(__STATS__.modules.filter(realModule).length).toBe(
 		4 + Number(WATCH_STEP)
 	);
 });

--- a/tests/webpack-test/watchCases/runtime/dynamic-import/0/index.js
+++ b/tests/webpack-test/watchCases/runtime/dynamic-import/0/index.js
@@ -1,5 +1,5 @@
 it("should change chunkhash of main chunk", function () {
-	const mainChunk = STATS_JSON.chunks.find((chunk) => chunk.names.indexOf("main") !== -1);
+	const mainChunk = __STATS__.chunks.find((chunk) => chunk.names.indexOf("main") !== -1);
 	expect(mainChunk).toBeDefined();
 	switch (WATCH_STEP) {
 		case "0":

--- a/tests/webpack-test/watchCases/runtime/static-import/0/index.js
+++ b/tests/webpack-test/watchCases/runtime/static-import/0/index.js
@@ -2,7 +2,7 @@ import * as both from './dynamic-and-static'
 import * as staticModule from './static'
 
 it("should not change chunkhash of manifest chunk", function () {
-	const manifestChunk = STATS_JSON.chunks.find((chunk) => chunk.names.indexOf("runtime~main") !== -1);
+	const manifestChunk = __STATS__.chunks.find((chunk) => chunk.names.indexOf("runtime~main") !== -1);
 	expect(!manifestChunk).toBe(false);
 	switch (WATCH_STEP) {
 		case "0":

--- a/tests/webpack-test/watchCases/simple/multi-compiler/0/index.js
+++ b/tests/webpack-test/watchCases/simple/multi-compiler/0/index.js
@@ -2,10 +2,10 @@ require("./changing-file")
 it("should watch for changes", function() {
 	switch(WATCH_STEP) {
 		case "0":
-			expect(STATS_JSON.children).toHaveLength(2);
+			expect(__STATS__.children).toHaveLength(2);
 			break;
 		case "1":
-			expect(STATS_JSON.children).toHaveLength(1);
+			expect(__STATS__.children).toHaveLength(1);
 			break;
 	}
 })

--- a/tests/webpack-test/watchCases/warnings/warnings-contribute-to-hash/0/index.js
+++ b/tests/webpack-test/watchCases/warnings/warnings-contribute-to-hash/0/index.js
@@ -3,10 +3,10 @@ require("./warning-loader!./changing-file");
 it("should detect a change on warnings change", function() {
 	switch(WATCH_STEP) {
 		case "0":
-			STATE.hash = STATS_JSON.hash;
+			STATE.hash = __STATS__.hash;
 			break;
 		case "1":
-			expect(STATS_JSON.hash).not.toBe(STATE.hash);
+			expect(__STATS__.hash).not.toBe(STATE.hash);
 			break;
 	}
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should not call `stats.toJson` in test runner if `__STATS__` is not used.

Before:
![image](https://github.com/user-attachments/assets/0a58412d-3c83-4742-8d9d-9cbccaa98456)


After:
![image](https://github.com/user-attachments/assets/ae6deb3d-ef77-4791-8b83-1b5d87dee7a3)


---

This pull request involves significant changes to the `rspack-test-tools` package, primarily focusing on modifying how compiler statistics are handled and passed around. The major changes include introducing a `createStatsGetter` method, updating various runner classes to use this new method, and altering test cases to reflect these changes.

### Major Changes:

#### Enhancements to Statistics Handling:
* Introduced the `createStatsGetter` method in `BasicRunnerFactory` to cache and retrieve compiler statistics efficiently.
* Updated `createRunner` method in multiple runner classes (`BasicRunnerFactory`, `MultipleRunnerFactory`, `NormalRunnerFactory`, `WatchRunnerFactory`) to use the `createStatsGetter` method instead of directly passing statistics. [[1]](diffhunk://#diff-ffb09cc036242173fb7f1876bb2276893e09c2e1d812e781042b064941d2bd4cL118-R120) [[2]](diffhunk://#diff-ffb09cc036242173fb7f1876bb2276893e09c2e1d812e781042b064941d2bd4cL1175-R1177) [[3]](diffhunk://#diff-ffb09cc036242173fb7f1876bb2276893e09c2e1d812e781042b064941d2bd4cL1220-R1222) [[4]](diffhunk://#diff-ffb09cc036242173fb7f1876bb2276893e09c2e1d812e781042b064941d2bd4cL1639-R1643) [[5]](diffhunk://#diff-d1a972d0490afd4d244d5e60da28355aff9f13c469f2b8ceffad141ec922ed13L22-R22) [[6]](diffhunk://#diff-81155976c3ec8eb9a3347635728e81c74fd5787fa4af4f0b6f27565744b3f805L16-R16) [[7]](diffhunk://#diff-25ee9cd25d53a78b9946bd6770c063e4e50e4f5e8eb141dd9dc0319f52f992d7R21-R42)

#### Interface Changes:
* Modified `IBasicRunnerOptions` to use a function returning `TCompilerStatsCompilation` instead of directly using the type. [[1]](diffhunk://#diff-ffb09cc036242173fb7f1876bb2276893e09c2e1d812e781042b064941d2bd4cL656-R658) [[2]](diffhunk://#diff-927fc8f1eeeab27bcf9a246dfca5324ad207c7e96d37a355eecce7dff82fe050L46-R46)

#### Test Case Updates:
* Updated test cases to use `__STATS__` instead of `STATS_JSON` to align with the new statistics handling approach. [[1]](diffhunk://#diff-db637bfcd5c564da3a3df6257f3e9e156906d3dfc2b7dacc74afdec726cc8424L14-R14) [[2]](diffhunk://#diff-fe1d046f6156fe653dc7d8123964062097c449fa226e9151aca809ca76451174L17-R18) [[3]](diffhunk://#diff-ff9d08cc9b005739c4c74263fffb003503cb42aba96fa02efca19f26a47dfe41L2-R2) [[4]](diffhunk://#diff-ec3136b4f381df742da5eb29f74bba49a01191fedb23f8151e4edd0561a24433L17-R17) [[5]](diffhunk://#diff-add49aeb79a8c3a0a58c65f22b3edebd48fd71f94b09a2791ff6f814683bbcb1L302-R302) [[6]](diffhunk://#diff-add49aeb79a8c3a0a58c65f22b3edebd48fd71f94b09a2791ff6f814683bbcb1L311-R311)

These changes improve the efficiency and consistency of how compiler statistics are accessed and used across different parts of the `rspack-test-tools` package.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
