### PR TITLE
test(loader-parallel): disable cases that rely on `import()` in node 16

### DIFF
--- a/packages/rspack-test-tools/src/helper/legacy/supportsImportFn.js
+++ b/packages/rspack-test-tools/src/helper/legacy/supportsImportFn.js
@@ -1,0 +1,12 @@
+// @ts-nocheck
+const nodeVersion = process.versions.node.split(".").map(Number);
+
+module.exports = function supportsImportFn() {
+	// Segmetation fault in vm with --experimental-vm-modules,
+	// which has not been resolved in node 16 yet.
+	// https://github.com/nodejs/node/issues/35889
+	if (nodeVersion[0] > 16) {
+		return true;
+	}
+	return false;
+};

--- a/packages/rspack-test-tools/src/helper/legacy/supportsImportFn.js
+++ b/packages/rspack-test-tools/src/helper/legacy/supportsImportFn.js
@@ -2,7 +2,7 @@
 const nodeVersion = process.versions.node.split(".").map(Number);
 
 module.exports = function supportsImportFn() {
-	// Segmetation fault in vm with --experimental-vm-modules,
+	// Segmentation fault in vm with --experimental-vm-modules,
 	// which has not been resolved in node 16 yet.
 	// https://github.com/nodejs/node/issues/35889
 	if (nodeVersion[0] > 16) {

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data-no-passthrough/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data-no-passthrough/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const path = require("path");
 
 /**
@@ -22,6 +23,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data-passthrough/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data-passthrough/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const path = require("path");
 
 /**
@@ -22,6 +23,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data/rspack.config.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 
 /**
  * @type {import('@rspack/core').RspackOptions}
@@ -17,6 +18,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/async/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/async/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const path = require("path");
 const file = path.join(__dirname, "a.js");
 const asyncLoader = path.join(__dirname, "asyncloader.js");
@@ -59,6 +60,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/binary-with-source-map/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/binary-with-source-map/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const path = require("path");
 
 /**
@@ -16,6 +17,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/issue-webpack-9053/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/issue-webpack-9053/rspack.config.js
@@ -1,3 +1,5 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	module: {
@@ -13,6 +15,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-error-async/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-error-async/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const path = require("path");
 const file = path.resolve(__dirname, "lib.js");
 
@@ -33,6 +34,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-raw-string/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-raw-string/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const path = require("path");
 const file = path.resolve(__dirname, "lib.js");
 const createUse = loaders =>
@@ -20,6 +21,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-raw/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-raw/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	context: __dirname,
@@ -11,6 +12,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-string/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-string/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 /**
  * @type {import('@rspack/core').RspackOptions}
  */
@@ -18,6 +19,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/module-build-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/module-build-error/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: "./index.js",
@@ -11,6 +12,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/options/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/options/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	mode: "none",
@@ -116,6 +117,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/parallel-option/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/parallel-option/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 module.exports = {
 	context: __dirname,
 	module: {
@@ -15,6 +16,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: false
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/pitching-mixed/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/pitching-mixed/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const { rspack } = require("@rspack/core");
 /**
  * @type {import('@rspack/core').RspackOptions[]}
@@ -22,7 +23,7 @@ module.exports = [
 			})
 		],
 		experiments: {
-			parallelLoader: true
+			parallelLoader: supportsImportFn()
 		}
 	},
 	{
@@ -48,7 +49,7 @@ module.exports = [
 			})
 		],
 		experiments: {
-			parallelLoader: true
+			parallelLoader: supportsImportFn()
 		}
 	},
 	{
@@ -74,7 +75,7 @@ module.exports = [
 			})
 		],
 		experiments: {
-			parallelLoader: true
+			parallelLoader: supportsImportFn()
 		}
 	},
 	{
@@ -94,6 +95,9 @@ module.exports = [
 			new rspack.DefinePlugin({
 				CONTEXT: JSON.stringify(__dirname)
 			})
-		]
+		],
+		experiments: {
+			parallelLoader: supportsImportFn()
+		}
 	}
 ];

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/pitching/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/pitching/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const { rspack } = require("@rspack/core");
 /**
  * @type {import('@rspack/core').RspackOptions[]}
@@ -22,7 +23,7 @@ module.exports = [
 			})
 		],
 		experiments: {
-			parallelLoader: true
+			parallelLoader: supportsImportFn()
 		}
 	},
 	{
@@ -48,7 +49,7 @@ module.exports = [
 			})
 		],
 		experiments: {
-			parallelLoader: true
+			parallelLoader: supportsImportFn()
 		}
 	},
 	{
@@ -74,7 +75,7 @@ module.exports = [
 			})
 		],
 		experiments: {
-			parallelLoader: true
+			parallelLoader: supportsImportFn()
 		}
 	},
 	{
@@ -98,6 +99,9 @@ module.exports = [
 			new rspack.DefinePlugin({
 				CONTEXT: JSON.stringify(__dirname)
 			})
-		]
+		],
+		experiments: {
+			parallelLoader: supportsImportFn()
+		}
 	}
 ];

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/pre-post-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/pre-post-loader/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 /**
  * @type {import('@rspack/core').RspackOptions}
  */
@@ -25,6 +26,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/source-map/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/source-map/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const path = require("path");
 
 /**
@@ -17,6 +18,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/sync/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/sync/rspack.config.js
@@ -1,3 +1,4 @@
+const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
 const path = require("path");
 const file = path.join(__dirname, "a.js");
 const asyncLoader = path.join(__dirname, "asyncloader.js");
@@ -37,6 +38,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		parallelLoader: true
+		parallelLoader: supportsImportFn()
 	}
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

In this PR, tests relying on `import()` are disabled. It causes segmentation fault in `vm` with `--experimental-vm-modules`, which is exactly what jest has been relying on and the issue has not been resolved in node 16 yet according to my local test. 

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or not required).
