### PR TITLE
refactor: remove `block_on` in asset generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,12 +3597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
 name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4566,7 +4560,6 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "pollster",
  "ropey",
  "rspack_allocator",
  "rspack_cacheable",
@@ -4970,6 +4963,7 @@ dependencies = [
 name = "rspack_plugin_json"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "cow-utils",
  "json",
  "ropey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ parcel_sourcemap   = { version = "2.1.1" }
 paste              = { version = "1.0.15" }
 path-clean         = { version = "1.0.1" }
 pathdiff           = { version = "0.2.3" }
-pollster           = { version = "0.4.0" }
 proc-macro2        = { version = "1.0.92" }
 quote              = { version = "1.0.38" }
 rayon              = { version = "1.10.0" }

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -47,7 +47,6 @@ derive_more        = { workspace = true, features = ["debug"] }
 futures            = { workspace = true }
 glob               = { workspace = true }
 heck               = { workspace = true }
-pollster           = { workspace = true }
 rspack_cacheable   = { workspace = true }
 rspack_ids         = { workspace = true }
 rspack_napi_macros = { workspace = true }

--- a/crates/node_binding/src/raw_options/raw_module/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_module/mod.rs
@@ -651,11 +651,13 @@ impl From<AssetGeneratorDataUrlFnCtx<'_>> for RawAssetGeneratorDataUrlFnCtx {
 
 impl From<RawAssetGeneratorDataUrlWrapper> for AssetGeneratorDataUrl {
   fn from(value: RawAssetGeneratorDataUrlWrapper) -> Self {
-    use pollster::block_on;
     match value.0 {
       Either::A(a) => Self::Options(a.into()),
       Either::B(b) => Self::Func(Arc::new(move |source, ctx| {
-        block_on(b.call((source.into(), ctx.into())))
+        let b = b.clone();
+        let source = source.into();
+        let ctx = ctx.into();
+        Box::pin(async move { b.call((source, ctx)).await })
       })),
     }
   }

--- a/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
+++ b/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
@@ -18,7 +18,8 @@ pub fn create_chunks_filter(raw: Chunks) -> rspack_plugin_split_chunks::ChunkFil
     }
     Either3::C(f) => Arc::new(move |chunk, compilation| {
       let f = f.clone();
-      Box::pin(async move { f.call(JsChunkWrapper::new(chunk.ukey(), compilation)).await })
+      let chunk_wrapper = JsChunkWrapper::new(chunk.ukey(), compilation);
+      Box::pin(async move { f.call(chunk_wrapper).await })
     }),
   }
 }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -636,19 +636,23 @@ impl Module for NormalModule {
         .runtime_requirements
         .insert(RuntimeGlobals::THIS_AS_EXPORTS);
     }
+
     for source_type in self.source_types() {
-      let generation_result = self.parser_and_generator.generate(
-        source,
-        self,
-        &mut GenerateContext {
-          compilation,
-          runtime_requirements: &mut code_generation_result.runtime_requirements,
-          data: &mut code_generation_result.data,
-          requested_source_type: *source_type,
-          runtime,
-          concatenation_scope: concatenation_scope.as_mut(),
-        },
-      )?;
+      let generation_result = self
+        .parser_and_generator
+        .generate(
+          source,
+          self,
+          &mut GenerateContext {
+            compilation,
+            runtime_requirements: &mut code_generation_result.runtime_requirements,
+            data: &mut code_generation_result.data,
+            requested_source_type: *source_type,
+            runtime,
+            concatenation_scope: concatenation_scope.as_mut(),
+          },
+        )
+        .await?;
       code_generation_result.add(*source_type, CachedSource::new(generation_result).boxed());
     }
     code_generation_result.concatenation_scope = concatenation_scope;

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -547,8 +547,9 @@ pub struct AssetGeneratorDataUrlFnCtx<'a> {
   pub compilation: &'a Compilation,
 }
 
-pub type AssetGeneratorDataUrlFn =
-  Arc<dyn Fn(Vec<u8>, AssetGeneratorDataUrlFnCtx) -> Result<String> + Sync + Send>;
+pub type AssetGeneratorDataUrlFn = Arc<
+  dyn Fn(Vec<u8>, AssetGeneratorDataUrlFnCtx) -> BoxFuture<'static, Result<String>> + Sync + Send,
+>;
 
 #[cacheable]
 pub enum AssetGeneratorDataUrl {

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -83,6 +83,7 @@ pub struct GenerateContext<'a> {
 }
 
 #[cacheable_dyn]
+#[async_trait::async_trait]
 pub trait ParserAndGenerator: Send + Sync + Debug + AsAny {
   /// The source types that the generator can generate (the source types you can make requests for)
   fn source_types(&self) -> &[SourceType];
@@ -91,7 +92,7 @@ pub trait ParserAndGenerator: Send + Sync + Debug + AsAny {
   /// Size of the original source
   fn size(&self, module: &dyn Module, source_type: Option<&SourceType>) -> f64;
   /// Generate source or AST based on the built source or AST
-  fn generate(
+  async fn generate(
     &self,
     source: &BoxSource,
     module: &dyn Module,

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -86,6 +86,7 @@ pub struct CssParserAndGenerator {
 }
 
 #[cacheable_dyn]
+#[async_trait::async_trait]
 impl ParserAndGenerator for CssParserAndGenerator {
   fn source_types(&self) -> &[SourceType] {
     if self.exports_only {
@@ -461,7 +462,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
   }
 
   #[allow(clippy::unwrap_in_result)]
-  fn generate(
+  async fn generate(
     &self,
     source: &BoxSource,
     module: &dyn rspack_core::Module,

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -92,6 +92,7 @@ impl JavaScriptParserAndGenerator {
 static SOURCE_TYPES: &[SourceType; 1] = &[SourceType::JavaScript];
 
 #[cacheable_dyn]
+#[async_trait::async_trait]
 impl ParserAndGenerator for JavaScriptParserAndGenerator {
   fn source_types(&self) -> &[SourceType] {
     SOURCE_TYPES
@@ -269,7 +270,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     )
   }
 
-  fn generate(
+  async fn generate(
     &self,
     source: &BoxSource,
     module: &dyn Module,

--- a/crates/rspack_plugin_json/Cargo.toml
+++ b/crates/rspack_plugin_json/Cargo.toml
@@ -8,6 +8,7 @@ version     = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait      = { workspace = true }
 cow-utils        = { workspace = true }
 json             = { workspace = true }
 ropey            = "1.6.1"

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -39,6 +39,7 @@ struct JsonParserAndGenerator {
 }
 
 #[cacheable_dyn]
+#[async_trait::async_trait]
 impl ParserAndGenerator for JsonParserAndGenerator {
   fn source_types(&self) -> &[SourceType] {
     &[SourceType::JavaScript]
@@ -155,7 +156,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
 
   // Safety: `ast_and_source` is available in code generation.
   #[allow(clippy::unwrap_in_result)]
-  fn generate(
+  async fn generate(
     &self,
     _source: &BoxSource,
     module: &dyn rspack_core::Module,

--- a/crates/rspack_plugin_split_chunks/src/common.rs
+++ b/crates/rspack_plugin_split_chunks/src/common.rs
@@ -4,12 +4,14 @@ use std::{
 };
 
 use derive_more::Debug;
+use futures::future::BoxFuture;
 use rspack_core::{Chunk, Compilation, Module, SourceType};
 use rspack_error::Result;
 use rspack_regex::RspackRegex;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-pub type ChunkFilter = Arc<dyn Fn(&Chunk, &Compilation) -> Result<bool> + Send + Sync>;
+pub type ChunkFilter =
+  Arc<dyn Fn(&Chunk, &Compilation) -> BoxFuture<'static, Result<bool>> + Sync + Send>;
 pub type ModuleTypeFilter = Arc<dyn Fn(&dyn Module) -> bool + Send + Sync>;
 pub type ModuleLayerFilter = Arc<dyn Fn(Option<String>) -> Result<bool> + Send + Sync>;
 
@@ -22,15 +24,21 @@ pub fn create_default_module_layer_filter() -> ModuleLayerFilter {
 }
 
 pub fn create_async_chunk_filter() -> ChunkFilter {
-  Arc::new(|chunk, compilation| Ok(!chunk.can_be_initial(&compilation.chunk_group_by_ukey)))
+  Arc::new(|chunk, compilation| {
+    let can_be_initial = chunk.can_be_initial(&compilation.chunk_group_by_ukey);
+    Box::pin(async move { Ok(!can_be_initial) })
+  })
 }
 
 pub fn create_initial_chunk_filter() -> ChunkFilter {
-  Arc::new(|chunk, compilation| Ok(chunk.can_be_initial(&compilation.chunk_group_by_ukey)))
+  Arc::new(|chunk, compilation| {
+    let can_be_initial = chunk.can_be_initial(&compilation.chunk_group_by_ukey);
+    Box::pin(async move { Ok(can_be_initial) })
+  })
 }
 
 pub fn create_all_chunk_filter() -> ChunkFilter {
-  Arc::new(|_chunk, _compilation| Ok(true))
+  Arc::new(|_chunk, _compilation| Box::pin(async move { Ok(true) }))
 }
 
 pub fn create_chunk_filter_from_str(chunks: &str) -> ChunkFilter {
@@ -43,7 +51,10 @@ pub fn create_chunk_filter_from_str(chunks: &str) -> ChunkFilter {
 }
 
 pub fn create_regex_chunk_filter_from_str(re: RspackRegex) -> ChunkFilter {
-  Arc::new(move |chunk, _| Ok(chunk.name().is_some_and(|name| re.test(name))))
+  Arc::new(move |chunk, _| {
+    let res = chunk.name().is_some_and(|name| re.test(name));
+    Box::pin(async move { Ok(res) })
+  })
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -480,89 +480,122 @@ fn similarity(a: &str, b: &str) -> usize {
 impl SplitChunksPlugin {
   /// Affected by `splitChunks.minSize`/`splitChunks.cacheGroups.{cacheGroup}.minSize`
   // #[tracing::instrument(skip_all)]
-  pub(super) fn ensure_max_size_fit(
+  pub(super) async fn ensure_max_size_fit(
     &self,
     compilation: &mut Compilation,
-    max_size_setting_map: UkeyMap<ChunkUkey, MaxSizeSetting>,
+    max_size_setting_map: &UkeyMap<ChunkUkey, MaxSizeSetting>,
   ) -> Result<()> {
     let fallback_cache_group = &self.fallback_cache_group;
     let chunk_group_db = &compilation.chunk_group_by_ukey;
     let compilation_ref = &*compilation;
 
-    let chunks_with_size_info = compilation_ref
-    .chunk_by_ukey
-    .values()
-    .par_bridge()
-    .map(|chunk| {
-      let max_size_setting = max_size_setting_map.get(&chunk.ukey());
-      tracing::trace!("max_size_setting : {max_size_setting:#?} for {:?}", chunk.ukey());
+    let chunks_with_size_info_results = rspack_futures::scope::<_, Result<_>>(|token| {
+      compilation_ref.chunk_by_ukey.values().for_each(|chunk| {
+        let s = unsafe {
+          token.used((
+            &*compilation,
+            chunk,
+            fallback_cache_group,
+            chunk_group_db,
+            &max_size_setting_map,
+          ))
+        };
+        s.spawn(
+          move |(
+            compilation,
+            chunk,
+            fallback_cache_group,
+            chunk_group_db,
+            max_size_setting_map,
+          )| async move {
+            let max_size_setting = max_size_setting_map.get(&chunk.ukey());
+            // tracing::trace!(
+            //   "max_size_setting : {max_size_setting:#?} for {:?}",
+            //   chunk.ukey()
+            // );
 
-      if max_size_setting.is_none()
-        && !(fallback_cache_group.chunks_filter)(chunk, compilation)?
-      {
-        tracing::debug!("Chunk({:?}) skips `maxSize` checking. Reason: max_size_setting.is_none() and chunks_filter is false", chunk.chunk_reason());
-        return Ok(None);
-      }
+            // if max_size_setting.is_none()
+            //   && !(fallback_cache_group.chunks_filter)(chunk, compilation).await?
+            // {
+            //   tracing::debug!("Chunk({:?}) skips `maxSize` checking. Reason: max_size_setting.is_none() and chunks_filter is false", chunk.chunk_reason());
+            //   return Ok(None);
+            // }
 
-      let min_size = max_size_setting
-        .map(|s| &s.min_size)
-        .unwrap_or(&fallback_cache_group.min_size);
-      let max_async_size = max_size_setting
-        .map(|s| &s.max_async_size)
-        .unwrap_or(&fallback_cache_group.max_async_size);
-      let max_initial_size: &SplitChunkSizes = max_size_setting
-        .map(|s| &s.max_initial_size)
-        .unwrap_or(&fallback_cache_group.max_initial_size);
-      let automatic_name_delimiter = max_size_setting.map(|s| &s.automatic_name_delimiter).unwrap_or(&fallback_cache_group.automatic_name_delimiter);
+            let min_size = max_size_setting
+              .map(|s| &s.min_size)
+              .unwrap_or(&fallback_cache_group.min_size);
+            let max_async_size = max_size_setting
+              .map(|s| &s.max_async_size)
+              .unwrap_or(&fallback_cache_group.max_async_size);
+            let max_initial_size: &SplitChunkSizes = max_size_setting
+              .map(|s| &s.max_initial_size)
+              .unwrap_or(&fallback_cache_group.max_initial_size);
+            let automatic_name_delimiter = max_size_setting
+              .map(|s| &s.automatic_name_delimiter)
+              .unwrap_or(&fallback_cache_group.automatic_name_delimiter);
 
-      let mut allow_max_size = if chunk.is_only_initial(chunk_group_db) {
-        Cow::Borrowed(max_initial_size)
-      } else if chunk.can_be_initial(chunk_group_db) {
-        let mut sizes = SplitChunkSizes::empty();
-        sizes.combine_with(max_async_size, &f64::min);
-        sizes.combine_with(max_initial_size, &f64::min);
-        Cow::Owned(sizes)
-      } else {
-        Cow::Borrowed(max_async_size)
-      };
+            let mut allow_max_size = if chunk.is_only_initial(chunk_group_db) {
+              Cow::Borrowed(max_initial_size)
+            } else if chunk.can_be_initial(chunk_group_db) {
+              let mut sizes = SplitChunkSizes::empty();
+              sizes.combine_with(max_async_size, &f64::min);
+              sizes.combine_with(max_initial_size, &f64::min);
+              Cow::Owned(sizes)
+            } else {
+              Cow::Borrowed(max_async_size)
+            };
 
-      // Fast path
-      if allow_max_size.is_empty() {
-        tracing::debug!(
-          "Chunk({:?}) skips the `maxSize` checking. Reason: allow_max_size is empty",
-          chunk.chunk_reason()
+            // Fast path
+            if allow_max_size.is_empty() {
+              // tracing::debug!(
+              //   "Chunk({:?}) skips the `maxSize` checking. Reason: allow_max_size is empty",
+              //   chunk.chunk_reason()
+              // );
+              return Ok(None);
+            }
+
+            let mut is_invalid = false;
+            allow_max_size.iter().for_each(|(ty, ty_max_size)| {
+              if let Some(ty_min_size) = min_size.get(ty) {
+                if ty_min_size > ty_max_size {
+                  is_invalid = true;
+                  // tracing::warn!(
+                  //   "minSize({}) should not be bigger than maxSize({})",
+                  //   ty_min_size,
+                  //   ty_max_size
+                  // );
+                }
+              }
+            });
+            if is_invalid {
+              allow_max_size.to_mut().combine_with(min_size, &f64::max);
+            }
+
+            Ok(Some(ChunkWithSizeInfo {
+              allow_max_size,
+              min_size,
+              chunk: chunk.ukey(),
+              automatic_name_delimiter,
+            }))
+          },
         );
-        return Ok(None);
-      }
-
-      let mut is_invalid = false;
-      allow_max_size.iter().for_each(|(ty, ty_max_size)| {
-        if let Some(ty_min_size) = min_size.get(ty) {
-          if ty_min_size > ty_max_size {
-            is_invalid = true;
-            tracing::warn!(
-              "minSize({}) should not be bigger than maxSize({})",
-              ty_min_size,
-              ty_max_size
-            );
-          }
-        }
       });
-      if is_invalid {
-        allow_max_size.to_mut().combine_with(min_size, &f64::max);
-      }
-
-      Ok(Some(ChunkWithSizeInfo {
-        allow_max_size,
-        min_size,
-        chunk: chunk.ukey(),
-        automatic_name_delimiter,
-      }))
-    }).collect::<Result<Vec<_>>>()?
+    })
+    .await
     .into_iter()
-    .flatten();
+    .map(|res| res.map_err(rspack_error::miette::Error::from_err))
+    .collect::<Result<Vec<_>>>()?;
+
+    let mut chunks_with_size_info = vec![];
+
+    for result in chunks_with_size_info_results {
+      if let Some(info) = result? {
+        chunks_with_size_info.push(info);
+      }
+    }
 
     let infos_with_results = chunks_with_size_info
+      .into_iter()
       .filter_map(|info| {
         let ChunkWithSizeInfo {
           chunk,

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -509,17 +509,17 @@ impl SplitChunksPlugin {
             max_size_setting_map,
           )| async move {
             let max_size_setting = max_size_setting_map.get(&chunk.ukey());
-            // tracing::trace!(
-            //   "max_size_setting : {max_size_setting:#?} for {:?}",
-            //   chunk.ukey()
-            // );
+            tracing::trace!(
+              "max_size_setting : {max_size_setting:#?} for {:?}",
+              chunk.ukey()
+            );
 
-            // if max_size_setting.is_none()
-            //   && !(fallback_cache_group.chunks_filter)(chunk, compilation).await?
-            // {
-            //   tracing::debug!("Chunk({:?}) skips `maxSize` checking. Reason: max_size_setting.is_none() and chunks_filter is false", chunk.chunk_reason());
-            //   return Ok(None);
-            // }
+            if max_size_setting.is_none()
+              && !(fallback_cache_group.chunks_filter)(chunk, compilation).await?
+            {
+              tracing::debug!("Chunk({:?}) skips `maxSize` checking. Reason: max_size_setting.is_none() and chunks_filter is false", chunk.chunk_reason());
+              return Ok(None);
+            }
 
             let min_size = max_size_setting
               .map(|s| &s.min_size)
@@ -547,10 +547,10 @@ impl SplitChunksPlugin {
 
             // Fast path
             if allow_max_size.is_empty() {
-              // tracing::debug!(
-              //   "Chunk({:?}) skips the `maxSize` checking. Reason: allow_max_size is empty",
-              //   chunk.chunk_reason()
-              // );
+              tracing::debug!(
+                "Chunk({:?}) skips the `maxSize` checking. Reason: allow_max_size is empty",
+                chunk.chunk_reason()
+              );
               return Ok(None);
             }
 
@@ -559,11 +559,11 @@ impl SplitChunksPlugin {
               if let Some(ty_min_size) = min_size.get(ty) {
                 if ty_min_size > ty_max_size {
                   is_invalid = true;
-                  // tracing::warn!(
-                  //   "minSize({}) should not be bigger than maxSize({})",
-                  //   ty_min_size,
-                  //   ty_max_size
-                  // );
+                  tracing::warn!(
+                    "minSize({}) should not be bigger than maxSize({})",
+                    ty_min_size,
+                    ty_max_size
+                  );
                 }
               }
             });

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -10,7 +10,6 @@
 use std::sync::LazyLock;
 use std::{borrow::Cow, hash::Hash};
 
-use rayon::prelude::*;
 use regex::Regex;
 use rspack_collections::{DatabaseItem, UkeyMap};
 use rspack_core::{
@@ -445,11 +444,11 @@ fn subtract_size_from(total: &mut SplitChunkSizes, size: &SplitChunkSizes) {
   });
 }
 
-struct ChunkWithSizeInfo<'a> {
+struct ChunkWithSizeInfo {
   pub chunk: ChunkUkey,
-  pub allow_max_size: Cow<'a, SplitChunkSizes>,
-  pub min_size: &'a SplitChunkSizes,
-  pub automatic_name_delimiter: &'a String,
+  pub allow_max_size: SplitChunkSizes,
+  pub min_size: SplitChunkSizes,
+  pub automatic_name_delimiter: String,
 }
 
 fn get_similarities(nodes: &[GroupItem]) -> Vec<usize> {
@@ -572,10 +571,10 @@ impl SplitChunksPlugin {
             }
 
             Ok(Some(ChunkWithSizeInfo {
-              allow_max_size,
-              min_size,
+              allow_max_size: allow_max_size.into_owned(),
+              min_size: min_size.clone(),
               chunk: chunk.ukey(),
-              automatic_name_delimiter,
+              automatic_name_delimiter: automatic_name_delimiter.clone(),
             }))
           },
         );

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -146,7 +146,9 @@ impl SplitChunksPlugin {
     logger.time_end(start);
 
     let start = logger.time("ensure max size fit");
-    self.ensure_max_size_fit(compilation, max_size_setting_map)?;
+    self
+      .ensure_max_size_fit(compilation, &max_size_setting_map)
+      .await?;
     logger.time_end(start);
 
     Ok(())

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -32,6 +32,7 @@ pub struct AsyncWasmParserAndGenerator {
 pub(crate) static WASM_SOURCE_TYPE: &[SourceType; 2] = &[SourceType::Wasm, SourceType::JavaScript];
 
 #[cacheable_dyn]
+#[async_trait::async_trait]
 impl ParserAndGenerator for AsyncWasmParserAndGenerator {
   fn source_types(&self) -> &[SourceType] {
     WASM_SOURCE_TYPE
@@ -122,7 +123,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
   }
 
   #[allow(clippy::unwrap_in_result)]
-  fn generate(
+  async fn generate(
     &self,
     source: &BoxSource,
     module: &dyn Module,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Remove `block_on` in asset generator to prevent deadlock
- Modify ParserAndGenerator::generate to async fn
- Say goodbye to pollster

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
