### PR TITLE
fix(core): remove blocking to avoid deadlock for multi compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       target: wasm32-wasip1-threads
       profile: "ci"
       runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
-      skipable: ${{ needs.check-changed.outputs.changed  != 'true' }}
+      skipable: true
       full-install: false
       test: false
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4283,6 +4283,7 @@ version = "0.2.0"
 dependencies = [
  "anymap3",
  "async-recursion",
+ "async-scoped",
  "async-trait",
  "bitflags 2.6.0",
  "cow-utils",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -8,6 +8,7 @@ version     = "0.2.0"
 [dependencies]
 anymap = { workspace = true }
 async-recursion = { workspace = true }
+async-scoped = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 cow-utils = { workspace = true }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1055,6 +1055,7 @@ impl Compilation {
     } else {
       self.chunk_by_ukey.keys().copied().collect()
     };
+    // SAFETY: await immediately and trust caller to poll future entirely
     let (_, results) = unsafe {
       async_scoped::TokioScope::scope_and_collect(
         |s: &mut TokioScope<'_, Result<(ChunkUkey, ChunkRenderResult)>>| {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1083,7 +1083,8 @@ impl Compilation {
     .await;
     let mut chunk_render_results: UkeyMap<ChunkUkey, ChunkRenderResult> = Default::default();
     for result in results {
-      let item: std::result::Result<(ChunkUkey, ChunkRenderResult), _> = result.unwrap();
+      let item: std::result::Result<(ChunkUkey, ChunkRenderResult), _> =
+        result.map_err(rspack_error::miette::Error::from_err)?;
       let (key, value) = item?;
       chunk_render_results.insert(key, value);
     }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -8,6 +8,7 @@ use std::{
   },
 };
 
+use async_scoped::TokioScope;
 use dashmap::DashSet;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
@@ -19,9 +20,9 @@ use rspack_cacheable::{
 use rspack_collections::{
   DatabaseItem, Identifiable, IdentifierDashMap, IdentifierMap, IdentifierSet, UkeyMap, UkeySet,
 };
+use rspack_error::error;
 use rspack_error::{
-  error, miette::diagnostic, Diagnostic, DiagnosticExt, InternalError, Result, RspackSeverity,
-  Severity,
+  miette::diagnostic, Diagnostic, DiagnosticExt, InternalError, Result, RspackSeverity, Severity,
 };
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_futures::FuturesResults;
@@ -1054,31 +1055,38 @@ impl Compilation {
     } else {
       self.chunk_by_ukey.keys().copied().collect()
     };
-    let chunk_render_results = chunks
-      .iter()
-      .map(|chunk| async {
-        let mut manifests = Vec::new();
-        let mut diagnostics = Vec::new();
-        plugin_driver
-          .compilation_hooks
-          .render_manifest
-          .call(self, chunk, &mut manifests, &mut diagnostics)
-          .await?;
+    let (_, results) = unsafe {
+      async_scoped::TokioScope::scope_and_collect(
+        |s: &mut TokioScope<'_, Result<(ChunkUkey, ChunkRenderResult)>>| {
+          chunks.iter().for_each(|chunk| {
+            s.spawn(async {
+              let mut manifests = Vec::new();
+              let mut diagnostics = Vec::new();
+              plugin_driver
+                .compilation_hooks
+                .render_manifest
+                .call(self, chunk, &mut manifests, &mut diagnostics)
+                .await?;
 
-        Ok((
-          *chunk,
-          ChunkRenderResult {
-            manifests,
-            diagnostics,
-          },
-        ))
-      })
-      .collect::<FuturesResults<Result<_>>>();
-    let chunk_render_results = chunk_render_results
-      .into_inner()
-      .into_iter()
-      .collect::<Result<UkeyMap<_, _>>>()?;
-
+              rspack_error::Result::Ok((
+                *chunk,
+                ChunkRenderResult {
+                  manifests,
+                  diagnostics,
+                },
+              ))
+            });
+          })
+        },
+      )
+    }
+    .await;
+    let mut chunk_render_results: UkeyMap<ChunkUkey, ChunkRenderResult> = Default::default();
+    for result in results {
+      let item: std::result::Result<(ChunkUkey, ChunkRenderResult), _> = result.unwrap();
+      let (key, value) = item?;
+      chunk_render_results.insert(key, value);
+    }
     let chunk_ukey_and_manifest = if mutations.is_some() {
       self.chunk_render_artifact.extend(chunk_render_results);
       self.chunk_render_artifact.clone()

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -344,6 +344,7 @@ impl Compiler {
       .await?;
 
     let mut new_emitted_asset_versions = HashMap::default();
+    // SAFETY: await immediately and trust caller to poll future entirely
     let _ = unsafe {
       TokioScope::scope_and_collect(|s| {
         self

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -5,6 +5,7 @@ mod rebuild;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
+use async_scoped::TokioScope;
 use rspack_error::Result;
 use rspack_fs::{IntermediateFileSystem, NativeFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_futures::FuturesResults;
@@ -343,36 +344,36 @@ impl Compiler {
       .await?;
 
     let mut new_emitted_asset_versions = HashMap::default();
-    let results = self
-      .compilation
-      .assets()
-      .iter()
-      .filter_map(|(filename, asset)| {
-        // collect version info to new_emitted_asset_versions
-        if self
-          .options
-          .experiments
-          .incremental
-          .contains(IncrementalPasses::EMIT_ASSETS)
-        {
-          new_emitted_asset_versions.insert(filename.to_string(), asset.info.version.clone());
-        }
+    let _ = unsafe {
+      TokioScope::scope_and_collect(|s| {
+        self
+          .compilation
+          .assets()
+          .iter()
+          .for_each(|(filename, asset)| {
+            // collect version info to new_emitted_asset_versions
+            if self
+              .options
+              .experiments
+              .incremental
+              .contains(IncrementalPasses::EMIT_ASSETS)
+            {
+              new_emitted_asset_versions.insert(filename.to_string(), asset.info.version.clone());
+            }
 
-        if let Some(old_version) = self.emitted_asset_versions.get(filename) {
-          if old_version.as_str() == asset.info.version && !old_version.is_empty() {
-            return None;
-          }
-        }
+            if let Some(old_version) = self.emitted_asset_versions.get(filename) {
+              if old_version.as_str() == asset.info.version && !old_version.is_empty() {
+                return;
+              }
+            }
 
-        Some(self.emit_asset(&self.options.output.path, filename, asset))
+            s.spawn(self.emit_asset(&self.options.output.path, filename, asset));
+          })
       })
-      .collect::<FuturesResults<_>>();
+    }
+    .await;
 
     self.emitted_asset_versions = new_emitted_asset_versions;
-    // return first error
-    for item in results.into_inner() {
-      item?;
-    }
 
     self
       .plugin_driver


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
FutureResults will call blocking_in_place to support non `'static` future parallel, but if there're multi compilers call it multi times, it will cause all tokio runtime working blocking and other  spawned task can't be scheduled, which will cause deadlock.

Unfortunately there're no safe way to implement parallel future which is proved in https://tmandry.gitlab.io/blog/posts/2023-03-01-scoped-tasks/

so we need choose use unsafe code or sacrifice parallel(which means sacrifice performance), for us performance is important so I choose use unsafe code.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
