### PR TITLE
docs: correct `experiments.outputModule` default value

### DIFF
--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -34,7 +34,7 @@ And it is enabled by default when [experiments.futureDefaults](#experimentsfutur
 ## experiments.outputModule
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `false`
 
 Once enabled, Rspack will output ECMAScript module syntax whenever possible. For instance, `import()` to load chunks, ESM exports to expose chunk data, among others.
 

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1516,7 +1516,7 @@ define('MyLibrary', [], factory);
 - **类型：** `boolean`
 - **默认值：** `false`
 
-以 ESM 模块的形式输出 JavaScript 文件。由于此功能还处于实验阶段，默认关闭，想要使用的话必须将 [`experiments.outputModule`](/config/experiments#experimentsoutputmodule) 设置为 true。
+以 ESM 模块的形式输出 JavaScript 文件。由于此功能仍处于实验阶段，默认为关闭状态。如需启用，请将 [`experiments.outputModule`](/config/experiments#experimentsoutputmodule) 设置为 `true`。
 
 当启用时，Rspack 会将 [`output.iife`](#outputiife) 设置为 `false`， [`output.scriptType`](#outputscripttype) 设置为 `'module'`。
 


### PR DESCRIPTION
## Summary

Correct `experiments.outputModule` default value, should be `false`.

The Chinese documentation is correct and does not need updating.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
