### PR TITLE
docs: add Angular Rspack and update example repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,19 @@ Come chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! Rspack team and R
 
 ## Links
 
-| Name                                                                                 | Description                                                                   |
-| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)                    | A curated list of awesome things related to Rspack                            |
-| [Rspack 1.x documentation](https://rspack.dev/)                                      | Documentation for Rspack 1.x (latest)                                         |
-| [Rspack 0.x documentation](https://v0.rspack.dev/)                                   | Documentation for Rspack 0.x version                                          |
-| [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                  | An out-of-the-box build tool based on Rspack                                  |
-| [Rspress](https://github.com/web-infra-dev/rspress)                                  | A fast static site generator based on Rsbuild                                 |
-| [Rsdoctor](https://github.com/web-infra-dev/rsdoctor)                                | A one-stop build analyzer for Rspack                                          |
-| [Rslib](https://github.com/web-infra-dev/rslib)                                      | A library development tool powered by Rsbuild                                       |
-| [rspack-dev-server](https://github.com/web-infra-dev/rspack-dev-server)              | Dev server for Rspack                                                         |
-| [rspack-examples](https://github.com/rspack-contrib/rspack-examples)                 | Lots of Rspack example projects                                               |
-| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust port of [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
-| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Design resources for Rspack Stack                                             |
+| Name                                                                                 | Description                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)                    | A curated list of awesome things related to Rspack                              |
+| [Rspack 1.x documentation](https://rspack.dev/)                                      | Documentation for Rspack 1.x (latest)                                           |
+| [Rspack 0.x documentation](https://v0.rspack.dev/)                                   | Documentation for Rspack 0.x version                                            |
+| [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                  | An out-of-the-box build tool based on Rspack                                    |
+| [Rspress](https://github.com/web-infra-dev/rspress)                                  | A fast static site generator based on Rsbuild                                   |
+| [Rsdoctor](https://github.com/web-infra-dev/rsdoctor)                                | A one-stop build analyzer for Rspack                                            |
+| [Rslib](https://github.com/web-infra-dev/rslib)                                      | A library development tool powered by Rsbuild                                   |
+| [rspack-dev-server](https://github.com/web-infra-dev/rspack-dev-server)              | Dev server for Rspack                                                           |
+| [rstack-examples](https://github.com/rspack-contrib/rstack-examples)                 | Examples showcasing Rstack ecosystem tools (Rspack, Rsbuild, Rspress, Rsdoctor) |
+| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust port of [webpack-sources](https://www.npmjs.com/package/webpack-sources)   |
+| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Design resources for Rspack Stack                                               |
 
 ## Contributors
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ Rspack 是一个基于 Rust 编写的高性能 JavaScript 打包工具，它提�
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor)                                | 针对 Rspack 的一站式构建分析工具                                             |
 | [Rslib](https://github.com/web-infra-dev/rslib)                                      | 基于 Rsbuild 的 library 开发工具                                             |
 | [rspack-dev-server](https://github.com/web-infra-dev/rspack-dev-server)              | Rspack 的开发服务器                                                          |
-| [rspack-examples](https://github.com/rspack-contrib/rspack-examples)                 | 丰富的 Rspack 示例项目                                                       |
+| [rstack-examples](https://github.com/rspack-contrib/rstack-examples)                 | Rstack 生态（Rspack、Rsbuild、Rspress、Rsdoctor）的示例                      |
 | [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust 版本的 [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
 | [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Rspack Stack 的设计资源                                                      |
 

--- a/website/docs/en/blog/announcing-0-2.mdx
+++ b/website/docs/en/blog/announcing-0-2.mdx
@@ -164,7 +164,7 @@ Although Rspack supports and enables the `experiments.css` feature of webpack by
 
 When using Rspack to package Node applications like NestJS, a common requirement is to package libraries containing addons. These libraries' native dependencies cannot be directly packaged into js, so they need special treatment. Rspack has adapted [node-loader](https://github.com/webpack-contrib/node-loader), so you can now use Rspack to build node applications.
 
-Rspack has additional adaptation of webpack's plugins. We have tracked the adapted plugins and loaders in [loader-compat](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/loader-compat) and [plugin-compat](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/plugin). If you find that a community plugin or loader you are using is also compatible, welcome to submit it to us so we can list it in our compatibility matrix.
+Rspack has additional adaptation of webpack's plugins. We have tracked the adapted plugins and loaders in [loader-compat](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/loader-compat) and [plugin-compat](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/plugin). If you find that a community plugin or loader you are using is also compatible, welcome to submit it to us so we can list it in our compatibility matrix.
 
 ## Framework ecosystem updates
 
@@ -188,7 +188,7 @@ Rspack 0.2 has achieved compatibility with vue-loader! For Vue3 projects, you ca
 
 ### Svelte
 
-Thanks to Rspack's excellent support for the Loader API and the excellent design of [svelte-loader](https://github.com/sveltejs/svelte-loader), Rspack has fully adapted [svelte-loader](https://github.com/sveltejs/svelte-loader). Therefore, you can directly use [svelte-loader](https://github.com/sveltejs/svelte-loader) in Rspack for svelte application development. You can refer to [example-svelte](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/svelte) to complete the svelte-loader related configuration.
+Thanks to Rspack's excellent support for the Loader API and the excellent design of [svelte-loader](https://github.com/sveltejs/svelte-loader), Rspack has fully adapted [svelte-loader](https://github.com/sveltejs/svelte-loader). Therefore, you can directly use [svelte-loader](https://github.com/sveltejs/svelte-loader) in Rspack for svelte application development. You can refer to [example-svelte](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/svelte) to complete the svelte-loader related configuration.
 
 ### Storybook
 

--- a/website/docs/en/blog/announcing-0-3.mdx
+++ b/website/docs/en/blog/announcing-0-3.mdx
@@ -87,7 +87,7 @@ export default {
 };
 ```
 
-You can refer to the [examples/postcss-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/postcss-loader) for a complete example.
+You can refer to the [examples/postcss-loader](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/postcss-loader) for a complete example.
 
 ### Access to internal modules restricted
 
@@ -159,7 +159,7 @@ export default defineConfig({
 });
 ```
 
-You can refer to [examples/builtin-swc-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/builtin-swc-loader) for more examples. Currently, `builtin:swc-loader` still has limitations, such as not supporting Wasm plugins, etc. Rspack will continue to iterate and support more features of `builtin:swc-loader` in future versions.
+You can refer to [examples/builtin-swc-loader](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/builtin-swc-loader) for more examples. Currently, `builtin:swc-loader` still has limitations, such as not supporting Wasm plugins, etc. Rspack will continue to iterate and support more features of `builtin:swc-loader` in future versions.
 
 ### Improved profile support
 

--- a/website/docs/en/blog/announcing-0-4.mdx
+++ b/website/docs/en/blog/announcing-0-4.mdx
@@ -195,7 +195,7 @@ To opt out of the new resolver, set `experiments.rspackFuture.newResolver` to `f
 
 ## Migration guide
 
-There is a [migrate example](https://github.com/rspack-contrib/rspack-examples/pull/2) demonstrating how to migrate from Rspack 0.3.14 to Rspack 0.4.0.
+There is a [migrate example](https://github.com/rspack-contrib/rstack-examples/pull/2) demonstrating how to migrate from Rspack 0.3.14 to Rspack 0.4.0.
 
 ### Choose `@rspack/cli` or `Rsbuild`?
 

--- a/website/docs/en/blog/announcing-0-6.mdx
+++ b/website/docs/en/blog/announcing-0-6.mdx
@@ -35,7 +35,7 @@ export default {
 };
 ```
 
-> There is an basic [project example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-with-extract-css).
+> There is an basic [project example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-with-extract-css).
 
 ### Enable new tree shaking by default
 
@@ -65,7 +65,7 @@ Remove `builtins.css`, please replace it with the CSS-related [`module.parser`](
 
 Also, starting from v0.6.0, Rspack's experiments CSS will align with webpack's experiments CSS as a target, which means that, like webpack experiments CSS, it will no longer support [browsers that do not support CSS variables](https://caniuse.com/css-variables) in the future. Therefore, for those projects that need to use configurations not yet supported by experiments CSS, or need to support older browsers, we recommend migrating to [`rspack.CssExtractRspackPlugin`](/plugins/rspack/css-extract-rspack-plugin.html).
 
-In v0.6.0, we introduced three new types of `module.generator` and `module.parser` options: `css/auto`, `css`, and `css/module`, which will only take effect when experiments.css is enabled, checkout [this example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/css-parser-generator-options) about how to use it.
+In v0.6.0, we introduced three new types of `module.generator` and `module.parser` options: `css/auto`, `css`, and `css/module`, which will only take effect when experiments.css is enabled, checkout [this example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/css-parser-generator-options) about how to use it.
 
 In the `module.parser` options, module types `css`, `css/auto`, and `css/module` all include the `namedExports` property. It has replaced the `builtins.css.namedExports` configuration.
 

--- a/website/docs/en/blog/announcing-1-2.mdx
+++ b/website/docs/en/blog/announcing-1-2.mdx
@@ -157,7 +157,7 @@ Nx team core member [Colum Ferry](https://github.com/Coly010) has brought comple
 
 With the newly released `@ng-rsbuild/plugin-angular` and `@ng-rspack/build` packages, developers can now use Rspack or Rsbuild to build Angular applications, with faster build performance and module federation support.
 
-Please visit [ng-rspack-build](https://github.com/Coly010/ng-rspack-build) for more information.
+Please visit [Angular Rspack](https://github.com/nrwl/angular-rspack) for more information.
 
 ### Rsbuild v1.2
 

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -319,7 +319,7 @@ export default {
 };
 ```
 
-[Click to see the example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/basic-ts).
+[Click to see the example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/basic-ts).
 
 ### resolve.tsConfig.configFile
 

--- a/website/docs/en/guide/compatibility/plugin.mdx
+++ b/website/docs/en/guide/compatibility/plugin.mdx
@@ -10,6 +10,6 @@ Note that the table only lists some common community plugins. For plugins that a
 
 <CommunityPluginCompatibleTable lang="en" />
 
-You can view examples of common plugins at [rspack-examples](https://github.com/rspack-contrib/rspack-examples).
+You can view examples of common plugins at [rstack-examples](https://github.com/rspack-contrib/rstack-examples).
 
 Additionally, you can check out the community Rspack plugins at [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack).

--- a/website/docs/en/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/features/builtin-swc-loader.mdx
@@ -265,7 +265,7 @@ export default {
 };
 ```
 
-this is an [example](https://github.com/rspack-contrib/rspack-examples/blob/d4b8aaef9915ed0f540edbe504217c3d1afe8989/rspack/builtin-swc-loader/rspack.config.js#L45) of Wasm plugin usage.
+this is an [example](https://github.com/rspack-contrib/rstack-examples/blob/d4b8aaef9915ed0f540edbe504217c3d1afe8989/rspack/builtin-swc-loader/rspack.config.js#L45) of Wasm plugin usage.
 
 #### Set cache root
 

--- a/website/docs/en/guide/features/module-federation.mdx
+++ b/website/docs/en/guide/features/module-federation.mdx
@@ -73,7 +73,7 @@ export default {
 };
 ```
 
-> Reference: [Module Federation v1.5 example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/module-federation-v1.5).
+> Reference: [Module Federation v1.5 example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/module-federation-v1.5).
 
 ### Module Federation v1.0
 

--- a/website/docs/en/guide/features/web-workers.mdx
+++ b/website/docs/en/guide/features/web-workers.mdx
@@ -30,9 +30,9 @@ Custom syntax can be provided via [`module.parser.javascript.worker`](/config/mo
 
 For examples:
 
-- [examples/worker](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/worker)
-- [examples/monaco-editor-js](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/monaco-editor-js)
-- [examples/monaco-editor-ts-react](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/monaco-editor-ts-react)
+- [examples/worker](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/worker)
+- [examples/monaco-editor-js](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/monaco-editor-js)
+- [examples/monaco-editor-ts-react](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/monaco-editor-ts-react)
 
 :::info
 The syntax was chosen to allow running code without bundler, it is also available in native ECMAScript modules in the browser.

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -196,6 +196,10 @@ Nuxt v3.14 introduces a new first-class Nuxt builder for Rspack, see [Nuxt 3.14]
 
 Re.Pack v5 uses Rspack and React Native community CLI's plugin system to allow you to bundle your application using Rspack and easily switch from Metro.
 
+### Angular Rspack
+
+[Angular Rspack](https://github.com/nrwl/angular-rspack) is a set of plugins and tools to make it easy and straightforward to build Angular applications with Rspack and Rsbuild.
+
 ### More
 
 Visit [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) to discover more projects within the Rspack ecosystem.

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -1,7 +1,7 @@
 # NestJS
 
 Rspack not only supports building frontend projects but also supports building Node.js App like NestJS.
-Rspack provides NestJS [example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/nestjs) for reference.
+Rspack provides NestJS [example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/nestjs) for reference.
 
 ## Native node modules
 

--- a/website/docs/en/guide/tech/preact.mdx
+++ b/website/docs/en/guide/tech/preact.mdx
@@ -57,7 +57,7 @@ export default {
 
 Refer to [Builtin swc-loader](guide/features/builtin-swc-loader) for detailed configurations.
 
-Refer to [examples/preact](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact) for the full example.
+Refer to [examples/preact](https://github.com/rspack-contrib/rstack-examples/blob/main/rspack/preact) for the full example.
 
 ## Preact Refresh
 
@@ -136,4 +136,4 @@ export default {
 };
 ```
 
-Refer to [examples/preact-refresh](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact-refresh) for the full example.
+Refer to [examples/preact-refresh](https://github.com/rspack-contrib/rstack-examples/blob/main/rspack/preact-refresh) for the full example.

--- a/website/docs/en/guide/tech/react.mdx
+++ b/website/docs/en/guide/tech/react.mdx
@@ -112,8 +112,8 @@ export default {
 
 Compared to the previous approach, this method decouples the React Fast Refresh code injection logic from the transformation logic. The code injection logic is handled uniformly by the @rspack/plugin-react-refresh plugin, while the code transformation is handled by loaders. This means that this plugin can be used in conjunction with `builtin:swc-loader`, `swc-loader`, or `babel-loader`:
 
-- For usage with `builtin:swc-loader`, you can refer to the example at [examples/react-refresh](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh), When using with `swc-loader`, simply replace `builtin:swc-loader` with `swc-loader`.
-- For usage with `babel-loader`, you can refer to the example at [examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh-babel-loader)
+- For usage with `builtin:swc-loader`, you can refer to the example at [examples/react-refresh](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-refresh), When using with `swc-loader`, simply replace `builtin:swc-loader` with `swc-loader`.
+- For usage with `babel-loader`, you can refer to the example at [examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-refresh-babel-loader)
 
 ## React Compiler
 
@@ -200,8 +200,8 @@ const ReactCompilerConfig = {
 
 You can refer to the following example projects:
 
-- [Rspack + React Compiler](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-compiler-babel)
-- [Rspack + React Compiler + TypeScript](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-compiler-babel-ts)
+- [Rspack + React Compiler](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-compiler-babel)
+- [Rspack + React Compiler + TypeScript](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-compiler-babel-ts)
 
 ## Integrating SVGR
 

--- a/website/docs/en/guide/tech/solid.mdx
+++ b/website/docs/en/guide/tech/solid.mdx
@@ -9,7 +9,7 @@ Rspack provides two solutions to support Solid:
 
 ## Configure Solid
 
-Thanks to the good compatibility of Rspack with the babel-loader, it is very easy to use Solid in Rspack. All you need is babel-loader and Solid babel preset. Rspack provides Solid [example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/solid) for reference.
+Thanks to the good compatibility of Rspack with the babel-loader, it is very easy to use Solid in Rspack. All you need is babel-loader and Solid babel preset. Rspack provides Solid [example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/solid) for reference.
 
 ```js title="rspack.config.mjs"
 import { defineConfig } from '@rspack/cli';

--- a/website/docs/en/guide/tech/svelte.mdx
+++ b/website/docs/en/guide/tech/svelte.mdx
@@ -9,7 +9,7 @@ Rspack provides two solutions to support Svelte:
 
 ## Configure svelte-loader
 
-Thanks to the good compatibility of Rspack with the [svelte-loader](https://github.com/sveltejs/svelte-loader), it is very easy to use Svelte in Rspack. All you need is to configure svelte-loader. Rspack provides Svelte [example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/svelte) for reference.
+Thanks to the good compatibility of Rspack with the [svelte-loader](https://github.com/sveltejs/svelte-loader), it is very easy to use Svelte in Rspack. All you need is to configure svelte-loader. Rspack provides Svelte [example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/svelte) for reference.
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';

--- a/website/docs/en/guide/tech/vue.mdx
+++ b/website/docs/en/guide/tech/vue.mdx
@@ -83,7 +83,7 @@ Besides, as Rspack has built-in TS support, we also support `lang="ts"` configur
 </script>
 ```
 
-You can refer to the related example [example-vue3](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/vue).
+You can refer to the related example [example-vue3](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/vue).
 
 ## Vue 2
 
@@ -122,7 +122,7 @@ export default {
 
 TypeScript is supported using Rspack's native `builtin:swc-loader`, see [this](/guide/features/builtin-swc-loader) for details.
 
-You can refer to the related example [example-vue2](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/vue2) and [example-vue2-ts](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/vue2-ts).
+You can refer to the related example [example-vue2](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/vue2) and [example-vue2-ts](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/vue2-ts).
 
 ## Vue 3 JSX
 
@@ -163,4 +163,4 @@ export default defineConfig({
 });
 ```
 
-Rspack provides a [example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/vue3-jsx) of Vue JSX for reference.
+Rspack provides a [example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/vue3-jsx) of Vue JSX for reference.

--- a/website/docs/zh/blog/announcing-0-2.mdx
+++ b/website/docs/zh/blog/announcing-0-2.mdx
@@ -161,7 +161,7 @@ export default {
 ### node-loader
 
 当使用 Rspack 打包如 NestJS 等 Node 应用时，一个常见的需求就是打包一些包含 addon 的库，这些库里的 native 依赖无法直接被打包进 JS 里，因此需要特殊处理，Rspack 适配了 [node-loader](https://github.com/webpack-contrib/node-loader) 所以你可以使用 Rspack 去构建 node 应用了。
-Rspack 适配的 webpack 的 plugin 和 loader 远不仅此，我们在 [loader-compat](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/loader-compat) 和 [plugin-compat](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/plugin) 对已经适配的 plugin 和 loader 进行了追踪，如果你发现你使用的社区 plugin 和 loader 也已经兼容，欢迎提交给我们。
+Rspack 适配的 webpack 的 plugin 和 loader 远不仅此，我们在 [loader-compat](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/loader-compat) 和 [plugin-compat](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/plugin) 对已经适配的 plugin 和 loader 进行了追踪，如果你发现你使用的社区 plugin 和 loader 也已经兼容，欢迎提交给我们。
 
 ## 框架生态更新
 
@@ -185,7 +185,7 @@ Rspack 0.2 已经完成了对 vue-loader 的兼容。对于 Vue3 项目，你可
 
 ### Svelte
 
-得益于 Rspack 对 Loader API 的良好支持和 [svelte-loader](https://github.com/sveltejs/svelte-loader) 的优良设计，Rspack 已经完全适配了 [svelte-loader](https://github.com/sveltejs/svelte-loader)，因此你可以在 Rspack 直接使用 [svelte-loader](https://github.com/sveltejs/svelte-loader) 进行 svelte 应用的开发，你可以参考 [example-svelte](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/svelte) 完成 svelte-loader 相关配置。
+得益于 Rspack 对 Loader API 的良好支持和 [svelte-loader](https://github.com/sveltejs/svelte-loader) 的优良设计，Rspack 已经完全适配了 [svelte-loader](https://github.com/sveltejs/svelte-loader)，因此你可以在 Rspack 直接使用 [svelte-loader](https://github.com/sveltejs/svelte-loader) 进行 svelte 应用的开发，你可以参考 [example-svelte](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/svelte) 完成 svelte-loader 相关配置。
 
 ### Storybook
 

--- a/website/docs/zh/blog/announcing-0-3.mdx
+++ b/website/docs/zh/blog/announcing-0-3.mdx
@@ -87,7 +87,7 @@ export default {
 };
 ```
 
-完整的示例可参考 [examples/postcss-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/postcss-loader)。
+完整的示例可参考 [examples/postcss-loader](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/postcss-loader)。
 
 ### 限制访问内部模块
 
@@ -159,7 +159,7 @@ export default defineConfig({
 });
 ```
 
-更多的示例可参考 [examples/builtin-swc-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/builtin-swc-loader)
+更多的示例可参考 [examples/builtin-swc-loader](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/builtin-swc-loader)
 目前的 `builtin:swc-loader` 仍然有诸多限制，如不支持 Wasm plugin 等，Rspack 在后续版本将继续迭代支持 `builtin:swc-loader` 的更多功能。
 
 ### 更好的 profile 支持

--- a/website/docs/zh/blog/announcing-0-4.mdx
+++ b/website/docs/zh/blog/announcing-0-4.mdx
@@ -179,7 +179,7 @@ export default {
 
 ## Migration guide
 
-迁移示例 [migrate example](https://github.com/rspack-contrib/rspack-examples/pull/2) 展示了如何从 Rspack 0.3.14 迁移到 Rspack 0.4.0
+迁移示例 [migrate example](https://github.com/rspack-contrib/rstack-examples/pull/2) 展示了如何从 Rspack 0.3.14 迁移到 Rspack 0.4.0
 
 ### 选择 `@rspack/cli` 还是 `Rsbuild`？
 

--- a/website/docs/zh/blog/announcing-0-6.mdx
+++ b/website/docs/zh/blog/announcing-0-6.mdx
@@ -35,7 +35,7 @@ export default {
 };
 ```
 
-> 你可以在[这里](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-with-extract-css)找到一个基础的项目例子。
+> 你可以在[这里](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-with-extract-css)找到一个基础的项目例子。
 
 ### 默认开启新版 tree shaking
 
@@ -64,7 +64,7 @@ Rspack 在 0.1.0 支持了基本的 tree shaking 功能，由于最初的架构�
 
 同时，从 v0.6.0 版本开始，Rspack 的 `experiments.css` 将会以 webpack 的 `experiments.css` 为目标进行对齐，这意味着和 webpack `experiments.css` 一样在未来将不再支持[不支持 CSS 变量的浏览器](https://caniuse.com/css-variables)。因此，对于那些需要使用尚未得到 `experiments.css` 支持的配置，或者需要兼容老版本浏览器的项目，我们推荐迁移至 [`rspack.CssExtractRspackPlugin`](/plugins/rspack/css-extract-rspack-plugin.html)。
 
-在 v0.6.0 中，我们引入了三种新的模块类型的 `module.generator` 和 `module.parser` 选项：`css/auto`、`css` 和 `css/module`，这些选项只有在启用 experiments.css 时才会生效，关于如何使用可查看[这个例子](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/css-parser-generator-options)。
+在 v0.6.0 中，我们引入了三种新的模块类型的 `module.generator` 和 `module.parser` 选项：`css/auto`、`css` 和 `css/module`，这些选项只有在启用 experiments.css 时才会生效，关于如何使用可查看[这个例子](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/css-parser-generator-options)。
 
 在 `module.parser` 选项中，`css`、`css/auto` 和 `css/module` 模块类型都包含了 `namedExports` 属性。它取代了 `builtins.css.namedExports` 配置。
 

--- a/website/docs/zh/blog/announcing-1-2.mdx
+++ b/website/docs/zh/blog/announcing-1-2.mdx
@@ -157,7 +157,7 @@ Nx 团队的核心成员 [Colum Ferry](https://github.com/Coly010) 为 Rspack �
 
 通过新发布的 `@ng-rsbuild/plugin-angular` 和 `@ng-rspack/build` 包，开发者现在可以使用 Rspack 或 Rsbuild 来构建 Angular 应用，获得更快的构建性能和模块联邦等特性。
 
-欢迎访问 [ng-rspack-build](https://github.com/Coly010/ng-rspack-build) 仓库了解详细信息。
+欢迎访问 [Angular Rspack](https://github.com/nrwl/angular-rspack) 仓库了解详细信息。
 
 ### Rsbuild v1.2
 

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -319,7 +319,7 @@ export default {
 };
 ```
 
-[点击查看例子](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/basic-ts)。
+[点击查看例子](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/basic-ts)。
 
 ### resolve.tsConfig.configFile
 

--- a/website/docs/zh/guide/compatibility/plugin.mdx
+++ b/website/docs/zh/guide/compatibility/plugin.mdx
@@ -10,6 +10,6 @@ Rspack 对 webpack 内置插件的支持情况可以参考 [webpack 内置插件
 
 <CommunityPluginCompatibleTable lang="zh" />
 
-你可以在 [rspack-examples](https://github.com/rspack-contrib/rspack-examples) 中查看常用插件的使用示例。
+你可以在 [rstack-examples](https://github.com/rspack-contrib/rstack-examples) 中查看常用插件的使用示例。
 
 此外，你可以在 [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) 中查看社区提供的 Rspack 插件。

--- a/website/docs/zh/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-swc-loader.mdx
@@ -265,7 +265,7 @@ Rspack 支持在 `builtin:swc-loader` 里加载 SWC 的 Wasm 插件, 你可以�
 }
 ```
 
-这是 Wasm 插件的一个[示例](https://github.com/rspack-contrib/rspack-examples/blob/d4b8aaef9915ed0f540edbe504217c3d1afe8989/rspack/builtin-swc-loader/rspack.config.js#L45)。
+这是 Wasm 插件的一个[示例](https://github.com/rspack-contrib/rstack-examples/blob/d4b8aaef9915ed0f540edbe504217c3d1afe8989/rspack/builtin-swc-loader/rspack.config.js#L45)。
 
 #### 设置缓存目录
 

--- a/website/docs/zh/guide/features/module-federation.mdx
+++ b/website/docs/zh/guide/features/module-federation.mdx
@@ -75,7 +75,7 @@ export default {
 };
 ```
 
-> 参考：[Module Federation v1.5 示例](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/module-federation-v1.5)。
+> 参考：[Module Federation v1.5 示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/module-federation-v1.5)。
 
 ### Module Federation v1.0
 

--- a/website/docs/zh/guide/features/web-workers.mdx
+++ b/website/docs/zh/guide/features/web-workers.mdx
@@ -30,9 +30,9 @@ new Worker(new URL('./worker.js', import.meta.url), {
 
 使用示例可参考：
 
-- [examples/worker](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/worker)
-- [examples/monaco-editor-js](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/monaco-editor-js)
-- [examples/monaco-editor-ts-react](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/monaco-editor-ts-react)
+- [examples/worker](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/worker)
+- [examples/monaco-editor-js](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/monaco-editor-js)
+- [examples/monaco-editor-ts-react](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/monaco-editor-ts-react)
 
 :::info
 选择该语法是因为该语法在不使用打包工具时也能运行代码，它可以直接运行在支持 ES modules 的浏览器上运行，是符合标准的 ECMAScript 语法。

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -201,6 +201,10 @@ Nuxt v3.14 引入了对 Rspack 的官方支持，详见 [Nuxt 3.14](https://nuxt
 
 Re.Pack v5 使用 Rspack 和 React Native 社区 CLI 的插件系统，允许你使用 Rspack 打包你的应用，并轻松切换到 Metro。
 
+### Angular Rspack
+
+[Angular Rspack](https://github.com/nrwl/angular-rspack) 是一套工具链和插件集合，能够让你简单直接地使用 Rspack 和 Rsbuild 构建 Angular 应用。
+
 ### 更多
 
 访问 [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) 来发现更多 Rspack 生态中的项目。

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -1,6 +1,6 @@
 # NestJS
 
-Rspack 不仅能用于构建前端应用，也可以用于构建 Node.js 应用，你可以使用 Rspack 来构建 NestJS，Rspack 提供了一个 [NestJS Example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/nestjs) 的例子供参考。
+Rspack 不仅能用于构建前端应用，也可以用于构建 Node.js 应用，你可以使用 Rspack 来构建 NestJS，Rspack 提供了一个 [NestJS Example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/nestjs) 的例子供参考。
 
 ## Native node modules
 

--- a/website/docs/zh/guide/tech/preact.mdx
+++ b/website/docs/zh/guide/tech/preact.mdx
@@ -57,7 +57,7 @@ export default {
 
 关于配置项的更多信息请参考 [内置 swc-loader](guide/features/builtin-swc-loader)。
 
-完整示例可参考：[examples/preact](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact)
+完整示例可参考：[examples/preact](https://github.com/rspack-contrib/rstack-examples/blob/main/rspack/preact)
 
 ## Preact Refresh
 
@@ -136,4 +136,4 @@ export default {
 };
 ```
 
-完整示例可参考：[examples/preact-refresh](https://github.com/rspack-contrib/rspack-examples/blob/main/rspack/preact-refresh)
+完整示例可参考：[examples/preact-refresh](https://github.com/rspack-contrib/rstack-examples/blob/main/rspack/preact-refresh)

--- a/website/docs/zh/guide/tech/react.mdx
+++ b/website/docs/zh/guide/tech/react.mdx
@@ -110,8 +110,8 @@ export default {
 
 这种实现方式将代码注入逻辑和转换逻辑解耦，代码注入逻辑统一通过 `@rspack/plugin-react-refresh` 插件完成，代码转换通过 loader 完成。这意味着该插件可以配合 `builtin:swc-loader`、`swc-loader` 或 `babel-loader` 使用：
 
-- 配合 `builtin:swc-loader` 使用方式可参考：[examples/react-refresh](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh)，使用 `swc-loader` 只需将 `builtin:swc-loader` 换为 `swc-loader` 即可。
-- 配合 `babel-loader` 的使用方式可参考：[examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh-babel-loader)
+- 配合 `builtin:swc-loader` 使用方式可参考：[examples/react-refresh](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-refresh)，使用 `swc-loader` 只需将 `builtin:swc-loader` 换为 `swc-loader` 即可。
+- 配合 `babel-loader` 的使用方式可参考：[examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-refresh-babel-loader)
 
 ## React Compiler
 
@@ -198,8 +198,8 @@ const ReactCompilerConfig = {
 
 你可以参考以下示例项目：
 
-- [Rspack + React Compiler](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-compiler-babel)
-- [Rspack + React Compiler + TypeScript](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-compiler-babel-ts)
+- [Rspack + React Compiler](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-compiler-babel)
+- [Rspack + React Compiler + TypeScript](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/react-compiler-babel-ts)
 
 ## 集成 SVGR
 

--- a/website/docs/zh/guide/tech/solid.mdx
+++ b/website/docs/zh/guide/tech/solid.mdx
@@ -9,7 +9,7 @@ Rspack 提供两种方案来支持 Solid：
 
 ## 配置 Solid
 
-得益于 Rspack 对 babel-loader 的良好兼容，在 Rspack 里使用 Solid 是非常简单的。只需要 babel-loader 配合 Solid 的 [babel-solid-preset](https://www.npmjs.com/package/babel-preset-solid) 即可。Rspack 提供了一个 Solid 的[示例](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/solid)可供参考。
+得益于 Rspack 对 babel-loader 的良好兼容，在 Rspack 里使用 Solid 是非常简单的。只需要 babel-loader 配合 Solid 的 [babel-solid-preset](https://www.npmjs.com/package/babel-preset-solid) 即可。Rspack 提供了一个 Solid 的[示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/solid)可供参考。
 
 ```js title="rspack.config.mjs"
 import { defineConfig } from '@rspack/cli';

--- a/website/docs/zh/guide/tech/svelte.mdx
+++ b/website/docs/zh/guide/tech/svelte.mdx
@@ -9,7 +9,7 @@ Rspack 提供两种方案来支持 Svelte：
 
 ## 配置 svelte-loader
 
-得益于 Rspack 对 [svelte-loader](https://github.com/sveltejs/svelte-loader) 的良好兼容，在 Rspack 里使用 Svelte 是非常简单的。只需要配置好 svelte-loader 即可。 Rspack 提供了一个 Svelte 的[例子](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/svelte)可供参考。
+得益于 Rspack 对 [svelte-loader](https://github.com/sveltejs/svelte-loader) 的良好兼容，在 Rspack 里使用 Svelte 是非常简单的。只需要配置好 svelte-loader 即可。 Rspack 提供了一个 Svelte 的[例子](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/svelte)可供参考。
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';

--- a/website/docs/zh/guide/tech/vue.mdx
+++ b/website/docs/zh/guide/tech/vue.mdx
@@ -83,7 +83,7 @@ export default {
 </script>
 ```
 
-相关示例可以参考 [example-vue3](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/vue)。
+相关示例可以参考 [example-vue3](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/vue)。
 
 ## Vue 2
 
@@ -122,7 +122,7 @@ export default {
 
 TypeScript 语法是通过 Rspack 内置的 `builtin:swc-loader` 进行支持的，点击[这里](/guide/features/builtin-swc-loader)查看更多信息。
 
-相关示例可以参考：[example-vue2](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/vue2) 和 [example-vue2-ts](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/vue2-ts)。
+相关示例可以参考：[example-vue2](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/vue2) 和 [example-vue2-ts](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/vue2-ts)。
 
 ## Vue 3 JSX
 
@@ -163,4 +163,4 @@ export default defineConfig({
 });
 ```
 
-Rspack 提供了一个 Vue JSX 的[示例](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/vue3-jsx)可供参考。
+Rspack 提供了一个 Vue JSX 的[示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/vue3-jsx)可供参考。


### PR DESCRIPTION
## Summary

- Add Angular Rspack to ecosystem, see https://x.com/Michael_Hladky/status/1897430323295588364
- Update the example links, the `rspack-examples` repo has been renamed to `rstack-examples`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
