### PR TITLE
fix: napi register module twice

### DIFF
--- a/crates/rspack_fs_node/Cargo.toml
+++ b/crates/rspack_fs_node/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait  = { workspace = true }
-napi         = { workspace = true, features = ["napi4", "tokio_rt"] }
+napi         = { workspace = true, features = ["napi4", "tokio_rt", "noop"] }
 napi-derive  = { workspace = true }
 rspack_error = { workspace = true }
 rspack_fs    = { workspace = true }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
the dep crate of napi don't need to register `exports`
so use noop feature to skip that: [ref](https://github.com/napi-rs/napi-rs/blob/main/crates/napi/src/bindgen_runtime/module_register.rs#L232-L241) 


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
