### PR TITLE
fix: change module matchResource in loader

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -260,6 +260,7 @@ export declare class JsModule {
   libIdent(options: JsLibIdentOptions): string | null
   get resourceResolveData(): JsResourceData | undefined
   get matchResource(): string | undefined
+  set matchResource(val: string | undefined)
   emitFile(filename: string, source: JsCompatSource, jsAssetInfo?: AssetInfo | undefined | null): void
 }
 

--- a/crates/node_binding/src/module.rs
+++ b/crates/node_binding/src/module.rs
@@ -4,8 +4,9 @@ use napi::JsString;
 use napi_derive::napi;
 use rspack_collections::{IdentifierMap, UkeyMap};
 use rspack_core::{
-  BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, Compilation, CompilationAsset,
-  CompilerId, LibIdentOptions, Module, ModuleIdentifier, RuntimeModuleStage, SourceType,
+  parse_resource, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, Compilation,
+  CompilationAsset, CompilerId, LibIdentOptions, Module, ModuleIdentifier, ResourceData,
+  ResourceParsedData, RuntimeModuleStage, SourceType,
 };
 use rspack_napi::{
   napi::bindgen_prelude::*, threadsafe_function::ThreadsafeFunction, OneShotInstanceRef,
@@ -318,6 +319,30 @@ impl JsModule {
       },
       None => Either::B(()),
     })
+  }
+
+  #[napi(setter)]
+  pub fn set_match_resource(&mut self, val: Either<String, ()>) -> napi::Result<()> {
+    match val {
+      Either::A(val) => {
+        let module: &mut dyn Module = self.as_mut()?;
+        if let Ok(normal_module) = module.try_as_normal_module_mut() {
+          let ResourceParsedData {
+            path,
+            query,
+            fragment,
+          } = parse_resource(&val).expect("Should parse resource");
+          *normal_module.match_resource_mut() = Some(
+            ResourceData::new(val)
+              .path(path)
+              .query_optional(query)
+              .fragment_optional(fragment),
+          );
+        }
+      }
+      Either::B(_) => {}
+    }
+    Ok(())
   }
 
   #[napi]

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -226,6 +226,10 @@ impl NormalModule {
     self.match_resource.as_ref()
   }
 
+  pub fn match_resource_mut(&mut self) -> &mut Option<ResourceData> {
+    &mut self.match_resource
+  }
+
   pub fn resource_resolved_data(&self) -> &ResourceData {
     &self.resource_data
   }

--- a/packages/rspack-test-tools/tests/configCases/asset/change-filename-by-match-resource/index.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/change-filename-by-match-resource/index.js
@@ -1,0 +1,5 @@
+import img from './img.png';
+
+it("should have the correct asset filename", () => {
+	expect(img).toBe("assets/renamed-img.jpg");
+})

--- a/packages/rspack-test-tools/tests/configCases/asset/change-filename-by-match-resource/loader.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/change-filename-by-match-resource/loader.js
@@ -1,0 +1,4 @@
+module.exports = function (source) {
+  this._module.matchResource = "renamed-img.jpg";
+  return source;
+}

--- a/packages/rspack-test-tools/tests/configCases/asset/change-filename-by-match-resource/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/change-filename-by-match-resource/rspack.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		assetModuleFilename: "assets/[name][ext]"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.png$/,
+				use: "./loader.js",
+				type: "asset/resource"
+			}
+		]
+	}
+};

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -327,6 +327,11 @@ export class Module {
 				enumerable: true,
 				get(): string | undefined {
 					return module.matchResource;
+				},
+				set(val: string | undefined) {
+					if (val) {
+						module.matchResource = val;
+					}
 				}
 			}
 		});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

In https://github.com/web-infra-dev/rspack/pull/9177 we add a getter for `Module.matchResource`, which means we can't modify matchResource in loader by `this._module` anymore, this breaks [image-minimizer-webpack-plugin](https://github.com/webpack-contrib/image-minimizer-webpack-plugin/blob/519045cb2cb60acbc834dfe6e899b4874e8d8e99/src/loader.js#L272-L274)

This PR add the setter for compatibility reason, a better solution should be https://github.com/webpack/webpack/pull/18714 (related issue: https://github.com/webpack/webpack/issues/14851)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
