### PR TITLE
chore: use tmpdir to avoid no space left error

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -60,6 +60,7 @@ runs:
           -v $CARGO_HOME/registry/index:/usr/local/cargo/registry/index \
           -v $CARGO_HOME/registry/cache:/usr/local/cargo/registry/cache \
           -v $CARGO_HOME/git/db:/usr/local/cargo/git/db \
+          -v /tmp:/tmp \
           ${{ inputs.options }} \
           -e CI=1 \
           -e HOME=$HOME \

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -36,6 +36,9 @@ env:
   # Since CI builds are more akin to from-scratch builds, incremental compilation adds unnecessary dependency-tracking and IO overhead, reducing caching effectiveness.
   # https://github.com/rust-lang/rust-analyzer/blob/25368d24308d6a94ffe8b99f0122bcf5a2175322/.github/workflows/ci.yaml#L11
   CARGO_INCREMENTAL: 0
+  # use a different TMPDIR to avoid no space left error caused by tmpfs is bloated
+  # related https://github.com/rust-lang/rust/issues/64276#issuecomment-529203825
+  TMPDIR: target/tmpdir
 
 permissions:
   # Allow commenting on issues
@@ -273,7 +276,7 @@ jobs:
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
       PUPPETEER_SKIP_DOWNLOAD: true
-      
+
     steps:
       - name: Checkout
         if: ${{ !inputs.skipable }}
@@ -392,7 +395,7 @@ jobs:
         with:
           save-cache: ${{ github.ref_name == 'main' }} # This should be safe because we have nightly building the cache every day
           shared-key: build-bench-${{ inputs.target }}-${{ inputs.profile }}
-      
+
       - name: Install cargo-codspeed binary
         uses: taiki-e/install-action@54b836426b3fa9aef432e760885ea0419ab50dab # v2
         with:
@@ -407,10 +410,10 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-name: 'Test Linux / Build'
+          check-name: "Test Linux / Build"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
-      
+
       - name: Download bindings
         uses: ./.github/actions/download-artifact
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -36,9 +36,6 @@ env:
   # Since CI builds are more akin to from-scratch builds, incremental compilation adds unnecessary dependency-tracking and IO overhead, reducing caching effectiveness.
   # https://github.com/rust-lang/rust-analyzer/blob/25368d24308d6a94ffe8b99f0122bcf5a2175322/.github/workflows/ci.yaml#L11
   CARGO_INCREMENTAL: 0
-  # use a different TMPDIR to avoid no space left error caused by tmpfs is bloated
-  # related https://github.com/rust-lang/rust/issues/64276#issuecomment-529203825
-  TMPDIR: target/tmpdir
 
 permissions:
   # Allow commenting on issues


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
use temp dir to avoid release debug eats all tmpfs memory, related to https://github.com/rust-lang/rust/issues/64276#issuecomment-529203825
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
