### PR TITLE
fix: return dynamic import script externals

### DIFF
--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -497,7 +497,7 @@ pub fn module_namespace_promise(
         }
         appending.push_str(
           format!(
-            ".then(function(m){{\n {}(m, {fake_type}) \n}})",
+            ".then(function(m){{\n return {}(m, {fake_type}) \n}})",
             RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT
           )
           .as_str(),

--- a/packages/rspack-test-tools/tests/configCases/externals/script-externals-dynamic-import/case.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/script-externals-dynamic-import/case.js
@@ -1,0 +1,1 @@
+const e1 = import('externals1')

--- a/packages/rspack-test-tools/tests/configCases/externals/script-externals-dynamic-import/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/script-externals-dynamic-import/index.js
@@ -1,0 +1,11 @@
+const fs = require("fs");
+const path = require("path");
+
+const readCase = (name)=> fs.readFileSync(path.resolve(__dirname, `${name}.js`), "utf-8");
+
+const caseContent = readCase("case");
+
+it("dynamic import script externals module should be returned", function () {
+	expect(caseContent).toContain(`return __webpack_require__.t(m, 22)`)
+
+});

--- a/packages/rspack-test-tools/tests/configCases/externals/script-externals-dynamic-import/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/script-externals-dynamic-import/rspack.config.js
@@ -1,0 +1,18 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = [
+	{
+		target: "node",
+		entry: {
+			index: "./index.js",
+			case: "./case.js"
+		},
+		output: {
+			module: false,
+			filename: "[name].js"
+		},
+		externals: {
+			externals1:
+				"script Externals1@https://unpkg.com/externals1@1.0.0/index.min.js"
+		}
+	}
+];

--- a/packages/rspack-test-tools/tests/configCases/externals/script-externals-dynamic-import/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/script-externals-dynamic-import/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../dist").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["index.js"];
+	}
+};


### PR DESCRIPTION


## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

As the [document](https://rspack.dev/zh/config/externals#externalstypescript) says, rspack supports `script` externalsType .Also, externals could be configured like `script global@your-cdn-link`.

When dynamically importing an externalscript module, the compiled code was missing a return statement , causing the import to resolve to undefined.


**rspack.config:**
```javascript
module.exports ={
  ...,
  externals: {
    example: 'script example@https://unpkg.com/example@1.0.0/index.min.js'
  }
}
```

**source code:**

```javascript
const example = import('example').then(mod => {
  console.log('example: ' mod);   // output: example: undefined
  return mod;
})
```

**compiled code:**

- Before:

  ```javascript
  .then(function(m) {
    __webpack_require__.t(m, 22)
  })
  ```

- After:
  ```javascript
  .then(function(m) {
    return __webpack_require__.t(m, 22)
  })
  ```

This fixes the issue where `import()` of external script modules returns undefined.

Built rspack locally and verified:
1. The generated code now contains the return statement
2. Dynamic imports of external modules properly resolve to the module content.
3. Built a new binding file then replaced it in my project.  It worked.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required).
