### PR TITLE
fix: `getModuleId` should return number for deterministic moduleIds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4979,7 +4979,6 @@ name = "rspack_plugin_lazy_compilation"
 version = "0.2.0"
 dependencies = [
  "async-trait",
- "cow-utils",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -175,7 +175,7 @@ export declare class JsChunkGraph {
   getChunkEntryDependentChunksIterable(chunk: JsChunk): JsChunk[]
   getChunkModulesIterableBySourceType(chunk: JsChunk, sourceType: string): Module[]
   getModuleChunks(module: Module): JsChunk[]
-  getModuleId(module: Module): string | null
+  getModuleId(module: Module): string | number | null
   getModuleHash(module: Module, runtime: string | string[] | undefined): string | null
   getBlockChunkGroup(jsBlock: AsyncDependenciesBlock): JsChunkGroup | null
 }
@@ -834,7 +834,7 @@ export declare enum JsLoaderState {
 export interface JsModuleDescriptor {
   identifier: string
   name: string
-  id?: string
+  id?: string | number | null
 }
 
 export interface JsNormalModuleFactoryCreateModuleArgs {

--- a/crates/node_binding/src/chunk_graph.rs
+++ b/crates/node_binding/src/chunk_graph.rs
@@ -2,12 +2,22 @@ use std::{ptr::NonNull, sync::Arc};
 
 use napi::{Either, Result};
 use napi_derive::napi;
-use rspack_core::{ChunkGraph, Compilation, SourceType};
+use rspack_core::{ChunkGraph, Compilation, ModuleId, SourceType};
 
 use crate::{
   AsyncDependenciesBlock, JsChunk, JsChunkGroupWrapper, JsChunkWrapper, JsRuntimeSpec,
   ModuleObject, ModuleObjectRef,
 };
+
+pub type JsModuleId = Either<String, u32>;
+
+pub fn to_js_module_id(module_id: &ModuleId) -> JsModuleId {
+  if let Some(id) = module_id.as_number() {
+    JsModuleId::B(id)
+  } else {
+    JsModuleId::A(module_id.to_string())
+  }
+}
 
 #[napi]
 pub struct JsChunkGraph {
@@ -133,12 +143,15 @@ impl JsChunkGraph {
     )
   }
 
-  #[napi(ts_args_type = "module: Module")]
-  pub fn get_module_id(&self, module: ModuleObjectRef) -> napi::Result<Option<&str>> {
+  #[napi(
+    ts_args_type = "module: Module",
+    ts_return_type = "string | number | null"
+  )]
+  pub fn get_module_id(&self, module: ModuleObjectRef) -> napi::Result<Option<JsModuleId>> {
     let compilation = self.as_ref()?;
     Ok(
       ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier)
-        .map(|module_id| module_id.as_str()),
+        .map(to_js_module_id),
     )
   }
 

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -1,7 +1,6 @@
 //!  There are methods whose verb is `ChunkGraphModule`
 
 use std::{
-  borrow::Borrow,
   fmt,
   hash::{Hash, Hasher},
   sync::Arc,
@@ -22,7 +21,7 @@ use crate::{
 };
 
 #[cacheable]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ModuleId {
   inner: Arc<str>,
 }
@@ -61,12 +60,6 @@ impl Serialize for ModuleId {
     } else {
       serializer.serialize_str(self.as_str())
     }
-  }
-}
-
-impl Borrow<str> for ModuleId {
-  fn borrow(&self) -> &str {
-    self.as_str()
   }
 }
 

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -344,14 +344,10 @@ impl Stats<'_> {
                 })
                 .unwrap_or_default();
 
-              let module_id = origin
-                .module
-                .map(|identifier| {
-                  ChunkGraph::get_module_id(&self.compilation.module_ids_artifact, identifier)
-                    .map(|s| s.to_string())
-                    .unwrap_or_default()
-                })
-                .unwrap_or_default();
+              let module_id = origin.module.and_then(|identifier| {
+                ChunkGraph::get_module_id(&self.compilation.module_ids_artifact, identifier)
+                  .cloned()
+              });
 
               StatsOriginRecord {
                 module: module_identifier,
@@ -861,10 +857,9 @@ impl Stats<'_> {
       stats.id = if executed {
         None
       } else {
-        ChunkGraph::get_module_id(&self.compilation.module_ids_artifact, identifier)
-          .map(|s| s.as_str())
+        ChunkGraph::get_module_id(&self.compilation.module_ids_artifact, identifier).cloned()
       };
-      stats.issuer_id = issuer_id.and_then(|i| i);
+      stats.issuer_id = issuer_id.flatten();
 
       let mut chunks: Vec<String> = if executed {
         vec![]
@@ -954,7 +949,7 @@ impl Stats<'_> {
           Some(StatsModuleReason {
             module_identifier: connection.original_module_identifier,
             module_name,
-            module_id: module_id.and_then(|i| i),
+            module_id: module_id.flatten(),
             module_chunks: connection.original_module_identifier.and_then(|id| {
               if self
                 .compilation
@@ -1116,7 +1111,7 @@ impl Stats<'_> {
     }
 
     if options.ids {
-      stats.id = Some("");
+      stats.id = Some("".into());
       stats.chunks = Some(vec![]);
     }
 
@@ -1235,7 +1230,7 @@ impl Stats<'_> {
     }
 
     if options.ids {
-      stats.id = Some("");
+      stats.id = Some("".into());
       stats.chunks = Some(chunks);
     }
 

--- a/crates/rspack_core/src/stats/struct.rs
+++ b/crates/rspack_core/src/stats/struct.rs
@@ -5,7 +5,7 @@ use rspack_sources::BoxSource;
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::{ChunkGroupOrderKey, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType};
+use crate::{ChunkGroupOrderKey, ModuleId, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType};
 
 pub enum EntrypointsStatsOption {
   Bool(bool),
@@ -42,7 +42,7 @@ pub struct StatsError<'s> {
   pub message: String,
   pub module_identifier: Option<ModuleIdentifier>,
   pub module_name: Option<Cow<'s, str>>,
-  pub module_id: Option<&'s str>,
+  pub module_id: Option<ModuleId>,
   pub loc: Option<String>,
   pub file: Option<Utf8PathBuf>,
 
@@ -60,7 +60,7 @@ pub struct StatsWarning<'s> {
   pub message: String,
   pub module_identifier: Option<ModuleIdentifier>,
   pub module_name: Option<Cow<'s, str>>,
-  pub module_id: Option<&'s str>,
+  pub module_id: Option<ModuleId>,
   pub loc: Option<String>,
   pub file: Option<Utf8PathBuf>,
 
@@ -84,7 +84,7 @@ pub struct StatsModuleTrace {
 pub struct StatsErrorModuleTraceModule {
   pub identifier: ModuleIdentifier,
   pub name: String,
-  pub id: Option<String>,
+  pub id: Option<ModuleId>,
 }
 
 #[derive(Debug)]
@@ -143,14 +143,14 @@ pub struct StatsModule<'s> {
   pub identifier: Option<ModuleIdentifier>,
   pub name: Option<Cow<'s, str>>,
   pub name_for_condition: Option<String>,
-  pub id: Option<&'s str>,
+  pub id: Option<ModuleId>,
   pub chunks: Option<Vec<String>>, // has id after the call of chunkIds hook
   pub size: f64,
   pub sizes: Vec<StatsSourceTypeSize>,
   pub dependent: Option<bool>,
   pub issuer: Option<ModuleIdentifier>,
   pub issuer_name: Option<Cow<'s, str>>,
-  pub issuer_id: Option<&'s str>,
+  pub issuer_id: Option<ModuleId>,
   pub issuer_path: Option<Vec<StatsModuleIssuer<'s>>>,
   pub reasons: Option<Vec<StatsModuleReason<'s>>>,
   pub assets: Option<Vec<String>>,
@@ -191,7 +191,7 @@ pub struct StatsModuleProfile {
 #[derive(Debug)]
 pub struct StatsOriginRecord {
   pub module: Option<ModuleIdentifier>,
-  pub module_id: String,
+  pub module_id: Option<ModuleId>,
   pub module_identifier: Option<ModuleIdentifier>,
   pub module_name: String,
   pub loc: String,
@@ -257,18 +257,18 @@ pub struct StatschunkGroupChildAssets {
 pub struct StatsModuleIssuer<'s> {
   pub identifier: ModuleIdentifier,
   pub name: Cow<'s, str>,
-  pub id: Option<&'s str>,
+  pub id: Option<ModuleId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StatsModuleReason<'s> {
   pub module_identifier: Option<ModuleIdentifier>,
   pub module_name: Option<Cow<'s, str>>,
-  pub module_id: Option<&'s str>,
+  pub module_id: Option<ModuleId>,
   pub module_chunks: Option<u32>,
   pub resolved_module_identifier: Option<ModuleIdentifier>,
   pub resolved_module_name: Option<Cow<'s, str>>,
-  pub resolved_module_id: Option<&'s str>,
+  pub resolved_module_id: Option<ModuleId>,
 
   pub r#type: Option<&'static str>,
   pub user_request: Option<&'s str>,

--- a/crates/rspack_core/src/stats/utils.rs
+++ b/crates/rspack_core/src/stats/utils.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
   BoxModule, Chunk, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupOrderKey, ChunkGroupUkey,
-  Compilation, CompilerOptions, ModuleGraph,
+  Compilation, CompilerOptions, ModuleGraph, ModuleId,
 };
 
 pub fn get_asset_size(file: &str, compilation: &Compilation) -> usize {
@@ -40,14 +40,13 @@ pub fn sort_modules(modules: &mut [StatsModule]) {
   });
 }
 
-pub fn get_stats_module_name_and_id<'s, 'c>(
+pub fn get_stats_module_name_and_id<'s>(
   module: &'s BoxModule,
-  compilation: &'c Compilation,
-) -> (Cow<'s, str>, Option<&'c str>) {
+  compilation: &Compilation,
+) -> (Cow<'s, str>, Option<ModuleId>) {
   let identifier = module.identifier();
   let name = module.readable_identifier(&compilation.options.context);
-  let id =
-    ChunkGraph::get_module_id(&compilation.module_ids_artifact, identifier).map(|s| s.as_str());
+  let id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, identifier).cloned();
   (name, id)
 }
 
@@ -178,7 +177,7 @@ pub fn get_module_trace(
         .readable_identifier(&options.context)
         .to_string(),
       id: ChunkGraph::get_module_id(&compilation.module_ids_artifact, origin_module.identifier())
-        .map(|s| s.to_string()),
+        .cloned(),
     };
 
     let current_stats_module = StatsErrorModuleTraceModule {
@@ -190,7 +189,7 @@ pub fn get_module_trace(
         &compilation.module_ids_artifact,
         current_module.identifier(),
       )
-      .map(|s| s.to_string()),
+      .cloned(),
     };
     let dependencies = module_graph
       .get_incoming_connections(&module_identifier)

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -41,7 +41,7 @@ fn assign_named_module_ids(
       invalid_and_repeat_names.insert(name);
     }
     // Also rename the conflicting modules in used_ids
-    else if let Some(item) = used_ids.get(name.as_str()) {
+    else if let Some(item) = used_ids.get(&name.as_str().into()) {
       items.insert(*item);
       invalid_and_repeat_names.insert(name);
     }
@@ -69,7 +69,7 @@ fn assign_named_module_ids(
     let items = name_to_items.entry(name.clone()).or_default();
     items.insert(item);
     // Also rename the conflicting modules in used_ids
-    if let Some(item) = used_ids.get(name.as_str()) {
+    if let Some(item) = used_ids.get(&name.as_str().into()) {
       items.insert(*item);
     }
   }
@@ -82,7 +82,7 @@ fn assign_named_module_ids(
       for item in items {
         unnamed_items.push(item)
       }
-    } else if items.len() == 1 && !used_ids.contains_key(name.as_str()) {
+    } else if items.len() == 1 && !used_ids.contains_key(&name.as_str().into()) {
       let item = items[0];
       let name: ModuleId = name.into();
       if ChunkGraph::set_module_id(module_ids, item, name.clone())
@@ -97,7 +97,7 @@ fn assign_named_module_ids(
       for item in items {
         let mut formatted_name = format!("{name}{}", itoa!(i));
         while name_to_items_keys.contains(&formatted_name)
-          && used_ids.contains_key(formatted_name.as_str())
+          && used_ids.contains_key(&formatted_name.as_str().into())
         {
           i += 1;
           formatted_name = format!("{name}{}", itoa!(i));
@@ -159,7 +159,7 @@ async fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result
     .filter(|&(module_identifier, module)| {
       let not_used =
         if let Some(module_id) = ChunkGraph::get_module_id(&module_ids, *module_identifier) {
-          !used_ids.contains_key(module_id.as_str())
+          !used_ids.contains_key(module_id)
         } else {
           true
         };
@@ -194,7 +194,7 @@ async fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result
     let mut next_id = 0;
     for module in unnamed_modules {
       let mut id = next_id.to_string();
-      while used_ids.contains_key(id.as_str()) {
+      while used_ids.contains_key(&id.as_str().into()) {
         next_id += 1;
         id = next_id.to_string();
       }

--- a/crates/rspack_plugin_lazy_compilation/Cargo.toml
+++ b/crates/rspack_plugin_lazy_compilation/Cargo.toml
@@ -10,7 +10,6 @@ version                 = "0.2.0"
 
 [dependencies]
 async-trait = { workspace = true }
-cow-utils   = { workspace = true }
 rustc-hash  = { workspace = true }
 tokio       = { workspace = true }
 tracing     = { workspace = true }

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, path::Path, sync::Arc};
 
-use cow_utils::CowUtils;
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Unsupported};
 use rspack_collections::Identifiable;
 use rspack_core::{
@@ -16,6 +15,7 @@ use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_plugin_javascript::dependency::CommonJsRequireDependency;
 use rspack_util::{
   ext::DynHash,
+  json_stringify,
   source_map::{ModuleSourceMapConfig, SourceMapKind},
 };
 use rustc_hash::FxHashSet;
@@ -240,7 +240,7 @@ impl Module for LazyCompilationProxyModule {
         module.exports = {};
         if (module.hot) {{
           module.hot.accept();
-          module.hot.accept(\"{}\", function() {{ module.hot.invalidate(); }});
+          module.hot.accept({}, function() {{ module.hot.invalidate(); }});
           module.hot.dispose(function(data) {{ delete data.resolveSelf; dispose(data); }});
           if (module.hot.data && module.hot.data.resolveSelf)
             module.hot.data.resolveSelf(module.exports);
@@ -256,10 +256,10 @@ impl Module for LazyCompilationProxyModule {
           "import()",
           false
         ),
-        ChunkGraph::get_module_id(&compilation.module_ids_artifact, *module)
-          .map(|s| s.as_str())
-          .expect("should have module id")
-          .cow_replace('"', r#"\""#),
+        json_stringify(
+          ChunkGraph::get_module_id(&compilation.module_ids_artifact, *module)
+            .expect("should have module id")
+        ),
         keep_active,
       ))
     } else {

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -148,10 +148,8 @@ pub fn generate_entry_startup(
     if let Some(module_id) = compilation
       .get_module_graph()
       .module_graph_module_by_identifier(module)
-      .map(|module| {
+      .and_then(|module| {
         ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.module_identifier)
-          .map(|s| s.as_str())
-          .unwrap_or("null")
       })
     {
       let module_id_expr = serde_json::to_string(module_id).expect("invalid module_id");

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/get-module-id/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/get-module-id/rspack.config.js
@@ -1,27 +1,38 @@
 class Plugin {
+	constructor(expectedModuleIds) {
+		this.expectedModuleIds = expectedModuleIds;
+	}
+
 	apply(compiler) {
 		compiler.hooks.compilation.tap("Test", compilation => {
 			compilation.hooks.processAssets.tap("Test", () => {
-				const module = Array.from(compilation.modules)[0];
-				const moduleId = compilation.chunkGraph.getModuleId(module);
-				expect(moduleId).toBeTruthy();
+				const moduleIds = Array.from(compilation.modules).map(m =>
+					compilation.chunkGraph.getModuleId(m)
+				);
+				expect(moduleIds).toEqual(this.expectedModuleIds);
 			});
 		});
 	}
 }
 
-/** @type {import("@rspack/core").Configuration} */
-module.exports = {
-	target: "web",
-	node: false,
-	entry: {
-		main: "./index.js"
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = [
+	{
+		optimization: {
+			moduleIds: "named"
+		},
+		plugins: [new Plugin(["./index.js"])]
 	},
-	output: {
-		filename: "[name].js"
+	{
+		optimization: {
+			moduleIds: "natural"
+		},
+		plugins: [new Plugin([0])]
 	},
-	optimization: {
-		sideEffects: false
-	},
-	plugins: [new Plugin()]
-};
+	{
+		optimization: {
+			moduleIds: "deterministic"
+		},
+		plugins: [new Plugin([10])]
+	}
+];

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -498,7 +498,7 @@ class ChunkGraph {
     // (undocumented)
     getModuleHash(module: Module, runtime: RuntimeSpec): string | null;
     // (undocumented)
-    getModuleId(module: Module): string | null;
+    getModuleId(module: Module): string | number | null;
     // (undocumented)
     getNumberOfEntryModules(chunk: Chunk): number;
 }
@@ -2924,7 +2924,7 @@ type KnownStatsChunkOrigin = {
     moduleName: string;
     loc: string;
     request: string;
-    moduleId?: string;
+    moduleId?: string | number | null;
 };
 
 // @public (undocumented)
@@ -2963,7 +2963,7 @@ type KnownStatsError = {
     moduleName?: string;
     loc?: string;
     chunkId?: string | number;
-    moduleId?: string | number;
+    moduleId?: string | number | null;
     moduleTrace?: StatsModuleTraceItem[];
     details?: any;
     stack?: string;
@@ -3018,8 +3018,8 @@ type KnownStatsModule = {
     cached: boolean;
     optional?: boolean;
     orphan?: boolean;
-    id?: string;
-    issuerId?: string;
+    id?: string | number | null;
+    issuerId?: string | number | null;
     chunks?: string[];
     assets?: string[];
     dependent?: boolean;
@@ -3044,7 +3044,7 @@ type KnownStatsModule = {
 type KnownStatsModuleIssuer = {
     identifier?: string;
     name?: string;
-    id?: string | number;
+    id?: string | number | null;
 };
 
 // @public (undocumented)
@@ -3059,7 +3059,7 @@ type KnownStatsModuleReason = {
     explanation?: string;
     userRequest?: string;
     loc?: string;
-    moduleId?: string | null;
+    moduleId?: string | number | null;
     resolvedModuleId?: string | number | null;
 };
 
@@ -5856,8 +5856,8 @@ type StatsModuleTraceItem = {
     originName?: string;
     moduleIdentifier?: string;
     moduleName?: string;
-    originId?: string;
-    moduleId?: string;
+    originId?: string | number | null;
+    moduleId?: string | number | null;
     dependencies?: StatsModuleTraceDependency[];
 };
 

--- a/packages/rspack/src/ChunkGraph.ts
+++ b/packages/rspack/src/ChunkGraph.ts
@@ -61,7 +61,7 @@ export class ChunkGraph {
 			.map(binding => Chunk.__from_binding(binding));
 	}
 
-	getModuleId(module: Module): string | null {
+	getModuleId(module: Module): string | number | null {
 		return this.#inner.getModuleId(module);
 	}
 

--- a/packages/rspack/src/stats/statsFactoryUtils.ts
+++ b/packages/rspack/src/stats/statsFactoryUtils.ts
@@ -118,8 +118,8 @@ export type KnownStatsModule = {
 	cached: boolean;
 	optional?: boolean;
 	orphan?: boolean;
-	id?: string;
-	issuerId?: string;
+	id?: string | number | null;
+	issuerId?: string | number | null;
 	chunks?: string[];
 	assets?: string[];
 	dependent?: boolean;
@@ -153,7 +153,7 @@ export type StatsModule = KnownStatsModule & Record<string, any>;
 export type KnownStatsModuleIssuer = {
 	identifier?: string;
 	name?: string;
-	id?: string | number;
+	id?: string | number | null;
 	// profile?: StatsProfile;
 };
 
@@ -169,7 +169,7 @@ export type KnownStatsError = {
 	moduleName?: string;
 	loc?: string;
 	chunkId?: string | number;
-	moduleId?: string | number;
+	moduleId?: string | number | null;
 	moduleTrace?: StatsModuleTraceItem[];
 	details?: any;
 	stack?: string;
@@ -182,8 +182,8 @@ export type StatsModuleTraceItem = {
 	originName?: string;
 	moduleIdentifier?: string;
 	moduleName?: string;
-	originId?: string;
-	moduleId?: string;
+	originId?: string | number | null;
+	moduleId?: string | number | null;
 	dependencies?: StatsModuleTraceDependency[];
 };
 
@@ -205,7 +205,7 @@ export type KnownStatsModuleReason = {
 	explanation?: string;
 	userRequest?: string;
 	loc?: string;
-	moduleId?: string | null;
+	moduleId?: string | number | null;
 	resolvedModuleId?: string | number | null;
 };
 
@@ -217,7 +217,7 @@ export type KnownStatsChunkOrigin = {
 	moduleName: string;
 	loc: string;
 	request: string;
-	moduleId?: string;
+	moduleId?: string | number | null;
 };
 
 export type StatsChunkOrigin = KnownStatsChunkOrigin & Record<string, any>;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`getModuleId` should return number for deterministic moduleIds

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
