### PR TITLE
ci: save cache in test task

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -68,7 +68,6 @@ jobs:
         if: ${{ !inputs.skipable }}
         uses: ./.github/actions/pnpm-cache
         with:
-          save-if: ${{ github.ref_name == 'main' }}
           run-install: ${{ inputs.full-install == 'true' }}
 
       - name: Install binding node dependencies
@@ -308,7 +307,7 @@ jobs:
         uses: ./.github/actions/pnpm-cache
         with:
           node-version: ${{ matrix.node }}
-
+          save-if: ${{ github.ref_name == 'main' && matrix.node == '18' }}
       ### x86_64-unknown-linux-gnu
 
       - name: Test x86_64-unknown-linux-gnu


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Pnpm cache of CI is not updated because the cache saving is skipped in `build` task. So change saving to `test` task.

This pull request includes updates to the `.github/workflows/reusable-build.yml` file to improve the caching mechanism for node dependencies.

Improvements to caching conditions:

* [`.github/workflows/reusable-build.yml`](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L71): Removed the `save-if` condition for saving the cache if the branch is `main` under certain conditions.
* [`.github/workflows/reusable-build.yml`](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L311-R310): Updated the `save-if` condition to save the cache only if the branch is `main` and the node version is `18`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
