### PR TITLE
fix: sort diagnostics before push to compilation

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -1401,6 +1401,7 @@ Or do you want to use the entrypoints '{name}' and '{entry_runtime}' independent
     }
     self.set_order_index_and_group_index(compilation);
 
+    errors.sort_unstable_by_key(|err| err.message());
     compilation.extend_diagnostics(errors);
 
     if enable_incremental {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

As chunk creations are from different threads, they have no determined order, so the diagnostics should be sorted before we push them to compilation

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
