### PR TITLE
refactor: clean threadsafe function methods

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1454,7 +1454,7 @@ export interface RawAssetResourceGeneratorOptions {
 }
 
 export interface RawBannerPluginOptions {
-  banner: string | ((...args: any[]) => any)
+  banner: string | ((args: { hash: string, chunk: JsChunk, filename: string }) => string)
   entryOnly?: boolean
   footer?: boolean
   raw?: boolean

--- a/crates/node_binding/src/module.rs
+++ b/crates/node_binding/src/module.rs
@@ -559,7 +559,7 @@ impl From<JsAddingRuntimeModule> for RuntimeModuleFromJs {
       stage: RuntimeModuleStage::from(value.stage),
       generator: Arc::new(move || {
         let generator = value.generator.clone();
-        Box::pin(async move { generator.call(()).await })
+        Box::pin(async move { generator.call_with_sync(()).await })
       }),
       source_map_kind: SourceMapKind::empty(),
       custom_source: None,

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_banner.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_banner.rs
@@ -38,7 +38,7 @@ impl TryFrom<RawBannerContentWrapper> for BannerContent {
         move |ctx: BannerContentFnCtx| {
           let ctx = ctx.into();
           let f = f.clone();
-          Box::pin(async move { f.call(ctx).await })
+          Box::pin(async move { f.call_with_sync(ctx).await })
         },
       ))),
     }
@@ -49,7 +49,9 @@ impl TryFrom<RawBannerContentWrapper> for BannerContent {
 #[napi(object, object_to_js = false)]
 pub struct RawBannerPluginOptions {
   #[debug(skip)]
-  #[napi(ts_type = "string | ((...args: any[]) => any)")]
+  #[napi(
+    ts_type = "string | ((args: { hash: string, chunk: JsChunk, filename: string }) => string)"
+  )]
   pub banner: RawBannerContent,
   pub entry_only: Option<bool>,
   pub footer: Option<bool>,

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_circular_dependency.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_circular_dependency.rs
@@ -55,7 +55,7 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
         let callback = callback.clone();
         Box::pin(async move {
           callback
-            .call((entrypoint, modules, JsCompilationWrapper::new(compilation)))
+            .call_with_sync((entrypoint, modules, JsCompilationWrapper::new(compilation)))
             .await?;
           Ok(())
         })
@@ -68,7 +68,7 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
           let callback = callback.clone();
           async move {
             callback
-              .call((entrypoint, modules, JsCompilationWrapper::new(compilation)))
+              .call_with_sync((entrypoint, modules, JsCompilationWrapper::new(compilation)))
               .await?;
             Ok(())
           }
@@ -82,7 +82,7 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
         Box::pin({
           async move {
             callback
-              .call(JsCompilationWrapper::new(compilation))
+              .call_with_sync(JsCompilationWrapper::new(compilation))
               .await?;
             Ok(())
           }
@@ -96,7 +96,7 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
         Box::pin({
           async move {
             callback
-              .call(JsCompilationWrapper::new(compilation))
+              .call_with_sync(JsCompilationWrapper::new(compilation))
               .await?;
             Ok(())
           }

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
@@ -117,7 +117,7 @@ impl From<RawCopyPattern> for CopyPattern {
         Either::B(f) => ToOption::Fn(Box::new(move |ctx| {
           let f = f.clone();
           Box::pin(async move {
-            f.call(RawToOptions {
+            f.call_with_sync(RawToOptions {
               context: ctx.context.as_str().to_owned(),
               absolute_filename: Some(ctx.absolute_filename.as_str().to_owned()),
             })
@@ -167,7 +167,7 @@ impl From<RawCopyPattern> for CopyPattern {
             }
 
             Box::pin(async move {
-              f.call((input.into(), absolute_filename.to_owned()))
+              f.call_with_sync((input.into(), absolute_filename.to_owned()))
                 .await
                 .map(convert_to_enum)
             })
@@ -185,7 +185,7 @@ impl From<RawCopyPattern> for CopyPattern {
           }
 
           Box::pin(async move {
-            f.call((input.into(), absolute_filename.to_owned()))
+            f.call_with_sync((input.into(), absolute_filename.to_owned()))
               .await
               .map(convert_to_enum)
           })

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_ignore.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_ignore.rs
@@ -26,7 +26,10 @@ impl From<RawIgnorePluginOptions> for IgnorePluginOptions {
         CheckResourceContent::Fn(Box::new(move |resource, context| {
           let f = check_resource.clone();
 
-          Box::pin(async move { f.call((resource.to_owned(), context.to_owned())).await })
+          Box::pin(async move {
+            f.call_with_sync((resource.to_owned(), context.to_owned()))
+              .await
+          })
         }))
       }),
     }

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_lazy_compilation.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_lazy_compilation.rs
@@ -54,7 +54,7 @@ impl LazyCompilationTestCheck for LazyCompilationTestFn {
     #[allow(clippy::unwrap_used)]
     let res = self
       .tsfn
-      .call(ModuleObject::with_ptr(
+      .call_with_sync(ModuleObject::with_ptr(
         NonNull::new(m as *const dyn Module as *mut dyn Module).unwrap(),
         compiler_id,
       ))
@@ -128,7 +128,7 @@ impl Backend for JsBackend {
   ) -> rspack_error::Result<ModuleInfo> {
     let module_info = self
       .module
-      .call(RawModuleArg {
+      .call_with_sync(RawModuleArg {
         module: identifier.to_string(),
         path,
       })

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_progress.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_progress.rs
@@ -31,7 +31,7 @@ impl From<RawProgressPluginOptions> for ProgressPluginOptions {
     if let Some(f) = value.handler {
       Self::Handler(Arc::new(move |percent, msg, items| {
         let f = f.clone();
-        Box::pin(async move { f.call((percent, msg, items)).await })
+        Box::pin(async move { f.call_with_sync((percent, msg, items)).await })
       }))
     } else {
       Self::Default(ProgressPluginDisplayOptions {

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_runtime_chunk.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_runtime_chunk.rs
@@ -40,7 +40,7 @@ impl From<RawRuntimeChunkNameWrapper> for RuntimeChunkName {
       Either::B(f) => RuntimeChunkName::Fn(Box::new(move |name| {
         let f = f.clone();
         Box::pin(async move {
-          f.call(RawRuntimeChunkNameFnCtx {
+          f.call_with_sync(RawRuntimeChunkNameFnCtx {
             name: name.to_string(),
           })
           .await

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_size_limits.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_size_limits.rs
@@ -22,7 +22,7 @@ impl From<RawSizeLimitsPluginOptions> for SizeLimitsPluginOptions {
         let asset_filter_fn: AssetFilterFn = Box::new(move |name| {
           let f = asset_filter.clone();
 
-          Box::pin(async move { f.call(name.to_owned()).await })
+          Box::pin(async move { f.call_with_sync(name.to_owned()).await })
         });
         asset_filter_fn
       }),

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_sri.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_sri.rs
@@ -28,7 +28,7 @@ impl From<RawSubresourceIntegrityPluginOptions> for SubresourceIntegrityPluginOp
       integrity_callback: if let Some(func) = options.integrity_callback {
         Some(Arc::new(move |data| {
           let func = func.clone();
-          Box::pin(async move { func.call(data.into()).await })
+          Box::pin(async move { func.call_with_sync(data.into()).await })
         }))
       } else {
         None

--- a/crates/node_binding/src/raw_options/raw_devtool.rs
+++ b/crates/node_binding/src/raw_options/raw_devtool.rs
@@ -41,7 +41,7 @@ fn normalize_raw_append(raw: RawAppend) -> Append {
     Either3::C(v) => Append::Fn(Box::new(move |ctx| {
       let v = v.clone();
       let value = ctx.into();
-      Box::pin(async move { v.call(value).await })
+      Box::pin(async move { v.call_with_sync(value).await })
     })),
   }
 }
@@ -92,7 +92,7 @@ fn normalize_raw_module_filename_template(
     Either::A(str) => ModuleFilenameTemplate::String(str),
     Either::B(v) => ModuleFilenameTemplate::Fn(Arc::new(move |ctx| {
       let v = v.clone();
-      Box::pin(async move { v.call(ctx.into()).await })
+      Box::pin(async move { v.call_with_sync(ctx.into()).await })
     })),
   }
 }

--- a/crates/node_binding/src/raw_options/raw_dynamic_entry.rs
+++ b/crates/node_binding/src/raw_options/raw_dynamic_entry.rs
@@ -1,3 +1,4 @@
+use napi::bindgen_prelude::Promise;
 use napi_derive::napi;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_dynamic_entry::{DynamicEntryPluginOptions, EntryDynamicResult};
@@ -11,7 +12,7 @@ pub struct RawEntryDynamicResult {
   pub options: JsEntryOptions,
 }
 
-pub type RawEntryDynamic = ThreadsafeFunction<(), Vec<RawEntryDynamicResult>>;
+pub type RawEntryDynamic = ThreadsafeFunction<(), Promise<Vec<RawEntryDynamicResult>>>;
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
@@ -28,7 +29,7 @@ impl From<RawDynamicEntryPluginOptions> for DynamicEntryPluginOptions {
       entry: Box::new(move || {
         let f = opts.entry.clone();
         Box::pin(async move {
-          let raw_result = f.call(()).await?;
+          let raw_result = f.call_with_promise(()).await?;
           let result = raw_result
             .into_iter()
             .map(

--- a/crates/node_binding/src/raw_options/raw_external.rs
+++ b/crates/node_binding/src/raw_options/raw_external.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
-use napi::bindgen_prelude::Either4;
+use napi::bindgen_prelude::{Either4, Promise};
 use napi_derive::napi;
 use rspack_core::{
   ExternalItem, ExternalItemFnCtx, ExternalItemFnResult, ExternalItemValue,
@@ -30,7 +30,7 @@ type RawExternalItem = Either4<
   String,
   RspackRegex,
   HashMap<String, RawExternalItemValue>,
-  ThreadsafeFunction<RawExternalItemFnCtx, RawExternalItemFnResult>,
+  ThreadsafeFunction<RawExternalItemFnCtx, Promise<RawExternalItemFnResult>>,
 >;
 type RawExternalItemValue = Either4<String, bool, Vec<String>, HashMap<String, Vec<String>>>;
 pub(crate) struct RawExternalItemWrapper(pub(crate) RawExternalItem);
@@ -144,7 +144,7 @@ impl TryFrom<RawExternalItemWrapper> for ExternalItem {
       )),
       Either4::D(v) => Ok(Self::Fn(Box::new(move |ctx: ExternalItemFnCtx| {
         let v = v.clone();
-        Box::pin(async move { v.call(ctx.into()).await.map(|r| r.into()) })
+        Box::pin(async move { v.call_with_promise(ctx.into()).await.map(|r| r.into()) })
       }))),
     }
   }

--- a/crates/node_binding/src/raw_options/raw_module/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_module/mod.rs
@@ -130,7 +130,7 @@ impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetCondition {
       RawRuleSetCondition::func(f) => Self::Func(Box::new(move |data| {
         let data = data.to_value();
         let f = f.clone();
-        Box::pin(async move { f.call(data).await })
+        Box::pin(async move { f.call_with_sync(data).await })
       })),
     };
 
@@ -468,7 +468,7 @@ impl From<RawJsonParserOptions> for JsonParserOptions {
     let parse = match value.parse {
       Some(f) => ParseOption::Func(Arc::new(move |s: String| {
         let f = f.clone();
-        Box::pin(async move { f.call(s).await })
+        Box::pin(async move { f.call_with_sync(s).await })
       })),
       _ => ParseOption::None,
     };
@@ -660,7 +660,7 @@ impl From<RawAssetGeneratorDataUrlWrapper> for AssetGeneratorDataUrl {
         let b = b.clone();
         let source = source.into();
         let ctx = ctx.into();
-        Box::pin(async move { b.call((source, ctx)).await })
+        Box::pin(async move { b.call_with_sync((source, ctx)).await })
       })),
     }
   }
@@ -806,7 +806,7 @@ impl TryFrom<RawModuleRule> for ModuleRule {
         move |ctx: FuncUseCtx| {
           let tsfn = tsfn.clone();
           Box::pin(async move {
-            tsfn.call(ctx.into()).await.map(|uses| {
+            tsfn.call_with_sync(ctx.into()).await.map(|uses| {
               uses
                 .into_iter()
                 .map(|rule_use| ModuleRuleUseLoader {
@@ -957,7 +957,7 @@ fn js_func_to_no_parse_test_func(
 ) -> ModuleNoParseTestFn {
   Box::new(move |s| {
     let v = v.clone();
-    Box::pin(async move { v.call(s).await.map(|v| v.unwrap_or_default()) })
+    Box::pin(async move { v.call_with_sync(s).await.map(|v| v.unwrap_or_default()) })
   })
 }
 

--- a/crates/node_binding/src/raw_options/raw_split_chunks/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_split_chunks/mod.rs
@@ -331,7 +331,7 @@ fn create_module_layer_filter(
     }
     Either3::C(f) => Arc::new(move |layer| {
       let f = f.clone();
-      Box::pin(async move { f.call(layer).await })
+      Box::pin(async move { f.call_with_sync(layer).await })
     }),
   }
 }

--- a/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
+++ b/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
@@ -32,7 +32,7 @@ pub(super) fn normalize_raw_cache_group_test(raw: RawCacheGroupTest) -> CacheGro
     Either3::C(v) => CacheGroupTest::Fn(Arc::new(move |ctx| {
       let ctx = ctx.into();
       let v = v.clone();
-      Box::pin(async move { v.call(ctx).await })
+      Box::pin(async move { v.call_with_sync(ctx).await })
     })),
   }
 }

--- a/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
+++ b/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
@@ -19,7 +19,7 @@ pub fn create_chunks_filter(raw: Chunks) -> rspack_plugin_split_chunks::ChunkFil
     Either3::C(f) => Arc::new(move |chunk, compilation| {
       let f = f.clone();
       let chunk_wrapper = JsChunkWrapper::new(chunk.ukey(), compilation);
-      Box::pin(async move { f.call(chunk_wrapper).await })
+      Box::pin(async move { f.call_with_sync(chunk_wrapper).await })
     }),
   }
 }

--- a/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_name.rs
+++ b/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_name.rs
@@ -46,7 +46,7 @@ pub(super) fn normalize_raw_chunk_name(raw: RawChunkOptionName) -> ChunkNameGett
     Either3::C(v) => ChunkNameGetter::Fn(Arc::new(move |ctx: ChunkNameGetterFnCtx| {
       let ctx = ctx.into();
       let v = v.clone();
-      Box::pin(async move { v.call(ctx).await })
+      Box::pin(async move { v.call_with_sync(ctx).await })
     })),
   }
 }

--- a/crates/rspack_napi/src/threadsafe_function.rs
+++ b/crates/rspack_napi/src/threadsafe_function.rs
@@ -5,12 +5,10 @@ use std::{
 };
 
 use napi::{
-  bindgen_prelude::{
-    Either3, Either4, FromNapiValue, JsValuesTupleIntoVec, Promise, TypeName, ValidateNapiValue,
-  },
+  bindgen_prelude::{FromNapiValue, JsValuesTupleIntoVec, Promise, TypeName, ValidateNapiValue},
   sys::{self, napi_env},
   threadsafe_function::{ThreadsafeFunction as RawThreadsafeFunction, ThreadsafeFunctionCallMode},
-  Either, Env, JsUnknown as Unknown, NapiRaw, Status, ValueType,
+  Env, JsUnknown as Unknown, NapiRaw, ValueType,
 };
 use oneshot::Receiver;
 use rspack_error::{miette::IntoDiagnostic, Error, Result};
@@ -99,22 +97,6 @@ impl<T: 'static + JsValuesTupleIntoVec, R> ThreadsafeFunction<T, R> {
     let rx = self.call_with_return(value);
     rx.await.expect("failed to receive tsfn value")
   }
-
-  fn blocking_call<D: 'static + FromNapiValue>(&self, value: T) -> Result<D> {
-    let rx = self.call_with_return(value);
-    rx.recv().expect("failed to receive tsfn value")
-  }
-}
-
-impl<T: 'static + JsValuesTupleIntoVec, R> ThreadsafeFunction<T, R> {
-  /// Synchronously call JS function and report error as `uncaughtException`.
-  /// See: [napi_create_threadsafe_function](https://nodejs.org/dist/latest/docs/api/n-api.html#napi_create_threadsafe_function)
-  pub fn call_with_fatal(&self, value: T) {
-    let status = self
-      .inner
-      .call(value, ThreadsafeFunctionCallMode::NonBlocking);
-    debug_assert_eq!(status, Status::Ok, "failed to call tsfn with fatal")
-  }
 }
 
 impl<T: 'static + JsValuesTupleIntoVec, R: 'static + FromNapiValue> ThreadsafeFunction<T, R> {
@@ -124,30 +106,10 @@ impl<T: 'static + JsValuesTupleIntoVec, R: 'static + FromNapiValue> ThreadsafeFu
   }
 
   /// Call the JS function with blocking.
+  /// Deprecated: will be removed in the future.
   pub fn blocking_call_with_sync(&self, value: T) -> Result<R> {
-    self.blocking_call::<R>(value)
-  }
-}
-
-impl<T: 'static + JsValuesTupleIntoVec, R: 'static + FromNapiValue + ValidateNapiValue>
-  ThreadsafeFunction<T, R>
-{
-  /// Call the JS function.
-  /// This method expects the returned value of JS function to be a `Promise<R>` or `R`.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  ///
-  /// ## Warning
-  /// This method is **NOT** recommended to be used in most cases. It makes return value ambiguous.
-  pub async fn call(&self, value: T) -> Result<R> {
-    match self.call_async::<Either<Promise<R>, R>>(value).await {
-      Ok(Either::A(r)) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-      Ok(Either::B(r)) => Ok(r),
-      Err(err) => Err(err),
-    }
+    let rx = self.call_with_return(value);
+    rx.recv().expect("failed to receive tsfn value")
   }
 }
 
@@ -164,220 +126,6 @@ impl<T: 'static + JsValuesTupleIntoVec, R: 'static + FromNapiValue>
         Err(err) => Err(self.resolve_error(err).await),
       },
       Err(err) => Err(err),
-    }
-  }
-}
-
-impl<
-    T: 'static + JsValuesTupleIntoVec,
-    R: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-  > ThreadsafeFunction<T, Either<Promise<R>, R>>
-{
-  /// Call the JS function and resolve the returned value depending on its type.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  pub async fn call_with_auto(&self, value: T) -> Result<R> {
-    match self.call_async::<Either<Promise<R>, R>>(value).await? {
-      Either::A(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-      Either::B(r) => Ok(r),
-    }
-  }
-}
-
-impl<
-    T: 'static + JsValuesTupleIntoVec,
-    R: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-  > ThreadsafeFunction<T, Either<R, Promise<R>>>
-{
-  /// Call the JS function and resolve the returned value depending on its type.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  pub async fn call_with_auto(&self, value: T) -> Result<R> {
-    match self.call_async::<Either<R, Promise<R>>>(value).await? {
-      Either::A(r) => Ok(r),
-      Either::B(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-    }
-  }
-}
-
-impl<
-    T: 'static + JsValuesTupleIntoVec,
-    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-  > ThreadsafeFunction<T, Either3<T0, T1, Promise<Either<T0, T1>>>>
-{
-  /// Call the JS function and resolve the returned value depending on its type.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  pub async fn call_with_auto(&self, value: T) -> Result<Either<T0, T1>> {
-    match self
-      .call_async::<Either3<T0, T1, Promise<Either<T0, T1>>>>(value)
-      .await?
-    {
-      Either3::A(r) => Ok(Either::A(r)),
-      Either3::B(r) => Ok(Either::B(r)),
-      Either3::C(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-    }
-  }
-}
-
-impl<
-    T: 'static + JsValuesTupleIntoVec,
-    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-  > ThreadsafeFunction<T, Either3<T0, Promise<Either<T0, T1>>, T1>>
-{
-  /// Call the JS function and resolve the returned value depending on its type.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  pub async fn call_with_auto(&self, value: T) -> Result<Either<T0, T1>> {
-    match self
-      .call_async::<Either3<T0, Promise<Either<T0, T1>>, T1>>(value)
-      .await?
-    {
-      Either3::A(r) => Ok(Either::A(r)),
-      Either3::B(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-      Either3::C(r) => Ok(Either::B(r)),
-    }
-  }
-}
-
-impl<
-    T: 'static + JsValuesTupleIntoVec,
-    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-  > ThreadsafeFunction<T, Either3<Promise<Either<T0, T1>>, T0, T1>>
-{
-  /// Call the JS function and resolve the returned value depending on its type.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  pub async fn call_with_auto(&self, value: T) -> Result<Either<T0, T1>> {
-    match self
-      .call_async::<Either3<Promise<Either<T0, T1>>, T0, T1>>(value)
-      .await?
-    {
-      Either3::A(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-      Either3::B(r) => Ok(Either::A(r)),
-      Either3::C(r) => Ok(Either::B(r)),
-    }
-  }
-}
-
-impl<
-    T: 'static + JsValuesTupleIntoVec,
-    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T2: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-  > ThreadsafeFunction<T, Either4<T0, T1, T2, Promise<Either3<T0, T1, T2>>>>
-{
-  /// Call the JS function and resolve the returned value depending on its type.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  pub async fn call_with_auto(&self, value: T) -> Result<Either3<T0, T1, T2>> {
-    match self
-      .call_async::<Either4<T0, T1, T2, Promise<Either3<T0, T1, T2>>>>(value)
-      .await?
-    {
-      Either4::A(r) => Ok(Either3::A(r)),
-      Either4::B(r) => Ok(Either3::B(r)),
-      Either4::C(r) => Ok(Either3::C(r)),
-      Either4::D(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-    }
-  }
-}
-
-impl<
-    T: 'static + JsValuesTupleIntoVec,
-    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T2: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-  > ThreadsafeFunction<T, Either4<T0, T1, Promise<Either3<T0, T1, T2>>, T2>>
-{
-  /// Call the JS function and resolve the returned value depending on its type.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  pub async fn call_with_auto(&self, value: T) -> Result<Either3<T0, T1, T2>> {
-    match self
-      .call_async::<Either4<T0, T1, Promise<Either3<T0, T1, T2>>, T2>>(value)
-      .await?
-    {
-      Either4::A(r) => Ok(Either3::A(r)),
-      Either4::B(r) => Ok(Either3::B(r)),
-      Either4::C(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-      Either4::D(r) => Ok(Either3::C(r)),
-    }
-  }
-}
-
-impl<
-    T: 'static + JsValuesTupleIntoVec,
-    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T2: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-  > ThreadsafeFunction<T, Either4<T0, Promise<Either3<T0, T1, T2>>, T1, T2>>
-{
-  /// Call the JS function and resolve the returned value depending on its type.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  pub async fn call_with_auto(&self, value: T) -> Result<Either3<T0, T1, T2>> {
-    match self
-      .call_async::<Either4<T0, Promise<Either3<T0, T1, T2>>, T1, T2>>(value)
-      .await?
-    {
-      Either4::A(r) => Ok(Either3::A(r)),
-      Either4::B(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-      Either4::C(r) => Ok(Either3::B(r)),
-      Either4::D(r) => Ok(Either3::C(r)),
-    }
-  }
-}
-
-impl<
-    T: 'static + JsValuesTupleIntoVec,
-    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-    T2: 'static + FromNapiValue + ValidateNapiValue + TypeName,
-  > ThreadsafeFunction<T, Either4<Promise<Either3<T0, T1, T2>>, T0, T1, T2>>
-{
-  /// Call the JS function and resolve the returned value depending on its type.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, if `T` is returned, it will be returned as-is.
-  pub async fn call_with_auto(&self, value: T) -> Result<Either3<T0, T1, T2>> {
-    match self
-      .call_async::<Either4<Promise<Either3<T0, T1, T2>>, T0, T1, T2>>(value)
-      .await?
-    {
-      Either4::A(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-      Either4::B(r) => Ok(Either3::A(r)),
-      Either4::C(r) => Ok(Either3::B(r)),
-      Either4::D(r) => Ok(Either3::C(r)),
     }
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Clean threadsafe function methods:
- Remove `call_with_auto` and `call_with_fatal ` which is never used
- Remove `call` which can be replaced with `call_with_sync` or `call_with_promise`
- Replace all `call` to `call_with_sync` or `call_with_promise`, according to their function types


> The napi binding function types should not support both sync and async modes. The logic of compatibility should be written in JavaScript.

> The `blocking_call_with_sync` will be removed in the future

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
