### PR TITLE
refactor: remove `block_on` in runtime modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5190,7 +5190,6 @@ dependencies = [
  "derive_more 1.0.0",
  "indexmap 2.7.1",
  "itertools 0.14.0",
- "pollster",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",

--- a/crates/rspack_core/src/utils/compile_boolean_matcher.rs
+++ b/crates/rspack_core/src/utils/compile_boolean_matcher.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 pub enum BooleanMatcher {
   Condition(bool),
-  Matcher(Box<dyn Fn(String) -> String>),
+  Matcher(Box<dyn Fn(String) -> String + Send + Sync + 'static>),
 }
 
 impl BooleanMatcher {

--- a/crates/rspack_plugin_runtime/Cargo.toml
+++ b/crates/rspack_plugin_runtime/Cargo.toml
@@ -14,7 +14,6 @@ dashmap                  = { workspace = true }
 derive_more              = { workspace = true, features = ["debug"] }
 indexmap                 = { workspace = true }
 itertools                = { workspace = true }
-pollster                 = { workspace = true }
 rspack_cacheable         = { workspace = true }
 rspack_collections       = { workspace = true }
 rspack_core              = { workspace = true }
@@ -30,4 +29,4 @@ serde_json = { workspace = true }
 tracing    = { workspace = true }
 
 [package.metadata.cargo-shear]
-ignored = ["tracing"]
+ignored = ["tracing", "tokio"]

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -1,7 +1,6 @@
 use std::ptr::NonNull;
 
 use cow_utils::CowUtils;
-use pollster::block_on;
 use rspack_collections::{DatabaseItem, Identifier};
 use rspack_core::{
   compile_boolean_matcher, impl_runtime_module,
@@ -228,19 +227,17 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       .to_string();
 
       let chunk_ukey = self.chunk.expect("The chunk should be attached");
-      let res = block_on(tokio::task::unconstrained(async {
-        hooks
-          .link_prefetch
-          .call(LinkPrefetchData {
-            code: link_prefetch_code,
-            chunk: RuntimeModuleChunkWrapper {
-              chunk_ukey,
-              compilation_id: compilation.id(),
-              compilation: NonNull::from(compilation),
-            },
-          })
-          .await
-      }))?;
+      let res = hooks
+        .link_prefetch
+        .call(LinkPrefetchData {
+          code: link_prefetch_code,
+          chunk: RuntimeModuleChunkWrapper {
+            chunk_ukey,
+            compilation_id: compilation.id(),
+            compilation: NonNull::from(compilation),
+          },
+        })
+        .await?;
 
       let source_with_prefetch = compilation.runtime_template.render(
         &self.template_id(TemplateId::WithPrefetch),
@@ -313,19 +310,17 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       .to_string();
 
       let chunk_ukey = self.chunk.expect("The chunk should be attached");
-      let res = block_on(tokio::task::unconstrained(async {
-        hooks
-          .link_preload
-          .call(LinkPreloadData {
-            code: link_preload_code,
-            chunk: RuntimeModuleChunkWrapper {
-              chunk_ukey,
-              compilation_id: compilation.id(),
-              compilation: NonNull::from(compilation),
-            },
-          })
-          .await
-      }))?;
+      let res = hooks
+        .link_preload
+        .call(LinkPreloadData {
+          code: link_preload_code,
+          chunk: RuntimeModuleChunkWrapper {
+            chunk_ukey,
+            compilation_id: compilation.id(),
+            compilation: NonNull::from(compilation),
+          },
+        })
+        .await?;
 
       let source_with_preload = compilation.runtime_template.render(
         &self.template_id(TemplateId::WithPreload),

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
@@ -1,7 +1,6 @@
 use std::ptr::NonNull;
 
 use cow_utils::CowUtils;
-use pollster::block_on;
 use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
@@ -138,19 +137,17 @@ impl RuntimeModule for LoadScriptRuntimeModule {
 
     let hooks = RuntimePlugin::get_compilation_hooks(compilation.id());
     let chunk_ukey = self.chunk_ukey;
-    let res = block_on(tokio::task::unconstrained(async {
-      hooks
-        .create_script
-        .call(CreateScriptData {
-          code: create_script_code,
-          chunk: RuntimeModuleChunkWrapper {
-            chunk_ukey,
-            compilation_id: compilation.id(),
-            compilation: NonNull::from(compilation),
-          },
-        })
-        .await
-    }))?;
+    let res = hooks
+      .create_script
+      .call(CreateScriptData {
+        code: create_script_code,
+        chunk: RuntimeModuleChunkWrapper {
+          chunk_ukey,
+          compilation_id: compilation.id(),
+          compilation: NonNull::from(compilation),
+        },
+      })
+      .await?;
 
     Ok(
       RawStringSource::from(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Remove `block_on` in runtime modules to prevent deadlock

---
This pull request includes several changes aimed at improving concurrency and simplifying the codebase in the `rspack_plugin_runtime` crate. The most important changes include adding `Send` and `Sync` bounds to the `BooleanMatcher` enum, removing the `pollster` dependency, and modifying the `JsonpChunkLoadingRuntimeModule` and `LoadScriptRuntimeModule` implementations to remove unnecessary async blocks.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
