### PR TITLE
test: fix import failed while running cases concurrently

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -54,6 +54,8 @@ export class BasicCaseCreator<T extends ECompilerType> {
     // (undocumented)
     protected registerConcurrentTask(name: string, starter: () => void): () => void;
     // (undocumented)
+    protected shouldRun(name: string): boolean;
+    // (undocumented)
     protected skip(name: string, reason: string | boolean): void;
     // (undocumented)
     protected tasks: [string, () => void][];

--- a/packages/rspack-test-tools/jest.config.js
+++ b/packages/rspack-test-tools/jest.config.js
@@ -33,7 +33,15 @@ const config = {
 	},
 	globals: {
 		updateSnapshot:
-			process.argv.includes("-u") || process.argv.includes("--updateSnapshot")
+			process.argv.includes("-u") || process.argv.includes("--updateSnapshot"),
+		testFilter:
+			process.argv.includes("--test") || process.argv.includes("-t")
+				? process.argv[
+						(process.argv.includes("-t")
+							? process.argv.indexOf("-t")
+							: process.argv.indexOf("--test")) + 1
+					]
+				: undefined
 	}
 };
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`-t` can only affect `it()`, so the build of every case will always compile while running concurrently. So we need to filter it manually to skip the whole `describe()`. In the future, we can add more filter logic in test creator to improve the DX of `-t`.

---
This pull request introduces a new feature to filter tests based on a provided string and includes several related changes across multiple files. The most important changes include adding a `shouldRun` method to determine if a test should be executed, updating the Jest configuration to support the new test filter, and declaring a global variable for the test filter.



## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
