### PR TITLE
refactor: convert errors and results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4322,11 +4322,13 @@ dependencies = [
  "rspack_cacheable",
  "rspack_collections",
  "rspack_paths",
+ "serde_json",
  "swc_core",
  "swc_parallel",
  "termcolor",
  "textwrap",
  "thiserror 1.0.69",
+ "tokio",
  "unicode-width 0.2.0",
 ]
 

--- a/crates/node_binding/src/error.rs
+++ b/crates/node_binding/src/error.rs
@@ -78,3 +78,23 @@ impl JsRspackError {
     .with_hide_stack(self.hide_stack)
   }
 }
+
+pub trait RspackErrorToNapiErrorExt {
+  fn to_napi_error(self) -> napi::Error;
+}
+
+impl<T: ToString> RspackErrorToNapiErrorExt for T {
+  fn to_napi_error(self) -> napi::Error {
+    napi::Error::from_reason(self.to_string())
+  }
+}
+
+pub trait RspackResultToNapiResultExt<T> {
+  fn to_napi_result(self) -> napi::Result<T>;
+}
+
+impl<T, E: ToString> RspackResultToNapiResultExt<T> for Result<T, E> {
+  fn to_napi_result(self) -> napi::Result<T> {
+    self.map_err(|e| napi::Error::from_reason(e.to_string()))
+  }
+}

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -156,13 +156,10 @@ impl JsCompiler {
     plugins.push(js_cleanup_plugin.boxed());
 
     for bp in builtin_plugins {
-      bp.append_to(env, &mut plugins)
-        .map_err(|e| Error::from_reason(format!("{e}")))?;
+      bp.append_to(env, &mut plugins).to_napi_result()?;
     }
 
-    let compiler_options: rspack_core::CompilerOptions = options
-      .try_into()
-      .map_err(|e| Error::from_reason(format!("{e}")))?;
+    let compiler_options: rspack_core::CompilerOptions = options.try_into().to_napi_result()?;
 
     tracing::info!("normalized_options: {:#?}", &compiler_options);
 
@@ -174,7 +171,7 @@ impl JsCompiler {
     let intermediate_filesystem: Option<Arc<dyn IntermediateFileSystem>> =
       if let Some(fs) = intermediate_filesystem {
         Some(Arc::new(NodeFileSystem::new(fs).map_err(|e| {
-          Error::from_reason(format!("Failed to create intermediate filesystem: {e}",))
+          format!("Failed to create intermediate filesystem: {e}").to_napi_error()
         })?))
       } else {
         None
@@ -186,7 +183,7 @@ impl JsCompiler {
       plugins,
       buildtime_plugins::buildtime_plugins(),
       Some(Arc::new(NodeFileSystem::new(output_filesystem).map_err(
-        |e| Error::from_reason(format!("Failed to create writable filesystem: {e}",)),
+        |e| format!("Failed to create writable filesystem: {e}").to_napi_error(),
       )?)),
       intermediate_filesystem,
       None,
@@ -214,10 +211,7 @@ impl JsCompiler {
       self.run(env, reference, |compiler, _guard| {
         callbackify(env, f, async move {
           compiler.build().await.map_err(|e| {
-            Error::new(
-              napi::Status::GenericFailure,
-              print_error_diagnostic(e, compiler.options.stats.colors),
-            )
+            print_error_diagnostic(e, compiler.options.stats.colors).to_napi_error()
           })?;
           tracing::info!("build ok");
           drop(_guard);
@@ -251,10 +245,7 @@ impl JsCompiler {
             )
             .await
             .map_err(|e| {
-              Error::new(
-                napi::Status::GenericFailure,
-                print_error_diagnostic(e, compiler.options.stats.colors),
-              )
+              print_error_diagnostic(e, compiler.options.stats.colors).to_napi_error()
             })?;
           tracing::info!("rebuild ok");
           drop(_guard);

--- a/crates/node_binding/src/plugins/js_loader/resolver.rs
+++ b/crates/node_binding/src/plugins/js_loader/resolver.rs
@@ -9,11 +9,7 @@ use rspack_core::{
   BoxLoader, Context, Loader, ModuleRuleUseLoader, NormalModuleFactoryResolveLoader, ResolveResult,
   Resolver, Resource, RunnerContext, BUILTIN_LOADER_PREFIX,
 };
-use rspack_error::{
-  error,
-  miette::{miette, LabeledSpan, SourceOffset},
-  Result,
-};
+use rspack_error::{error, Result, SerdeResultToRspackResultExt};
 use rspack_hook::plugin_hook;
 use rspack_loader_lightningcss::{config::Config, LIGHTNINGCSS_LOADER_IDENTIFIER};
 use rspack_loader_preact_refresh::PREACT_REFRESH_LOADER_IDENTIFIER;
@@ -37,16 +33,6 @@ impl Identifiable for JsLoader {
     self.0
   }
 }
-// convert serde_error to miette report for pretty error
-pub fn serde_error_to_miette(
-  e: serde_json::Error,
-  content: Arc<str>,
-  msg: &str,
-) -> rspack_error::miette::Report {
-  let offset = SourceOffset::from_location(content.as_ref(), e.line(), e.column());
-  let span = LabeledSpan::at_offset(offset.offset(), e.to_string());
-  miette!(labels = vec![span], "{msg}").with_source_code(content.clone())
-}
 
 type SwcLoaderCache<'a> = LazyLock<RwLock<FxHashMap<(Cow<'a, str>, Arc<str>), Arc<SwcLoader>>>>;
 static SWC_LOADER_CACHE: SwcLoaderCache = LazyLock::new(|| RwLock::new(FxHashMap::default()));
@@ -64,13 +50,10 @@ pub async fn get_builtin_loader(builtin: &str, options: Option<&str>) -> Result<
 
     let loader = Arc::new(
       rspack_loader_swc::SwcLoader::new(options.as_ref())
-        .map_err(|e| {
-          serde_error_to_miette(
-            e,
-            options.clone(),
-            "failed to parse builtin:swc-loader options",
-          )
-        })?
+        .to_rspack_result_with_detail(
+          options.as_ref(),
+          "failed to parse builtin:swc-loader options",
+        )?
         .with_identifier(builtin.into()),
     );
 
@@ -83,13 +66,10 @@ pub async fn get_builtin_loader(builtin: &str, options: Option<&str>) -> Result<
 
   if builtin.starts_with(LIGHTNINGCSS_LOADER_IDENTIFIER) {
     let config: rspack_loader_lightningcss::config::RawConfig =
-      serde_json::from_str(options.as_ref()).map_err(|e| {
-        serde_error_to_miette(
-          e,
-          options,
-          "Could not parse builtin:lightningcss-loader options",
-        )
-      })?;
+      serde_json::from_str(options.as_ref()).to_rspack_result_with_detail(
+        options.as_ref(),
+        "Could not parse builtin:lightningcss-loader options",
+      )?;
     // TODO: builtin-loader supports function
     return Ok(Arc::new(
       rspack_loader_lightningcss::LightningCssLoader::new(None, Config::try_from(config)?, builtin),

--- a/crates/node_binding/src/resolver_factory.rs
+++ b/crates/node_binding/src/resolver_factory.rs
@@ -8,7 +8,7 @@ use crate::{
   raw_resolve::{
     normalize_raw_resolve_options_with_dependency_type, RawResolveOptionsWithDependencyType,
   },
-  JsResolver,
+  JsResolver, RspackResultToNapiResultExt,
 };
 
 #[napi]
@@ -67,17 +67,17 @@ impl JsResolverFactory {
   ) -> napi::Result<JsResolver> {
     match r#type.as_str() {
       "normal" => {
-        let options = normalize_raw_resolve_options_with_dependency_type(raw, false).map_err(|e| napi::Error::from_reason(format!("{e}")))?;
+        let options = normalize_raw_resolve_options_with_dependency_type(raw, false).to_napi_result()?;
         let resolver_factory = self.get_resolver_factory(*options.resolve_options.clone().unwrap_or_default());
         Ok(JsResolver::new(resolver_factory, options))
       }
       "loader" => {
-        let options = normalize_raw_resolve_options_with_dependency_type(raw, false).map_err(|e| napi::Error::from_reason(format!("{e}")))?;
+        let options = normalize_raw_resolve_options_with_dependency_type(raw, false).to_napi_result()?;
         let resolver_factory = self.get_loader_resolver_factory(*options.resolve_options.clone().unwrap_or_default());
         Ok(JsResolver::new(resolver_factory, options))
       }
       "context" => {
-        let options = normalize_raw_resolve_options_with_dependency_type(raw, true).map_err(|e| napi::Error::from_reason(format!("{e}")))?;
+        let options = normalize_raw_resolve_options_with_dependency_type(raw, true).to_napi_result()?;
         let resolver_factory = self.get_resolver_factory(*options.resolve_options.clone().unwrap_or_default());
         Ok(JsResolver::new(resolver_factory, options))
       }

--- a/crates/node_binding/src/source.rs
+++ b/crates/node_binding/src/source.rs
@@ -8,6 +8,8 @@ use rspack_core::rspack_sources::{
 };
 use rspack_napi::napi::bindgen_prelude::*;
 
+use crate::RspackResultToNapiResultExt;
+
 /// Zero copy `JsCompatSource` slice shared between Rust and Node.js if buffer is used.
 ///
 /// It can only be used in non-async context and the lifetime is bound to the fn closure.
@@ -321,8 +323,5 @@ impl ToJsCompatSourceOwned for dyn Source + '_ {
 fn to_webpack_map(source: &dyn Source) -> Result<Option<String>> {
   let map = source.map(&MapOptions::default());
 
-  map
-    .map(|m| m.to_json())
-    .transpose()
-    .map_err(|err| napi::Error::from_reason(err.to_string()))
+  map.map(|m| m.to_json()).transpose().to_napi_result()
 }

--- a/crates/node_binding/src/stats.rs
+++ b/crates/node_binding/src/stats.rs
@@ -16,7 +16,9 @@ use rspack_napi::{
 use rspack_util::itoa;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::{identifier::JsIdentifier, to_js_module_id, JsCompilation, JsModuleId};
+use crate::{
+  identifier::JsIdentifier, to_js_module_id, JsCompilation, JsModuleId, RspackResultToNapiResultExt,
+};
 
 thread_local! {
   static MODULE_DESCRIPTOR_REFS: RefCell<HashMap<Identifier, OneShotRef>> = Default::default();
@@ -546,7 +548,7 @@ impl TryFrom<StatsModule<'_>> for JsStatsModule {
           .collect::<Result<_>>()
       })
       .transpose()
-      .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+      .to_napi_result()?;
 
     let reasons = match stats.reasons {
       Some(reasons) => {
@@ -1112,7 +1114,7 @@ impl JsStats {
       .get_modules(options, |res| {
         res.into_iter().map(JsStatsModule::try_from).collect()
       })
-      .map_err(|e| napi::Error::from_reason(e.to_string()))?
+      .to_napi_result()?
   }
 
   fn chunks(&self, options: &ExtendedStatsOptions) -> Result<Vec<JsStatsChunk>> {
@@ -1121,7 +1123,7 @@ impl JsStats {
       .get_chunks(options, |res| {
         res.into_iter().map(JsStatsChunk::try_from).collect()
       })
-      .map_err(|e| napi::Error::from_reason(e.to_string()))?
+      .to_napi_result()?
   }
 
   fn entrypoints(

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -21,8 +21,8 @@ use rspack_collections::{
   DatabaseItem, Identifiable, IdentifierDashMap, IdentifierMap, IdentifierSet, UkeyMap, UkeySet,
 };
 use rspack_error::{
-  error, miette::diagnostic, Diagnostic, DiagnosticExt, InternalError, Result, RspackSeverity,
-  Severity,
+  error, miette::diagnostic, Diagnostic, DiagnosticExt, InternalError, JoinResultToRspackResultExt,
+  Result, RspackSeverity, Severity,
 };
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -1016,7 +1016,7 @@ impl Compilation {
     .await;
     let results = results
       .into_iter()
-      .map(|res| res.map_err(rspack_error::miette::Error::from_err))
+      .map(|res| res.to_rspack_result())
       .collect::<Result<Vec<_>>>()?;
 
     for (module, runtimes, (codegen_res, from_cache)) in results {
@@ -1144,8 +1144,7 @@ impl Compilation {
 
     let mut chunk_render_results: UkeyMap<ChunkUkey, ChunkRenderResult> = Default::default();
     for result in results {
-      let item: std::result::Result<(ChunkUkey, ChunkRenderResult), _> =
-        result.map_err(rspack_error::miette::Error::from_err)?;
+      let item = result.to_rspack_result()?;
       let (key, value) = item?;
       chunk_render_results.insert(key, value);
     }
@@ -1857,7 +1856,7 @@ impl Compilation {
     })
     .await
     .into_iter()
-    .map(|res| res.map_err(rspack_error::miette::Error::from_err))
+    .map(|r| r.to_rspack_result())
     .collect::<Result<Vec<_>>>()?;
 
     for entry in module_results {
@@ -2267,7 +2266,7 @@ impl Compilation {
     })
     .await
     .into_iter()
-    .map(|res| res.map_err(rspack_error::miette::Error::from_err))
+    .map(|res| res.to_rspack_result())
     .collect::<Result<Vec<_>>>()?;
 
     let mut runtime_module_sources = IdentifierMap::<BoxSource>::default();
@@ -2347,7 +2346,7 @@ impl Compilation {
     })
     .await
     .into_iter()
-    .map(|res| res.map_err(rspack_error::miette::Error::from_err))
+    .map(|r| r.to_rspack_result())
     .collect::<Result<Vec<_>>>()?;
 
     for result in results {

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -17,7 +17,9 @@ use rspack_cacheable::{
 use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
-use rspack_error::{Diagnosable, Diagnostic, DiagnosticKind, Result, TraceableError};
+use rspack_error::{
+  Diagnosable, Diagnostic, DiagnosticKind, JoinResultToRspackResultExt, Result, TraceableError,
+};
 use rspack_hash::{HashDigest, HashFunction, RspackHash, RspackHashDigest};
 use rspack_hook::define_hook;
 use rspack_sources::{
@@ -662,7 +664,7 @@ impl Module for ConcatenatedModule {
     })
     .await
     .into_iter()
-    .map(|res| res.map_err(rspack_error::miette::Error::from_err))
+    .map(|r| r.to_rspack_result())
     .collect::<Result<Vec<_>>>()?;
 
     let mut updated_pairs = vec![];

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, hash::Hash, iter};
 
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
-use rspack_error::{error, impl_empty_diagnosable_trait, Result};
+use rspack_error::{impl_empty_diagnosable_trait, Result, SerdeResultToRspackResultExt};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_macros::impl_source_map_config;
 use rspack_util::{ext::DynHash, json_stringify, source_map::SourceMapKind};
@@ -431,9 +431,8 @@ if(typeof {global} !== "undefined") return resolve();
 "#,
           export = get_namespace_object_export(concatenation_scope, supports_const),
           global = url_and_global.global,
-          global_str =
-            serde_json::to_string(url_and_global.global).map_err(|e| error!(e.to_string()))?,
-          url_str = serde_json::to_string(url_and_global.url).map_err(|e| error!(e.to_string()))?,
+          global_str = serde_json::to_string(url_and_global.global).to_rspack_result()?,
+          url_str = serde_json::to_string(url_and_global.url).to_rspack_result()?,
           load_script = RuntimeGlobals::LOAD_SCRIPT.name()
         )
       }
@@ -586,7 +585,7 @@ impl Module for ExternalModule {
           SourceType::JavaScript,
           RawStringSource::from(format!(
             "module.exports = {};",
-            serde_json::to_string(request.primary()).map_err(|e| error!(e.to_string()))?
+            serde_json::to_string(request.primary()).to_rspack_result()?
           ))
           .boxed(),
         );
@@ -599,7 +598,7 @@ impl Module for ExternalModule {
           SourceType::Css,
           RawStringSource::from(format!(
             "@import url({});",
-            serde_json::to_string(request.primary()).map_err(|e| error!(e.to_string()))?
+            serde_json::to_string(request.primary()).to_rspack_result()?
           ))
           .boxed(),
         );

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -7,7 +7,7 @@ use std::{
 use cow_utils::CowUtils;
 use itertools::Itertools;
 use rspack_dojang::{Context, Dojang, Operand};
-use rspack_error::{miette, Result};
+use rspack_error::{error, miette, Result};
 use serde_json::{Map, Value};
 
 use crate::{Environment, RuntimeGlobals};
@@ -122,15 +122,9 @@ impl RuntimeTemplate {
         )
         // Replace Windows-style line endings (\r\n) with Unix-style (\n) to ensure consistent runtime templates across platforms
         .map(|render| render.cow_replace("\r\n", "\n").to_string())
-        .map_err(|err| {
-          miette::Error::msg(format!(
-            "Runtime module: failed to render template {key} from: {err}"
-          ))
-        })
+        .map_err(|err| error!("Runtime module: failed to render template {key} from: {err}"))
     } else {
-      Err(miette::Error::msg(format!(
-        "Runtime module: Template {key} is not found"
-      )))
+      Err(error!("Runtime module: Template {key} is not found"))
     }
   }
 

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -18,11 +18,13 @@ owo-colors         = "4.0.0"
 rspack_cacheable   = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_paths       = { workspace = true }
+serde_json         = { workspace = true }
 swc_core           = { workspace = true, features = ["common", "common_concurrent"] }
 swc_parallel       = { workspace = true, default-features = false }
 termcolor          = "1.4.1"
 textwrap           = "0.16.1"
 thiserror          = "1.0.69"
+tokio              = { workspace = true }
 
 unicode-width = "0.2.0"
 

--- a/crates/rspack_error/src/convert.rs
+++ b/crates/rspack_error/src/convert.rs
@@ -1,0 +1,31 @@
+use miette::{miette, LabeledSpan, SourceOffset};
+
+use crate::Result;
+
+pub trait SerdeResultToRspackResultExt<T> {
+  fn to_rspack_result_with_detail(self, content: &str, msg: &str) -> Result<T>;
+  fn to_rspack_result(self) -> Result<T>;
+}
+
+impl<T> SerdeResultToRspackResultExt<T> for std::result::Result<T, serde_json::Error> {
+  fn to_rspack_result_with_detail(self, content: &str, msg: &str) -> Result<T> {
+    self.map_err(|e| {
+      let offset = SourceOffset::from_location(content, e.line(), e.column());
+      let span = LabeledSpan::at_offset(offset.offset(), e.to_string());
+      miette!(labels = vec![span], "{msg}").with_source_code(content.to_string())
+    })
+  }
+  fn to_rspack_result(self) -> Result<T> {
+    self.map_err(|e| miette!(e.to_string()))
+  }
+}
+
+pub trait JoinResultToRspackResultExt<T> {
+  fn to_rspack_result(self) -> Result<T>;
+}
+
+impl<T> JoinResultToRspackResultExt<T> for std::result::Result<T, tokio::task::JoinError> {
+  fn to_rspack_result(self) -> Result<T> {
+    self.map_err(|e| miette!(e.to_string()))
+  }
+}

--- a/crates/rspack_error/src/lib.rs
+++ b/crates/rspack_error/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(anonymous_lifetime_in_impl_trait)]
 
 mod catch_unwind;
+mod convert;
 mod diagnostic;
 mod error;
 mod ext;
@@ -12,6 +13,7 @@ pub use diagnostic::*;
 pub use error::*;
 pub use ext::*;
 pub mod emitter;
+pub use convert::*;
 
 mod macros;
 

--- a/crates/rspack_fs/src/error.rs
+++ b/crates/rspack_fs/src/error.rs
@@ -15,6 +15,12 @@ pub enum Error {
   Io(std::io::Error),
 }
 
+impl Error {
+  pub fn new(kind: std::io::ErrorKind, message: &str) -> Self {
+    Error::Io(std::io::Error::new(kind, message))
+  }
+}
+
 impl From<std::io::Error> for Error {
   fn from(value: std::io::Error) -> Self {
     Self::Io(value)
@@ -29,6 +35,15 @@ impl From<Error> for rspack_error::Error {
   }
 }
 
+impl From<rspack_error::Error> for Error {
+  fn from(e: rspack_error::Error) -> Self {
+    Error::Io(std::io::Error::new(
+      std::io::ErrorKind::Other,
+      e.to_string(),
+    ))
+  }
+}
+
 impl Display for Error {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
@@ -38,3 +53,19 @@ impl Display for Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+pub trait RspackResultToFsResultExt<T> {
+  fn to_fs_result(self) -> Result<T>;
+}
+
+impl<T, E: ToString> RspackResultToFsResultExt<T> for std::result::Result<T, E> {
+  fn to_fs_result(self) -> Result<T> {
+    match self {
+      Ok(t) => Ok(t),
+      Err(e) => Err(Error::Io(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        e.to_string(),
+      ))),
+    }
+  }
+}

--- a/crates/rspack_fs/src/lib.rs
+++ b/crates/rspack_fs/src/lib.rs
@@ -20,4 +20,4 @@ mod memory_fs;
 pub use memory_fs::{MemoryFileSystem, MemoryReadStream, MemoryWriteStream};
 
 mod error;
-pub use error::{Error, Result};
+pub use error::{Error, Result, RspackResultToFsResultExt};

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -191,12 +191,12 @@ impl CopyRspackPlugin {
       let to = match to {
         ToOption::String(s) => s.to_owned(),
         ToOption::Fn(r) => {
-          let to_result = r(ToFnCtx {
+          let result = r(ToFnCtx {
             context,
             absolute_filename: &absolute_filename,
           })
           .await;
-          let to = match to_result {
+          let to = match result {
             Ok(to) => to,
             Err(e) => {
               diagnostics


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Add `RspackResultToNapiResultExt` to convert `Result<T, miette::Error>` to `Result<T, napi::Error>`
- Add `RspackResultToFsResultExt` to convert `Result<T, miette::Error>` to `Result<T, rspack_fs::Error>`
- Add `SerdeResultToRspackResultExt` to convert `Result<T, serde_json::Error>` to `Result<T, miette::Error>`
- Add `JoinResultToRspackResultExt` to convert `Result<T, tokio::task::JoinError>` to `Result<T, miette::Error>`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
