### PR TITLE
docs: fix the reference to process asset stages in examples

### DIFF
--- a/website/docs/en/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compilation-hooks.mdx
@@ -725,10 +725,11 @@ Process the assets before emit.
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
+  const { Compilation } = compiler.webpack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
-      stage: compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+      stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
     },
     assets => {
       const { RawSource } = compiler.webpack.sources;
@@ -743,10 +744,11 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
+  const { Compilation } = compiler.webpack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
-      stage: compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+      stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
     },
     assets => {
       const asset = assets['foo.js'];
@@ -769,10 +771,11 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
+  const { Compilation } = compiler.webpack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
-      stage: compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
+      stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
     },
     assets => {
       const assetName = 'unwanted-script.js';

--- a/website/docs/zh/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compilation-hooks.mdx
@@ -727,10 +727,11 @@ console.log(__webpack_require__.p);
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
+  const { Compilation } = compiler.webpack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
-      stage: compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+      stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
     },
     assets => {
       const { RawSource } = compiler.webpack.sources;
@@ -745,10 +746,11 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
+  const { Compilation } = compiler.webpack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
-      stage: compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+      stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
     },
     assets => {
       const asset = assets['foo.js'];
@@ -771,10 +773,11 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
+  const { Compilation } = compiler.webpack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
-      stage: compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
+      stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
     },
     assets => {
       const assetName = 'unwanted-script.js';


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

When using process assets examples provided by the document, I encountered the following TS error: **Property 'PROCESS_ASSETS_STAGE_ADDITIONS' does not exist on type 'Compilation'.** 

Actually, asset processing stages are exported by `compiler.webpack.Compilation` instead of `compilation`. See [Webpack docs](https://webpack.js.org/api/compilation-hooks/#processassets).

<img width="1195" alt="Screenshot 2025-02-27 at 09 40 21" src="https://github.com/user-attachments/assets/34c50f4b-e94e-47d8-b7f6-b85d66e6ed2f" />


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
