### PR TITLE
feat(copyRspackPlugin): align transform api with webpack plugin

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1558,7 +1558,7 @@ export interface RawCopyPattern {
    * @default false
    */
   copyPermissions?: boolean
-  transform?: (input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>
+  transform?: { transformer: (input: string, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>  } | ((input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>)
 }
 
 export interface RawCopyRspackPluginOptions {
@@ -2360,7 +2360,11 @@ export interface RawSwcJsMinimizerRspackPluginOptions {
 
 export interface RawToOptions {
   context: string
-  absoluteFilename: string
+  absoluteFilename?: string
+}
+
+export interface RawTransformWithCacheOptions {
+  transformer: TransformerFn
 }
 
 export interface RawTrustedTypes {

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -2363,7 +2363,7 @@ export interface RawToOptions {
   absoluteFilename?: string
 }
 
-export interface RawTransformWithCacheOptions {
+export interface RawTransformOptions {
   transformer: TransformerFn
 }
 

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -2364,7 +2364,7 @@ export interface RawToOptions {
 }
 
 export interface RawTransformOptions {
-  transformer: TransformerFn
+transformer: { transformer: (input: string, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>  }
 }
 
 export interface RawTrustedTypes {

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
@@ -10,7 +10,7 @@ use rspack_plugin_copy::{
 };
 
 type TransformerFn = ThreadsafeFunction<(Buffer, String), Either<String, Buffer>>;
-type RawTransformer = Either<RawTransformWithCacheOptions, TransformerFn>;
+type RawTransformer = Either<RawTransformOptions, TransformerFn>;
 
 type RawToFn = ThreadsafeFunction<RawToOptions, String>;
 
@@ -18,7 +18,7 @@ type RawTo = Either<String, RawToFn>;
 
 #[derive(Debug, Clone)]
 #[napi(object, object_to_js = false)]
-pub struct RawTransformWithCacheOptions {
+pub struct RawTransformOptions {
   pub transformer: TransformerFn,
 }
 

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
@@ -19,6 +19,10 @@ type RawTo = Either<String, RawToFn>;
 #[derive(Debug, Clone)]
 #[napi(object, object_to_js = false)]
 pub struct RawTransformOptions {
+  #[debug(skip)]
+  #[napi(
+    ts_type = "{ transformer: (input: string, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>  }"
+  )]
   pub transformer: TransformerFn,
 }
 

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -75,11 +75,11 @@ impl Display for ToType {
 pub type TransformerFn =
   Box<dyn for<'a> Fn(Vec<u8>, &'a str) -> BoxFuture<'a, Result<RawSource>> + Sync + Send>;
 
-pub type TransformerWithCacheOpt = (TransformerFn, Option<bool>);
+pub type TransformerOpts = (TransformerFn, Option<bool>);
 
 pub enum Transformer {
   Fn(TransformerFn),
-  Opt(TransformerWithCacheOpt),
+  Opt(TransformerOpts),
 }
 
 pub struct ToFnCtx<'a> {
@@ -309,35 +309,17 @@ impl CopyRspackPlugin {
           )
           .await
         }
-        Transformer::Opt((transformer, cache)) => match cache {
-          Some(true) => {
-            // let content_hash = Self::get_content_hash(
-            //   &source,
-            //   &compilation.options.output.hash_function,
-            //   &compilation.options.output.hash_digest,
-            //   &compilation.options.output.hash_salt,
-            // );
-            // let content_hash = content_hash.rendered(compilation.options.output.hash_digest_length);
-            // let cache_key = format!(
-            //   "transform|sourceFilename|{}|contentHash{}idx{:?}",
-            //   source_filename.as_str(),
-            //   content_hash,
-            //   pattern_index
-            // );
-            // TODO: need compilation support get_cache() api
-            todo!()
-          }
-          _ => {
-            handle_transform(
-              transformer,
-              source_vec,
-              absolute_filename.clone(),
-              &mut source,
-              diagnostics,
-            )
-            .await
-          }
-        },
+        // TODO: support cache in the furture.
+        Transformer::Opt((transformer, _)) => {
+          handle_transform(
+            transformer,
+            source_vec,
+            absolute_filename.clone(),
+            &mut source,
+            diagnostics,
+          )
+          .await
+        }
       }
     }
 

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -309,7 +309,7 @@ impl CopyRspackPlugin {
           )
           .await
         }
-        // TODO: support cache in the furture.
+        // TODO: support cache in the future.
         Transformer::Opt((transformer, _)) => {
           handle_transform(
             transformer,

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -163,7 +163,7 @@ impl CopyRspackPlugin {
     output_path: &Utf8Path,
     from_type: FromType,
     file_dependencies: &DashSet<PathBuf>,
-    diagnostics: &Mutex<Vec<Diagnostic>>,
+    diagnostics: Arc<Mutex<Vec<Diagnostic>>>,
     compilation: &Compilation,
     logger: &CompilationLogger,
     pattern_index: usize,
@@ -392,7 +392,7 @@ impl CopyRspackPlugin {
     index: usize,
     file_dependencies: &DashSet<PathBuf>,
     context_dependencies: &DashSet<PathBuf>,
-    diagnostics: &Mutex<Vec<Diagnostic>>,
+    diagnostics: Arc<Mutex<Vec<Diagnostic>>>,
     logger: &CompilationLogger,
   ) -> Option<Vec<Option<RunPatternResult>>> {
     let orig_from = &pattern.from;
@@ -554,7 +554,7 @@ impl CopyRspackPlugin {
             output_path,
             from_type,
             file_dependencies,
-            diagnostics,
+            diagnostics.clone(),
             compilation,
             logger,
             index,
@@ -619,7 +619,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let start = logger.time("run pattern");
   let file_dependencies = DashSet::default();
   let context_dependencies = DashSet::default();
-  let diagnostics = Mutex::new(Vec::new());
+  let diagnostics = Arc::new(Mutex::new(Vec::new()));
 
   let mut copied_result: Vec<(i32, RunPatternResult)> =
     join_all(self.patterns.iter().enumerate().map(|(index, pattern)| {
@@ -629,7 +629,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         index,
         &file_dependencies,
         &context_dependencies,
-        &diagnostics,
+        diagnostics.clone(),
         &logger,
       )
     }))
@@ -823,7 +823,7 @@ async fn handle_transform(
   source_vec: Vec<u8>,
   absolute_filename: Utf8PathBuf,
   source: &mut RawSource,
-  diagnostics: &Mutex<Vec<Diagnostic>>,
+  diagnostics: Arc<Mutex<Vec<Diagnostic>>>,
 ) {
   match transformer(source_vec, absolute_filename.as_str()).await {
     Ok(code) => {

--- a/packages/rspack-test-tools/tests/configCases/plugins/copy-plugin-transform/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/copy-plugin-transform/index.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+// Export a function that will be called by the test runner
+module.exports = function () {
+	it("should transform file when transform is an object contains `transformer`", () => {
+		const sourcePath = path.join(__dirname, "src", "test.txt");
+		const outputPath = path.join(__dirname, "dist", "test.txt");
+
+		// List the contents of the dist directory
+		if (fs.existsSync(path.join(__dirname, "dist"))) {
+			console.log("Dist directory contents:", fs.readdirSync(path.join(__dirname, "dist")));
+		} else {
+			console.log("Dist directory does not exist");
+		}
+
+		assert(fs.existsSync(outputPath), "Output file should exist");
+	});
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/copy-plugin-transform/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/copy-plugin-transform/rspack.config.js
@@ -1,0 +1,22 @@
+const { CopyRspackPlugin } = require("@rspack/core");
+const path = require("path");
+
+module.exports = {
+	entry: "./index.js",
+	target: "node",
+	plugins: [
+		new CopyRspackPlugin({
+			patterns: [
+				{
+					from: path.join(__dirname, "src", "test.txt"),
+					copyPermissions: true,
+					transform: {
+						transformer: (content, absoluteFilename) => {
+							return `file: ${absoluteFilename} transformed: ${content} changed`;
+						}
+					}
+				}
+			]
+		})
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/copy-plugin-transform/src/test.txt
+++ b/packages/rspack-test-tools/tests/configCases/plugins/copy-plugin-transform/src/test.txt
@@ -1,0 +1,1 @@
+This is a test file for copying transform config.

--- a/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
@@ -405,10 +405,17 @@ export default {
 - **Type:**
 
 ```ts
-type Transform = (
-  input: Buffer,
-  absoluteFilename: string,
-) => string | Buffer | Promise<string> | Promise<Buffer>;
+type transform =
+  | {
+      transformer: (
+        input: string,
+        absoluteFilename: string,
+      ) => string | Buffer | Promise<string> | Promise<Buffer>;
+    }
+  | ((
+      input: string,
+      absoluteFilename: string,
+    ) => string | Buffer | Promise<string> | Promise<Buffer>);
 ```
 
 - **Default:** `undefined`
@@ -424,8 +431,8 @@ export default {
           from: 'src/*.png',
           // The `content` argument is a [`Buffer`](https://nodejs.org/api/buffer.html) object,
           // it could be converted to a string to be processed using `content.toString()`.
-          // The `absoluteFrom` argument is a string, it is absolute path from where the file is being copied.
-          transform(content, absoluteFrom) {
+          // The `absoluteFilename` argument is a string, it is absolute path from where the file is being copied.
+          transform(content, absoluteFilename) {
             return optimize(content);
           },
         },

--- a/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
@@ -409,10 +409,17 @@ export default {
 - **类型：**
 
 ```ts
-type Transform = (
-  content: Buffer,
-  absoluteFrom: string,
-) => string | Buffer | Promise<string> | Promise<Buffer>;
+type transform =
+  | {
+      transformer: (
+        input: string,
+        absoluteFilename: string,
+      ) => string | Buffer | Promise<string> | Promise<Buffer>;
+    }
+  | ((
+      input: string,
+      absoluteFilename: string,
+    ) => string | Buffer | Promise<string> | Promise<Buffer>);
 ```
 
 - **默认值：** `undefined`
@@ -428,8 +435,8 @@ export default {
           from: 'src/*.png',
           // `content` 参数是一个 [`Buffer`](https://nodejs.org/api/buffer.html) 对象，
           // 可以使用 `content.toString()` 转换为字符串。
-          // `absoluteFrom` 参数是一个字符串，是文件被拷贝的绝对路径。
-          transform(content, absoluteFrom) {
+          // `absoluteFilename` 参数是一个字符串，是文件被拷贝的绝对路径。
+          transform(content, absoluteFilename) {
             return optimize(content);
           },
         },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

closes: #8957 

Api align need something more to support:

- [x] transform api align with webpack
- [ ] copyRspackPlugin support cache feature
   - [ ]  Rspack compilation support `get_cache()` function

I will support cache feature after `compilation` support `compilation.get_cache()` function, so this pr will not execute it.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

