### PR TITLE
perf: try reduce max_blocking_threads to save memory and reduce fs contention

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -340,6 +340,12 @@ enum TraceState {
 #[ctor]
 fn init() {
   panic::install_panic_handler();
+  let rt = tokio::runtime::Builder::new_multi_thread()
+    .max_blocking_threads(8)
+    .enable_all()
+    .build()
+    .expect("Create tokio runtime failed");
+  create_custom_tokio_runtime(rt);
 }
 
 fn print_error_diagnostic(e: rspack_error::Error, colored: bool) -> String {

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -340,8 +340,14 @@ enum TraceState {
 #[ctor]
 fn init() {
   panic::install_panic_handler();
+  // control the number of blocking threads, similar as https://github.com/tokio-rs/tokio/blob/946401c345d672d357693740bc51f77bc678c5c4/tokio/src/loom/std/mod.rs#L93
+  const ENV_BLOCKING_THREADS: &str = "RSPACK_BLOCKING_THREADS";
+  let blocking_threads = std::env::var(ENV_BLOCKING_THREADS)
+    .ok()
+    .and_then(|v| v.parse::<usize>().ok())
+    .unwrap_or(8);
   let rt = tokio::runtime::Builder::new_multi_thread()
-    .max_blocking_threads(8)
+    .max_blocking_threads(blocking_threads)
     .enable_all()
     .build()
     .expect("Create tokio runtime failed");

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -342,10 +342,17 @@ fn init() {
   panic::install_panic_handler();
   // control the number of blocking threads, similar as https://github.com/tokio-rs/tokio/blob/946401c345d672d357693740bc51f77bc678c5c4/tokio/src/loom/std/mod.rs#L93
   const ENV_BLOCKING_THREADS: &str = "RSPACK_BLOCKING_THREADS";
+  // reduce default blocking threads on macOS cause macOS holds IORWLock on every file open
+  // reference from https://github.com/oven-sh/bun/pull/17577/files#diff-c9bc275f9466e5179bb80454b6445c7041d2a0fb79932dd5de7a5c3196bdbd75R144
+  let default_blocking_threads = if std::env::consts::OS == "macos" {
+    8
+  } else {
+    512
+  };
   let blocking_threads = std::env::var(ENV_BLOCKING_THREADS)
     .ok()
     .and_then(|v| v.parse::<usize>().ok())
-    .unwrap_or(8);
+    .unwrap_or(default_blocking_threads);
   let rt = tokio::runtime::Builder::new_multi_thread()
     .max_blocking_threads(blocking_threads)
     .enable_all()


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
inspired by https://x.com/jarredsumner/status/1893195528764076534 
it seems result is not bad,15% faster(bench based on https://github.com/rspack-contrib/build-tools-performance on macOS) with 20% memory reduction, and I think the cause is
* every thread will allocation 2M memory, even the thread is lazy initialized we still get about hundreds of threads sometimes which bloat memory
* less thread with less lock contention
![image](https://github.com/user-attachments/assets/55e0a7b0-a5ee-4f28-bfc7-101a21308466)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
