### PR TITLE
ci: cache support self hosted runner

### DIFF
--- a/.github/actions/artifact/download/action.yml
+++ b/.github/actions/artifact/download/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: "Destination path"
     required: true
   force-use-github:
-    description: "force download from github"
+    description: "Force download from github"
     default: false
     required: false
 
@@ -23,9 +23,9 @@ runs:
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
-#    - name: Download artifact from local
-#      uses: lynx-infra/download-artifact
-#      if: ${{ input.force-use-github != 'true' && runner.environment == 'self-hosted' }}
-#      with:
-#        name: ${{ inputs.name }}
-#        path: ${{ inputs.path }}
+    - name: Download artifact from local
+      uses: lynx-infra/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 #main
+      if: ${{ inputs.force-use-github != 'true' && runner.environment == 'self-hosted' }}
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}

--- a/.github/actions/artifact/upload/action.yml
+++ b/.github/actions/artifact/upload/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: "A file, directory or wildcard pattern that describes what to upload"
     required: true
   force-use-github:
-    description: "force upload to github"
+    description: "Force upload to github"
     default: false
     require: false
 
@@ -25,9 +25,9 @@ runs:
         path: ${{ inputs.path }}
         if-no-files-found: error
         overwrite: true
-#    - name: Upload artifact to local
-#      uses: lynx-infra/upload-artifact
-#      if: ${{ inputs.force-use-github != 'true' && runner.environment == 'self-hosted' }}
-#      with:
-#        name: ${{ inputs.name }}
-#        path: ${{ inputs.path }}
+    - name: Upload artifact to local
+      uses: lynx-infra/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 #main
+      if: ${{ inputs.force-use-github != 'true' && runner.environment == 'self-hosted' }}
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}

--- a/.github/actions/cache/restore/action.yml
+++ b/.github/actions/cache/restore/action.yml
@@ -16,8 +16,7 @@ inputs:
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
-    value: ${{ steps.github-cache.outputs.cache-hit }}
-#    value: ${{ steps.github-cache.outputs.cache-hit || steps.local-cache.outputs.cache-hit }}
+    value: ${{ steps.github-cache.outputs.cache-hit || steps.local-cache.outputs.cache-hit }}
 
 runs:
   using: composite
@@ -30,11 +29,11 @@ runs:
         key: ${{ inputs.key }}
         path: ${{ inputs.path }}
         restore-keys: ${{ inputs.restore-keys }}
-#    - name: Restore cache to local
-#      id: local-cache
-#      if: ${{ runner.environment == 'self-hosted' }}
-#      uses: lynx-infra/cache/restore@ad9f115f5b15348eb208a52ec6f7ffa82e8108df # main
-#      with:
-#        key: ${{ inputs.key }}
-#        path: ${{ inputs.path }}
-#        restore-keys: ${{ inputs.restore-keys }}
+    - name: Restore cache to local
+      id: local-cache
+      if: ${{ runner.environment == 'self-hosted' }}
+      uses: lynx-infra/cache/restore@ad9f115f5b15348eb208a52ec6f7ffa82e8108df # main
+      with:
+        key: ${{ inputs.key }}
+        path: ${{ inputs.path }}
+        restore-keys: ${{ inputs.restore-keys }}

--- a/.github/actions/cache/save/action.yml
+++ b/.github/actions/cache/save/action.yml
@@ -19,9 +19,9 @@ runs:
       with:
         key: ${{ inputs.key }}
         path: ${{ inputs.path }}
-#    - name: Save cache to local
-#      if: ${{ runner.environment == 'self-hosted' }}
-#      uses: lynx-infra/cache/save@ad9f115f5b15348eb208a52ec6f7ffa82e8108df # main
-#      with:
-#        key: ${{ inputs.key }}
-#        path: ${{ inputs.path }}
+    - name: Save cache to local
+      if: ${{ runner.environment == 'self-hosted' }}
+      uses: lynx-infra/cache/save@ad9f115f5b15348eb208a52ec6f7ffa82e8108df # main
+      with:
+        key: ${{ inputs.key }}
+        path: ${{ inputs.path }}

--- a/.github/actions/debuger/action.yml
+++ b/.github/actions/debuger/action.yml
@@ -1,0 +1,9 @@
+name: Debug action
+
+description: Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)
+
+runs:
+  using: composite
+  steps:
+    - name: Debug
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19

--- a/.github/actions/docker/linux-build/action.yml
+++ b/.github/actions/docker/linux-build/action.yml
@@ -35,14 +35,11 @@ runs:
   using: composite
   steps:
     - name: Docker Build ${{ inputs.target }}
-      shell: bash
-      run: |
-        code='
+      uses: ./.github/actions/docker/run
+      with:
+        image: ${{ inputs.image }}
+        script: |
           set -e
-          if [ -x "$(command -v sccache)" ]; then
-            export RUSTC_WRAPPER=sccache
-            echo "enable sccache"
-          fi
           ${{ inputs.pre }}
           rustup target add ${{ inputs.target }}
 
@@ -52,25 +49,10 @@ runs:
 
           RUST_TARGET=${{ inputs.target }} ${{ inputs.plugin == 'false' && 'DISABLE_PLUGIN=1' || '' }} pnpm build:binding:${{ inputs.profile }}
           ${{ inputs.post }}
-        '
-        if [[ ! -n "$CARGO_HOME" ]]; then
-          CARGO_HOME="$(dirname $(dirname $(which cargo)))"
-        fi
-
-        docker run \
-          --rm \
-          --privileged \
-          --user 0:0 \
-          -v $CARGO_HOME/registry/index:/usr/local/cargo/registry/index \
-          -v $CARGO_HOME/registry/cache:/usr/local/cargo/registry/cache \
-          -v $CARGO_HOME/git/db:/usr/local/cargo/git/db \
+        options: |
+          -v ~/.cargo/registry/index:/usr/local/cargo/registry/index \
+          -v ~/.cargo/registry/cache:/usr/local/cargo/registry/cache \
+          -v ~/.cargo/git/db:/usr/local/cargo/git/db \
+          -v ~/.rustup/toolchains:/usr/local/rustup/toolchains \
           -v /tmp:/tmp \
           ${{ inputs.options }} \
-          -e CI=1 \
-          -e HOME=$HOME \
-          -v $HOME/.cache:$HOME/.cache \
-          -v ${{ github.workspace }}:/build \
-          -w /build \
-          -i \
-          ${{ inputs.image }} \
-          bash -c "$code"

--- a/.github/actions/docker/run/action.yml
+++ b/.github/actions/docker/run/action.yml
@@ -18,6 +18,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup dockerd, if needed
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        docker ps || nohup sudo dockerd >/dev/null 2>&1 &
+
     - name: Docker Build ${{ inputs.target }}
       shell: bash
       run: |
@@ -28,8 +34,6 @@ runs:
           --user 0:0 \
           ${{ inputs.options }} \
           -e CI=1 \
-          -e HOME=$HOME \
-          -v $HOME/.cache:$HOME/.cache \
           -v ${{ github.workspace }}:/rspack \
           -w /rspack \
           -i \

--- a/.github/actions/pnpm/setup/action.yml
+++ b/.github/actions/pnpm/setup/action.yml
@@ -38,15 +38,3 @@ runs:
         dest: ${{ runner.tool_cache }}/pnpm
         # Use `@pnpm/exe` for Node 16
         standalone: true
-
-    - name: Get pnpm store directory
-      id: pnpm-cache
-      shell: bash
-      run: |
-        # set store-dir to $(pnpm config get store-dir)/$(pnpm -v)
-        global_store_path=$(pnpm config get store-dir)
-        if [ -z "${global_store_path}" ] || [ "${global_store_path}" = "undefined" ]; then
-          global_store_path=~/.cache/pnpm
-        fi
-        pnpm config set store-dir $global_store_path/$(pnpm -v) --location project
-        echo "STORE_PATH is $(pnpm store path)"

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -8,52 +8,59 @@ name: Rustup
 description: Install Rust with cache
 
 inputs:
-  # See https://rust-lang.github.io/rustup/concepts/components.html
-  clippy:
-    default: false
-    required: false
-    type: boolean
-  fmt:
-    default: false
-    required: false
-    type: boolean
-  docs:
-    default: false
-    required: false
-    type: boolean
-  miri:
-    default: false
-    required: false
-    type: boolean
-  save-cache:
-    default: false
-    required: false
-    type: boolean
-  shared-key:
-    default: "check"
-    required: false
+  key:
+    required: true
     type: string
+  save-if:
+    default: false
+    required: false
+    type: boolean
 
 runs:
   using: composite
   steps:
-    - name: Print Inputs
+    - name: Install rustup, if needed
+      if: runner.os != 'Windows'
       shell: bash
       run: |
-        echo 'clippy: ${{ inputs.clippy }}'
-        echo 'fmt: ${{ inputs.fmt }}'
-        echo 'docs: ${{ inputs.docs }}'
-        echo 'save-cache: ${{ inputs.save-cache }}'
-        echo 'shared-key: ${{ inputs.shared-key }}'
+        if ! command -v rustup &> /dev/null ; then
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+        fi
+
+    - name: Get toolchain
+      id: get-toolchain
+      shell: bash
+      run: |
+        toolchain=$(grep -E "^channel\s*=" rust-toolchain.toml | sed -n -E 's/^[ \t]*channel[ \t]*=[ \t]*"([^"]*)"[^#]*.*$/\1/p' | tr -d '[:space:]')
+        echo "toolchain=${toolchain}" >> $GITHUB_OUTPUT
+
+    - name: Restore rustup cache
+      id: restore
+      uses: ./.github/actions/cache/restore
+      with:
+        path: ~/.rustup/toolchains
+        key: rustup-cache-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
 
     # install components for nightly toolchain
     - name: Install
       shell: bash
       run: |
-        channel=$(grep -E "^channel\s*=" rust-toolchain.toml | sed -n -E 's/^[ \t]*channel[ \t]*=[ \t]*"([^"]*)"[^#]*.*$/\1/p' | tr -d '[:space:]')
-        rustup toolchain install $channel -c rustc -c cargo -c rust-std ${{ inputs.clippy == 'true' && '-c clippy' || '' }} ${{ inputs.fmt == 'true' && '-c rustfmt' || '' }} ${{ inputs.docs == 'true' && '-c rust-docs' || '' }} ${{ inputs.miri == 'true' && '-c miri' || '' }}
+        toolchain='${{ steps.get-toolchain.outputs.toolchain }}'
+        rustup toolchain install $toolchain \
+          -c rustc \
+          -c cargo \
+          -c rust-std
 
-    - name: Cache on ${{ github.ref_name }}
-      uses: ./.github/actions/rustup/cache
+    - name: Save rustup cache
+      uses: ./.github/actions/cache/save
+      if: ${{ inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       with:
-        key: ${{ inputs.shared-key }}
+        path: ~/.rustup/toolchains/${{ steps.get-toolchain.outputs.toolchain }}*
+        key: rustup-cache-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
+
+    - name: Cargo cache
+      uses: ./.github/actions/rustup/cargo
+      with:
+        key: ${{ inputs.key }}
+        save-if: ${{ inputs.save-if }}

--- a/.github/actions/rustup/cargo/action.yml
+++ b/.github/actions/rustup/cargo/action.yml
@@ -1,14 +1,14 @@
-name: rust cache
+name: cargo cache
 
 description: Cache rust dependencies to github or local
 
 inputs:
   key:
     required: true
-#  save-if:
-#    default: false
-#    required: false
-#    type: boolean
+  save-if:
+    default: false
+    required: false
+    type: boolean
 
 runs:
   using: composite
@@ -18,12 +18,16 @@ runs:
       uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
       with:
         shared-key: ${{ inputs.key }}
-        save-if: ${{ github.ref_name == 'main' }}
+        save-if: ${{ inputs.save-if }}
+
 #    - name: Cache to local
 #      uses: lynx-infra/cache
 #      if: ${{ runner.environment == 'self-hosted' }}
 #      with:
-#        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-#        key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-#        restore-keys: |
-#          node-cache-${{ runner.os }}-pnpm-
+#        path: |
+#          ~/.cargo/bin
+#          ~/.cargo/.crates.toml
+#          ~/.cargo/.crates2.json
+#          ~/.cargo/registry
+#          ~/.cargo/git
+#        key: ${{ inputs.key }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -58,12 +58,6 @@ jobs:
           ref: ${{ inputs.ref }}
           clean: ${{ runner.environment == 'github-hosted' }}
 
-      - name: Clean
-        if: ${{ !inputs.skipable && runner.environment == 'self-hosted' }}
-        uses: ./.github/actions/clean
-        with:
-          target: ${{ inputs.target }}
-
       - name: Pnpm Setup
         if: ${{ !inputs.skipable }}
         uses: ./.github/actions/pnpm/setup
@@ -82,7 +76,7 @@ jobs:
         if: ${{ !inputs.skipable }}
         uses: ./.github/actions/rustup
         with:
-          shared-key: build-${{ inputs.target }}-${{ inputs.profile }}
+          key: build-${{ inputs.target }}-${{ inputs.profile }}
 
       - name: Trim paths
         if: ${{ !inputs.skipable }}
@@ -113,9 +107,16 @@ jobs:
           tool-cache: false
 
       # Linux
+      - name: Build x86_64-unknown-linux-gnu native
+        if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' && inputs.profile == 'ci' && steps.check_cache.outputs.exists != 'true' && !inputs.skipable }}
+        shell: bash
+        run: |
+          unset CC_x86_64_unknown_linux_gnu && unset CC # for jemallocator to compile
+          rustup target add x86_64-unknown-linux-gnu
+          RUST_TARGET=x86_64-unknown-linux-gnu pnpm build:binding:ci
       - name: Build x86_64-unknown-linux-gnu in Docker
-        if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' && steps.check_cache.outputs.exists != 'true' && !inputs.skipable }}
-        uses: ./.github/actions/docker-build
+        if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' && inputs.profile != 'ci' && steps.check_cache.outputs.exists != 'true' && !inputs.skipable }}
+        uses: ./.github/actions/docker/linux-build
         with:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           target: ${{ inputs.target }}
@@ -124,7 +125,7 @@ jobs:
       # runner these build in docker since we don't have github runner machine for it
       - name: Build aarch64-unknown-linux-gnu in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-gnu' && steps.check_cache.outputs.files_exists != 'true' && !inputs.skipable }}
-        uses: ./.github/actions/docker-build
+        uses: ./.github/actions/docker/linux-build
         with:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
@@ -134,7 +135,7 @@ jobs:
 
       - name: Build x86_64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'x86_64-unknown-linux-musl' && steps.check_cache.outputs.files_exists != 'true' && !inputs.skipable }}
-        uses: ./.github/actions/docker-build
+        uses: ./.github/actions/docker/linux-build
         with:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
@@ -153,7 +154,7 @@ jobs:
 
       - name: Build aarch64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-musl' && steps.check_cache.outputs.files_exists != 'true' && !inputs.skipable }}
-        uses: ./.github/actions/docker-build
+        uses: ./.github/actions/docker/linux-build
         with:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
@@ -215,13 +216,11 @@ jobs:
         with:
           name: bindings-${{ inputs.target }}
           path: crates/node_binding/*.node
-          try-local-cache: ${{ inputs.profile == 'ci' }}
-          mv-when-local: true
 
       # WASM
       - name: Build wasm32-wasip1-threads with linux in Docker
         if: ${{ inputs.target == 'wasm32-wasip1-threads' && steps.check_cache.outputs.exists != 'true' && !inputs.skipable }}
-        uses: ./.github/actions/docker-build
+        uses: ./.github/actions/docker/linux-build
         with:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           target: ${{ inputs.target }}
@@ -236,8 +235,6 @@ jobs:
         with:
           name: bindings-wasm32-wasi
           path: crates/node_binding/rspack.wasm32-wasi.wasm
-          try-local-cache: ${{ inputs.profile == 'ci' }}
-          mv-when-local: true
 
   e2e:
     name: E2E Testing
@@ -250,12 +247,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           clean: ${{ runner.environment == 'github-hosted' }}
-
-      - name: Clean
-        if: ${{ runner.environment == 'self-hosted' }}
-        uses: ./.github/actions/clean
-        with:
-          target: ${{ inputs.target }}
 
       - name: Download bindings
         uses: ./.github/actions/artifact/download
@@ -279,12 +270,12 @@ jobs:
           echo "path=$NODE_BIN_PATH" >> $GITHUB_OUTPUT
 
       - name: Run e2e
-        uses: ./.github/actions/docker-run
+        uses: ./.github/actions/docker/run
         with:
           # Jammy uses ubuntu 22.04
           # If this is to change, make sure to upgrade the ubuntu version in GitHub Actions
           image: mcr.microsoft.com/playwright:v1.47.0-jammy
-          # .cache is required by download artifact, and mount in ./.github/actions/docker-run
+          # .cache is required by download artifact, and mount in ./.github/actions/docker/run
           # .tool_cache is required by pnpm
           options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}}
           script: |
@@ -313,12 +304,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           clean: ${{ runner.environment == 'github-hosted' }}
-
-      - name: Clean
-        if: ${{ !inputs.skipable && runner.environment == 'self-hosted' }}
-        uses: ./.github/actions/clean
-        with:
-          target: ${{ inputs.target }}
 
       - name: Download bindings
         if: ${{ !inputs.skipable }}
@@ -403,17 +388,11 @@ jobs:
           ref: ${{ inputs.ref }}
           clean: ${{ runner.environment == 'github-hosted' }}
 
-      - name: Clean
-        if: ${{ runner.environment == 'self-hosted' }}
-        uses: ./.github/actions/clean
-        with:
-          target: ${{ inputs.target }}
-
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:
-          save-cache: ${{ github.ref_name == 'main' }} # This should be safe because we have nightly building the cache every day
-          shared-key: build-bench-${{ inputs.target }}-${{ inputs.profile }}
+          save-if: ${{ github.ref_name == 'main' }} # This should be safe because we have nightly building the cache every day
+          key: build-bench-${{ inputs.target }}-${{ inputs.profile }}
 
       - name: Install cargo-codspeed binary
         uses: taiki-e/install-action@5651179950649c44da31d346537e20c0534f0f25 # v2


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. update cache/restore, cache/save, artifact/download, artifact/upload to support self host runner.
2. move `docker-run` and `docker-build` to docker folder.
3. linux build directly to avoid download docker image.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
