### PR TITLE
chore(deps): bump swc to 16.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,12 +678,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chili"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72f874459a658df39dd1d99f7f62a9c421792efc26eaae8d497ae5d2e816a62"
-
-[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6221,9 +6215,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fbd21a1179166b5635d4b7a6b5930cf34b803a7361e0297b04f84dc820db04"
+checksum = "9e4a932c152e7142de2d5dba1c393e5523c47cd8fe656e5b0d411954bbaf1810"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -6306,9 +6300,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "16.7.0"
+version = "16.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bdc40ff1db02b1e32541b1fd8348406497554eb481f229b91f35c9563baebfb"
+checksum = "f7453b2e6771d55f483903ed12fa9cf949ff7a3fefdfe4a63a5ea13b542e9eca"
 dependencies = [
  "swc",
  "swc_allocator",
@@ -6334,9 +6328,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "8.0.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b5c514e22bcd65176a356c0bd2de295881b97079a45b991b98c4dca666ac78"
+checksum = "01f80679b1afc52ae0663eed0a2539cc3c108d48c287b5601712f9850d9fa9c2"
 dependencies = [
  "bitflags 2.6.0",
  "bytecheck 0.8.0",
@@ -6646,9 +6640,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "12.2.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb9f5964120e890a88ec048f049fe1f5e525d54aa394b50de2fcf2fd9bbb228"
+checksum = "7856c7095f57c0990ba9c22d18469d57b9f68e851cf27d8d99b5a0238648f0ce"
 dependencies = [
  "arrayvec",
  "indexmap 2.7.1",
@@ -6683,9 +6677,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9576fd56e613f83990190778878139ab1a8d5ff0b316318ba34204407a0142a2"
+checksum = "edfbfa5baabd14901a310f9d55d991625787d27d94de5c38a1a2ef85ebc19c97"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -6884,9 +6878,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "11.0.2"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6815f07e48c8274ee5eee6331ede60169985b087e1b511819dddfefde4570f7"
+checksum = "83c0a8368b173d030aa2fb43688dcae11a98332239c902ccd97002327a1573f3"
 dependencies = [
  "dashmap 5.5.3",
  "indexmap 2.7.1",
@@ -6904,6 +6898,7 @@ dependencies = [
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_fast_graph",
+ "swc_parallel",
  "tracing",
 ]
 
@@ -6974,9 +6969,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "12.0.1"
+version = "12.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384c49a5891a06857543370518bd37e1e27727e3174e439dc662b79333d6a652"
+checksum = "8af89be14ef84b16529f89a70972c7f85b0e9e2599ea09d9f7c3e5b186b8f225"
 dependencies = [
  "indexmap 2.7.1",
  "rustc-hash 2.1.0",
@@ -7038,9 +7033,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "9.1.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e83aafbb585409572a46e4dd00c56d25af1268309bfb9613644dd181377a6"
+checksum = "7938665a5561d6c3e2b796b5b2d0bc9a961d461db960cb5139f12e82b45bb471"
 dependencies = [
  "anyhow",
  "miette",
@@ -7207,11 +7202,10 @@ dependencies = [
 
 [[package]]
 name = "swc_parallel"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f75f1094d69174ef628e3665fff0f81d58e9f568802e3c90d332c72b0b6026"
+checksum = "8f16052d5123ec45c1c49100781363f3f4e4a6be2da6d82f473b79db1e3abeb8"
 dependencies = [
- "chili",
  "once_cell",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,6 +4163,7 @@ dependencies = [
  "swc_core",
  "swc_error_reporters",
  "swc_node_comments",
+ "swc_parallel",
 ]
 
 [[package]]
@@ -4291,6 +4292,7 @@ dependencies = [
  "sugar_path",
  "swc_core",
  "swc_node_comments",
+ "swc_parallel",
  "tokio",
  "tracing",
  "ustr-fxhash",
@@ -4321,6 +4323,7 @@ dependencies = [
  "rspack_collections",
  "rspack_paths",
  "swc_core",
+ "swc_parallel",
  "termcolor",
  "textwrap",
  "thiserror 1.0.69",
@@ -5303,6 +5306,7 @@ dependencies = [
  "swc_config",
  "swc_core",
  "swc_ecma_minifier",
+ "swc_parallel",
  "tracing",
 ]
 
@@ -7207,6 +7211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f16052d5123ec45c1c49100781363f3f4e4a6be2da6d82f473b79db1e3abeb8"
 dependencies = [
  "once_cell",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,9 +96,9 @@ rkyv      = { version = "=0.8.8" }
 # Must be pinned with the same swc versions
 swc                 = { version = "=16.1.1" }
 swc_config          = { version = "=2.0.0" }
-swc_core            = { version = "=16.7.0", default-features = false }
-swc_ecma_minifier   = { version = "=12.2.0", default-features = false }
-swc_error_reporters = { version = "=9.1.0" }
+swc_core            = { version = "=16.10.0", default-features = false }
+swc_ecma_minifier   = { version = "=12.4.0", default-features = false }
+swc_error_reporters = { version = "=9.1.1" }
 swc_html            = { version = "=12.0.0" }
 swc_html_minifier   = { version = "=12.0.0", default-features = false }
 swc_node_comments   = { version = "=8.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ swc_error_reporters = { version = "=9.1.1" }
 swc_html            = { version = "=12.0.0" }
 swc_html_minifier   = { version = "=12.0.0", default-features = false }
 swc_node_comments   = { version = "=8.0.0" }
+swc_parallel        = { version = "1.3.0", default-features = false, features = ["rayon"] }
 
 pnp = { version = "0.9.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ignored = [
   "rspack_binding",
   "rspack_plugin_merge",
   "rspack",
+  "swc_parallel",
 ]
 [workspace.dependencies]
 anyhow             = { version = "1.0.95", features = ["backtrace"] }

--- a/crates/rspack_ast/Cargo.toml
+++ b/crates/rspack_ast/Cargo.toml
@@ -24,4 +24,6 @@ swc_core = { workspace = true, features = [
 ] }
 swc_error_reporters = { workspace = true }
 swc_node_comments = { workspace = true }
-swc_parallel = { workspace = true, default-features = false, features = ["rayon"] }
+swc_parallel = { workspace = true, default-features = false }
+[package.metadata.cargo-shear]
+ignored = ["swc_parallel"]

--- a/crates/rspack_ast/Cargo.toml
+++ b/crates/rspack_ast/Cargo.toml
@@ -24,3 +24,4 @@ swc_core = { workspace = true, features = [
 ] }
 swc_error_reporters = { workspace = true }
 swc_node_comments = { workspace = true }
+swc_parallel = { workspace = true, default-features = false, features = ["rayon"] }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -67,7 +67,7 @@ swc_core = { workspace = true, features = [
   "swc_ecma_visit",
 ] }
 swc_node_comments = { workspace = true }
-swc_parallel = { workspace = true, default-features = false, features = ["rayon"] }
+swc_parallel = { workspace = true, default-features = false }
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing = { workspace = true }
 ustr = { workspace = true }
@@ -76,4 +76,7 @@ ustr = { workspace = true }
 pretty_assertions = { version = "1.4.1" }
 
 [lints]
+
 workspace = true
+[package.metadata.cargo-shear]
+ignored = ["swc_parallel"]

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -67,6 +67,7 @@ swc_core = { workspace = true, features = [
   "swc_ecma_visit",
 ] }
 swc_node_comments = { workspace = true }
+swc_parallel = { workspace = true, default-features = false, features = ["rayon"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing = { workspace = true }
 ustr = { workspace = true }

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -19,9 +19,12 @@ rspack_cacheable   = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_paths       = { workspace = true }
 swc_core           = { workspace = true, features = ["common", "common_concurrent"] }
-swc_parallel       = { workspace = true, default-features = false, features = ["rayon"] }
+swc_parallel       = { workspace = true, default-features = false }
 termcolor          = "1.4.1"
 textwrap           = "0.16.1"
 thiserror          = "1.0.69"
 
 unicode-width = "0.2.0"
+
+[package.metadata.cargo-shear]
+ignored = ["swc_parallel"]

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -19,6 +19,7 @@ rspack_cacheable   = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_paths       = { workspace = true }
 swc_core           = { workspace = true, features = ["common", "common_concurrent"] }
+swc_parallel       = { workspace = true, default-features = false, features = ["rayon"] }
 termcolor          = "1.4.1"
 textwrap           = "0.16.1"
 thiserror          = "1.0.69"

--- a/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
@@ -34,8 +34,8 @@ swc_core = { workspace = true, features = [
   "ecma_quote",
 ] }
 swc_ecma_minifier = { workspace = true, features = ["concurrent"] }
-swc_parallel = { workspace = true, default-features = false, features = ["rayon"] }
+swc_parallel = { workspace = true, default-features = false }
 tracing = { workspace = true }
 
 [package.metadata.cargo-shear]
-ignored = ["tracing"]
+ignored = ["tracing", "swc_parallel"]

--- a/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
@@ -34,6 +34,7 @@ swc_core = { workspace = true, features = [
   "ecma_quote",
 ] }
 swc_ecma_minifier = { workspace = true, features = ["concurrent"] }
+swc_parallel = { workspace = true, default-features = false, features = ["rayon"] }
 tracing = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/packages/rspack-test-tools/tests/configCases/source-map/verify-es6-minify/index.js
+++ b/packages/rspack-test-tools/tests/configCases/source-map/verify-es6-minify/index.js
@@ -27,7 +27,7 @@ it("verify es6 (esmodule) minify bundle source map", async () => {
 			// "*b0*", "*b1*" is eliminate by minify
 			['"*b2*"']: checkColumn("webpack:///b-dir/b.js"),
 			// "*c0*" is eliminate by minify
-			['"*c1*"']: "webpack:///b-dir/c-dir/c.js",
+			// "*c1*" is eliminate by minify
 			['"*c2*"']: "webpack:///b-dir/c-dir/c.js"
 		})
 	).toBe(true);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Swc lastest version has a performance improvement in swc_ecma_minifier and fix some bugs in es/minifier and ts/fast-strip. So we bump swc version.

- bump `swc_core` to 16.10.0
- bump `swc_ecma_minifier` to 12.4.0
- bump `swc_error_reporters` to 9.1.1

By default, Swc using chili when open concurrent features, but chili has high Idle CPU usage. So swc recommends open concurrent features using rayon.
- Open `rayon` features when concurrent is open.

More detail see: https://github.com/swc-project/swc/issues/10243#issuecomment-2742856826

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
