### PR TITLE
feat(memory-allocator): use mimalloc-v3 on macOS and bump mimalloc to v2.1.7 on other platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,16 +2683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libmimalloc-sys-rspack"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7997f74815cc4b73f7b1897f13aed74d8ea49e7d86192d9c08779edfc9e1d9f"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,11 +2953,11 @@ dependencies = [
 
 [[package]]
 name = "mimalloc-rspack"
-version = "0.1.44"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63bb1f78735e4b7d309a05ea64f47b70a9b0ca3d0b6a6e4470f99915cdb836c6"
+checksum = "4a20c79e2af9969e00c35087512ea1d35b11b728b4f0448c595822247f33adcf"
 dependencies = [
- "libmimalloc-sys-rspack",
+ "rspack-libmimalloc-sys",
 ]
 
 [[package]]
@@ -4200,6 +4190,16 @@ dependencies = [
  "rustc-hash 2.1.0",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "rspack-libmimalloc-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8b968dfa086e029c06fd926d1db4c8a40d08c28edd4b23ecddab5eb73baacbc"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc-rspack"
-version = "0.2.2"
+version = "0.2.3-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a20c79e2af9969e00c35087512ea1d35b11b728b4f0448c595822247f33adcf"
+checksum = "92adcff8fb05d665068ae7fbab197804ed828467d6e6d6c04235615ab2429855"
 dependencies = [
  "rspack-libmimalloc-sys",
 ]
@@ -4194,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "rspack-libmimalloc-sys"
-version = "0.2.2"
+version = "0.2.3-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b968dfa086e029c06fd926d1db4c8a40d08c28edd4b23ecddab5eb73baacbc"
+checksum = "4b656d1a2d8267d4924922633fe83ac249db9ef109c7281492b1eb1493632ba2"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc-rspack"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92adcff8fb05d665068ae7fbab197804ed828467d6e6d6c04235615ab2429855"
+checksum = "4e7183f84cbe10d63d277f1dce9e04a41a6670247f1e2171024d3474fd6b49b3"
 dependencies = [
  "rspack-libmimalloc-sys",
 ]
@@ -4194,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "rspack-libmimalloc-sys"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b656d1a2d8267d4924922633fe83ac249db9ef109c7281492b1eb1493632ba2"
+checksum = "77d3261219a73922d83550152a76313a7eb897bed1352d838f53e7bb284091ab"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ itertools          = { version = "0.14.0" }
 json               = { version = "0.12.4" }
 lightningcss       = { version = "1.0.0-alpha.63" }
 linked_hash_set    = { version = "0.1.5" }
-mimalloc           = { version = "0.2.2", package = "mimalloc-rspack" }
+mimalloc           = { version = "0.2.3-alpha.0", package = "mimalloc-rspack" }
 mime_guess         = { version = "2.0.5" }
 once_cell          = { version = "1.20.2" }
 parcel_sourcemap   = { version = "2.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ itertools          = { version = "0.14.0" }
 json               = { version = "0.12.4" }
 lightningcss       = { version = "1.0.0-alpha.63" }
 linked_hash_set    = { version = "0.1.5" }
-mimalloc           = { version = "0.1.44", package = "mimalloc-rspack" }
+mimalloc           = { version = "0.2.2", package = "mimalloc-rspack" }
 mime_guess         = { version = "2.0.5" }
 once_cell          = { version = "1.20.2" }
 parcel_sourcemap   = { version = "2.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ itertools          = { version = "0.14.0" }
 json               = { version = "0.12.4" }
 lightningcss       = { version = "1.0.0-alpha.63" }
 linked_hash_set    = { version = "0.1.5" }
-mimalloc           = { version = "0.2.3-alpha.0", package = "mimalloc-rspack" }
+mimalloc           = { version = "0.2.3", package = "mimalloc-rspack" }
 mime_guess         = { version = "2.0.5" }
 once_cell          = { version = "1.20.2" }
 parcel_sourcemap   = { version = "2.1.1" }

--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -11,5 +11,8 @@ version     = "0.2.0"
 # Turned on `local_dynamic_tls` to avoid issue: https://github.com/microsoft/mimalloc/issues/147
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 
-[target.'cfg(not(target_os = "linux"))'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
+mimalloc = { workspace = true, features = ["v3"] }
+
+[target.'cfg(all(not(target_os = "linux"), not(target_os = "macos")))'.dependencies]
 mimalloc = { workspace = true }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. Bumped mimalloc to v3 for macOS. 

According to my [investigation](https://github.com/microsoft/mimalloc/issues/1025#issuecomment-2693504806), although memory is still growing, upgrading mimalloc to v3 will greatly mitigate the memory bloating issue in development mode. That is to say, memory growing is slower than it was on mimalloc-v2 for each time the compiler rebuilds:

**With mimalloc dev3-bin:**
```
hyperfine --warmup 2 --runs 5 './target/release/mimalloc-test'
Benchmark 1: ./target/release/mimalloc-test
  Time (mean ± σ):      9.230 s ±  0.157 s    [User: 28.923 s, System: 13.791 s]
  Range (min … max):    9.052 s …  9.450 s    5 runs
```

**With mimalloc dev2-bin (rspack main):**
```
hyperfine --warmup 2 --runs 5 './target/release/mimalloc-test'
Benchmark 1: ./target/release/mimalloc-test
  Time (mean ± σ):      9.360 s ±  0.126 s    [User: 29.537 s, System: 14.543 s]
  Range (min … max):    9.216 s …  9.525 s    5 runs
```

Case: building 10000 modules and rebuild 10 times, for each time a new `console.log` will be written to the entry module.

2. Bumped mimalloc to v2.1.7 for non-macOS platforms.

This is the latest version of mimalloc-v2. We don't want to rollout too much change at once. So we're staying at v2 at least for now.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
