### PR TITLE
feat: support alias false

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -2211,8 +2211,8 @@ export interface RawResolveOptions {
   mainFiles?: Array<string>
   mainFields?: Array<string>
   conditionNames?: Array<string>
-  alias?: Array<RawAliasOptionItem>
-  fallback?: Array<RawAliasOptionItem>
+  alias?: Array<RawAliasOptionItem> | false
+  fallback?: Array<RawAliasOptionItem> | false
   symlinks?: boolean
   tsconfig?: RawResolveTsconfigOptions
   modules?: Array<string>
@@ -2236,8 +2236,8 @@ export interface RawResolveOptionsWithDependencyType {
   mainFiles?: Array<string>
   mainFields?: Array<string>
   conditionNames?: Array<string>
-  alias?: Array<RawAliasOptionItem>
-  fallback?: Array<RawAliasOptionItem>
+  alias?: Array<RawAliasOptionItem> | false
+  fallback?: Array<RawAliasOptionItem> | false
   symlinks?: boolean
   tsconfig?: RawResolveTsconfigOptions
   modules?: Array<string>

--- a/crates/node_binding/src/resolver.rs
+++ b/crates/node_binding/src/resolver.rs
@@ -61,14 +61,13 @@ impl JsResolver {
       Ok(mut options) => {
         options.resolve_options = match options.resolve_options.take() {
           Some(resolve_options) => match &self.options.resolve_options {
-            Some(origin_resolve_options) => Some(Box::new(
-              resolve_options.merge(*origin_resolve_options.clone()),
+            Some(base_resolve_options) => Some(Box::new(
+              base_resolve_options.clone().merge(*resolve_options),
             )),
             None => Some(resolve_options),
           },
           None => self.options.resolve_options.clone(),
         };
-
         Ok(Self::new(self.resolver_factory.clone(), options))
       }
       Err(e) => Err(napi::Error::from_reason(format!("{e}"))),

--- a/crates/rspack_core/src/options/resolve/clever_merge.rs
+++ b/crates/rspack_core/src/options/resolve/clever_merge.rs
@@ -2300,19 +2300,19 @@ mod test {
   }
 
   #[test]
-  fn merge_resolver_options_empty_alias() {
+  fn merge_resolver_options_false_alias() {
     let first = Resolve {
       alias: Some(vec![("2".to_string(), vec![AliasMap::Ignore])].into()),
       ..Default::default()
     };
     let second = Resolve {
-      alias: Some(vec![].into()),
+      alias: Some(Alias::OverwriteToNoAlias),
       ..Default::default()
     };
     pretty_assertions::assert_eq!(
       merge_resolve(first, second),
       Resolve {
-        alias: Some(vec![].into()),
+        alias: Some(Alias::OverwriteToNoAlias),
         ..Default::default()
       }
     )

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -15,7 +15,9 @@ use rspack_util::location::try_line_column_length_to_offset_length;
 use rustc_hash::FxHashSet as HashSet;
 
 use super::{boxfs::BoxFS, ResolveResult, Resource};
-use crate::{AliasMap, DependencyCategory, Resolve, ResolveArgs, ResolveOptionsWithDependencyType};
+use crate::{
+  Alias, AliasMap, DependencyCategory, Resolve, ResolveArgs, ResolveOptionsWithDependencyType,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct ResolveContext {
@@ -200,21 +202,22 @@ fn to_rspack_resolver_options(
   let extensions = options
     .extensions
     .unwrap_or_else(|| vec![".js".to_string(), ".json".to_string(), ".wasm".to_string()]);
-  let alias = options
-    .alias
-    .unwrap_or_default()
-    .into_iter()
-    .map(|(key, value)| {
-      let value = value
-        .into_iter()
-        .map(|x| match x {
-          AliasMap::Path(target) => rspack_resolver::AliasValue::Path(target),
-          AliasMap::Ignore => rspack_resolver::AliasValue::Ignore,
-        })
-        .collect();
-      (key, value)
-    })
-    .collect();
+  let alias = match options.alias.unwrap_or_default() {
+    Alias::OverwriteToNoAlias => vec![],
+    Alias::MergeAlias(alias) => alias
+      .into_iter()
+      .map(|(key, value)| {
+        let value = value
+          .into_iter()
+          .map(|x| match x {
+            AliasMap::Path(target) => rspack_resolver::AliasValue::Path(target),
+            AliasMap::Ignore => rspack_resolver::AliasValue::Ignore,
+          })
+          .collect();
+        (key, value)
+      })
+      .collect(),
+  };
   let prefer_relative = options.prefer_relative.unwrap_or(false);
   let prefer_absolute = options.prefer_absolute.unwrap_or(false);
   let symlinks = options.symlinks.unwrap_or(true);
@@ -230,21 +233,22 @@ fn to_rspack_resolver_options(
   let modules = options
     .modules
     .unwrap_or_else(|| vec!["node_modules".to_string()]);
-  let fallback = options
-    .fallback
-    .unwrap_or_default()
-    .into_iter()
-    .map(|(key, value)| {
-      let value = value
-        .into_iter()
-        .map(|x| match x {
-          AliasMap::Path(target) => rspack_resolver::AliasValue::Path(target),
-          AliasMap::Ignore => rspack_resolver::AliasValue::Ignore,
-        })
-        .collect();
-      (key, value)
-    })
-    .collect();
+  let fallback = match options.fallback.unwrap_or_default() {
+    Alias::OverwriteToNoAlias => vec![],
+    Alias::MergeAlias(items) => items
+      .into_iter()
+      .map(|(key, value)| {
+        let value = value
+          .into_iter()
+          .map(|x| match x {
+            AliasMap::Path(target) => rspack_resolver::AliasValue::Path(target),
+            AliasMap::Ignore => rspack_resolver::AliasValue::Ignore,
+          })
+          .collect();
+        (key, value)
+      })
+      .collect(),
+  };
   let fully_specified = options.fully_specified.unwrap_or_default();
   let exports_fields = options
     .exports_fields

--- a/packages/rspack-test-tools/tests/configCases/resolve/alias/index.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/alias/index.js
@@ -2,10 +2,12 @@ import value from "@b";
 import value2 from "xx";
 import value3 from "alias";
 import value4 from "ignored";
+import * as noAlias from "./no-alias";
 
 it("alias should work", () => {
 	expect(value).toBe("a");
 	expect(value2).toBe("a");
 	expect(value3).toBe("a");
 	expect(value4).toStrictEqual({});
+	expect(noAlias.b).toBe("@b");
 });

--- a/packages/rspack-test-tools/tests/configCases/resolve/alias/no-alias.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/alias/no-alias.js
@@ -1,0 +1,3 @@
+import b from "@b";
+
+export { b };

--- a/packages/rspack-test-tools/tests/configCases/resolve/alias/node_modules/@b/index.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/alias/node_modules/@b/index.js
@@ -1,0 +1,1 @@
+module.exports = "@b";

--- a/packages/rspack-test-tools/tests/configCases/resolve/alias/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/alias/rspack.config.js
@@ -18,6 +18,12 @@ module.exports = {
 						ignored: false
 					}
 				}
+			},
+			{
+				test: /no-alias/,
+				resolve: {
+					alias: false
+				}
 			}
 		]
 	}

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4695,7 +4695,7 @@ export type Resolve = ResolveOptions;
 // @public
 export type ResolveAlias = {
     [x: string]: string | false | (string | false)[];
-};
+} | false;
 
 // @public (undocumented)
 type ResolveCallback = (err: null | ErrorWithDetails, res?: string | false, req?: ResolveRequest) => void;

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -148,10 +148,13 @@ function getRawExtensionAlias(
 function getRawAlias(
 	alias: Resolve["alias"] = {}
 ): RawOptions["resolve"]["alias"] {
-	return Object.entries(alias).map(([key, value]) => ({
-		path: key,
-		redirect: Array.isArray(value) ? value : [value]
-	}));
+	if (typeof alias === "object" && alias !== null && !Array.isArray(alias)) {
+		return Object.entries(alias).map(([key, value]) => ({
+			path: key,
+			redirect: Array.isArray(value) ? value : [value]
+		}));
+	}
+	return false;
 }
 
 function getRawResolveByDependency(

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -682,9 +682,11 @@ export type Output = {
  * // - require("abc/file.js") will not match, and it will attempt to resolve node_modules/abc/file.js.
  * ```
  * */
-export type ResolveAlias = {
-	[x: string]: string | false | (string | false)[];
-};
+export type ResolveAlias =
+	| {
+			[x: string]: string | false | (string | false)[];
+	  }
+	| false;
 
 /** The replacement of [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin) in Rspack. */
 export type ResolveTsConfig =

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -380,12 +380,14 @@ const output = z.strictObject({
 //#endregion
 
 //#region Resolve
-const resolveAlias = z.record(
-	z
-		.literal(false)
-		.or(z.string())
-		.or(z.array(z.string().or(z.literal(false))))
-) satisfies z.ZodType<t.ResolveAlias>;
+const resolveAlias = z
+	.record(
+		z
+			.literal(false)
+			.or(z.string())
+			.or(z.array(z.string().or(z.literal(false))))
+	)
+	.or(z.literal(false)) satisfies z.ZodType<t.ResolveAlias>;
 
 const resolveTsConfigFile = z.string();
 const resolveTsConfig = resolveTsConfigFile.or(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

[webpack supports object and array for alias](https://github.com/webpack/enhanced-resolve/blob/38e9fd9acb79643a70e7bcd0d85dabc600ea321f/lib/ResolverFactory.js#L158-L172), the difference is object will merge with the default resolve options alias but array will overwrite the default resolve options alias, unless there is `"..."`, and undefined is equal to {}, false is equal to [].

I've never seen a requirement that needs to support array, so for now I only support false here for simplicity.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
