### PR TITLE
chore: disable tokio lifo optimization

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -32,8 +32,8 @@ rustflags = [
 
   "-Aclippy::default_constructed_unit_structs",
   "-Zshare-generics=y", # make the current crate share its generic instantiations
-  "-Zthreads=8" # parallel frontend https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
-  
+  "-Zthreads=8", # parallel frontend https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
+  "--cfg", "tokio_unstable" # enable unstable features for tokio
 ]
 
 # Fix napi breaking in test environment <https://github.com/napi-rs/napi-rs/issues/1005#issuecomment-1011034770>

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -360,6 +360,7 @@ fn init() {
   let rt = tokio::runtime::Builder::new_multi_thread()
     .max_blocking_threads(blocking_threads)
     .enable_all()
+    .disable_lifo_slot()
     .build()
     .expect("Create tokio runtime failed");
   create_custom_tokio_runtime(rt);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
LIFO has some know issues https://github.com/tokio-rs/tokio/issues/4941  which may cause work-stealing not work well in some edge cases and this optimization is used to ensure work fairness and work latency which is not meaningful for rspack, so disable it for better deterministic scheduler
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
