### PR TITLE
chore: bump swc to v18.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,6 +3315,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
+name = "par-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b506ab63a8bd3cd38858c7bfc2d078a189dc3210c7f8c9be1bbaf50c082a0ae"
+dependencies = [
+ "once_cell",
+ "rayon",
+]
+
+[[package]]
+name = "par-iter"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b20f31e9ba82bfcbbb54a67aa40be6cebec9f668ba5753be138f9523c531a"
+dependencies = [
+ "either",
+ "par-core",
+]
+
+[[package]]
 name = "parcel_selectors"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,6 +3496,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
+ "indexmap 2.7.1",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
  "indexmap 2.7.1",
 ]
 
@@ -6141,9 +6171,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "swc"
-version = "16.1.1"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afca37a21a7f4eed3a77bb067e5693fa7dedb98bb85fd90a9bd9a04df4882174"
+checksum = "1ccfeff9af7ffb8fb7243dc698c598e00963486ef5cdeff449abf1cccacef417"
 dependencies = [
  "anyhow",
  "base64",
@@ -6153,6 +6183,8 @@ dependencies = [
  "jsonc-parser",
  "lru",
  "once_cell",
+ "par-core",
+ "par-iter",
  "parking_lot",
  "pathdiff",
  "regex",
@@ -6269,9 +6301,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "13.0.1"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278d50af64cf07f4e9893a294b5b25488de48de56e352fc5cdebff985854ecd8"
+checksum = "806774262e8cc665d986364c109bdaa91eeadebf71402df6894c7c3c2be92795"
 dependencies = [
  "anyhow",
  "base64",
@@ -6322,10 +6354,11 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "16.10.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7453b2e6771d55f483903ed12fa9cf949ff7a3fefdfe4a63a5ea13b542e9eca"
+checksum = "6448a3f005d6cd35ae201595669421af9292397e29d04530fa753069c9cf3913"
 dependencies = [
+ "par-core",
  "swc",
  "swc_allocator",
  "swc_atoms",
@@ -6372,9 +6405,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "8.0.2"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92103aa982740f265d6850bb3ffffbf6c3c1dee30ab0ed25117ca553f0d7467d"
+checksum = "f131ade75f9a3cfea38dbce11893f5636b0954de973ad29a2556124322a08372"
 dependencies = [
  "ascii",
  "compact_str",
@@ -6407,9 +6440,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf52155fac8dbf8b13cf412da46e81f8bbe57467334a4e9434837f7bd61506"
+checksum = "5e908297dfe18472b82b391ae444a72dbd63c4b5f2823eba52c1bf7972903952"
 dependencies = [
  "rustc-hash 2.1.0",
  "swc_atoms",
@@ -6425,9 +6458,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09054aad2b52da3e6cf72089237700ff43fc5e6ab3ee1c521583c2c549522a38"
+checksum = "bb2d5902317bbf8e8c1944e63f19057e6dff1fb60a8a73f33bb26bdb2d365662"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6438,9 +6471,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124d5fdcdc9973b7dba1eb18874c5a7a40b9fadb32bc7c5e2fc4f30c69129fa1"
+checksum = "fb1efa640c57cbc4eaa40625275a86ff99a29cd0f4997668c88117e86390e821"
 dependencies = [
  "arrayvec",
  "indexmap 2.7.1",
@@ -6465,9 +6498,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d557bc5bc9242e07d16e5d42fb1882856d9bafcd26eab77ba124b9e68444e83"
+checksum = "b5b890417e8080d460e1962c73d58f94cca5b27c5ec89f8ba37a114c7dd6a76b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6482,9 +6515,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "11.0.1"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619d010fc6e5c6067f8397fba8887d6395dda21fe55c6f5346f815f4eb028901"
+checksum = "5c2d327146bb2b7b936b0d78e4212b039b1aa4149bbc187fd76db1ee3176e755"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6500,9 +6533,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b926094b18e30780c231032ce8ad6240842d0b0cca01938c61370b67ed8911fc"
+checksum = "a41fe86e2a237f1b87ed4d34c20a3721665328fc8f1b8e5e6bdeb022ce52f148"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6519,9 +6552,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658ab6efb4ff84a91429d90f5add80c1cf19d9d720cb8e0a47863fc2628e3564"
+checksum = "e06197f2f74f2a6366cfbf68d4de4feabf42bd2532413c71347ba7cdbe964c40"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6535,9 +6568,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0eac482a0ed60af3b7de78ca85e664095dfbd96a21dbafc8dff43e2f13b66"
+checksum = "92568d138eec2894c644fbf865401778026b42b45fa1073739b732cd66d55b42"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6553,9 +6586,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89dd2f25812eab659bd088c2ace9837d5b6f064e7a184f27d7199d5aae493b20"
+checksum = "6b38614b689a8ed0b4cda05bee30a7f908ea621db6010888f407be282884ecbe"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6569,9 +6602,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9e163b2badafc208995f771524492f8b003e52b82e0dff6c11fcb06662dc99"
+checksum = "2923bf7ce2236f36aef951bd204ec115a17af421cdc696ff526c9ba22983533f"
 dependencies = [
  "rustc-hash 2.1.0",
  "swc_atoms",
@@ -6589,9 +6622,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5bce31592c053191996262d502f219a23edd53ae87ae7f54204bbdd94e5fcc"
+checksum = "cf4b386df40a8b1d0a71eb54b5766ce483bb4f9311c4df931035542a39341861"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6604,9 +6637,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111d812c5e61ffc4f2e18573b0f09bcd870463b7eaa0a0419014d88cc7fc084b"
+checksum = "0064bdc27ebff66cb92e596b13e9c0e13c671c56b327c0083c200e4793c8db2b"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -6618,12 +6651,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "11.0.1"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c61cc0dd2b072152de9cdb6eaf6cb57e979b359ed8d0eb86ce8c3450308b2e"
+checksum = "ac89356dc7ab49dc30e9219fdb57cfc35a80aec3c0ae2e12c2a3488f9cfce7dd"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
+ "par-core",
  "parking_lot",
  "regex",
  "rustc-hash 2.1.0",
@@ -6634,7 +6668,6 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "swc_parallel",
 ]
 
 [[package]]
@@ -6662,19 +6695,20 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "12.4.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7856c7095f57c0990ba9c22d18469d57b9f68e851cf27d8d99b5a0238648f0ce"
+checksum = "fb6c3ea74a80bf1d21bba94f823aa9e90f903b81b345f99c1595faf87d732c63"
 dependencies = [
  "arrayvec",
  "indexmap 2.7.1",
  "num-bigint",
  "num_cpus",
  "once_cell",
+ "par-core",
+ "par-iter",
  "parking_lot",
  "phf",
  "radix_fmt",
- "rayon",
  "regex",
  "rustc-hash 2.1.0",
  "ryu-js",
@@ -6692,16 +6726,15 @@ dependencies = [
  "swc_ecma_usage_analyzer",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "swc_parallel",
  "swc_timer",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_parser"
-version = "10.0.2"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfbfa5baabd14901a310f9d55d991625787d27d94de5c38a1a2ef85ebc19c97"
+checksum = "41e06ecaef86a547831f7f01f342434e4b0d0f363762f8e7a2b84da7a0a5f92e"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -6722,9 +6755,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fa37f57f20e5641bdc5b728955e254b7cbc4dcc4313f6e8e088dd9ec62775d"
+checksum = "cd6e90087fe511cde69e3648bceb90b04be01236451ced67486371f827d691e1"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -6747,9 +6780,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4822fc4052681e583cbac5f823351d38de3347b59edd56bebface11dc05e863"
+checksum = "26132f0851c46a258f954cc00ca6c71fe6ab4520f6fde722e6e8a200c61f6c83"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6765,10 +6798,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243295ffdee377b2ee66c94145017f0f60f28f70353d1c02047c9e409f7cd0e2"
+checksum = "13aeeeb6ba750d144d49d96f900063706e8e4ff45d63d1ccde0ce5f441bcee6a"
 dependencies = [
+ "par-core",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -6785,14 +6819,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "11.2.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39889063ff4819eae414dfe6426aa5cd72ebb0f9f48739a1fa1e7eb82d0adc78"
+checksum = "b0b747f04a004d9b56b903305e4567e1d30c9cd226a8310a29cac06f7ac8173a"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.6.0",
  "indexmap 2.7.1",
  "once_cell",
+ "par-core",
  "phf",
  "rayon",
  "rustc-hash 2.1.0",
@@ -6804,15 +6839,14 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "swc_parallel",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2111a904b8f3c5dd63f56e7c8048851fcd8f748691a162a5d19a5da49f4a9d35"
+checksum = "d871bbd46d14d032a48c14096abd778a8a87831638343f28b581c3025daa7086"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6824,14 +6858,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e25a5cc997638fd050e5e1ddccb49688300f13940ade79ee9bbe584158697b"
+checksum = "dbfdfb50bd6db7991105f371b23ebb7cc79d48f43f53866a9a55dfbf7cfacd36"
 dependencies = [
  "arrayvec",
  "indexmap 2.7.1",
  "is-macro",
  "num-bigint",
+ "par-core",
  "serde",
  "smallvec",
  "swc_atoms",
@@ -6872,9 +6907,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "12.1.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781eae62860d78d45b1e63d836f89249492db6c136f1893d0c8e0ebdbb7f540a"
+checksum = "d0cf50886962aa3d7d20317a486971b91002a930b236c1e4af1f1050280b4070"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6900,14 +6935,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "11.1.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c0a8368b173d030aa2fb43688dcae11a98332239c902ccd97002327a1573f3"
+checksum = "6646a0a5e3662a2a86369a42f5203f1c92584c37502f9b79d4d10613db0c1fb3"
 dependencies = [
  "dashmap 5.5.3",
  "indexmap 2.7.1",
  "once_cell",
- "petgraph",
+ "par-core",
+ "petgraph 0.7.1",
  "rayon",
  "rustc-hash 2.1.0",
  "serde_json",
@@ -6919,16 +6955,14 @@ dependencies = [
  "swc_ecma_transforms_macros",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "swc_fast_graph",
- "swc_parallel",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "11.0.1"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3072700bb4401fffed5a152248d0d173a41da94584a4267355fa6772538880b"
+checksum = "048ba8acaa043f9468bb3bd1f5aae6f2e6b06865119226f9c45a971a012cc2d8"
 dependencies = [
  "either",
  "rustc-hash 2.1.0",
@@ -6946,9 +6980,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "12.0.1"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db098e259f9543aaa0f77961e64d351a7fd1394ab7588a691eb15aee2ab236e"
+checksum = "3b66c31438de864f9694493d3f3a08744a5604b59df03774d09e0f541f29976c"
 dependencies = [
  "base64",
  "dashmap 5.5.3",
@@ -6972,9 +7006,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "12.0.1"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4f2ea9134fa999039ace105daee34e4811cc58e34322605bafcd57de4a124c"
+checksum = "cec3c91a2c37372746ebc5608e30b7c2c3af60216768b59ec6413ee2bfe44c29"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.0",
@@ -6991,9 +7025,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "12.0.2"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af89be14ef84b16529f89a70972c7f85b0e9e2599ea09d9f7c3e5b186b8f225"
+checksum = "037ca87d5d7c72a341f1aef8059b7eeca4785fedca7361e6d380f749a6f53c58"
 dependencies = [
  "indexmap 2.7.1",
  "rustc-hash 2.1.0",
@@ -7008,13 +7042,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721dc779e7de200da96ac4002c710bc32c988e3e1ebf62b39d32bf99f14d9765"
+checksum = "71d6c8ba7d987dcc254f05ad2c23e7a6ec3f259611af2923a8c1a0602556cd21"
 dependencies = [
  "indexmap 2.7.1",
  "num_cpus",
  "once_cell",
+ "par-core",
+ "par-iter",
  "rayon",
  "rustc-hash 2.1.0",
  "ryu-js",
@@ -7022,7 +7058,6 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_visit",
- "swc_parallel",
  "tracing",
  "unicode-id",
 ]
@@ -7070,22 +7105,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_fast_graph"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd24b9798b0538803d0a69cffa5f5e051087fa2bd0d23e5a2f05d32edf9ab671"
-dependencies = [
- "indexmap 2.7.1",
- "petgraph",
- "rustc-hash 2.1.0",
- "swc_common",
-]
-
-[[package]]
 name = "swc_html"
-version = "12.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bf6ae0d81ab47a7458a609830d5c72e0466dca0d5149d9d48229f9793094f9"
+checksum = "80e2196c3738ab57e802fd0163442f9ea2a028381f827b527a19791bcfc4a2d8"
 dependencies = [
  "swc_html_ast",
  "swc_html_codegen",
@@ -7135,9 +7158,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_minifier"
-version = "12.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c5003ccd6e6e57b9cd9168657abc958689c0f25c355eb5e013f9fe0d6ad0ce"
+checksum = "8783aeab2a218ebc0f3d9a0033df55b14c945e2122966216ec7b09561c3e8202"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.0",
@@ -7251,9 +7274,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ff89ad36e3a28870dcf64fdc55fff1b8e3c0fad3c01af4cafdf8f2e0472eab"
+checksum = "132317a7245b344d654da8cd3c6cdb6fcd72d1e7d028d1085aa679cfb5e9801a"
 dependencies = [
  "anyhow",
  "enumset",
@@ -7266,6 +7289,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_plugin_proxy",
+ "swc_transform_common",
  "tokio",
  "tracing",
  "vergen",
@@ -7298,24 +7322,25 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79319c2165695896119f0cb22847dedfb0bd7f77acd98dbc5bc1f081105db6f3"
+checksum = "e40bbeef964d6edd66081a31bbfeef913bb0be536e398392f99e8e91b7da63eb"
 dependencies = [
  "better_scoped_tls",
  "once_cell",
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",
+ "swc_common",
 ]
 
 [[package]]
 name = "swc_typescript"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8facec2d8504b0e38195d60de884056d0d2365ffdc78cd2300ee595fcf9c625d"
+checksum = "1b8f660e0ab0e92551747a41335ab6a0c7b685885da37f4e8e79ac5737bc4e04"
 dependencies = [
- "petgraph",
+ "petgraph 0.7.1",
  "rustc-hash 2.1.0",
  "swc_atoms",
  "swc_common",
@@ -8671,7 +8696,7 @@ dependencies = [
  "lz4_flex",
  "num_enum",
  "once_cell",
- "petgraph",
+ "petgraph 0.6.5",
  "pin-project",
  "pin-utils",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,13 +96,13 @@ inventory = { version = "0.3.17" }
 rkyv      = { version = "=0.8.8" }
 
 # Must be pinned with the same swc versions
-swc                 = { version = "=16.1.1" }
+swc                 = { version = "=18.0.0" }
 swc_config          = { version = "=2.0.0" }
-swc_core            = { version = "=16.10.0", default-features = false }
-swc_ecma_minifier   = { version = "=12.4.0", default-features = false }
+swc_core            = { version = "=18.0.0", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_minifier   = { version = "=14.0.0", default-features = false }
 swc_error_reporters = { version = "=9.1.1" }
-swc_html            = { version = "=12.0.0" }
-swc_html_minifier   = { version = "=12.0.0", default-features = false }
+swc_html            = { version = "=14.0.0" }
+swc_html_minifier   = { version = "=14.0.0", default-features = false }
 swc_node_comments   = { version = "=8.0.0" }
 swc_parallel        = { version = "1.3.0", default-features = false, features = ["rayon"] }
 

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
@@ -49,7 +49,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: 9cd19fc0a208da71,
+      hash: f9d8b3d321c1b466,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -179,7 +179,7 @@ Object {
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: 23417a360dbe1de8,
+  hash: 2a8e79da1ef69229,
   modules: Array [
     Object {
       assets: Array [],
@@ -330,7 +330,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: 526d08f00e1e8f2f,
+      hash: 88021ac7017fde9b,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -718,7 +718,7 @@ Object {
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: 1bb5e91c0d72ce7a,
+  hash: 8796aec893b9f765,
   modules: Array [
     Object {
       assets: Array [],
@@ -1521,7 +1521,7 @@ Object {
       files: Array [
         main.js,
       ],
-      hash: 9cd19fc0a208da71,
+      hash: f9d8b3d321c1b466,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -1661,7 +1661,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: 9cf6270d68f3f78e,
+      hash: 36ba1dc6843c2ffa,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -2030,7 +2030,7 @@ exports.c = require("./c?c=3");,
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: 2026699fe6b29204,
+  hash: d8ffe6346d449bd4,
   modules: Array [
     Object {
       assets: Array [],

--- a/packages/rspack-test-tools/tests/statsAPICases/basic.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/basic.js
@@ -37,7 +37,7 @@ module.exports = {
 		  entry ./fixtures/a
 		  cjs self exports reference self [585] ./fixtures/a.js
 		  
-		Rspack compiled successfully (23417a360dbe1de8)
+		Rspack compiled successfully (2a8e79da1ef69229)
 	`);
 	}
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the tim
This pull request includes updates to the `Cargo.toml` dependencies and changes to the snapshot files in the `rspack-test-tools` package. The most important changes are listed below:

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

### Upgrade swc to v18.0.0.
Dependency updates:
* Updated `swc` to version `18.0.0` in `Cargo.toml`.
* Updated `swc_core` to version `18.0.0` with the `parallel_rayon` feature enabled in `Cargo.toml`.
* Updated `swc_ecma_minifier` to version `14.0.0` in `Cargo.toml`.
* Updated `swc_html` to version `14.0.0` in `Cargo.toml`.
* Updated `swc_html_minifier` to version `14.0.0` in `Cargo.toml`.

More detail see: [SWC ChangeLog](https://github.com/swc-project/swc/blob/main/CHANGELOG-CORE.md)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
