### PR TITLE
docs: improve lazy compilation guide

### DIFF
--- a/website/docs/en/guide/features/_meta.json
+++ b/website/docs/en/guide/features/_meta.json
@@ -7,6 +7,7 @@
   "module-resolution",
   "module-federation",
   "web-workers",
+  "lazy-compilation",
   "builtin-swc-loader",
   "builtin-lightningcss-loader"
 ]

--- a/website/docs/en/guide/features/lazy-compilation.mdx
+++ b/website/docs/en/guide/features/lazy-compilation.mdx
@@ -1,12 +1,34 @@
-# Lazy Compilation
+# Lazy compilation
 
-Lazy compilation is an effective strategy to improve the startup performance of the development phase. Instead of compiling all modules at initialization, it compiles modules on demand as they're needed. This means that developers can quickly see the application running when starting the dev server, and build the required modules in batches. By compiling on demand, unnecessary compilation time can be reduced. As the project scales up, compilation time does not significantly increase, which greatly enhances the development experience.
+Lazy compilation is an effective strategy to improve the startup performance of the development phase. Instead of compiling all modules at initialization, it compiles modules on demand as they're needed. This means that developers can quickly see the application running when starting the dev server, and build the required modules in batches.
 
-## Quick Start
+By compiling on demand, unnecessary compilation time can be reduced. As the project scales up, compilation time does not significantly increase, which greatly enhances the development experience.
 
-For users of `@rspack/cli`, you can enable lazy compilation through [experiments.lazyCompilation](/config/experiments#experimentslazycompilation) configuration. Assuming you are developing a project with multiple entry points, when developing one of these entry points, Rspack will only build the entry point you are currently accessing.
+:::tip
+Lazy compilation is only effective for dev builds and does not affect production builds.
+:::
 
-Detailed configuration please refer to [experiments.lazyCompilation](/config/experiments#experimentslazycompilation).
+## How to use
+
+### Rspack CLI
+
+For users of `@rspack/cli`, you can enable lazy compilation through [experiments.lazyCompilation](/config/experiments#experimentslazycompilation) configuration. Assuming you are developing a multi-page application (MPA), when developing one of these pages, Rspack will only build the entry point you are currently accessing.
+
+```js title="rspack.config.mjs"
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
+  entry: {
+    Home: './src/Home.js',
+    About: './src/About.js',
+  },
+  experiments: {
+    lazyCompilation: true,
+  },
+});
+```
+
+`lazyCompilation: true` is equivalent to:
 
 ```js title="rspack.config.mjs"
 import { defineConfig } from '@rspack/cli';
@@ -20,7 +42,6 @@ export default defineConfig({
     lazyCompilation: {
       // lazy compile entries
       entries: true,
-
       // lazy compile dynamic imports
       imports: true,
     },
@@ -28,13 +49,21 @@ export default defineConfig({
 });
 ```
 
+> See [experiments.lazyCompilation](/config/experiments#experimentslazycompilation) for more details.
+
 :::info
-When lazy compilation is enabled for entries, entry modules will actually be asynchronously dynamically imported. Therefore if you have configured `splitChunks`, entry modules will be treated as `async Chunk`, which may result in slight differences between development and production artifacts.
+When lazy compilation is enabled for entries, entry modules will actually be asynchronously dynamically imported. Therefore if you have configured [splitChunks](/config/optimization#optimizationsplitchunks), entry modules will be treated as async chunk, which may result in slight differences between development and production artifacts.
 :::
 
-## Filtering Modules for Lazy Compilation
+### Rsbuild
 
-In addition to two coarse-grained configurations `entries` and `imports`, you can also use a `test` configuration to filter out certain modules for lazy compilation. If you want to disable lazy compilation for the `About` entry point, you can refer to the following configuration:
+Use the [dev.lazyCompilation](https://rsbuild.dev/config/dev/lazy-compilation) option to enable lazy compilation with Rsbuild.
+
+## Filtering modules
+
+In addition to two options `entries` and `imports`, you can also use a `test` option to filter out certain modules for lazy compilation.
+
+For example, if you want to disable lazy compilation for the `About` entry point, you can refer to the following configuration:
 
 ```js title="rspack.config.mjs"
 import { defineConfig } from '@rspack/cli';
@@ -65,11 +94,11 @@ Only when corresponding entries and modules are executed will Rspack compile the
 
 ![image](https://assets.rspack.dev/rspack/assets/lazy-proxy-module.png)
 
-## Using custom dev server
+## Integrating with custom server
 
-In the configuration above, the `experiments.lazyCompilation` option is actually processed by `@rspack/cli`. It adds an [Express-style middleware](https://expressjs.com/en/guide/using-middleware.html) to `@rspack/dev-server` specifically designed to handle lazy compilation client requests.
+When using Rspack CLI, the `experiments.lazyCompilation` option is actually processed by `@rspack/cli`. It adds an [Express-style middleware](https://expressjs.com/en/guide/using-middleware.html) to `@rspack/dev-server` specifically designed to handle lazy compilation client requests.
 
-If you are using a custom dev server, you will need to manually integrate this middleware into your dev server.
+If you are using a custom dev server, you will need to manually integrate `rspack.experiments.lazyCompilationMiddleware` into your dev server.
 
 ```js title="start.mjs"
 import { experiments, rspack } from '@rspack/core';
@@ -92,3 +121,8 @@ const server = new DevServer(compiler, {
 
 server.start();
 ```
+
+`lazyCompilationMiddleware` accepts two parameters:
+
+- `compiler`: The current [Compiler](/api/javascript-api/compiler) instance
+- `options`: The lazy compilation options, same as [experiments.lazyCompilation](/config/experiments#experimentslazycompilation)

--- a/website/docs/zh/guide/features/_meta.json
+++ b/website/docs/zh/guide/features/_meta.json
@@ -7,6 +7,7 @@
   "module-resolution",
   "module-federation",
   "web-workers",
+  "lazy-compilation",
   "builtin-swc-loader",
   "builtin-lightningcss-loader"
 ]

--- a/website/docs/zh/guide/features/lazy-compilation.mdx
+++ b/website/docs/zh/guide/features/lazy-compilation.mdx
@@ -1,10 +1,18 @@
-# Lazy Compilation
+# Lazy compilation
 
-Lazy compilation 是一个提升开发阶段启动性能的有效手段，它采用按需编译模块的方式，而非在启动时编译全部模块。这意味着开发者在启动 dev server 时，可以很快看到应用运行，并分次构建所需的模块。通过这种按需编译的机制，可以减少不必要的编译时间，且随着项目规模的扩大，编译时间不会显著增长，从而大幅提升开发体验。
+Lazy compilation 是一个提升开发阶段启动性能的有效手段，它采用按需编译模块的方式，而非在启动时编译全部模块。这意味着开发者在启动 dev server 时，可以很快看到应用运行，并分次构建所需的模块。
 
-## 快速开始
+通过这种按需编译的机制，可以减少不必要的编译时间，且随着项目规模的扩大，编译时间不会显著增长，从而大幅提升开发体验。
 
-对于使用 `@rspack/cli` 的用户，你可以通过 [experiments.lazyCompilation](/config/experiments#experimentslazycompilation) 配置开启懒编译，假设你正在开发一个包含多个入口的项目，当开发其中一个入口时，Rspack 只会构建你当前访问的入口。
+:::tip
+Lazy compilation 仅在开发阶段有效，对于生产构建不会产生影响。
+:::
+
+## 如何使用
+
+### Rspack CLI
+
+对于使用 `@rspack/cli` 的用户，你可以通过 [experiments.lazyCompilation](/config/experiments#experimentslazycompilation) 配置开启懒编译，假设你正在开发一个包含多页面应用（MPA），当开发其中一个页面时，Rspack 只会构建你当前访问的入口。
 
 ```js title="rspack.config.mjs"
 import { defineConfig } from '@rspack/cli';
@@ -15,26 +23,45 @@ export default defineConfig({
     About: './src/About.js',
   },
   experiments: {
-    lazyCompilation: {
-      // 对入口开启懒编译
-      entries: true,
-
-      // 对动态引入的模块开启懒编译
-      imports: true,
-    },
+    lazyCompilation: true,
   },
 });
 ```
 
-详细配置请参考 [experiments.lazyCompilation](/config/experiments#experimentslazycompilation)。
+`lazyCompilation: true` 等价于：
+
+```js title="rspack.config.mjs"
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
+  entry: {
+    Home: './src/Home.js',
+    About: './src/About.js',
+  },
+  experiments: {
+    // 对入口开启懒编译
+    entries: true,
+    // 对动态引入的模块开启懒编译
+    imports: true,
+  },
+});
+```
+
+> 详细配置请参考 [experiments.lazyCompilation](/config/experiments#experimentslazycompilation)。
 
 :::info
-当对入口开启懒编译后，入口模块实际上会被异步地动态引入，因此如果你配置了 `splitChunks`，入口模块会被视为 `async Chunk`，这可能会导致开发环境和生产环境的产物内容有微小差别。
+当对入口开启懒编译后，入口模块实际上会被异步地动态引入，因此如果你配置了 [splitChunks](/config/optimization#optimizationsplitchunks)，入口模块会被视为 async chunk，这可能会导致开发环境和生产环境的产物内容有微小差别。
 :::
 
-### 筛选部分模块开启懒编译
+### Rsbuild
 
-除了 `entries` 和 `imports` 两个粗粒度配置以外，你也可以使用 `test` 配置筛选部分模块开启懒编译。如果你想要禁止懒编译 `About` 入口，你可以参考如下配置。
+使用 Rsbuild 的 [dev.lazyCompilation](https://rsbuild.dev/zh/config/dev/lazy-compilation) 选项开启。
+
+## 筛选部分模块
+
+除了 `entries` 和 `imports` 两个选项以外，你也可以使用 `test` 选项来筛选部分模块开启懒编译。
+
+例如，如果你想要避免懒编译 `About` 入口，可以参考如下配置：
 
 ```js title="rspack.config.mjs"
 import { defineConfig } from '@rspack/cli';
@@ -67,9 +94,11 @@ export default defineConfig({
 
 只有当执行对应的入口或时，Rspack 才会编译对应的入口和 Module 以及他们的所有依赖。
 
-## 使用自定义的开发服务器
+## 与自定义的服务器集成
 
-在上面的配置中，`experiments.lazyCompilation` 配置实际上是由 `@rspack/cli` 消费，并向 `@rspack/dev-server` 中添加一个用于处理 `lazyCompilation` 客户端请求的[Express 风格的 middleware](https://expressjs.com/en/guide/using-middleware.html) 来处理懒编译的请求，如果你使用自己的开发服务器，你需要手动将该 middleware 的处理逻辑添加到你的开发服务器。
+当你使用 Rspack CLI 时，`experiments.lazyCompilation` 选项实际上是由 `@rspack/cli` 消费，并向 `@rspack/dev-server` 中添加一个用于处理 `lazyCompilation` 客户端请求的 [Express 风格的中间件](https://expressjs.com/en/guide/using-middleware.html) 来处理懒编译请求。
+
+如果你使用自己的开发服务器，你需要手动将 `rspack.experiments.lazyCompilationMiddleware` 集成到你的开发服务器中：
 
 ```js title="start.mjs"
 import { experiments, rspack } from '@rspack/core';
@@ -92,3 +121,8 @@ const server = new DevServer(compiler, {
 
 server.start();
 ```
+
+`lazyCompilationMiddleware` 接受两个参数：
+
+- `compiler`: 当前的 [Compiler](/api/javascript-api/compiler) 实例
+- `options`: 懒编译的配置，与 [experiments.lazyCompilation](/config/experiments#experimentslazycompilation) 相同


### PR DESCRIPTION
## Summary

Improve the lazy compilation guide:

- Add `lazy-compilation.mdx` to sidebar to display it.
- Add description for `lazyCompilationMiddleware` options.
- Add Rsbuild `dev.lazyCompilation` link.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
