### PR TITLE
docs: add debugging guide

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,105 +1,29 @@
 {
   "configurations": [
     {
-      "name": "debug-js",
-      "port": 9229,
-      "request": "attach",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
-      "sourceMaps": true,
-      "continueOnAttach": true,
-      "type": "node",
-      "presentation": {
-        "hidden": true
-      }
-    },
-    {
       "type": "lldb",
       "request": "launch",
-      "sourceLanguages": [
-        "rust"
-      ],
-      "name": "debug-rust-jest",
+      "name": "Launch Rspack CLI",
       "program": "node",
       "args": [
-        "--inspect-brk",
-        "../../node_modules/.bin/jest",
-        "--workerThreads"
+        "packages/rspack-cli/bin/rspack.js",
+        "-c",
+        "${input:rspackConfigPath}"
       ],
-      "cwd": "${workspaceFolder}/packages/rspack"
+      "cwd": "${workspaceFolder}"
     },
     {
       "type": "lldb",
       "request": "attach",
-      "sourceLanguages": [
-        "rust"
-      ],
-      "pid": "${command:pickMyProcess}",
-      "name": "debug-rust-attach"
-    },
-    {
-      "type": "lldb",
-      "request": "launch",
-      "sourceLanguages": [
-        "rust"
-      ],
-      "name": "debug-rust-basic",
-      "program": "node",
-      "args": [
-        "--inspect-brk",
-        "${workspaceFolder}/packages/rspack-cli/bin/rspack",
-        "-c",
-        "rspack.config.js"
-      ],
-      "cwd": "${workspaceFolder}/examples/issue-11673",
-      "presentation": {
-        "hidden": true
-      }
-    },
-    {
-      "type": "lldb",
-      "request": "launch",
-      "sourceLanguages": [
-        "rust"
-      ],
-      "name": "debug-rust-angular",
-      "program": "node",
-      "args": [
-        "--inspect-brk",
-        "${workspaceFolder}/packages/rspack-cli/bin/rspack",
-        "-c",
-        "./rspack.config.js"
-      ],
-      "cwd": "${workspaceFolder}/examples/angular",
-      "presentation": {
-        "hidden": true
-      }
+      "name": "Attach to Rspack Process",
+      "pid": "${command:pickMyProcess}" // use ${command:pickProcess} to pick other users' processes
     }
   ],
-  "compounds": [
+  "inputs": [
     {
-      "name": "debug-basic",
-      "configurations": [
-        "debug-js",
-        "debug-rust-basic"
-      ],
-      "stopAll": true,
-      "presentation": {
-        "group": "examples",
-        "order": 1
-      }
-    },
-    {
-      "name": "debug-angular",
-      "configurations": [
-        "debug-js",
-        "debug-rust-angular"
-      ],
-      "presentation": {
-        "group": "examples",
-        "order": 2
-      }
+      "id": "rspackConfigPath",
+      "type": "promptString",
+      "description": "the rspack config path of your project"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,27 +3,48 @@
     {
       "type": "lldb",
       "request": "launch",
-      "name": "Launch Rspack CLI",
+      "name": "Debug Rspack",
       "program": "node",
       "args": [
         "packages/rspack-cli/bin/rspack.js",
+        "${input:rspackCommand}",
         "-c",
         "${input:rspackConfigPath}"
       ],
       "cwd": "${workspaceFolder}"
     },
     {
+      "name": "Attach JavaScript",
+      "processId": "${command:PickProcess}",
+      "request": "attach",
+      "skipFiles": [
+          "<node_internals>/**"
+      ],
+      "type": "node"
+     },
+    {
       "type": "lldb",
       "request": "attach",
-      "name": "Attach to Rspack Process",
-      "pid": "${command:pickMyProcess}" // use ${command:pickProcess} to pick other users' processes
-    }
+      "name": "Attach Rust",
+      "pid": "${command:pickMyProcess}"
+    },
   ],
   "inputs": [
     {
+      "id": "rspackCommand",
+      "type": "pickString",
+      "options": [
+        "build",
+        "dev"
+      ],
+      "description": "choose build or dev mode",
+      "default": "dev"
+    },
+    {
       "id": "rspackConfigPath",
       "type": "promptString",
-      "description": "the rspack config path of your project"
+      "description": "the rspack config path of your project",
+      "default": "examples/basic/rspack.config.cjs"
     }
   ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ opt-level = 2
 
 # This is for production for profiling production build
 [profile.profiling]
-debug           = true
+debug           = "limited"
 inherits        = "release"
 lto             = "thin"
 split-debuginfo = "off"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ opt-level = 2
 
 # This is for production for profiling production build
 [profile.profiling]
-debug           = "limited"
+debug           = true
 inherits        = "release"
 lto             = "thin"
 split-debuginfo = "off"

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,2 @@
+# Example 
+This is only used for debugging Rspack, don't commit unnecessary code here.

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -1,0 +1,1 @@
+import "./lib";

--- a/examples/basic/lib.js
+++ b/examples/basic/lib.js
@@ -1,0 +1,1 @@
+console.log("Debugging Rspack");

--- a/examples/basic/rspack.config.cjs
+++ b/examples/basic/rspack.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+	context: __dirname,
+	entry: {
+		main: './index.js'
+	}
+}

--- a/website/docs/en/contribute/development/debugging.mdx
+++ b/website/docs/en/contribute/development/debugging.mdx
@@ -5,7 +5,25 @@
 1. Install `go install github.com/go-delve/delve/cmd/dlv@latest`
 2. Install VS Code extension [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) and [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
 3. build `@rspack/cli` and napi binding by run `pnpm install && pnpm -w build:cli:dev`
-4. In VS Code's `Run and Debug` tab, select `debug-rspack` to start debugging the initial launch of `@rspack/cli`. This task can be configured in `.vscode/launch.json`, which launches the Node and Rust debugger together.
+4. In VS Code's `Run and Debug` tab, select `Debug Rspack` to start debugging the initial launch of `@rspack/cli` with a simple rspack project. This task can be configured in `.vscode/launch.json`.
+
+### Common Debugging Scenarios Guide
+
+#### Debugging Rust
+
+Simply set breakpoints in the specified Rust code and start `Debug Rspack` to begin debugging.
+
+#### Debugging JavaScript
+
+When starting `Debug Rspack`, select the `--inspect` or `--inspect-brk` option, then start `Attach JavaScript` and choose the PID of the corresponding process.
+
+#### Debugging a running Rspack process
+
+When Rspack is integrated into other frameworks or tools (such as Nx), it may be difficult to independently start Rspack in Launch mode. In this case, you can debug the code through attach mode. Start `Attach Rust` and select the PID of the Rspack process, and start `Attach JavaScript` to debug JavaScript.
+
+#### Debugging a Rspack process with a deadlock
+
+When using `Attach Rust` to attach the debugger to the Rspack process, click the Pause button on the Debugger to set breakpoints at the deadlock scene.
 
 ## Tracing
 
@@ -88,118 +106,3 @@ Process 23110 stopped
    247
 Target 0: (node) stopped.
 ```
-
-## Mixed debug
-
-This section aims to illustrate the method for mixed debugging between JavaScript and Rust.
-
-### Prerequisites
-
-To illustrate this process, I'll use an example. Let's start by introduce the environment and example I have used.
-
-- System: macos
-- IDE: vscode
-- Debugging target: `rspack build ${projectRoot}/basic`
-
-Firstly, you need to build rspack in debug mode. To do this, execute the following commands in the project's root directory:
-
-```bash
-npm run build:binding:dev
-npm run build:js
-```
-
-### Configure `launch.json` in VS Code
-
-It's necessary to configure two debug configurations within in `.vscode/launch.json.`
-
-- attach for node:
-
-```jsonc
-{
-  "name": "attach:node",
-  "request": "attach", // refer: https://code.visualstudio.com/docs/editor/debugging#_launch-versus-attach-configurations
-  "type": "node",
-  // `9229` is the default port of message
-  "port": 9229,
-}
-```
-
-- and launch for lldb
-
-```jsonc
-{
-  "name": "launch:rust-from-node",
-  "request": "launch",
-  "type": "lldb", // it means we use `lldb` to launch the binary file of `node`
-  "program": "node",
-  "args": [
-    "--inspect",
-    "--enable-source-maps",
-    "${workspaceFolder}/packages/rspack-cli/bin/rspack",
-    "build",
-    "-c",
-    "${workspaceFolder}/examples/basic/rspack.config.js",
-  ],
-  // `cwd` is just for rspack find the correctly entry.
-  "cwd": "${workspaceFolder}/examples/basic/",
-}
-```
-
-Next, we can utilize [compounds](https://code.visualstudio.com/docs/editor/debugging#_compound-launch-configurations) to amalgamate the two commands:
-
-```json
-{
-  "name": "mix-debug",
-  "configurations": ["attach:node", "launch:rust-from-node"]
-}
-```
-
-Finally, your `launch.json` should appear as follows:
-
-```json
-{
-  "configurations": [
-    {
-      "name": "attach:node",
-      "request": "attach",
-      "type": "node",
-      "port": 9229
-    },
-    {
-      "name": "launch:rust-from-node",
-      "request": "launch",
-      "type": "lldb",
-      "program": "node",
-      "args": [
-        "--inspect",
-        "--enable-source-maps",
-        "${workspaceFolder}/packages/rspack-cli/bin/rspack",
-        "build",
-        "-c",
-        "${workspaceFolder}/examples/basic/rspack.config.js"
-      ],
-      "cwd": "${workspaceFolder}/examples/basic/"
-    }
-  ],
-  "compounds": [
-    {
-      "name": "mix-debug",
-      "configurations": ["attach:node", "launch:rust-from-node"]
-    }
-  ]
-}
-```
-
-### Debugging attempt
-
-Next, we can introduce some breakpoints and commence debugging.
-
-The result appears as follows:
-
-<video width="640" height="480" controls>
-  <source
-    src="https://github.com/web-infra-dev/rspack/assets/30187863/106983f7-a59e-4d9e-9001-552f4441d88b"
-    type="video/mp4"
-  />
-  Your browser does not support the video tag.
-</video>

--- a/website/docs/zh/contribute/development/debugging.mdx
+++ b/website/docs/zh/contribute/development/debugging.mdx
@@ -5,7 +5,29 @@
 1. 安装 `go install github.com/go-delve/delve/cmd/dlv@latest`
 2. 安装 VS Code 扩展 [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) 和 [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
 3. 通过执行 `pnpm install && pnpm -w build:cli:dev` 构建 `@rspack/cli` 和 napi binding
-4. 在 VS Code 的 `Run and Debug` 栏中, 选择 `debug-rspack` 开始调试 `@rspack/cli` 的启动过程。 该任务可以在 `.vscode/launch.json` 中配置，会同时启动 Node 和 Rust 的调试器。
+4. 在 VS Code 的 `Run and Debug` 栏中, 选择 `Debug Rspack` 开始调试 `@rspack/cli` 的启动过程。 该任务可以在 `.vscode/launch.json` 中配置，会同时启动 Node 和 Rust 的调试器。
+
+:::note
+其他工具集成的一般是 Rspack 的 release 版本，其中并不包含调试信息，这时候需要使用对应的含有debug 的版本进行override替换，方可调试。
+:::
+
+### 常见调试场景指南
+
+#### 调试 Rust
+
+只需在指定的 Rust 代码处设置断点后启动 `Debug Rspack` 即可进行调试。
+
+#### 调试 JavaScript
+
+启动 `Debug Rspack` 时，选择 `--inspect` 或 `--inspect-brk` 选项，然后启动 `Attach JavaScript` 并选择相应进程的 PID 即可。
+
+#### 调试已启动的 Rspack 进程
+
+当 Rspack 被集成到其他框架或工具（如 Nx）中时，可能难以独立使用 Launch 模式启动 Rspack。此时，可以通过 attach 模式调试代码。启动 `Attach Rust` 并选择 Rspack 所属进程的 PID 即可,启动 `Attach JavaScript` 即可调试 JavaScript。
+
+#### 调试发生死锁的 Rspack 进程
+
+当使用 `Attach Rust` 将调试器 attach 到 Rspack 所属进程后，点击 Debugger 的 Pause 按钮即可在死锁现场设置断点。
 
 ## Tracing
 
@@ -88,118 +110,3 @@ Process 23110 stopped
    247
 Target 0: (node) stopped.
 ```
-
-## 混合调试
-
-本节旨在说明 JavaScript 和 Rust 混合调试的方法。
-
-### 准备工作
-
-为了说明这个过程，我将使用一个例子。首先介绍一下我使用的环境和例子。
-
-- System: macos
-- IDE: vscode
-- Debugging target: `rspack build ${projectRoot}/basic`
-
-首先，你需要在调试模式下构建 rspack。为此，请在项目的根目录中执行以下命令：
-
-```bash
-npm run build:binding:dev
-npm run build:js
-```
-
-### 在 VS Code 中设置 `launch.json`
-
-需要在 `.vscode/launch.json` 中配置两个调试配置。
-
-- 给 node 添加 attach:
-
-```jsonc
-{
-  "name": "attach:node",
-  "request": "attach", // refer: https://code.visualstudio.com/docs/editor/debugging#_launch-versus-attach-configurations
-  "type": "node",
-  // `9229` is the default port of message
-  "port": 9229,
-}
-```
-
-- 和 lldb 的 launch 配置
-
-```jsonc
-{
-  "name": "launch:rust-from-node",
-  "request": "launch",
-  "type": "lldb", // it means we use `lldb` to launch the binary file of `node`
-  "program": "node",
-  "args": [
-    "--inspect",
-    "--enable-source-maps",
-    "${workspaceFolder}/packages/rspack-cli/bin/rspack",
-    "build",
-    "-c",
-    "${workspaceFolder}/examples/basic/rspack.config.js",
-  ],
-  // `cwd` is just for rspack find the correctly entry.
-  "cwd": "${workspaceFolder}/examples/basic/",
-}
-```
-
-之后，我们可以利用 [compounds](https://code.visualstudio.com/docs/editor/debugging#_compound-launch-configurations) 合并这两个命令：
-
-```json
-{
-  "name": "mix-debug",
-  "configurations": ["attach:node", "launch:rust-from-node"]
-}
-```
-
-最终，你的 `launch.json` 应如下所示:
-
-```json
-{
-  "configurations": [
-    {
-      "name": "attach:node",
-      "request": "attach",
-      "type": "node",
-      "port": 9229
-    },
-    {
-      "name": "launch:rust-from-node",
-      "request": "launch",
-      "type": "lldb",
-      "program": "node",
-      "args": [
-        "--inspect",
-        "--enable-source-maps",
-        "${workspaceFolder}/packages/rspack-cli/bin/rspack",
-        "build",
-        "-c",
-        "${workspaceFolder}/examples/basic/rspack.config.js"
-      ],
-      "cwd": "${workspaceFolder}/examples/basic/"
-    }
-  ],
-  "compounds": [
-    {
-      "name": "mix-debug",
-      "configurations": ["attach:node", "launch:rust-from-node"]
-    }
-  ]
-}
-```
-
-### Debugging 尝试
-
-接下来，我们可以引入一些断点并开始调试。
-
-结果如下:
-
-<video width="640" height="480" controls>
-  <source
-    src="https://github.com/web-infra-dev/rspack/assets/30187863/106983f7-a59e-4d9e-9001-552f4441d88b"
-    type="video/mp4"
-  />
-  Your browser does not support the video tag.
-</video>


### PR DESCRIPTION
This pull request includes several changes to improve debugging configurations and documentation for the Rspack project. The most important changes involve updates to the `.vscode/launch.json` file, enhancements to debugging documentation, and the addition of example files for debugging.

### Debugging Configuration Updates:

* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L3-R47): Removed outdated configurations and added new ones for debugging Rspack, including 
* `Debug Rspack`: use lldb to debug rust code 
* `Attach JavaScript`: used to debug javascript code
* `Attach Rust`: used to debug launched rspack process

Also added input options for rspack command and configuration path

* rspackProjectPath: rspack config path,  default to examples/basic/rspack.config.js, so rspack constributors don't need to setup a new project to debug rspack
* rspackCommand: dev & build

### Documentation Enhancements:

* [`website/docs/en/contribute/development/debugging.mdx`](diffhunk://#diff-7e86c9f57b4e16d5fafb45938eba5027bd28841b1f8a3126c08f78bf49376568L8-R26): Updated the debugging guide to reflect the new configurations in `.vscode/launch.json` and added common debugging scenarios for Rust and JavaScript. [[1]](diffhunk://#diff-7e86c9f57b4e16d5fafb45938eba5027bd28841b1f8a3126c08f78bf49376568L8-R26) [[2]](diffhunk://#diff-7e86c9f57b4e16d5fafb45938eba5027bd28841b1f8a3126c08f78bf49376568L91-L205)
* [`website/docs/zh/contribute/development/debugging.mdx`](diffhunk://#diff-0508ca290245e56e348e3ffdaad62db125fb2e66231230ebea1adfd42f15b3dbL8-R30): Updated the Chinese debugging guide similarly to the English version, including new configurations and scenarios. [[1]](diffhunk://#diff-0508ca290245e56e348e3ffdaad62db125fb2e66231230ebea1adfd42f15b3dbL8-R30) [[2]](diffhunk://#diff-0508ca290245e56e348e3ffdaad62db125fb2e66231230ebea1adfd42f15b3dbL91-L205)

### Example Files for Debugging:

* [`examples/basic/README.md`](diffhunk://#diff-fe83992f154cc181844b6bf965a0b6aba367c7b498a3a0db43b5b212d041531bR1-R2): Added a note indicating that the example is only for debugging Rspack.
* [`examples/basic/index.js`](diffhunk://#diff-aedb0b6d09c16f875a7aad26f28becf1742187b359a3d439ab8b3e9893d120bfR1): Imported the `lib.js` module for debugging purposes.
* [`examples/basic/lib.js`](diffhunk://#diff-282aefb685125edebd84c9f0fabc9cbeb3710170131b8ae505a2f4fdcf624f66R1): Added a simple console log for debugging.
* [`examples/basic/rspack.config.cjs`](diffhunk://#diff-e478b969ffe9b6539b3765833f067c78e994778c3e8576a4bca50fa5911582dcR1-R6): Created a basic Rspack configuration file for the example.
