### PR TITLE
refactor(rust): improve `replace_all_placeholder`

### DIFF
--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -341,7 +341,7 @@ fn render_template(
   }
   if let Some(hash) = options.chunk_hash {
     t = t.map(|t| {
-      t.replace_all(CHUNK_HASH_PLACEHOLDER, |len| {
+      t.replace_all_with_len(CHUNK_HASH_PLACEHOLDER, |len| {
         let hash: &str = &hash[..hash_len(hash, len)];
         if let Some(asset_info) = asset_info.as_mut() {
           asset_info.set_immutable(Some(true));

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -17,7 +17,7 @@ use rspack_util::atom::Atom;
 use rspack_util::ext::CowExt;
 use rspack_util::MergeFrom;
 
-use crate::replace_all_placeholder;
+use crate::ReplaceAllPlaceholder;
 use crate::{parse_resource, AssetInfo, PathData, ResourceParsedData};
 
 static FILE_PLACEHOLDER: &str = "[file]";
@@ -244,15 +244,14 @@ fn render_template(
         .unwrap_or("");
 
       t = t
-        .map(|t| replace_all_placeholder(t, FILE_PLACEHOLDER, ""))
-        .map(|t| replace_all_placeholder(t, QUERY_PLACEHOLDER, ""))
-        .map(|t| replace_all_placeholder(t, FRAGMENT_PLACEHOLDER, ""))
-        .map(|t| replace_all_placeholder(t, PATH_PLACEHOLDER, ""))
-        .map(|t| replace_all_placeholder(t, BASE_PLACEHOLDER, replacer))
-        .map(|t| replace_all_placeholder(t, NAME_PLACEHOLDER, replacer))
+        .map(|t| t.replace_all(FILE_PLACEHOLDER, ""))
+        .map(|t| t.replace_all(QUERY_PLACEHOLDER, ""))
+        .map(|t| t.replace_all(FRAGMENT_PLACEHOLDER, ""))
+        .map(|t| t.replace_all(PATH_PLACEHOLDER, ""))
+        .map(|t| t.replace_all(BASE_PLACEHOLDER, replacer))
+        .map(|t| t.replace_all(NAME_PLACEHOLDER, replacer))
         .map(|t| {
-          replace_all_placeholder(
-            t,
+          t.replace_all(
             EXT_PLACEHOLDER,
             &ext.map(|ext| format!(".{ext}")).unwrap_or_default(),
           )
@@ -264,10 +263,9 @@ fn render_template(
     }) = parse_resource(filename)
     {
       t = t
-        .map(|t| replace_all_placeholder(t, FILE_PLACEHOLDER, file.as_str()))
+        .map(|t| t.replace_all(FILE_PLACEHOLDER, file.as_str()))
         .map(|t| {
-          replace_all_placeholder(
-            t,
+          t.replace_all(
             EXT_PLACEHOLDER,
             &file
               .extension()
@@ -277,15 +275,14 @@ fn render_template(
         });
 
       if let Some(base) = file.file_name() {
-        t = t.map(|t| replace_all_placeholder(t, BASE_PLACEHOLDER, base));
+        t = t.map(|t| t.replace_all(BASE_PLACEHOLDER, base));
       }
       if let Some(name) = file.file_stem() {
-        t = t.map(|t| replace_all_placeholder(t, NAME_PLACEHOLDER, name));
+        t = t.map(|t| t.replace_all(NAME_PLACEHOLDER, name));
       }
       t = t
         .map(|t| {
-          replace_all_placeholder(
-            t,
+          t.replace_all(
             PATH_PLACEHOLDER,
             &file
               .parent()
@@ -295,15 +292,15 @@ fn render_template(
               .unwrap_or_default(),
           )
         })
-        .map(|t| replace_all_placeholder(t, QUERY_PLACEHOLDER, &query.unwrap_or_default()))
-        .map(|t| replace_all_placeholder(t, FRAGMENT_PLACEHOLDER, &fragment.unwrap_or_default()));
+        .map(|t| t.replace_all(QUERY_PLACEHOLDER, &query.unwrap_or_default()))
+        .map(|t| t.replace_all(FRAGMENT_PLACEHOLDER, &fragment.unwrap_or_default()));
     }
   }
   // compilation-level
   if let Some(hash) = options.hash {
     for key in [HASH_PLACEHOLDER, FULL_HASH_PLACEHOLDER] {
       t = t.map(|t| {
-        replace_all_placeholder(t, key, |len| {
+        t.replace_all_with_len(key, |len| {
           let hash = &hash[..hash_len(hash, len)];
           if let Some(asset_info) = asset_info.as_mut() {
             asset_info.set_immutable(Some(true));
@@ -316,11 +313,11 @@ fn render_template(
   }
   // shared by chunk-level and module-level
   if let Some(id) = options.id {
-    t = t.map(|t| replace_all_placeholder(t, ID_PLACEHOLDER, id));
+    t = t.map(|t| t.replace_all(ID_PLACEHOLDER, id));
   } else if let Some(chunk_id) = options.chunk_id {
-    t = t.map(|t| replace_all_placeholder(t, ID_PLACEHOLDER, chunk_id));
+    t = t.map(|t| t.replace_all(ID_PLACEHOLDER, chunk_id));
   } else if let Some(module_id) = options.module_id {
-    t = t.map(|t| replace_all_placeholder(t, ID_PLACEHOLDER, module_id));
+    t = t.map(|t| t.replace_all(ID_PLACEHOLDER, module_id));
   }
   if let Some(content_hash) = options.content_hash {
     if let Some(asset_info) = asset_info.as_mut() {
@@ -328,7 +325,7 @@ fn render_template(
       asset_info.version = content_hash.to_string();
     }
     t = t.map(|t| {
-      replace_all_placeholder(t, CONTENT_HASH_PLACEHOLDER, |len| {
+      t.replace_all_with_len(CONTENT_HASH_PLACEHOLDER, |len| {
         let hash: &str = &content_hash[..hash_len(content_hash, len)];
         if let Some(asset_info) = asset_info.as_mut() {
           asset_info.set_immutable(Some(true));
@@ -340,11 +337,11 @@ fn render_template(
   }
   // chunk-level
   if let Some(name) = options.chunk_name {
-    t = t.map(|t| replace_all_placeholder(t, NAME_PLACEHOLDER, name));
+    t = t.map(|t| t.replace_all(NAME_PLACEHOLDER, name));
   }
   if let Some(hash) = options.chunk_hash {
     t = t.map(|t| {
-      replace_all_placeholder(t, CHUNK_HASH_PLACEHOLDER, |len| {
+      t.replace_all(CHUNK_HASH_PLACEHOLDER, |len| {
         let hash: &str = &hash[..hash_len(hash, len)];
         if let Some(asset_info) = asset_info.as_mut() {
           asset_info.set_immutable(Some(true));
@@ -355,9 +352,9 @@ fn render_template(
     });
   }
   // other things
-  t = t.map(|t| replace_all_placeholder(t, RUNTIME_PLACEHOLDER, options.runtime.unwrap_or("_")));
+  t = t.map(|t| t.replace_all(RUNTIME_PLACEHOLDER, options.runtime.unwrap_or("_")));
   if let Some(url) = options.url {
-    t = t.map(|t| replace_all_placeholder(t, URL_PLACEHOLDER, url));
+    t = t.map(|t| t.replace_all(URL_PLACEHOLDER, url));
   }
   t.into_owned()
 }

--- a/crates/rspack_core/src/utils/hash.rs
+++ b/crates/rspack_core/src/utils/hash.rs
@@ -140,7 +140,7 @@ pub trait ReplaceAllPlaceholder {
 impl ReplaceAllPlaceholder for str {
   #[inline]
   fn replace_all<'a>(&'a self, placeholder: &'a str, replacer: impl Replacer) -> Cow<'a, str> {
-    replace_all_placeholder_impl(&self, false, placeholder, replacer)
+    replace_all_placeholder_impl(self, false, placeholder, replacer)
   }
 
   #[inline]
@@ -149,7 +149,7 @@ impl ReplaceAllPlaceholder for str {
     placeholder: &'a str,
     replacer: impl Replacer,
   ) -> Cow<'a, str> {
-    replace_all_placeholder_impl(&self, true, placeholder, replacer)
+    replace_all_placeholder_impl(self, true, placeholder, replacer)
   }
 }
 

--- a/crates/rspack_core/src/utils/hash.rs
+++ b/crates/rspack_core/src/utils/hash.rs
@@ -36,19 +36,19 @@ pub fn include_hash(filename: &str, hashes: &HashSet<String>) -> bool {
 }
 
 pub trait Replacer {
-  fn get_replacer(&mut self, hash_len: Option<usize>) -> Cow<'_, str>;
+  fn get(&mut self, hash_len: Option<usize>) -> Cow<'_, str>;
 }
 
 impl Replacer for &str {
   #[inline]
-  fn get_replacer(&mut self, _: Option<usize>) -> Cow<'_, str> {
+  fn get(&mut self, _: Option<usize>) -> Cow<'_, str> {
     Cow::Borrowed(self)
   }
 }
 
 impl Replacer for &String {
   #[inline]
-  fn get_replacer(&mut self, _: Option<usize>) -> Cow<'_, str> {
+  fn get(&mut self, _: Option<usize>) -> Cow<'_, str> {
     Cow::Borrowed(self.as_str())
   }
 }
@@ -59,62 +59,110 @@ where
   S: AsRef<str>,
 {
   #[inline]
-  fn get_replacer(&mut self, hash_len: Option<usize>) -> Cow<'_, str> {
+  fn get(&mut self, hash_len: Option<usize>) -> Cow<'_, str> {
     Cow::Owned((*self)(hash_len).as_ref().to_string())
   }
 }
 
-/// Replace all `[placeholder]` or `[placeholder:8]` in the pattern
-pub fn replace_all_placeholder<'a>(
+fn replace_all_placeholder_impl<'a>(
   pattern: &'a str,
-  placeholder: &'a str,
+  is_len_enabled: bool,
+  mut placeholder: &'a str,
   mut replacer: impl Replacer,
 ) -> Cow<'a, str> {
   let offset = placeholder.len() - 1;
-  let mut iter = pattern.match_indices(&placeholder[..offset]).peekable();
+
+  if is_len_enabled {
+    placeholder = &placeholder[..offset];
+  }
+
+  let mut iter = pattern.match_indices(placeholder).peekable();
 
   if iter.peek().is_none() {
     return Cow::Borrowed(pattern);
   }
 
-  let mut ending = 0;
+  let mut last_end = 0;
   let mut result = String::with_capacity(pattern.len());
 
   for (start, _) in iter {
-    if start < ending {
+    if start < last_end {
       continue;
     }
 
     let start_offset = start + offset;
-    if let Some(end) = pattern[start_offset..].find(']') {
-      let end = start_offset + end;
+    let (end, len) = if is_len_enabled {
+      let rest = &pattern[start_offset..];
+      match rest.as_bytes().first() {
+        Some(&b':') => {
+          if let Some(index) = rest.find(']') {
+            match rest[1..index].parse::<usize>() {
+              Ok(len) => (start_offset + index, Some(len)),
+              Err(_) => continue,
+            }
+          } else {
+            continue;
+          }
+        }
+        Some(&b']') => (start_offset, None),
+        _ => continue,
+      }
+    } else {
+      (start_offset, None)
+    };
 
-      let replacer = replacer.get_replacer(
-        pattern[start_offset..end]
-          .strip_prefix(':')
-          .and_then(|n| n.parse::<usize>().ok()),
-      );
+    let replacer = replacer.get(len);
 
-      result.push_str(&pattern[ending..start]);
-      result.push_str(replacer.as_ref());
+    result.push_str(&pattern[last_end..start]);
+    result.push_str(replacer.as_ref());
 
-      ending = end + 1;
-    }
+    last_end = end + 1;
   }
 
-  if ending < pattern.len() {
-    result.push_str(&pattern[ending..]);
+  if last_end < pattern.len() {
+    result.push_str(&pattern[last_end..]);
   }
 
   Cow::Owned(result)
 }
 
+/// Replace all `[placeholder]` or `[placeholder:8]` in the pattern
+pub trait ReplaceAllPlaceholder {
+  fn replace_all<'a>(&'a self, placeholder: &'a str, replacer: impl Replacer) -> Cow<'a, str>;
+
+  fn replace_all_with_len<'a>(
+    &'a self,
+    placeholder: &'a str,
+    replacer: impl Replacer,
+  ) -> Cow<'a, str>;
+}
+
+impl ReplaceAllPlaceholder for str {
+  #[inline]
+  fn replace_all<'a>(&'a self, placeholder: &'a str, replacer: impl Replacer) -> Cow<'a, str> {
+    replace_all_placeholder_impl(&self, false, placeholder, replacer)
+  }
+
+  #[inline]
+  fn replace_all_with_len<'a>(
+    &'a self,
+    placeholder: &'a str,
+    replacer: impl Replacer,
+  ) -> Cow<'a, str> {
+    replace_all_placeholder_impl(&self, true, placeholder, replacer)
+  }
+}
+
 #[test]
 fn test_replace_all_placeholder() {
-  let result = replace_all_placeholder("hello-[hash].js", "[hash]", "abc");
-  assert_eq!(result, "hello-abc.js");
-  let result = replace_all_placeholder("hello-[hash]-[hash:5].js", "[hash]", |n: Option<usize>| {
-    &"abcdefgh"[..n.unwrap_or(8)]
-  });
-  assert_eq!(result, "hello-abcdefgh-abcde.js");
+  let result = "hello-[hash]-[hash_name]-[hash:1].js".replace_all("[hash]", "abc");
+  assert_eq!(result, "hello-abc-[hash_name]-[hash:1].js");
+
+  let result =
+    "hello-[hash]-[hash:-]-[hash_name]-[hash:1]-[hash:].js".replace_all_with_len("[hash]", "abc");
+  assert_eq!(result, "hello-abc-[hash:-]-[hash_name]-abc-[hash:].js");
+
+  let result = "hello-[hash]-[hash:5]-[hash_name]-[hash:o].js"
+    .replace_all_with_len("[hash]", |n: Option<usize>| &"abcdefgh"[..n.unwrap_or(8)]);
+  assert_eq!(result, "hello-abcdefgh-abcde-[hash_name]-[hash:o].js");
 }


### PR DESCRIPTION
## Summary

Related to #9304 

I made some improvements to ensure optimal performance in general cases while achieving a slight performance boost. Additionally, I fixed boundary errors in the `[hash:8]` case to maintain correctness and ensure consistent performance.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
