### PR TITLE
refactor: async hooks in rust

### DIFF
--- a/crates/node_binding/src/plugins/js_loader/scheduler.rs
+++ b/crates/node_binding/src/plugins/js_loader/scheduler.rs
@@ -10,7 +10,7 @@ use rspack_loader_runner::State as LoaderState;
 use super::{JsLoaderContext, JsLoaderRspackPlugin, JsLoaderRspackPluginInner};
 
 #[plugin_hook(NormalModuleLoaderShouldYield for JsLoaderRspackPlugin)]
-pub(crate) fn loader_should_yield(
+pub(crate) async fn loader_should_yield(
   &self,
   loader_context: &LoaderContext<RunnerContext>,
 ) -> Result<Option<bool>> {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -59,40 +59,40 @@ use crate::{
   Stats,
 };
 
-define_hook!(CompilationAddEntry: AsyncSeries(compilation: &mut Compilation, entry_name: Option<&str>));
-define_hook!(CompilationBuildModule: AsyncSeries(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule));
+define_hook!(CompilationAddEntry: Series(compilation: &mut Compilation, entry_name: Option<&str>));
+define_hook!(CompilationBuildModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule));
 // NOTE: This is a Rspack-specific hook and has not been standardized yet. Do not expose it to the JS side.
-define_hook!(CompilationRevokedModules: AsyncSeries(revoked_modules: &IdentifierSet));
-define_hook!(CompilationStillValidModule: AsyncSeries(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule));
-define_hook!(CompilationSucceedModule: AsyncSeries(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule));
+define_hook!(CompilationRevokedModules: Series(revoked_modules: &IdentifierSet));
+define_hook!(CompilationStillValidModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule));
+define_hook!(CompilationSucceedModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule));
 define_hook!(CompilationExecuteModule:
-  AsyncSeries(module: &ModuleIdentifier, runtime_modules: &IdentifierSet, codegen_results: &CodeGenerationResults, execute_module_id: &ExecuteModuleId));
-define_hook!(CompilationFinishModules: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationSeal: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationOptimizeDependencies: AsyncSeriesBail(compilation: &mut Compilation) -> bool);
-define_hook!(CompilationOptimizeModules: AsyncSeriesBail(compilation: &mut Compilation) -> bool);
-define_hook!(CompilationAfterOptimizeModules: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationOptimizeChunks: AsyncSeriesBail(compilation: &mut Compilation) -> bool);
-define_hook!(CompilationOptimizeTree: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationOptimizeChunkModules: AsyncSeriesBail(compilation: &mut Compilation) -> bool);
-define_hook!(CompilationModuleIds: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationChunkIds: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationRuntimeModule: AsyncSeries(compilation: &mut Compilation, module: &ModuleIdentifier, chunk: &ChunkUkey));
-define_hook!(CompilationAdditionalModuleRuntimeRequirements: AsyncSeries(compilation: &Compilation, module_identifier: &ModuleIdentifier, runtime_requirements: &mut RuntimeGlobals));
-define_hook!(CompilationRuntimeRequirementInModule: AsyncSeriesBail(compilation: &Compilation, module_identifier: &ModuleIdentifier, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals));
-define_hook!(CompilationAdditionalChunkRuntimeRequirements: AsyncSeries(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, runtime_requirements: &mut RuntimeGlobals));
-define_hook!(CompilationRuntimeRequirementInChunk: AsyncSeriesBail(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals));
-define_hook!(CompilationAdditionalTreeRuntimeRequirements: AsyncSeries(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, runtime_requirements: &mut RuntimeGlobals));
-define_hook!(CompilationRuntimeRequirementInTree: AsyncSeriesBail(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals));
-define_hook!(CompilationOptimizeCodeGeneration: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationAfterCodeGeneration: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationChunkHash: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash));
-define_hook!(CompilationContentHash: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, hashes: &mut HashMap<SourceType, RspackHash>));
-define_hook!(CompilationRenderManifest: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, manifest: &mut Vec<RenderManifestEntry>, diagnostics: &mut Vec<Diagnostic>));
-define_hook!(CompilationChunkAsset: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, filename: &str));
-define_hook!(CompilationProcessAssets: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationAfterProcessAssets: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilationAfterSeal: AsyncSeries(compilation: &mut Compilation));
+  Series(module: &ModuleIdentifier, runtime_modules: &IdentifierSet, codegen_results: &CodeGenerationResults, execute_module_id: &ExecuteModuleId));
+define_hook!(CompilationFinishModules: Series(compilation: &mut Compilation));
+define_hook!(CompilationSeal: Series(compilation: &mut Compilation));
+define_hook!(CompilationOptimizeDependencies: SeriesBail(compilation: &mut Compilation) -> bool);
+define_hook!(CompilationOptimizeModules: SeriesBail(compilation: &mut Compilation) -> bool);
+define_hook!(CompilationAfterOptimizeModules: Series(compilation: &mut Compilation));
+define_hook!(CompilationOptimizeChunks: SeriesBail(compilation: &mut Compilation) -> bool);
+define_hook!(CompilationOptimizeTree: Series(compilation: &mut Compilation));
+define_hook!(CompilationOptimizeChunkModules: SeriesBail(compilation: &mut Compilation) -> bool);
+define_hook!(CompilationModuleIds: Series(compilation: &mut Compilation));
+define_hook!(CompilationChunkIds: Series(compilation: &mut Compilation));
+define_hook!(CompilationRuntimeModule: Series(compilation: &mut Compilation, module: &ModuleIdentifier, chunk: &ChunkUkey));
+define_hook!(CompilationAdditionalModuleRuntimeRequirements: Series(compilation: &Compilation, module_identifier: &ModuleIdentifier, runtime_requirements: &mut RuntimeGlobals));
+define_hook!(CompilationRuntimeRequirementInModule: SeriesBail(compilation: &Compilation, module_identifier: &ModuleIdentifier, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals));
+define_hook!(CompilationAdditionalChunkRuntimeRequirements: Series(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, runtime_requirements: &mut RuntimeGlobals));
+define_hook!(CompilationRuntimeRequirementInChunk: SeriesBail(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals));
+define_hook!(CompilationAdditionalTreeRuntimeRequirements: Series(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, runtime_requirements: &mut RuntimeGlobals));
+define_hook!(CompilationRuntimeRequirementInTree: SeriesBail(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals));
+define_hook!(CompilationOptimizeCodeGeneration: Series(compilation: &mut Compilation));
+define_hook!(CompilationAfterCodeGeneration: Series(compilation: &mut Compilation));
+define_hook!(CompilationChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash));
+define_hook!(CompilationContentHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hashes: &mut HashMap<SourceType, RspackHash>));
+define_hook!(CompilationRenderManifest: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, manifest: &mut Vec<RenderManifestEntry>, diagnostics: &mut Vec<Diagnostic>));
+define_hook!(CompilationChunkAsset: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, filename: &str));
+define_hook!(CompilationProcessAssets: Series(compilation: &mut Compilation));
+define_hook!(CompilationAfterProcessAssets: Series(compilation: &mut Compilation));
+define_hook!(CompilationAfterSeal: Series(compilation: &mut Compilation));
 
 #[derive(Debug, Default)]
 pub struct CompilationHooks {

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -30,17 +30,17 @@ use crate::{
 };
 
 // should be SyncHook, but rspack need call js hook
-define_hook!(CompilerThisCompilation: AsyncSeries(compilation: &mut Compilation, params: &mut CompilationParams));
+define_hook!(CompilerThisCompilation: Series(compilation: &mut Compilation, params: &mut CompilationParams));
 // should be SyncHook, but rspack need call js hook
-define_hook!(CompilerCompilation: AsyncSeries(compilation: &mut Compilation, params: &mut CompilationParams));
+define_hook!(CompilerCompilation: Series(compilation: &mut Compilation, params: &mut CompilationParams));
 // should be AsyncParallelHook
-define_hook!(CompilerMake: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilerFinishMake: AsyncSeries(compilation: &mut Compilation));
+define_hook!(CompilerMake: Series(compilation: &mut Compilation));
+define_hook!(CompilerFinishMake: Series(compilation: &mut Compilation));
 // should be SyncBailHook, but rspack need call js hook
-define_hook!(CompilerShouldEmit: AsyncSeriesBail(compilation: &mut Compilation) -> bool);
-define_hook!(CompilerEmit: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilerAfterEmit: AsyncSeries(compilation: &mut Compilation));
-define_hook!(CompilerAssetEmitted: AsyncSeries(compilation: &Compilation, filename: &str, info: &AssetEmittedInfo));
+define_hook!(CompilerShouldEmit: SeriesBail(compilation: &mut Compilation) -> bool);
+define_hook!(CompilerEmit: Series(compilation: &mut Compilation));
+define_hook!(CompilerAfterEmit: Series(compilation: &mut Compilation));
+define_hook!(CompilerAssetEmitted: Series(compilation: &Compilation, filename: &str, info: &AssetEmittedInfo));
 
 #[derive(Debug, Default)]
 pub struct CompilerHooks {

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -54,7 +54,7 @@ use crate::{
 };
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
-define_hook!(ConcatenatedModuleExportsDefinitions: SyncSeriesBail(exports_definitions: &mut ExportsDefinitionArgs, is_entry_module: bool) -> bool);
+define_hook!(ConcatenatedModuleExportsDefinitions: AsyncSeriesBail(exports_definitions: &mut ExportsDefinitionArgs, is_entry_module: bool) -> bool);
 
 #[derive(Debug, Default)]
 pub struct ConcatenatedModuleHooks {
@@ -1030,7 +1030,8 @@ impl Module for ConcatenatedModule {
         .call(
           &mut exports_final_names,
           compilation.chunk_graph.is_entry_module(&self.id),
-        )?;
+        )
+        .await?;
 
       if !matches!(should_skip_render_definitions, Some(true)) {
         runtime_requirements.insert(RuntimeGlobals::EXPORTS);

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -54,7 +54,7 @@ use crate::{
 };
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
-define_hook!(ConcatenatedModuleExportsDefinitions: AsyncSeriesBail(exports_definitions: &mut ExportsDefinitionArgs, is_entry_module: bool) -> bool);
+define_hook!(ConcatenatedModuleExportsDefinitions: SeriesBail(exports_definitions: &mut ExportsDefinitionArgs, is_entry_module: bool) -> bool);
 
 #[derive(Debug, Default)]
 pub struct ConcatenatedModuleHooks {

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -75,8 +75,8 @@ pub struct AfterResolveData {
   pub resolve_dependencies: ResolveContextModuleDependencies,
 }
 
-define_hook!(ContextModuleFactoryBeforeResolve: AsyncSeriesWaterfall(data: BeforeResolveResult) -> BeforeResolveResult);
-define_hook!(ContextModuleFactoryAfterResolve: AsyncSeriesWaterfall(data: AfterResolveResult) -> AfterResolveResult);
+define_hook!(ContextModuleFactoryBeforeResolve: SeriesWaterfall(data: BeforeResolveResult) -> BeforeResolveResult);
+define_hook!(ContextModuleFactoryAfterResolve: SeriesWaterfall(data: AfterResolveResult) -> AfterResolveResult);
 
 #[derive(Debug, Default)]
 pub struct ContextModuleFactoryHooks {

--- a/crates/rspack_core/src/loader/loader_runner.rs
+++ b/crates/rspack_core/src/loader/loader_runner.rs
@@ -16,5 +16,6 @@ pub struct RunnerContext {
 }
 
 unsafe impl Send for RunnerContext {}
+unsafe impl Sync for RunnerContext {}
 
 pub type BoxLoader = Arc<dyn for<'a> Loader<RunnerContext>>;

--- a/crates/rspack_core/src/loader/rspack_loader.rs
+++ b/crates/rspack_core/src/loader/rspack_loader.rs
@@ -41,12 +41,13 @@ impl LoaderRunnerPlugin for RspackLoaderRunnerPlugin {
     Ok(None)
   }
 
-  fn should_yield(&self, context: &LoaderContext<Self::Context>) -> Result<bool> {
+  async fn should_yield(&self, context: &LoaderContext<Self::Context>) -> Result<bool> {
     let res = self
       .plugin_driver
       .normal_module_hooks
       .loader_should_yield
-      .call(context)?;
+      .call(context)
+      .await?;
 
     if let Some(res) = res {
       return Ok(res);

--- a/crates/rspack_core/src/loader/rspack_loader.rs
+++ b/crates/rspack_core/src/loader/rspack_loader.rs
@@ -18,8 +18,13 @@ impl LoaderRunnerPlugin for RspackLoaderRunnerPlugin {
     "rspack-loader-runner"
   }
 
-  fn before_all(&self, context: &mut LoaderContext<Self::Context>) -> Result<()> {
-    self.plugin_driver.normal_module_hooks.loader.call(context)
+  async fn before_all(&self, context: &mut LoaderContext<Self::Context>) -> Result<()> {
+    self
+      .plugin_driver
+      .normal_module_hooks
+      .loader
+      .call(context)
+      .await
   }
 
   async fn process_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -79,7 +79,7 @@ impl ModuleIssuer {
 }
 
 define_hook!(NormalModuleReadResource: AsyncSeriesBail(resource_data: &ResourceData) -> Content);
-define_hook!(NormalModuleLoader: SyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
+define_hook!(NormalModuleLoader: AsyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
 define_hook!(NormalModuleLoaderShouldYield: SyncSeriesBail(loader_context: &LoaderContext<RunnerContext>) -> bool);
 define_hook!(NormalModuleLoaderStartYielding: AsyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
 define_hook!(NormalModuleBeforeLoaders: SyncSeries(module: &mut NormalModule));

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -80,9 +80,9 @@ impl ModuleIssuer {
 
 define_hook!(NormalModuleReadResource: AsyncSeriesBail(resource_data: &ResourceData) -> Content);
 define_hook!(NormalModuleLoader: AsyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
-define_hook!(NormalModuleLoaderShouldYield: SyncSeriesBail(loader_context: &LoaderContext<RunnerContext>) -> bool);
+define_hook!(NormalModuleLoaderShouldYield: AsyncSeriesBail(loader_context: &LoaderContext<RunnerContext>) -> bool);
 define_hook!(NormalModuleLoaderStartYielding: AsyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
-define_hook!(NormalModuleBeforeLoaders: SyncSeries(module: &mut NormalModule));
+define_hook!(NormalModuleBeforeLoaders: AsyncSeries(module: &mut NormalModule));
 define_hook!(NormalModuleAdditionalData: AsyncSeries(additional_data: &mut Option<&mut AdditionalData>));
 
 #[derive(Debug, Default)]
@@ -388,7 +388,8 @@ impl Module for NormalModule {
       .plugin_driver
       .normal_module_hooks
       .before_loaders
-      .call(self)?;
+      .call(self)
+      .await?;
 
     let plugin = Arc::new(RspackLoaderRunnerPlugin {
       plugin_driver: build_context.plugin_driver.clone(),

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -78,12 +78,12 @@ impl ModuleIssuer {
   }
 }
 
-define_hook!(NormalModuleReadResource: AsyncSeriesBail(resource_data: &ResourceData) -> Content);
-define_hook!(NormalModuleLoader: AsyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
-define_hook!(NormalModuleLoaderShouldYield: AsyncSeriesBail(loader_context: &LoaderContext<RunnerContext>) -> bool);
-define_hook!(NormalModuleLoaderStartYielding: AsyncSeries(loader_context: &mut LoaderContext<RunnerContext>));
-define_hook!(NormalModuleBeforeLoaders: AsyncSeries(module: &mut NormalModule));
-define_hook!(NormalModuleAdditionalData: AsyncSeries(additional_data: &mut Option<&mut AdditionalData>));
+define_hook!(NormalModuleReadResource: SeriesBail(resource_data: &ResourceData) -> Content);
+define_hook!(NormalModuleLoader: Series(loader_context: &mut LoaderContext<RunnerContext>));
+define_hook!(NormalModuleLoaderShouldYield: SeriesBail(loader_context: &LoaderContext<RunnerContext>) -> bool);
+define_hook!(NormalModuleLoaderStartYielding: Series(loader_context: &mut LoaderContext<RunnerContext>));
+define_hook!(NormalModuleBeforeLoaders: Series(module: &mut NormalModule));
+define_hook!(NormalModuleAdditionalData: Series(additional_data: &mut Option<&mut AdditionalData>));
 
 #[derive(Debug, Default)]
 pub struct NormalModuleHooks {

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -25,16 +25,16 @@ use crate::{
   ResolverFactory, ResourceData, ResourceParsedData, RunnerContext, SharedPluginDriver,
 };
 
-define_hook!(NormalModuleFactoryBeforeResolve: AsyncSeriesBail(data: &mut ModuleFactoryCreateData) -> bool);
-define_hook!(NormalModuleFactoryFactorize: AsyncSeriesBail(data: &mut ModuleFactoryCreateData) -> BoxModule);
-define_hook!(NormalModuleFactoryResolve: AsyncSeriesBail(data: &mut ModuleFactoryCreateData) -> NormalModuleFactoryResolveResult);
-define_hook!(NormalModuleFactoryResolveForScheme: AsyncSeriesBail(data: &mut ModuleFactoryCreateData, resource_data: &mut ResourceData, for_name: &Scheme) -> bool);
-define_hook!(NormalModuleFactoryResolveInScheme: AsyncSeriesBail(data: &mut ModuleFactoryCreateData, resource_data: &mut ResourceData, for_name: &Scheme) -> bool);
-define_hook!(NormalModuleFactoryAfterResolve: AsyncSeriesBail(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData) -> bool);
-define_hook!(NormalModuleFactoryCreateModule: AsyncSeriesBail(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData) -> BoxModule);
-define_hook!(NormalModuleFactoryModule: AsyncSeries(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData, module: &mut BoxModule));
-define_hook!(NormalModuleFactoryParser: AsyncSeries(module_type: &ModuleType, parser: &mut dyn ParserAndGenerator, parser_options: Option<&ParserOptions>));
-define_hook!(NormalModuleFactoryResolveLoader: AsyncSeriesBail(context: &Context, resolver: &Resolver, l: &ModuleRuleUseLoader) -> BoxLoader);
+define_hook!(NormalModuleFactoryBeforeResolve: SeriesBail(data: &mut ModuleFactoryCreateData) -> bool);
+define_hook!(NormalModuleFactoryFactorize: SeriesBail(data: &mut ModuleFactoryCreateData) -> BoxModule);
+define_hook!(NormalModuleFactoryResolve: SeriesBail(data: &mut ModuleFactoryCreateData) -> NormalModuleFactoryResolveResult);
+define_hook!(NormalModuleFactoryResolveForScheme: SeriesBail(data: &mut ModuleFactoryCreateData, resource_data: &mut ResourceData, for_name: &Scheme) -> bool);
+define_hook!(NormalModuleFactoryResolveInScheme: SeriesBail(data: &mut ModuleFactoryCreateData, resource_data: &mut ResourceData, for_name: &Scheme) -> bool);
+define_hook!(NormalModuleFactoryAfterResolve: SeriesBail(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData) -> bool);
+define_hook!(NormalModuleFactoryCreateModule: SeriesBail(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData) -> BoxModule);
+define_hook!(NormalModuleFactoryModule: Series(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData, module: &mut BoxModule));
+define_hook!(NormalModuleFactoryParser: Series(module_type: &ModuleType, parser: &mut dyn ParserAndGenerator, parser_options: Option<&ParserOptions>));
+define_hook!(NormalModuleFactoryResolveLoader: SeriesBail(context: &Context, resolver: &Resolver, l: &ModuleRuleUseLoader) -> BoxLoader);
 
 pub enum NormalModuleFactoryResolveResult {
   Module(BoxModule),

--- a/crates/rspack_loader_runner/src/plugin.rs
+++ b/crates/rspack_loader_runner/src/plugin.rs
@@ -17,7 +17,7 @@ pub trait LoaderRunnerPlugin: Send + Sync {
     Ok(())
   }
 
-  fn should_yield(&self, _context: &LoaderContext<Self::Context>) -> Result<bool> {
+  async fn should_yield(&self, _context: &LoaderContext<Self::Context>) -> Result<bool> {
     Ok(false)
   }
 

--- a/crates/rspack_loader_runner/src/plugin.rs
+++ b/crates/rspack_loader_runner/src/plugin.rs
@@ -13,7 +13,7 @@ pub trait LoaderRunnerPlugin: Send + Sync {
     "unknown"
   }
 
-  fn before_all(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
+  async fn before_all(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -102,7 +102,7 @@ async fn create_loader_context<Context>(
   };
 
   if let Some(plugin) = loader_context.plugin.clone() {
-    plugin.before_all(&mut loader_context)?;
+    plugin.before_all(&mut loader_context).await?;
   }
 
   Ok(loader_context)
@@ -263,7 +263,7 @@ mod test {
       "test-content"
     }
 
-    fn before_all(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
+    async fn before_all(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
       Ok(())
     }
 

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -16,7 +16,7 @@ use crate::{
 impl<Context> LoaderContext<Context> {
   async fn start_yielding(&mut self) -> Result<bool> {
     if let Some(plugin) = &self.plugin
-      && plugin.should_yield(self)?
+      && plugin.should_yield(self).await?
     {
       plugin.clone().start_yielding(self).await?;
       return Ok(true);

--- a/crates/rspack_macros_test/tests/hook.rs
+++ b/crates/rspack_macros_test/tests/hook.rs
@@ -4,7 +4,7 @@ use rspack_hook::{define_hook, plugin, plugin_hook};
 mod simple {
   use super::*;
 
-  define_hook!(Render: AsyncSeriesBail(compilation: &Compilation, source: &mut Source) -> bool);
+  define_hook!(Render: SeriesBail(compilation: &Compilation, source: &mut Source) -> bool);
 
   struct Compilation {
     id: u32,

--- a/crates/rspack_macros_test/tests/plugin.rs
+++ b/crates/rspack_macros_test/tests/plugin.rs
@@ -1,7 +1,7 @@
 use rspack_macros::{plugin, plugin_hook};
 
 mod mock_hook {
-  pub trait AsyncSeries<T, R> {
+  pub trait Series<T, R> {
     fn run(&self, a: T) -> R;
     fn stage(&self) -> i32 {
       0
@@ -26,17 +26,17 @@ mod named_struct {
     state: usize,
   }
 
-  #[plugin_hook(mock_hook::AsyncSeries<mock_core::Compilation, String> for Plugin)]
+  #[plugin_hook(mock_hook::Series<mock_core::Compilation, String> for Plugin)]
   fn process_assets(&self, _a: mock_core::Compilation) -> String {
     format!("process_assets {} {}", self.options, self.state)
   }
 
-  #[plugin_hook(mock_hook::AsyncSeries<mock_core::Compilation, String> for Plugin, stage = 100)]
+  #[plugin_hook(mock_hook::Series<mock_core::Compilation, String> for Plugin, stage = 100)]
   fn make(&self, _a: mock_core::Compilation) -> String {
     format!("make {} {}", self.options, self.state)
   }
 
-  #[plugin_hook(mock_hook::AsyncSeries<mock_core::Compilation, String> for Plugin, stage = mock_core::BASIC_STAGE)]
+  #[plugin_hook(mock_hook::Series<mock_core::Compilation, String> for Plugin, stage = mock_core::BASIC_STAGE)]
   fn compilation(&self, _a: mock_core::Compilation) -> String {
     format!("compilation {} {}", self.options, self.state)
   }
@@ -47,17 +47,17 @@ mod named_struct {
     let hook1 = &compilation::new(&plugin);
     let hook2 = &make::new(&plugin);
     let hook3 = &process_assets::new(&plugin);
-    let r = mock_hook::AsyncSeries::run(hook1, mock_core::Compilation);
+    let r = mock_hook::Series::run(hook1, mock_core::Compilation);
     assert_eq!(r, "compilation aa 0");
-    let s = mock_hook::AsyncSeries::stage(hook1);
+    let s = mock_hook::Series::stage(hook1);
     assert_eq!(s, 20);
-    let r = mock_hook::AsyncSeries::run(hook2, mock_core::Compilation);
+    let r = mock_hook::Series::run(hook2, mock_core::Compilation);
     assert_eq!(r, "make aa 0");
-    let s = mock_hook::AsyncSeries::stage(hook2);
+    let s = mock_hook::Series::stage(hook2);
     assert_eq!(s, 100);
-    let r = mock_hook::AsyncSeries::run(hook3, mock_core::Compilation);
+    let r = mock_hook::Series::run(hook3, mock_core::Compilation);
     assert_eq!(r, "process_assets aa 0");
-    let s = mock_hook::AsyncSeries::stage(hook3);
+    let s = mock_hook::Series::stage(hook3);
     assert_eq!(s, 0);
   }
 }
@@ -69,17 +69,17 @@ mod unit_struct {
   #[derive(Debug, Default, Clone)]
   struct Plugin;
 
-  #[plugin_hook(mock_hook::AsyncSeries<mock_core::Compilation, String> for Plugin)]
+  #[plugin_hook(mock_hook::Series<mock_core::Compilation, String> for Plugin)]
   fn process_assets(&self, _a: mock_core::Compilation) -> String {
     "process_assets".to_string()
   }
 
-  #[plugin_hook(mock_hook::AsyncSeries<mock_core::Compilation, String> for Plugin, stage = 100)]
+  #[plugin_hook(mock_hook::Series<mock_core::Compilation, String> for Plugin, stage = 100)]
   fn make(&self, _a: mock_core::Compilation) -> String {
     "make".to_string()
   }
 
-  #[plugin_hook(mock_hook::AsyncSeries<mock_core::Compilation, String> for Plugin, stage = mock_core::BASIC_STAGE)]
+  #[plugin_hook(mock_hook::Series<mock_core::Compilation, String> for Plugin, stage = mock_core::BASIC_STAGE)]
   fn compilation(&self, _a: mock_core::Compilation) -> String {
     "compilation".to_string()
   }
@@ -90,17 +90,17 @@ mod unit_struct {
     let hook1 = &compilation::new(&plugin);
     let hook2 = &make::new(&plugin);
     let hook3 = &process_assets::new(&plugin);
-    let r = mock_hook::AsyncSeries::run(hook1, mock_core::Compilation);
+    let r = mock_hook::Series::run(hook1, mock_core::Compilation);
     assert_eq!(r, "compilation");
-    let s = mock_hook::AsyncSeries::stage(hook1);
+    let s = mock_hook::Series::stage(hook1);
     assert_eq!(s, 20);
-    let r = mock_hook::AsyncSeries::run(hook2, mock_core::Compilation);
+    let r = mock_hook::Series::run(hook2, mock_core::Compilation);
     assert_eq!(r, "make");
-    let s = mock_hook::AsyncSeries::stage(hook2);
+    let s = mock_hook::Series::stage(hook2);
     assert_eq!(s, 100);
-    let r = mock_hook::AsyncSeries::run(hook3, mock_core::Compilation);
+    let r = mock_hook::Series::run(hook3, mock_core::Compilation);
     assert_eq!(r, "process_assets");
-    let s = mock_hook::AsyncSeries::stage(hook3);
+    let s = mock_hook::Series::stage(hook3);
     assert_eq!(s, 0);
   }
 }

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -167,7 +167,7 @@ async fn eval_devtool_plugin_js_chunk_hash(
 }
 
 #[plugin_hook(JavascriptModulesInlineInRuntimeBailout for EvalDevToolModulePlugin)]
-fn eval_devtool_plugin_inline_in_runtime_bailout(
+async fn eval_devtool_plugin_inline_in_runtime_bailout(
   &self,
   _compilation: &Compilation,
 ) -> Result<Option<String>> {

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -211,7 +211,7 @@ async fn eval_source_map_devtool_plugin_js_chunk_hash(
 }
 
 #[plugin_hook(JavascriptModulesInlineInRuntimeBailout for EvalSourceMapDevToolPlugin)]
-fn eval_source_map_devtool_plugin_inline_in_runtime_bailout(
+async fn eval_source_map_devtool_plugin_inline_in_runtime_bailout(
   &self,
   _compilation: &Compilation,
 ) -> Result<Option<String>> {

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -683,7 +683,7 @@ async fn render_manifest(
 }
 
 #[plugin_hook(NormalModuleFactoryParser for PluginCssExtract)]
-fn nmf_parser(
+async fn nmf_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut dyn ParserAndGenerator,

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -392,7 +392,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 }
 
 #[plugin_hook(NormalModuleLoader for HotModuleReplacementPlugin)]
-fn normal_module_loader(&self, context: &mut LoaderContext<RunnerContext>) -> Result<()> {
+async fn normal_module_loader(&self, context: &mut LoaderContext<RunnerContext>) -> Result<()> {
   context.hot = true;
   Ok(())
 }

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -398,7 +398,7 @@ fn normal_module_loader(&self, context: &mut LoaderContext<RunnerContext>) -> Re
 }
 
 #[plugin_hook(NormalModuleFactoryParser for HotModuleReplacementPlugin)]
-fn normal_module_factory_parser(
+async fn normal_module_factory_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut dyn ParserAndGenerator,

--- a/crates/rspack_plugin_html/src/drive.rs
+++ b/crates/rspack_plugin_html/src/drive.rs
@@ -52,12 +52,12 @@ pub struct AfterEmitData {
   pub compilation_id: CompilationId,
 }
 
-define_hook!(HtmlPluginBeforeAssetTagGeneration: AsyncSeriesWaterfall(data: BeforeAssetTagGenerationData) -> BeforeAssetTagGenerationData);
-define_hook!(HtmlPluginAlterAssetTags: AsyncSeriesWaterfall(data: AlterAssetTagsData) -> AlterAssetTagsData);
-define_hook!(HtmlPluginAlterAssetTagGroups: AsyncSeriesWaterfall(data: AlterAssetTagGroupsData) -> AlterAssetTagGroupsData);
-define_hook!(HtmlPluginAfterTemplateExecution: AsyncSeriesWaterfall(data: AfterTemplateExecutionData) -> AfterTemplateExecutionData);
-define_hook!(HtmlPluginBeforeEmit: AsyncSeriesWaterfall(data: BeforeEmitData) -> BeforeEmitData);
-define_hook!(HtmlPluginAfterEmit: AsyncSeriesWaterfall(data: AfterEmitData) -> AfterEmitData);
+define_hook!(HtmlPluginBeforeAssetTagGeneration: SeriesWaterfall(data: BeforeAssetTagGenerationData) -> BeforeAssetTagGenerationData);
+define_hook!(HtmlPluginAlterAssetTags: SeriesWaterfall(data: AlterAssetTagsData) -> AlterAssetTagsData);
+define_hook!(HtmlPluginAlterAssetTagGroups: SeriesWaterfall(data: AlterAssetTagGroupsData) -> AlterAssetTagGroupsData);
+define_hook!(HtmlPluginAfterTemplateExecution: SeriesWaterfall(data: AfterTemplateExecutionData) -> AfterTemplateExecutionData);
+define_hook!(HtmlPluginBeforeEmit: SeriesWaterfall(data: BeforeEmitData) -> BeforeEmitData);
+define_hook!(HtmlPluginAfterEmit: SeriesWaterfall(data: AfterEmitData) -> AfterEmitData);
 
 #[derive(Debug, Default)]
 pub struct HtmlPluginHooks {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/mod.rs
@@ -85,7 +85,7 @@ async fn compilation(
 }
 
 #[plugin_hook(NormalModuleFactoryParser for DefinePlugin)]
-fn nmf_parser(
+async fn nmf_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut dyn ParserAndGenerator,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
@@ -144,7 +144,7 @@ impl JavascriptParserPlugin for ProvidePlugin {
 }
 
 #[plugin_hook(NormalModuleFactoryParser for ProvidePlugin)]
-fn nmf_parser(
+async fn nmf_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut dyn ParserAndGenerator,

--- a/crates/rspack_plugin_javascript/src/plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/drive.rs
@@ -5,16 +5,16 @@ use rspack_core::{
 use rspack_hash::RspackHash;
 use rspack_hook::define_hook;
 
-define_hook!(JavascriptModulesRenderChunk: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource));
-define_hook!(JavascriptModulesRender: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource));
-define_hook!(JavascriptModulesRenderStartup: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &ModuleIdentifier, source: &mut RenderSource));
-define_hook!(JavascriptModulesRenderModuleContent: AsyncSeries(compilation: &Compilation, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
-define_hook!(JavascriptModulesRenderModuleContainer: AsyncSeries(compilation: &Compilation, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
-define_hook!(JavascriptModulesRenderModulePackage: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
-define_hook!(JavascriptModulesChunkHash: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash));
-define_hook!(JavascriptModulesInlineInRuntimeBailout: AsyncSeriesBail(compilation: &Compilation) -> String);
-define_hook!(JavascriptModulesEmbedInRuntimeBailout: AsyncSeriesBail(compilation: &Compilation, module: &BoxModule, chunk: &Chunk) -> String);
-define_hook!(JavascriptModulesStrictRuntimeBailout: AsyncSeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> String);
+define_hook!(JavascriptModulesRenderChunk: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource));
+define_hook!(JavascriptModulesRender: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource));
+define_hook!(JavascriptModulesRenderStartup: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &ModuleIdentifier, source: &mut RenderSource));
+define_hook!(JavascriptModulesRenderModuleContent: Series(compilation: &Compilation, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
+define_hook!(JavascriptModulesRenderModuleContainer: Series(compilation: &Compilation, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
+define_hook!(JavascriptModulesRenderModulePackage: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
+define_hook!(JavascriptModulesChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash));
+define_hook!(JavascriptModulesInlineInRuntimeBailout: SeriesBail(compilation: &Compilation) -> String);
+define_hook!(JavascriptModulesEmbedInRuntimeBailout: SeriesBail(compilation: &Compilation, module: &BoxModule, chunk: &Chunk) -> String);
+define_hook!(JavascriptModulesStrictRuntimeBailout: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> String);
 
 #[derive(Debug, Default)]
 pub struct JavascriptModulesPluginHooks {

--- a/crates/rspack_plugin_javascript/src/plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/drive.rs
@@ -12,9 +12,9 @@ define_hook!(JavascriptModulesRenderModuleContent: AsyncSeries(compilation: &Com
 define_hook!(JavascriptModulesRenderModuleContainer: AsyncSeries(compilation: &Compilation, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
 define_hook!(JavascriptModulesRenderModulePackage: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &BoxModule, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments));
 define_hook!(JavascriptModulesChunkHash: AsyncSeries(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash));
-define_hook!(JavascriptModulesInlineInRuntimeBailout: SyncSeriesBail(compilation: &Compilation) -> String);
-define_hook!(JavascriptModulesEmbedInRuntimeBailout: SyncSeriesBail(compilation: &Compilation, module: &BoxModule, chunk: &Chunk) -> String);
-define_hook!(JavascriptModulesStrictRuntimeBailout: SyncSeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> String);
+define_hook!(JavascriptModulesInlineInRuntimeBailout: AsyncSeriesBail(compilation: &Compilation) -> String);
+define_hook!(JavascriptModulesEmbedInRuntimeBailout: AsyncSeriesBail(compilation: &Compilation, module: &BoxModule, chunk: &Chunk) -> String);
+define_hook!(JavascriptModulesStrictRuntimeBailout: AsyncSeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> String);
 
 #[derive(Debug, Default)]
 pub struct JavascriptModulesPluginHooks {

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -167,7 +167,9 @@ async fn chunk_hash(
     .expect_get(chunk_ukey)
     .has_runtime(&compilation.chunk_group_by_ukey)
   {
-    self.update_hash_with_bootstrap(chunk_ukey, compilation, hasher)?;
+    self
+      .update_hash_with_bootstrap(chunk_ukey, compilation, hasher)
+      .await?;
   }
   Ok(())
 }
@@ -185,7 +187,9 @@ async fn content_hash(
     .or_insert_with(|| RspackHash::from(&compilation.options.output));
 
   if chunk.has_runtime(&compilation.chunk_group_by_ukey) {
-    self.update_hash_with_bootstrap(chunk_ukey, compilation, hasher)?;
+    self
+      .update_hash_with_bootstrap(chunk_ukey, compilation, hasher)
+      .await?;
   } else {
     chunk.id(&compilation.chunk_ids_artifact).hash(&mut hasher);
   }

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -364,7 +364,7 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(JavascriptModulesEmbedInRuntimeBailout for AssignLibraryPlugin)]
-fn embed_in_runtime_bailout(
+async fn embed_in_runtime_bailout(
   &self,
   compilation: &Compilation,
   module: &BoxModule,
@@ -398,7 +398,7 @@ fn embed_in_runtime_bailout(
 }
 
 #[plugin_hook(JavascriptModulesStrictRuntimeBailout for AssignLibraryPlugin)]
-fn strict_runtime_bailout(
+async fn strict_runtime_bailout(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -403,7 +403,7 @@ async fn compilation(
 }
 
 #[plugin_hook(ConcatenatedModuleExportsDefinitions for ModernModuleLibraryPlugin)]
-fn exports_definitions(
+async fn exports_definitions(
   &self,
   _exports_definitions: &mut Vec<(String, String)>,
   is_entry_module: bool,

--- a/crates/rspack_plugin_real_content_hash/src/drive.rs
+++ b/crates/rspack_plugin_real_content_hash/src/drive.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rspack_core::{rspack_sources::Source, Compilation};
 use rspack_hook::define_hook;
 
-define_hook!(RealContentHashPluginUpdateHash: AsyncSeriesBail(compilation: &Compilation, assets: &[Arc<dyn Source>], old_hash: &str) -> String);
+define_hook!(RealContentHashPluginUpdateHash: SeriesBail(compilation: &Compilation, assets: &[Arc<dyn Source>], old_hash: &str) -> String);
 
 #[derive(Debug, Default)]
 pub struct RealContentHashPluginHooks {

--- a/crates/rspack_plugin_rsdoctor/src/drive.rs
+++ b/crates/rspack_plugin_rsdoctor/src/drive.rs
@@ -5,11 +5,11 @@ use crate::{
   RsdoctorModuleSourcesPatch,
 };
 
-define_hook!(RsdoctorPluginModuleGraph: AsyncSeriesBail(data: &mut RsdoctorModuleGraph) -> bool);
-define_hook!(RsdoctorPluginChunkGraph: AsyncSeriesBail(data: &mut RsdoctorChunkGraph) -> bool);
-define_hook!(RsdoctorPluginModuleIds: AsyncSeriesBail(data: &mut RsdoctorModuleIdsPatch) -> bool);
-define_hook!(RsdoctorPluginModuleSources: AsyncSeriesBail(data: &mut RsdoctorModuleSourcesPatch) -> bool);
-define_hook!(RsdoctorPluginAssets: AsyncSeriesBail(data: &mut RsdoctorAssetPatch) -> bool);
+define_hook!(RsdoctorPluginModuleGraph: SeriesBail(data: &mut RsdoctorModuleGraph) -> bool);
+define_hook!(RsdoctorPluginChunkGraph: SeriesBail(data: &mut RsdoctorChunkGraph) -> bool);
+define_hook!(RsdoctorPluginModuleIds: SeriesBail(data: &mut RsdoctorModuleIdsPatch) -> bool);
+define_hook!(RsdoctorPluginModuleSources: SeriesBail(data: &mut RsdoctorModuleSourcesPatch) -> bool);
+define_hook!(RsdoctorPluginAssets: SeriesBail(data: &mut RsdoctorAssetPatch) -> bool);
 
 #[derive(Debug, Default)]
 pub struct RsdoctorPluginHooks {

--- a/crates/rspack_plugin_runtime/src/drive.rs
+++ b/crates/rspack_plugin_runtime/src/drive.rs
@@ -30,9 +30,9 @@ pub struct RuntimeModuleChunkWrapper {
 
 unsafe impl Send for RuntimeModuleChunkWrapper {}
 
-define_hook!(RuntimePluginCreateScript: AsyncSeriesWaterfall(data: CreateScriptData) -> CreateScriptData);
-define_hook!(RuntimePluginLinkPreload: AsyncSeriesWaterfall(data: LinkPreloadData) -> LinkPreloadData);
-define_hook!(RuntimePluginLinkPrefetch: AsyncSeriesWaterfall(data: LinkPrefetchData) -> LinkPrefetchData);
+define_hook!(RuntimePluginCreateScript: SeriesWaterfall(data: CreateScriptData) -> CreateScriptData);
+define_hook!(RuntimePluginLinkPreload: SeriesWaterfall(data: LinkPreloadData) -> LinkPreloadData);
+define_hook!(RuntimePluginLinkPrefetch: SeriesWaterfall(data: LinkPrefetchData) -> LinkPrefetchData);
 
 #[derive(Debug, Default)]
 pub struct RuntimePluginHooks {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

There is no need to use sync hook in rust:
- Modify all sync hooks to async
- Remove macros of sync hook
- Rename async hook trait, remove `async` in their names cause

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
