### PR TITLE
chore: Upgrade Rust to nightly of 1.86.0 release date

### DIFF
--- a/crates/node_binding/src/options/entry.rs
+++ b/crates/node_binding/src/options/entry.rs
@@ -57,7 +57,7 @@ impl From<JsEntryOptions> for EntryOptions {
       base_uri: value.base_uri,
       filename: value.filename.map(Into::into),
       library: value.library.map(Into::into),
-      depend_on: value.depend_on.map(Into::into),
+      depend_on: value.depend_on,
       layer: value.layer,
     }
   }

--- a/crates/rspack_collections/src/lib.rs
+++ b/crates/rspack_collections/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(const_type_name)]
-#![feature(map_many_mut)]
 
 mod identifier;
 mod ukey;

--- a/crates/rspack_collections/src/ukey.rs
+++ b/crates/rspack_collections/src/ukey.rs
@@ -155,7 +155,7 @@ where
     &mut self,
     ids: [&<Item as DatabaseItem>::ItemUkey; N],
   ) -> [Option<&mut Item>; N] {
-    self.inner.get_many_mut(ids)
+    self.inner.get_disjoint_mut(ids)
   }
 
   pub fn get(&self, id: &<Item as DatabaseItem>::ItemUkey) -> Option<&Item> {

--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -743,7 +743,7 @@ impl CodeSplitter {
           .dependency_by_id(dep_id)
           .expect("should have dep")
           .as_module_dependency()
-          .map_or(true, |module_dep| !module_dep.weak())
+          .is_none_or(|module_dep| !module_dep.weak())
       })
       .filter_map(|dep| module_graph.connection_by_dependency_id(dep))
       .map(|conn| (conn.module_identifier(), conn))

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -416,14 +416,11 @@ impl Compiler {
             || include_hash(target_file, &asset.info.full_hash));
       }
 
-      let stat = match self
+      let stat = self
         .output_filesystem
         .stat(file_path.as_path().as_ref())
         .await
-      {
-        Ok(stat) => Some(stat),
-        Err(_) => None,
-      };
+        .ok();
 
       let need_write = if !self.options.output.compare_before_emit {
         // write when compare_before_emit is false

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -410,7 +410,6 @@ fn visit_dirs(
       }
     } else if path.file_name().is_some_and(|name| name.starts_with('.')) {
       // ignore hidden files
-      continue;
     } else {
       if let Some(include) = include
         && !include.test(path_str)

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -837,6 +837,15 @@ impl UsedName {
   }
 }
 
+impl AsRef<[Atom]> for UsedName {
+  fn as_ref(&self) -> &[Atom] {
+    match self {
+      UsedName::Str(atom) => std::slice::from_ref(atom),
+      UsedName::Vec(vec) => vec,
+    }
+  }
+}
+
 pub fn string_of_used_name(used: Option<&UsedName>) -> String {
   match used {
     Some(UsedName::Str(str)) => str.to_string(),

--- a/crates/rspack_core/src/incremental/mutations.rs
+++ b/crates/rspack_core/src/incremental/mutations.rs
@@ -184,7 +184,7 @@ fn compute_affected_modules_with_module_graph(
       };
       match dependency.could_affect_referencing_module() {
         AffectType::True => affected = AffectType::True,
-        AffectType::False => continue,
+        AffectType::False => {}
         AffectType::Transitive => return AffectType::Transitive,
       }
     }
@@ -240,7 +240,7 @@ fn compute_affected_modules_with_module_graph(
           continue;
         }
         match reduce_affect_type(module_graph, &connections) {
-          AffectType::False => continue,
+          AffectType::False => {}
           AffectType::True => {
             direct_affected_modules.insert(referencing_module);
           }

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(iter_intersperse)]
 #![feature(box_patterns)]
 #![feature(anonymous_lifetime_in_impl_trait)]
-#![feature(hash_raw_entry)]
 #![feature(async_closure)]
 
 use std::{fmt, sync::Arc};

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(iter_intersperse)]
 #![feature(box_patterns)]
 #![feature(anonymous_lifetime_in_impl_trait)]
-#![feature(async_closure)]
+#![feature(async_trait_bounds)]
 
 use std::{fmt, sync::Arc};
 mod artifacts;

--- a/crates/rspack_fs/src/error.rs
+++ b/crates/rspack_fs/src/error.rs
@@ -37,10 +37,7 @@ impl From<Error> for rspack_error::Error {
 
 impl From<rspack_error::Error> for Error {
   fn from(e: rspack_error::Error) -> Self {
-    Error::Io(std::io::Error::new(
-      std::io::ErrorKind::Other,
-      e.to_string(),
-    ))
+    Error::Io(std::io::Error::other(e.to_string()))
   }
 }
 
@@ -62,10 +59,7 @@ impl<T, E: ToString> RspackResultToFsResultExt<T> for std::result::Result<T, E> 
   fn to_fs_result(self) -> Result<T> {
     match self {
       Ok(t) => Ok(t),
-      Err(e) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        e.to_string(),
-      ))),
+      Err(e) => Err(Error::Io(std::io::Error::other(e.to_string()))),
     }
   }
 }

--- a/crates/rspack_fs/src/intermediate.rs
+++ b/crates/rspack_fs/src/intermediate.rs
@@ -22,10 +22,7 @@ pub trait ReadStream: Debug + Sync + Send {
   async fn read_line(&mut self) -> Result<String> {
     match String::from_utf8(self.read_until(b'\n').await?) {
       Ok(s) => Ok(s),
-      Err(_) => Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "invalid utf8 line",
-      ))),
+      Err(_) => Err(Error::Io(std::io::Error::other("invalid utf8 line"))),
     }
   }
   async fn read(&mut self, length: usize) -> Result<Vec<u8>>;

--- a/crates/rspack_fs/src/memory_fs.rs
+++ b/crates/rspack_fs/src/memory_fs.rs
@@ -20,7 +20,7 @@ fn current_time() -> u64 {
 }
 
 fn new_error(msg: &str) -> Error {
-  Error::Io(std::io::Error::new(std::io::ErrorKind::Other, msg))
+  Error::Io(std::io::Error::other(msg))
 }
 
 #[derive(Debug)]

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -51,7 +51,7 @@ pub fn get_used_module_ids_and_modules(
       if let Some(module_id) = module_id {
         used_ids.insert(module_id.to_string());
       } else {
-        if filter.as_ref().map_or(true, |f| (f)(module))
+        if filter.as_ref().is_none_or(|f| (f)(module))
           && chunk_graph.get_number_of_module_chunks(module.identifier()) != 0
         {
           modules.push(module.identifier());

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -152,7 +152,7 @@ async fn eval_source_map_devtool_plugin_render_module_content(
         };
         let module_filenames =
           ModuleFilenameHelpers::replace_duplicates(module_filenames, |mut filename, _, n| {
-            filename.extend(std::iter::repeat('*').take(n));
+            filename.extend(std::iter::repeat_n('*', n));
             filename
           });
         map.set_sources(module_filenames);

--- a/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
+++ b/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
@@ -82,7 +82,11 @@ impl ModuleFilenameHelpers {
 
         let hash = get_hash(&identifier, output_options);
 
-        let resource = short_identifier.split('!').last().unwrap_or("").to_string();
+        let resource = short_identifier
+          .split('!')
+          .next_back()
+          .unwrap_or("")
+          .to_string();
 
         let loaders = get_before(&short_identifier, "!");
         let all_loaders = get_before(&identifier, "!");
@@ -118,7 +122,7 @@ impl ModuleFilenameHelpers {
         let resource = short_identifier
           .clone()
           .split('!')
-          .last()
+          .next_back()
           .unwrap_or("")
           .to_string();
 
@@ -137,7 +141,7 @@ impl ModuleFilenameHelpers {
           short_identifier,
           identifier,
           module_id: "".to_string(),
-          absolute_resource_path: source.split('!').last().unwrap_or("").to_string(),
+          absolute_resource_path: source.split('!').next_back().unwrap_or("").to_string(),
           hash,
           resource,
           loaders,

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -135,7 +135,7 @@ impl Module for CssModule {
     self
       .identifier
       .split('!')
-      .last()
+      .next_back()
       .map(|resource| resource.split('?').next().unwrap_or(resource).into())
   }
 

--- a/crates/rspack_plugin_javascript/src/lib.rs
+++ b/crates/rspack_plugin_javascript/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(box_patterns)]
-#![feature(trait_upcasting)]
 #![recursion_limit = "256"]
 
 pub mod ast;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
@@ -600,7 +600,7 @@ fn to_code(code: &Value, asi_safe: Option<bool>, obj_keys: Option<FxHashSet<Stri
       let elements = obj
         .iter()
         .filter_map(|(key, value)| {
-          if obj_keys.as_ref().map_or(true, |keys| keys.contains(key)) {
+          if obj_keys.as_ref().is_none_or(|keys| keys.contains(key)) {
             Some(format!("{}:{}", json!(key), to_code(value, None, None)))
           } else {
             None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -202,11 +202,11 @@ impl InnerGraphPlugin {
         if is_terminal {
           keys_to_remove.push(key.clone());
           // We use `""` to represent global_key
-          if key == "" {
+          if key.is_empty() {
             let global_value = state.inner_graph.get(&Atom::from("")).cloned();
             if let Some(global_value) = global_value {
               for (key, value) in state.inner_graph.iter_mut() {
-                if key != "" && value != &InnerGraphMapValue::True {
+                if !key.is_empty() && value != &InnerGraphMapValue::True {
                   if global_value == InnerGraphMapValue::True {
                     *value = InnerGraphMapValue::True;
                   } else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
@@ -19,7 +19,7 @@ impl JavascriptParserPlugin for RequireContextDependencyParserPlugin {
     if expr
       .callee
       .as_expr()
-      .map_or(true, |expr| !is_require_context(&**expr))
+      .is_none_or(|expr| !is_require_context(&**expr))
     {
       return None;
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
@@ -58,7 +58,7 @@ impl JavascriptParserPlugin for RequireEnsureDependenciesBlockParserPlugin {
     if expr
       .callee
       .as_expr()
-      .map_or(true, |expr| !is_require_ensure(&**expr))
+      .is_none_or(|expr| !is_require_ensure(&**expr))
     {
       return None;
     }

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -628,7 +628,7 @@ impl JsPlugin {
     if let Some(inlined_modules) = inlined_modules {
       let last_entry_module = inlined_modules
         .keys()
-        .last()
+        .next_back()
         .expect("should have last entry module");
       let mut startup_sources = ConcatSource::default();
 
@@ -757,7 +757,7 @@ impl JsPlugin {
       .chunk_graph
       .get_chunk_entry_modules_with_chunk_group_iterable(chunk_ukey)
       .keys()
-      .last()
+      .next_back()
     {
       let mut render_source = RenderSource {
         source: RawStringSource::from(startup.join("\n") + "\n").boxed(),

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -235,13 +235,7 @@ pub fn parse_order_string(x: &str) -> Option<i32> {
   match x {
     "true" => Some(0),
     "false" => None,
-    _ => {
-      if let Ok(order) = x.parse::<i32>() {
-        Some(order)
-      } else {
-        None
-      }
-    }
+    _ => x.parse::<i32>().ok(),
   }
 }
 

--- a/crates/rspack_plugin_library/src/lib.rs
+++ b/crates/rspack_plugin_library/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(let_chains)]
-#![feature(async_closure)]
 
 mod amd_library_plugin;
 mod assign_library_plugin;

--- a/crates/rspack_plugin_mf/src/lib.rs
+++ b/crates/rspack_plugin_mf/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(let_chains)]
-#![feature(hash_raw_entry)]
 
 mod container;
 mod sharing;

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
@@ -55,10 +55,7 @@ impl RuntimeModule for ShareRuntimeModule {
           continue;
         };
         for item in &data.items {
-          let (_, stages) = init_per_scope
-            .raw_entry_mut()
-            .from_key(&item.share_scope)
-            .or_insert_with(|| (item.share_scope.to_owned(), LinkedHashMap::default()));
+          let stages = init_per_scope.entry(item.share_scope.clone()).or_default();
           let list = stages
             .entry(item.init_stage)
             .or_insert_with(LinkedHashSet::default);

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -150,7 +150,7 @@ async fn render_chunk(
         let start_up_source = generate_entry_startup(compilation, chunk_ukey, entries, true);
         let last_entry_module = entries
           .keys()
-          .last()
+          .next_back()
           .expect("should have last entry module");
         let mut render_source = RenderSource {
           source: start_up_source,

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -137,7 +137,7 @@ async fn render_chunk(
     let start_up_source = generate_entry_startup(compilation, chunk_ukey, entries, false);
     let last_entry_module = entries
       .keys()
-      .last()
+      .next_back()
       .expect("should have last entry module");
     let mut startup_render_source = RenderSource {
       source: start_up_source,

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -205,7 +205,7 @@ async fn render_chunk(
 
     let last_entry_module = entries
       .keys()
-      .last()
+      .next_back()
       .expect("should have last entry module");
     let mut render_source = RenderSource {
       source: RawStringSource::from(startup_source.join("\n")).boxed(),

--- a/crates/rspack_plugin_schemes/src/http_uri/lockfile.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/lockfile.rs
@@ -148,11 +148,11 @@ impl LockfileAsync for Lockfile {
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid UTF-8 path"))?;
     let content = self
       .to_json_string()
-      .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+      .map_err(|e| io::Error::other(e.to_string()))?;
     filesystem
       .write(utf8_path, content.as_bytes())
       .await
-      .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+      .map_err(|e| io::Error::other(e.to_string()))?;
     Ok(())
   }
 }
@@ -207,18 +207,18 @@ impl LockfileCache {
           .filesystem
           .create_dir_all(utf8_parent)
           .await
-          .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+          .map_err(|e| io::Error::other(e.to_string()))?;
       }
       let content = lockfile
         .to_json_string()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        .map_err(|e| io::Error::other(e.to_string()))?;
       let utf8_lockfile_path = Utf8Path::from_path(lockfile_path)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid UTF-8 path"))?;
       self
         .filesystem
         .write(utf8_lockfile_path, content.as_bytes())
         .await
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        .map_err(|e| io::Error::other(e.to_string()))?;
     }
 
     Ok(())

--- a/crates/rspack_plugin_split_chunks/src/lib.rs
+++ b/crates/rspack_plugin_split_chunks/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(map_many_mut)]
 #![feature(let_chains)]
 
 mod common;

--- a/crates/rspack_storage/src/fs/error.rs
+++ b/crates/rspack_storage/src/fs/error.rs
@@ -59,7 +59,7 @@ impl FSError {
   pub fn from_message(file: &Utf8Path, opt: FSOperation, message: String) -> Self {
     Self {
       file: file.to_string(),
-      inner: rspack_fs::Error::Io(std::io::Error::new(std::io::ErrorKind::Other, message)),
+      inner: rspack_fs::Error::Io(std::io::Error::other(message)),
       opt,
     }
   }

--- a/crates/rspack_util/src/node_path.rs
+++ b/crates/rspack_util/src/node_path.rs
@@ -108,6 +108,7 @@ pub trait NodePath {
 
   fn node_push_win32(&mut self, path: impl AsRef<Utf8Path>);
 
+  #[must_use]
   fn node_normalize(&self) -> Utf8PathBuf;
 
   fn node_normalize_posix(&self) -> Utf8PathBuf;
@@ -303,7 +304,6 @@ impl NodePath for Utf8PathBuf {
   }
 
   #[inline]
-  #[must_use]
   fn node_normalize(&self) -> Utf8PathBuf {
     if cfg!(windows) {
       self.node_normalize_win32()

--- a/crates/rspack_util/src/test.rs
+++ b/crates/rspack_util/src/test.rs
@@ -77,9 +77,8 @@ pub static HOT_TEST_UPDATED: LazyLock<String> = LazyLock::new(|| {
 });
 
 pub static HOT_TEST_RUNTIME: LazyLock<String> = LazyLock::new(|| {
-  is_hot_test()
-    .then(|| {
-      r#"
+  if is_hot_test() {
+    r#"
       currentUpdateRuntime[i](new Proxy(__webpack_require__, {
         set(target, prop, value, receiver) {
           self.__HMR_UPDATED_RUNTIME__.javascript.updatedRuntime.push(`__webpack_require__.${prop}`);
@@ -88,8 +87,9 @@ pub static HOT_TEST_RUNTIME: LazyLock<String> = LazyLock::new(|| {
       }));
       "#
       .to_string()
-    })
-    .unwrap_or_else(|| "currentUpdateRuntime[i](__webpack_require__);".to_string())
+  } else {
+    "currentUpdateRuntime[i](__webpack_require__);".to_string()
+  }
 });
 
 pub static HOT_TEST_ACCEPT: LazyLock<String> = LazyLock::new(|| {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 profile = "default"
 # Use nightly for better access to the latest Rust features.
 # This date is aligned to stable release dates.
-# stable-2025-02-20 -> v1.85.0
-channel = "nightly-2024-11-27"
+# stable-2025-04-03 -> v1.86.0
+channel = "nightly-2025-04-03"

--- a/tasks/benchmark/benches/benches.rs
+++ b/tasks/benchmark/benches/benches.rs
@@ -1,4 +1,3 @@
-#![feature(trait_upcasting)]
 #![allow(clippy::unwrap_used)]
 
 use criterion::criterion_main;

--- a/tasks/benchmark/benches/groups/basic_build.rs
+++ b/tasks/benchmark/benches/groups/basic_build.rs
@@ -1,4 +1,3 @@
-#![feature(trait_upcasting)]
 #![allow(unused_attributes)]
 #![allow(clippy::unwrap_used)]
 

--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -1,4 +1,3 @@
 #![allow(clippy::unwrap_used)]
-#![feature(trait_upcasting)]
 
 pub use criterion::*;


### PR DESCRIPTION
## Summary

[Rust 1.86.0 stable](https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html) was released on 2025-04-03. Upgrade to the 2025-04-03 nightly, fixing all build errors and Clippy warnings.

(I’m not sure there’s advantage to aligning the date this way, given that stable is branched from nightly well before the release, but this matches what we’ve done before.)

I carefully made one commit per warning type, so ideally this should be merged using either **Merge** or **Rebase and merge** to preserve the individual commits, rather than **Squash and merge** which does not.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
