### PR TITLE
feat: support passing `PathBuf` and `&Path` to `Context`

### DIFF
--- a/crates/rspack/src/lib.rs
+++ b/crates/rspack/src/lib.rs
@@ -1,14 +1,6 @@
 #![forbid(missing_docs)]
 
-//! Rspack is a high performance JavaScript bundler written in Rust. It offers strong compatibility with the webpack ecosystem, allowing for seamless replacement of webpack, and provides lightning fast build speeds.
-//!
-//! ## Why rspack?
-//!
-//! Rspack was initially created to solve performance problems encountered at ByteDance, a tech company that maintains many large monolithic app projects with complex bundling requirements. Production build times had grown to ten minutes or even half an hour in some cases, and cold start times could exceed several minutes. After experimenting with many bundlers and optimization ideas, a common set of requirements emerged:
-//! - **Dev mode startup performance.** npm run dev is a command that developers may invoke many times per hour. Engineering productivity suffers if startup time exceeds 10-15 seconds.
-//! - **Fast builds.** npm run build is used in CI/CD pipelines and directly impacts merging productivity and application delivery time. Large applications may spend 20-30 minutes running these pipelines, and bundling time is often a major contributor.
-//! - **Flexible configuration.** From experimenting with various popular bundlers, we found that one-size-fits-all configurations encountered many problems when trying to accommodate real world projects. A major advantage of webpack is its flexibility and ease of accommodating customized requirements for each project. This in turn may pose steep migration costs for legacy projects that try to migrate away from webpack.
-//! - **Production optimization capabilities.** All of the existing bundling solutions also had various limitations when optimizing for a production environment, such as insufficiently fine-grained code splitting, etc. Rspack has an opportunity to rethink these optimizations from the ground up, leveraging Rust-specific features such as multithreading.
+//! Rspack is a high performance JavaScript bundler written in Rust. It offers strong compatibility with the webpack ecosystem, allowing for seamless replacement of webpack, and provides lightning fast build 
 //!
 //! ## Example
 //!

--- a/crates/rspack/src/lib.rs
+++ b/crates/rspack/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //! Currently, there's still alot of features that are not implemented yet. Here's a list of features that are not implemented yet:
 //!
-//! - [x] Basic `CompilerBuilder` API
+//! - [x] `CompilerBuilder` API
 //! - [ ] `SplitChunksPlugin` API
 //! - [ ] `BundlerInfoPlugin` API
 //! - [ ] `StatsPrinter` API

--- a/crates/rspack/src/lib.rs
+++ b/crates/rspack/src/lib.rs
@@ -1,5 +1,64 @@
 #![forbid(missing_docs)]
 
-//! The Rspack compiler.
-
+//! Rspack is a high performance JavaScript bundler written in Rust. It offers strong compatibility with the webpack ecosystem, allowing for seamless replacement of webpack, and provides lightning fast build speeds.
+//!
+//! ## Why rspack?
+//!
+//! Rspack was initially created to solve performance problems encountered at ByteDance, a tech company that maintains many large monolithic app projects with complex bundling requirements. Production build times had grown to ten minutes or even half an hour in some cases, and cold start times could exceed several minutes. After experimenting with many bundlers and optimization ideas, a common set of requirements emerged:
+//! - **Dev mode startup performance.** npm run dev is a command that developers may invoke many times per hour. Engineering productivity suffers if startup time exceeds 10-15 seconds.
+//! - **Fast builds.** npm run build is used in CI/CD pipelines and directly impacts merging productivity and application delivery time. Large applications may spend 20-30 minutes running these pipelines, and bundling time is often a major contributor.
+//! - **Flexible configuration.** From experimenting with various popular bundlers, we found that one-size-fits-all configurations encountered many problems when trying to accommodate real world projects. A major advantage of webpack is its flexibility and ease of accommodating customized requirements for each project. This in turn may pose steep migration costs for legacy projects that try to migrate away from webpack.
+//! - **Production optimization capabilities.** All of the existing bundling solutions also had various limitations when optimizing for a production environment, such as insufficiently fine-grained code splitting, etc. Rspack has an opportunity to rethink these optimizations from the ground up, leveraging Rust-specific features such as multithreading.
+//!
+//! ## Example
+//!
+//! Rspack uses [`tokio`](https://docs.rs/tokio) as the runtime for async operations. Here's an example of how to use with `Compiler`:
+//!
+//! ```toml
+//! [dependencies]
+//! tokio = { version = "1", features = ["full"] }
+//! rspack = "0.3"
+//! rspack_core = "0.3"
+//! ```
+//!
+//! ```
+//! use std::path::PathBuf;
+//! use rspack::builder::{Builder, CompilerBuilder};
+//! use rspack_core::Compiler;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//! # let context = PathBuf::from(env!("CARGO_MANIFEST_DIR").to_string()).join("tests/fixtures/basic");
+//!   let compiler = Compiler::builder()
+//!     .context(context)
+//!     .entry("main", "./src/index.js")
+//!     .build()
+//!     .unwrap();
+//!
+//!   let errors: Vec<_> = compiler.compilation.get_errors().collect();
+//!   assert!(errors.is_empty());
+//! }
+//! ```
+//!
+//! ## Stability
+//!
+//! This crate and the dependencies that this crate are relying on are not stable yet. The API may change at any time.
+//! We do not guarantee any backward compatibility at the moment.
+//!
+//! ## Features
+//!
+//! Currently, there's still alot of features that are not implemented yet. Here's a list of features that are not implemented yet:
+//!
+//! - [x] Basic `CompilerBuilder` API
+//! - [ ] `SplitChunksPlugin` API
+//! - [ ] `BundlerInfoPlugin` API
+//! - [ ] `StatsPrinter` API
+//! - [ ] Stable `Compiler` API
+//! - [ ] Stable `Compilation` API
+//! - [ ] Rust Plugin for Rspack
+//! - [ ] ...
+//!
+//!
+//!
+//! To track the current stats for API, please refer to [this](https://github.com/web-infra-dev/rspack/issues/9378) GitHub issue.
 pub mod builder;

--- a/crates/rspack/src/lib.rs
+++ b/crates/rspack/src/lib.rs
@@ -1,6 +1,8 @@
 #![forbid(missing_docs)]
 
-//! Rspack is a high performance JavaScript bundler written in Rust. It offers strong compatibility with the webpack ecosystem, allowing for seamless replacement of webpack, and provides lightning fast build 
+//! Rspack is a high performance JavaScript bundler written in Rust. It offers strong compatibility with the webpack ecosystem, allowing for seamless replacement of webpack, and provides lightning fast build.
+//!
+//! For guide level documentation, please refer to the [Rspack Guide](https://rspack.dev/guide/start/introduction).
 //!
 //! ## Example
 //!

--- a/crates/rspack_core/src/options/context.rs
+++ b/crates/rspack_core/src/options/context.rs
@@ -1,8 +1,12 @@
-use std::{fmt, ops::Deref, path::Path};
+use std::{
+  fmt,
+  ops::Deref,
+  path::{Path, PathBuf},
+};
 
 use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_loader_runner::ResourceData;
-use rspack_paths::{Utf8Path, Utf8PathBuf};
+use rspack_paths::{AssertUtf8, Utf8Path, Utf8PathBuf};
 use rspack_util::atom::Atom;
 
 use crate::{contextify, parse_resource};
@@ -79,6 +83,18 @@ impl From<&Utf8Path> for Context {
     Self {
       inner: v.as_str().into(),
     }
+  }
+}
+
+impl From<PathBuf> for Context {
+  fn from(value: PathBuf) -> Self {
+    value.assert_utf8().into()
+  }
+}
+
+impl From<&Path> for Context {
+  fn from(value: &Path) -> Self {
+    value.assert_utf8().into()
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Polish rspack crate document and add `PathBuf` and `&Path` support to `Context`. This cuts a dependency that users need to rely on to run rspack in Rust.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [X] Documentation updated (or not required).
