### PR TITLE
feat: add `module._constructorName`

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -231,6 +231,7 @@ export declare class JsExportsInfo {
 }
 
 export declare class JsModule {
+  get constructorName(): string
   get context(): string | undefined
   get originalSource(): JsCompatSource | undefined
   get resource(): string | undefined

--- a/crates/node_binding/src/module.rs
+++ b/crates/node_binding/src/module.rs
@@ -85,6 +85,27 @@ impl JsModule {
 #[napi]
 impl JsModule {
   #[napi(getter)]
+  pub fn constructor_name(&mut self) -> napi::Result<String> {
+    let (_, module) = self.as_ref()?;
+    let name = if module.as_concatenated_module().is_some() {
+      "ConcatenatedModule"
+    } else if module.as_normal_module().is_some() {
+      "NormalModule"
+    } else if module.as_context_module().is_some() {
+      "ContextModule"
+    } else if module.as_external_module().is_some() {
+      "ExternalModule"
+    } else if module.as_raw_module().is_some() {
+      "RawModule"
+    } else if module.as_self_module().is_some() {
+      "SelfModule"
+    } else {
+      "Module"
+    };
+    Ok(name.to_string())
+  }
+
+  #[napi(getter)]
   pub fn context(&mut self) -> napi::Result<Either<String, ()>> {
     let (_, module) = self.as_ref()?;
 

--- a/packages/rspack-test-tools/tests/configCases/hooks/module-constructor-name/a.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/module-constructor-name/a.js
@@ -1,0 +1,1 @@
+export const a = 3;

--- a/packages/rspack-test-tools/tests/configCases/hooks/module-constructor-name/b.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/module-constructor-name/b.js
@@ -1,0 +1,1 @@
+export const b = 4;

--- a/packages/rspack-test-tools/tests/configCases/hooks/module-constructor-name/index.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/module-constructor-name/index.js
@@ -1,0 +1,6 @@
+import { a } from "./a.js";
+import { b } from "./b.js";
+
+it("should compile", () => {
+	expect(a + b).toBe(7);
+});

--- a/packages/rspack-test-tools/tests/configCases/hooks/module-constructor-name/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/module-constructor-name/rspack.config.js
@@ -1,0 +1,27 @@
+const { strict } = require("assert");
+const pluginName = "plugin";
+
+class Plugin {
+	apply(compiler) {
+		let names = [];
+		compiler.hooks.finishMake.tap(pluginName, compilation => {
+			compilation.hooks.processAssets.tap(pluginName, () => {
+				for (const m of compilation.modules) {
+					names.push(m._constructorName);
+				}
+			});
+		});
+		compiler.hooks.done.tap(pluginName, () => {
+			strict(names.filter(n => n === "NormalModule").length === 3);
+			strict(names.filter(n => n === "ConcatenatedModule").length === 1);
+		});
+	}
+}
+
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+	plugins: [new Plugin()],
+	optimization: {
+		concatenateModules: true
+	}
+};

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -240,6 +240,15 @@ export class Module {
 		this.buildMeta = {};
 
 		Object.defineProperties(this, {
+			/**
+			 * @internal maybe temp solution for plugin distinguish between different modules.
+			 */
+			_constructorName: {
+				enumerable: true,
+				get: (): string => {
+					return module.constructorName;
+				}
+			},
 			type: {
 				enumerable: true,
 				get(): string | null {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Add `_constructorName` for module, some plugin need to have different behavior for different kind of module, add `_constructorName` to support that

PS: I'm not sure is there a better solution for this, this PR maybe a temp solution or maybe not, so I use `_constructorName` with `@internal` JSDoc for now

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
