### PR TITLE
fix: should re-build chunk graph when adding a entry connection

### DIFF
--- a/crates/rspack_core/src/artifacts/cgm_hash_artifact.rs
+++ b/crates/rspack_core/src/artifacts/cgm_hash_artifact.rs
@@ -18,8 +18,19 @@ impl CgmHashArtifact {
     hashes.get(runtime)
   }
 
-  pub fn set_hashes(&mut self, module: ModuleIdentifier, hashes: RuntimeSpecMap<RspackHashDigest>) {
-    self.module_to_hashes.insert(module, hashes);
+  pub fn set_hashes(
+    &mut self,
+    module: ModuleIdentifier,
+    hashes: RuntimeSpecMap<RspackHashDigest>,
+  ) -> bool {
+    if let Some(old) = self.module_to_hashes.get(&module)
+      && old == &hashes
+    {
+      false
+    } else {
+      self.module_to_hashes.insert(module, hashes);
+      true
+    }
   }
 
   pub fn remove(&mut self, module: &ModuleIdentifier) -> Option<RuntimeSpecMap<RspackHashDigest>> {

--- a/crates/rspack_core/src/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/build_chunk_graph/incremental.rs
@@ -509,16 +509,14 @@ impl CodeSplitter {
 
     // If after edges rebuild there are still some entries not included in entrypoints
     // then they are new added entries and we build them.
-    if compilation.entries.len() > compilation.entrypoints.len() {
-      let new_entries: Vec<_> = compilation
-        .entries
-        .keys()
-        .filter(|entry| !compilation.entrypoints.contains_key(entry.as_str()))
-        .map(|entry| ChunkReCreation::Entry(entry.to_owned()))
-        .collect();
-      for edge in new_entries {
-        edge.rebuild(self, compilation)?;
-      }
+    let new_entries: Vec<_> = compilation
+      .entries
+      .keys()
+      .filter(|entry| !compilation.entrypoints.contains_key(entry.as_str()))
+      .map(|entry| ChunkReCreation::Entry(entry.to_owned()))
+      .collect();
+    for edge in new_entries {
+      edge.rebuild(self, compilation)?;
     }
 
     // Ensure entrypoints always have the same order with entries

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -273,10 +273,10 @@ impl ChunkGraph {
     compilation: &mut Compilation,
     module_identifier: ModuleIdentifier,
     hashes: RuntimeSpecMap<RspackHashDigest>,
-  ) {
+  ) -> bool {
     compilation
       .cgm_hash_artifact
-      .set_hashes(module_identifier, hashes);
+      .set_hashes(module_identifier, hashes)
   }
 
   pub fn try_get_module_chunks(

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1421,14 +1421,46 @@ impl Compilation {
       for revoked_module in revoked_modules {
         self.cgm_hash_artifact.remove(&revoked_module);
       }
-      let modules = mutations.get_affected_modules_with_chunk_graph(self);
+      let mg = self.get_module_graph();
+      let mut affected_modules = mutations.get_affected_modules_with_module_graph(&mg);
+      for mutation in mutations.iter() {
+        match mutation {
+          Mutation::ModuleSetAsync { module } => {
+            affected_modules.insert(*module);
+          }
+          Mutation::ModuleSetId { module } => {
+            affected_modules.insert(*module);
+            affected_modules.extend(
+              mg.get_incoming_connections(module)
+                .filter_map(|c| c.original_module_identifier),
+            );
+          }
+          Mutation::ChunkAdd { chunk } => {
+            affected_modules.extend(self.chunk_graph.get_chunk_modules_identifier(chunk));
+          }
+          Mutation::ChunkSetId { chunk } => {
+            let chunk = self.chunk_by_ukey.expect_get(chunk);
+            affected_modules.extend(
+              chunk
+                .groups()
+                .iter()
+                .flat_map(|group| {
+                  let group = self.chunk_group_by_ukey.expect_get(group);
+                  group.origins()
+                })
+                .filter_map(|origin| origin.module),
+            );
+          }
+          _ => {}
+        }
+      }
       let logger = self.get_logger("rspack.incremental.modulesHashes");
       logger.log(format!(
         "{} modules are affected, {} in total",
-        modules.len(),
-        self.get_module_graph().modules().len()
+        affected_modules.len(),
+        mg.modules().len()
       ));
-      modules
+      affected_modules
     } else {
       self.get_module_graph().modules().keys().copied().collect()
     };
@@ -1456,7 +1488,13 @@ impl Compilation {
       for revoked_module in revoked_modules {
         self.code_generation_results.remove(&revoked_module);
       }
-      let modules = mutations.get_affected_modules_with_chunk_graph(self);
+      let modules: IdentifierSet = mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+          Mutation::ModuleSetHashes { module } => Some(*module),
+          _ => None,
+        })
+        .collect();
       let logger = self.get_logger("rspack.incremental.modulesCodegen");
       logger.log(format!(
         "{} modules are affected, {} in total",
@@ -1490,7 +1528,13 @@ impl Compilation {
           .cgm_runtime_requirements_artifact
           .remove(&revoked_module);
       }
-      let modules = mutations.get_affected_modules_with_chunk_graph(self);
+      let modules: IdentifierSet = mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+          Mutation::ModuleSetHashes { module } => Some(*module),
+          _ => None,
+        })
+        .collect();
       let logger = self.get_logger("rspack.incremental.modulesRuntimeRequirements");
       logger.log(format!(
         "{} modules are affected, {} in total",
@@ -2164,7 +2208,11 @@ impl Compilation {
       })
       .collect::<Result<_>>()?;
     for (module, hashes) in results {
-      ChunkGraph::set_module_hashes(self, module, hashes);
+      if ChunkGraph::set_module_hashes(self, module, hashes)
+        && let Some(mutations) = self.incremental.mutations_write()
+      {
+        mutations.add(Mutation::ModuleSetHashes { module });
+      }
     }
     Ok(())
   }

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -62,11 +62,6 @@ impl Compiler {
 
       new_compilation.hot_index = self.compilation.hot_index + 1;
 
-      if let Some(mutations) = new_compilation.incremental.mutations_write()
-        && let Some(old_mutations) = self.compilation.incremental.mutations_write()
-      {
-        mutations.swap_modules_with_chunk_graph_cache(old_mutations);
-      }
       if new_compilation
         .incremental
         .can_read_mutations(IncrementalPasses::MAKE)

--- a/crates/rspack_core/src/incremental/mutations.rs
+++ b/crates/rspack_core/src/incremental/mutations.rs
@@ -1,18 +1,12 @@
-use std::{
-  fmt,
-  hash::{Hash, Hasher},
-  sync::RwLock,
-};
+use std::fmt;
 
 use itertools::{Either, Itertools};
 use once_cell::sync::OnceCell;
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
-use rspack_collections::{IdentifierMap, IdentifierSet, UkeySet};
-use rustc_hash::FxHasher;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rspack_collections::{IdentifierSet, UkeySet};
 
 use crate::{
-  AffectType, ChunkGraph, ChunkUkey, Compilation, Logger, Module, ModuleGraph,
-  ModuleGraphConnection, ModuleIdentifier,
+  AffectType, ChunkUkey, Compilation, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
 };
 
 #[derive(Debug, Default)]
@@ -20,18 +14,6 @@ pub struct Mutations {
   inner: Vec<Mutation>,
 
   affected_modules_with_module_graph: OnceCell<IdentifierSet>,
-  affected_modules_with_chunk_graph: OnceCell<IdentifierSet>,
-  // we need the cache to check the affected modules (with chunk graph) is really affected or not
-  // because usually people will still enable splitChunks for dev mode, and that will cause lots of
-  // chunks can't reuse from the previous compilation by incremental build chunk graph (code splitting),
-  // and affect lots of modules, but actually most of the affected modules are not really affected, which
-  // can be detected by this cache.
-  // An alternative way is to give chunk a chunk identifier, but currently I don't have a good idea to
-  // choose what as the chunk identifier.
-  // (probably the chunk name, and the chunk index in its chunk group, webpack RecordIdsPlugin use this way:
-  // https://github.com/webpack/webpack/blob/3612d36e44bda5644dc3b353e2cade7fe442ba59/lib/RecordIdsPlugin.js#L126)
-  // I leave it at that for now. I leave it to future to decide :)
-  modules_with_chunk_graph_cache: RwLock<IdentifierMap<Option<u64>>>,
   affected_chunks_with_chunk_graph: OnceCell<UkeySet<ChunkUkey>>,
 }
 
@@ -52,6 +34,7 @@ pub enum Mutation {
   ModuleRemove { module: ModuleIdentifier },
   ModuleSetAsync { module: ModuleIdentifier },
   ModuleSetId { module: ModuleIdentifier },
+  ModuleSetHashes { module: ModuleIdentifier },
   ChunkSetId { chunk: ChunkUkey },
   ChunkAdd { chunk: ChunkUkey },
   ChunkSplit { from: ChunkUkey, to: ChunkUkey },
@@ -67,6 +50,7 @@ impl fmt::Display for Mutation {
       Mutation::ModuleRemove { module } => write!(f, "remove module {module}"),
       Mutation::ModuleSetAsync { module } => write!(f, "set async module {module}"),
       Mutation::ModuleSetId { module } => write!(f, "set id module {module}"),
+      Mutation::ModuleSetHashes { module } => write!(f, "set hashes module {module}"),
       Mutation::ChunkSetId { chunk } => write!(f, "set id chunk {}", chunk.as_u32()),
       Mutation::ChunkAdd { chunk } => write!(f, "add chunk {}", chunk.as_u32()),
       Mutation::ChunkSplit { from, to } => {
@@ -89,13 +73,6 @@ impl Mutations {
 
   pub fn is_empty(&self) -> bool {
     self.inner.is_empty()
-  }
-
-  pub fn swap_modules_with_chunk_graph_cache(&mut self, to: &mut Self) {
-    std::mem::swap(
-      &mut self.modules_with_chunk_graph_cache,
-      &mut to.modules_with_chunk_graph_cache,
-    );
   }
 }
 
@@ -157,60 +134,6 @@ impl Mutations {
       .clone()
   }
 
-  pub fn get_affected_modules_with_chunk_graph(&self, compilation: &Compilation) -> IdentifierSet {
-    self
-      .affected_modules_with_chunk_graph
-      .get_or_init(|| {
-        let module_graph = compilation.get_module_graph();
-        let mut affected_modules =
-          self.get_affected_modules_with_module_graph(&compilation.get_module_graph());
-        let mut maybe_affected_modules = IdentifierSet::default();
-        for mutation in self.iter() {
-          match mutation {
-            Mutation::ModuleSetAsync { module } => {
-              affected_modules.insert(*module);
-            }
-            Mutation::ModuleSetId { module } => {
-              affected_modules.insert(*module);
-              affected_modules.extend(
-                module_graph
-                  .get_incoming_connections(module)
-                  .filter_map(|c| c.original_module_identifier),
-              );
-            }
-            Mutation::ChunkSetId { chunk } => {
-              let chunk = compilation.chunk_by_ukey.expect_get(chunk);
-              maybe_affected_modules.extend(
-                chunk
-                  .groups()
-                  .iter()
-                  .flat_map(|group| {
-                    let group = compilation.chunk_group_by_ukey.expect_get(group);
-                    group.origins()
-                  })
-                  .filter_map(|origin| origin.module),
-              );
-            }
-            _ => {}
-          }
-        }
-        compute_affected_modules_with_chunk_graph(
-          affected_modules,
-          maybe_affected_modules,
-          self
-            .iter()
-            .filter_map(|mutation| match mutation {
-              Mutation::ModuleRemove { module } => Some(*module),
-              _ => None,
-            })
-            .collect(),
-          &self.modules_with_chunk_graph_cache,
-          compilation,
-        )
-      })
-      .clone()
-  }
-
   pub fn get_affected_chunks_with_chunk_graph(
     &self,
     compilation: &Compilation,
@@ -218,29 +141,28 @@ impl Mutations {
     self
       .affected_chunks_with_chunk_graph
       .get_or_init(|| {
-        compute_affected_chunks_with_chunk_graph(
-          self.get_affected_modules_with_chunk_graph(compilation),
-          self.iter().fold(UkeySet::default(), |mut acc, mutation| {
-            match mutation {
-              Mutation::ChunkAdd { chunk } => {
-                acc.insert(*chunk);
-              }
-              Mutation::ChunkSplit { from, to } => {
-                acc.insert(*from);
-                acc.insert(*to);
-              }
-              Mutation::ChunksIntegrate { to } => {
-                acc.insert(*to);
-              }
-              Mutation::ChunkRemove { chunk } => {
-                acc.remove(chunk);
-              }
-              _ => {}
-            };
-            acc
-          }),
-          &compilation.chunk_graph,
-        )
+        self.iter().fold(UkeySet::default(), |mut acc, mutation| {
+          match mutation {
+            Mutation::ModuleSetHashes { module } => {
+              acc.extend(compilation.chunk_graph.get_module_chunks(*module));
+            }
+            Mutation::ChunkAdd { chunk } => {
+              acc.insert(*chunk);
+            }
+            Mutation::ChunkSplit { from, to } => {
+              acc.insert(*from);
+              acc.insert(*to);
+            }
+            Mutation::ChunksIntegrate { to } => {
+              acc.insert(*to);
+            }
+            Mutation::ChunkRemove { chunk } => {
+              acc.remove(chunk);
+            }
+            _ => {}
+          };
+          acc
+        })
       })
       .clone()
   }
@@ -331,100 +253,4 @@ fn compute_affected_modules_with_module_graph(
   }
   all_affected_modules.extend(direct_affected_modules);
   all_affected_modules
-}
-
-#[tracing::instrument(skip_all)]
-fn compute_affected_modules_with_chunk_graph(
-  sure_affected_modules: IdentifierSet,
-  maybe_affected_modules: IdentifierSet,
-  revoked_modules: IdentifierSet,
-  cache: &RwLock<IdentifierMap<Option<u64>>>,
-  compilation: &Compilation,
-) -> IdentifierSet {
-  let logger = compilation.get_logger("rspack.incremental (affected modules with chunk graph)");
-  let sure_affected_modules_len = sure_affected_modules.len();
-  let maybe_affected_modules_len = maybe_affected_modules.len();
-
-  #[tracing::instrument(skip_all, fields(module = ?module.identifier()))]
-  fn create_block_invalidate_key(
-    chunk_graph: &ChunkGraph,
-    compilation: &Compilation,
-    module: &dyn Module,
-  ) -> u64 {
-    let mut hasher = FxHasher::default();
-    for block_id in module.get_blocks() {
-      let Some(chunk_group) =
-        chunk_graph.get_block_chunk_group(block_id, &compilation.chunk_group_by_ukey)
-      else {
-        continue;
-      };
-      for chunk in &chunk_group.chunks {
-        let chunk = compilation.chunk_by_ukey.expect_get(chunk);
-        chunk.id(&compilation.chunk_ids_artifact).hash(&mut hasher);
-      }
-    }
-    hasher.finish()
-  }
-
-  {
-    let mut write_cache = cache.write().expect("should have write lock");
-    // GC the revoked modules from the cache
-    for module in revoked_modules {
-      write_cache.remove(&module);
-    }
-    for module in &sure_affected_modules {
-      write_cache.insert(*module, None);
-    }
-  }
-
-  // Only check the cache for the updated modules, which is "maybe affected"
-  let update_cache_entries: IdentifierMap<Option<u64>> = {
-    let module_graph = compilation.get_module_graph();
-    let read_cache = cache.read().expect("should have read lock");
-    sure_affected_modules
-      .into_par_iter()
-      .chain(maybe_affected_modules)
-      .filter_map(|module_identifier| {
-        let module = module_graph
-          .module_by_identifier(&module_identifier)
-          .expect("should have module");
-        let invalidate_key =
-          create_block_invalidate_key(&compilation.chunk_graph, compilation, module.as_ref());
-        if let Some(Some(old_invalidate_key)) = read_cache.get(&module_identifier)
-          && *old_invalidate_key == invalidate_key
-        {
-          return None;
-        }
-        Some((module_identifier, Some(invalidate_key)))
-      })
-      .collect()
-  };
-
-  // Update the cache for those really affected modules
-  let affected_modules: IdentifierSet = update_cache_entries.keys().copied().collect();
-  {
-    let mut write_cache = cache.write().expect("should have write lock");
-    write_cache.extend(update_cache_entries);
-  }
-
-  logger.log(format!(
-    "{} modules are really affected, {} modules are maybe affected",
-    affected_modules.len() - sure_affected_modules_len,
-    maybe_affected_modules_len,
-  ));
-
-  affected_modules
-}
-
-fn compute_affected_chunks_with_chunk_graph(
-  updated_modules: IdentifierSet,
-  mut updated_chunks: UkeySet<ChunkUkey>,
-  chunk_graph: &ChunkGraph,
-) -> UkeySet<ChunkUkey> {
-  updated_chunks.extend(
-    updated_modules
-      .into_iter()
-      .flat_map(|m| chunk_graph.get_module_chunks(m).iter().copied()),
-  );
-  updated_chunks
 }

--- a/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
@@ -130,6 +130,14 @@ impl CodeSplittingCache {
       }
     }
 
+    if !this_compilation
+      .entries
+      .keys()
+      .eq(this_compilation.code_splitting_cache.entrypoints.keys())
+    {
+      return false;
+    }
+
     true
   }
 }

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -136,7 +136,7 @@ impl RuntimeSpec {
 
 pub type RuntimeKey = String;
 
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RuntimeMode {
   #[default]
   Empty = 0,
@@ -332,7 +332,7 @@ pub fn compare_runtime(a: &RuntimeSpec, b: &RuntimeSpec) -> Ordering {
   Ordering::Equal
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeSpecMap<T> {
   pub mode: RuntimeMode,
   pub map: HashMap<RuntimeKey, T>,

--- a/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-add-same-entry/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-add-same-entry/0/index.js
@@ -1,0 +1,3 @@
+it("should have correct entrypoints", function() {
+  expect(1).toBe(1);
+})

--- a/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-add-same-entry/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-add-same-entry/rspack.config.js
@@ -1,0 +1,48 @@
+let step = 0;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: () => {
+		if (step === 0) {
+			return {
+				bundle0: "./index.js"
+			};
+		} else if (step === 1) {
+			return {
+				bundle0: "./index.js",
+				bundle1: "./index.js"
+			};
+		} else {
+			throw new Error("no more steps");
+		}
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		function (compiler) {
+			compiler.hooks.done.tap("test", () => {
+				if (step === 0) {
+					process.nextTick(() => {
+						step += 1;
+						compiler.watching.invalidate();
+					});
+				}
+			});
+			compiler.hooks.thisCompilation.tap("MyPlugin", compilation => {
+				compilation.hooks.processAssets.tap("MyPlugin", () => {
+					if (step === 0) {
+						expect([...compilation.entrypoints.keys()]).toEqual(["bundle0"]);
+					} else if (step === 1) {
+						expect([...compilation.entrypoints.keys()]).toEqual([
+							"bundle0",
+							"bundle1"
+						]);
+					} else {
+						throw new Error("no more steps");
+					}
+				});
+			});
+		}
+	]
+};

--- a/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-add-same-entry/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-add-same-entry/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle(i) {
+		return ["bundle0.js"];
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should re-build chunk graph when adding a entry connection, which connect a module that already exist in the module graph by other connections, checkout the test case for more detail

This fix both incremental and non-incremental for the case, and refactor incremental `get_affected_modules_with_chunk_graph`: before we use it for moduleHashes, moduleCodegen, and moduleRuntimeRequirement, we use some strategy to guess the affected chunk modules, but we didn't consider an important fact, that the `chunk.runtime` will also affect, moduleHashes already have a well tested strategy to find all the add/updated chunk modules, so we just to refactor to use moduleHashes to find the affected chunk modules directly

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
