### PR TITLE
feat(compiler-builder)!: support `BuilderError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,6 +4142,7 @@ dependencies = [
  "insta",
  "regex",
  "rspack_core",
+ "rspack_error",
  "rspack_fs",
  "rspack_hash",
  "rspack_ids",

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -21,6 +21,7 @@ enum-tag     = { workspace = true }
 indexmap     = { workspace = true, features = ["rayon"] }
 regex        = { workspace = true }
 rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
 rspack_fs    = { workspace = true }
 rspack_hash  = { workspace = true }
 rspack_ids   = { workspace = true }

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -446,7 +446,6 @@ impl CompilerBuilder {
   }
 
   /// Build [`Compiler`] from options and plugins.
-  #[must_use]
   pub fn build(&mut self) -> Result<Compiler> {
     let mut builder_context = BuilderContext::default();
     let compiler_options = self.options_builder.build(&mut builder_context)?;
@@ -892,7 +891,6 @@ impl CompilerOptionsBuilder {
   ///
   /// [`BuilderContext`]: crate::builder::BuilderContext
   /// [`CompilerOptions`]: rspack_core::options::CompilerOptions
-  #[must_use]
   pub fn build(&mut self, builder_context: &mut BuilderContext) -> Result<CompilerOptions> {
     let name = self.name.take();
     let context = f!(self.context.take(), || {
@@ -1537,7 +1535,6 @@ impl NodeOptionBuilder {
   /// Build [`NodeOption`] from options.
   ///
   /// [`NodeOption`]: rspack_core::options::NodeOption
-  #[must_use]
   fn build(
     &mut self,
     target_properties: &TargetProperties,
@@ -1664,7 +1661,6 @@ impl ModuleOptionsBuilder {
   /// Normally, you don't need to call this function, it's used internally by [`CompilerBuilder::build`].
   ///
   /// [`ModuleOptions`]: rspack_core::options::ModuleOptions
-  #[must_use]
   fn build(
     &mut self,
     _builder_context: &mut BuilderContext,
@@ -2625,7 +2621,6 @@ impl OutputOptionsBuilder {
   ///
   /// [`OutputOptions`]: rspack_core::options::OutputOptions
   #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
-  #[must_use]
   fn build(
     &mut self,
     builder_context: &mut BuilderContext,
@@ -2809,40 +2804,38 @@ impl OutputOptionsBuilder {
 
     let chunk_format = if let Some(chunk_format) = self.chunk_format.take() {
       chunk_format
-    } else {
-      if let Some(tp) = tp {
-        let help_message = if is_affected_by_browserslist {
-          "Make sure that your 'browserslist' includes only platforms that support these features or select an appropriate 'target' to allow selecting a chunk format by default. Alternatively specify the 'output.chunkFormat' directly."
-        } else {
-          "Select an appropriate 'target' to allow selecting one by default, or specify the 'output.chunkFormat' directly."
-        };
+    } else if let Some(tp) = tp {
+      let help_message = if is_affected_by_browserslist {
+        "Make sure that your 'browserslist' includes only platforms that support these features or select an appropriate 'target' to allow selecting a chunk format by default. Alternatively specify the 'output.chunkFormat' directly."
+      } else {
+        "Select an appropriate 'target' to allow selecting one by default, or specify the 'output.chunkFormat' directly."
+      };
 
-        if output_module {
-          if tp.dynamic_import() {
-            "module".to_string()
-          } else if tp.document() {
-            "array-push".to_string()
-          } else {
-            return Err(BuilderError::Option("output.chunk_format".to_string(), format!("For the selected environment is no default ESM chunk format available:\nESM exports can be chosen when 'import()' is available.\nJSONP Array push can be chosen when 'document' is available.\n{help_message}")).into());
-          }
+      if output_module {
+        if tp.dynamic_import() {
+          "module".to_string()
         } else if tp.document() {
           "array-push".to_string()
-        } else if tp.require() || tp.node_builtins() {
-          "commonjs".to_string()
-        } else if tp.import_scripts() {
-          "array-push".to_string()
         } else {
-          return Err(BuilderError::Option("output.chunk_format".to_string(), format!("For the selected environment is no default script chunk format available:\nJSONP Array push can be chosen when 'document' or 'importScripts' is available.\nCommonJs exports can be chosen when 'require' or node builtins are available.\n{help_message}")).into());
+          return Err(BuilderError::Option("output.chunk_format".to_string(), format!("For the selected environment is no default ESM chunk format available:\nESM exports can be chosen when 'import()' is available.\nJSONP Array push can be chosen when 'document' is available.\n{help_message}")).into());
         }
+      } else if tp.document() {
+        "array-push".to_string()
+      } else if tp.require() || tp.node_builtins() {
+        "commonjs".to_string()
+      } else if tp.import_scripts() {
+        "array-push".to_string()
       } else {
-        return Err(
-          BuilderError::Option(
-            "output.chunk_format".to_string(),
-            "Chunk format can't be selected by default when no target is specified".to_string(),
-          )
-          .into(),
-        );
+        return Err(BuilderError::Option("output.chunk_format".to_string(), format!("For the selected environment is no default script chunk format available:\nJSONP Array push can be chosen when 'document' or 'importScripts' is available.\nCommonJs exports can be chosen when 'require' or node builtins are available.\n{help_message}")).into());
       }
+    } else {
+      return Err(
+        BuilderError::Option(
+          "output.chunk_format".to_string(),
+          "Chunk format can't be selected by default when no target is specified".to_string(),
+        )
+        .into(),
+      );
     };
 
     match &*chunk_format {
@@ -3385,7 +3378,6 @@ impl OptimizationOptionsBuilder {
   /// Build [`Optimization`] from options.
   ///
   /// [`Optimization`]: rspack_core::options::Optimization
-  #[must_use]
   fn build(
     &mut self,
     builder_context: &mut BuilderContext,
@@ -3745,7 +3737,6 @@ impl ExperimentsBuilder {
   /// Build [`Experiments`] from options.
   ///
   /// [`Experiments`]: rspack_core::options::Experiments
-  #[must_use]
   fn build(
     &mut self,
     _builder_context: &mut BuilderContext,

--- a/crates/rspack/tests/basic.rs
+++ b/crates/rspack/tests/basic.rs
@@ -7,7 +7,8 @@ async fn basic() {
   let mut compiler = Compiler::builder()
     .context(Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/basic"))
     .entry("main", "./src/index.js")
-    .build();
+    .build()
+    .unwrap();
 
   compiler.build().await.unwrap();
 
@@ -24,7 +25,8 @@ async fn basic_sourcemap() {
     .context(Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/basic"))
     .entry("main", "./src/index.js")
     .devtool(Devtool::SourceMap)
-    .build();
+    .build()
+    .unwrap();
 
   compiler.build().await.unwrap();
 

--- a/crates/rspack/tests/defaults.rs
+++ b/crates/rspack/tests/defaults.rs
@@ -6,7 +6,8 @@ async fn default_options() {
   let mut builder_context = BuilderContext::default();
   let options = CompilerOptionsBuilder::default()
     .mode(Mode::None)
-    .build(&mut builder_context);
+    .build(&mut builder_context)
+    .unwrap();
   let cwd = std::env::current_dir().unwrap();
 
   let mut settings = insta::Settings::clone_current();

--- a/crates/rspack/tests/errors.rs
+++ b/crates/rspack/tests/errors.rs
@@ -1,0 +1,19 @@
+use rspack::builder::Builder;
+use rspack_core::{Compiler, Optimization};
+
+macro_rules! assert_snapshot {
+  ($compiler:expr) => {
+    let compiler = $compiler;
+    let error = compiler.unwrap_err();
+    insta::assert_snapshot!(error);
+  };
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn options() {
+  assert_snapshot!(Compiler::builder()
+    .optimization(Optimization::builder().module_ids("unknown".to_string()))
+    .build());
+
+  assert_snapshot!(Compiler::builder().target(vec![]).build());
+}

--- a/crates/rspack/tests/loader.rs
+++ b/crates/rspack/tests/loader.rs
@@ -32,7 +32,8 @@ async fn lightningcss() {
     }))
     .experiments(Experiments::builder().css(true))
     .enable_loader_lightningcss()
-    .build();
+    .build()
+    .unwrap();
 
   compiler.build().await.unwrap();
 
@@ -77,7 +78,8 @@ async fn swc() {
     }))
     .experiments(Experiments::builder().css(true))
     .enable_loader_swc()
-    .build();
+    .build()
+    .unwrap();
 
   compiler.build().await.unwrap();
 
@@ -128,7 +130,8 @@ async fn react_refresh() {
     .experiments(Experiments::builder().css(true))
     .enable_loader_swc()
     .enable_loader_react_refresh()
-    .build();
+    .build()
+    .unwrap();
 
   compiler.build().await.unwrap();
 
@@ -179,7 +182,8 @@ async fn preact_refresh() {
     .experiments(Experiments::builder().css(true))
     .enable_loader_swc()
     .enable_loader_preact_refresh()
-    .build();
+    .build()
+    .unwrap();
 
   compiler.build().await.unwrap();
 

--- a/crates/rspack/tests/snapshots/errors__options-2.snap
+++ b/crates/rspack/tests/snapshots/errors__options-2.snap
@@ -1,0 +1,8 @@
+---
+source: crates/rspack/tests/errors.rs
+expression: error
+---
+Invalid option 'output.chunk_format': For the selected environment is no default script chunk format available:
+JSONP Array push can be chosen when 'document' or 'importScripts' is available.
+CommonJs exports can be chosen when 'require' or node builtins are available.
+Select an appropriate 'target' to allow selecting one by default, or specify the 'output.chunkFormat' directly.

--- a/crates/rspack/tests/snapshots/errors__options.snap
+++ b/crates/rspack/tests/snapshots/errors__options.snap
@@ -1,0 +1,5 @@
+---
+source: crates/rspack/tests/errors.rs
+expression: error
+---
+Invalid option 'optimization.module_ids': unknown is not implemented

--- a/tasks/benchmark/benches/basic.rs
+++ b/tasks/benchmark/benches/basic.rs
@@ -27,7 +27,7 @@ async fn basic_compile(fs: Arc<dyn FileSystem>, sm: bool) {
     builder.devtool(Devtool::SourceMap);
   }
 
-  let mut compiler = builder.build();
+  let mut compiler = builder.build().unwrap();
 
   compiler.run().await.unwrap();
 

--- a/tasks/benchmark/benches/build_chunk_graph.rs
+++ b/tasks/benchmark/benches/build_chunk_graph.rs
@@ -115,7 +115,8 @@ pub fn build_chunk_graph_benchmark(c: &mut Criterion) {
     .output_filesystem(fs.clone())
     .optimization(Optimization::builder().remove_available_modules(true))
     .experiments(Experiments::builder().incremental(IncrementalPasses::empty()))
-    .build();
+    .build()
+    .unwrap();
 
   let compiler_id = compiler.id();
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Closing https://github.com/web-infra-dev/rspack/issues/9379

Support  printing `BuilderError` and remove panics.

`CompilerBuilder::build` now returns `rspack_error::Result<Compiler>` (previously, `Compiler`).

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
