### PR TITLE
refactor!: lazy compilation middleware supports multiCompiler and use config from compiler instance

### DIFF
--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -105,24 +105,17 @@ export class ServeCommand implements RspackCommand {
 
 				const result = (compilerForDevServer.options.devServer ??= {});
 
-				if (compilerForDevServer.options.experiments.lazyCompilation) {
-					const options =
-						compilerForDevServer.options.experiments.lazyCompilation;
+				const setupMiddlewares = result.setupMiddlewares;
 
-					const setupMiddlewares = result.setupMiddlewares;
-					const lazyCompileMiddleware =
-						rspack.experiments.lazyCompilationMiddleware(
-							compilerForDevServer,
-							options
-						);
-					result.setupMiddlewares = (middlewares, server) => {
-						let finalMiddlewares = middlewares;
-						if (setupMiddlewares) {
-							finalMiddlewares = setupMiddlewares(finalMiddlewares, server);
-						}
-						return [lazyCompileMiddleware, ...finalMiddlewares];
-					};
-				}
+				const lazyCompileMiddleware =
+					rspack.experiments.lazyCompilationMiddleware(compiler);
+				result.setupMiddlewares = (middlewares, server) => {
+					let finalMiddlewares = middlewares;
+					if (setupMiddlewares) {
+						finalMiddlewares = setupMiddlewares(finalMiddlewares, server);
+					}
+					return [lazyCompileMiddleware, ...finalMiddlewares];
+				};
 
 				/**
 				 * Enable this to tell Rspack that we need to enable React Refresh by default

--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -4,14 +4,14 @@
 
 ```ts
 
-import type { Compiler } from '@rspack/core';
+import { Compiler } from '@rspack/core';
 import type { Compiler as Compiler_2 } from 'webpack';
 import type { Configuration } from 'webpack';
 import type EventEmitter from 'node:events';
 import { IBasicGlobalContext as IBasicGlobalContext_2 } from '../../type';
 import { IBasicModuleScope as IBasicModuleScope_2 } from '../../type';
 import { ITestCompilerManager as ITestCompilerManager_2 } from '../type';
-import type { MultiCompiler } from '@rspack/core';
+import { MultiCompiler } from '@rspack/core';
 import type { MultiStats } from '@rspack/core';
 import type { MultiStats as MultiStats_2 } from 'webpack';
 import type { RspackOptions } from '@rspack/core';

--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -11,6 +11,7 @@ import type EventEmitter from 'node:events';
 import { IBasicGlobalContext as IBasicGlobalContext_2 } from '../../type';
 import { IBasicModuleScope as IBasicModuleScope_2 } from '../../type';
 import { ITestCompilerManager as ITestCompilerManager_2 } from '../type';
+import type { MultiCompiler } from '@rspack/core';
 import type { MultiStats } from '@rspack/core';
 import type { MultiStats as MultiStats_2 } from 'webpack';
 import type { RspackOptions } from '@rspack/core';
@@ -1231,7 +1232,7 @@ export class JSDOMWebRunner<T extends ECompilerType = ECompilerType.Rspack> exte
 // @public (undocumented)
 export class LazyCompilationTestPlugin {
     // (undocumented)
-    apply(compiler: Compiler): void;
+    apply(compiler: Compiler | MultiCompiler): void;
 }
 
 // @public (undocumented)

--- a/packages/rspack-test-tools/src/plugin/lazy-compilation-test-plugin.ts
+++ b/packages/rspack-test-tools/src/plugin/lazy-compilation-test-plugin.ts
@@ -1,16 +1,11 @@
 import { createServer } from "node:http";
 import type { Socket } from "node:net";
 import type { AddressInfo } from "node:net";
-import type { Compiler } from "@rspack/core";
+import type { Compiler, MultiCompiler } from "@rspack/core";
 import { experiments } from "@rspack/core";
 
 export class LazyCompilationTestPlugin {
-	apply(compiler: Compiler) {
-		const options = compiler.options.experiments.lazyCompilation!;
-		if (!options) {
-			return;
-		}
-
+	apply(compiler: Compiler | MultiCompiler) {
 		let middleware: any;
 		const server = createServer();
 		const sockets = new Set<Socket>();
@@ -27,12 +22,10 @@ export class LazyCompilationTestPlugin {
 						: addr.family === "IPv6"
 							? `${protocol}://[${addr.address}]:${addr.port}`
 							: `${protocol}://${addr.address}:${addr.port}`;
-
 				middleware = experiments.lazyCompilationMiddleware(compiler, {
 					// @ts-expect-error cacheable is hidden config only for tests
 					cacheable: false,
-					serverUrl: urlBase,
-					...options
+					serverUrl: urlBase
 				});
 
 				resolve(null);

--- a/packages/rspack-test-tools/tests/fixtures/esm/d-dynamic.js
+++ b/packages/rspack-test-tools/tests/fixtures/esm/d-dynamic.js
@@ -1,0 +1,1 @@
+export default 4;

--- a/packages/rspack-test-tools/tests/fixtures/esm/d.js
+++ b/packages/rspack-test-tools/tests/fixtures/esm/d.js
@@ -1,0 +1,1 @@
+export default import('./d-dynamic');

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4150,7 +4150,7 @@ interface LabeledStatement extends Node_4, HasSpan {
 export type Layer = string | null;
 
 // @public (undocumented)
-const lazyCompilationMiddleware: (compiler: Compiler, userOptions?: LazyCompilationOptions | boolean) => DevServerMiddleware;
+const lazyCompilationMiddleware: (compiler: Compiler | MultiCompiler, userOptions?: LazyCompilationOptions | boolean) => Middleware;
 
 // @public
 export type LazyCompilationOptions = {
@@ -4825,6 +4825,8 @@ export class MultiCompiler {
     hooks: {
         done: liteTapable.SyncHook<MultiStats>;
         invalid: liteTapable.MultiHook<liteTapable.SyncHook<[string | null, number]>>;
+        beforeCompile: liteTapable.MultiHook<liteTapable.AsyncSeriesHook<[CompilationParams]>>;
+        shutdown: liteTapable.MultiHook<liteTapable.AsyncSeriesHook<[]>>;
         run: liteTapable.MultiHook<liteTapable.AsyncSeriesHook<[Compiler]>>;
         watchClose: liteTapable.SyncHook<[]>;
         watchRun: liteTapable.MultiHook<liteTapable.AsyncSeriesHook<[Compiler]>>;
@@ -4863,6 +4865,8 @@ export class MultiCompiler {
     // (undocumented)
     get watchFileSystem(): WatchFileSystem;
     set watchFileSystem(value: WatchFileSystem);
+    // (undocumented)
+    watching?: MultiWatching;
 }
 
 // @public (undocumented)
@@ -4899,6 +4903,8 @@ class MultiWatching {
     compiler: MultiCompiler;
     // (undocumented)
     invalidate(callback: Callback<Error, void>): void;
+    // (undocumented)
+    invalidateWithChangesAndRemovals(changedFiles?: Set<string>, removedFiles?: Set<string>, callback?: Callback<Error, void>): void;
     // (undocumented)
     resume(): void;
     // (undocumented)

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4150,7 +4150,7 @@ interface LabeledStatement extends Node_4, HasSpan {
 export type Layer = string | null;
 
 // @public (undocumented)
-const lazyCompilationMiddleware: (compiler: Compiler | MultiCompiler, userOptions?: LazyCompilationOptions | boolean) => Middleware;
+const lazyCompilationMiddleware: (compiler: Compiler | MultiCompiler) => MiddlewareHandler;
 
 // @public
 export type LazyCompilationOptions = {

--- a/packages/rspack/src/MultiWatching.ts
+++ b/packages/rspack/src/MultiWatching.ts
@@ -42,6 +42,31 @@ class MultiWatching {
 		}
 	}
 
+	invalidateWithChangesAndRemovals(
+		changedFiles?: Set<string>,
+		removedFiles?: Set<string>,
+		callback?: Callback<Error, void>
+	) {
+		if (callback) {
+			asyncLib.each(
+				this.watchings,
+				(watching, callback) =>
+					watching.invalidateWithChangesAndRemovals(
+						changedFiles,
+						removedFiles,
+						callback
+					),
+				// cannot be resolved without assertion
+				// Type 'Error | null | undefined' is not assignable to type 'Error | null'
+				callback as (err: Error | null | undefined) => void
+			);
+		} else {
+			for (const watching of this.watchings) {
+				watching.invalidateWithChangesAndRemovals(changedFiles, removedFiles);
+			}
+		}
+	}
+
 	close(callback: Callback<Error, void>) {
 		asyncLib.each(
 			this.watchings,

--- a/packages/rspack/src/config/devServer.ts
+++ b/packages/rspack/src/config/devServer.ts
@@ -208,7 +208,7 @@ type DevMiddlewareContext<
 };
 type Server = any;
 
-type MiddlewareHandler<
+export type MiddlewareHandler<
 	RequestInternal extends Request = Request,
 	ResponseInternal extends Response = Response
 > = (

--- a/tests/e2e/fixtures/rspack.ts
+++ b/tests/e2e/fixtures/rspack.ts
@@ -36,7 +36,7 @@ class Rspack {
 		});
 		const DevServerConstructor = RspackDevServer;
 		if (compiler.options.experiments.lazyCompilation) {
-			const middleware = experiments.lazyCompilationMiddleware(compiler, compiler.options.experiments.lazyCompilation)
+			const middleware = experiments.lazyCompilationMiddleware(compiler)
 			compiler.options.devServer ??= {};
 			const setupMiddlewares = compiler.options.devServer.setupMiddlewares;
 			compiler.options.devServer.setupMiddlewares = (middlewares, server) => {
@@ -84,7 +84,7 @@ class Rspack {
 		const DevServerConstructor = RspackDevServer;
 
 		if (compiler.options.experiments.lazyCompilation) {
-			const middleware = experiments.lazyCompilationMiddleware(compiler, compiler.options.experiments.lazyCompilation)
+			const middleware = experiments.lazyCompilationMiddleware(compiler)
 			compiler.options.devServer ??= {};
 			const setupMiddleware = compiler.options.devServer.setupMiddlewares;
 			compiler.options.devServer.setupMiddlewares = (middlewares, server) => {

--- a/website/docs/en/guide/features/lazy-compilation.mdx
+++ b/website/docs/en/guide/features/lazy-compilation.mdx
@@ -107,10 +107,7 @@ import DevServer from 'webpack-dev-server';
 
 const compiler = rspack(config);
 
-const middleware = experiments.lazyCompilationMiddleware(
-  compiler,
-  config.experiments.lazyCompilation,
-);
+const middleware = experiments.lazyCompilationMiddleware(compiler);
 
 const server = new DevServer(
   {
@@ -125,10 +122,9 @@ const server = new DevServer(
 server.start();
 ```
 
-`lazyCompilationMiddleware` accepts two parameters:
+`lazyCompilationMiddleware` accepts one parameter:
 
 - `compiler`: The current [Compiler](/api/javascript-api/compiler) instance
-- `options`: The lazy compilation options, same as [experiments.lazyCompilation](/config/experiments#experimentslazycompilation)
 
 ## Customizing lazy compilation endpoint
 

--- a/website/docs/zh/guide/features/lazy-compilation.mdx
+++ b/website/docs/zh/guide/features/lazy-compilation.mdx
@@ -107,10 +107,7 @@ import DevServer from 'webpack-dev-server';
 
 const compiler = rspack(config);
 
-const middleware = experiments.lazyCompilationMiddleware(
-  compiler,
-  config.experiments.lazyCompilation,
-);
+const middleware = experiments.lazyCompilationMiddleware(compiler);
 
 const server = new DevServer(
   {
@@ -125,10 +122,9 @@ const server = new DevServer(
 server.start();
 ```
 
-`lazyCompilationMiddleware` 接受两个参数：
+`lazyCompilationMiddleware` 接受一个参数：
 
 - `compiler`: 当前的 [Compiler](/api/javascript-api/compiler) 实例
-- `options`: 懒编译的配置，与 [experiments.lazyCompilation](/config/experiments#experimentslazycompilation) 相同
 
 ## 自定义懒编译端点
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Lazy compilation middleware can receive multiCompiler as parameter

When there is a module triggers update, we notify the multiWatching, then multiWatching will invalidate its sub watching.

Every compiler can has its own lazy-compilation config, for example you can make compiler_1 only lazy compiles entries, while compiler_2 only lazy compiles imports

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
