### PR TITLE
refactor: remove `block_on` in split chunk name and test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5243,11 +5243,13 @@ version = "0.2.0"
 dependencies = [
  "dashmap 6.1.0",
  "derive_more 1.0.0",
+ "futures",
  "rayon",
  "regex",
  "rspack_collections",
  "rspack_core",
  "rspack_error",
+ "rspack_futures",
  "rspack_hash",
  "rspack_hook",
  "rspack_regex",

--- a/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
+++ b/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
@@ -26,11 +26,14 @@ impl<'a> From<CacheGroupTestFnCtx<'a>> for JsCacheGroupTestCtx {
 }
 
 pub(super) fn normalize_raw_cache_group_test(raw: RawCacheGroupTest) -> CacheGroupTest {
-  use pollster::block_on;
   match raw {
     Either3::A(str) => CacheGroupTest::String(str),
     Either3::B(regexp) => CacheGroupTest::RegExp(regexp),
-    Either3::C(v) => CacheGroupTest::Fn(Arc::new(move |ctx| block_on(v.call(ctx.into())))),
+    Either3::C(v) => CacheGroupTest::Fn(Arc::new(move |ctx| {
+      let ctx = ctx.into();
+      let v = v.clone();
+      Box::pin(async move { v.call(ctx).await })
+    })),
   }
 }
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -72,7 +72,7 @@ define_hook!(CompilationSeal: AsyncSeries(compilation: &mut Compilation));
 define_hook!(CompilationOptimizeDependencies: SyncSeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationOptimizeModules: AsyncSeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationAfterOptimizeModules: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationOptimizeChunks: SyncSeriesBail(compilation: &mut Compilation) -> bool);
+define_hook!(CompilationOptimizeChunks: AsyncSeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationOptimizeTree: AsyncSeries(compilation: &mut Compilation));
 define_hook!(CompilationOptimizeChunkModules: AsyncSeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationModuleIds: SyncSeries(compilation: &mut Compilation));
@@ -1398,7 +1398,11 @@ impl Compilation {
       .instrument(info_span!("Compilation:after_optimize_modules"))
       .await?;
     while matches!(
-      plugin_driver.compilation_hooks.optimize_chunks.call(self)?,
+      plugin_driver
+        .compilation_hooks
+        .optimize_chunks
+        .call(self)
+        .await?,
       Some(true)
     ) {}
     logger.time_end(start);

--- a/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
+++ b/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
@@ -8,7 +8,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 pub struct EnsureChunkConditionsPlugin;
 
 #[plugin_hook(CompilationOptimizeChunks for EnsureChunkConditionsPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_BASIC)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let logger = compilation.get_logger(self.name());
   let start = logger.time("ensure chunk conditions");
 

--- a/crates/rspack_plugin_limit_chunk_count/src/lib.rs
+++ b/crates/rspack_plugin_limit_chunk_count/src/lib.rs
@@ -57,7 +57,7 @@ impl LimitChunkCountPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for LimitChunkCountPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let max_chunks = self.options.max_chunks;
   if max_chunks < 1 {
     return Ok(None);

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashSet as HashSet;
 pub struct MergeDuplicateChunksPlugin;
 
 #[plugin_hook(CompilationOptimizeChunks for MergeDuplicateChunksPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_BASIC)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let mut not_duplicates = HashSet::default();
 
   let mut chunk_ukeys = compilation

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -431,7 +431,7 @@ async fn after_optimize_modules(&self, _compilation: &mut Compilation) -> Result
 }
 
 #[plugin_hook(CompilationOptimizeChunks for ProgressPlugin)]
-fn optimize_chunks(&self, _compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, _compilation: &mut Compilation) -> Result<Option<bool>> {
   self.sealing_hooks_report("chunk optimization", 9)?;
   Ok(None)
 }

--- a/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
+++ b/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
@@ -21,7 +21,7 @@ impl std::default::Default for RemoveDuplicateModulesPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for RemoveDuplicateModulesPlugin)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let module_graph = compilation.get_module_graph();
   let chunk_graph = &compilation.chunk_graph;
 

--- a/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
+++ b/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
@@ -40,7 +40,7 @@ impl RemoveEmptyChunksPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for RemoveEmptyChunksPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   self.remove_empty_chunks(compilation);
   Ok(None)
 }

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -180,7 +180,7 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilationOptimizeChunks for RsdoctorPlugin, stage = 9999)]
-fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   if !self.has_chunk_graph_feature(RsdoctorPluginChunkGraphFeature::ChunkGraph) {
     return Ok(None);
   }

--- a/crates/rspack_plugin_split_chunks/Cargo.toml
+++ b/crates/rspack_plugin_split_chunks/Cargo.toml
@@ -11,11 +11,13 @@ version     = "0.2.0"
 [dependencies]
 dashmap            = { workspace = true }
 derive_more        = { workspace = true, features = ["debug"] }
+futures            = { workspace = true }
 rayon              = { workspace = true }
 regex              = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_core        = { workspace = true }
 rspack_error       = { workspace = true }
+rspack_futures     = { workspace = true }
 rspack_hash        = { workspace = true }
 rspack_hook        = { workspace = true }
 rspack_regex       = { workspace = true }

--- a/crates/rspack_plugin_split_chunks/src/options/cache_group_test.rs
+++ b/crates/rspack_plugin_split_chunks/src/options/cache_group_test.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
 use rspack_core::{Compilation, Module};
 use rspack_error::Result;
 
@@ -8,7 +9,8 @@ pub struct CacheGroupTestFnCtx<'a> {
   pub module: &'a dyn Module,
 }
 
-type CacheGroupTestFn = Arc<dyn Fn(CacheGroupTestFnCtx<'_>) -> Result<Option<bool>> + Send + Sync>;
+type CacheGroupTestFn =
+  Arc<dyn Fn(CacheGroupTestFnCtx<'_>) -> BoxFuture<'static, Result<Option<bool>>> + Send + Sync>;
 
 #[derive(Clone)]
 pub enum CacheGroupTest {

--- a/crates/rspack_plugin_split_chunks/src/options/chunk_name.rs
+++ b/crates/rspack_plugin_split_chunks/src/options/chunk_name.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
 use rspack_core::{Chunk, Compilation, Module};
 use rspack_error::Result;
 
@@ -10,8 +11,11 @@ pub struct ChunkNameGetterFnCtx<'a> {
   pub cache_group_key: &'a str,
 }
 
-type ChunkNameGetterFn =
-  Arc<dyn for<'a> Fn(ChunkNameGetterFnCtx<'a>) -> Result<Option<String>> + Send + Sync>;
+type ChunkNameGetterFn = Arc<
+  dyn for<'a> Fn(ChunkNameGetterFnCtx<'a>) -> BoxFuture<'static, Result<Option<String>>>
+    + Sync
+    + Send,
+>;
 
 #[derive(Clone)]
 pub enum ChunkNameGetter {

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -40,10 +40,10 @@ impl SplitChunksPlugin {
     )
   }
 
-  fn inner_impl(&self, compilation: &mut Compilation) -> Result<()> {
+  async fn inner_impl(&self, compilation: &mut Compilation) -> Result<()> {
     let logger = compilation.get_logger(self.name());
     let start = logger.time("prepare module group map");
-    let mut module_group_map = self.prepare_module_group_map(compilation)?;
+    let mut module_group_map = self.prepare_module_group_map(compilation).await?;
     tracing::trace!("prepared module_group_map {:#?}", module_group_map);
     logger.time_end(start);
 
@@ -160,8 +160,8 @@ impl Debug for SplitChunksPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for SplitChunksPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-pub fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
-  self.inner_impl(compilation)?;
+async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+  self.inner_impl(compilation).await?;
   Ok(None)
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Remove `block_on` in split chunk `name` and `test` of cache group options.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
