### PR TITLE
chore: disable lto for ci

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,8 +373,7 @@ opt-level = "s"
 [profile.ci]
 codegen-units = 256
 inherits      = "release"
-## reduce little optimization to reduce build time
-lto = "thin"
+lto           = false
 ## reduce little optimization to reduce build time
 opt-level = 2
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
disable lto in ci will speedup ci time
link time reduced from 5min to 1min
* before
![image](https://github.com/user-attachments/assets/e8b1fa81-3ce5-4bd4-8c94-b4c7d8b2e480)

* after 
![image](https://github.com/user-attachments/assets/540cfcf1-48ec-4eeb-abdd-2ee9aae30a5e)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
