### PR TITLE
chore: mark `compiler.compile` as private method

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -894,7 +894,6 @@ export class Compiler {
     cache: Cache_2;
     // (undocumented)
     close(callback: (error?: Error | null) => void): void;
-    // (undocumented)
     compile(callback: liteTapable.Callback<Error, Compilation>): void;
     // (undocumented)
     compilerPath: string;

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -656,6 +656,11 @@ class Compiler {
 		return !isRoot;
 	}
 
+	/**
+	 * Create a compilation and run it, which is the basic method that `compiler.run` and `compiler.watch` depend on.
+	 * TODO: make this method private in the next major release
+	 * @private this method is only used in Rspack core
+	 */
 	compile(callback: liteTapable.Callback<Error, Compilation>) {
 		const startTime = Date.now();
 		const params = this.#newCompilationParams();

--- a/website/docs/en/api/javascript-api/compiler.mdx
+++ b/website/docs/en/api/javascript-api/compiler.mdx
@@ -118,26 +118,6 @@ The Watching object provides the following methods:
   </CollapsePanel>
 </Collapse>
 
-### compile
-
-Create a compilation and run it, which is the basic method that `compiler.run` and `compiler.watch` depend on.
-
-```ts
-compile(
-  callback: (compilation: Compilation) => void // callback after this compilation
-): void
-```
-
-<Collapse>
-  <CollapsePanel
-    className="collapse-code-panel"
-    header="Compilation.ts"
-    key="Compilation"
-  >
-    <CompilationType />
-  </CollapsePanel>
-</Collapse>
-
 ### close
 
 Close the current compiler, and handle low-priority tasks such as caching during this period.

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -118,26 +118,6 @@ Watching 对象提供如下方法：
   </CollapsePanel>
 </Collapse>
 
-### compile
-
-创建 Compilation 并执行编译流程，是 `compiler.run` 和 `compiler.watch` 依赖的底层方法。
-
-```ts
-function compile(
-  callback: (compilation: Compilation) => void, // 编译流程完成后回调
-): void;
-```
-
-<Collapse>
-  <CollapsePanel
-    className="collapse-code-panel"
-    header="Compilation.ts"
-    key="Compilation"
-  >
-    <CompilationType />
-  </CollapsePanel>
-</Collapse>
-
 ### close
 
 关闭当前构建器，在此期间处理低优先级任务，如缓存等。


### PR DESCRIPTION
## Summary

`compiler.compile` is an internal low-level method and should not be used by Rspack users.

This PR removes `compiler.compile` from the documentation and marks it as `@private`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
