### PR TITLE
fix(html): include `innerHTML` content in rendered asset tags

### DIFF
--- a/crates/rspack_plugin_html/src/tag.rs
+++ b/crates/rspack_plugin_html/src/tag.rs
@@ -8,7 +8,7 @@ use serde::{
   Deserialize, Deserializer, Serialize, Serializer,
 };
 use swc_core::{atoms::Atom, common::DUMMY_SP};
-use swc_html::ast::{Attribute, Element, Namespace};
+use swc_html::ast::{Attribute, Child, Element, Namespace, Text};
 
 use crate::config::{HtmlRspackPluginBaseOptions, HtmlScriptLoading};
 
@@ -279,7 +279,13 @@ impl From<HtmlPluginTag> for Element {
         .sorted_unstable_by(|a, b| a.attr_name.cmp(&b.attr_name))
         .map(Attribute::from)
         .collect::<Vec<_>>(),
-      children: vec![],
+      children: tag.inner_html.map_or(vec![], |inner_html| {
+        vec![Child::Text(Text {
+          span: DUMMY_SP,
+          data: Atom::from(inner_html),
+          raw: None,
+        })]
+      }),
       content: None,
       is_self_closing: tag.void_tag,
       namespace: Namespace::HTML,

--- a/tests/e2e/cases/html/asset-tag-hooks/index.test.ts
+++ b/tests/e2e/cases/html/asset-tag-hooks/index.test.ts
@@ -1,0 +1,12 @@
+import {test, expect} from "@/fixtures";
+
+test("should inject innerHTML for added asset tags", async ({
+    page
+}) => {
+    const scripts = await page.$$("script[id=inner-html-tag]");
+
+    for (const script of scripts) {
+        const innerHtml = await script.innerHTML();
+        expect(innerHtml).toEqual('console.log("injected source code");');
+    }
+});

--- a/tests/e2e/cases/html/asset-tag-hooks/rspack.config.js
+++ b/tests/e2e/cases/html/asset-tag-hooks/rspack.config.js
@@ -1,0 +1,33 @@
+const {rspack} = require("@rspack/core");
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+  context: __dirname,
+  mode: "development",
+  entry: "./src/index.js",
+  stats: "none",
+  plugins: [
+    new rspack.HtmlRspackPlugin({
+      template: "./src/index.html"
+    }),
+    {
+      /** @param {import('@rspack/core').Compiler} compiler */
+      apply(compiler) {
+        compiler.hooks.compilation.tap("TestPlugin", (compilation) => {
+          rspack.HtmlRspackPlugin.getCompilationHooks(compilation).alterAssetTags.tap("TestPlugin", (data) => {
+            data.assetTags.scripts.push({
+              tagName: 'script',
+              innerHTML: 'console.log("injected source code");',
+              voidTag: false,
+              attributes: {id: 'inner-html-tag'},
+            })
+            return data;
+          });
+        });
+      }
+    }
+  ],
+  devServer: {
+    port: 3000
+  }
+};

--- a/tests/e2e/cases/html/asset-tag-hooks/src/index.html
+++ b/tests/e2e/cases/html/asset-tag-hooks/src/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head> </head>
+	<body>
+		<div id="root"></div>
+	</body>
+</html>


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

I was trying to implement an `HtmlRspackPlugin` addition using the `alterAssetTags` hook, and for my use case I needed to set `innerHTML` on the generated tag (to get something like `<script>console.log("Hello")</script>`). After a lot of confusion about why things weren't showing up as I expected and instead got empty tags, I went to look at the implementation and found that [`HtmlPluginTag` was always setting `children` to an empty vector](https://github.com/web-infra-dev/rspack/blob/39f2bfba38266f72ea9e2dcdaacffe5a23cc322f/crates/rspack_plugin_html/src/tag.rs#L282).

This PR fixes that to render the `innerHTML` property of the tag there as a plain `Text` node if it's present. I also tried to add an end to end test for this, but wasn't able to get them running locally immediately, so hopefully CI will indicate if it's correct, otherwise I'll get them set up and running to try it out.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
