### PR TITLE
refactor: remove `block_on` in rspack_storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,7 +5430,6 @@ dependencies = [
  "cow-utils",
  "futures",
  "itertools 0.14.0",
- "pollster",
  "rayon",
  "rspack_error",
  "rspack_fs",

--- a/crates/rspack_storage/Cargo.toml
+++ b/crates/rspack_storage/Cargo.toml
@@ -13,7 +13,6 @@ async-trait  = { workspace = true }
 cow-utils    = { workspace = true }
 futures      = { workspace = true }
 itertools    = { workspace = true }
-pollster     = { workspace = true }
 rayon        = { workspace = true }
 rspack_error = { workspace = true }
 rspack_fs    = { workspace = true }

--- a/crates/rspack_storage/Cargo.toml
+++ b/crates/rspack_storage/Cargo.toml
@@ -19,7 +19,7 @@ rspack_error = { workspace = true }
 rspack_fs    = { workspace = true }
 rspack_paths = { workspace = true }
 rustc-hash   = { workspace = true }
-tokio        = { workspace = true }
+tokio        = { workspace = true, features = ["time"] }
 tracing      = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rspack_storage/src/pack/manager/mod.rs
+++ b/crates/rspack_storage/src/pack/manager/mod.rs
@@ -3,7 +3,6 @@ mod queue;
 use std::sync::Arc;
 
 use futures::future::join_all;
-use pollster::block_on;
 use queue::TaskQueue;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use tokio::sync::oneshot::Receiver;
@@ -44,14 +43,16 @@ impl ScopeManager {
   }
 
   pub fn save(&self, updates: ScopeUpdates) -> Result<Receiver<Result<()>>> {
-    let pack_options = self.pack_options.clone();
     let strategy = self.strategy.clone();
     let scopes = self.scopes.clone();
     let root_meta = self.root_meta.clone();
-    block_on(tokio::task::unconstrained(async move {
-      let mut scopes_guard = scopes.lock().await;
+    let pack_options = self.pack_options.clone();
+    let root_options = self.root_options.clone();
+    let (tx, rx) = oneshot::channel();
+    self.queue.add_task(Box::pin(async move {
+      let mut scopes_lock = scopes.lock().await;
       match update_scopes(
-        &mut scopes_guard,
+        &mut scopes_lock,
         updates,
         pack_options.clone(),
         strategy.as_ref(),
@@ -60,26 +61,20 @@ impl ScopeManager {
       {
         Ok(_) => {
           *root_meta.lock().await = RootMetaState::Value(Some(RootMeta::new(
-            scopes_guard
+            scopes_lock
               .iter()
               .filter(|(_, scope)| scope.loaded())
               .map(|(name, _)| name.clone())
               .collect::<HashSet<_>>(),
-            self.root_options.expire,
+            root_options.expire,
           )));
-          Ok(())
         }
-        Err(e) => Err(e),
-      }
-    }))?;
+        Err(e) => {
+          let _ = tx.send(Err(e));
+          return;
+        }
+      };
 
-    let strategy = self.strategy.clone();
-    let scopes = self.scopes.clone();
-    let root_meta = self.root_meta.clone();
-    let root_options = self.root_options.clone();
-    let (tx, rx) = oneshot::channel();
-    self.queue.add_task(Box::pin(async move {
-      let mut scopes_lock = scopes.lock().await;
       let root_meta = root_meta
         .lock()
         .await
@@ -374,8 +369,6 @@ mod tests {
     );
     let rx = manager.save(scope_updates)?;
 
-    assert_eq!(manager.load("scope1").await?.len(), 100);
-    assert_eq!(manager.load("scope2").await?.len(), 100);
     assert!(!(fs.exists(root.join("scope1/scope_meta").as_path()).await?));
     assert!(!(fs.exists(root.join("scope2/scope_meta").as_path()).await?));
 
@@ -431,17 +424,6 @@ mod tests {
         .collect::<HashMap<_, _>>(),
     );
     let rx = manager.save(scope_updates)?;
-    let (update_items, insert_items): (Vec<_>, Vec<_>) = manager
-      .load("scope1")
-      .await?
-      .into_iter()
-      .partition(|(_, v)| {
-        let val = String::from_utf8(v.to_vec()).unwrap();
-        val.ends_with("_new")
-      });
-    assert_eq!(insert_items.len(), 50);
-    assert_eq!(update_items.len(), 50);
-    assert_eq!(manager.load("scope2").await?.len(), 50);
     let scope1_mtime = fs
       .metadata(root.join("scope1/scope_meta").as_path())
       .await?

--- a/crates/rspack_storage/tests/dev.rs
+++ b/crates/rspack_storage/tests/dev.rs
@@ -65,9 +65,8 @@ mod test_storage_dev {
         format!("val_{:0>3}", i).as_bytes().to_vec(),
       );
     }
-    storage.trigger_save()?;
+    storage.trigger_save()?.await.expect("should save")?;
 
-    assert_eq!(storage.load("test_scope").await?.len(), 700);
     for i in 700..1000 {
       storage.set(
         "test_scope",
@@ -77,8 +76,8 @@ mod test_storage_dev {
     }
     let rx = storage.trigger_save()?;
 
-    assert_eq!(storage.load("test_scope").await?.len(), 1000);
     rx.await.expect("should save")?;
+    assert_eq!(storage.load("test_scope").await?.len(), 1000);
 
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())
@@ -98,7 +97,7 @@ mod test_storage_dev {
       format!("new_{:0>3}", 100).as_bytes().to_vec(),
     );
     storage.remove("test_scope", format!("key_{:0>3}", 200).as_bytes().as_ref());
-    storage.trigger_save()?;
+    storage.trigger_save()?.await.expect("should save")?;
     assert_eq!(storage.load("test_scope").await?.len(), 999);
 
     storage.set(
@@ -108,9 +107,8 @@ mod test_storage_dev {
     );
     storage.remove("test_scope", format!("key_{:0>3}", 400).as_bytes().as_ref());
     let rx = storage.trigger_save()?;
-    assert_eq!(storage.load("test_scope").await?.len(), 998);
-
     rx.await.expect("should save")?;
+    assert_eq!(storage.load("test_scope").await?.len(), 998);
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())
   }

--- a/crates/rspack_storage/tests/error.rs
+++ b/crates/rspack_storage/tests/error.rs
@@ -56,9 +56,8 @@ mod test_storage_error {
       );
     }
     let rx = storage.trigger_save()?;
-    assert_eq!(storage.load("test_scope").await?.len(), 1000);
-
     rx.await.expect("should save")?;
+    assert_eq!(storage.load("test_scope").await?.len(), 1000);
     assert!(fs.exists(&root.join("test_scope/scope_meta")).await?);
     Ok(())
   }

--- a/crates/rspack_storage/tests/expire.rs
+++ b/crates/rspack_storage/tests/expire.rs
@@ -48,9 +48,8 @@ mod test_storage_expire {
       );
     }
     let rx = storage.trigger_save()?;
-    assert_eq!(storage.load("test_scope").await?.len(), 100);
-
     rx.await.expect("should save")?;
+    assert_eq!(storage.load("test_scope").await?.len(), 100);
     assert!(
       fs.exists(&root.join(version).join("test_scope/scope_meta"))
         .await?

--- a/crates/rspack_storage/tests/lock.rs
+++ b/crates/rspack_storage/tests/lock.rs
@@ -111,8 +111,6 @@ mod test_storage_lock {
       );
     }
     let rx = storage.trigger_save()?;
-    assert_eq!(storage.load("test_scope").await?.len(), 100);
-
     assert!(rx
       .await
       .expect("should save")


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Remove `block_on` in rspack_storage to prevent deadlock. This modification will make the cache scopes not to merge until writing files. So remove related test cases which run `.load()` just after save and before receiving the signal of saving scopes.



## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
