### PR TITLE
docs: update Module Federation syntax downgrade FAQ

### DIFF
--- a/website/docs/en/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/en/plugins/webpack/module-federation-plugin.mdx
@@ -158,17 +158,14 @@ The SharedConfig can include the following sub-options:
 
 - Found non-downgraded syntax in the build output?
 
-  If you need to be compatible with legacy browsers, please add [builtin:swc-loader](/guide/features/builtin-swc-loader) for syntax downgrade, and make sure it matches `@module-federation/runtime` and `@module-federation/sdk`. Here is an example:
+  If you need to be compatible with legacy browsers, please add [builtin:swc-loader](/guide/features/builtin-swc-loader) for syntax downgrade, and make sure it matches packages under `@module-federation` scope. Here is an example:
 
   ```js title="rspack.config.mjs"
   export default {
     module: {
       rules: [
         {
-          include: [
-            /@module-federation[\\/]sdk/,
-            /@module-federation[\\/]runtime/,
-          ],
+          include: [/@module-federation[\\/]/],
           use: {
             loader: 'builtin:swc-loader',
             options: {

--- a/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
@@ -158,17 +158,14 @@ export default {
 
 - 构建产物中存在未降级语法？
 
-  如果你需要兼容低版本浏览器，请添加 [builtin:swc-loader](/guide/features/builtin-swc-loader) 进行语法降级，需要匹配 `@module-federation/runtime` 和 `@module-federation/sdk`。示例如下：
+  如果你需要兼容低版本浏览器，请添加 [builtin:swc-loader](/guide/features/builtin-swc-loader) 进行语法降级，需要匹配 `@module-federation` scope 下的 npm 包。示例如下：
 
   ```js title="rspack.config.mjs"
   export default {
     module: {
       rules: [
         {
-          include: [
-            /@module-federation[\\/]sdk/,
-            /@module-federation[\\/]runtime/,
-          ],
+          include: [/@module-federation[\\/]/],
           use: {
             loader: 'builtin:swc-loader',
             options: {


### PR DESCRIPTION
## Summary

Update Module Federation syntax downgrade FAQ, add all `@module-federation/*` packages to `source.include` to avoid browser compatibility issues.

This change is to fix a syntax issue introduced in `@module-federation/webpack-bundler-runtime` in 0.9.1.

<img width="1294" alt="Screenshot 2025-03-03 at 10 28 30" src="https://github.com/user-attachments/assets/87aef811-f594-4605-8c3a-ae59816252fc" />

## Related links

- https://github.com/module-federation/core/pull/3565
- https://github.com/web-infra-dev/rsbuild/actions/runs/13622050663/job/38073072909?pr=4690#step:7:920

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
