### PR TITLE
docs: fix invalid link in roadmap

### DIFF
--- a/website/docs/en/misc/planning/roadmap.mdx
+++ b/website/docs/en/misc/planning/roadmap.mdx
@@ -18,7 +18,7 @@ You can see the current progress in this PR: [#9134](https://github.com/web-infr
 
 ## Introduce Rstest
 
-We are implementing [Rstest](https://github.com/rspack/rstest), a testing framework based on Rspack. It can seamlessly integrate with Rspack's ecosystem and provide out-of-the-box testing capabilities.
+We are implementing **Rstest**, a testing framework based on Rspack. It can seamlessly integrate with Rspack's ecosystem and provide out-of-the-box testing capabilities.
 
 We plan to release the first version of Rstest in the second half of 2025.
 

--- a/website/docs/zh/misc/planning/roadmap.mdx
+++ b/website/docs/zh/misc/planning/roadmap.mdx
@@ -18,7 +18,7 @@ Rspack 将每隔 2～3 个月发布一个 minor 版本，minor 版本将包含�
 
 ## 发布 Rstest
 
-我们正在实现 [Rstest](https://github.com/rspack/rstest)，一个基于 Rspack 的测试框架。它能够与 Rspack 生态中的工具和框架无缝集成，提供开箱即用的测试能力。
+我们正在实现 **Rstest**，一个基于 Rspack 的测试框架。它能够与 Rspack 生态中的工具和框架无缝集成，提供开箱即用的测试能力。
 
 我们计划于 2025 年下半年发布 Rstest 的首个版本。
 


### PR DESCRIPTION
## Summary

Fix the invalid Rstest link in roadmap (generated by cursor by mistake).

The Rstest repository is still private, and we'll make it public when it's ready for preview.

Ref: https://x.com/Romej_/status/1896775888878117242

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
