### PR TITLE
chore: test mac on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,12 @@ jobs:
       full-install: false
 
   test-mac:
-    name: Test Mac
+    name: Test Mac Arm64
     needs: [get-runner-labels, check-changed]
     if: github.ref_name == 'main' || contains(github.event.pull_request.title, '!macos')
     uses: ./.github/workflows/reusable-build.yml
     with:
-      target: x86_64-apple-darwin
+      target: aarch64-apple-darwin
       profile: "ci"
       runner: ${{ needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS }}
       skipable: ${{ needs.check-changed.outputs.changed  != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       full-install: false
 
   test-mac:
-    name: Test Mac Arm64
+    name: Test Mac ARM64
     needs: [get-runner-labels, check-changed]
     if: github.ref_name == 'main' || contains(github.event.pull_request.title, '!macos')
     uses: ./.github/workflows/reusable-build.yml

--- a/a.sh
+++ b/a.sh
@@ -1,0 +1,3 @@
+if [[ "ARM64" == ARM* ]]; then
+  echo "String starts with ARM"
+fi

--- a/a.sh
+++ b/a.sh
@@ -1,3 +1,0 @@
-if [[ "ARM64" == ARM* ]]; then
-  echo "String starts with ARM"
-fi


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
the current macos runner is target to aarch64 which cause https://github.com/web-infra-dev/rspack/actions/runs/13832395298/job/38700157592#step:9:3 fail
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
