### PR TITLE
fix: concate with external runtime specific modules

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/a.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/a.js
@@ -1,0 +1,5 @@
+import { Provide } from "./should-concat/lib";
+import Comp from "./comp";
+
+Provide();
+Comp();

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/b.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/b.js
@@ -1,0 +1,3 @@
+import { Provide } from "./should-concat/lib";
+
+Provide();

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/comp.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/comp.js
@@ -1,0 +1,3 @@
+import { connect } from "./should-concat/lib";
+
+export default connect;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/rspack.config.js
@@ -1,0 +1,35 @@
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+	mode: "production",
+	entry: {
+		a: "./a.js",
+		b: "./b.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	module: {
+		rules: [
+			{
+				test: /value\.js/,
+				sideEffects: false
+			}
+		]
+	},
+	optimization: {
+		usedExports: true,
+		innerGraph: true,
+		sideEffects: true,
+		concatenateModules: true,
+		splitChunks: {
+			cacheGroups: {
+				shared: {
+					test: /should-concat/,
+					chunks: "all",
+					minSize: 0,
+					name: "shared"
+				}
+			}
+		}
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/should-concat/connect.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/should-concat/connect.js
@@ -1,0 +1,7 @@
+import { value } from "./value";
+
+export function connect() {
+  value;
+}
+
+console.log('')

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/should-concat/lib.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/should-concat/lib.js
@@ -1,0 +1,10 @@
+export { connect } from "./connect";
+// external value for runtime a
+import { value } from "./value";
+
+
+console.log('')
+
+export function Provide() {
+  value;
+}

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/should-concat/value.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/should-concat/value.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-specific-external/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["b.js", "a.js", "shared.js"];
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close #8649

### Runtime Condition

Runtime Condition is used when an export is utilized in one runtime but not in another. Rspack will generate code like this:

```js
if (__webpack_require__.j === 'main') {
var lib = __webpack_require__('./foo');
}
```

This means that if users enter this code, the execution of 'foo' and its sub-modules will only occur if they go through the main runtime; otherwise, it can be skipped.

In our architecture, modules are connected through various connections. Some connections point to the same module, where one may be active in a particular runtime while others are not. This scenario can occur.

When this happens, we need to ensure that all connections are valid for the concatenated module to function properly.

```js
if (__webpack_require__.j === 'bar') {
var lib = __webpack_require__('./foo');
}
if (__webpack_require__.j === 'foo') {
var lib = __webpack_require__('./foo');
}
```

We must guarantee that 'lib' can be active for all possible runtimes. In the previous implementation, we incorrectly used only one of valid runtime.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
