### PR TITLE
refactor: use `Filename` uniformly

### DIFF
--- a/crates/node_binding/src/filename.rs
+++ b/crates/node_binding/src/filename.rs
@@ -41,12 +41,12 @@ impl From<JsFilename> for Filename {
   fn from(value: JsFilename) -> Self {
     match value.filename {
       Either::A(template) => Filename::from(template),
-      Either::B(f) => Filename::from_fn(Arc::new(ThreadSafeFilenameFn(Arc::new(
+      Either::B(f) => Filename::from(Arc::new(ThreadSafeFilenameFn(Arc::new(
         move |path_data, asset_info| {
           let f = f.clone();
           Box::pin(async move { f.call_with_sync((path_data, asset_info)).await })
         },
-      )))),
+      ))) as Arc<dyn FilenameFn>),
     }
   }
 }
@@ -55,12 +55,12 @@ impl From<JsFilename> for PublicPath {
   fn from(value: JsFilename) -> Self {
     match value.filename {
       Either::A(template) => template.into(),
-      Either::B(f) => PublicPath::Filename(Filename::from_fn(Arc::new(ThreadSafeFilenameFn(
-        Arc::new(move |path_data, asset_info| {
+      Either::B(f) => PublicPath::Filename(Filename::from(Arc::new(ThreadSafeFilenameFn(Arc::new(
+        move |path_data, asset_info| {
           let f = f.clone();
           Box::pin(async move { f.call_with_sync((path_data, asset_info)).await })
-        }),
-      )))),
+        },
+      ))) as Arc<dyn FilenameFn>)),
     }
   }
 }

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -46,10 +46,10 @@ use rspack_core::{
   CssAutoParserOptions, CssExportsConvention, CssGeneratorOptions, CssModuleGeneratorOptions,
   CssModuleParserOptions, CssParserOptions, DynamicImportMode, EntryDescription, EntryOptions,
   EntryRuntime, Environment, ExperimentCacheOptions, Experiments, ExternalItem, ExternalType,
-  Filename, FilenameTemplate, GeneratorOptions, GeneratorOptionsMap, JavascriptParserOptions,
-  JavascriptParserOrder, JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions, LibraryName,
-  LibraryNonUmdObject, LibraryOptions, LibraryType, MangleExportsOption, Mode, ModuleNoParseRules,
-  ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleType, NodeDirnameOption, NodeFilenameOption,
+  Filename, GeneratorOptions, GeneratorOptionsMap, JavascriptParserOptions, JavascriptParserOrder,
+  JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions, LibraryName, LibraryNonUmdObject,
+  LibraryOptions, LibraryType, MangleExportsOption, Mode, ModuleNoParseRules, ModuleOptions,
+  ModuleRule, ModuleRuleEffect, ModuleType, NodeDirnameOption, NodeFilenameOption,
   NodeGlobalOption, NodeOption, Optimization, OutputOptions, ParseOption, ParserOptions,
   ParserOptionsMap, PathInfo, PublicPath, Resolve, RspackFuture, RuleSetCondition,
   RuleSetLogicalConditions, SideEffectOption, StatsOptions, TrustedTypes, UsedExportsOption,
@@ -2113,7 +2113,7 @@ pub struct OutputOptionsBuilder {
   /// Set the wasm loading.
   wasm_loading: Option<WasmLoading>,
   /// Set the wasm module filename.
-  webassembly_module_filename: Option<FilenameTemplate>,
+  webassembly_module_filename: Option<Filename>,
   /// Set the unique name.
   unique_name: Option<String>,
   /// Set the chunk loading.
@@ -2137,9 +2137,9 @@ pub struct OutputOptionsBuilder {
   /// Set the css chunk filename.
   css_chunk_filename: Option<Filename>,
   /// Set the hot update main filename.
-  hot_update_main_filename: Option<FilenameTemplate>,
+  hot_update_main_filename: Option<Filename>,
   /// Set the hot update chunk filename.
-  hot_update_chunk_filename: Option<FilenameTemplate>,
+  hot_update_chunk_filename: Option<Filename>,
   /// Set the hot update global.
   hot_update_global: Option<String>,
   /// Set the library.
@@ -2165,7 +2165,7 @@ pub struct OutputOptionsBuilder {
   /// Set the trusted types.
   trusted_types: Option<TrustedTypes>,
   /// Set the source map filename.
-  source_map_filename: Option<FilenameTemplate>,
+  source_map_filename: Option<Filename>,
   /// Set the hash function.
   hash_function: Option<HashFunction>,
   /// Set the hash digest.
@@ -2187,9 +2187,9 @@ pub struct OutputOptionsBuilder {
   /// Set the devtool namespace.
   devtool_namespace: Option<String>,
   /// Set the devtool module filename template.
-  devtool_module_filename_template: Option<FilenameTemplate>,
+  devtool_module_filename_template: Option<Filename>,
   /// Set the devtool fallback module filename template.
-  devtool_fallback_module_filename_template: Option<FilenameTemplate>,
+  devtool_fallback_module_filename_template: Option<Filename>,
   /// Set the environment.
   environment: Option<Environment>,
   /// Set the compare before emit.
@@ -2361,7 +2361,7 @@ impl OutputOptionsBuilder {
   /// This option determines the name of each output wasm bundle.
   ///
   /// Default set to `"[hash].module.wasm"`.
-  pub fn webassembly_module_filename(&mut self, filename: FilenameTemplate) -> &mut Self {
+  pub fn webassembly_module_filename(&mut self, filename: Filename) -> &mut Self {
     self.webassembly_module_filename = Some(filename);
     self
   }
@@ -2441,7 +2441,7 @@ impl OutputOptionsBuilder {
   /// Customize the main hot update filename. [fullhash] and [runtime] are available as placeholder.
   ///
   /// Default set to `"[runtime].[fullhash].hot-update.json"`.
-  pub fn hot_update_main_filename(&mut self, filename: FilenameTemplate) -> &mut Self {
+  pub fn hot_update_main_filename(&mut self, filename: Filename) -> &mut Self {
     self.hot_update_main_filename = Some(filename);
     self
   }
@@ -2449,7 +2449,7 @@ impl OutputOptionsBuilder {
   /// Customize the filenames of hot update chunks.
   ///
   /// Default set to `"[id].[fullhash].hot-update.js"`.
-  pub fn hot_update_chunk_filename(&mut self, filename: FilenameTemplate) -> &mut Self {
+  pub fn hot_update_chunk_filename(&mut self, filename: Filename) -> &mut Self {
     self.hot_update_chunk_filename = Some(filename);
     self
   }
@@ -2529,7 +2529,7 @@ impl OutputOptionsBuilder {
   }
 
   /// Set the name of the source map file.
-  pub fn source_map_filename(&mut self, filename: FilenameTemplate) -> &mut Self {
+  pub fn source_map_filename(&mut self, filename: Filename) -> &mut Self {
     self.source_map_filename = Some(filename);
     self
   }
@@ -2595,16 +2595,13 @@ impl OutputOptionsBuilder {
   }
 
   /// Set the template of the devtool module filename.
-  pub fn devtool_module_filename_template(&mut self, filename: FilenameTemplate) -> &mut Self {
+  pub fn devtool_module_filename_template(&mut self, filename: Filename) -> &mut Self {
     self.devtool_module_filename_template = Some(filename);
     self
   }
 
   /// Set the template of the devtool fallback module filename.
-  pub fn devtool_fallback_module_filename_template(
-    &mut self,
-    filename: FilenameTemplate,
-  ) -> &mut Self {
+  pub fn devtool_fallback_module_filename_template(&mut self, filename: Filename) -> &mut Self {
     self.devtool_fallback_module_filename_template = Some(filename);
     self
   }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -53,10 +53,9 @@ use crate::{
   CodeGenerationJob, CodeGenerationResult, CodeGenerationResults, CompilationLogger,
   CompilationLogging, CompilerOptions, DependenciesDiagnosticsArtifact, DependencyId,
   DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId,
-  Filename, ImportVarMap, LocalFilenameFn, Logger, ModuleFactory, ModuleGraph, ModuleGraphPartial,
-  ModuleIdentifier, ModuleIdsArtifact, PathData, ResolverFactory, RuntimeGlobals, RuntimeModule,
-  RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact, SourceType,
-  Stats,
+  Filename, ImportVarMap, Logger, ModuleFactory, ModuleGraph, ModuleGraphPartial, ModuleIdentifier,
+  ModuleIdsArtifact, PathData, ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpecMap,
+  RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact, SourceType, Stats,
 };
 
 define_hook!(CompilationAddEntry: Series(compilation: &mut Compilation, entry_name: Option<&str>));
@@ -2399,9 +2398,9 @@ impl Compilation {
       .map(|hash| hash.rendered(self.options.output.hash_digest_length))
   }
 
-  pub fn get_path<'b, 'a: 'b, F: LocalFilenameFn>(
+  pub fn get_path<'b, 'a: 'b>(
     &'a self,
-    filename: &Filename<F>,
+    filename: &Filename,
     mut data: PathData<'b>,
   ) -> Result<String> {
     if data.hash.is_none() {
@@ -2410,9 +2409,9 @@ impl Compilation {
     filename.render(data, None)
   }
 
-  pub fn get_path_with_info<'b, 'a: 'b, F: LocalFilenameFn>(
+  pub fn get_path_with_info<'b, 'a: 'b>(
     &'a self,
-    filename: &Filename<F>,
+    filename: &Filename,
     mut data: PathData<'b>,
     info: &mut AssetInfo,
   ) -> Result<String> {
@@ -2423,17 +2422,13 @@ impl Compilation {
     Ok(path)
   }
 
-  pub fn get_asset_path<F: LocalFilenameFn>(
-    &self,
-    filename: &Filename<F>,
-    data: PathData,
-  ) -> Result<String> {
+  pub fn get_asset_path(&self, filename: &Filename, data: PathData) -> Result<String> {
     filename.render(data, None)
   }
 
-  pub fn get_asset_path_with_info<F: LocalFilenameFn>(
+  pub fn get_asset_path_with_info(
     &self,
-    filename: &Filename<F>,
+    filename: &Filename,
     data: PathData,
   ) -> Result<(String, AssetInfo)> {
     let mut info = AssetInfo::default();

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -1,7 +1,6 @@
 use std::{
   fmt::{self, Debug},
   ops::{Deref, DerefMut},
-  str::FromStr,
   sync::Arc,
 };
 
@@ -668,7 +667,7 @@ pub struct JsonGeneratorOptions {
 #[cacheable]
 #[derive(Debug, Clone, MergeFrom)]
 pub struct LocalIdentName {
-  pub template: crate::FilenameTemplate,
+  pub template: Filename,
 }
 
 impl From<String> for LocalIdentName {
@@ -682,7 +681,7 @@ impl From<String> for LocalIdentName {
 impl From<&str> for LocalIdentName {
   fn from(value: &str) -> Self {
     Self {
-      template: crate::FilenameTemplate::from_str(value).expect("should be infalliable"),
+      template: crate::Filename::from(value),
     }
   }
 }

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -8,7 +8,7 @@ use rspack_macros::MergeFrom;
 use rspack_paths::Utf8PathBuf;
 
 use super::CleanOptions;
-use crate::{Chunk, ChunkGroupByUkey, ChunkKind, Compilation, Filename, FilenameTemplate};
+use crate::{Chunk, ChunkGroupByUkey, ChunkKind, Compilation, Filename};
 
 #[derive(Debug)]
 pub enum PathInfo {
@@ -27,7 +27,7 @@ pub struct OutputOptions {
   pub public_path: PublicPath,
   pub asset_module_filename: Filename,
   pub wasm_loading: WasmLoading,
-  pub webassembly_module_filename: FilenameTemplate,
+  pub webassembly_module_filename: Filename,
   pub unique_name: String,
   pub chunk_loading: ChunkLoading,
   pub chunk_loading_global: String,
@@ -38,8 +38,8 @@ pub struct OutputOptions {
   pub cross_origin_loading: CrossOriginLoading,
   pub css_filename: Filename,
   pub css_chunk_filename: Filename,
-  pub hot_update_main_filename: FilenameTemplate,
-  pub hot_update_chunk_filename: FilenameTemplate,
+  pub hot_update_main_filename: Filename,
+  pub hot_update_chunk_filename: Filename,
   pub hot_update_global: String,
   pub library: Option<LibraryOptions>,
   pub enabled_library_types: Option<Vec<String>>,
@@ -50,7 +50,7 @@ pub struct OutputOptions {
   pub iife: bool,
   pub module: bool,
   pub trusted_types: Option<TrustedTypes>,
-  pub source_map_filename: FilenameTemplate,
+  pub source_map_filename: Filename,
   pub hash_function: HashFunction,
   pub hash_digest: HashDigest,
   pub hash_digest_length: usize,
@@ -411,7 +411,7 @@ impl FromStr for PublicPath {
     if s.eq("auto") {
       Ok(Self::Auto)
     } else {
-      Ok(Self::Filename(Filename::from_str(s)?))
+      Ok(Self::Filename(Filename::from(s)))
     }
   }
 }
@@ -450,7 +450,7 @@ pub fn get_js_chunk_filename_template(
   if let Some(filename_template) = chunk.filename_template() {
     filename_template.clone()
   } else if matches!(chunk.kind(), ChunkKind::HotUpdate) {
-    output_options.hot_update_chunk_filename.clone().into()
+    output_options.hot_update_chunk_filename.clone()
   } else if chunk.can_be_initial(chunk_group_by_ukey) {
     output_options.filename.clone()
   } else {

--- a/crates/rspack_core/src/utils/runtime.rs
+++ b/crates/rspack_core/src/utils/runtime.rs
@@ -48,9 +48,7 @@ pub fn get_entry_runtime(
   }
 }
 
-pub fn get_filename_without_hash_length<F: Clone>(
-  filename: &Filename<F>,
-) -> (Filename<F>, HashMap<String, usize>) {
+pub fn get_filename_without_hash_length(filename: &Filename) -> (Filename, HashMap<String, usize>) {
   let mut hash_len_map = HashMap::default();
   let Some(template) = filename.template() else {
     return (filename.clone(), hash_len_map);

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -12,9 +12,9 @@ use rspack_core::{
   AssetParserDataUrl, BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ChunkUkey,
   CodeGenerationDataAssetInfo, CodeGenerationDataFilename, CodeGenerationDataUrl,
   CodeGenerationPublicPathAutoReplace, Compilation, CompilationRenderManifest, CompilerOptions,
-  Filename, GenerateContext, GeneratorOptions, LocalFilenameFn, Module, ModuleGraph, NormalModule,
-  ParseContext, ParserAndGenerator, PathData, Plugin, PublicPath, RenderManifestEntry,
-  ResourceData, RuntimeGlobals, RuntimeSpec, SourceType, NAMESPACE_OBJECT_EXPORT,
+  Filename, GenerateContext, GeneratorOptions, Module, ModuleGraph, NormalModule, ParseContext,
+  ParserAndGenerator, PathData, Plugin, PublicPath, RenderManifestEntry, ResourceData,
+  RuntimeGlobals, RuntimeSpec, SourceType, NAMESPACE_OBJECT_EXPORT,
 };
 use rspack_error::{error, Diagnostic, IntoTWithDiagnosticArray, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -284,13 +284,13 @@ impl AssetParserAndGenerator {
     Ok((original_filename, filename, asset_info))
   }
 
-  fn get_public_path<F: LocalFilenameFn>(
+  fn get_public_path(
     &self,
     module: &NormalModule,
     compilation: &Compilation,
     contenthash: Option<&str>,
     source_file_name: &str,
-    template: &Filename<F>,
+    template: &Filename,
   ) -> Result<(String, AssetInfo)> {
     let (public_path, info) = compilation.get_asset_path_with_info(
       template,

--- a/crates/rspack_plugin_banner/src/lib.rs
+++ b/crates/rspack_plugin_banner/src/lib.rs
@@ -10,8 +10,7 @@ use futures::future::BoxFuture;
 use regex::Regex;
 use rspack_core::{
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
-  to_comment, Chunk, Compilation, CompilationProcessAssets, FilenameTemplate, Logger, PathData,
-  Plugin,
+  to_comment, Chunk, Compilation, CompilationProcessAssets, Filename, Logger, PathData, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -186,7 +185,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         }
       };
       let comment = compilation.get_path(
-        &FilenameTemplate::from(banner),
+        &Filename::from(banner),
         PathData::default()
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -17,7 +17,7 @@ use regex::Regex;
 use rspack_core::{
   rspack_sources::{RawSource, Source},
   AssetInfo, AssetInfoRelated, Compilation, CompilationAsset, CompilationLogger,
-  CompilationProcessAssets, FilenameTemplate, Logger, PathData, Plugin,
+  CompilationProcessAssets, Filename, Logger, PathData, Plugin,
 };
 use rspack_error::{Diagnostic, DiagnosticError, Error, ErrorExt, Result};
 use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest};
@@ -342,7 +342,7 @@ impl CopyRspackPlugin {
       );
       let content_hash = content_hash.rendered(compilation.options.output.hash_digest_length);
       let template_str = compilation.get_asset_path(
-        &FilenameTemplate::from(filename.to_string()),
+        &Filename::from(filename.to_string()),
         PathData::default()
           .filename(source_filename.as_str())
           .content_hash(content_hash)

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -14,8 +14,8 @@ use regex::Regex;
 use rspack_collections::DatabaseItem;
 use rspack_core::{
   rspack_sources::{ConcatSource, MapOptions, RawStringSource, Source, SourceExt},
-  AssetInfo, Chunk, ChunkUkey, Compilation, CompilationAsset, CompilationProcessAssets,
-  FilenameTemplate, Logger, ModuleIdentifier, PathData, Plugin, PluginContext,
+  AssetInfo, Chunk, ChunkUkey, Compilation, CompilationAsset, CompilationProcessAssets, Filename,
+  Logger, ModuleIdentifier, PathData, Plugin, PluginContext,
 };
 use rspack_error::{error, miette::IntoDiagnostic, Result};
 use rspack_hash::RspackHash;
@@ -131,7 +131,7 @@ pub(crate) struct MappedAsset {
 #[plugin]
 #[derive(Debug)]
 pub struct SourceMapDevToolPlugin {
-  source_map_filename: Option<FilenameTemplate>,
+  source_map_filename: Option<Filename>,
   #[debug(skip)]
   source_mapping_url_comment: Option<SourceMappingUrlComment>,
   file_context: Option<String>,
@@ -200,7 +200,7 @@ impl SourceMapDevToolPlugin {
         ));
 
     Self::new_inner(
-      options.filename.map(FilenameTemplate::from),
+      options.filename.map(Filename::from),
       source_mapping_url_comment,
       options.file_context,
       module_filename_template,
@@ -504,11 +504,11 @@ impl SourceMapDevToolPlugin {
               let data = data.url(&source_map_url);
               let current_source_mapping_url_comment = match &current_source_mapping_url_comment {
                 SourceMappingUrlCommentRef::String(s) => {
-                  compilation.get_asset_path(&FilenameTemplate::from(s.as_ref()), data)?
+                  compilation.get_asset_path(&Filename::from(s.as_ref()), data)?
                 }
                 SourceMappingUrlCommentRef::Fn(f) => {
                   let comment = f(data).await?;
-                  FilenameTemplate::from(comment).render(data, None)?
+                  Filename::from(comment).render(data, None)?
                 }
               };
               let current_source_mapping_url_comment = current_source_mapping_url_comment

--- a/crates/rspack_plugin_html/src/asset.rs
+++ b/crates/rspack_plugin_html/src/asset.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use rayon::prelude::*;
 use rspack_core::{
   rspack_sources::{RawBufferSource, RawStringSource, SourceExt},
-  AssetInfo, Compilation, CompilationAsset, Filename, NoFilenameFn, PathData,
+  AssetInfo, Compilation, CompilationAsset, Filename, PathData,
 };
 use rspack_error::{miette, AnyhowError, Result};
 use rspack_paths::Utf8PathBuf;
@@ -43,7 +43,7 @@ impl HtmlPluginAssets {
     compilation: &'a Compilation,
     public_path: &str,
     output_path: &Utf8PathBuf,
-    html_file_name: &Filename<NoFilenameFn>,
+    html_file_name: &Filename,
   ) -> Result<(HtmlPluginAssets, HashMap<String, &'a CompilationAsset>)> {
     let mut assets: HtmlPluginAssets = HtmlPluginAssets::default();
     let mut asset_map = HashMap::new();
@@ -351,7 +351,7 @@ pub fn create_favicon_asset(
 }
 
 pub fn create_html_asset(
-  output_file_name: &Filename<NoFilenameFn>,
+  output_file_name: &Filename,
   html: &str,
   template_file_name: &str,
   compilation: &Compilation,

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -5,10 +5,7 @@ use std::{
 };
 
 use cow_utils::CowUtils;
-use rspack_core::{
-  Compilation, CompilationId, CompilationProcessAssets, Filename, FilenameTemplate, NoFilenameFn,
-  Plugin,
-};
+use rspack_core::{Compilation, CompilationId, CompilationProcessAssets, Filename, Plugin};
 use rspack_error::{miette, Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::fx_hash::FxDashMap;
@@ -59,7 +56,7 @@ impl HtmlRspackPlugin {
 
 async fn generate_html(
   filename: &str,
-  html_file_name: &Filename<NoFilenameFn>,
+  html_file_name: &Filename,
   config: &HtmlRspackPluginOptions,
   compilation: &mut Compilation,
   hooks: &HtmlPluginHooks,
@@ -210,7 +207,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       }
     };
 
-    let output_file_name = FilenameTemplate::from(filename.to_string());
+    let output_file_name = Filename::from(filename.to_string());
 
     let (template_file_name, html) = match generate_html(
       filename.as_ref(),

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -3,8 +3,8 @@ use std::hash::Hash;
 use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   ApplyContext, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
-  CompilationParams, CompilerCompilation, CompilerOptions, ExternalModule, FilenameTemplate,
-  LibraryName, LibraryNonUmdObject, LibraryOptions, LibraryType, PathData, Plugin, PluginContext,
+  CompilationParams, CompilerCompilation, CompilerOptions, ExternalModule, Filename, LibraryName,
+  LibraryNonUmdObject, LibraryOptions, LibraryType, PathData, Plugin, PluginContext,
   RuntimeGlobals, SourceType,
 };
 use rspack_error::{error_bail, Result};
@@ -129,7 +129,7 @@ async fn render(
     )));
   } else if let Some(name) = options.name {
     let normalize_name = compilation.get_path(
-      &FilenameTemplate::from(name.to_string()),
+      &Filename::from(name),
       PathData::default()
         .chunk_id_optional(
           chunk

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -7,9 +7,9 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier, ApplyContext, BoxModule, Chunk, ChunkUkey, CodeGenerationDataTopLevelDeclarations,
   Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules,
-  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportInfoProvided,
-  FilenameTemplate, LibraryExport, LibraryName, LibraryNonUmdObject, LibraryOptions,
-  ModuleIdentifier, PathData, Plugin, PluginContext, RuntimeGlobals, SourceType, UsageState,
+  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportInfoProvided, Filename,
+  LibraryExport, LibraryName, LibraryNonUmdObject, LibraryOptions, ModuleIdentifier, PathData,
+  Plugin, PluginContext, RuntimeGlobals, SourceType, UsageState,
 };
 use rspack_error::{error, error_bail, Result};
 use rspack_hash::RspackHash;
@@ -150,7 +150,7 @@ impl AssignLibraryPlugin {
       let mut prefix = self.options.prefix.value(compilation);
       let get_path = |v: &str| {
         compilation.get_path(
-          &FilenameTemplate::from(v.to_owned()),
+          &Filename::from(v),
           PathData::default()
             .chunk_id_optional(
               chunk

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -4,9 +4,8 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   ApplyContext, Chunk, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationParams, CompilerCompilation, CompilerOptions, ExternalModule, ExternalRequest,
-  FilenameTemplate, LibraryAuxiliaryComment, LibraryCustomUmdObject, LibraryName,
-  LibraryNonUmdObject, LibraryOptions, LibraryType, PathData, Plugin, PluginContext,
-  RuntimeGlobals, SourceType,
+  Filename, LibraryAuxiliaryComment, LibraryCustomUmdObject, LibraryName, LibraryNonUmdObject,
+  LibraryOptions, LibraryType, PathData, Plugin, PluginContext, RuntimeGlobals, SourceType,
 };
 use rspack_error::{error, Result};
 use rspack_hash::RspackHash;
@@ -307,7 +306,7 @@ fn library_name(v: &[String], chunk: &Chunk, compilation: &Compilation) -> Resul
 
 fn replace_keys(v: String, chunk: &Chunk, compilation: &Compilation) -> Result<String> {
   compilation.get_path(
-    &FilenameTemplate::from(v),
+    &Filename::from(v),
     PathData::default()
       .chunk_id_optional(
         chunk

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -7,8 +7,8 @@ use rspack_collections::{DatabaseItem, Identifier, UkeyIndexMap, UkeyIndexSet};
 use rspack_core::{
   get_filename_without_hash_length, impl_runtime_module,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
-  Chunk, ChunkGraph, ChunkUkey, Compilation, Filename, FilenameTemplate, NoFilenameFn, PathData,
-  RuntimeGlobals, RuntimeModule, SourceType,
+  Chunk, ChunkGraph, ChunkUkey, Compilation, Filename, PathData, RuntimeGlobals, RuntimeModule,
+  SourceType,
 };
 use rspack_util::itoa;
 use rustc_hash::FxHashMap;
@@ -184,7 +184,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
           })
           .collect::<UkeyIndexSet<ChunkUkey>>();
         let (fake_filename, hash_len_map) =
-          get_filename_without_hash_length(&FilenameTemplate::from(dynamic_filename.to_string()));
+          get_filename_without_hash_length(&Filename::from(dynamic_filename.to_string()));
 
         let chunk_id = "\" + chunkId + \"";
         let chunk_name = stringify_dynamic_chunk_map(
@@ -242,7 +242,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
         };
 
         compilation.get_path(
-          &Filename::<NoFilenameFn>::from(
+          &Filename::from(
             serde_json::to_string(fake_filename.as_str()).expect("invalid json to_string"),
           ),
           PathData::default()
@@ -317,7 +317,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
         };
 
         let filename = compilation.get_path(
-          &Filename::<NoFilenameFn>::from(
+          &Filename::from(
             serde_json::to_string(
               fake_filename
                 .render(

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
@@ -2,7 +2,7 @@ use rspack_collections::Identifier;
 use rspack_core::{
   impl_runtime_module,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
-  ChunkUkey, Compilation, FilenameTemplate, PathData, RuntimeGlobals, RuntimeModule, SourceType,
+  ChunkUkey, Compilation, PathData, RuntimeGlobals, RuntimeModule, SourceType,
 };
 
 // TODO workaround for get_chunk_update_filename
@@ -39,7 +39,7 @@ impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
     if let Some(chunk_ukey) = self.chunk {
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
       let filename = compilation.get_path(
-        &FilenameTemplate::from(compilation.options.output.hot_update_chunk_filename.clone()),
+        &compilation.options.output.hot_update_chunk_filename,
         PathData::default()
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -403,12 +403,7 @@ async fn runtime_requirements_in_tree(
           GetMainFilenameRuntimeModule::new(
             "update manifest",
             RuntimeGlobals::GET_UPDATE_MANIFEST_FILENAME,
-            compilation
-              .options
-              .output
-              .hot_update_main_filename
-              .clone()
-              .into(),
+            compilation.options.output.hot_update_main_filename.clone(),
           )
           .boxed(),
         )?;

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -11,9 +11,9 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
   AssetInfo, BoxDependency, BuildMetaExportsType, ChunkGraph, Compilation,
   DependencyType::WasmImport,
-  FilenameTemplate, GenerateContext, Module, ModuleDependency, ModuleGraph, ModuleId,
-  ModuleIdentifier, NormalModule, ParseContext, ParseResult, ParserAndGenerator, PathData,
-  RuntimeGlobals, SourceType, StaticExportsDependency, StaticExportsSpec, UsedName,
+  Filename, GenerateContext, Module, ModuleDependency, ModuleGraph, ModuleId, ModuleIdentifier,
+  NormalModule, ParseContext, ParseResult, ParserAndGenerator, PathData, RuntimeGlobals,
+  SourceType, StaticExportsDependency, StaticExportsSpec, UsedName,
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_util::itoa;
@@ -311,7 +311,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
 fn render_wasm_name(
   compilation: &Compilation,
   normal_module: &NormalModule,
-  wasm_filename_template: &FilenameTemplate,
+  wasm_filename_template: &Filename,
   hash: &str,
 ) -> Result<(String, AssetInfo)> {
   compilation.get_asset_path_with_info(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Clean code of `Filename`:
- Remove `FilenameTemplate` and use `Filename` instead
- Remove `NoFilenameFn` which can be replaced by `Filename::Template`
- Remove unnecessary generic type of `Filename`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
