### PR TITLE
fix(deps): update create lightningcss to 1.0.0-alpha.64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,24 +481,6 @@ checksum = "50fd5174866dc2fa2ddc96e8fb800852d37f064f32a45c7b7c2f8fa2c64c77fa"
 
 [[package]]
 name = "browserslist-rs"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf0ca73de70c3da94e4194e4a01fe732378f55d47cf4c0588caab22a0dbfa14"
-dependencies = [
- "ahash 0.8.11",
- "chrono",
- "either",
- "indexmap 2.7.1",
- "itertools 0.13.0",
- "nom",
- "once_cell",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "browserslist-rs"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c973b79d9b6b89854493185ab760c6ef8e54bcfad10ad4e33991e46b374ac8"
@@ -2705,13 +2687,13 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.63"
+version = "1.0.0-alpha.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a75fcbcdbcc84fc1ae7c60c31f99337560b620757a9bfc1c9f84df3cff8ac24"
+checksum = "a296273515b1036d06fce6c1d6bfc11347083458e1765ae4a70d6288cdb15521"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
- "browserslist-rs 0.16.0",
+ "browserslist-rs",
  "const-str",
  "cssparser",
  "cssparser-color",
@@ -3680,7 +3662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07852df2dda2f0ab8c3407a6fd19e9389563af11c20f6c299bd07ff9fc96d6ae"
 dependencies = [
  "anyhow",
- "browserslist-rs 0.17.0",
+ "browserslist-rs",
  "dashmap 5.5.3",
  "from_variant",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ indoc              = { version = "2.0.5" }
 insta              = { version = "1.42.0" }
 itertools          = { version = "0.14.0" }
 json               = { version = "0.12.4" }
-lightningcss       = { version = "1.0.0-alpha.63" }
+lightningcss       = { version = "1.0.0-alpha.64" }
 linked_hash_set    = { version = "0.1.5" }
 mimalloc           = { version = "0.2.3", package = "mimalloc-rspack" }
 mime_guess         = { version = "2.0.5" }

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
@@ -49,7 +49,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: 50f4182a210ae3fc,
+      hash: 9cd19fc0a208da71,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -179,7 +179,7 @@ Object {
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: 59afbeeb2d3dd524,
+  hash: 23417a360dbe1de8,
   modules: Array [
     Object {
       assets: Array [],
@@ -330,7 +330,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: 6b90d3665b9a32f0,
+      hash: 526d08f00e1e8f2f,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -718,7 +718,7 @@ Object {
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: 78322e9a4de35476,
+  hash: 1bb5e91c0d72ce7a,
   modules: Array [
     Object {
       assets: Array [],
@@ -1521,7 +1521,7 @@ Object {
       files: Array [
         main.js,
       ],
-      hash: 50f4182a210ae3fc,
+      hash: 9cd19fc0a208da71,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -1661,7 +1661,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: e813d411c0f3d316,
+      hash: 9cf6270d68f3f78e,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -2030,7 +2030,7 @@ exports.c = require("./c?c=3");,
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: 27d6c5d54c85318d,
+  hash: 2026699fe6b29204,
   modules: Array [
     Object {
       assets: Array [],

--- a/packages/rspack-test-tools/tests/statsAPICases/basic.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/basic.js
@@ -37,7 +37,7 @@ module.exports = {
 		  entry ./fixtures/a
 		  cjs self exports reference self [585] ./fixtures/a.js
 		  
-		Rspack compiled successfully (59afbeeb2d3dd524)
+		Rspack compiled successfully (23417a360dbe1de8)
 	`);
 	}
 };


### PR DESCRIPTION
## Summary

Update create lightningcss to 1.0.0-alpha.64 to:

- Dedupe the `browserslist-rs` crate.
- Fix Wasm issue, see https://github.com/web-infra-dev/rspack/pull/9585

Release note: https://github.com/parcel-bundler/lightningcss/releases/tag/v1.29.2

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
