### PR TITLE
test(webpack): Sync new webpack configCases tests: runtime and source-map

### DIFF
--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/five.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/five.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/four.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/four.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/one.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/one.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/six.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/six.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/test.config.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/test.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	findBundle: function () {
+		return [
+			"./dir5/dir6/runtime~one.js",
+			"./one.js",
+			"./dir5/dir6/runtime~two.js",
+			"./dir2/two.js",
+			"./dir5/dir6/runtime~three.js",
+			"./three.js",
+			"./dir5/dir6/runtime~four.js",
+			"./dir4/four.js",
+			"./dir5/dir6/runtime~five.js",
+			"./dir5/dir6/five.js",
+			"./dir5/dir6/runtime~six.js",
+			"./dir5/dir6/six.js"
+		];
+	}
+};

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/test.filter.js
@@ -1,0 +1,2 @@
+// optimization.runtimeChunk.name not taken into account
+module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/three.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/three.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/two.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/two.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/webpack.config.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/webpack.config.js
@@ -1,0 +1,21 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].js"
+	},
+	target: ["es2022", "async-node"],
+	entry: {
+		one: "./one",
+		"dir2/two": "./two",
+		"/three": "./three",
+		"/dir4/four": "./four",
+		"/dir5/dir6/five": "./five",
+		"/dir5/dir6/six": "./six"
+	},
+	optimization: {
+		runtimeChunk: {
+			name: entrypoint =>
+				`dir5/dir6/runtime~${entrypoint.name.split("/").pop()}`
+		}
+	}
+};

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/five.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/five.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/four.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/four.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/one.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/one.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/six.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/six.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/test.config.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/test.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	findBundle: function () {
+		return [
+			"./dir5/dir6/runtime~one.mjs",
+			"./one.mjs",
+			"./dir5/dir6/runtime~two.mjs",
+			"./dir2/two.mjs",
+			"./dir5/dir6/runtime~three.mjs",
+			"./three.mjs",
+			"./dir5/dir6/runtime~four.mjs",
+			"./dir4/four.mjs",
+			"./dir5/dir6/runtime~five.mjs",
+			"./dir5/dir6/five.mjs",
+			"./dir5/dir6/runtime~six.mjs",
+			"./dir5/dir6/six.mjs"
+		];
+	}
+};

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/test.filter.js
@@ -1,0 +1,2 @@
+// optimization.runtimeChunk.name not taken into account
+module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/three.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/three.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/two.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/two.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/webpack.config.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/webpack.config.js
@@ -1,0 +1,25 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].mjs",
+		module: true
+	},
+	target: ["es2022", "async-node"],
+	entry: {
+		one: "./one",
+		"dir2/two": "./two",
+		"/three": "./three",
+		"/dir4/four": "./four",
+		"/dir5/dir6/five": "./five",
+		"/dir5/dir6/six": "./six"
+	},
+	optimization: {
+		runtimeChunk: {
+			name: entrypoint =>
+				`dir5/dir6/runtime~${entrypoint.name.split("/").pop()}`
+		}
+	},
+	experiments: {
+		outputModule: true
+	}
+};

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/five.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/five.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/four.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/four.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/one.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/one.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/six.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/six.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/test.config.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/test.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	findBundle: function () {
+		return [
+			"./runtime/one.js",
+			"./one.js",
+			"./runtime/dir2/two.js",
+			"./dir2/two.js",
+			"./runtime/three.js",
+			"./three.js",
+			"./runtime/dir4/four.js",
+			"./dir4/four.js",
+			"./runtime/dir5/dir6/five.js",
+			"./dir5/dir6/five.js",
+			"./runtime/dir5/dir6/six.js",
+			"./dir5/dir6/six.js"
+		];
+	}
+};

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/test.filter.js
@@ -1,0 +1,2 @@
+// optimization.runtimeChunk.name not taken into account
+module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/three.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/three.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/two.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/two.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/webpack.config.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/webpack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].js"
+	},
+	target: ["es2022", "async-node"],
+	entry: {
+		one: "./one",
+		"dir2/two": "./two",
+		"/three": "./three",
+		"/dir4/four": "./four",
+		"/dir5/dir6/five": "./five",
+		"/dir5/dir6/six": "./six"
+	},
+	optimization: {
+		runtimeChunk: {
+			name: entrypoint => `runtime/${entrypoint.name.replace(/^\/+/g, "")}`
+		}
+	}
+};

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/five.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/five.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/four.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/four.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/one.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/one.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/six.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/six.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/test.config.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/test.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	findBundle: function () {
+		return [
+			"./runtime/one.mjs",
+			"./one.mjs",
+			"./runtime/dir2/two.mjs",
+			"./dir2/two.mjs",
+			"./runtime/three.mjs",
+			"./three.mjs",
+			"./runtime/dir4/four.mjs",
+			"./dir4/four.mjs",
+			"./runtime/dir5/dir6/five.mjs",
+			"./dir5/dir6/five.mjs",
+			"./runtime/dir5/dir6/six.mjs",
+			"./dir5/dir6/six.mjs"
+		];
+	}
+};

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/test.filter.js
@@ -1,0 +1,2 @@
+// optimization.runtimeChunk.name not taken into account
+module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/three.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/three.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/two.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/two.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/webpack.config.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/webpack.config.js
@@ -1,0 +1,24 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].mjs",
+		module: true
+	},
+	target: ["es2022", "async-node"],
+	entry: {
+		one: "./one",
+		"dir2/two": "./two",
+		"/three": "./three",
+		"/dir4/four": "./four",
+		"/dir5/dir6/five": "./five",
+		"/dir5/dir6/six": "./six"
+	},
+	optimization: {
+		runtimeChunk: {
+			name: entrypoint => `runtime/${entrypoint.name.replace(/^\/+/g, "")}`
+		}
+	},
+	experiments: {
+		outputModule: true
+	}
+};

--- a/tests/webpack-test/configCases/runtime/opt-in-finally2/exception.js
+++ b/tests/webpack-test/configCases/runtime/opt-in-finally2/exception.js
@@ -1,0 +1,1 @@
+throw new Error("Exception");

--- a/tests/webpack-test/configCases/runtime/opt-in-finally2/index.js
+++ b/tests/webpack-test/configCases/runtime/opt-in-finally2/index.js
@@ -1,0 +1,8 @@
+it("should throw exception on every try to load a module", function() {
+	expect(function() {
+		require("./exception");
+	}).toThrowError();
+	expect(function() {
+		require("./exception");
+	}).toThrowError();
+});

--- a/tests/webpack-test/configCases/runtime/opt-in-finally2/webpack.config.js
+++ b/tests/webpack-test/configCases/runtime/opt-in-finally2/webpack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		strictModuleErrorHandling: true
+	}
+};

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/five.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/five.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/four.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/four.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/one.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/one.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/six.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/six.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/test.config.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/test.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	findBundle: function () {
+		return [
+			"./runtime.js",
+			"./one.js",
+			"./dir2/two.js",
+			"./three.js",
+			"./dir4/four.js",
+			"./dir5/dir6/five.js",
+			"./dir5/dir6/six.js"
+		];
+	}
+};

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/test.filter.js
@@ -1,0 +1,2 @@
+// optimization.runtimeChunk: "single" not taken into account
+module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/three.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/three.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/two.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/two.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/webpack.config.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/webpack.config.js
@@ -1,0 +1,18 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].js"
+	},
+	target: ["es2022", "async-node"],
+	entry: {
+		one: "./one",
+		"dir2/two": "./two",
+		"/three": "./three",
+		"/dir4/four": "./four",
+		"/dir5/dir6/five": "./five",
+		"/dir5/dir6/six": "./six"
+	},
+	optimization: {
+		runtimeChunk: "single"
+	}
+};

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/five.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/five.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/four.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/four.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/one.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/one.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/six.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/six.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/test.config.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/test.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	findBundle: function () {
+		return [
+			"./runtime.mjs",
+			"./one.mjs",
+			"./dir2/two.mjs",
+			"./three.mjs",
+			"./dir4/four.mjs",
+			"./dir5/dir6/five.mjs",
+			"./dir5/dir6/six.mjs"
+		];
+	}
+};

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/test.filter.js
@@ -1,0 +1,2 @@
+// optimization.runtimeChunk: "single" not taken into account
+module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/three.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/three.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/two.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/two.js
@@ -1,0 +1,1 @@
+it("should compile", () => {});

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/webpack.config.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/webpack.config.js
@@ -1,0 +1,22 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].mjs",
+		module: true
+	},
+	target: ["es2022", "async-node"],
+	entry: {
+		one: "./one",
+		"dir2/two": "./two",
+		"/three": "./three",
+		"/dir4/four": "./four",
+		"/dir5/dir6/five": "./five",
+		"/dir5/dir6/six": "./six"
+	},
+	optimization: {
+		runtimeChunk: "single"
+	},
+	experiments: {
+		outputModule: true
+	}
+};

--- a/tests/webpack-test/configCases/runtime/target-webworker-with-dynamic/async.js
+++ b/tests/webpack-test/configCases/runtime/target-webworker-with-dynamic/async.js
@@ -1,0 +1,1 @@
+export default "async";

--- a/tests/webpack-test/configCases/runtime/target-webworker-with-dynamic/index.js
+++ b/tests/webpack-test/configCases/runtime/target-webworker-with-dynamic/index.js
@@ -1,0 +1,7 @@
+it("should compile and run", done => {
+	expect(true).toBe(true);
+	import("./async").then(module => {
+		expect(module.default).toBe("async");
+		done();
+	}, done);
+});

--- a/tests/webpack-test/configCases/runtime/target-webworker-with-dynamic/test.config.js
+++ b/tests/webpack-test/configCases/runtime/target-webworker-with-dynamic/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function () {
+		return ["./runtime.js", "./main.js"];
+	}
+};

--- a/tests/webpack-test/configCases/runtime/target-webworker-with-dynamic/webpack.config.js
+++ b/tests/webpack-test/configCases/runtime/target-webworker-with-dynamic/webpack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "webworker",
+	devtool: false,
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		runtimeChunk: "single"
+	}
+};

--- a/tests/webpack-test/configCases/runtime/target-webworker/index.js
+++ b/tests/webpack-test/configCases/runtime/target-webworker/index.js
@@ -1,0 +1,3 @@
+it("should compile and run", () => {
+	expect(true).toBe(true)
+});

--- a/tests/webpack-test/configCases/runtime/target-webworker/test.config.js
+++ b/tests/webpack-test/configCases/runtime/target-webworker/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function () {
+		return ["./runtime.js", "./main.js"];
+	}
+};

--- a/tests/webpack-test/configCases/runtime/target-webworker/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/target-webworker/test.filter.js
@@ -1,0 +1,2 @@
+// No tests exported by test case
+module.exports = () => false

--- a/tests/webpack-test/configCases/runtime/target-webworker/webpack.config.js
+++ b/tests/webpack-test/configCases/runtime/target-webworker/webpack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "webworker",
+	devtool: false,
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		runtimeChunk: "single"
+	}
+};

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval-source-map/src/entry-a.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval-source-map/src/entry-a.js
@@ -1,0 +1,5 @@
+it("should include webpack://library-entry-a/./src/entry-a.js in SourceMap", function() {
+	const fs = require("fs");
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source).toContain("sourceURL=webpack://library-entry-a/./src/entry-a.js");
+});

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval-source-map/src/entry-b.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval-source-map/src/entry-b.js
@@ -1,0 +1,5 @@
+it("should include webpack://library-entry-b/./src/entry-b.js in SourceMap", function() {
+	const fs = require("fs");
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source).toContain("sourceURL=webpack://library-entry-b/./src/entry-b.js");
+});

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval-source-map/test.config.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval-source-map/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["entry-a-bundle.js", "entry-b-bundle.js"];
+	}
+};

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval-source-map/webpack.config.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval-source-map/webpack.config.js
@@ -1,0 +1,18 @@
+const path = require("path");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	entry: {
+		"entry-a": [path.join(__dirname, "./src/entry-a")],
+		"entry-b": [path.join(__dirname, "./src/entry-b")]
+	},
+
+	output: {
+		filename: "[name]-bundle.js",
+		library: "library-[name]",
+		libraryTarget: "commonjs",
+		devtoolNamespace: "library-[name]"
+	},
+	devtool: "eval-source-map"
+};

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval/src/entry-a.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval/src/entry-a.js
@@ -1,0 +1,5 @@
+it("should include webpack://library-entry-a/./src/entry-a.js in SourceMap", function() {
+	const fs = require("fs");
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source).toContain("sourceURL=webpack://library-entry-a/./src/entry-a.js");
+});

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval/src/entry-b.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval/src/entry-b.js
@@ -1,0 +1,5 @@
+it("should include webpack://library-entry-b/./src/entry-b.js in SourceMap", function() {
+	const fs = require("fs");
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source).toContain("sourceURL=webpack://library-entry-b/./src/entry-b.js");
+});

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval/test.config.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["entry-a-bundle.js", "entry-b-bundle.js"];
+	}
+};

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval/webpack.config.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-eval/webpack.config.js
@@ -1,0 +1,18 @@
+const path = require("path");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	entry: {
+		"entry-a": [path.join(__dirname, "./src/entry-a")],
+		"entry-b": [path.join(__dirname, "./src/entry-b")]
+	},
+
+	output: {
+		filename: "[name]-bundle.js",
+		library: "library-[name]",
+		libraryTarget: "commonjs",
+		devtoolNamespace: "library-[name]"
+	},
+	devtool: "eval"
+};

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/index.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/index.js
@@ -1,0 +1,6 @@
+it("should include webpack://library-entry-a/./src/entry-a.js in SourceMap", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename + ".map", "utf-8");
+	var map = JSON.parse(source);
+	expect(map.sources).toContain("sourceURL=webpack://library-entry-a/./src/entry-a.js");
+});

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/src/entry-a.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/src/entry-a.js
@@ -1,0 +1,6 @@
+it("should include webpack://library-entry-a/./src/entry-a.js in SourceMap", function() {
+	const fs = require("fs");
+	const source = fs.readFileSync(__filename + ".map", "utf-8");
+	const map = JSON.parse(source);
+	expect(map.sources).toContain("webpack://library-entry-a/./src/entry-a.js");
+});

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/src/entry-b.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/src/entry-b.js
@@ -1,0 +1,6 @@
+it("should include webpack://library-entry-b/./src/entry-b.js in SourceMap", function() {
+	const fs = require("fs");
+	const source = fs.readFileSync(__filename + ".map", "utf-8");
+	const map = JSON.parse(source);
+	expect(map.sources).toContain("webpack://library-entry-b/./src/entry-b.js");
+});

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/test.config.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["entry-a-bundle.js", "entry-b-bundle.js"];
+	}
+};

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/test.filter.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/test.filter.js
@@ -1,0 +1,2 @@
+// missing substitution on output.library
+module.exports = () => false

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/webpack.config.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/webpack.config.js
@@ -1,0 +1,18 @@
+const path = require("path");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	entry: {
+		"entry-a": [path.join(__dirname, "./src/entry-a")],
+		"entry-b": [path.join(__dirname, "./src/entry-b")]
+	},
+
+	output: {
+		filename: "[name]-bundle.js",
+		library: "library-[name]",
+		libraryTarget: "commonjs",
+		devtoolNamespace: "library-[name]"
+	},
+	devtool: "source-map"
+};

--- a/tests/webpack-test/configCases/source-map/eval-nosources-source-map/index.js
+++ b/tests/webpack-test/configCases/source-map/eval-nosources-source-map/index.js
@@ -1,0 +1,11 @@
+it("should not include sourcesContent if noSources option is used", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+  var match = /\/\/# sourceMappingURL\s*=\s*data:application\/json;charset=utf-8;base64,(.*)\\n\/\/#/.exec(source);
+  var mapString = Buffer.from(match[1], 'base64').toString('utf-8');
+	var map = JSON.parse(mapString);
+	expect(map).not.toHaveProperty("sourcesContent");
+	expect(/\.js(\?.+)?$/.test(map.file)).toBe(true);
+});
+
+if (Math.random() < 0) require("./test.js");

--- a/tests/webpack-test/configCases/source-map/eval-nosources-source-map/index.ts
+++ b/tests/webpack-test/configCases/source-map/eval-nosources-source-map/index.ts
@@ -1,0 +1,11 @@
+it("should not include sourcesContent if noSources option is used", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+  var match = /\/\/# sourceMappingURL\s*=\s*data:application\/json;charset=utf-8;base64,(.*)\\n\/\/#/.exec(source);
+  var mapString = Buffer.from(match[1], 'base64').toString('utf-8');
+	var map = JSON.parse(mapString);
+	expect(map).not.toHaveProperty("sourcesContent");
+	expect(/\.ts(\?.+)?$/.test(map.file)).toBe(true);
+});
+
+if (Math.random() < 0) require("./test.js");

--- a/tests/webpack-test/configCases/source-map/eval-nosources-source-map/node_modules/pkg/index.js
+++ b/tests/webpack-test/configCases/source-map/eval-nosources-source-map/node_modules/pkg/index.js
@@ -1,0 +1,1 @@
+import "../../index.js";

--- a/tests/webpack-test/configCases/source-map/eval-nosources-source-map/test.filter.js
+++ b/tests/webpack-test/configCases/source-map/eval-nosources-source-map/test.filter.js
@@ -1,0 +1,7 @@
+// var supportsOptionalChaining = require("../../../helpers/supportsOptionalChaining");
+// module.exports = function (config) {
+// 	return supportsOptionalChaining();
+// };
+
+// moduleIds: size is not implemented
+module.exports = () => false;

--- a/tests/webpack-test/configCases/source-map/eval-nosources-source-map/test.js
+++ b/tests/webpack-test/configCases/source-map/eval-nosources-source-map/test.js
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/tests/webpack-test/configCases/source-map/eval-nosources-source-map/webpack.config.js
+++ b/tests/webpack-test/configCases/source-map/eval-nosources-source-map/webpack.config.js
@@ -1,0 +1,83 @@
+const devtool = "eval-nosources-source-map";
+
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = [
+	{
+		devtool
+	},
+	{
+		devtool,
+		optimization: {
+			moduleIds: "natural"
+		}
+	},
+	{
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		}
+	},
+	{
+		devtool,
+		optimization: {
+			moduleIds: "deterministic"
+		}
+	},
+	{
+		devtool,
+		optimization: {
+			moduleIds: "size"
+		}
+	},
+	{
+		entry: "./index?foo=bar",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		}
+	},
+	{
+		entry: "./index.js?foo=bar",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		}
+	},
+	{
+		entry: "alias",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		},
+		resolve: {
+			alias: {
+				alias: "./index?foo=bar"
+			}
+		}
+	},
+	{
+		entry: "pkg",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		}
+	},
+	{
+		entry: "./index.ts?foo=bar",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.ts$/,
+					loader: "ts-loader",
+					options: {
+						transpileOnly: true
+					}
+				}
+			]
+		}
+	}
+];

--- a/tests/webpack-test/configCases/source-map/eval-source-map-debugids/index.js
+++ b/tests/webpack-test/configCases/source-map/eval-source-map-debugids/index.js
@@ -1,0 +1,16 @@
+const fs = require("fs");
+
+it("should not include sourcesContent if noSources option is used", function() {
+  const source = fs.readFileSync(__filename, "utf-8");
+	const match = /\/\/# sourceMappingURL\s*=\s*data:application\/json;charset=utf-8;base64,(.*)\\n\/\/#/.exec(source);
+	const mapString = Buffer.from(match[1], 'base64').toString('utf-8');
+	const map = JSON.parse(mapString);
+	expect(map).toHaveProperty("sourcesContent");
+	expect(map).toHaveProperty("debugId");
+	expect(
+		/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i.test(map.debugId)
+	).toBe(true);
+	expect(/\.js(\?.+)?$/.test(map.file)).toBe(true);
+});
+
+if (Math.random() < 0) require("./test.js");

--- a/tests/webpack-test/configCases/source-map/eval-source-map-debugids/test.filter.js
+++ b/tests/webpack-test/configCases/source-map/eval-source-map-debugids/test.filter.js
@@ -1,0 +1,2 @@
+// missing debugId property in sourceMappingURL base64 content
+module.exports = () => false

--- a/tests/webpack-test/configCases/source-map/eval-source-map-debugids/test.js
+++ b/tests/webpack-test/configCases/source-map/eval-source-map-debugids/test.js
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/tests/webpack-test/configCases/source-map/eval-source-map-debugids/webpack.config.js
+++ b/tests/webpack-test/configCases/source-map/eval-source-map-debugids/webpack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	devtool: "eval-source-map-debugids"
+};

--- a/tests/webpack-test/configCases/source-map/eval-source-map/index.js
+++ b/tests/webpack-test/configCases/source-map/eval-source-map/index.js
@@ -1,0 +1,11 @@
+it("should not include sourcesContent if noSources option is used", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+  var match = /\/\/# sourceMappingURL\s*=\s*data:application\/json;charset=utf-8;base64,(.*)\\n\/\/#/.exec(source);
+  var mapString = Buffer.from(match[1], 'base64').toString('utf-8');
+	var map = JSON.parse(mapString);
+	expect(map).toHaveProperty("sourcesContent");
+	expect(/\.js(\?.+)?$/.test(map.file)).toBe(true);
+});
+
+if (Math.random() < 0) require("./test.js");

--- a/tests/webpack-test/configCases/source-map/eval-source-map/index.ts
+++ b/tests/webpack-test/configCases/source-map/eval-source-map/index.ts
@@ -1,0 +1,11 @@
+it("should not include sourcesContent if noSources option is used", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+	var match = /\/\/# sourceMappingURL\s*=\s*data:application\/json;charset=utf-8;base64,(.*)\\n\/\/#/.exec(source);
+	var mapString = Buffer.from(match[1], 'base64').toString('utf-8');
+	var map = JSON.parse(mapString);
+	expect(map).toHaveProperty("sourcesContent");
+	expect(/\.ts(\?.+)?$/.test(map.file)).toBe(true);
+});
+
+if (Math.random() < 0) require("./test.js");

--- a/tests/webpack-test/configCases/source-map/eval-source-map/node_modules/pkg/index.js
+++ b/tests/webpack-test/configCases/source-map/eval-source-map/node_modules/pkg/index.js
@@ -1,0 +1,1 @@
+import "../../index.js";

--- a/tests/webpack-test/configCases/source-map/eval-source-map/test.filter.js
+++ b/tests/webpack-test/configCases/source-map/eval-source-map/test.filter.js
@@ -1,0 +1,7 @@
+// var supportsOptionalChaining = require("../../../helpers/supportsOptionalChaining");
+// module.exports = function (config) {
+// 	return supportsOptionalChaining();
+// };
+
+// moduleIds: size is not implemented
+module.exports = () => false;

--- a/tests/webpack-test/configCases/source-map/eval-source-map/test.js
+++ b/tests/webpack-test/configCases/source-map/eval-source-map/test.js
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/tests/webpack-test/configCases/source-map/eval-source-map/webpack.config.js
+++ b/tests/webpack-test/configCases/source-map/eval-source-map/webpack.config.js
@@ -1,0 +1,83 @@
+const devtool = "eval-source-map";
+
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = [
+	{
+		devtool
+	},
+	{
+		devtool,
+		optimization: {
+			moduleIds: "natural"
+		}
+	},
+	{
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		}
+	},
+	{
+		devtool,
+		optimization: {
+			moduleIds: "deterministic"
+		}
+	},
+	{
+		devtool,
+		optimization: {
+			moduleIds: "size"
+		}
+	},
+	{
+		entry: "./index?foo=bar",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		}
+	},
+	{
+		entry: "./index.js?foo=bar",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		}
+	},
+	{
+		entry: "alias",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		},
+		resolve: {
+			alias: {
+				alias: "./index?foo=bar"
+			}
+		}
+	},
+	{
+		entry: "pkg",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		}
+	},
+	{
+		entry: "./index.ts?foo=bar",
+		devtool,
+		optimization: {
+			moduleIds: "named"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.ts$/,
+					loader: "ts-loader",
+					options: {
+						transpileOnly: true
+					}
+				}
+			]
+		}
+	}
+];

--- a/tests/webpack-test/configCases/source-map/harmony-eval-source-map/index.js
+++ b/tests/webpack-test/configCases/source-map/harmony-eval-source-map/index.js
@@ -1,0 +1,2 @@
+export {}
+it("should run fine", function() {});

--- a/tests/webpack-test/configCases/source-map/harmony-eval-source-map/webpack.config.js
+++ b/tests/webpack-test/configCases/source-map/harmony-eval-source-map/webpack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	devtool: "eval-source-map"
+};

--- a/tests/webpack-test/configCases/source-map/harmony-eval/index.js
+++ b/tests/webpack-test/configCases/source-map/harmony-eval/index.js
@@ -1,0 +1,2 @@
+export {}
+it("should run fine", function() {});

--- a/tests/webpack-test/configCases/source-map/harmony-eval/webpack.config.js
+++ b/tests/webpack-test/configCases/source-map/harmony-eval/webpack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	devtool: "eval"
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
Sync missing tests or missing files in existing webpack configCases tests: runtime and source-map.
Every failing tests above obvious corrections are disabled. It still adds a meaningful coverage.

My aim is to also sync existing tests but that was a first good batch

This is split version of https://github.com/web-infra-dev/rspack/pull/9564

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
