### PR TITLE
fix: should give js entry dependency id when hit cache

### DIFF
--- a/crates/node_binding/src/compilation/mod.rs
+++ b/crates/node_binding/src/compilation/mod.rs
@@ -736,6 +736,7 @@ impl JsCompilation {
         let dependency = if let Some(map) = include_dependencies_map.get(&js_dependency.request)
           && let Some(dependency) = map.get(&options)
         {
+          js_dependency.dependency_id = Some(*dependency.id());
           dependency.clone()
         } else {
           let dependency = js_dependency.resolve(js_context.into(), layer)?;

--- a/packages/rspack-test-tools/tests/watchCases/add-include/reuse-deps-for-incremental-make/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/add-include/reuse-deps-for-incremental-make/rspack.config.js
@@ -9,12 +9,15 @@ module.exports = {
 			const { EntryPlugin } = compiler.webpack;
 			compiler.hooks.finishMake.tapPromise(PLUGIN_NAME, compilation => {
 				return new Promise((resolve, reject) => {
+					const dependency = EntryPlugin.createDependency("./foo.js");
 					compilation.addInclude(
 						compiler.context,
-						EntryPlugin.createDependency("./foo.js"),
+						dependency,
 						{},
 						err => {
 							if (err) return reject(err);
+							const module = compilation.moduleGraph.getModule(dependency);
+							expect(module).toBeTruthy();
 							return resolve();
 						}
 					);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

When hit the cache for js dependency, should give the dependency id to js object.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
