### PR TITLE
fix: revoke dependency clean dependency at module and block

### DIFF
--- a/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
+++ b/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
@@ -25,6 +25,7 @@ pub struct ModernModuleImportDependency {
 
 impl ModernModuleImportDependency {
   pub fn new(
+    id: DependencyId,
     request: Atom,
     target_request: ExternalRequest,
     external_type: ExternalType,
@@ -34,11 +35,11 @@ impl ModernModuleImportDependency {
     let resource_identifier =
       create_resource_identifier_for_esm_dependency(request.as_str(), attributes.as_ref());
     Self {
+      id,
       request,
       target_request,
       external_type,
       range,
-      id: DependencyId::new(),
       attributes,
       resource_identifier,
       factorize_info: Default::default(),

--- a/crates/rspack_plugin_library/src/modern_module/reexport_star_external_dependency.rs
+++ b/crates/rspack_plugin_library/src/modern_module/reexport_star_external_dependency.rs
@@ -22,13 +22,18 @@ pub struct ModernModuleReexportStarExternalDependency {
 }
 
 impl ModernModuleReexportStarExternalDependency {
-  pub fn new(request: Atom, target_request: ExternalRequest, external_type: ExternalType) -> Self {
+  pub fn new(
+    id: DependencyId,
+    request: Atom,
+    target_request: ExternalRequest,
+    external_type: ExternalType,
+  ) -> Self {
     let resource_identifier = create_resource_identifier_for_esm_dependency(request.as_str(), None);
     Self {
+      id,
       request,
       target_request,
       external_type,
-      id: DependencyId::new(),
       resource_identifier,
       factorize_info: Default::default(),
     }

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -218,7 +218,7 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
   let mut external_connections = HashSet::default();
 
   // Remove `import()` runtime.
-  for (_, module) in &mg.modules() {
+  for module in mg.modules().values() {
     for block_id in module.get_blocks() {
       let block = mg.block_by_id(block_id).expect("should have block");
       for block_dep_id in block.get_dependencies() {

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -213,96 +213,71 @@ fn render_startup(
 
 #[plugin_hook(CompilerFinishMake for ModernModuleLibraryPlugin)]
 async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
-  let mut mg = compilation.get_module_graph_mut();
-  let modules = mg.modules();
-  let module_ids = modules.keys().cloned().collect::<Vec<_>>();
+  let mg = compilation.get_module_graph();
+  let mut deps_to_replace: Vec<BoxDependency> = Vec::new();
+  let mut external_connections = HashSet::default();
 
   // Remove `import()` runtime.
-  for module_id in &module_ids {
-    let mut deps_to_replace = Vec::new();
-    let module = mg.module_by_identifier(module_id).expect("should have mgm");
-
-    let connections: HashSet<_> = mg.get_outgoing_connections(module_id).collect();
-    let block_ids = module.get_blocks();
-
-    for block_id in block_ids {
+  for (_, module) in &mg.modules() {
+    for block_id in module.get_blocks() {
       let block = mg.block_by_id(block_id).expect("should have block");
       for block_dep_id in block.get_dependencies() {
         let block_dep = mg.dependency_by_id(block_dep_id);
         if let Some(block_dep) = block_dep {
           if let Some(import_dependency) = block_dep.as_any().downcast_ref::<ImportDependency>() {
-            let import_dep_connection = connections
-              .iter()
-              .find(|c| c.dependency_id == *block_dep_id);
+            let import_dep_connection = mg
+              .connection_by_dependency_id(block_dep_id)
+              .expect("should have dependency");
 
             // Try find the connection with a import dependency pointing to an external module.
             // If found, remove the connection and add a new import dependency to performs the external module ID replacement.
-            if let Some(import_dep_connection) = import_dep_connection {
-              let import_module_id = import_dep_connection.module_identifier();
-              let import_module = mg
-                .module_by_identifier(import_module_id)
-                .expect("should have mgm");
+            let import_module_id = import_dep_connection.module_identifier();
+            let import_module = mg
+              .module_by_identifier(import_module_id)
+              .expect("should have mgm");
 
-              if let Some(external_module) = import_module.as_external_module() {
-                let new_dep = ModernModuleImportDependency::new(
-                  *block_dep.id(),
-                  import_dependency.request.as_str().into(),
-                  external_module.request.clone(),
-                  external_module.external_type.clone(),
-                  import_dependency.range.clone(),
-                  import_dependency.get_attributes().cloned(),
-                );
+            if let Some(external_module) = import_module.as_external_module() {
+              let new_dep = ModernModuleImportDependency::new(
+                *block_dep.id(),
+                import_dependency.request.as_str().into(),
+                external_module.request.clone(),
+                external_module.external_type.clone(),
+                import_dependency.range.clone(),
+                import_dependency.get_attributes().cloned(),
+              );
 
-                deps_to_replace.push(new_dep);
-              }
+              deps_to_replace.push(Box::new(new_dep));
             }
           }
         }
       }
     }
-
-    for dep in deps_to_replace {
-      mg.revoke_dependency(dep.id(), false);
-      let boxed_dep = Box::new(dep) as BoxDependency;
-      mg.add_dependency(boxed_dep);
-    }
   }
 
   // Reexport star from external module.
-  for module_id in &module_ids {
-    // Only preserve star reexports for module graph entry, nested reexports are not supported.
-    if let Some(mgm) = mg.module_graph_module_by_identifier(module_id) {
-      let is_mg_entry = mgm.issuer().get_module(&mg).is_none();
-      if !is_mg_entry {
-        continue;
-      }
-    }
-
-    let mut deps_to_replace = Vec::new();
-    let mut external_connections = Vec::new();
-    let module = mg.module_by_identifier(module_id).expect("should have mgm");
-    let connections: HashSet<_> = mg.get_outgoing_connections(module_id).collect();
-    let dep_ids = module.get_dependencies();
+  // Only preserve star reexports for module graph entry, nested reexports are not supported.
+  for dep_id in &compilation.make_artifact.entry_dependencies {
+    let module = mg
+      .get_module_by_dependency_id(dep_id)
+      .expect("should have mgm");
 
     let mut module_id_to_connections: IdentifierMap<Vec<DependencyId>> = IdentifierMap::default();
-    connections.iter().for_each(|connection| {
-      module_id_to_connections
-        .entry(*connection.module_identifier())
-        .or_default()
-        .push(connection.dependency_id);
-    });
+    mg.get_outgoing_connections(&module.identifier())
+      .for_each(|connection| {
+        module_id_to_connections
+          .entry(*connection.module_identifier())
+          .or_default()
+          .push(connection.dependency_id);
+      });
 
-    for dep_id in dep_ids {
+    for dep_id in module.get_dependencies() {
       if let Some(export_dep) = mg.dependency_by_id(dep_id) {
         if let Some(reexport_dep) = export_dep
           .as_any()
           .downcast_ref::<ESMExportImportedSpecifierDependency>()
         {
           if self.reexport_star_from_external_module(reexport_dep, &mg) {
-            let reexport_connection = connections
-              .iter()
-              .find(|c| c.dependency_id == reexport_dep.id);
-
+            let reexport_connection = mg.connection_by_dependency_id(&reexport_dep.id);
             if let Some(reexport_connection) = reexport_connection {
               let import_module_id = reexport_connection.module_identifier();
               let import_module = mg
@@ -334,7 +309,7 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
                     // safe to remove the connection to clean up.
                     if non_reexport_star == 0 {
                       for c in connections.iter() {
-                        external_connections.push(*c);
+                        external_connections.insert(*c);
                       }
                     }
                   }
@@ -346,7 +321,7 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
                     external_module.external_type.clone(),
                   );
 
-                  deps_to_replace.push(new_dep);
+                  deps_to_replace.push(Box::new(new_dep));
                 }
               }
             }
@@ -354,23 +329,20 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
         }
       }
     }
+  }
 
-    for new_dep in deps_to_replace {
-      let dep_id = *new_dep.id();
-      let boxed_dep = Box::new(new_dep) as BoxDependency;
-      mg.add_dependency(boxed_dep);
-      mg.revoke_dependency(&dep_id, false);
-      external_connections.retain(|item| item != &dep_id);
-    }
+  let mut mg = compilation.get_module_graph_mut();
+  for dep in deps_to_replace {
+    let dep_id = dep.id();
+    external_connections.remove(dep_id);
+    // remove connection
+    mg.revoke_dependency(dep_id, false);
+    // overwrite dependency
+    mg.add_dependency(dep);
+  }
 
-    for connection in external_connections.iter() {
-      let importer = mg
-        .module_by_identifier_mut(module_id)
-        .expect("should have module");
-
-      importer.remove_dependency_id(*connection);
-      mg.revoke_dependency(connection, true);
-    }
+  for connection in &external_connections {
+    mg.revoke_dependency(connection, true);
   }
 
   Ok(())


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. `mg.revoke_dependency` will clean dependency at module and block when the `force` parameter is true

``` rust
impl ModuleGraph {
  fn revoke_dependency(&mut self, dep_id: &DependencyId) {
    ...
    if force {
      original_module.remove_dependency_id(dep_id);
      parent_block.remove_dependency_id(dep_id);
    }
  }
}
```

2. optimize ModernModule finish_make hook code, remove useless clone and module queries.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
