### PR TITLE
docs: add guide for assets base path

### DIFF
--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1616,73 +1616,17 @@ It also adds some info about tree shaking to the generated bundle.
 - **Type:** `'auto' | string | ((pathData: PathData, assetInfo?: AssetInfo) => string)`
 - **Default:** `'auto'` when [target](/config/target) is `'web'` or `'webworker'`, `undefined` otherwise
 
-This option determines the URL prefix of the referenced resource, such as: image, file, etc.
-
-For example, given a configuration file.
+Set the base URL path prefix for bundled static assets (such as JS, CSS, images, etc.).
 
 ```js title="rspack.config.mjs"
 export default {
   output: {
     publicPath: '/assets/',
-    chunkFilename: '[id].chunk.js',
-    assetModuleFilename: '[name][ext]',
   },
 };
 ```
 
-For a non-initial chunk file, its request URL looks like this: `/assets/1.chunk.js`.
-
-For a reference to an image, the request URL looks like this: `/assets/logo.png`.
-
-Also, it is useful when you deploy the product using a CDN
-
-```js title="rspack.config.mjs"
-export default {
-  output: {
-    publicPath: 'https://cdn.example.com/assets/',
-    assetModuleFilename: '[name][ext]',
-  },
-};
-```
-
-For all asset resources, their request URLs look like this: `https://cdn.example.com/assets/logo.png`.
-
-### Dynamically set publicPath
-
-You can set `publicPath` dynamically using `__webpack_public_path__` in your JavaScript code.
-
-The `__webpack_public_path__` will override the `output.publicPath` in the Rspack config, but it will only take effect for dynamically loaded resources, not for resources loaded via `<script src="...">`.
-
-First create a `publicPath.js`:
-
-```js title="publicPath.js"
-__webpack_public_path__ =
-  location.hostname === 'foo.com'
-    ? 'https://cdn1.com/assets/'
-    : 'https://cdn2.com/assets/';
-```
-
-Then import it into the first line of the entry file to ensure that `publicPath` is set before async resources are loaded:
-
-```js title="entry.js"
-import './publicPath.js';
-import './others.js';
-```
-
-### Automatic publicPath
-
-There are chances that you don't know what the `publicPath` will be in advance, and Rspack can automatically calculate the `publicPath` value by parsing some variables like [import.meta.url](/api/runtime-api/module-variables#importmetaurl), [document.currentScript](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript), `script.src` or `self.location`.
-
-What you need is to set `output.publicPath` to `'auto'`:
-
-```js title="rspack.config.mjs"
-export default {
-  output: {
-    // this is the default value when `target` is `'web'` or `'webworker'`
-    publicPath: 'auto',
-  },
-};
-```
+See [Asset base path](/guide/features/asset-base-path) for more details.
 
 ## output.scriptType
 

--- a/website/docs/en/guide/features/_meta.json
+++ b/website/docs/en/guide/features/_meta.json
@@ -3,6 +3,7 @@
   "loader",
   "dev-server",
   "asset-module",
+  "asset-base-path",
   "module-resolution",
   "module-federation",
   "web-workers",

--- a/website/docs/en/guide/features/asset-base-path.mdx
+++ b/website/docs/en/guide/features/asset-base-path.mdx
@@ -44,6 +44,7 @@ With this configuration, all assets will be loaded from the `/assets/` path, for
 
 - The value of `output.publicPath` usually ends with `/`.
 - Do not set `output.publicPath` to a relative path, such as `./assets/`. Using a relative path may cause assets to load incorrectly when they are located at different path depths.
+- If setting `output.publicPath` to an empty string, the asset URL path will be relative to the HTML page (same directory).
 
 :::
 

--- a/website/docs/en/guide/features/asset-base-path.mdx
+++ b/website/docs/en/guide/features/asset-base-path.mdx
@@ -1,0 +1,104 @@
+# Asset base path
+
+Rspack provides the [output.publicPath](/config/output#outputpublicpath) option, which sets the base URL path prefix for bundled static assets (such as JS, CSS, images, etc.).
+
+## Use cases
+
+Imagine the following scenarios:
+
+- Your static assets need to be deployed to a CDN
+- Your web application is not deployed under the root path of the domain
+- You need to use different assets paths for different environments (development, testing, or production)
+
+In these scenarios, configuring `output.publicPath` can help you load static assets correctly.
+
+## Basic example
+
+Set `output.publicPath` to `/`, then the assets path will be relative to the root path.
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    publicPath: '/',
+  },
+};
+```
+
+With this configuration, the assets access path is `http://[domain]/`, for example `http://localhost:8080/main.js`.
+
+## Subdirectory
+
+If your application needs to be deployed under a subdirectory, you can set `output.publicPath` to the corresponding subdirectory path:
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    publicPath: '/assets/',
+  },
+};
+```
+
+With this configuration, all assets will be loaded from the `/assets/` path, for example `http://localhost:8080/assets/main.js`.
+
+:::tip
+
+- The value of `output.publicPath` usually ends with `/`.
+- Do not set `output.publicPath` to a relative path, such as `./assets/`. Using a relative path may cause assets to load incorrectly when they are located at different path depths.
+
+:::
+
+## Use CDN
+
+When deploying static assets using CDN, you can set `output.publicPath` based on the environment variable, and set it to the CDN URL prefix during the production build.
+
+```js title="rspack.config.mjs"
+const isProd = process.env.NODE_ENV === 'production';
+
+export default {
+  output: {
+    publicPath: isProd ? 'https://cdn.example.com/' : '/',
+  },
+};
+```
+
+With this configuration:
+
+- In the development mode, the assets access path is `http://[domain]/`, for example `http://localhost:8080/main.js`.
+- In the production mode, the assets access path is `https://cdn.example.com/`, for example `https://cdn.example.com/main.[hash].js`.
+
+## Dynamically set publicPath
+
+You can set `publicPath` dynamically using `__webpack_public_path__` in your JavaScript code.
+
+The `__webpack_public_path__` will override the `output.publicPath` in the Rspack config, but it will only take effect for dynamically loaded assets, not for assets loaded via `<script src="...">`.
+
+First create a `publicPath.js`:
+
+```js title="publicPath.js"
+__webpack_public_path__ =
+  location.hostname === 'foo.com'
+    ? 'https://cdn1.com/assets/'
+    : 'https://cdn2.com/assets/';
+```
+
+Then import it into the first line of the entry file to ensure that `publicPath` is set before async assets are loaded:
+
+```js title="entry.js"
+import './publicPath.js';
+import './others.js';
+```
+
+## Automatic publicPath
+
+There are chances that you don't know what the `publicPath` will be in advance, and Rspack can automatically calculate the `publicPath` value by parsing some variables like [import.meta.url](/api/runtime-api/module-variables#importmetaurl), [document.currentScript](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript), `script.src` or `self.location`.
+
+What you need is to set `output.publicPath` to `'auto'`:
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    // this is the default value when `target` is `'web'` or `'webworker'`
+    publicPath: 'auto',
+  },
+};
+```

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1608,73 +1608,17 @@ export default {
 - **类型：** `'auto' | string | ((pathData: PathData, assetInfo?: AssetInfo) => string)`
 - **默认值：** [target](/config/target) 为 `'web'` 或 `'webworker'` 时为 `'auto'`，否则为 `undefined`
 
-此选项决定了引用的资源的 URL 前缀，如: 图片、文件等等。
-
-例如，给定一个配置文件：
+用于设置打包后的静态资源文件（如 JS、CSS、图片等）的 URL 路径前缀。
 
 ```js title="rspack.config.mjs"
 export default {
   output: {
     publicPath: '/assets/',
-    chunkFilename: '[id].chunk.js',
-    assetModuleFilename: '[name][ext]',
   },
 };
 ```
 
-对于某一个非初始（non-initial） chunk 文件，它的请求 URL 看起来像是这样： `/assets/1.chunk.js`。
-
-对于一个图片的引用，它的请求 URL 看起来像是这样：`/assets/logo.png`。
-
-同时，当你使用 CDN 对产物进行部署时则非常有用：
-
-```js title="rspack.config.mjs"
-export default {
-  output: {
-    publicPath: 'https://cdn.example.com/assets/',
-    assetModuleFilename: '[name][ext]',
-  },
-};
-```
-
-对于所有 asset 资源，它们的请求 URL 看起来像是这样：`https://cdn.example.com/assets/logo.png`。
-
-### 动态设置 publicPath
-
-在 JavaScript 代码中，你可以通过 [`__webpack_public_path__`](/api/runtime-api/module-variables#__webpack_public_path__) 来动态设置 `publicPath`。
-
-`__webpack_public_path__` 会覆盖 Rspack 配置中的 `output.publicPath`，但它只能对异步加载的资源生效，不会对 HTML 中通过 `<script src="...">` 加载的资源生效。
-
-首先创建一个 `publicPath.js`：
-
-```js title="publicPath.js"
-__webpack_public_path__ =
-  location.hostname === 'foo.com'
-    ? 'https://cdn1.com/assets/'
-    : 'https://cdn2.com/assets/';
-```
-
-然后在入口文件的第一行引入它，以确保 `publicPath` 在异步资源被加载之前被设置：
-
-```js title="entry.js"
-import './publicPath.js';
-import './others.js';
-```
-
-### 自动 publicPath
-
-在某些情况下，你可能事先并不知道 `publicPath` 应该设置为什么值。这时 Rspack 可以通过解析一些变量来自动计算出 `publicPath` 的值，这些变量包括 [import.meta.url](/api/runtime-api/module-variables#importmetaurl)、[document.currentScript](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)、`script.src` 或 `self.location`。
-
-你只需要将 `output.publicPath` 设置为 `'auto'` 即可：
-
-```js title="rspack.config.mjs"
-export default {
-  output: {
-    // 当 `target` 为 `'web'` 或 `'webworker'` 时，这是默认值
-    publicPath: 'auto',
-  },
-};
-```
+参考 [资源基础路径](/guide/features/asset-base-path) 了解完整用法。
 
 ## output.scriptType
 

--- a/website/docs/zh/guide/features/_meta.json
+++ b/website/docs/zh/guide/features/_meta.json
@@ -3,6 +3,7 @@
   "loader",
   "dev-server",
   "asset-module",
+  "asset-base-path",
   "module-resolution",
   "module-federation",
   "web-workers",

--- a/website/docs/zh/guide/features/asset-base-path.mdx
+++ b/website/docs/zh/guide/features/asset-base-path.mdx
@@ -44,6 +44,7 @@ export default {
 
 - `output.publicPath` 的值通常以 `/` 结尾。
 - 不建议将 `output.publicPath` 设置为相对路径，比如 `./assets/`。因为当资源位于不同的路径深度时，使用相对路径可能会导致资源无法正确加载。
+- 将 `output.publicPath` 设置为空字符串时，资源 URL 路径会相对于 HTML 页面（同个目录）。
 
 :::
 

--- a/website/docs/zh/guide/features/asset-base-path.mdx
+++ b/website/docs/zh/guide/features/asset-base-path.mdx
@@ -1,0 +1,104 @@
+# 资源基础路径
+
+Rspack 提供了 [output.publicPath](/config/output#outputpublicpath) 选项，用于设置打包后的静态资源文件（如 JS、CSS、图片等）的 URL 路径前缀，它决定了你的应用在浏览器中如何加载这些资源。
+
+## 使用场景
+
+想象一下以下场景:
+
+- 你的静态资源需要部署到 CDN
+- 你的 web 应用并不是部署在域名根路径下
+- 你需要根据不同环境（开发、测试或生产）来使用不同的资源路径
+
+在这些场景下，配置 `output.publicPath` 可以帮助你正确地加载静态资源。
+
+## 基础示例
+
+将 `output.publicPath` 设置为 `/`，则资源路径会相对于根路径。
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    publicPath: '/',
+  },
+};
+```
+
+在这种配置下，资源访问路径为 `http://[domain]/`，例如 `http://localhost:8080/main.js`。
+
+## 子目录
+
+如果你的应用需要部署在某个子目录下，可以将 `output.publicPath` 设置为对应的子目录路径：
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    publicPath: '/assets/',
+  },
+};
+```
+
+在这种配置下，所有资源都会从 `/assets/` 路径下加载，例如 `http://localhost:8080/assets/main.js`。
+
+:::tip
+
+- `output.publicPath` 的值通常以 `/` 结尾。
+- 不建议将 `output.publicPath` 设置为相对路径，比如 `./assets/`。因为当资源位于不同的路径深度时，使用相对路径可能会导致资源无法正确加载。
+
+:::
+
+## 使用 CDN
+
+在使用 CDN 来部署静态资源时，你可以根据环境变量来设置 `output.publicPath`，在生产构建时设置为 CDN 的 URL 前缀。
+
+```js title="rspack.config.mjs"
+const isProd = process.env.NODE_ENV === 'production';
+
+export default {
+  output: {
+    publicPath: isProd ? 'https://cdn.example.com/' : '/',
+  },
+};
+```
+
+在这种配置下：
+
+- 在开发模式下，资源访问路径为 `http://[domain]/`，例如 `http://localhost:8080/main.js`。
+- 在生产模式下，资源访问路径为 `https://cdn.example.com/`，例如 `https://cdn.example.com/main.[hash].js`。
+
+## 动态设置 publicPath
+
+在 JavaScript 代码中，你可以通过 Rspack 的 [`__webpack_public_path__`](/api/runtime-api/module-variables#__webpack_public_path__) 来动态设置 `publicPath`。
+
+`__webpack_public_path__` 会覆盖 Rspack 配置中的 `output.publicPath`，但它只能对异步加载的资源生效，不会对 HTML 中通过 `<script src="...">` 加载的资源生效。
+
+首先创建一个 `publicPath.js`：
+
+```js title="publicPath.js"
+__webpack_public_path__ =
+  location.hostname === 'foo.com'
+    ? 'https://cdn1.com/assets/'
+    : 'https://cdn2.com/assets/';
+```
+
+然后在入口文件的第一行引入它，以确保 `publicPath` 在异步资源被加载之前被设置：
+
+```js title="entry.js"
+import './publicPath.js';
+import './others.js';
+```
+
+## 自动 publicPath
+
+在某些情况下，你可能事先并不知道 `publicPath` 应该设置为什么值。这时 Rspack 可以通过解析一些变量来自动计算出 `publicPath` 的值，这些变量包括 [import.meta.url](/api/runtime-api/module-variables#importmetaurl)、[document.currentScript](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)、`script.src` 或 `self.location`。
+
+你只需要将 `output.publicPath` 设置为 `'auto'` 即可：
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    // 当 `target` 为 `'web'` 或 `'webworker'` 时，这是默认值
+    publicPath: 'auto',
+  },
+};
+```


### PR DESCRIPTION
## Summary

Add a new guide page for `output.publicPath` and updates to existing configuration documentation.

## Context

Currently, Rspack documentation has two issues:

1. The configuration page is extremely long
2. Guide documentation is insufficient (compared to webpack)

We will reorganize the content as follows:

- Provide dedicated guide pages for each major feature
- For configuration options that have corresponding guides, move detailed content to the guide pages and add cross-references

This restructuring will make the documentation more organized and easier to navigate.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
