### PR TITLE
feat(cli): `rspack preview` support for `nodeEnv` flag and default env

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -44,14 +44,7 @@ export class RspackCLI {
 		process.env.RSPACK_CONFIG_VALIDATE ??= "loose";
 		process.env.WATCHPACK_WATCHER_LIMIT =
 			process.env.WATCHPACK_WATCHER_LIMIT || "20";
-		const nodeEnv = process?.env?.NODE_ENV;
-		const rspackCommandDefaultEnv =
-			rspackCommand === "build" ? "production" : "development";
-		if (typeof options.nodeEnv === "string") {
-			process.env.NODE_ENV = nodeEnv || options.nodeEnv;
-		} else {
-			process.env.NODE_ENV = nodeEnv || rspackCommandDefaultEnv;
-		}
+
 		let config = await this.loadConfig(options);
 		config = await this.buildConfig(config, options, rspackCommand);
 

--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -117,9 +117,6 @@ export class RspackCLI {
 	): Promise<RspackOptions | MultiRspackOptions> {
 		const isBuild = command === "build";
 		const isServe = command === "serve";
-		const commandDefaultEnv: "production" | "development" = isBuild
-			? "production"
-			: "development";
 
 		const internalBuildConfig = async (item: RspackOptions) => {
 			if (options.entry) {
@@ -158,7 +155,7 @@ export class RspackCLI {
 			}
 			// auto set default mode if user config don't set it
 			if (!item.mode) {
-				item.mode = commandDefaultEnv ?? "none";
+				item.mode = isBuild ? "production" : "development";
 			}
 			// user parameters always has highest priority than default mode and config mode
 			if (options.mode) {

--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -7,7 +7,8 @@ import {
 	commonOptions,
 	commonOptionsForBuildAndServe,
 	ensureEnvObject,
-	setBuiltinEnvArg
+	setBuiltinEnvArg,
+	setDefaultNodeEnv
 } from "../utils/options";
 
 export class BuildCommand implements RspackCommand {
@@ -33,13 +34,16 @@ export class BuildCommand implements RspackCommand {
 				});
 			},
 			async options => {
+				setDefaultNodeEnv(options, "production");
 				const env = ensureEnvObject(options);
+
 				if (options.watch) {
 					setBuiltinEnvArg(env, "WATCH", true);
 				} else {
 					setBuiltinEnvArg(env, "BUNDLE", true);
 					setBuiltinEnvArg(env, "BUILD", true);
 				}
+
 				const logger = cli.getLogger();
 				let createJsonStringifyStream: typeof import("@discoveryjs/json-ext").stringifyStream;
 				if (options.json) {

--- a/packages/rspack-cli/src/commands/preview.ts
+++ b/packages/rspack-cli/src/commands/preview.ts
@@ -9,7 +9,7 @@ import type yargs from "yargs";
 
 import type { RspackCLI } from "../cli";
 import type { RspackCommand, RspackPreviewCLIOptions } from "../types";
-import { commonOptions } from "../utils/options";
+import { commonOptions, setDefaultNodeEnv } from "../utils/options";
 
 const previewOptions = (yargs: yargs.Argv) => {
 	yargs.positional("dir", {
@@ -49,6 +49,8 @@ export class PreviewCommand implements RspackCommand {
 			"run the rspack server for build output",
 			previewOptions,
 			async options => {
+				setDefaultNodeEnv(options, "production");
+
 				const rspackOptions = { ...options, argv: { ...options } };
 				const { RspackDevServer } = await import("@rspack/dev-server");
 

--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -7,7 +7,8 @@ import {
 	commonOptions,
 	commonOptionsForBuildAndServe,
 	ensureEnvObject,
-	setBuiltinEnvArg
+	setBuiltinEnvArg,
+	setDefaultNodeEnv
 } from "../utils/options";
 
 export class ServeCommand implements RspackCommand {
@@ -40,7 +41,9 @@ export class ServeCommand implements RspackCommand {
 					}
 				}),
 			async options => {
+				setDefaultNodeEnv(options, "development");
 				setBuiltinEnvArg(ensureEnvObject(options), "SERVE", true);
+
 				const rspackOptions = {
 					...options,
 					argv: {

--- a/packages/rspack-cli/src/types.ts
+++ b/packages/rspack-cli/src/types.ts
@@ -25,6 +25,7 @@ export interface RspackCLIOptions {
 	argv?: Record<string, any>;
 	configName?: string[];
 	configLoader?: string;
+	nodeEnv?: string;
 }
 
 export interface RspackBuildCLIOptions extends RspackCLIOptions {
@@ -35,7 +36,6 @@ export interface RspackBuildCLIOptions extends RspackCLIOptions {
 	analyze?: boolean;
 	profile?: boolean;
 	env?: Record<string, any>;
-	nodeEnv?: string;
 	outputPath?: string;
 }
 

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -21,6 +21,10 @@ export const commonOptions = (yargs: yargs.Argv) => {
 			default: "register",
 			describe:
 				"Specify the loader to load the config file, can be `native` or `register`."
+		},
+		nodeEnv: {
+			string: true,
+			describe: "sets `process.env.NODE_ENV` to be specified value"
 		}
 	});
 };
@@ -52,10 +56,6 @@ export const commonOptionsForBuildAndServe = (yargs: yargs.Argv) => {
 				type: "array",
 				string: true,
 				describe: "env passed to config function"
-			},
-			nodeEnv: {
-				string: true,
-				describe: "sets process.env.NODE_ENV to be specified value"
 			},
 			devtool: {
 				type: "boolean",
@@ -143,4 +143,16 @@ export function ensureEnvObject<T extends Record<string, unknown>>(
 	}
 	options.env = options.env || {};
 	return options.env as T;
+}
+
+export function setDefaultNodeEnv(
+	options: yargs.Arguments,
+	defaultEnv: string
+) {
+	if (process.env.NODE_ENV !== undefined) {
+		return;
+	}
+
+	process.env.NODE_ENV =
+		typeof options.nodeEnv === "string" ? options.nodeEnv : defaultEnv;
 }

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -21,13 +21,14 @@ npx rspack -h
 
 Rspack CLI provides several common flags that can be used with all commands:
 
-| Flag                 | Description                                                                                                                    |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| -c, --config [value] | Specify the path to the configuration file, see [Specify the configuration file](/config/index#specify-the-configuration-file) |
-| --configLoader       | Specify the loader to load the config file, can be `native` or `register`, defaults to `register`                              |
-| --configName         | Specify the name of the configuration to use.                                                                                  |
-| -h, --help           | Show help information                                                                                                          |
-| -v, --version        | Show version number                                                                                                            |
+| Flag                 | Description                                                                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| -c, --config [value] | Specify the path to the configuration file, see [Specify the configuration file](/config/index#specify-the-configuration-file)                |
+| --configLoader       | Specify the loader to load the config file, can be `native` or `register`, defaults to `register`                                             |
+| --configName         | Specify the name of the configuration to use.                                                                                                 |
+| --nodeEnv            | Set the value of `process.env.NODE_ENV`, defaults to `development` for `rspack dev`, and `production` for `rspack build` and `rspack preview` |
+| -h, --help           | Show help information                                                                                                                         |
+| -v, --version        | Show version number                                                                                                                           |
 
 :::tip
 All flags in Rspack CLI support the `camelCase` and `kebab-case`, for example, both `--configLoader` and `--config-loader` are valid.
@@ -64,7 +65,6 @@ Options:
   -m, --mode           mode                                             [string]
   -w, --watch          watch                          [boolean] [default: false]
       --env            env passed to config function                     [array]
-      --nodeEnv        sets process.env.NODE_ENV to be specified value  [string]
   -d, --devtool        devtool                        [boolean] [default: false]
       --analyze        analyze                        [boolean] [default: false]
       --json           emit stats json
@@ -104,7 +104,6 @@ Options:
   -m, --mode           mode                                             [string]
   -w, --watch          watch                          [boolean] [default: false]
       --env            env passed to config function                     [array]
-      --nodeEnv        sets process.env.NODE_ENV to be specified value  [string]
   -d, --devtool        devtool                        [boolean] [default: false]
       --hot            enables hot module replacement
       --port           allows to specify a port to use                  [number]

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -21,13 +21,14 @@ npx rspack -h
 
 Rspack CLI 提供了一些公共选项，可以用于所有命令：
 
-| 选项                 | 描述                                                                 |
-| -------------------- | -------------------------------------------------------------------- |
-| -c, --config [value] | 指定配置文件路径，详见 [指定配置文件](/config/index#指定配置文件)    |
-| --configLoader       | 指定配置文件加载器，可以是 `native` 或 `register`，默认是 `register` |
-| --configName         | 指定配置文件名称                                                     |
-| -h, --help           | 显示帮助信息                                                         |
-| -v, --version        | 显示版本号                                                           |
+| 选项                 | 描述                                                                                                                        |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| -c, --config [value] | 指定配置文件路径，详见 [指定配置文件](/config/index#指定配置文件)                                                           |
+| --configLoader       | 指定配置文件加载器，可以是 `native` 或 `register`，默认是 `register`                                                        |
+| --configName         | 指定配置文件名称                                                                                                            |
+| --nodeEnv            | 设置 `process.env.NODE_ENV` 的值，`rspack dev` 默认是 `development`，`rspack build` 和 `rspack preview` 默认是 `production` |
+| -h, --help           | 显示帮助信息                                                                                                                |
+| -v, --version        | 显示版本号                                                                                                                  |
 
 :::tip
 Rspack CLI 的所有选项都支持使用 `camelCase`（驼峰命名）和 `kebab-case`（短横线命名），例如 `--configLoader` 和 `--config-loader` 都是有效的。
@@ -64,7 +65,6 @@ Options:
   -m, --mode         mode                                               [string]
   -w, --watch        watch                            [boolean] [default: false]
       --env          env passed to config function                       [array]
-      --nodeEnv     sets process.env.NODE_ENV to be specified value    [string]
   -d, --devtool      devtool                          [boolean] [default: false]
       --analyze      analyze                          [boolean] [default: false]
       --json         emit stats json
@@ -104,7 +104,6 @@ Options:
   -m, --mode         mode                                               [string]
   -w, --watch        watch                            [boolean] [default: false]
       --env          env passed to config function                       [array]
-      --nodeEnv      sets process.env.NODE_ENV to be specified value    [string]
   -d, --devtool      devtool                          [boolean] [default: false]
       --hot          enables hot module replacement
       --port         allows to specify a port to use                    [number]


### PR DESCRIPTION
## Summary

Enhance the `rspack preview` command:

- Add support for `--nodeEnv` flag
- Set `process.env.NODE_ENV` to `production` by default (align with Rsbuild and other community tools)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
