### PR TITLE
ci: alpine apk use stable release branch

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -140,6 +140,11 @@ jobs:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           profile: ${{ inputs.profile }}
           pre: |
+            # set apk repositories to stable release branch
+            rm /etc/apk/repositories
+            echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories
+            echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories
+            apk update
             # musl will enable clang-sys static linking
             # https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#static
             # llvm19-dev is used to install llvm-config
@@ -155,6 +160,11 @@ jobs:
           profile: ${{ inputs.profile }}
           pre: |
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+            # set apk repositories to stable release branch
+            rm /etc/apk/repositories
+            echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories
+            echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories
+            apk update
             # musl will enable clang-sys static linking
             # https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#static
             # llvm19-dev is used to install llvm-config


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The docker image `ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine` will use [edge](https://wiki.alpinelinux.org/wiki/Repositories#Edge) repository in apk by default, which may cause the following unstable bugs.

![image](https://github.com/user-attachments/assets/c0380736-2f65-4d2a-98eb-e0e42f7779b6)

This PR will set `/etc/apk/repositories` to the v3.21 stable release branch to fix these bugs.

Test CI: https://github.com/web-infra-dev/rspack/actions/runs/14170169636/job/39692016419


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
