### PR TITLE
fix(diagnostics): enhance transform method to return diagnostics alongside AST

### DIFF
--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -132,7 +132,7 @@ impl SwcLoader {
 
     // apply swc diagnostics
     for diagnostic in diagnostics {
-      loader_context.emit_diagnostic(miette::MietteDiagnostic::new(diagnostic));
+      loader_context.emit_diagnostic(miette::miette!(diagnostic).into());
     }
 
     if source_map_kind.enabled() {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This pull request includes several changes to the `SwcCompiler` and `SwcLoader` implementations in the `crates/rspack_loader_swc` module. The changes primarily focus on improving the handling of diagnostics and the structure of the transformation output.

The Swc plugin emit warn diagnostics will ignore by swc before, according to this PR [#10027](https://github.com/swc-project/swc/pull/10027), swc will return a diagnostics. So we can emit diagnostics to loaderContext.

Improvements to diagnostics handling and transformation output:

* [`crates/rspack_loader_swc/src/compiler.rs`](diffhunk://#diff-2af37dc1c677bb8f7d6cc3d1c81840dc61458482fa18cd002ee21d661c9c352fL349-R361): Modified the `transform` method to return a new `SwcTransformOutput` struct that includes both the AST and diagnostics. This change enhances the ability to capture and handle diagnostics during the transformation process. [[1]](diffhunk://#diff-2af37dc1c677bb8f7d6cc3d1c81840dc61458482fa18cd002ee21d661c9c352fL349-R361) [[2]](diffhunk://#diff-2af37dc1c677bb8f7d6cc3d1c81840dc61458482fa18cd002ee21d661c9c352fL380-R385) [[3]](diffhunk://#diff-2af37dc1c677bb8f7d6cc3d1c81840dc61458482fa18cd002ee21d661c9c352fL393-R401)
* [`crates/rspack_loader_swc/src/compiler.rs`](diffhunk://#diff-2af37dc1c677bb8f7d6cc3d1c81840dc61458482fa18cd002ee21d661c9c352fR554-R558): Added a new `SwcTransformOutput` struct to encapsulate the AST and diagnostics.
## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
