### PR TITLE
fix: make Compilation check logs clearer

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -184,6 +184,14 @@ export type NormalizedStatsOptions = KnownNormalizedStatsOptions &
 	Omit<StatsOptions, keyof KnownNormalizedStatsOptions> &
 	Record<string, any>;
 
+export const checkCompilation = (compilation: Compilation) => {
+	if (!(compilation instanceof Compilation)) {
+		throw new TypeError(
+			`The 'compilation' argument must be an instance of Compilation. This usually occurs when multiple versions of "@rspack/core" are used, or when the code in "@rspack/core" is executed multiple times.`
+		);
+	}
+};
+
 export class Compilation {
 	#inner: JsCompilation;
 	#shutdown: boolean;

--- a/packages/rspack/src/NormalModule.ts
+++ b/packages/rspack/src/NormalModule.ts
@@ -2,7 +2,7 @@ import util from "node:util";
 import * as binding from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
 import type { Source } from "webpack-sources";
-import { Compilation } from "./Compilation";
+import { type Compilation, checkCompilation } from "./Compilation";
 import type { Module } from "./Module";
 import type { LoaderContext } from "./config";
 import { JsSource } from "./util/source";
@@ -100,11 +100,8 @@ Object.defineProperty(binding.NormalModule, "getCompilationHooks", {
 	enumerable: true,
 	configurable: true,
 	value(compilation: Compilation): NormalModuleCompilationHooks {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
+		checkCompilation(compilation);
+
 		let hooks = compilationHooksMap.get(compilation);
 		if (hooks === undefined) {
 			hooks = {

--- a/packages/rspack/src/builtin-plugin/JavascriptModulesPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/JavascriptModulesPlugin.ts
@@ -2,7 +2,7 @@ import { type BuiltinPlugin, BuiltinPluginName } from "@rspack/binding";
 
 import * as liteTapable from "@rspack/lite-tapable";
 import type { Chunk } from "../Chunk";
-import { Compilation } from "../Compilation";
+import { type Compilation, checkCompilation } from "../Compilation";
 import type Hash from "../util/hash";
 import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 
@@ -22,11 +22,8 @@ export class JavascriptModulesPlugin extends RspackBuiltinPlugin {
 	}
 
 	static getCompilationHooks(compilation: Compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
+		checkCompilation(compilation);
+
 		let hooks = compilationHooksMap.get(compilation);
 		if (hooks === undefined) {
 			hooks = {

--- a/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
@@ -26,7 +26,7 @@ import {
 } from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
 import { z } from "zod";
-import { Compilation } from "../Compilation";
+import { type Compilation, checkCompilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import type { CreatePartialRegisters } from "../taps/types";
 import { validate } from "../util/validate";
@@ -122,11 +122,8 @@ const RsdoctorPlugin = RsdoctorPluginImpl as typeof RsdoctorPluginImpl & {
 RsdoctorPlugin.getHooks = RsdoctorPlugin.getCompilationHooks = (
 	compilation: Compilation
 ) => {
-	if (!(compilation instanceof Compilation)) {
-		throw new TypeError(
-			"The 'compilation' argument must be an instance of Compilation"
-		);
-	}
+	checkCompilation(compilation);
+
 	let hooks = compilationHooksMap.get(compilation);
 	if (hooks === undefined) {
 		hooks = {

--- a/packages/rspack/src/builtin-plugin/RuntimePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RuntimePlugin.ts
@@ -2,7 +2,7 @@ import * as binding from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
 
 import { Chunk } from "../Chunk";
-import { Compilation } from "../Compilation";
+import { type Compilation, checkCompilation } from "../Compilation";
 import type { CreatePartialRegisters } from "../taps/types";
 import { create } from "./base";
 
@@ -32,11 +32,8 @@ const compilationHooksMap: WeakMap<Compilation, RuntimePluginHooks> =
 RuntimePlugin.getHooks = RuntimePlugin.getCompilationHooks = (
 	compilation: Compilation
 ) => {
-	if (!(compilation instanceof Compilation)) {
-		throw new TypeError(
-			"The 'compilation' argument must be an instance of Compilation"
-		);
-	}
+	checkCompilation(compilation);
+
 	let hooks = compilationHooksMap.get(compilation);
 	if (hooks === undefined) {
 		hooks = {

--- a/packages/rspack/src/builtin-plugin/html-plugin/hooks.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/hooks.ts
@@ -7,7 +7,7 @@ import type {
 	JsBeforeEmitData
 } from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
-import { Compilation } from "../../Compilation";
+import { type Compilation, checkCompilation } from "../../Compilation";
 import type { HtmlRspackPluginOptions } from "./options";
 
 const compilationHooksMap: WeakMap<Compilation, HtmlRspackPluginHooks> =
@@ -39,11 +39,8 @@ export type HtmlRspackPluginHooks = {
 };
 
 export const getPluginHooks = (compilation: Compilation) => {
-	if (!(compilation instanceof Compilation)) {
-		throw new TypeError(
-			"The 'compilation' argument must be an instance of Compilation"
-		);
-	}
+	checkCompilation(compilation);
+
 	let hooks = compilationHooksMap.get(compilation);
 	if (hooks === undefined) {
 		hooks = {


### PR DESCRIPTION
## Summary

Make Compilation check logs clearer and extract a helper function. 

This should help users resolve issues with Rspack multiple instances after upgrading to 1.3.0.

Related: https://github.com/web-infra-dev/rspack/issues/9841

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
