### PR TITLE
chore: adjust defaultRustTraceFilter to info

### DIFF
--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -75,7 +75,7 @@ const defaultRustTraceChromeOutput = path.join(
 	"./trace.json"
 );
 const defaultRustTraceLoggerOutput = "stdout";
-const defaultRustTraceFilter = "trace";
+const defaultRustTraceFilter = "info";
 const defaultRustTraceLayer = "chrome";
 const defaultLoggingOutput = path.join(defaultOutputDirname, "./logging.json");
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
adjust default traceFilter to "info" since release binary doesn't support trace level otherwise it will generate following warning 
![image](https://github.com/user-attachments/assets/aeed260e-9267-4658-a35a-0e04ba7a8b34)

related to https://github.com/web-infra-dev/rspack/pull/9825
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
