### PR TITLE
feat: incremental for new code splitting

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/build_chunk_graph/mod.rs
@@ -8,6 +8,7 @@ use crate::{incremental::IncrementalPasses, Compilation};
 pub(crate) mod code_splitter;
 pub(crate) mod incremental;
 pub(crate) mod new_code_splitter;
+mod remove_available_modules;
 
 #[instrument("Compilation:build_chunk_graph", skip_all)]
 pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<()> {

--- a/crates/rspack_core/src/build_chunk_graph/remove_available_modules.rs
+++ b/crates/rspack_core/src/build_chunk_graph/remove_available_modules.rs
@@ -1,0 +1,107 @@
+use num_bigint::BigUint;
+use rustc_hash::FxHashSet as HashSet;
+
+use super::new_code_splitter::{CacheableChunkItem, ChunkDesc, EntryChunkDesc};
+
+pub fn remove_available_modules(
+  chunks: &mut [(bool, CacheableChunkItem)],
+  roots: &[usize],
+  chunk_parents: &[Vec<usize>],
+  chunk_children: &[Vec<usize>],
+) {
+  let mut chunk_incomings: Vec<usize> = chunk_parents.iter().map(|parents| parents.len()).collect();
+
+  let mut stack = roots
+    .iter()
+    .filter(|root| {
+      matches!(&chunks[**root].1.chunk_desc, ChunkDesc::Entry(box EntryChunkDesc{initial, ..}) if *initial)
+    })
+    .map(|root| (BigUint::ZERO, *root, false))
+    .collect::<Vec<_>>();
+
+  let mut pending = HashSet::<usize>::default();
+
+  let mut available_modules = vec![None; chunks.len()];
+
+  let mut calc_count = vec![0; chunks.len()];
+
+  while !pending.is_empty() || !stack.is_empty() {
+    if let Some(pending_chunk_index) = pending.iter().next().copied() {
+      // we have cycle, clear one pending randomly
+      pending.remove(&pending_chunk_index);
+      stack.push((
+        available_modules[pending_chunk_index]
+          .clone()
+          .expect("pending chunk have calculated available modules before"),
+        pending_chunk_index,
+        true,
+      ));
+    }
+
+    while let Some((parent_available_modules, chunk_index, force_continue)) = stack.pop() {
+      let (_, chunk) = &chunks[chunk_index];
+      calc_count[chunk_index] += 1;
+
+      if chunk_incomings[chunk_index] >= 1 {
+        chunk_incomings[chunk_index] -= 1;
+      }
+
+      let mut has_change = true;
+      let curr_parents_modules = if let Some(ref mut curr) = available_modules[chunk_index] {
+        // if already calculated
+        let res: BigUint = &*curr & &parent_available_modules;
+        // no change
+        has_change = &res != curr;
+        if !has_change && !force_continue {
+          continue;
+        }
+        *curr = res;
+        curr.clone()
+      } else {
+        available_modules[chunk_index] = Some(parent_available_modules.clone());
+        parent_available_modules
+      };
+
+      // we have incomings that not be calculated, wait till we calculated
+      if chunk_incomings[chunk_index] != 0 {
+        pending.insert(chunk_index);
+        continue;
+      }
+
+      // if we reach here, means all incomings have calculated (if no cycle)
+      //, we can continue calculate children
+      pending.remove(&chunk_index);
+      let curr_chunk_modules = chunk.chunk_desc.chunk_modules_ordinal();
+      let child_available = &curr_parents_modules | curr_chunk_modules;
+
+      for child in &chunk_children[chunk_index] {
+        if !has_change && force_continue && available_modules[*child].is_some() {
+          // if force_continue, means this calc is from cycle
+          // check if we really needs to continue
+          continue;
+        }
+
+        if matches!(
+          chunks[*child].1.chunk_desc,
+          ChunkDesc::Entry(box EntryChunkDesc { initial, .. }) if !initial
+        ) {
+          // async entrypoint has no dependOn and not parent modules
+          stack.push((BigUint::ZERO, *child, false));
+        } else {
+          stack.push((child_available.clone(), *child, false));
+        }
+      }
+    }
+  }
+
+  let mut not_visited = vec![];
+  for (chunk_index, available) in available_modules.iter().enumerate() {
+    let chunk = &mut chunks[chunk_index].1.chunk_desc;
+    if let Some(available) = available {
+      *chunk.available_modules_mut() = available.clone();
+    } else {
+      not_visited.push(chunk_index);
+      *chunk.available_modules_mut() = BigUint::ZERO;
+    }
+  }
+}

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -143,6 +143,10 @@ impl Chunk {
     &self.groups
   }
 
+  pub fn clear_groups(&mut self) {
+    self.groups.clear();
+  }
+
   pub fn add_group(&mut self, group: ChunkGroupUkey) {
     self.groups.insert(group);
   }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -97,6 +97,10 @@ impl ChunkGraphChunk {
   pub fn modules(&self) -> &IdentifierSet {
     &self.modules
   }
+
+  pub fn modules_mut(&mut self) -> &mut IdentifierSet {
+    &mut self.modules
+  }
 }
 
 fn get_modules_size(modules: &[&BoxModule], compilation: &Compilation) -> f64 {

--- a/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
@@ -6,7 +6,10 @@ use rustc_hash::FxHashMap as HashMap;
 use tracing::instrument;
 
 use crate::{
-  build_chunk_graph::code_splitter::{CodeSplitter, DependenciesBlockIdentifier},
+  build_chunk_graph::{
+    code_splitter::{CodeSplitter, DependenciesBlockIdentifier},
+    new_code_splitter::CodeSplitter as NewCodeSplitter,
+  },
   incremental::{IncrementalPasses, Mutation},
   ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation, Logger,
   ModuleIdentifier,
@@ -22,6 +25,7 @@ pub struct CodeSplittingCache {
   named_chunk_groups: HashMap<String, ChunkGroupUkey>,
   named_chunks: HashMap<String, ChunkUkey>,
   pub(crate) code_splitter: CodeSplitter,
+  pub(crate) new_code_splitter: NewCodeSplitter,
   pub(crate) module_idx: HashMap<ModuleIdentifier, (u32, u32)>,
 }
 

--- a/crates/rspack_core/src/options/entry.rs
+++ b/crates/rspack_core/src/options/entry.rs
@@ -31,7 +31,7 @@ where
   }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
 pub struct EntryData {
   pub dependencies: Vec<DependencyId>,
   pub include_dependencies: Vec<DependencyId>,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

CodeSplitting reuses some calculate result from previous build.

The new code splitting steps are as following:

1. Analyze blocks to find all chunk entry
2. Find chunk modules in parallel
3. Find chunk's parents and children based on incoming blocks and outgoing blocks
4. Remove modules in chunk which are already present in the parent chunks
5. Create chunk and chunk group, connect chunk and module

We can cache results from step 1, step 2 and reuse some chunk in step 5, so next stages in seal can get information about which chunk has changed

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
