### PR TITLE
fix: compilation.*_dependencies iterator ignore added items when sync call

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/compilation/update-context-dependencies/index.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/update-context-dependencies/index.js
@@ -1,0 +1,1 @@
+console.log("test update context dependencies");

--- a/packages/rspack-test-tools/tests/configCases/compilation/update-context-dependencies/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/update-context-dependencies/rspack.config.js
@@ -1,0 +1,25 @@
+const path = require("path");
+
+const PLUGIN_NAME = "plugin";
+const TEST_DIR = path.resolve(__dirname, "./src/");
+
+class Plugin {
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.afterCompile.tap(PLUGIN_NAME, compilation => {
+			compilation.contextDependencies.add(TEST_DIR);
+			expect(compilation.contextDependencies.has(TEST_DIR)).toBeTruthy();
+			expect(
+				[...compilation.contextDependencies].includes(TEST_DIR)
+			).toBeTruthy();
+		});
+	}
+}
+
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+	entry: "./index.js",
+	plugins: [new Plugin()]
+};

--- a/packages/rspack/src/util/MergeCaller.ts
+++ b/packages/rspack/src/util/MergeCaller.ts
@@ -14,6 +14,10 @@ export default class MergeCaller<D> {
 		this.callFn(args);
 	};
 
+	pendingData() {
+		return this.callArgs;
+	}
+
 	push(...data: D[]) {
 		if (this.callArgs.length === 0) {
 			queueMicrotask(this.finalCall);

--- a/packages/rspack/src/util/fake.ts
+++ b/packages/rspack/src/util/fake.ts
@@ -9,13 +9,15 @@ export function createFakeCompilationDependencies(
 	const addDepsCaller = new MergeCaller(addDeps);
 	return {
 		*[Symbol.iterator]() {
-			const deps = getDeps();
+			const deps = new Set([...getDeps(), ...addDepsCaller.pendingData()]);
 			for (const dep of deps) {
 				yield dep;
 			}
 		},
 		has(dep: string): boolean {
-			return getDeps().includes(dep);
+			return (
+				addDepsCaller.pendingData().includes(dep) || getDeps().includes(dep)
+			);
 		},
 		add: (dep: string) => {
 			addDepsCaller.push(dep);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

MergeCaller will store the calls to `compilation.*_dependencies.add` and add them to the rust side in the next microtask. However, if methods such as `has` and `iterator` are called before the microtask is executed, these pending items will not be obtained.

``` js
compiler.hooks.afterCompile.tap("TEST", compilation => {
	compilation.contextDependencies.add("/a");
	console.log(compilation.contextDependencies.has("/a"))) // ==> false
	console.log([...compilation.contextDependencies].includes("/a")) // ==> false
});
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
