### PR TITLE
fix(lazy-compilation): should have separate state in multi-compiler

### DIFF
--- a/packages/rspack-test-tools/tests/NewIncremental-node.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-node.test.js
@@ -32,8 +32,7 @@ describeByWalk(
 		dist: path.resolve(
 			__dirname,
 			`./js/new-incremental/webpack-test/hot-async-node`
-		),
-		exclude: [/move-between-runtime/]
+		)
 	}
 );
 
@@ -45,7 +44,6 @@ describeByWalk(
 	},
 	{
 		source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
-		dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-node`),
-		exclude: [/move-between-runtime/]
+		dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-node`)
 	}
 );

--- a/packages/rspack-test-tools/tests/NewIncremental-web.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-web.test.js
@@ -28,7 +28,6 @@ describeByWalk(
 	},
 	{
 		source: path.resolve(__dirname, "../../../tests/webpack-test/hotCases"),
-		dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-web`),
-		exclude: [/move-between-runtime/]
+		dist: path.resolve(__dirname, `./js/new-incremental/webpack-test/hot-web`)
 	}
 );

--- a/packages/rspack-test-tools/tests/NewIncremental-webworker.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-webworker.test.js
@@ -32,7 +32,6 @@ describeByWalk(
 		dist: path.resolve(
 			__dirname,
 			`./js/new-incremental/webpack-test/hot-webworker`
-		),
-		exclude: [/move-between-runtime/]
+		)
 	}
 );

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -6540,8 +6540,6 @@ export const rspackOptions: z.ZodObject<{
             test: z.ZodOptional<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodBoolean>]>>;
         }, "strip", z.ZodTypeAny, {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-            imports?: boolean | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -6557,10 +6555,10 @@ export const rspackOptions: z.ZodObject<{
                 protocol?: "http" | "https" | undefined;
                 server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
+            imports?: boolean | undefined;
         }, {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-            imports?: boolean | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -6576,6 +6574,8 @@ export const rspackOptions: z.ZodObject<{
                 protocol?: "http" | "https" | undefined;
                 server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
+            imports?: boolean | undefined;
         }>]>;
         asyncWebAssembly: z.ZodOptional<z.ZodBoolean>;
         outputModule: z.ZodOptional<z.ZodBoolean>;
@@ -6680,8 +6680,6 @@ export const rspackOptions: z.ZodObject<{
         } | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-            imports?: boolean | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -6697,6 +6695,8 @@ export const rspackOptions: z.ZodObject<{
                 protocol?: "http" | "https" | undefined;
                 server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
+            imports?: boolean | undefined;
         } | undefined;
         asyncWebAssembly?: boolean | undefined;
         outputModule?: boolean | undefined;
@@ -6748,8 +6748,6 @@ export const rspackOptions: z.ZodObject<{
         } | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-            imports?: boolean | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -6765,6 +6763,8 @@ export const rspackOptions: z.ZodObject<{
                 protocol?: "http" | "https" | undefined;
                 server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
+            imports?: boolean | undefined;
         } | undefined;
         asyncWebAssembly?: boolean | undefined;
         outputModule?: boolean | undefined;
@@ -8734,8 +8734,6 @@ export const rspackOptions: z.ZodObject<{
         } | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-            imports?: boolean | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -8751,6 +8749,8 @@ export const rspackOptions: z.ZodObject<{
                 protocol?: "http" | "https" | undefined;
                 server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
+            imports?: boolean | undefined;
         } | undefined;
         asyncWebAssembly?: boolean | undefined;
         outputModule?: boolean | undefined;
@@ -9345,8 +9345,6 @@ export const rspackOptions: z.ZodObject<{
         } | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-            imports?: boolean | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -9362,6 +9360,8 @@ export const rspackOptions: z.ZodObject<{
                 protocol?: "http" | "https" | undefined;
                 server?: Record<string, any> | ((...args: unknown[]) => any) | undefined;
             } | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
+            imports?: boolean | undefined;
         } | undefined;
         asyncWebAssembly?: boolean | undefined;
         outputModule?: boolean | undefined;

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/backend.ts
@@ -60,191 +60,179 @@ export type ServerOptionsHttps<
 	Response extends typeof ServerResponse = typeof ServerResponse
 > = SecureContextOptions & TlsOptions & ServerOptionsImport<Request, Response>;
 
-const getBackend =
-	(
-		options: Omit<LazyCompilationDefaultBackendOptions, "client"> & {
-			client: NonNullable<LazyCompilationDefaultBackendOptions["client"]>;
-		}
-	) =>
-	(
-		compiler: Compiler,
-		callback: (
-			err: Error | null,
-			obj?: {
-				dispose: (callback: (err: any) => void) => void;
-				module: (args: { module: string; path: string }) => {
-					data: string;
-					client: string;
-					active: boolean;
-				};
-			}
-		) => void
-	) => {
-		const logger = compiler.getInfrastructureLogger("LazyCompilationBackend");
-		const activeModules = new Map();
-		const filesByKey: Map<string, string> = new Map();
-		const prefix = "/lazy-compilation-using-";
-		const isHttps =
-			options.protocol === "https" ||
-			(typeof options.server === "object" &&
-				("key" in options.server || "pfx" in options.server));
+const getBackend = (
+	options: Omit<LazyCompilationDefaultBackendOptions, "client"> & {
+		client: NonNullable<LazyCompilationDefaultBackendOptions["client"]>;
+	}
+) => {
+	const state = {
+		module: unimplemented as any,
+		dispose: unimplemented as any
+	};
 
-		const createServer =
-			typeof options.server === "function"
-				? options.server
-				: (() => {
-						const http = isHttps ? require("node:https") : require("node:http");
-						return http.createServer.bind(http, options.server);
-					})();
-		const listen =
-			typeof options.listen === "function"
-				? options.listen
-				: typeof options.server === "function" && !options.listen
-					? // if user offers custom server, no need to listen
-						() => {}
-					: (server: Server) => {
-							let { listen } = options;
-							if (typeof listen === "object" && !("port" in listen))
-								listen = { ...listen, port: undefined };
-							server.listen(listen as ListenOptions);
-						};
-
-		const protocol = options.protocol || (isHttps ? "https" : "http");
-
-		const requestListener = (req: IncomingMessage, res: ServerResponse) => {
-			if (!req.url?.startsWith(prefix)) {
-				return;
-			}
-			const keys = req.url.slice(prefix.length).split("@");
-			req.socket.on("close", () => {
-				setTimeout(() => {
-					for (const key of keys) {
-						const oldValue = activeModules.get(key) || 0;
-						activeModules.set(key, oldValue - 1);
-						if (oldValue === 1) {
-							logger.log(
-								`${key} is no longer in use. Next compilation will skip this module.`
-							);
-						}
-					}
-				}, 120000);
-			});
-			req.socket.setNoDelay(true);
-			res.writeHead(200, {
-				"content-type": "text/event-stream",
-				"Access-Control-Allow-Origin": "*",
-				"Access-Control-Allow-Methods": "*",
-				"Access-Control-Allow-Headers": "*"
-			});
-			res.write("\n");
-			const moduleActivated = [];
-			for (const key of keys) {
-				const oldValue = activeModules.get(key) || 0;
-				activeModules.set(key, oldValue + 1);
-				if (oldValue === 0) {
-					logger.log(`${key} is now in use and will be compiled.`);
-					moduleActivated.push(key);
-				}
-			}
-
-			if (moduleActivated.length && compiler.watching) {
-				compiler.watching.lazyCompilationInvalidate(
-					new Set(moduleActivated.map(key => filesByKey.get(key)!))
-				);
-			}
-		};
-
-		const server = createServer() as Server;
-		server.on("request", requestListener);
-
-		let isClosing = false;
-		const sockets: Set<Socket> = new Set();
-		server.on("connection", socket => {
-			sockets.add(socket);
-			socket.on("close", () => {
-				sockets.delete(socket);
-			});
-			if (isClosing) socket.destroy();
-		});
-
-		server.on("listening", err => {
-			if (err) return callback(err);
-			const addr = server.address() as AddressInfo;
-			if (typeof addr === "string")
-				throw new Error("addr must not be a string");
-			const urlBase =
-				addr.address === "::" || addr.address === "0.0.0.0"
-					? `${protocol}://localhost:${addr.port}`
-					: addr.family === "IPv6"
-						? `${protocol}://[${addr.address}]:${addr.port}`
-						: `${protocol}://${addr.address}:${addr.port}`;
-			logger.log(
-				`Server-Sent-Events server for lazy compilation open at ${urlBase}.`
-			);
-
-			const result = {
-				dispose(callback: any) {
-					isClosing = true;
-					// Removing the listener is a workaround for a memory leak in node.js
-					server.off("request", requestListener);
-					server.close(err => {
-						callback(err);
-					});
-					for (const socket of sockets) {
-						socket.destroy(new Error("Server is disposing"));
-					}
-				},
-				module({
-					module: originalModule,
-					path
-				}: {
-					module: string;
-					path: string;
-				}) {
-					const key = `${encodeURIComponent(
-						originalModule.replace(/\\/g, "/").replace(/@/g, "_")
-					).replace(/%(2F|3A|24|26|2B|2C|3B|3D|3A)/g, decodeURIComponent)}`;
-					filesByKey.set(key, path);
-					const active = activeModules.get(key) > 0;
-					return {
-						client: `${options.client}?${encodeURIComponent(urlBase + prefix)}`,
-						data: key,
-						active
+	return {
+		state,
+		backend: (
+			compiler: Compiler,
+			callback: (
+				err: Error | null,
+				obj?: {
+					dispose: (callback: (err: any) => void) => void;
+					module: (args: { module: string; path: string }) => {
+						data: string;
+						client: string;
+						active: boolean;
 					};
 				}
-			};
-			state.module = result.module;
-			state.dispose = result.dispose;
-			callback(null, result);
-		});
+			) => void
+		) => {
+			const logger = compiler.getInfrastructureLogger("LazyCompilationBackend");
+			const activeModules = new Map();
+			const filesByKey: Map<string, string> = new Map();
+			const prefix = "/lazy-compilation-using-";
+			const isHttps =
+				options.protocol === "https" ||
+				(typeof options.server === "object" &&
+					("key" in options.server || "pfx" in options.server));
 
-		listen(server);
+			const createServer =
+				typeof options.server === "function"
+					? options.server
+					: (() => {
+							const http = isHttps
+								? require("node:https")
+								: require("node:http");
+							return http.createServer.bind(http, options.server);
+						})();
+			const listen =
+				typeof options.listen === "function"
+					? options.listen
+					: typeof options.server === "function" && !options.listen
+						? // if user offers custom server, no need to listen
+							() => {}
+						: (server: Server) => {
+								let { listen } = options;
+								if (typeof listen === "object" && !("port" in listen))
+									listen = { ...listen, port: undefined };
+								server.listen(listen as ListenOptions);
+							};
+
+			const protocol = options.protocol || (isHttps ? "https" : "http");
+
+			const requestListener = (req: IncomingMessage, res: ServerResponse) => {
+				if (!req.url?.startsWith(prefix)) {
+					return;
+				}
+				const keys = req.url.slice(prefix.length).split("@");
+				req.socket.on("close", () => {
+					setTimeout(() => {
+						for (const key of keys) {
+							const oldValue = activeModules.get(key) || 0;
+							activeModules.set(key, oldValue - 1);
+							if (oldValue === 1) {
+								logger.log(
+									`${key} is no longer in use. Next compilation will skip this module.`
+								);
+							}
+						}
+					}, 120000);
+				});
+				req.socket.setNoDelay(true);
+				res.writeHead(200, {
+					"content-type": "text/event-stream",
+					"Access-Control-Allow-Origin": "*",
+					"Access-Control-Allow-Methods": "*",
+					"Access-Control-Allow-Headers": "*"
+				});
+				res.write("\n");
+				const moduleActivated = [];
+				for (const key of keys) {
+					const oldValue = activeModules.get(key) || 0;
+					activeModules.set(key, oldValue + 1);
+					if (oldValue === 0) {
+						logger.log(`${key} is now in use and will be compiled.`);
+						moduleActivated.push(key);
+					}
+				}
+
+				if (moduleActivated.length && compiler.watching) {
+					compiler.watching.lazyCompilationInvalidate(
+						new Set(moduleActivated.map(key => filesByKey.get(key)!))
+					);
+				}
+			};
+
+			const server = createServer() as Server;
+			server.on("request", requestListener);
+
+			let isClosing = false;
+			const sockets: Set<Socket> = new Set();
+			server.on("connection", socket => {
+				sockets.add(socket);
+				socket.on("close", () => {
+					sockets.delete(socket);
+				});
+				if (isClosing) socket.destroy();
+			});
+
+			server.on("listening", err => {
+				if (err) return callback(err);
+				const addr = server.address() as AddressInfo;
+				if (typeof addr === "string")
+					throw new Error("addr must not be a string");
+				const urlBase =
+					addr.address === "::" || addr.address === "0.0.0.0"
+						? `${protocol}://localhost:${addr.port}`
+						: addr.family === "IPv6"
+							? `${protocol}://[${addr.address}]:${addr.port}`
+							: `${protocol}://${addr.address}:${addr.port}`;
+				logger.log(
+					`Server-Sent-Events server for lazy compilation open at ${urlBase}.`
+				);
+
+				const result = {
+					dispose(callback: any) {
+						isClosing = true;
+						// Removing the listener is a workaround for a memory leak in node.js
+						server.off("request", requestListener);
+						server.close(err => {
+							callback(err);
+						});
+						for (const socket of sockets) {
+							socket.destroy(new Error("Server is disposing"));
+						}
+					},
+					module({
+						module: originalModule,
+						path
+					}: {
+						module: string;
+						path: string;
+					}) {
+						const key = `${encodeURIComponent(
+							originalModule.replace(/\\/g, "/").replace(/@/g, "_")
+						).replace(/%(2F|3A|24|26|2B|2C|3B|3D|3A)/g, decodeURIComponent)}`;
+						filesByKey.set(key, path);
+						const active = activeModules.get(key) > 0;
+						return {
+							client: `${options.client}?${encodeURIComponent(urlBase + prefix)}`,
+							data: key,
+							active
+						};
+					}
+				};
+				state.module = result.module;
+				state.dispose = result.dispose;
+				callback(null, result);
+			});
+
+			listen(server);
+		}
 	};
+};
 
 export default getBackend;
 
 function unimplemented() {
 	throw new Error("access before initialization");
-}
-
-const state: {
-	module: typeof moduleImpl;
-	dispose: typeof dispose;
-} = {
-	module: unimplemented as any,
-	dispose: unimplemented
-};
-
-export function dispose(callback: any) {
-	state.dispose(callback);
-	state.dispose = unimplemented;
-	state.module = unimplemented as any;
-}
-
-export function moduleImpl(args: { module: string; path: string }): {
-	active: boolean;
-	data: string;
-	client: string;
-} {
-	return state.module(args);
 }

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/plugin.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/plugin.ts
@@ -2,9 +2,7 @@ import type { JsModule } from "@rspack/binding";
 
 import type { Compiler } from "../..";
 import getBackend, {
-	dispose,
-	type LazyCompilationDefaultBackendOptions,
-	moduleImpl
+	type LazyCompilationDefaultBackendOptions
 } from "./backend";
 import { BuiltinLazyCompilationPlugin } from "./lazyCompilation";
 
@@ -30,7 +28,7 @@ export default class LazyCompilationPlugin {
 	}
 
 	apply(compiler: Compiler) {
-		const backend = getBackend({
+		const { state, backend } = getBackend({
 			client: require.resolve(
 				`../hot/lazy-compilation-${
 					compiler.options.externalsPresets.node ? "node" : "web"
@@ -40,7 +38,7 @@ export default class LazyCompilationPlugin {
 		});
 
 		new BuiltinLazyCompilationPlugin(
-			moduleImpl,
+			args => state.module(args),
 			this.cacheable,
 			this.entries,
 			this.imports,
@@ -84,7 +82,7 @@ export default class LazyCompilationPlugin {
 		);
 
 		compiler.hooks.shutdown.tapAsync("LazyCompilationPlugin", callback => {
-			dispose(callback);
+			state.dispose(callback);
 		});
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close #7578
close #8305

Each compiler instance should have its own lazyCompilation state. Implementing communication between compilers and lazyCompilation using a global state can be disrupted by different compilers.



<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
