### PR TITLE
feat: persistent cache snapshot support hashPaths

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1711,6 +1711,7 @@ export interface RawExperimentSnapshotOptions {
   immutablePaths: Array<string|RegExp>
   unmanagedPaths: Array<string|RegExp>
   managedPaths: Array<string|RegExp>
+  hashPaths: Array<string|RegExp>
 }
 
 export interface RawExposeOptions {

--- a/crates/node_binding/src/raw_options/raw_experiments/raw_cache/raw_snapshot.rs
+++ b/crates/node_binding/src/raw_options/raw_experiments/raw_cache/raw_snapshot.rs
@@ -12,6 +12,8 @@ pub struct RawExperimentSnapshotOptions {
   pub unmanaged_paths: Vec<RawPathMatcher>,
   #[napi(ts_type = r#"Array<string|RegExp>"#)]
   pub managed_paths: Vec<RawPathMatcher>,
+  #[napi(ts_type = r#"Array<string|RegExp>"#)]
+  pub hash_paths: Vec<RawPathMatcher>,
 }
 
 type RawPathMatcher = Either<String, RspackRegex>;
@@ -31,6 +33,11 @@ impl From<RawExperimentSnapshotOptions> for SnapshotOptions {
         .collect(),
       value
         .managed_paths
+        .into_iter()
+        .map(normalize_raw_path_matcher)
+        .collect(),
+      value
+        .hash_paths
         .into_iter()
         .map(normalize_raw_path_matcher)
         .collect(),

--- a/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
@@ -1,4 +1,5 @@
 use std::{
+  hash::{DefaultHasher, Hash, Hasher},
   path::Path,
   sync::Arc,
   time::{SystemTime, UNIX_EPOCH},
@@ -21,8 +22,14 @@ pub enum Strategy {
 
   /// Check by compile time
   ///
-  /// This strategy will compare the compile time and the file update time
+  /// This strategy will compare the compile time and the file update time.
   CompileTime(u64),
+
+  /// Check by file hash
+  ///
+  /// This strategy will first compare the compile time and the file update time,
+  /// and then compare the file hash if the file has been updated.
+  PathHash { compile_time: u64, hash: u64 },
 }
 
 /// Validate Result
@@ -39,13 +46,19 @@ pub enum ValidateResult {
 pub struct StrategyHelper {
   fs: Arc<dyn ReadableFileSystem>,
   package_version_cache: DashMap<ArcPath, Option<String>>,
+  compile_time: u64,
 }
 
 impl StrategyHelper {
   pub fn new(fs: Arc<dyn ReadableFileSystem>) -> Self {
+    let now = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .expect("get current time failed")
+      .as_millis() as u64;
     Self {
       fs,
       package_version_cache: Default::default(),
+      compile_time: now,
     }
   }
 
@@ -90,13 +103,18 @@ impl StrategyHelper {
     res
   }
 
+  fn content_hash(&self, path: &Path) -> Option<u64> {
+    let Ok(content) = self.fs.read(path.assert_utf8()) else {
+      return None;
+    };
+    let mut hasher = DefaultHasher::new();
+    content.hash(&mut hasher);
+    Some(hasher.finish())
+  }
+
   /// get current time as compile time strategy
-  pub fn compile_time() -> Strategy {
-    let now = SystemTime::now()
-      .duration_since(UNIX_EPOCH)
-      .expect("get current time failed")
-      .as_millis() as u64;
-    Strategy::CompileTime(now)
+  pub fn compile_time(&self) -> Strategy {
+    Strategy::CompileTime(self.compile_time)
   }
   /// get path file package version strategy
   pub async fn package_version(&self, path: &Path) -> Option<Strategy> {
@@ -105,30 +123,49 @@ impl StrategyHelper {
       .await
       .map(Strategy::PackageVersion)
   }
+  /// get path file hash strategy
+  pub async fn path_hash(&self, path: &Path) -> Option<Strategy> {
+    let hash = self.content_hash(path)?;
+    Some(Strategy::PathHash {
+      compile_time: self.compile_time,
+      hash,
+    })
+  }
 
   /// validate path file by target strategy
   pub async fn validate(&self, path: &Path, strategy: &Strategy) -> ValidateResult {
+    let Some(modified_time) = self.modified_time(path).await else {
+      return ValidateResult::Deleted;
+    };
     match strategy {
       Strategy::PackageVersion(version) => {
-        if let Some(ref cur_version) = self.package_version_with_cache(path).await {
-          if cur_version == version {
-            ValidateResult::NoChanged
-          } else {
-            ValidateResult::Modified
-          }
+        let Some(ref cur_version) = self.package_version_with_cache(path).await else {
+          return ValidateResult::Deleted;
+        };
+        if cur_version == version {
+          ValidateResult::NoChanged
         } else {
-          ValidateResult::Deleted
+          ValidateResult::Modified
         }
       }
       Strategy::CompileTime(compile_time) => {
-        if let Some(ref modified_time) = self.modified_time(path).await {
-          if modified_time > compile_time {
-            ValidateResult::Modified
-          } else {
-            ValidateResult::NoChanged
-          }
+        if &modified_time > compile_time {
+          ValidateResult::Modified
         } else {
-          ValidateResult::Deleted
+          ValidateResult::NoChanged
+        }
+      }
+      Strategy::PathHash { compile_time, hash } => {
+        if &modified_time < compile_time {
+          return ValidateResult::NoChanged;
+        }
+        let Some(file_hash) = self.content_hash(path) else {
+          return ValidateResult::Deleted;
+        };
+        if &file_hash == hash {
+          ValidateResult::NoChanged
+        } else {
+          ValidateResult::Modified
         }
       }
     }
@@ -139,135 +176,187 @@ impl StrategyHelper {
 mod tests {
   use std::{path::Path, sync::Arc};
 
-  use rspack_fs::{MemoryFileSystem, ReadableFileSystem, WritableFileSystem};
+  use rspack_fs::{MemoryFileSystem, WritableFileSystem};
 
   use super::{Strategy, StrategyHelper, ValidateResult};
 
   #[tokio::test]
-  async fn should_strategy_works() {
+  async fn compile_time() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    let helper = StrategyHelper::new(fs.clone());
+    let compile_time_1 = helper.compile_time();
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let compile_time_2 = helper.compile_time();
+    assert_eq!(compile_time_1, compile_time_2);
+  }
+
+  #[tokio::test]
+  async fn package_version() {
     let fs = Arc::new(MemoryFileSystem::default());
     fs.create_dir_all("/packages/p1".into()).await.unwrap();
-    fs.create_dir_all("/packages/p2".into()).await.unwrap();
     fs.write(
       "/packages/p1/package.json".into(),
+      r#"{"version": "1.2.0"}"#.as_bytes(),
+    )
+    .await
+    .unwrap();
+
+    let helper = StrategyHelper::new(fs.clone());
+    assert_eq!(
+      helper
+        .package_version(Path::new("/packages/p1/file.js"))
+        .await,
+      Some(Strategy::PackageVersion("1.2.0".into()))
+    );
+    assert_eq!(
+      helper
+        .package_version(Path::new("/packages/p2/file.js"))
+        .await,
+      None
+    );
+  }
+
+  #[tokio::test]
+  async fn path_hash() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    fs.create_dir_all("/".into()).await.unwrap();
+    fs.write("/hash.js".into(), "abc".as_bytes()).await.unwrap();
+
+    let helper = StrategyHelper::new(fs.clone());
+    assert_eq!(helper.path_hash(Path::new("/not_exist.js")).await, None);
+
+    let hash1 = helper.path_hash(Path::new("/hash.js")).await;
+    fs.write("/hash.js".into(), "abc".as_bytes()).await.unwrap();
+    let hash2 = helper.path_hash(Path::new("/hash.js")).await;
+    assert_eq!(hash1, hash2);
+
+    fs.write("/hash.js".into(), "abcd".as_bytes())
+      .await
+      .unwrap();
+    let hash3 = helper.path_hash(Path::new("/hash.js")).await;
+    assert_ne!(hash1, hash3);
+  }
+
+  #[tokio::test]
+  async fn validate_compile_time() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    fs.create_dir_all("/".into()).await.unwrap();
+    fs.write("/file1.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let helper = StrategyHelper::new(fs.clone());
+    let strategy = helper.compile_time();
+    assert!(matches!(
+      helper.validate(Path::new("/file1.js"), &strategy).await,
+      ValidateResult::NoChanged
+    ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.write("/file1.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
+    assert!(matches!(
+      helper.validate(Path::new("/file1.js"), &strategy).await,
+      ValidateResult::Modified
+    ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.remove_file("/file1.js".into()).await.unwrap();
+    assert!(matches!(
+      helper.validate(Path::new("/file1.js"), &strategy).await,
+      ValidateResult::Deleted
+    ));
+  }
+
+  #[tokio::test]
+  async fn validate_package_version() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    fs.create_dir_all("/packages/lib".into()).await.unwrap();
+    fs.write(
+      "/packages/lib/package.json".into(),
       r#"{"version": "1.0.0"}"#.as_bytes(),
     )
     .await
     .unwrap();
+    fs.write("/packages/lib/file.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
+
+    let strategy = Strategy::PackageVersion("1.0.0".into());
+    let helper = StrategyHelper::new(fs.clone());
+    assert!(matches!(
+      helper
+        .validate(Path::new("/packages/lib/file.js"), &strategy)
+        .await,
+      ValidateResult::NoChanged
+    ));
+
+    helper.package_version_cache.clear();
     fs.write(
-      "/packages/p2/package.json".into(),
-      r#"{"version": "1.1.0"}"#.as_bytes(),
+      "/packages/lib/package.json".into(),
+      r#"{"version": "1.2.0"}"#.as_bytes(),
     )
     .await
     .unwrap();
-    fs.write("/file1".into(), "abc".as_bytes()).await.unwrap();
-
-    // compile_time
-    let Strategy::CompileTime(time1) = StrategyHelper::compile_time() else {
-      unreachable!()
-    };
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    let Strategy::CompileTime(time2) = StrategyHelper::compile_time() else {
-      unreachable!()
-    };
-    assert!(time1 < time2);
-
-    let helper = StrategyHelper::new(fs.clone());
-    // modified_time
-    assert_eq!(
-      helper.modified_time(Path::new("/file1")).await,
-      Some(fs.metadata("/file1".into()).unwrap().mtime_ms)
-    );
-    assert!(helper.modified_time(Path::new("/file2")).await.is_none());
-
-    // package_version_with_cache
-    assert_eq!(
-      helper
-        .package_version_with_cache(Path::new("/packages/p1/file"))
-        .await
-        .unwrap(),
-      "1.0.0"
-    );
-    assert_eq!(
-      helper
-        .package_version_with_cache(Path::new("/packages/p2/file"))
-        .await
-        .unwrap(),
-      "1.1.0"
-    );
-    assert_eq!(
-      helper
-        .package_version_with_cache(Path::new("/packages/p2/dir1/dir2/dir3/file"))
-        .await
-        .unwrap(),
-      "1.1.0"
-    );
-    assert!(helper
-      .package_version_with_cache(Path::new("/file1"))
-      .await
-      .is_none());
-    assert!(helper
-      .package_version_with_cache(Path::new("/file2"))
-      .await
-      .is_none());
-
-    // package_version
-    assert_eq!(
-      helper
-        .package_version(Path::new("/packages/p1/file"))
-        .await
-        .unwrap(),
-      Strategy::PackageVersion("1.0.0".into())
-    );
-    assert_eq!(
-      helper
-        .package_version(Path::new("/packages/p2/file"))
-        .await
-        .unwrap(),
-      Strategy::PackageVersion("1.1.0".into())
-    );
-    assert_eq!(
-      helper
-        .package_version(Path::new("/packages/p2/dir1/dir2/dir3/file"))
-        .await
-        .unwrap(),
-      Strategy::PackageVersion("1.1.0".into())
-    );
-    assert!(helper.package_version(Path::new("/file1")).await.is_none());
-    assert!(helper.package_version(Path::new("/file2")).await.is_none());
-
-    // validate
-    let now = StrategyHelper::compile_time();
     assert!(matches!(
-      helper.validate(Path::new("/file1"), &now).await,
-      ValidateResult::NoChanged
-    ));
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    fs.write("/file1".into(), "abcd".as_bytes()).await.unwrap();
-    assert!(matches!(
-      helper.validate(Path::new("/file1"), &now).await,
+      helper
+        .validate(Path::new("/packages/lib/file.js"), &strategy)
+        .await,
       ValidateResult::Modified
     ));
+
+    helper.package_version_cache.clear();
+    fs.remove_file("/packages/lib/package.json".into())
+      .await
+      .unwrap();
     assert!(matches!(
-      helper.validate(Path::new("/file2"), &now).await,
+      helper
+        .validate(Path::new("/packages/lib/file.js"), &strategy)
+        .await,
       ValidateResult::Deleted
     ));
+  }
 
-    let version = Strategy::PackageVersion("1.0.0".into());
+  #[tokio::test]
+  async fn validate_path_hash() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    fs.create_dir_all("/".into()).await.unwrap();
+    fs.write("/file1.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let helper = StrategyHelper::new(fs.clone());
+    let strategy = helper.path_hash(Path::new("/file1.js")).await.unwrap();
     assert!(matches!(
-      helper
-        .validate(Path::new("/packages/p1/file1"), &version)
-        .await,
+      helper.validate(Path::new("/file1.js"), &strategy).await,
       ValidateResult::NoChanged
     ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.write("/file1.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
     assert!(matches!(
-      helper
-        .validate(Path::new("/packages/p2/file1"), &version)
-        .await,
+      helper.validate(Path::new("/file1.js"), &strategy).await,
+      ValidateResult::NoChanged
+    ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.write("/file1.js".into(), "abcd".as_bytes())
+      .await
+      .unwrap();
+    assert!(matches!(
+      helper.validate(Path::new("/file1.js"), &strategy).await,
       ValidateResult::Modified
     ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.remove_file("/file1.js".into()).await.unwrap();
     assert!(matches!(
-      helper.validate(Path::new("/file2"), &version).await,
+      helper.validate(Path::new("/file1.js"), &strategy).await,
       ValidateResult::Deleted
     ));
   }

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/hash-paths/file.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/hash-paths/file.js
@@ -1,0 +1,7 @@
+export default 1;
+---
+export default 2;
+---
+export default 3;
+---
+export default 4;

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/hash-paths/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/hash-paths/index.js
@@ -1,0 +1,15 @@
+import value from "./file";
+
+it("should hash paths work", async () => {
+	if (COMPILER_INDEX == 0) {
+		expect(value).toBe(1);
+		await NEXT_HMR();
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(value).toBe(2);
+		await NEXT_HMR();
+		expect(value).toBe(4);
+	}
+});

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/hash-paths/rspack.config.js
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/hash-paths/rspack.config.js
@@ -1,0 +1,14 @@
+const path = require("path");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	experiments: {
+		cache: {
+			type: "persistent",
+			snapshot: {
+				hashPaths: [path.join(__dirname, "./file.js")]
+			}
+		}
+	}
+};

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -1901,6 +1901,7 @@ export type ExperimentCacheNormalized = boolean | {
         immutablePaths: Array<string | RegExp>;
         unmanagedPaths: Array<string | RegExp>;
         managedPaths: Array<string | RegExp>;
+        hashPaths: Array<string | RegExp>;
     };
     storage: {
         type: "filesystem";
@@ -1919,6 +1920,7 @@ export type ExperimentCacheOptions = boolean | {
         immutablePaths?: Array<string | RegExp>;
         unmanagedPaths?: Array<string | RegExp>;
         managedPaths?: Array<string | RegExp>;
+        hashPaths?: Array<string | RegExp>;
     };
     storage?: {
         type: "filesystem";

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -333,7 +333,8 @@ export const getNormalizedRspackOptions = (
 						unmanagedPaths: nestedArray(snapshot.unmanagedPaths, p => [...p]),
 						managedPaths: optionalNestedArray(snapshot.managedPaths, p => [
 							...p
-						]) || [/\/node_modules\//]
+						]) || [/\/node_modules\//],
+						hashPaths: nestedArray(snapshot.hashPaths, p => [...p])
 					},
 					storage: {
 						type: "filesystem",
@@ -591,6 +592,7 @@ export type ExperimentCacheNormalized =
 				immutablePaths: Array<string | RegExp>;
 				unmanagedPaths: Array<string | RegExp>;
 				managedPaths: Array<string | RegExp>;
+				hashPaths: Array<string | RegExp>;
 			};
 			storage: {
 				type: "filesystem";

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2427,6 +2427,7 @@ export type ExperimentCacheOptions =
 				immutablePaths?: Array<string | RegExp>;
 				unmanagedPaths?: Array<string | RegExp>;
 				managedPaths?: Array<string | RegExp>;
+				hashPaths?: Array<string | RegExp>;
 			};
 			storage?: {
 				type: "filesystem";

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1324,7 +1324,8 @@ const experimentCacheOptions = z
 						.or(z.instanceof(RegExp))
 						.array()
 						.optional(),
-					managedPaths: z.string().or(z.instanceof(RegExp)).array().optional()
+					managedPaths: z.string().or(z.instanceof(RegExp)).array().optional(),
+					hashPaths: z.string().or(z.instanceof(RegExp)).array().optional()
 				})
 				.optional(),
 			storage: z


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Persistent cache snapshot is used to calculate the state of file modifications when rspack hot start, but only two strategies are supported: PackageVersion(config snapshot.managePaths) and ModifiedFiles.

This PR will add a new strategy `PathHash` which will determine if a file is modified by checking the file hash.

``` js
// rspack.config.js
export default {
  experiments: {
    type: "persistent",
    snapshot: {
      hashPaths: [path.join(__dirname, "./src")]
    }
  }
}
```

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
