### PR TITLE
chore: try use lto=thin for release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,11 +208,10 @@ panic         = "abort"
 [profile.release]
 codegen-units = 1
 debug         = false
-# Performs “fat” LTO which attempts to perform optimizations across all crates within the dependency graph.
-lto       = "fat"
-opt-level = 3
-panic     = "abort"
-strip     = true
+lto           = "thin"
+opt-level     = 3
+panic         = "abort"
+strip         = true
 
 [profile.release.package]
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
lto fat -> thin will cutoff half of the release build time 
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
