### PR TITLE
fix: rebuild ignore modules contain built-in loader errors

### DIFF
--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -447,6 +447,15 @@ impl Module for NormalModule {
           .with_stack(stack)
           .with_hide_stack(captured_error.hide_stack)
         } else {
+          self.build_info.cacheable = false;
+          if let Some(file_path) = &self.resource_data.resource_path {
+            if file_path.is_absolute() {
+              self
+                .build_info
+                .file_dependencies
+                .insert(file_path.clone().into_std_path_buf().into());
+            }
+          }
           let node_error = r.downcast_ref::<NodeError>();
           let stack = node_error.and_then(|e| e.stack.clone());
           let hide_stack = node_error.and_then(|e| e.hide_stack);

--- a/tests/e2e/cases/make/failed_module_by_builtin_loader/index.test.ts
+++ b/tests/e2e/cases/make/failed_module_by_builtin_loader/index.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@/fixtures";
+
+test("should compile", async ({ page, fileAction, rspack }) => {
+	await expect(page.getByText("index")).toBeVisible();
+
+	fileAction.updateFile("src/index.js", content =>
+		content.replace('div.innerText = "index";', 'div.innerText = "er;')
+	);
+
+	await page.reload();
+	await expect(page.locator("#webpack-dev-server-client-overlay")).toHaveCount(
+		1
+	);
+	let stats = rspack.compiler._lastCompilation
+		?.getStats()
+		.toJson({ all: false, errors: true });
+	expect(stats?.errors?.length).toBe(1);
+
+	fileAction.updateFile("src/index.js", content =>
+		content.replace('div.innerText = "er;', 'div.innerText = "index";')
+	);
+	await page.reload();
+	await expect(page.locator("#webpack-dev-server-client-overlay")).toHaveCount(
+		0
+	);
+	await expect(page.getByText("index")).toBeVisible();
+	stats = rspack.compiler._lastCompilation
+		?.getStats()
+		.toJson({ all: false, errors: true });
+	expect(stats?.errors?.length).toBe(0);
+});

--- a/tests/e2e/cases/make/failed_module_by_builtin_loader/rspack.config.js
+++ b/tests/e2e/cases/make/failed_module_by_builtin_loader/rspack.config.js
@@ -11,6 +11,7 @@ module.exports = {
 			{
 				test: /\.js$/,
 				exclude: [/node_modules/],
+				include: [/src/],
 				loader: "builtin:swc-loader"
 			}
 		]

--- a/tests/e2e/cases/make/failed_module_by_builtin_loader/rspack.config.js
+++ b/tests/e2e/cases/make/failed_module_by_builtin_loader/rspack.config.js
@@ -1,0 +1,21 @@
+const rspack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./src/index.js",
+	context: __dirname,
+	mode: "development",
+	plugins: [new rspack.HtmlRspackPlugin()],
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				exclude: [/node_modules/],
+				loader: "builtin:swc-loader"
+			}
+		]
+	},
+	devServer: {
+		hot: true
+	}
+};

--- a/tests/e2e/cases/make/failed_module_by_builtin_loader/src/index.js
+++ b/tests/e2e/cases/make/failed_module_by_builtin_loader/src/index.js
@@ -1,0 +1,6 @@
+Promise.resolve().then(() => {
+	const div = document.createElement("div");
+	div.innerText = "index";
+	div.id = "index";
+	document.body.appendChild(div);
+});

--- a/tests/e2e/cases/make/failed_module_by_js_loader/index.test.ts
+++ b/tests/e2e/cases/make/failed_module_by_js_loader/index.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@/fixtures";
+
+test("should compile", async ({ page, fileAction, rspack }) => {
+	await expect(page.getByText("index")).toBeVisible();
+
+	fileAction.updateFile("src/index.js", content =>
+		content.replace('div.innerText = "index";', 'div.innerText = "error";')
+	);
+
+	await page.reload();
+	await expect(page.locator("#webpack-dev-server-client-overlay")).toHaveCount(
+		1
+	);
+	let stats = rspack.compiler._lastCompilation
+		?.getStats()
+		.toJson({ all: false, errors: true });
+	expect(stats?.errors?.length).toBe(1);
+
+	fileAction.updateFile("src/index.js", content =>
+		content.replace('div.innerText = "error";', 'div.innerText = "index";')
+	);
+	await page.reload();
+	await expect(page.locator("#webpack-dev-server-client-overlay")).toHaveCount(
+		0
+	);
+	await expect(page.getByText("index")).toBeVisible();
+	stats = rspack.compiler._lastCompilation
+		?.getStats()
+		.toJson({ all: false, errors: true });
+	expect(stats?.errors?.length).toBe(0);
+});

--- a/tests/e2e/cases/make/failed_module_by_js_loader/loader.js
+++ b/tests/e2e/cases/make/failed_module_by_js_loader/loader.js
@@ -1,0 +1,6 @@
+module.exports = function (content) {
+	if (content.includes("error")) {
+		throw new Error("loader transform error");
+	}
+	return content;
+};

--- a/tests/e2e/cases/make/failed_module_by_js_loader/rspack.config.js
+++ b/tests/e2e/cases/make/failed_module_by_js_loader/rspack.config.js
@@ -1,0 +1,21 @@
+const rspack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./src/index.js",
+	context: __dirname,
+	mode: "development",
+	plugins: [new rspack.HtmlRspackPlugin()],
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				exclude: [/node_modules/],
+				loader: "./loader.js"
+			}
+		]
+	},
+	devServer: {
+		hot: true
+	}
+};

--- a/tests/e2e/cases/make/failed_module_by_js_loader/rspack.config.js
+++ b/tests/e2e/cases/make/failed_module_by_js_loader/rspack.config.js
@@ -11,6 +11,7 @@ module.exports = {
 			{
 				test: /\.js$/,
 				exclude: [/node_modules/],
+				include: [/src/],
 				loader: "./loader.js"
 			}
 		]

--- a/tests/e2e/cases/make/failed_module_by_js_loader/src/index.js
+++ b/tests/e2e/cases/make/failed_module_by_js_loader/src/index.js
@@ -1,0 +1,6 @@
+Promise.resolve().then(() => {
+	const div = document.createElement("div");
+	div.innerText = "index";
+	div.id = "index";
+	document.body.appendChild(div);
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Builtin loaders throw error will make normal module does not contains  any file_dependencies and mark as cacheable, those modules will never rebuild forever with memory cache. This PR will mark those module as cacheable and set they resourcePath as file_dependencies.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
