### PR TITLE
ci: install nightly components manually

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -33,6 +33,7 @@ rustflags = [
   "-Aclippy::default_constructed_unit_structs",
   "-Zshare-generics=y", # make the current crate share its generic instantiations
   "-Zthreads=8" # parallel frontend https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
+  
 ]
 
 # Fix napi breaking in test environment <https://github.com/napi-rs/napi-rs/issues/1005#issuecomment-1011034770>

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -49,7 +49,9 @@ runs:
     # install components for nightly toolchain
     - name: Install
       shell: bash
-      run: rustup toolchain install nightly-2024-11-27 -c rustc -c cargo -c rust-std ${{ inputs.clippy == 'true' && '-c clippy' || '' }} ${{ inputs.fmt == 'true' && '-c rustfmt' || '' }} ${{ inputs.docs == 'true' && '-c rust-docs' || '' }} ${{ inputs.miri == 'true' && '-c miri' || '' }}
+      run: |
+        channel=$(grep -E "^channel\s*=" rust-toolchain.toml | sed -n -E 's/^[ \t]*channel[ \t]*=[ \t]*"([^"]*)"[^#]*.*$/\1/p' | tr -d '[:space:]')
+        rustup toolchain install $channel -c rustc -c cargo -c rust-std ${{ inputs.clippy == 'true' && '-c clippy' || '' }} ${{ inputs.fmt == 'true' && '-c rustfmt' || '' }} ${{ inputs.docs == 'true' && '-c rust-docs' || '' }} ${{ inputs.miri == 'true' && '-c miri' || '' }}
 
     - name: Cache on ${{ github.ref_name }}
       uses: ./.github/actions/rustup/cache

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -57,4 +57,3 @@ runs:
       uses: ./.github/actions/rustup/cache
       with:
         key: ${{ inputs.shared-key }}
-        save-if: ${{ github.ref_name == 'main' }}

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -49,7 +49,7 @@ runs:
     # install components for nightly toolchain
     - name: Install
       shell: bash
-      run: rustup toolchain install nightly-2024-11-27 -c rustc -c cargo -c rust-std ${{ inputs.clippy == 'true' ? '-c clippy' : '' }} ${{ inputs.fmt == 'true' ? '-c rustfmt' : '' }} ${{ inputs.docs == 'true' ? '-c rust-docs' : '' }} ${{ inputs.miri == 'true' ? '-c miri' : '' }}
+      run: rustup toolchain install nightly-2024-11-27 -c rustc -c cargo -c rust-std ${{ inputs.clippy == 'true' && '-c clippy' || '' }} ${{ inputs.fmt == 'true' && '-c rustfmt' || '' }} ${{ inputs.docs == 'true' && '-c rust-docs' || '' }} ${{ inputs.miri == 'true' && '-c miri' || '' }}
 
     - name: Cache on ${{ github.ref_name }}
       uses: ./.github/actions/rustup/cache

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -57,3 +57,4 @@ runs:
       uses: ./.github/actions/rustup/cache
       with:
         key: ${{ inputs.shared-key }}
+        save-if: ${{ github.ref_name == 'main' }}

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -46,43 +46,10 @@ runs:
         echo 'save-cache: ${{ inputs.save-cache }}'
         echo 'shared-key: ${{ inputs.shared-key }}'
 
-    - name: Remove `profile` line on MacOS
-      shell: bash
-      if: runner.os == 'macOS'
-      run: sed -i '' '/profile/d' rust-toolchain.toml
-
-    - name: Remove `profile` line on non-MacOS
-      shell: bash
-      if: runner.os != 'macOS'
-      run: sed -i '/profile/d' rust-toolchain.toml
-
-    - name: Set minimal
-      shell: bash
-      run: rustup set profile minimal
-
-    - name: Add Miri
-      shell: bash
-      if: ${{ inputs.miri == 'true' }}
-      run: rustup component add miri
-
-    - name: Add Clippy
-      shell: bash
-      if: ${{ inputs.clippy == 'true' }}
-      run: rustup component add clippy
-
-    - name: Add Rustfmt
-      shell: bash
-      if: ${{ inputs.fmt == 'true' }}
-      run: rustup component add rustfmt
-
-    - name: Add docs
-      shell: bash
-      if: ${{ inputs.docs == 'true' }}
-      run: rustup component add rust-docs
-
+    # install components for nightly toolchain
     - name: Install
       shell: bash
-      run: rustup show
+      run: rustup toolchain install nightly-2024-11-27 -c rustc -c cargo -c rust-std ${{ inputs.clippy == 'true' ? '-c clippy' : '' }} ${{ inputs.fmt == 'true' ? '-c rustfmt' : '' }} ${{ inputs.docs == 'true' ? '-c rust-docs' : '' }} ${{ inputs.miri == 'true' ? '-c miri' : '' }}
 
     - name: Cache on ${{ github.ref_name }}
       uses: ./.github/actions/rustup/cache

--- a/.github/actions/rustup/cache/action.yml
+++ b/.github/actions/rustup/cache/action.yml
@@ -18,6 +18,7 @@ runs:
       uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
       with:
         shared-key: ${{ inputs.key }}
+        save-if: ${{ github.ref_name == 'main' }}
 #    - name: Cache to local
 #      uses: lynx-infra/cache
 #      if: ${{ runner.environment == 'self-hosted' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: x86_64-pc-windows-msvc
-      profile: "dev"
+      profile: "ci"
       runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
       skipable: ${{ needs.check-changed.outputs.changed != 'true' }}
       full-install: false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,5 @@
 profile = "default"
 # Use nightly for better access to the latest Rust features.
 # This date is aligned to stable release dates.
-channel = "nightly-2024-11-27" # v1.83.0
+# stable-2025-02-20 -> v1.85.0
+channel = "nightly-2024-11-27"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. Nightly will always install rust-docs which rspack does not use if install throw rust-toolchain.toml.
2. There is no need to store rust cache if it is not on main branch.
3. Use CI profile to build binding on windows.

Before:
![image](https://github.com/user-attachments/assets/eb86ada0-925e-4820-beb1-66292a2ff0b2)


After: 
![image](https://github.com/user-attachments/assets/70cd9fe3-5dfb-4295-9489-af85dc17a376)


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
