### PR TITLE
chore: ecosystem benchmark should download artifact from github

### DIFF
--- a/.github/actions/artifact/download/action.yml
+++ b/.github/actions/artifact/download/action.yml
@@ -9,19 +9,23 @@ inputs:
   path:
     description: "Destination path"
     required: true
+  force-use-github:
+    description: "force download from github"
+    default: false
+    required: false
 
 runs:
   using: composite
   steps:
     - name: Download artifact from github
       uses: actions/download-artifact@v4.1.7
-      if: ${{ runner.environment == 'github-hosted' }}
+      if: ${{ inputs.force-use-github == 'true' || runner.environment == 'github-hosted' }}
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
 #    - name: Download artifact from local
 #      uses: lynx-infra/download-artifact
-#      if: ${{ runner.environment == 'self-hosted' }}
+#      if: ${{ input.force-use-github != 'true' && runner.environment == 'self-hosted' }}
 #      with:
 #        name: ${{ inputs.name }}
 #        path: ${{ inputs.path }}

--- a/.github/actions/artifact/upload/action.yml
+++ b/.github/actions/artifact/upload/action.yml
@@ -9,13 +9,17 @@ inputs:
   path:
     description: "A file, directory or wildcard pattern that describes what to upload"
     required: true
+  force-use-github:
+    description: "force upload to github"
+    default: false
+    require: false
 
 runs:
   using: composite
   steps:
     - name: Upload artifact to github
       uses: actions/upload-artifact@v4
-      if: ${{ runner.environment == 'github-hosted' }}
+      if: ${{ inputs.force-use-github == 'true' || runner.environment == 'github-hosted' }}
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
@@ -23,7 +27,7 @@ runs:
         overwrite: true
 #    - name: Upload artifact to local
 #      uses: lynx-infra/upload-artifact
-#      if: ${{ runner.environment == 'self-hosted' }}
+#      if: ${{ inputs.force-use-github != 'true' && runner.environment == 'self-hosted' }}
 #      with:
 #        name: ${{ inputs.name }}
 #        path: ${{ inputs.path }}

--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: crates/node_binding/
-          try-local-cache: false
+          force-use-github: true
 
       - name: Show restored binding
         shell: bash

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -145,7 +145,6 @@ jobs:
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: crates/node_binding/
-          try-local-cache: false
 
       - name: Show restored binding
         shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -205,8 +205,6 @@ jobs:
         with:
           name: bindings-${{ inputs.target }}
           path: crates/node_binding/*.node
-          try-local-cache: ${{ inputs.profile == 'ci' }}
-          mv-when-local: true
 
   e2e:
     name: E2E Testing
@@ -231,8 +229,6 @@ jobs:
         with:
           name: bindings-${{ inputs.target }}
           path: crates/node_binding/
-          try-local-cache: ${{ inputs.profile == 'ci' }}
-          link-when-local: true
 
       - name: Setup Pnpm
         uses: ./.github/actions/pnpm/setup
@@ -297,8 +293,6 @@ jobs:
         with:
           name: bindings-${{ inputs.target }}
           path: crates/node_binding/
-          try-local-cache: ${{ inputs.profile == 'ci' }}
-          link-when-local: true
 
       - name: Show restored binding
         if: ${{ !inputs.skipable }}
@@ -413,8 +407,6 @@ jobs:
         with:
           name: bindings-${{ inputs.target }}
           path: crates/node_binding/
-          try-local-cache: ${{ inputs.profile == 'ci' }}
-          link-when-local: true
 
       - name: Show restored binding
         shell: bash


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The ecosystem benchmark will build rspack with github runner and run it with self hosted runner, so download artifact should support force use github artifact.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
