### PR TITLE
fix(core): use future_scope to run parallel future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,7 +4284,6 @@ version = "0.2.0"
 dependencies = [
  "anymap3",
  "async-recursion",
- "async-scoped",
  "async-trait",
  "bitflags 2.6.0",
  "cow-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4398,6 +4398,7 @@ version = "0.2.0"
 dependencies = [
  "async-scoped",
  "futures",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -8,7 +8,6 @@ version     = "0.2.0"
 [dependencies]
 anymap = { workspace = true }
 async-recursion = { workspace = true }
-async-scoped = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 cow-utils = { workspace = true }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -8,7 +8,6 @@ use std::{
   },
 };
 
-use async_scoped::TokioScope;
 use dashmap::DashSet;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
@@ -1055,33 +1054,32 @@ impl Compilation {
     } else {
       self.chunk_by_ukey.keys().copied().collect()
     };
-    // SAFETY: await immediately and trust caller to poll future entirely
-    let (_, results) = unsafe {
-      async_scoped::TokioScope::scope_and_collect(
-        |s: &mut TokioScope<'_, Result<(ChunkUkey, ChunkRenderResult)>>| {
-          chunks.iter().for_each(|chunk| {
-            s.spawn(async {
-              let mut manifests = Vec::new();
-              let mut diagnostics = Vec::new();
-              plugin_driver
-                .compilation_hooks
-                .render_manifest
-                .call(self, chunk, &mut manifests, &mut diagnostics)
-                .await?;
+    let results = rspack_futures::scope::<_, Result<_>>(|token| {
+      chunks.iter().for_each(|chunk| {
+        // SAFETY: await immediately and trust caller to poll future entirely
+        let s = unsafe { token.used((&self, &plugin_driver, chunk)) };
 
-              rspack_error::Result::Ok((
-                *chunk,
-                ChunkRenderResult {
-                  manifests,
-                  diagnostics,
-                },
-              ))
-            });
-          })
-        },
-      )
-    }
+        s.spawn(|(this, plugin_driver, chunk)| async {
+          let mut manifests = Vec::new();
+          let mut diagnostics = Vec::new();
+          plugin_driver
+            .compilation_hooks
+            .render_manifest
+            .call(this, chunk, &mut manifests, &mut diagnostics)
+            .await?;
+
+          rspack_error::Result::Ok((
+            *chunk,
+            ChunkRenderResult {
+              manifests,
+              diagnostics,
+            },
+          ))
+        });
+      })
+    })
     .await;
+
     let mut chunk_render_results: UkeyMap<ChunkUkey, ChunkRenderResult> = Default::default();
     for result in results {
       let item: std::result::Result<(ChunkUkey, ChunkRenderResult), _> =

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -5,7 +5,6 @@ mod rebuild;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
-use async_scoped::TokioScope;
 use rspack_error::Result;
 use rspack_fs::{IntermediateFileSystem, NativeFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_futures::FuturesResults;
@@ -344,34 +343,37 @@ impl Compiler {
       .await?;
 
     let mut new_emitted_asset_versions = HashMap::default();
-    // SAFETY: await immediately and trust caller to poll future entirely
-    let _ = unsafe {
-      TokioScope::scope_and_collect(|s| {
-        self
-          .compilation
-          .assets()
-          .iter()
-          .for_each(|(filename, asset)| {
-            // collect version info to new_emitted_asset_versions
-            if self
-              .options
-              .experiments
-              .incremental
-              .contains(IncrementalPasses::EMIT_ASSETS)
-            {
-              new_emitted_asset_versions.insert(filename.to_string(), asset.info.version.clone());
-            }
 
-            if let Some(old_version) = self.emitted_asset_versions.get(filename) {
-              if old_version.as_str() == asset.info.version && !old_version.is_empty() {
-                return;
-              }
-            }
+    rspack_futures::scope(|token| {
+      self
+        .compilation
+        .assets()
+        .iter()
+        .for_each(|(filename, asset)| {
+          // collect version info to new_emitted_asset_versions
+          if self
+            .options
+            .experiments
+            .incremental
+            .contains(IncrementalPasses::EMIT_ASSETS)
+          {
+            new_emitted_asset_versions.insert(filename.to_string(), asset.info.version.clone());
+          }
 
-            s.spawn(self.emit_asset(&self.options.output.path, filename, asset));
-          })
-      })
-    }
+          if let Some(old_version) = self.emitted_asset_versions.get(filename) {
+            if old_version.as_str() == asset.info.version && !old_version.is_empty() {
+              return;
+            }
+          }
+
+          // SAFETY: await immediately and trust caller to poll future entirely
+          let s = unsafe { token.used((&self, filename, asset)) };
+
+          s.spawn(|(this, filename, asset)| {
+            this.emit_asset(&this.options.output.path, filename, asset)
+          });
+        })
+    })
     .await;
 
     self.emitted_asset_versions = new_emitted_asset_versions;

--- a/crates/rspack_futures/Cargo.toml
+++ b/crates/rspack_futures/Cargo.toml
@@ -11,3 +11,4 @@ futures = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 async-scoped = { workspace = true, features = ["use-tokio"] }
+tokio        = { version = "1", features = ["rt"] }

--- a/crates/rspack_futures/src/lib.rs
+++ b/crates/rspack_futures/src/lib.rs
@@ -1,7 +1,11 @@
+pub mod scope;
+
 use std::{
   future::Future,
   ops::{Deref, DerefMut},
 };
+
+pub use scope::scope;
 
 /// Run futures in parallel.
 ///

--- a/crates/rspack_futures/src/scope.rs
+++ b/crates/rspack_futures/src/scope.rs
@@ -1,0 +1,159 @@
+use std::cell::RefCell;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+
+use tokio::task::{JoinError, JoinHandle};
+
+/// Scope Token
+pub struct Token<'scope, 'spawner, O> {
+  list: &'spawner RefCell<Vec<JoinHandle<O>>>,
+  _phantom: PhantomData<&'scope mut &'scope ()>,
+}
+
+/// Scope Spawner
+pub struct Spawner<'scope, 'spawner, T, O> {
+  list: &'spawner RefCell<Vec<JoinHandle<O>>>,
+  used: T,
+  _phantom: PhantomData<&'scope mut &'scope ()>,
+}
+
+/// Async scope helper
+///
+/// This function helps you write unsafe
+/// asynchronous structured concurrent code more easily.
+/// but it is **still unsafe**, so need to be careful when using it.
+///
+/// To use it safely,
+/// the user needs to ensure that the task is done within used reference lifetime.
+/// Due to `std::mem::forget`, the Rust currently cannot guarantee it.
+///
+/// From a practical point of view, the following points need to be note
+///
+/// * `.await` as early as possible
+/// * Don't put task into container unless you know what you are doing
+/// * Don't call `std::mem::forget`
+///
+/// # Example
+///
+/// ```rust
+/// # #[tokio::test]
+/// # async fn foo() {
+/// let list: Vec<u32> = vec![1, 2, 3, 4];
+///
+/// rspack_futures::scope(|token| {
+///   for i in 0..list.len() {
+///     let s = unsafe { token.used(&list) };
+///
+///     s.spawn(move |list| async move {
+///       &list[i];
+///     });
+///   }
+/// })
+/// .await;
+/// # }
+/// ```
+///
+/// This doesn't compile
+///
+/// ```rust,compile_fail
+/// # async fn foo() {
+/// rspack_futures::scope(|token| {
+///   let list: Vec<u32> = vec![1, 2, 3, 4];
+///
+///   for i in 0..list.len() {
+///     let s = unsafe { token.used(&list) };
+///
+///     s.spawn(move |list| async move {
+///       &list[i];
+///     });
+///   }
+/// })
+/// .await;
+/// # }
+/// ```
+pub async fn scope<'scope, F, O>(f: F) -> Vec<Result<O, JoinError>>
+where
+  for<'spawner> F: FnOnce(Token<'scope, 'spawner, O>),
+  O: Send + 'static,
+{
+  struct ScopeGuard(());
+
+  impl ScopeGuard {
+    fn forget(self) {
+      std::mem::forget(self);
+    }
+  }
+
+  impl Drop for ScopeGuard {
+    fn drop(&mut self) {
+      // avoid unsound caused by poll interruption
+      std::process::abort();
+    }
+  }
+
+  let guard = ScopeGuard(());
+  let list = RefCell::new(Vec::new());
+
+  let token = Token {
+    list: &list,
+    _phantom: PhantomData,
+  };
+
+  f(token);
+
+  let list = RefCell::into_inner(list);
+  let mut output = Vec::with_capacity(list.len());
+
+  for j in list {
+    output.push(j.await);
+  }
+
+  guard.forget();
+  output
+}
+
+impl<'scope, 'spawner, O> Token<'scope, 'spawner, O> {
+  /// Use references
+  ///
+  /// Specify the reference to use when spawning the task.
+  ///
+  /// # Safety
+  ///
+  /// This is not sound.
+  ///
+  /// the user must ensure that `scope` task is legally consumed,
+  /// and assume that the runtime handles the task correctly.
+  pub unsafe fn used<T: 'scope>(&self, used: T) -> Spawner<'scope, 'spawner, T, O> {
+    Spawner {
+      list: self.list,
+      used,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+impl<'scope, T, O> Spawner<'scope, '_, T, O> {
+  /// Spawn task from used reference
+  pub fn spawn<F, Fut>(self, f: F)
+  where
+    // TODO Use AsyncOnce
+    F: FnOnce(T) -> Fut + 'static,
+    Fut: Future<Output = O> + Send + 'scope,
+    T: Send + Sync + 'scope,
+    O: Send + 'static,
+  {
+    let fut = f(self.used);
+    let fut: Pin<Box<dyn Future<Output = O> + Send + 'scope>> = Box::pin(fut);
+
+    // # Safety
+    //
+    // The safety guarantee here comes from `Token::used`.
+    // The user needs to ensure that the task will done within used reference lifetime.
+    let fut: Pin<Box<dyn Future<Output = O> + Send + 'static>> =
+      unsafe { std::mem::transmute(fut) };
+
+    let j = tokio::spawn(fut);
+    self.list.borrow_mut().push(j);
+  }
+}

--- a/crates/rspack_futures/src/scope.rs
+++ b/crates/rspack_futures/src/scope.rs
@@ -137,7 +137,7 @@ impl<'scope, T, O> Spawner<'scope, '_, T, O> {
   /// Spawn task from used reference
   pub fn spawn<F, Fut>(self, f: F)
   where
-    // TODO Use AsyncOnce
+    // TODO Use AsyncFnOnce
     F: FnOnce(T) -> Fut + 'static,
     Fut: Future<Output = O> + Send + 'scope,
     T: Send + Sync + 'scope,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
future_scope is more safe than async_scope cause you need explicitly pass ref to it and reviewer just need to review whether the passed ref is still valid during future execution
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
