### PR TITLE
test: import from @rspack/test-tools instead of using relative paths

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -1378,6 +1378,9 @@ export class StatsProcessor<T extends ECompilerType> extends MultiTaskProcessor<
 }
 
 // @public (undocumented)
+export function supportsImportFn(): boolean;
+
+// @public (undocumented)
 export type TBasicRunnerFile = {
     path: string;
     content: string;

--- a/packages/rspack-test-tools/src/helper/index.ts
+++ b/packages/rspack-test-tools/src/helper/index.ts
@@ -4,3 +4,4 @@ export * from "./read-config-file";
 export * from "./update-snapshot";
 export * from "./win";
 export * from "./util/checkStats";
+export * from "./legacy/supportsImportFn";

--- a/packages/rspack-test-tools/src/helper/legacy/supportsImportFn.ts
+++ b/packages/rspack-test-tools/src/helper/legacy/supportsImportFn.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 const nodeVersion = process.versions.node.split(".").map(Number);
 
-module.exports = function supportsImportFn() {
+export function supportsImportFn() {
 	// Segmentation fault in vm with --experimental-vm-modules,
 	// which has not been resolved in node 16 yet.
 	// https://github.com/nodejs/node/issues/35889

--- a/packages/rspack-test-tools/tests/Cache.test.js
+++ b/packages/rspack-test-tools/tests/Cache.test.js
@@ -2,7 +2,7 @@
 process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
-const { describeByWalk, createCacheCase } = require("../dist");
+const { describeByWalk, createCacheCase } = require("@rspack/test-tools");
 
 // Run tests rspack-test-tools/tests/cacheCases in target async-node
 describeByWalk(

--- a/packages/rspack-test-tools/tests/Error.test.js
+++ b/packages/rspack-test-tools/tests/Error.test.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { createErrorCase, describeByWalk } = require("../dist");
+const { createErrorCase, describeByWalk } = require("@rspack/test-tools");
 const caseDir = path.resolve(__dirname, "./errorCases");
 
 describeByWalk(

--- a/packages/rspack-test-tools/tests/Hash.test.js
+++ b/packages/rspack-test-tools/tests/Hash.test.js
@@ -1,4 +1,4 @@
-const { createHashCase, describeByWalk } = require("../dist");
+const { createHashCase, describeByWalk } = require("@rspack/test-tools");
 
 describeByWalk(
 	__filename,

--- a/packages/rspack-test-tools/tests/Hook.test.js
+++ b/packages/rspack-test-tools/tests/Hook.test.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { createHookCase, describeByWalk } = require("../dist");
+const { createHookCase, describeByWalk } = require("@rspack/test-tools");
 const source = path.resolve(__dirname, "./fixtures");
 
 describeByWalk(__filename, (name, src, dist) => {

--- a/packages/rspack-test-tools/tests/HotNode.test.js
+++ b/packages/rspack-test-tools/tests/HotNode.test.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { describeByWalk, createHotCase } = require("../dist");
+const { describeByWalk, createHotCase } = require("@rspack/test-tools");
 
 describeByWalk(
 	__filename,

--- a/packages/rspack-test-tools/tests/HotSnapshot.hottest.js
+++ b/packages/rspack-test-tools/tests/HotSnapshot.hottest.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { describeByWalk, createHotStepCase } = require("../dist");
+const { describeByWalk, createHotStepCase } = require("@rspack/test-tools");
 
 describeByWalk(__filename, (name, src, dist) => {
 	createHotStepCase(name, src, dist, "web");

--- a/packages/rspack-test-tools/tests/HotWeb.test.js
+++ b/packages/rspack-test-tools/tests/HotWeb.test.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { describeByWalk, createHotCase } = require("../dist");
+const { describeByWalk, createHotCase } = require("@rspack/test-tools");
 
 describeByWalk(
 	__filename,

--- a/packages/rspack-test-tools/tests/HotWorker.test.js
+++ b/packages/rspack-test-tools/tests/HotWorker.test.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { describeByWalk, createHotCase } = require("../dist");
+const { describeByWalk, createHotCase } = require("@rspack/test-tools");
 
 describeByWalk(
 	__filename,

--- a/packages/rspack-test-tools/tests/NewIncremental-node.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-node.test.js
@@ -2,7 +2,10 @@
 process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
-const { describeByWalk, createHotNewIncrementalCase } = require("../dist");
+const {
+	describeByWalk,
+	createHotNewIncrementalCase
+} = require("@rspack/test-tools");
 
 function v(name) {
 	return path.join(__dirname, `new-incremental ${name}`);

--- a/packages/rspack-test-tools/tests/NewIncremental-watch-webpack.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-watch-webpack.test.js
@@ -2,7 +2,10 @@
 process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
-const { describeByWalk, createWatchNewIncrementalCase } = require("../dist");
+const {
+	describeByWalk,
+	createWatchNewIncrementalCase
+} = require("@rspack/test-tools");
 
 function v(name) {
 	return path.join(__dirname, `new-incremental ${name}`);

--- a/packages/rspack-test-tools/tests/NewIncremental-watch.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-watch.test.js
@@ -2,7 +2,10 @@
 process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
-const { describeByWalk, createWatchNewIncrementalCase } = require("../dist");
+const {
+	describeByWalk,
+	createWatchNewIncrementalCase
+} = require("@rspack/test-tools");
 
 function v(name) {
 	return path.join(__dirname, `new-incremental ${name}`);

--- a/packages/rspack-test-tools/tests/NewIncremental-web.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-web.test.js
@@ -2,7 +2,10 @@
 process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
-const { describeByWalk, createHotNewIncrementalCase } = require("../dist");
+const {
+	describeByWalk,
+	createHotNewIncrementalCase
+} = require("@rspack/test-tools");
 
 function v(name) {
 	return path.join(__dirname, `new-incremental ${name}`);

--- a/packages/rspack-test-tools/tests/NewIncremental-webworker.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-webworker.test.js
@@ -2,7 +2,10 @@
 process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
-const { describeByWalk, createHotNewIncrementalCase } = require("../dist");
+const {
+	describeByWalk,
+	createHotNewIncrementalCase
+} = require("@rspack/test-tools");
 
 function v(name) {
 	return path.join(__dirname, `new-incremental ${name}`);

--- a/packages/rspack-test-tools/tests/Serial.test.js
+++ b/packages/rspack-test-tools/tests/Serial.test.js
@@ -1,4 +1,4 @@
-const { describeByWalk, createSerialCase } = require("../dist");
+const { describeByWalk, createSerialCase } = require("@rspack/test-tools");
 
 describeByWalk(__filename, (name, src, dist) => {
 	createSerialCase(name, src, dist);

--- a/packages/rspack-test-tools/tests/Watch.test.js
+++ b/packages/rspack-test-tools/tests/Watch.test.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { describeByWalk, createWatchCase } = require("../dist");
+const { describeByWalk, createWatchCase } = require("@rspack/test-tools");
 const tempDir = path.resolve(__dirname, `./js/temp`);
 
 describeByWalk(__filename, (name, src, dist) => {

--- a/packages/rspack-test-tools/tests/compilerCases/cache-compilation.js
+++ b/packages/rspack-test-tools/tests/compilerCases/cache-compilation.js
@@ -19,7 +19,7 @@ class MyPlugin {
   }
 }
 
-/** @type {import('../../dist').TCompilerCaseConfig} */
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
 module.exports = {
   description: "should share cache cross compilations",
   options(context) {

--- a/packages/rspack-test-tools/tests/compilerCases/compare-before-emit-disable.js
+++ b/packages/rspack-test-tools/tests/compilerCases/compare-before-emit-disable.js
@@ -4,7 +4,7 @@ const { rimrafSync } = require("rimraf");
 
 let first_asset_mtime;
 
-/** @type {import('../../dist').TCompilerCaseConfig} */
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
 module.exports = {
 	description: "should write same content to same file",
 	options(context) {

--- a/packages/rspack-test-tools/tests/compilerCases/consistent.js
+++ b/packages/rspack-test-tools/tests/compilerCases/consistent.js
@@ -1,6 +1,6 @@
 const stats = [];
 
-/** @type {import('../../dist').TCompilerCaseConfig} */
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
 module.exports = {
 	description: "should be called every compilation",
 	options(context) {

--- a/packages/rspack-test-tools/tests/compilerCases/invalidation-multi-times.js
+++ b/packages/rspack-test-tools/tests/compilerCases/invalidation-multi-times.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
-const mockWatchRunFn = jest.fn(() => {});
-const mockInvalidFn = jest.fn(() => {});
+const mockWatchRunFn = jest.fn(() => { });
+const mockInvalidFn = jest.fn(() => { });
 
 class MyPlugin {
 	apply(compiler) {
@@ -10,7 +10,7 @@ class MyPlugin {
 	}
 }
 
-/** @type {import('../../dist').TCompilerCaseConfig} */
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
 module.exports = {
 	description: "should be invalidated correctly",
 	options(context) {
@@ -38,7 +38,7 @@ module.exports = {
 					}
 				});
 			});
-		} catch(err) {
+		} catch (err) {
 			throw err
 		}
 

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-condition/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/runtime-condition/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TDiffCaseConfig} */
+/** @type {import('@rspack/test-tools').TDiffCaseConfig} */
 module.exports = {
 	modules: true,
 	files: ["shared.js", "a.js", "b.js"]

--- a/packages/rspack-test-tools/tests/configCases/externals/commonjs-import/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/commonjs-import/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	findBundle: (i, options) => {
 		return ["index.js"];

--- a/packages/rspack-test-tools/tests/configCases/externals/reexport-star/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/reexport-star/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	findBundle: (i, options) => {
 		return ["index.mjs"];

--- a/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/rslib-issue-580/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	findBundle: (i, options) => {
 		return ["main.mjs"];

--- a/packages/rspack-test-tools/tests/configCases/hooks/get-path-custom-chunk/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/get-path-custom-chunk/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	noTests: true
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/get-path-existing-chunk/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/get-path-existing-chunk/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	noTests: true
 };

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	findBundle: (i, options) => {
 		return ["index.js"];

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data-no-passthrough/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data-no-passthrough/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const path = require("path");
 
 /**

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data-passthrough/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data-passthrough/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const path = require("path");
 
 /**

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/additional-data/rspack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 
 /**
  * @type {import('@rspack/core').RspackOptions}

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/async/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/async/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const path = require("path");
 const file = path.join(__dirname, "a.js");
 const asyncLoader = path.join(__dirname, "asyncloader.js");

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/binary-with-source-map/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/binary-with-source-map/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const path = require("path");
 
 /**

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/issue-webpack-9053/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/issue-webpack-9053/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-error-async/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-error-async/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const path = require("path");
 const file = path.resolve(__dirname, "lib.js");
 

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-raw-string/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-raw-string/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const path = require("path");
 const file = path.resolve(__dirname, "lib.js");
 const createUse = loaders =>

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-raw/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-raw/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	context: __dirname,

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-string/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/loader-string/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 /**
  * @type {import('@rspack/core').RspackOptions}
  */

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/module-build-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/module-build-error/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: "./index.js",

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/options/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/options/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	mode: "none",

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/parallel-option/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/parallel-option/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 module.exports = {
 	context: __dirname,
 	module: {

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/pitching-mixed/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/pitching-mixed/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const { rspack } = require("@rspack/core");
 /**
  * @type {import('@rspack/core').RspackOptions[]}

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/pitching/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/pitching/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const { rspack } = require("@rspack/core");
 /**
  * @type {import('@rspack/core').RspackOptions[]}

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/pre-post-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/pre-post-loader/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 /**
  * @type {import('@rspack/core').RspackOptions}
  */

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/source-map/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/source-map/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const path = require("path");
 
 /**

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/sync/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/sync/rspack.config.js
@@ -1,4 +1,4 @@
-const supportsImportFn = require("../../../../dist/helper/legacy/supportsImportFn");
+const { supportsImportFn } = require("@rspack/test-tools");
 const path = require("path");
 const file = path.join(__dirname, "a.js");
 const asyncLoader = path.join(__dirname, "asyncloader.js");

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-disable-minify/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-disable-minify/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	findBundle: (i, options) => {
 		return ["main.js"];

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/assets/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/assets/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TDiffCaseConfig} */
+/** @type {import('@rspack/test-tools').TDiffCaseConfig} */
 module.exports = {
 	concurrent: false,
 	files: ["a.js", "b.js"]

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/chunkGraph/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/chunkGraph/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TDiffCaseConfig} */
+/** @type {import('@rspack/test-tools').TDiffCaseConfig} */
 module.exports = {
 	concurrent: false,
 	files: ["a.js", "b.js"]

--- a/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-split-with-css/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/max-size-split-with-css/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	findBundle: function (i, options) {
 		// should split based on their file path

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/loader.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").PitchLoaderDefinitionFunction} */
+/** @type {import('@rspack/test-tools').PitchLoaderDefinitionFunction} */
 module.exports = async function () {
 	try {
 		const result = await this.importModule("./syntax-error.js");

--- a/packages/rspack-test-tools/tests/hashCases/real-content-hash-md4/test.config.js
+++ b/packages/rspack-test-tools/tests/hashCases/real-content-hash-md4/test.config.js
@@ -1,6 +1,6 @@
 // const crypto = require("node:crypto");
 
-/** @type {import('../../../dist').THashCaseConfig} */
+/** @type {import("@rspack/test-tools").THashCaseConfig} */
 module.exports = {
 	validate(stats) {
 		const assets = stats.stats[0].toJson().assets.map(i => i.name);

--- a/packages/rspack-test-tools/tests/hashCases/real-content-hash-xxhash64/test.config.js
+++ b/packages/rspack-test-tools/tests/hashCases/real-content-hash-xxhash64/test.config.js
@@ -1,6 +1,6 @@
 // const crypto = require("node:crypto");
 
-/** @type {import('../../../dist').THashCaseConfig} */
+/** @type {import("@rspack/test-tools").THashCaseConfig} */
 module.exports = {
 	validate(stats) {
 		const assets = stats.stats[0].toJson().assets.map(i => i.name);

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/runtime-condition/test.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/runtime-condition/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TDiffCaseConfig} */
+/** @type {import('@rspack/test-tools').TDiffCaseConfig} */
 module.exports = {
 	renameModule: raw => {
 		// remove hash for concated module identifier

--- a/packages/rspack-test-tools/tests/serialCases/container-1-5/0-container-full/test.config.js
+++ b/packages/rspack-test-tools/tests/serialCases/container-1-5/0-container-full/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	findBundle: function (i, options) {
 		return i === 0 ? "./main.js" : "./module/main.mjs";

--- a/packages/rspack-test-tools/tests/serialCases/container-1-5/1-container-full/test.config.js
+++ b/packages/rspack-test-tools/tests/serialCases/container-1-5/1-container-full/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	findBundle: function (i, options) {
 		return i === 0 ? "./main.js" : "./module/main.mjs";

--- a/packages/rspack-test-tools/tests/serialCases/externals/0-concatenation-tree-shaking/test.config.js
+++ b/packages/rspack-test-tools/tests/serialCases/externals/0-concatenation-tree-shaking/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	noTests: true
 };

--- a/packages/rspack-test-tools/tests/serialCases/externals/1-concatenation-tree-shaking/test.config.js
+++ b/packages/rspack-test-tools/tests/serialCases/externals/1-concatenation-tree-shaking/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	findBundle: (i, options) => {
 		return ["main.mjs"];

--- a/packages/rspack-test-tools/tests/serialCases/library/0-create-library/test.config.js
+++ b/packages/rspack-test-tools/tests/serialCases/library/0-create-library/test.config.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../dist").TConfigCaseConfig} */
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
 module.exports = {
 	noTests: true
 };

--- a/packages/rspack-test-tools/tests/statsAPICases/build-time-executed-runtime.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/build-time-executed-runtime.js
@@ -1,6 +1,6 @@
 const { CssExtractRspackPlugin } = require("@rspack/core");
 
-/** @type {import('../../dist').TStatsAPICaseConfig} */
+/** @type {import('@rspack/test-tools').TStatsAPICaseConfig} */
 module.exports = {
 	description: "should have build time executed",
 	options(context) {

--- a/packages/rspack-test-tools/tests/statsAPICases/bundler-info.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/bundler-info.js
@@ -1,4 +1,4 @@
-/** @type {import('../../dist').TStatsAPICaseConfig} */
+/** @type {import('@rspack/test-tools').TStatsAPICaseConfig} */
 module.exports = {
 	description: "should inject bundler info runtime modules",
 	options(context) {

--- a/packages/rspack-test-tools/tests/statsAPICases/chunks.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/chunks.js
@@ -14,7 +14,7 @@ function deepReplace(obj) {
 	}
 }
 
-/** @type {import('../../dist').TStatsAPICaseConfig} */
+/** @type {import('@rspack/test-tools').TStatsAPICaseConfig} */
 module.exports = {
 	description: "should output the chunks",
 	options(context) {

--- a/packages/rspack-test-tools/tests/statsAPICases/error-chunk.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/error-chunk.js
@@ -1,4 +1,4 @@
-/** @type {import('../../dist').TStatsAPICaseConfig} */
+/** @type {import('@rspack/test-tools').TStatsAPICaseConfig} */
 module.exports = {
 	description: "should output error chunk info",
 	options(context) {

--- a/packages/rspack-test-tools/tests/statsAPICases/layer-stats.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/layer-stats.js
@@ -1,4 +1,4 @@
-/** @type {import('../../dist').TStatsAPICaseConfig} */
+/** @type {import('@rspack/test-tools').TStatsAPICaseConfig} */
 module.exports = {
 	description: "should have module layer",
 	options(context) {


### PR DESCRIPTION
## Summary

Import from `@rspack/test-tools` instead of using relative paths.

Benifits:

- No longer use long relative paths, etc. `"../../../../dist/helper/legacy/supportsImportFn"`.
- Allow us to move `<root>/packages/rspack-test-tools/tests` to `<root>/tests` in the future.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
