### PR TITLE
chore: revert "chore: disable tokio lifo optimization"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -32,8 +32,8 @@ rustflags = [
 
   "-Aclippy::default_constructed_unit_structs",
   "-Zshare-generics=y", # make the current crate share its generic instantiations
-  "-Zthreads=8", # parallel frontend https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
-  "--cfg", "tokio_unstable" # enable unstable features for tokio
+  "-Zthreads=8" # parallel frontend https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
+  
 ]
 
 # Fix napi breaking in test environment <https://github.com/napi-rs/napi-rs/issues/1005#issuecomment-1011034770>

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -360,7 +360,6 @@ fn init() {
   let rt = tokio::runtime::Builder::new_multi_thread()
     .max_blocking_threads(blocking_threads)
     .enable_all()
-    .disable_lifo_slot()
     .build()
     .expect("Create tokio runtime failed");
   create_custom_tokio_runtime(rt);


### PR DESCRIPTION
Reverts web-infra-dev/rspack#9706
https://github.com/web-infra-dev/rspack/actions/runs/13915075923/job/38939976174#step:14:1545 build on aarch64-linux-musl failed caused by https://github.com/napi-rs/napi-rs/issues/2151 
