### PR TITLE
fix: array in asset info

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/compilation/emit-asset/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/emit-asset/rspack.config.js
@@ -14,9 +14,35 @@ class Plugin {
                     stage: rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
                 },
                 () => {
-                    compilation.emitAsset("/foo.txt", new compiler.webpack.sources.RawSource("foo"));
+                    compilation.emitAsset("/foo.txt", new compiler.webpack.sources.RawSource("foo"), {
+                        bool: true,
+                        number: 1,
+                        string: "foo",
+                        array: ["foo", "bar"],
+                        object: {
+                            bool: true,
+                            number: 1,
+                            string: "foo",
+                            array: ["foo", "bar"],
+                        }
+                    });
                 }
-            )
+            );
+
+            compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, () => {
+                const { info } = compilation.getAsset("/foo.txt");
+
+                expect(info.bool).toBe(true);
+                expect(info.number).toBe(1);
+                expect(info.string).toBe("foo");
+                expect(info.array).toEqual(["foo", "bar"]);
+                expect(info.object).toEqual({
+                    bool: true,
+                    number: 1,
+                    string: "foo",
+                    array: ["foo", "bar"],
+                });
+            });
         });
     }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

```js
compilation.emitAsset("/foo.txt", new compiler.webpack.sources.RawSource("foo"), {
    additionalKeys: ["foo", "bar"],
});
```

`additionalKeys` will transform to the array like object `{0: "foo", 1: "bar"}`. but we expected the array.

The reason is Rust not transform js array right.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
