### PR TITLE
feat: introduce par_iter_then_collect

### DIFF
--- a/crates/rspack_futures/Cargo.toml
+++ b/crates/rspack_futures/Cargo.toml
@@ -7,4 +7,7 @@ repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.2.0"
 
 [dependencies]
-tokio = { version = "1", features = ["rt"] }
+tokio = { workspace = true, features = ["rt"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }

--- a/crates/rspack_futures/src/lib.rs
+++ b/crates/rspack_futures/src/lib.rs
@@ -1,2 +1,111 @@
 pub mod scope;
+use std::{
+  cell::UnsafeCell,
+  future::Future,
+  iter::ExactSizeIterator,
+  mem::{ManuallyDrop, MaybeUninit},
+};
+
 pub use scope::scope;
+
+/// par_iter then collect into vec
+///
+/// This is a wrapper around `scope`, but allows non-'static return values.
+///
+/// # Safety
+///
+/// Its safety assumptions are the same as `scope`.
+///
+/// # Example
+///
+/// ```rust
+/// # #[tokio::test]
+/// # async fn foo() {
+/// async fn handle(s: &str) -> (usize, &str) {
+///   (s.len(), s)
+/// }
+///
+/// let data: Vec<String> = vec!["hello".into(), "world".into(), "!".into()];
+/// let tasks = data.iter().map(|s| handle(s));
+///
+/// let list = unsafe { par_iter_then_collect(tasks) };
+///
+/// assert_eq!(list, vec![(5, "hello"), (5, "world"), (1, "!")]);
+/// # }
+/// ```
+pub async unsafe fn par_iter_then_collect<I, F, O>(iter: I) -> Vec<O>
+where
+  I: IntoIterator<Item = F>,
+  I::IntoIter: ExactSizeIterator,
+  F: Future<Output = O> + Send + Sync,
+  O: Send + Sync,
+{
+  // TODO use `std::cell::SyncUnsafeCell`
+  //
+  // see https://github.com/rust-lang/rust/issues/95439
+  #[repr(transparent)]
+  struct SyncUnsafeCell<T: ?Sized>(UnsafeCell<T>);
+
+  // # Safety
+  //
+  // We guarantee that `SyncUnsafeCell` will never be accesse parallel
+  unsafe impl<T: ?Sized + Sync> Sync for SyncUnsafeCell<T> {}
+
+  let iter = iter.into_iter();
+  let output: Box<[MaybeUninit<SyncUnsafeCell<O>>]> = Box::new_uninit_slice(iter.len());
+
+  scope(|token| {
+    for (i, f) in iter.enumerate() {
+      // # Safety
+      //
+      // The caller needs to ensure that the task is legally consumed
+      let spawner = unsafe { token.used((f, &output)) };
+
+      spawner.spawn(move |(f, output)| async move {
+        let result = f.await;
+
+        // # Safety
+        //
+        // This assumes that the length provided by the `ExactSizeIterator` is correct,
+        // and will abort if it is not.
+        let slot = &output[i];
+
+        // # Safety
+        //
+        // because transparent repr
+        let slot = slot.as_ptr().cast::<UnsafeCell<O>>();
+
+        // # Safety
+        //
+        // This slot is exclusive to the thread and
+        // will not be accessed by other threads at the same time.
+        unsafe {
+          UnsafeCell::raw_get(slot).write(result);
+        }
+      });
+    }
+  })
+  .await;
+
+  // # Safety
+  //
+  // `scope` ensures that all slots are initialized after completion
+  let output = unsafe { output.assume_init() };
+  let output = Vec::from(output);
+
+  unsafe {
+    // TODO use into_raw_parts
+    //
+    // see https://github.com/rust-lang/rust/issues/65816
+    let mut output = ManuallyDrop::new(output);
+    let ptr = output.as_mut_ptr();
+    let len = output.len();
+    let cap = output.capacity();
+
+    // # Safety
+    //
+    // because transparent repr
+    let ptr = ptr.cast::<O>();
+    Vec::from_raw_parts(ptr, len, cap)
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This PR introduces `par_iter_then_collect` to provide rayon-like `par_iter().collect()` feature, but async. this is implemented based on `rspack_futures::scope`, so it requires unsafe.

cc @hardfist 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
