### PR TITLE
docs: deprecate `sri` option of HTML plugin

### DIFF
--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -90,7 +90,7 @@ export type HtmlRspackPluginOptions = {
 	chunksSortMode?: "auto" | "manual";
 
 	/**
-	 * The SRI hash algorithm, disabled by default.
+	 * Configure the SRI hash algorithm, which is disabled by default.
 	 * @deprecated Use `experiments.SubresourceIntegrityPlugin` instead.
 	 */
 	sri?: "sha256" | "sha384" | "sha512";

--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -89,7 +89,10 @@ export type HtmlRspackPluginOptions = {
 	 */
 	chunksSortMode?: "auto" | "manual";
 
-	/** The SRI hash algorithm, disabled by default. */
+	/**
+	 * The SRI hash algorithm, disabled by default.
+	 * @deprecated Use `experiments.SubresourceIntegrityPlugin` instead.
+	 */
 	sri?: "sha256" | "sha384" | "sha512";
 
 	/**

--- a/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
@@ -275,7 +275,7 @@ type HtmlRspackPluginOptions = {
       type: '`"sha256"" | "sha384"" | "sha512"" | undefined`',
       default: '`undefined`',
       description:
-        '<p>**Deprecated**: use [`SubresourceIntegrityPlugin`](./subresource-integrity-plugin) instead.</p><p>The SRI hash algorithm, disabled by default. </p>',
+        '<p>**Deprecated**: use [`SubresourceIntegrityPlugin`](./subresource-integrity-plugin) instead.</p><p>Configure the SRI hash algorithm, which is disabled by default.</p>',
     },
     {
       name: '`minify`',

--- a/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
@@ -274,7 +274,8 @@ type HtmlRspackPluginOptions = {
       name: '`sri`',
       type: '`"sha256"" | "sha384"" | "sha512"" | undefined`',
       default: '`undefined`',
-      description: 'The SRI hash algorithm, disabled by default.',
+      description:
+        '<p>**Deprecated**: use [`SubresourceIntegrityPlugin`](./subresource-integrity-plugin) instead.</p><p>The SRI hash algorithm, disabled by default. </p>',
     },
     {
       name: '`minify`',

--- a/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
@@ -273,7 +273,7 @@ type HtmlRspackPluginOptions = {
       type: '`"sha256"" | "sha384"" | "sha512"" | undefined`',
       default: '`undefined`',
       description:
-        '<p>**已废弃**：请使用 [`SubresourceIntegrityPlugin`](./subresource-integrity-plugin)。</p><p>SRI hash 算法，默认不开启 SRI。</p>',
+        '<p>**已废弃**：请使用 [`SubresourceIntegrityPlugin`](./subresource-integrity-plugin) 代替。</p><p>配置 SRI hash 算法，默认不开启 SRI。</p>',
     },
     {
       name: '`minify`',

--- a/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
@@ -272,7 +272,8 @@ type HtmlRspackPluginOptions = {
       name: '`sri`',
       type: '`"sha256"" | "sha384"" | "sha512"" | undefined`',
       default: '`undefined`',
-      description: 'SRI hash 算法，默认不开启 SRI',
+      description:
+        '<p>**已废弃**：请使用 [`SubresourceIntegrityPlugin`](./subresource-integrity-plugin)。</p><p>SRI hash 算法，默认不开启 SRI。</p>',
     },
     {
       name: '`minify`',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The `sri` option of html rspack plugin only support html tags and not support dynamic import chunk loading. The full-featured SRI has been supported by `SubresourceIntegrityPlugin`. So the `sri` option of html rspack should be deprecated.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
