### PR TITLE
chore: add rayon worker name and forbid block_on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,6 +4560,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "rayon",
  "ropey",
  "rspack_allocator",
  "rspack_cacheable",

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,10 +2,18 @@ allow-dbg-in-tests    = true
 allow-unwrap-in-tests = true
 
 disallowed-methods = [
+  
   { path = "str::to_ascii_lowercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_ascii_lowercase` instead." },
   { path = "str::to_ascii_uppercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_ascii_uppercase` instead." },
   { path = "str::to_lowercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_lowercase` instead." },
   { path = "str::to_uppercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_uppercase` instead." },
   { path = "str::replace", reason = "To avoid memory allocation, use `cow_utils::CowUtils::replace` instead." },
   { path = "str::replacen", reason = "To avoid memory allocation, use `cow_utils::CowUtils::replacen` instead." },
+  { path = "std::mem::forget", reason = "future::scope is unsafe when used with forget" },
+  { path = "tokio::runtime::Runtime::block_on", reason="block_on can cause deadlock easily"},
+  { path = "tokio::runtime::Handle::block_on", reason = "block_on can cause deadlock easily" },
+  { path = "napi::bindgen_prelude::block_on", reason = "block_on can cause deadlock easily" },
+  { path = "futures::executor::block_on", reason = "block_on can cause deadlock easily" },
+  { path = "async_std::task::block_on", reason = "block_on can cause deadlock easily" },
+  { path = "pollster::block_on", reason = "block_on can cause deadlock easily" }
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -10,9 +10,6 @@ disallowed-methods = [
   { path = "str::replace", reason = "To avoid memory allocation, use `cow_utils::CowUtils::replace` instead." },
   { path = "str::replacen", reason = "To avoid memory allocation, use `cow_utils::CowUtils::replacen` instead." },
   { path = "std::mem::forget", reason = "future::scope is unsafe when used with forget" },
-  { path = "tokio::runtime::Runtime::block_on", reason="block_on can cause deadlock easily"},
-  { path = "tokio::runtime::Handle::block_on", reason = "block_on can cause deadlock easily" },
-  { path = "napi::bindgen_prelude::block_on", reason = "block_on can cause deadlock easily" },
   { path = "futures::executor::block_on", reason = "block_on can cause deadlock easily" },
   { path = "async_std::task::block_on", reason = "block_on can cause deadlock easily" },
   { path = "pollster::block_on", reason = "block_on can cause deadlock easily" }

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -57,7 +57,7 @@ serde_json         = { workspace = true }
 swc_core           = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
 tokio              = { workspace = true, features = ["rt", "macros", "test-util", "parking_lot"] }
 
-
+rayon                                  = { workspace = true }
 rspack_loader_lightningcss             = { workspace = true }
 rspack_loader_preact_refresh           = { workspace = true }
 rspack_loader_react_refresh            = { workspace = true }

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -365,6 +365,11 @@ fn init() {
     .build()
     .expect("Create tokio runtime failed");
   create_custom_tokio_runtime(rt);
+  // initialize rayon
+  rayon::ThreadPoolBuilder::new()
+    .thread_name(|id| format!("rayon-worker-{}", id))
+    .build_global()
+    .expect("Create rayon thread pool failed");
 }
 
 fn print_error_diagnostic(e: rspack_error::Error, colored: bool) -> String {

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -361,13 +361,14 @@ fn init() {
     .unwrap_or(default_blocking_threads);
   let rt = tokio::runtime::Builder::new_multi_thread()
     .max_blocking_threads(blocking_threads)
+    .thread_name("tokio")
     .enable_all()
     .build()
     .expect("Create tokio runtime failed");
   create_custom_tokio_runtime(rt);
   // initialize rayon
   rayon::ThreadPoolBuilder::new()
-    .thread_name(|id| format!("rayon-worker-{}", id))
+    .thread_name(|_| "rayon".to_string())
     .build_global()
     .expect("Create rayon thread pool failed");
 }

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -372,11 +372,6 @@ fn init() {
     .build()
     .expect("Create tokio runtime failed");
   create_custom_tokio_runtime(rt);
-  // initialize rayon
-  rayon::ThreadPoolBuilder::new()
-    .thread_name(|id| format!("rayon-{}", id))
-    .build_global()
-    .expect("Create rayon thread pool failed");
 }
 
 fn print_error_diagnostic(e: rspack_error::Error, colored: bool) -> String {

--- a/crates/rspack_core/src/utils/fast_actions.rs
+++ b/crates/rspack_core/src/utils/fast_actions.rs
@@ -8,16 +8,22 @@ where
   T: Send + 'static,
 {
   let old = mem::replace(dest, src);
-  thread::spawn(move || {
-    mem::drop(old);
-  });
+  thread::Builder::new()
+    .name("fast_set".to_string())
+    .spawn(move || {
+      mem::drop(old);
+    })
+    .expect("spawn fast_set thread failed");
 }
 
 pub fn fast_drop<T>(src: T)
 where
   T: Send + 'static,
 {
-  thread::spawn(move || {
-    mem::drop(src);
-  });
+  thread::Builder::new()
+    .name("fast_drop".to_string())
+    .spawn(move || {
+      mem::drop(src);
+    })
+    .expect("spawn fast_drop thread failed");
 }

--- a/crates/rspack_futures/src/scope.rs
+++ b/crates/rspack_futures/src/scope.rs
@@ -78,6 +78,7 @@ where
 
   impl ScopeGuard {
     fn forget(self) {
+      #[allow(clippy::disallowed_methods)]
       std::mem::forget(self);
     }
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
add rule to forbid block_on and std::mem::forget
add worker name so profiler can differentiate it with other thread
* before:
![image](https://github.com/user-attachments/assets/fd85ad86-375d-42d6-90a6-25507ce7b73e)

* after:
![image](https://github.com/user-attachments/assets/a8f3cb1a-290c-4458-a1cb-f85a6de58433)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
