### PR TITLE
fix: apply global `overrideStrict` for ContextModule

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -186,7 +186,10 @@ impl ContextModule {
       identifier: create_identifier(&options),
       options,
       factory_meta: None,
-      build_info: Default::default(),
+      build_info: BuildInfo {
+        strict: true,
+        ..Default::default()
+      },
       build_meta: BuildMeta {
         exports_type: BuildMetaExportsType::Default,
         default_object: BuildMetaDefaultObject::RedirectWarn { ignore: false },

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/issuse_2960/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/issuse_2960/__snapshots__/output.snap.txt
@@ -21,6 +21,7 @@ console.log("a");
 
 }),
 "./resources sync recursive ^\\.\\/pre_.*\\.js$": (function (module, __unused_webpack_exports, __webpack_require__) {
+"use strict";
 var map = {
   "./pre_a.js": "./resources/pre_a.js",
   "./pre_b.js": "./resources/pre_b.js",

--- a/packages/rspack-test-tools/tests/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
@@ -33,6 +33,7 @@ const b = "b";
 ```js title=main.js
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["main"], {
 "./child lazy recursive ^\\.\\/.*\\.js$": (function (module, __unused_webpack_exports, __webpack_require__) {
+"use strict";
 var map = {
   "./a.js": [
     "./child/a.js",

--- a/packages/rspack-test-tools/tests/treeShakingCases/context-module/__snapshots__/treeshaking.snap.txt
+++ b/packages/rspack-test-tools/tests/treeShakingCases/context-module/__snapshots__/treeshaking.snap.txt
@@ -21,6 +21,7 @@ const value = "dynamic";
 
 }),
 "./child sync recursive ^\\.\\/.*\\.js$": (function (module, __unused_webpack_exports, __webpack_require__) {
+"use strict";
 var map = {
   "./child/index.js": "./child/child/index.js",
   "./index.js": "./child/index.js"

--- a/tests/webpack-test/configCases/concatenate-modules/context-module/index.mjs
+++ b/tests/webpack-test/configCases/concatenate-modules/context-module/index.mjs
@@ -1,0 +1,41 @@
+/** @type {import('fs')} */
+const fs = __non_webpack_require__("fs");
+
+it("should import", async () => {
+	const n = "a.js";
+	const { default: a1 } = await import(`./sub/${n}`);
+	expect(a1).toBe("a");
+});
+
+it("should startsWith use strict", async () => {
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source.length).not.toBe(0);
+	expect(source.startsWith('/******/ "use strict"')).toBeTruthy();
+});
+
+it("should have all strict modules", () => {
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source.length).not.toBe(0);
+
+	expect(source).not.toContain(
+		[
+			"This",
+			"entry",
+			"needs",
+			"to",
+			"be",
+			"wrapped",
+			"in",
+			"an",
+			"IIFE",
+			"because",
+			"it",
+			"needs",
+			"to",
+			"be",
+			"in",
+			"strict",
+			"mode."
+		].join(" ")
+	);
+});

--- a/tests/webpack-test/configCases/concatenate-modules/context-module/infrastructure-log.js
+++ b/tests/webpack-test/configCases/concatenate-modules/context-module/infrastructure-log.js
@@ -1,0 +1,7 @@
+module.exports = options => {
+	if (options.cache && options.cache.type === "filesystem") {
+		return [/Pack got invalid because of write to/];
+	}
+
+	return [];
+};

--- a/tests/webpack-test/configCases/concatenate-modules/context-module/sub/a.js
+++ b/tests/webpack-test/configCases/concatenate-modules/context-module/sub/a.js
@@ -1,0 +1,1 @@
+export default "a"

--- a/tests/webpack-test/configCases/concatenate-modules/context-module/webpack.config.js
+++ b/tests/webpack-test/configCases/concatenate-modules/context-module/webpack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index.mjs",
+	output: { iife: false },
+	optimization: { concatenateModules: true }
+};


### PR DESCRIPTION
## Summary

- Port webpack/webpack#21142 to make ContextModule respect the global `module.parser.javascript.overrideStrict` option.
- Apply the global override when creating Rspack `ContextModule`s instead of forcing every context module to `strict: true`.
- Add the upstream webpack config case for `parsing/override-strict-context-module`, with only `webpack.config.js` renamed to `rspack.config.js`.

## Upstream PR

- https://github.com/webpack/webpack/pull/21142
- Upstream title: `fix: apply global overrideStrict for ContextModule`
- This supersedes the earlier Rspack PR approach that was blocked while the webpack-side change was not merged.

## Test Plan

- [x] `pnpm run build:binding:dev`
- [x] `cd tests/rspack-test && pnpm run test -t "configCases/parsing/override-strict"`
