### PR TITLE
chore: add build:wasm scripts

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -18,6 +18,7 @@
     "build:ci": "node scripts/build.js --profile ci",
     "build:profiling": "node scripts/build.js --profile profiling",
     "build:release": "node scripts/build.js --profile release",
+    "build:wasm": "DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads node scripts/build.js",
     "move-binding": "node scripts/move-binding",
     "test": "tsc -p tsconfig.type-test.json"
   },
@@ -28,7 +29,8 @@
     "@napi-rs/cli": "3.0.0-alpha.73",
     "@napi-rs/wasm-runtime": "^0.2.7",
     "emnapi": "^1.3.1",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "@emnapi/core": "^1.3.1"
   },
   "napi": {
     "binaryName": "rspack",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
         specifier: workspace:*
         version: link:../../npm/win32-x64-msvc
     devDependencies:
+      '@emnapi/core':
+        specifier: ^1.3.1
+        version: 1.3.1
       '@napi-rs/cli':
         specifier: 3.0.0-alpha.73
         version: 3.0.0-alpha.73(@emnapi/runtime@1.3.1)(@types/node@20.17.23)(emnapi@1.3.1)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
add a `build:wasm` script used for locally test wasm build 
swc's wasm plugin is not supported now due to https://github.com/swc-project/swc/blob/bccdafc0c394bf3979da3c6a06d974c7d2c9bcee/crates/swc/src/plugin.rs#L68
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
