### PR TITLE
docs: complete loader context API doc and JSDoc

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3400,96 +3400,62 @@ export interface LoaderContext<OptionsType = {}> {
     __internal__parseMeta: Record<string, string>;
     // (undocumented)
     addBuildDependency(file: string): void;
-    // (undocumented)
     addContextDependency(context: string): void;
-    // (undocumented)
     addDependency(file: string): void;
-    // (undocumented)
     addMissingDependency(missing: string): void;
-    // (undocumented)
     async(): LoaderContextCallback;
-    // (undocumented)
     cacheable(cacheable?: boolean): void;
-    // (undocumented)
     callback: LoaderContextCallback;
-    // (undocumented)
     clearDependencies(): void;
-    // (undocumented)
     _compilation: Compilation;
-    // (undocumented)
     _compiler: Compiler;
-    // (undocumented)
     context: string | null;
     // (undocumented)
     currentRequest: string;
-    // (undocumented)
     data: unknown;
-    // (undocumented)
     dependency(file: string): void;
-    // (undocumented)
     emitError(error: Error): void;
-    // (undocumented)
     emitFile(name: string, content: string | Buffer, sourceMap?: string, assetInfo?: AssetInfo): void;
-    // (undocumented)
     emitWarning(warning: Error): void;
     experiments: LoaderExperiments;
-    // (undocumented)
     fs: any;
     // (undocumented)
     getContextDependencies(): string[];
     // (undocumented)
     getDependencies(): string[];
-    // (undocumented)
     getLogger(name: string): Logger;
     // (undocumented)
     getMissingDependencies(): string[];
-    // (undocumented)
     getOptions(schema?: any): OptionsType;
-    // (undocumented)
     getResolve(options: Resolve): ((context: string, request: string, callback: ResolveCallback) => void) | ((context: string, request: string) => Promise<string | false | undefined>);
-    // (undocumented)
     hot?: boolean;
     importModule<T = any>(request: string, options: ImportModuleOptions | undefined, callback: (err?: null | Error, exports?: T) => any): void;
     // (undocumented)
     importModule<T = any>(request: string, options?: ImportModuleOptions): Promise<T>;
-    // (undocumented)
     loaderIndex: number;
     loaders: LoaderObject[];
-    // (undocumented)
     mode?: Mode;
-    // (undocumented)
+    // @deprecated (undocumented)
     _module: Module;
     // (undocumented)
     previousRequest: string;
-    // (undocumented)
     query: string | OptionsType;
     // (undocumented)
     remainingRequest: string;
-    // (undocumented)
     request: string;
-    // (undocumented)
     resolve(context: string, request: string, callback: (arg0: null | Error, arg1?: string | false, arg2?: ResolveRequest) => void): void;
-    // (undocumented)
     resource: string;
-    // (undocumented)
     resourceFragment: string;
-    // (undocumented)
     resourcePath: string;
-    // (undocumented)
     resourceQuery: string;
-    // (undocumented)
     rootContext: string;
-    // (undocumented)
     sourceMap: boolean;
-    // (undocumented)
     target?: Target;
-    // (undocumented)
     utils: {
         absolutify: (context: string, request: string) => string;
         contextify: (context: string, request: string) => string;
         createHash: (algorithm?: string) => Hash_2;
     };
-    // (undocumented)
     version: 2;
 }
 

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -107,21 +107,83 @@ export interface ImportModuleOptions {
 }
 
 export interface LoaderContext<OptionsType = {}> {
+	/**
+	 * The version number of the loader API. Currently 2.
+	 * This is useful for providing backwards compatibility. Using the version you can specify
+	 * custom logic or fallbacks for breaking changes.
+	 */
 	version: 2;
+	/**
+	 * The path string of the current module.
+	 * @example `'/abc/resource.js?query#hash'`.
+	 */
 	resource: string;
+	/**
+	 * The path string of the current module, excluding the query and fragment parameters.
+	 * @example `'/abc/resource.js?query#hash'` in `'/abc/resource.js'`.
+	 */
 	resourcePath: string;
+	/**
+	 * The query parameter for the path string of the current module.
+	 * @example `'?query'` in `'/abc/resource.js?query#hash'`.
+	 */
 	resourceQuery: string;
+	/**
+	 * The fragment parameter of the current module's path string.
+	 * @example `'#hash'` in `'/abc/resource.js?query#hash'`.
+	 */
 	resourceFragment: string;
+	/**
+	 * Tells Rspack that this loader will be called asynchronously. Returns `this.callback`.
+	 */
 	async(): LoaderContextCallback;
+	/**
+	 * A function that can be called synchronously or asynchronously in order to return multiple
+	 * results. The expected arguments are:
+	 *
+	 * 1. The first parameter must be `Error` or `null`, which marks the current module as a
+	 * compilation failure.
+	 * 2. The second argument is a `string` or `Buffer`, which indicates the contents of the file
+	 * after the module has been processed by the loader.
+	 * 3. The third parameter is a source map that can be processed by the loader.
+	 * 4. The fourth parameter is ignored by Rspack and can be anything (e.g. some metadata).
+	 */
 	callback: LoaderContextCallback;
+	/**
+	 * A function that sets the cacheable flag.
+	 * By default, the processing results of the loader are marked as cacheable.
+	 * Calling this method and passing `false` turns off the loader's ability to
+	 * cache processing results.
+	 */
 	cacheable(cacheable?: boolean): void;
+	/**
+	 * Tells if source map should be generated. Since generating source maps can be an expensive task,
+	 * you should check if source maps are actually requested.
+	 */
 	sourceMap: boolean;
+	/**
+	 * The base path configured in Rspack config via `context`.
+	 */
 	rootContext: string;
+	/**
+	 * The directory path of the currently processed module, which changes with the
+	 * location of each processed module.
+	 * For example, if the loader is processing `/project/src/components/Button.js`,
+	 * then the value of `this.context` would be `/project/src/components`.
+	 */
 	context: string | null;
+	/**
+	 * The index in the loaders array of the current loader.
+	 */
 	loaderIndex: number;
 	remainingRequest: string;
 	currentRequest: string;
 	previousRequest: string;
+	/**
+	 * The module specifier string after being resolved.
+	 * For example, if a `resource.js` is processed by `loader1.js` and `loader2.js`, the value of
+	 * `this.request` will be `/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js`.
+	 */
 	request: string;
 	/**
 	 * An array of all the loaders. It is writeable in the pitch phase.
@@ -142,13 +204,33 @@ export interface LoaderContext<OptionsType = {}> {
 	 * ]
 	 */
 	loaders: LoaderObject[];
+	/**
+	 * The value of `mode` is read when Rspack is run.
+	 * The possible values are: `'production'`, `'development'`, `'none'`
+	 */
 	mode?: Mode;
+	/**
+	 * The current compilation target. Passed from `target` configuration options.
+	 */
 	target?: Target;
+	/**
+	 * Whether HMR is enabled.
+	 */
 	hot?: boolean;
 	/**
-	 * @param schema To provide the best performance, Rspack does not perform the schema validation. If your loader requires schema validation, please call scheme-utils or zod on your own.
+	 * Get the options passed in by the loader's user.
+	 * @param schema To provide the best performance, Rspack does not perform the schema
+	 * validation. If your loader requires schema validation, please call scheme-utils or
+	 * zod on your own.
 	 */
 	getOptions(schema?: any): OptionsType;
+	/**
+	 * Resolve a module specifier.
+	 * @param context The absolute path to a directory. This directory is used as the starting
+	 * location for resolving.
+	 * @param request The module specifier to be resolved.
+	 * @param callback A callback function that gives the resolved path.
+	 */
 	resolve(
 		context: string,
 		request: string,
@@ -158,6 +240,9 @@ export interface LoaderContext<OptionsType = {}> {
 			arg2?: ResolveRequest
 		) => void
 	): void;
+	/**
+	 * Create a resolver like `this.resolve`.
+	 */
 	getResolve(
 		options: Resolve
 	):
@@ -166,25 +251,58 @@ export interface LoaderContext<OptionsType = {}> {
 				context: string,
 				request: string
 		  ) => Promise<string | false | undefined>);
+	/**
+	 * Get the logger of this compilation, through which messages can be logged.
+	 */
 	getLogger(name: string): Logger;
+	/**
+	 * Emit an error. Unlike `throw` and `this.callback(err)` in the loader, it does not
+	 * mark the current module as a compilation failure, it just adds an error to Rspack's
+	 * Compilation and displays it on the command line at the end of this compilation.
+	 */
 	emitError(error: Error): void;
+	/**
+	 * Emit a warning.
+	 */
 	emitWarning(warning: Error): void;
+	/**
+	 * Emit a new file. This method allows you to create new files during the loader execution.
+	 */
 	emitFile(
 		name: string,
 		content: string | Buffer,
 		sourceMap?: string,
 		assetInfo?: AssetInfo
 	): void;
+	/**
+	 * Add a file as a dependency on the loader results so that any changes to them can be listened to.
+	 * For example, `sass-loader`, `less-loader` use this trick to recompile when the imported style
+	 * files change.
+	 */
 	addDependency(file: string): void;
+	/**
+	 * Alias of `this.addDependency()`.
+	 */
 	dependency(file: string): void;
+	/**
+	 * Add the directory as a dependency for the loader results so that any changes to the
+	 * files in the directory can be listened to.
+	 */
 	addContextDependency(context: string): void;
+	/**
+	 * Add a currently non-existent file as a dependency of the loader result, so that its
+	 * creation and any changes can be listened. For example, when a new file is created at
+	 * that path, it will trigger a rebuild.
+	 */
 	addMissingDependency(missing: string): void;
+	/**
+	 * Removes all dependencies of the loader result.
+	 */
 	clearDependencies(): void;
 	getDependencies(): string[];
 	getContextDependencies(): string[];
 	getMissingDependencies(): string[];
 	addBuildDependency(file: string): void;
-
 	/**
 	 * Compile and execute a module at the build time.
 	 * This is an alternative lightweight solution for the child compiler.
@@ -207,26 +325,58 @@ export interface LoaderContext<OptionsType = {}> {
 		request: string,
 		options?: ImportModuleOptions
 	): Promise<T>;
-
+	/**
+	 * Access to the `compilation` object's `inputFileSystem` property.
+	 */
 	fs: any;
 	/**
 	 * This is an experimental API and maybe subject to change.
 	 * @experimental
 	 */
 	experiments: LoaderExperiments;
+	/**
+	 * Access to some utilities.
+	 */
 	utils: {
+		/**
+		 * Return a new request string using absolute paths when possible.
+		 */
 		absolutify: (context: string, request: string) => string;
+		/**
+		 * Return a new request string avoiding absolute paths when possible.
+		 */
 		contextify: (context: string, request: string) => string;
+		/**
+		 * Return a new Hash object from provided hash function.
+		 */
 		createHash: (algorithm?: string) => Hash;
 	};
-	query: string | OptionsType;
-	data: unknown;
-	_compiler: Compiler;
-	_compilation: Compilation;
-	_module: Module;
-
 	/**
-	 * Note: This is not a webpack public API, maybe removed in future.
+	 * The value depends on the loader configuration:
+	 * - If the current loader was configured with an options object, `this.query` will
+	 * point to that object.
+	 * - If the current loader has no options, but was invoked with a query string, this
+	 * will be a string starting with `?`.
+	 */
+	query: string | OptionsType;
+	/**
+	 * A data object shared between the pitch and the normal phase.
+	 */
+	data: unknown;
+	/**
+	 * Access to the current Compiler object of Rspack.
+	 */
+	_compiler: Compiler;
+	/**
+	 * Access to the current Compilation object of Rspack.
+	 */
+	_compilation: Compilation;
+	/**
+	 * @deprecated Hacky access to the Module object being loaded.
+	 */
+	_module: Module;
+	/**
+	 * Note: This is not a Rspack public API, maybe removed in future.
 	 * Store some data from loader, and consume it from parser, it may be removed in the future
 	 *
 	 * @internal

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -81,9 +81,16 @@ Tells Rspack that this loader will be called asynchronously. Returns [this.callb
 function cacheable(flag: boolean = true): void;
 ```
 
-A function that sets the cacheable flag:
+A function that sets the cacheable flag.
 
 By default, the processing results of the loader are marked as cacheable. Calling this method and passing `false` turns off the loader's ability to cache processing results.
+
+```js title="loader.js"
+module.exports = function loader(source) {
+  this.cacheable(false);
+  return source;
+};
+```
 
 ## this.callback()
 
@@ -138,6 +145,12 @@ module.exports = function loader(source) {
 ```
 
 If the module being processed is not from the file system, such as a virtual module, then the value of `this.context` is `null`.
+
+## this.loaderIndex
+
+- **Type:** `number`
+
+The index in the loaders array of the current loader.
 
 ## this.data
 
@@ -217,6 +230,12 @@ module.exports = function loader(source) {
 };
 ```
 
+## this.fs
+
+- **Type:** `InputFileSystem`
+
+Access to the `compilation` object's `inputFileSystem` property.
+
 ## this.getOptions()
 
 - **Type:**
@@ -291,6 +310,19 @@ function getResolve(options: ResolveOptions): resolve;
 ```
 
 Create a resolver like `this.resolve`.
+
+## this.hot
+
+- **Type:** `boolean`
+
+Whether HMR is enabled.
+
+```js title="loader.js"
+module.exports = function (source) {
+  console.log(this.hot); // true if HMR is enabled
+  return source;
+};
+```
 
 ## this.importModule()
 
@@ -368,6 +400,23 @@ module.exports = function loader(source) {
 };
 ```
 
+## this.query
+
+- **Type:** `string | OptionsType`
+
+The value depends on the loader configuration:
+
+- If the current loader was configured with an options object, `this.query` will point to that object.
+- If the current loader has no options, but was invoked with a query string, this will be a string starting with `?`.
+
+## this.request
+
+- **Type:** `string`
+
+The module specifier string after being resolved.
+
+For example, if a `resource.js` is processed by `loader1.js` and `loader2.js`, the value of `this.request` will be `/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js`.
+
 ## this.resolve()
 
 - **Type:**
@@ -405,12 +454,49 @@ module.exports = function loader(source) {
 
 - **Type:** `Target`
 
-The value of [`target`](/config/target) is read when Rspack is run.
+The current compilation target. Passed from [`target`](/config/target) configuration options.
 
 ```js title="loader.js"
 module.exports = function loader(source) {
   console.log(this.target); // 'web' or other values
   return source;
+};
+```
+
+## this.utils
+
+- **Type:**
+
+```ts
+type Utils = {
+  absolutify: (context: string, request: string) => string;
+  contextify: (context: string, request: string) => string;
+  createHash: (algorithm?: string) => Hash;
+};
+```
+
+Access to the following utilities.
+
+- `absolutify`: Return a new request string using absolute paths when possible.
+- `contextify`: Return a new request string avoiding absolute paths when possible.
+- `createHash`: Return a new Hash object from provided hash function.
+
+```js title="loader.js"
+module.exports = function (content) {
+  this.utils.contextify(
+    this.context,
+    this.utils.absolutify(this.context, './index.js'),
+  );
+
+  this.utils.absolutify(this.context, this.resourcePath);
+
+  const mainHash = this.utils.createHash(
+    this._compilation.outputOptions.hashFunction,
+  );
+  mainHash.update(content);
+  mainHash.digest('hex');
+
+  return content;
 };
 ```
 
@@ -483,7 +569,9 @@ module.exports = function loader(source) {
 
 - **Type:** `boolean`
 
-Whether a source map should be generated.
+Tells if source map should be generated.
+
+Since generating source maps can be an expensive task, you should check if source maps are actually requested.
 
 ## this.getLogger()
 
@@ -494,3 +582,23 @@ function getLogger(name?: string): Logger;
 ```
 
 Get the logger of this compilation, through which messages can be logged.
+
+## this.version
+
+- **Type:** `number`
+
+The version number of the loader API. Currently 2.
+
+This is useful for providing backwards compatibility. Using the version you can specify custom logic or fallbacks for breaking changes.
+
+## this.\_compiler
+
+- **Type:** `Compiler`
+
+Access to the current [Compiler](/api/javascript-api/compiler) object of Rspack.
+
+## this.\_compilation
+
+- **Type:** `Compilation`
+
+Access to the current [Compilation](/api/javascript-api/compilation) object of Rspack.

--- a/website/docs/en/api/loader-api/examples.mdx
+++ b/website/docs/en/api/loader-api/examples.mdx
@@ -85,6 +85,28 @@ export function pitch(remainingRequest, precedingRequest, data) {
 ESM loader and CommonJS loader have the same functionality, but use different module syntax. You can choose the format based on your project needs.
 :::
 
+### Write with TypeScript
+
+If you write Rspack loader using TypeScript, you can import `LoaderContext` to add types to the loader:
+
+```ts title="my-loader.ts"
+import type { LoaderContext } from '@rspack/core';
+
+// Declare the type of loader options
+type MyLoaderOptions = {
+  foo: string;
+};
+
+export default function myLoader(
+  this: LoaderContext<MyLoaderOptions>,
+  source: string,
+) {
+  const options = this.getOptions();
+  console.log(options); // { foo: 'bar' }
+  return source;
+}
+```
+
 ## 'Raw' Loader
 
 By default, resource files are converted to UTF-8 strings and passed to the loader. loaders can receive raw `Buffer` by setting `raw` to `true`. Each loader can pass its processing results as `String` or `Buffer`, and the Rspack compiler will convert them to and from the loader.

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -83,6 +83,13 @@ function cacheable(flag: boolean = true): void;
 
 默认情况下，loader 的处理结果会被标记为可缓存。调用这个方法然后传入 `false`，可以关闭 loader 处理结果的缓存能力。
 
+```js title="loader.js"
+module.exports = function loader(source) {
+  this.cacheable(false);
+  return source;
+};
+```
+
 ## this.clearDependencies()
 
 - **类型：**
@@ -133,6 +140,12 @@ module.exports = function loader(source) {
 ```
 
 如果被处理的是模块不是来自文件系统，例如虚拟模块，那么 `this.context` 的值为 `null`。
+
+## this.loaderIndex
+
+- **类型：** `number`
+
+当前 loader 在 loaders 数组中的索引。
 
 ## this.data
 
@@ -212,6 +225,12 @@ module.exports = function loader(source) {
 };
 ```
 
+## this.fs
+
+- **类型：** `InputFileSystem`
+
+访问 `compilation` 对象的 `inputFileSystem` 属性。
+
 ## this.getOptions()
 
 - **类型：**
@@ -286,6 +305,19 @@ function getResolve(options: ResolveOptions): resolve;
 ```
 
 创建一个类似于 `this.resolve` 的解析函数。
+
+## this.hot
+
+- **类型：** `boolean`
+
+是否启用了 HMR。
+
+```js title="loader.js"
+module.exports = function (source) {
+  console.log(this.hot); // true if HMR is enabled
+  return source;
+};
+```
 
 ## this.importModule()
 
@@ -363,6 +395,23 @@ module.exports = function loader(source) {
 };
 ```
 
+## this.query
+
+- **类型：** `string | OptionsType`
+
+该值取决于 loader 的配置方式：
+
+- 如果当前 loader 配置了一个选项对象，`this.query` 将指向这个对象。
+- 如果当前 loader 没有选项，但是通过查询字符串调用，这将是一个以 `?` 开头的字符串。
+
+## this.request
+
+- **类型：** `string`
+
+解析后的 module specifier 字符串。
+
+例如，如果 `resource.js` 被 `loader1.js` 和 `loader2.js` 处理，那么 `this.request` 的值为 `/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js`。
+
 ## this.resolve()
 
 - **类型：**
@@ -398,12 +447,49 @@ module.exports = function loader(source) {
 
 - **类型：** `Target`
 
-当 Rspack 运行时读取 [target](/config/target) 的值。
+当前编译的目标。对应 [`target`](/config/target) 配置项的值。
 
 ```js title="loader.js"
 module.exports = function loader(source) {
   console.log(this.target); // 'web' or other values
   return source;
+};
+```
+
+## this.utils
+
+- **类型：**
+
+```ts
+type Utils = {
+  absolutify: (context: string, request: string) => string;
+  contextify: (context: string, request: string) => string;
+  createHash: (algorithm?: string) => Hash;
+};
+```
+
+访问以下 utils：
+
+- `absolutify`: 返回一个新的 request 字符串，尽可能使用绝对路径。
+- `contextify`: 返回一个新的 request 字符串，尽可能避免使用绝对路径。
+- `createHash`: 基于提供的哈希函数返回一个新的 Hash 对象。
+
+```js title="loader.js"
+module.exports = function (content) {
+  this.utils.contextify(
+    this.context,
+    this.utils.absolutify(this.context, './index.js'),
+  );
+
+  this.utils.absolutify(this.context, this.resourcePath);
+
+  const mainHash = this.utils.createHash(
+    this._compilation.outputOptions.hashFunction,
+  );
+  mainHash.update(content);
+  mainHash.digest('hex');
+
+  return content;
 };
 ```
 
@@ -476,7 +562,9 @@ module.exports = function loader(source) {
 
 - **类型：** `boolean`
 
-是否应该生成一个 source map。
+是否应该生成 source map。
+
+由于生成 source map 通常是一项耗费资源的任务，你应该检查是否需要 source map。
 
 ## this.getLogger()
 
@@ -487,3 +575,23 @@ function getLogger(name?: string): Logger;
 ```
 
 获取此次编译过程的 logger，可通过该 logger 记录消息。
+
+## this.version
+
+- **类型：** `number`
+
+loader API 的版本号。当前为 2。
+
+这对于提供向后兼容性很有用。基于版本号，你可以为 breaking changes 指定自定义逻辑或降级方案。
+
+## this.\_compiler
+
+- **类型：** `Compiler`
+
+访问当前的 Rspack [Compiler](/api/javascript-api/compiler) 对象。
+
+## this.\_compilation
+
+- **类型：** `Compilation`
+
+访问当前的 Rspack [Compilation](/api/javascript-api/compilation) 对象。

--- a/website/docs/zh/api/loader-api/examples.mdx
+++ b/website/docs/zh/api/loader-api/examples.mdx
@@ -87,6 +87,28 @@ export function pitch(remainingRequest, precedingRequest, data) {
 ESM loader 和 CommonJS loader 的功能完全相同，只是使用了不同的模块语法。你可以根据项目需求选择使用哪种格式。
 :::
 
+### 使用 TypeScript 编写
+
+如果你使用 TypeScript 来编写 Rspack loader，可以引入 `LoaderContext` 来为 loader 添加类型：
+
+```ts title="my-loader.ts"
+import type { LoaderContext } from '@rspack/core';
+
+// 声明 loader 选项的类型
+type MyLoaderOptions = {
+  foo: string;
+};
+
+export default function myLoader(
+  this: LoaderContext<MyLoaderOptions>,
+  source: string,
+) {
+  const options = this.getOptions();
+  console.log(options); // { foo: 'bar' }
+  return source;
+}
+```
+
 ## 'Raw' Loader
 
 默认情况下，资源文件会被转化为 UTF-8 字符串，然后传给 loader。通过设置 `raw` 为 `true`，loader 可以接收原始的 `Buffer`。每一个 loader 都可以用 `String` 或者 `Buffer` 的形式传递它的处理结果。Compiler 将会把它们在 loader 之间相互转换。

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -1,4 +1,5 @@
 aarch
+absolutify
 ahabhgk
 Akait
 alexander-akait


### PR DESCRIPTION
## Summary

- Complete loader context API documentation.
- Add JSDoc for the `LoaderContext` type.
- Add an example of TypeScript loader.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
