### PR TITLE
feat(memory-cache): add `maxGenerations` support

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1410,6 +1410,7 @@ export interface RawCacheGroupOptions {
 
 export interface RawCacheOptions {
   type: string
+  maxGenerations?: number
 }
 
 export interface RawConsumeOptions {

--- a/crates/node_binding/src/raw_options/raw_cache.rs
+++ b/crates/node_binding/src/raw_options/raw_cache.rs
@@ -5,14 +5,18 @@ use rspack_core::CacheOptions;
 #[napi(object, object_to_js = false)]
 pub struct RawCacheOptions {
   pub r#type: String,
+  pub max_generations: Option<u32>,
 }
 
 impl From<RawCacheOptions> for CacheOptions {
   fn from(value: RawCacheOptions) -> CacheOptions {
-    let RawCacheOptions { r#type } = value;
+    let RawCacheOptions {
+      r#type,
+      max_generations,
+    } = value;
 
     match r#type.as_str() {
-      "memory" => CacheOptions::Memory,
+      "memory" => CacheOptions::Memory { max_generations },
       _ => CacheOptions::Disabled,
     }
   }

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -916,7 +916,9 @@ impl CompilerOptionsBuilder {
     let bail = d!(self.bail.take(), false);
     let cache = d!(self.cache.take(), {
       if development {
-        CacheOptions::Memory
+        CacheOptions::Memory {
+          max_generations: None,
+        }
       } else {
         CacheOptions::Disabled
       }

--- a/crates/rspack_core/src/old_cache/mod.rs
+++ b/crates/rspack_core/src/old_cache/mod.rs
@@ -1,10 +1,4 @@
-use std::{
-  path::PathBuf,
-  sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-  },
-};
+use std::{path::PathBuf, sync::Arc};
 
 use crate::CompilerOptions;
 
@@ -17,7 +11,6 @@ use storage::new_storage;
 
 #[derive(Debug)]
 pub struct Cache {
-  is_idle: AtomicBool,
   pub code_generate_occasion: CodeGenerateOccasion,
   pub process_runtime_requirements_occasion: ProcessRuntimeRequirementsOccasion,
   pub chunk_render_occasion: ChunkRenderOccasion,
@@ -26,7 +19,6 @@ pub struct Cache {
 impl Cache {
   pub fn new(options: Arc<CompilerOptions>) -> Self {
     Self {
-      is_idle: true.into(),
       code_generate_occasion: CodeGenerateOccasion::new(new_storage(&options.cache)),
       process_runtime_requirements_occasion: ProcessRuntimeRequirementsOccasion::new(new_storage(
         &options.cache,
@@ -40,12 +32,10 @@ impl Cache {
   }
 
   pub fn begin_idle(&self) {
-    if self.is_idle.load(Ordering::Relaxed) {
-      // TODO clean cache
-    }
+    self.code_generate_occasion.begin_idle();
+    self.process_runtime_requirements_occasion.begin_idle();
+    self.chunk_render_occasion.begin_idle();
   }
 
-  pub fn end_idle(&self) {
-    self.is_idle.store(false, Ordering::Relaxed);
-  }
+  pub fn end_idle(&self) {}
 }

--- a/crates/rspack_core/src/old_cache/occasion/chunk_render.rs
+++ b/crates/rspack_core/src/old_cache/occasion/chunk_render.rs
@@ -17,6 +17,12 @@ impl ChunkRenderOccasion {
     Self { storage }
   }
 
+  pub fn begin_idle(&self) {
+    if let Some(s) = &self.storage {
+      s.begin_idle();
+    }
+  }
+
   pub async fn use_cache<G, F>(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_core/src/old_cache/occasion/code_generate.rs
+++ b/crates/rspack_core/src/old_cache/occasion/code_generate.rs
@@ -16,6 +16,12 @@ impl CodeGenerateOccasion {
     Self { storage }
   }
 
+  pub fn begin_idle(&self) {
+    if let Some(s) = &self.storage {
+      s.begin_idle();
+    }
+  }
+
   // #[tracing::instrument(skip_all, fields(module = ?job.module))]
   pub fn use_cache(
     &self,

--- a/crates/rspack_core/src/old_cache/occasion/process_runtime_requirements.rs
+++ b/crates/rspack_core/src/old_cache/occasion/process_runtime_requirements.rs
@@ -18,6 +18,12 @@ impl ProcessRuntimeRequirementsOccasion {
     Self { storage }
   }
 
+  pub fn begin_idle(&self) {
+    if let Some(s) = &self.storage {
+      s.begin_idle();
+    }
+  }
+
   // #[tracing::instrument(skip_all, fields(module = ?module))]
   pub fn use_cache(
     &self,

--- a/crates/rspack_core/src/old_cache/storage/memory.rs
+++ b/crates/rspack_core/src/old_cache/storage/memory.rs
@@ -1,16 +1,34 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use dashmap::DashMap;
 use rspack_collections::{Identifier, IdentifierDashMap};
 
 use super::Storage;
 
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct CacheData<Item> {
+  item: Item,
+  generation: u32,
+}
+
+impl<Item> CacheData<Item> {
+  fn new(item: Item, generation: u32) -> Self {
+    Self { item, generation }
+  }
+}
+
 #[derive(Debug)]
 pub struct MemoryStorage<Item> {
-  data: IdentifierDashMap<Item>,
+  generation: AtomicU32,
+  max_generations: u32,
+  data: IdentifierDashMap<CacheData<Item>>,
 }
 
 impl<Item> MemoryStorage<Item> {
-  pub fn new() -> Self {
+  pub fn new(max_generations: u32) -> Self {
     Self {
+      generation: AtomicU32::new(0),
+      max_generations,
       data: DashMap::default(),
     }
   }
@@ -21,12 +39,31 @@ where
   Item: Clone + std::fmt::Debug + Send + Sync,
 {
   fn get(&self, id: &Identifier) -> Option<Item> {
-    self.data.get(id).map(|item| item.clone())
+    self.data.get_mut(id).map(|mut item| {
+      // Reset the generation to the current generation if the item is accessed
+      item.generation = self.generation.load(Ordering::Relaxed);
+      item.item.clone()
+    })
   }
   fn set(&self, id: Identifier, data: Item) {
-    self.data.insert(id, data);
+    self.data.insert(
+      id,
+      CacheData::new(data, self.generation.load(Ordering::Relaxed)),
+    );
   }
   fn remove(&self, id: &Identifier) {
     self.data.remove(id);
+  }
+  fn begin_idle(&self) {
+    let generation = self.generation.fetch_add(1, Ordering::Relaxed) + 1;
+    self.data.retain(|_, cache_data| {
+      // Remove the data if it is not accessed for `max_generations`.
+      // With `max_generations` set to x, the cache was generated on generation y, will be removed on generation x + y + 1.
+      //
+      // For example:
+      // Cache created on generation 0 will be removed on generation 2 with `max_generations` set to 1,
+      // If it's not accessed on generation 1.
+      cache_data.generation.saturating_add(self.max_generations) >= generation
+    });
   }
 }

--- a/crates/rspack_core/src/old_cache/storage/mod.rs
+++ b/crates/rspack_core/src/old_cache/storage/mod.rs
@@ -11,7 +11,7 @@ pub trait Storage<Item>: Debug + Send + Sync {
   fn get(&self, id: &Identifier) -> Option<Item>;
   fn set(&self, id: Identifier, data: Item);
   fn remove(&self, id: &Identifier);
-  // fn begin_idle(&self);
+  fn begin_idle(&self);
   // fn end_idle(&self);
   // fn clear(&self);
 }
@@ -22,6 +22,8 @@ where
 {
   match options {
     CacheOptions::Disabled => None,
-    _ => Some(Box::new(MemoryStorage::new())),
+    CacheOptions::Memory { max_generations } => {
+      Some(Box::new(MemoryStorage::new(max_generations.unwrap_or(1))))
+    }
   }
 }

--- a/crates/rspack_core/src/options/cache.rs
+++ b/crates/rspack_core/src/options/cache.rs
@@ -2,5 +2,11 @@
 pub enum CacheOptions {
   #[default]
   Disabled,
-  Memory,
+  Memory {
+    /// The maximum number of generations to keep in memory.
+    ///
+    /// For example, if `max_generations` is set to 1,
+    /// the cache will be removed if it's not accessed for 1 compilation generation.
+    max_generations: Option<u32>,
+  },
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Close https://github.com/web-infra-dev/rspack/issues/9405

Added `maxGenerations` support for memory cache. By default, `maxGenerations` is set to 1.

The option is used to define how many cycles will memory cache survive if it's not being accessed to in future generations:
With `max_generations` set to x, the cache was generated on generation y, will be removed on generation x + y + 1. 

For example: Cache created on generation 0 will be removed on generation 2 with `max_generations` set to 1, if it's not accessed on generation 1.

This option is not being exposed to users for now, as the cache key is encoded with hash, resulting it's not likely to be reused between compilations if it's source was changed.

Lifting memory consumption in https://github.com/web-infra-dev/rspack/issues/8976#issuecomment-2656274506

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
