### PR TITLE
test: should not output too much logs during the test

### DIFF
--- a/packages/rspack-test-tools/jest.config.js
+++ b/packages/rspack-test-tools/jest.config.js
@@ -41,7 +41,8 @@ const config = {
 							? process.argv.indexOf("-t")
 							: process.argv.indexOf("--test")) + 1
 					]
-				: undefined
+				: undefined,
+		printLogger: process.argv.includes("--verbose")
 	}
 };
 

--- a/packages/rspack-test-tools/src/processor/config.ts
+++ b/packages/rspack-test-tools/src/processor/config.ts
@@ -96,5 +96,10 @@ export class ConfigProcessor<
 				outputModule ? ".mjs" : ".js"
 			}`;
 		}
+		if (!global.printLogger) {
+			options.infrastructureLogging = {
+				level: "error"
+			};
+		}
 	}
 }

--- a/packages/rspack-test-tools/src/processor/hot.ts
+++ b/packages/rspack-test-tools/src/processor/hot.ts
@@ -160,5 +160,10 @@ export class HotProcessor<T extends ECompilerType> extends BasicProcessor<T> {
 				new rspack.LoaderOptionsPlugin(this.updateOptions)
 			);
 		}
+		if (!global.printLogger) {
+			options.infrastructureLogging = {
+				level: "error"
+			};
+		}
 	}
 }

--- a/packages/rspack-test-tools/src/processor/watch.ts
+++ b/packages/rspack-test-tools/src/processor/watch.ts
@@ -308,6 +308,12 @@ export class WatchProcessor<
 			(
 				options as TCompilerOptions<ECompilerType.Rspack>
 			).experiments!.rspackFuture!.bundlerInfo!.force ??= false;
+
+			if (!global.printLogger) {
+				options.infrastructureLogging = {
+					level: "error"
+				};
+			}
 		};
 	}
 

--- a/packages/rspack-test-tools/src/runner/runner/cjs.ts
+++ b/packages/rspack-test-tools/src/runner/runner/cjs.ts
@@ -11,6 +11,10 @@ import type {
 } from "../type";
 import { BasicRunner } from "./basic";
 
+declare global {
+	var printLogger: boolean;
+}
+
 const define = (...args: unknown[]) => {
 	const factory = args.pop() as () => {};
 	factory();
@@ -23,22 +27,32 @@ export class CommonJsRunner<
 		return {
 			console: {
 				log: (...args: any[]) => {
-					console.log(...args);
+					if (printLogger) {
+						console.log(...args);
+					}
 				},
 				warn: (...args: any[]) => {
-					console.warn(...args);
+					if (printLogger) {
+						console.warn(...args);
+					}
 				},
 				error: (...args: any[]) => {
 					console.error(...args);
 				},
 				info: (...args: any[]) => {
-					console.info(...args);
+					if (printLogger) {
+						console.info(...args);
+					}
 				},
 				debug: (...args: any[]) => {
-					console.debug(...args);
+					if (printLogger) {
+						console.info(...args);
+					}
 				},
 				trace: (...args: any[]) => {
-					console.trace(...args);
+					if (printLogger) {
+						console.info(...args);
+					}
 				},
 				assert: (...args: any[]) => {
 					console.assert(...args);

--- a/packages/rspack-test-tools/tests/configCases/hooks/stillValidModule/plugins/MyStillValidModulePlugin.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/stillValidModule/plugins/MyStillValidModulePlugin.js
@@ -1,13 +1,17 @@
+const mockFn = jest.fn();
+
 class MyStillValidModulePlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap("MyStillValidModulePlugin", compilation => {
 			compilation.hooks.stillValidModule.tap(
 				"MyStillValidModulePlugin",
 				module => {
-					console.log("this module is valid and not need rebuild");
-					console.log(module);
+					mockFn();
 				}
 			);
+		});
+		compiler.hooks.done.tap("MyStillValidModulePlugin", () => {
+			expect(mockFn).toBeCalledTimes(0);
 		});
 	}
 }

--- a/packages/rspack-test-tools/tests/configCases/hooks/succeedModule/plugins/MySucceedModulePlugin.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/succeedModule/plugins/MySucceedModulePlugin.js
@@ -1,10 +1,14 @@
+const mockFn = jest.fn();
+
 class MySucceedModulePlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap("MySucceedModulePlugin", compilation => {
 			compilation.hooks.succeedModule.tap("MySucceedModulePlugin", module => {
-				console.log("trigger succeedModule hook success");
-				console.log(module);
+				mockFn();
 			});
+		});
+		compiler.hooks.done.tap("MySucceedModulePlugin", () => {
+			expect(mockFn).toBeCalledTimes(4);
 		});
 	}
 }

--- a/packages/rspack-test-tools/tests/configCases/svg/different-module-by-loaders/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/svg/different-module-by-loaders/test.config.js
@@ -5,11 +5,5 @@ module.exports = {
 		link1.rel = "stylesheet";
 		link1.href = "bundle0.css";
 		scope.window.document.head.appendChild(link1);
-
-		console.log(
-			scope.window
-				.getComputedStyle(scope.document.head)
-				.getPropertyValue("--webpack--main")
-		);
 	}
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Too much useless logs are print during the test. Only output them when test with `--verbose`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
