### PR TITLE
chore: Consolidate and organize `use` statements for better readability

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -1,6 +1,7 @@
 use std::{
   borrow::Cow,
   collections::{hash_map::Entry, HashMap, HashSet},
+  hash::Hash,
   ops::Deref,
   sync::{Arc, LazyLock},
 };

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -1,7 +1,8 @@
 use std::{
-  collections::{HashMap, HashSet},
+  borrow::Cow,
+  collections::{hash_map::Entry, HashMap, HashSet},
   ops::Deref,
-  sync::Arc,
+  sync::{Arc, LazyLock},
 };
 
 use rayon::prelude::*;
@@ -15,8 +16,6 @@ mod mangle_exports_plugin;
 pub mod module_concatenation_plugin;
 mod module_info_header_plugin;
 mod side_effects_flag_plugin;
-
-use std::{borrow::Cow, collections::hash_map::Entry, hash::Hash, sync::LazyLock};
 
 pub use drive::*;
 pub use flag_dependency_exports_plugin::*;


### PR DESCRIPTION
## Summary

This PR refactors the use statements in the crates/rspack_plugin_javascript/src/plugin/mod.rs file to consolidate and organize them for better readability and maintainability. The redundant and unnecessary imports have been removed, ensuring a cleaner and more efficient import structure.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
