### PR TITLE
refactor: add unconstrained to tokio spawn tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5237,6 +5237,7 @@ dependencies = [
  "rspack_util",
  "rustc-hash 2.1.0",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/rspack_plugin_runtime/Cargo.toml
+++ b/crates/rspack_plugin_runtime/Cargo.toml
@@ -23,6 +23,7 @@ rspack_hash              = { workspace = true }
 rspack_hook              = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
 rspack_util              = { workspace = true }
+tokio                    = { workspace = true }
 
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -227,7 +227,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       .to_string();
 
       let chunk_ukey = self.chunk.expect("The chunk should be attached");
-      let res = block_on(async {
+      let res = block_on(tokio::task::unconstrained(async {
         hooks
           .link_prefetch
           .call(LinkPrefetchData {
@@ -239,7 +239,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
             },
           })
           .await
-      })?;
+      }))?;
 
       let source_with_prefetch = compilation.runtime_template.render(
         &self.template_id(TemplateId::WithPrefetch),
@@ -312,7 +312,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       .to_string();
 
       let chunk_ukey = self.chunk.expect("The chunk should be attached");
-      let res = block_on(async {
+      let res = block_on(tokio::task::unconstrained(async {
         hooks
           .link_preload
           .call(LinkPreloadData {
@@ -324,7 +324,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
             },
           })
           .await
-      })?;
+      }))?;
 
       let source_with_preload = compilation.runtime_template.render(
         &self.template_id(TemplateId::WithPreload),

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
@@ -137,7 +137,7 @@ impl RuntimeModule for LoadScriptRuntimeModule {
 
     let hooks = RuntimePlugin::get_compilation_hooks(compilation.id());
     let chunk_ukey = self.chunk_ukey;
-    let res = block_on(async {
+    let res = block_on(tokio::task::unconstrained(async {
       hooks
         .create_script
         .call(CreateScriptData {
@@ -149,7 +149,7 @@ impl RuntimeModule for LoadScriptRuntimeModule {
           },
         })
         .await
-    })?;
+    }))?;
 
     Ok(
       RawStringSource::from(

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -48,7 +48,7 @@ impl ScopeManager {
     let strategy = self.strategy.clone();
     let scopes = self.scopes.clone();
     let root_meta = self.root_meta.clone();
-    block_on(async move {
+    block_on(tokio::task::unconstrained(async move {
       let mut scopes_guard = scopes.lock().await;
       match update_scopes(
         &mut scopes_guard,
@@ -71,7 +71,7 @@ impl ScopeManager {
         }
         Err(e) => Err(e),
       }
-    })?;
+    }))?;
 
     let strategy = self.strategy.clone();
     let scopes = self.scopes.clone();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Add `unconstrained` to tokio spawn tasks to prevent deadlock which caused by budget exhaustion . See [tokio blog](https://tokio.rs/blog/2020-04-preemption) for more details.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
