### PR TITLE
fix: should convert diagnostic.loc to string

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/errors/push-custom-error/errors.js
+++ b/packages/rspack-test-tools/tests/configCases/errors/push-custom-error/errors.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/test/]
+];

--- a/packages/rspack-test-tools/tests/configCases/errors/push-custom-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/errors/push-custom-error/rspack.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+	plugins: [
+		{
+			apply(
+				/**@type {import('@rspack/core').Compiler} */
+				compiler
+			) {
+				compiler.hooks.compilation.tap("test", compilation => {
+					compilation.hooks.seal.tap("test", () => {
+						compilation.errors.push([
+							{
+								name: "test error",
+								message: "",
+								loc: {
+									start: {
+										line: 0,
+										column: 0
+									},
+									end: {
+										line: 0,
+										column: 0
+									}
+								}
+							}
+						]);
+					});
+				});
+			}
+		}
+	]
+};

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -91,6 +91,11 @@ export function concatErrorMsgAndStack(
 	}
 	// maybe `null`, use `undefined` to compatible with `Option<String>`
 	err.stack = err.stack || undefined;
+
+	if ("loc" in err) {
+		err.loc = JSON.stringify(err.loc);
+	}
+
 	return err;
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should convert `loc` field to string type. Some plugin(TsChecker for example) will push error to compilation which contains object type `loc` field, currently Rspack will just panic in that situation

Even if we are not consuming `loc` field, we should not panic



<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
