### PR TITLE
chore: bump napi 3.0.0-alpha.24 -> 3.0.0-alpha.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,6 @@ dependencies = [
  "async-trait",
  "color-backtrace",
  "cow-utils",
- "ctor",
  "derive_more 1.0.0",
  "futures",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cooked-waker"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,13 +1161,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "07e9666f4a9a948d4f1dff0c08a4512b0f7c86414b23960104c243c10d79f4c3"
 dependencies = [
- "quote",
- "syn 2.0.95",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
 name = "darling"
@@ -1478,6 +1493,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222ef136a1c687d4aa0395c175f2c4586e379924c352fd02f7870cf7de783c23"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "dunce"
@@ -2687,7 +2717,7 @@ version = "1.0.0-alpha.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12744d1279367caed41739ef094c325d53fb0ffcd4f9b84a368796f870252"
 dependencies = [
- "convert_case",
+ "convert_case 0.6.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2989,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.0.0-alpha.24"
+version = "3.0.0-alpha.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de0beff58a431b3bd6568b690bcf55d72d8dd7f8e0e613a0193a8a9a8eef26b"
+checksum = "c857a2b38c994db8bec785554ab4216d45ad63469832070c86a992be0b5491ad"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3011,11 +3041,11 @@ checksum = "e28acfa557c083f6e254a786e01ba253fc56f18ee000afcd4f79af735f73a6da"
 
 [[package]]
 name = "napi-derive"
-version = "3.0.0-alpha.22"
+version = "3.0.0-alpha.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f5e3b98fb51282253a2fa9903ae62273c68d89d6f8f304876de30354e86e1e"
+checksum = "c7165d931d54f68115e651330d5fe0ae0081133d3f4ee3ab55b0b808f0c23f71"
 dependencies = [
- "convert_case",
+ "convert_case 0.8.0",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -3024,11 +3054,11 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "2.0.0-alpha.22"
+version = "2.0.0-alpha.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a986ad1072af191e8e1e10a170644025f5b2ee28f2148f3acda818210960cc1a"
+checksum = "ce3f36354262054df8e1c3a73bdcd36ea13f130feb1e4d86b67cab9e10d6ef6d"
 dependencies = [
- "convert_case",
+ "convert_case 0.8.0",
  "proc-macro2",
  "quote",
  "semver 1.0.24",
@@ -4550,6 +4580,7 @@ dependencies = [
  "async-trait",
  "color-backtrace",
  "cow-utils",
+ "ctor",
  "derive_more 1.0.0",
  "futures",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,9 +87,10 @@ ustr               = { package = "ustr-fxhash", version = "1.0.1" }
 xxhash-rust        = { version = "0.8.14" }
 
 # Pinned
-napi        = { version = "3.0.0-alpha.24", features = ["anyhow"] }
+ctor        = { version = "0.4.1" }
+napi        = { version = "3.0.0-alpha.33", features = ["anyhow"] }
 napi-build  = { version = "2.1.6" }
-napi-derive = { version = "3.0.0-alpha.22" }
+napi-derive = { version = "3.0.0-alpha.29" }
 
 # Serialize and Deserialize
 inventory = { version = "0.3.17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ ustr               = { package = "ustr-fxhash", version = "1.0.1" }
 xxhash-rust        = { version = "0.8.14" }
 
 # Pinned
-ctor        = { version = "0.4.1" }
 napi        = { version = "3.0.0-alpha.33", features = ["anyhow"] }
 napi-build  = { version = "2.1.6" }
 napi-derive = { version = "3.0.0-alpha.29" }

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -38,6 +38,7 @@ cow-utils          = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+ctor        = { workspace = true }
 napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
 napi-derive = { workspace = true }
 

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -38,7 +38,6 @@ cow-utils          = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-ctor        = { workspace = true }
 napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
 napi-derive = { workspace = true }
 

--- a/crates/node_binding/src/filename.rs
+++ b/crates/node_binding/src/filename.rs
@@ -10,10 +10,13 @@ use rspack_napi::threadsafe_function::ThreadsafeFunction;
 
 use crate::{AssetInfo, JsPathData};
 
+type FilenameValue =
+  Either<String, ThreadsafeFunction<FnArgs<(JsPathData, Option<AssetInfo>)>, String>>;
+
 /// A js filename value. Either a string or a function
 #[derive(Debug)]
 pub struct JsFilename {
-  pub filename: Either<String, ThreadsafeFunction<FnArgs<(JsPathData, Option<AssetInfo>)>, String>>,
+  pub filename: FilenameValue,
 }
 
 impl FromNapiValue for JsFilename {

--- a/crates/node_binding/src/fs_node/node.rs
+++ b/crates/node_binding/src/fs_node/node.rs
@@ -1,5 +1,5 @@
 use napi::{
-  bindgen_prelude::{Buffer, Either3, Promise},
+  bindgen_prelude::{Buffer, Either3, FnArgs, Promise},
   Either,
 };
 use napi_derive::napi;
@@ -10,7 +10,7 @@ use rspack_napi::threadsafe_function::ThreadsafeFunction;
 #[napi(object, object_to_js = false, js_name = "ThreadsafeNodeFS")]
 pub struct ThreadsafeNodeFS {
   #[napi(ts_type = "(name: string, content: Buffer) => Promise<void>")]
-  pub write_file: ThreadsafeFunction<(String, Buffer), Promise<()>>,
+  pub write_file: ThreadsafeFunction<FnArgs<(String, Buffer)>, Promise<()>>,
   #[napi(ts_type = "(name: string) => Promise<void>")]
   pub remove_file: ThreadsafeFunction<String, Promise<()>>,
   #[napi(ts_type = "(name: string) => Promise<void>")]
@@ -28,21 +28,21 @@ pub struct ThreadsafeNodeFS {
   #[napi(ts_type = "(name: string) => Promise<NodeFsStats | void>")]
   pub lstat: ThreadsafeFunction<String, Promise<Either<NodeFsStats, ()>>>,
   #[napi(ts_type = "(name: string, flags: string) => Promise<number | void>")]
-  pub open: ThreadsafeFunction<(String, String), Promise<Either<i32, ()>>>,
+  pub open: ThreadsafeFunction<FnArgs<(String, String)>, Promise<Either<i32, ()>>>,
   #[napi(ts_type = "(from: string, to: string) => Promise<void>")]
-  pub rename: ThreadsafeFunction<(String, String), Promise<()>>,
+  pub rename: ThreadsafeFunction<FnArgs<(String, String)>, Promise<()>>,
   #[napi(ts_type = "(fd: number) => Promise<void>")]
   pub close: ThreadsafeFunction<i32, Promise<()>>,
   #[napi(ts_type = "(fd: number, content: Buffer, position: number) => Promise<number | void>")]
-  pub write: ThreadsafeFunction<(i32, Buffer, u32), Promise<Either<u32, ()>>>,
+  pub write: ThreadsafeFunction<FnArgs<(i32, Buffer, u32)>, Promise<Either<u32, ()>>>,
   #[napi(ts_type = "(fd: number, content: Buffer) => Promise<number | void>")]
-  pub write_all: ThreadsafeFunction<(i32, Buffer), Promise<()>>,
+  pub write_all: ThreadsafeFunction<FnArgs<(i32, Buffer)>, Promise<()>>,
   #[napi(ts_type = "(fd: number, length: number, position: number) => Promise<Buffer | void>")]
-  pub read: ThreadsafeFunction<(i32, u32, u32), Promise<Either<Buffer, ()>>>,
+  pub read: ThreadsafeFunction<FnArgs<(i32, u32, u32)>, Promise<Either<Buffer, ()>>>,
   #[napi(ts_type = "(fd: number, code: number, position: number) => Promise<Buffer | void>")]
-  pub read_until: ThreadsafeFunction<(i32, u8, u32), Promise<Either<Buffer, ()>>>,
+  pub read_until: ThreadsafeFunction<FnArgs<(i32, u8, u32)>, Promise<Either<Buffer, ()>>>,
   #[napi(ts_type = "(fd: number, position: number) => Promise<Buffer | void>")]
-  pub read_to_end: ThreadsafeFunction<(i32, u32), Promise<Either<Buffer, ()>>>,
+  pub read_to_end: ThreadsafeFunction<FnArgs<(i32, u32)>, Promise<Either<Buffer, ()>>>,
 }
 
 #[napi(object, object_to_js = false)]

--- a/crates/node_binding/src/fs_node/node.rs
+++ b/crates/node_binding/src/fs_node/node.rs
@@ -6,6 +6,12 @@ use napi_derive::napi;
 use rspack_fs::FileMetadata;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 
+type Open = ThreadsafeFunction<FnArgs<(String, String)>, Promise<Either<i32, ()>>>;
+type Write = ThreadsafeFunction<FnArgs<(i32, Buffer, u32)>, Promise<Either<u32, ()>>>;
+type Read = ThreadsafeFunction<FnArgs<(i32, u32, u32)>, Promise<Either<Buffer, ()>>>;
+type ReadUtil = ThreadsafeFunction<FnArgs<(i32, u8, u32)>, Promise<Either<Buffer, ()>>>;
+type ReadToEnd = ThreadsafeFunction<FnArgs<(i32, u32)>, Promise<Either<Buffer, ()>>>;
+
 #[derive(Debug)]
 #[napi(object, object_to_js = false, js_name = "ThreadsafeNodeFS")]
 pub struct ThreadsafeNodeFS {
@@ -28,21 +34,21 @@ pub struct ThreadsafeNodeFS {
   #[napi(ts_type = "(name: string) => Promise<NodeFsStats | void>")]
   pub lstat: ThreadsafeFunction<String, Promise<Either<NodeFsStats, ()>>>,
   #[napi(ts_type = "(name: string, flags: string) => Promise<number | void>")]
-  pub open: ThreadsafeFunction<FnArgs<(String, String)>, Promise<Either<i32, ()>>>,
+  pub open: Open,
   #[napi(ts_type = "(from: string, to: string) => Promise<void>")]
   pub rename: ThreadsafeFunction<FnArgs<(String, String)>, Promise<()>>,
   #[napi(ts_type = "(fd: number) => Promise<void>")]
   pub close: ThreadsafeFunction<i32, Promise<()>>,
   #[napi(ts_type = "(fd: number, content: Buffer, position: number) => Promise<number | void>")]
-  pub write: ThreadsafeFunction<FnArgs<(i32, Buffer, u32)>, Promise<Either<u32, ()>>>,
+  pub write: Write,
   #[napi(ts_type = "(fd: number, content: Buffer) => Promise<number | void>")]
   pub write_all: ThreadsafeFunction<FnArgs<(i32, Buffer)>, Promise<()>>,
   #[napi(ts_type = "(fd: number, length: number, position: number) => Promise<Buffer | void>")]
-  pub read: ThreadsafeFunction<FnArgs<(i32, u32, u32)>, Promise<Either<Buffer, ()>>>,
+  pub read: Read,
   #[napi(ts_type = "(fd: number, code: number, position: number) => Promise<Buffer | void>")]
-  pub read_until: ThreadsafeFunction<FnArgs<(i32, u8, u32)>, Promise<Either<Buffer, ()>>>,
+  pub read_until: ReadUtil,
   #[napi(ts_type = "(fd: number, position: number) => Promise<Buffer | void>")]
-  pub read_to_end: ThreadsafeFunction<FnArgs<(i32, u32)>, Promise<Either<Buffer, ()>>>,
+  pub read_to_end: ReadToEnd,
 }
 
 #[napi(object, object_to_js = false)]

--- a/crates/node_binding/src/fs_node/write.rs
+++ b/crates/node_binding/src/fs_node/write.rs
@@ -63,7 +63,7 @@ impl WritableFileSystem for NodeFileSystem {
     self
       .0
       .write_file
-      .call_with_promise((file, data.into()))
+      .call_with_promise((file, data.into()).into())
       .await
       .map_err(map_error_to_fs_error)
   }
@@ -145,7 +145,7 @@ impl IntermediateFileSystemExtras for NodeFileSystem {
     self
       .0
       .rename
-      .call_with_promise((from, to))
+      .call_with_promise((from, to).into())
       .await
       .map_err(map_error_to_fs_error)
   }
@@ -174,7 +174,7 @@ impl NodeReadStream {
   pub async fn try_new(file: &Utf8Path, fs: Arc<ThreadsafeNodeFS>) -> Result<Self> {
     let res = fs
       .open
-      .call_with_promise((file.as_str().to_string(), "r".to_string()))
+      .call_with_promise((file.as_str().to_string(), "r".to_string()).into())
       .await
       .map_err(map_error_to_fs_error)?;
 
@@ -191,7 +191,7 @@ impl ReadStream for NodeReadStream {
     let buffer = self
       .fs
       .read
-      .call_with_promise((self.fd, length as u32, self.pos as u32))
+      .call_with_promise((self.fd, length as u32, self.pos as u32).into())
       .await
       .map_err(map_error_to_fs_error)?;
 
@@ -208,7 +208,7 @@ impl ReadStream for NodeReadStream {
     let buffer = self
       .fs
       .read_until
-      .call_with_promise((self.fd, byte, self.pos as u32))
+      .call_with_promise((self.fd, byte, self.pos as u32).into())
       .await
       .map_err(map_error_to_fs_error)?;
 
@@ -224,7 +224,7 @@ impl ReadStream for NodeReadStream {
     let buffer = self
       .fs
       .read_to_end
-      .call_with_promise((self.fd, self.pos as u32))
+      .call_with_promise((self.fd, self.pos as u32).into())
       .await
       .map_err(map_error_to_fs_error)?;
 
@@ -261,7 +261,7 @@ impl NodeWriteStream {
   pub async fn try_new(file: &Utf8Path, fs: Arc<ThreadsafeNodeFS>) -> Result<Self> {
     let res = fs
       .open
-      .call_with_promise((file.as_str().to_string(), "w+".to_string()))
+      .call_with_promise((file.as_str().to_string(), "w+".to_string()).into())
       .await
       .map_err(map_error_to_fs_error)?;
 
@@ -283,7 +283,7 @@ impl WriteStream for NodeWriteStream {
     let res = self
       .fs
       .write
-      .call_with_promise((self.fd, buf.to_vec().into(), self.pos as u32))
+      .call_with_promise((self.fd, buf.to_vec().into(), self.pos as u32).into())
       .await
       .map_err(map_error_to_fs_error)?;
 
@@ -299,7 +299,7 @@ impl WriteStream for NodeWriteStream {
     self
       .fs
       .write_all
-      .call_with_promise((self.fd, buf.to_vec().into()))
+      .call_with_promise((self.fd, buf.to_vec().into()).into())
       .await
       .map_err(map_error_to_fs_error)
   }

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -342,7 +342,7 @@ enum TraceState {
 }
 
 #[cfg(not(target_family = "wasm"))]
-#[ctor::ctor]
+#[napi::ctor::ctor(crate_path = ::napi::ctor)]
 fn init() {
   use std::{
     sync::atomic::{AtomicUsize, Ordering},

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -342,7 +342,7 @@ enum TraceState {
 }
 
 #[cfg(not(target_family = "wasm"))]
-#[ctor]
+#[ctor::ctor]
 fn init() {
   use std::{
     sync::atomic::{AtomicUsize, Ordering},

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_circular_dependency.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_circular_dependency.rs
@@ -1,5 +1,5 @@
 use derive_more::Debug;
-use napi::Either;
+use napi::{bindgen_prelude::FnArgs, Either};
 use napi_derive::napi;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_circular_dependencies::{
@@ -33,10 +33,10 @@ pub struct RawCircularDependencyRspackPluginOptions {
   pub ignored_connections: Option<Vec<(ConnectionPattern, ConnectionPattern)>>,
   #[debug(skip)]
   #[napi(ts_type = "(entrypoint: Module, modules: string[], compilation: JsCompilation) => void")]
-  pub on_detected: Option<ThreadsafeFunction<CycleHookParams, ()>>,
+  pub on_detected: Option<ThreadsafeFunction<FnArgs<CycleHookParams>, ()>>,
   #[debug(skip)]
   #[napi(ts_type = "(entrypoint: Module, modules: string[], compilation: JsCompilation) => void")]
-  pub on_ignored: Option<ThreadsafeFunction<CycleHookParams, ()>>,
+  pub on_ignored: Option<ThreadsafeFunction<FnArgs<CycleHookParams>, ()>>,
   #[debug(skip)]
   #[napi(ts_type = "(compilation: JsCompilation) => void")]
   pub on_start: Option<ThreadsafeFunction<JsCompilationWrapper, ()>>,
@@ -55,7 +55,7 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
         let callback = callback.clone();
         Box::pin(async move {
           callback
-            .call_with_sync((entrypoint, modules, JsCompilationWrapper::new(compilation)))
+            .call_with_sync((entrypoint, modules, JsCompilationWrapper::new(compilation)).into())
             .await?;
           Ok(())
         })
@@ -68,7 +68,7 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
           let callback = callback.clone();
           async move {
             callback
-              .call_with_sync((entrypoint, modules, JsCompilationWrapper::new(compilation)))
+              .call_with_sync((entrypoint, modules, JsCompilationWrapper::new(compilation)).into())
               .await?;
             Ok(())
           }

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
@@ -1,6 +1,9 @@
 use cow_utils::CowUtils;
 use derive_more::Debug;
-use napi::{bindgen_prelude::Buffer, Either};
+use napi::{
+  bindgen_prelude::{Buffer, FnArgs},
+  Either,
+};
 use napi_derive::napi;
 use rspack_core::rspack_sources::RawSource;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
@@ -9,7 +12,7 @@ use rspack_plugin_copy::{
   Transformer,
 };
 
-type TransformerFn = ThreadsafeFunction<(Buffer, String), Either<String, Buffer>>;
+type TransformerFn = ThreadsafeFunction<FnArgs<(Buffer, String)>, Either<String, Buffer>>;
 type RawTransformer = Either<RawTransformOptions, TransformerFn>;
 
 type RawToFn = ThreadsafeFunction<RawToOptions, String>;
@@ -167,7 +170,7 @@ impl From<RawCopyPattern> for CopyPattern {
             }
 
             Box::pin(async move {
-              f.call_with_sync((input.into(), absolute_filename.to_owned()))
+              f.call_with_sync((input.into(), absolute_filename.to_owned()).into())
                 .await
                 .map(convert_to_enum)
             })
@@ -185,7 +188,7 @@ impl From<RawCopyPattern> for CopyPattern {
           }
 
           Box::pin(async move {
-            f.call_with_sync((input.into(), absolute_filename.to_owned()))
+            f.call_with_sync((input.into(), absolute_filename.to_owned()).into())
               .await
               .map(convert_to_enum)
           })

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_http_uri.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_http_uri.rs
@@ -11,6 +11,9 @@ use rspack_plugin_schemes::{
 use rspack_regex::RspackRegex;
 use rspack_util::asset_condition::{AssetCondition, AssetConditions};
 
+type HttpClientRequest =
+  ThreadsafeFunction<FnArgs<(String, HashMap<String, String>)>, Promise<JsHttpResponseRaw>>;
+
 #[napi(object, object_to_js = false)]
 #[derive(Debug)]
 pub struct RawHttpUriPluginOptions {
@@ -22,8 +25,7 @@ pub struct RawHttpUriPluginOptions {
   // pub proxy: Option<String>,
   // pub frozen: Option<bool>,
   #[napi(ts_type = "(url: string, headers: Record<string, string>) => Promise<JsHttpResponseRaw>")]
-  pub http_client:
-    ThreadsafeFunction<FnArgs<(String, HashMap<String, String>)>, Promise<JsHttpResponseRaw>>,
+  pub http_client: HttpClientRequest,
 }
 
 #[napi(object)]
@@ -33,10 +35,12 @@ pub struct JsHttpResponseRaw {
   pub body: Buffer,
 }
 
+type JsHttpClientFunction =
+  ThreadsafeFunction<FnArgs<(String, HashMap<String, String>)>, Promise<JsHttpResponseRaw>>;
+
 #[derive(Debug, Clone)]
 pub struct JsHttpClient {
-  function:
-    ThreadsafeFunction<FnArgs<(String, HashMap<String, String>)>, Promise<JsHttpResponseRaw>>,
+  function: JsHttpClientFunction,
 }
 
 #[async_trait]

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_ignore.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_ignore.rs
@@ -1,9 +1,10 @@
+use napi::bindgen_prelude::FnArgs;
 use napi_derive::napi;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_ignore::{CheckResourceContent, IgnorePluginOptions};
 use rspack_regex::RspackRegex;
 
-type RawCheckResource = ThreadsafeFunction<(String, String), bool>;
+type RawCheckResource = ThreadsafeFunction<FnArgs<(String, String)>, bool>;
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
@@ -27,7 +28,7 @@ impl From<RawIgnorePluginOptions> for IgnorePluginOptions {
           let f = check_resource.clone();
 
           Box::pin(async move {
-            f.call_with_sync((resource.to_owned(), context.to_owned()))
+            f.call_with_sync((resource.to_owned(), context.to_owned()).into())
               .await
           })
         }))

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_progress.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_progress.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use derive_more::Debug;
-use napi::Either;
+use napi::{bindgen_prelude::FnArgs, Either};
 use napi_derive::napi;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_progress::{ProgressPluginDisplayOptions, ProgressPluginOptions};
 
-type HandlerFn = ThreadsafeFunction<(f64, String, Vec<String>), ()>;
+type HandlerFn = ThreadsafeFunction<FnArgs<(f64, String, Vec<String>)>, ()>;
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
 pub struct RawProgressPluginOptions {
@@ -31,7 +31,7 @@ impl From<RawProgressPluginOptions> for ProgressPluginOptions {
     if let Some(f) = value.handler {
       Self::Handler(Arc::new(move |percent, msg, items| {
         let f = f.clone();
-        Box::pin(async move { f.call_with_sync((percent, msg, items)).await })
+        Box::pin(async move { f.call_with_sync((percent, msg, items).into()).await })
       }))
     } else {
       Self::Default(ProgressPluginDisplayOptions {

--- a/crates/node_binding/src/raw_options/raw_module/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_module/mod.rs
@@ -949,11 +949,7 @@ fn js_func_to_no_parse_test_func(
 ) -> ModuleNoParseTestFn {
   Box::new(move |s| {
     let v = v.clone();
-    Box::pin(async move {
-      v.call_with_sync(s.into())
-        .await
-        .map(|v| v.unwrap_or_default())
-    })
+    Box::pin(async move { v.call_with_sync(s).await.map(|v| v.unwrap_or_default()) })
   })
 }
 

--- a/crates/node_binding/src/raw_options/raw_module/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_module/mod.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt::Formatter, sync::Arc};
 
 use derive_more::Debug;
 use napi::{
-  bindgen_prelude::{Buffer, Either3},
+  bindgen_prelude::{Buffer, Either3, FnArgs},
   Either,
 };
 use napi_derive::napi;
@@ -624,7 +624,7 @@ impl From<RawAssetResourceGeneratorOptions> for AssetResourceGeneratorOptions {
 
 type RawAssetGeneratorDataUrl = Either<
   RawAssetGeneratorDataUrlOptions,
-  ThreadsafeFunction<(Buffer, RawAssetGeneratorDataUrlFnCtx), String>,
+  ThreadsafeFunction<FnArgs<(Buffer, RawAssetGeneratorDataUrlFnCtx)>, String>,
 >;
 struct RawAssetGeneratorDataUrlWrapper(RawAssetGeneratorDataUrl);
 
@@ -652,7 +652,7 @@ impl From<RawAssetGeneratorDataUrlWrapper> for AssetGeneratorDataUrl {
         let b = b.clone();
         let source = source.into();
         let ctx = ctx.into();
-        Box::pin(async move { b.call_with_sync((source, ctx)).await })
+        Box::pin(async move { b.call_with_sync((source, ctx).into()).await })
       })),
     }
   }
@@ -949,7 +949,11 @@ fn js_func_to_no_parse_test_func(
 ) -> ModuleNoParseTestFn {
   Box::new(move |s| {
     let v = v.clone();
-    Box::pin(async move { v.call_with_sync(s).await.map(|v| v.unwrap_or_default()) })
+    Box::pin(async move {
+      v.call_with_sync(s.into())
+        .await
+        .map(|v| v.unwrap_or_default())
+    })
   })
 }
 

--- a/crates/node_binding/src/source.rs
+++ b/crates/node_binding/src/source.rs
@@ -43,7 +43,6 @@ impl<'s> From<JsCompatSource<'s>> for BoxSource {
 }
 
 #[napi(object)]
-#[derive(Clone)]
 pub struct JsCompatSourceOwned {
   pub source: Either<String, Buffer>,
   pub map: Option<String>,


### PR DESCRIPTION
## Summary

This is necessary for rspack wasi.

There is a big break change: https://github.com/napi-rs/napi-rs/pull/2401. Rust tuple passed into tsfn now becomes a single array arg in js. We should wrap it into `FnArgs { data: (...) }`.

Before: rs `tsfn((a, b))` -> js `tsfn(a,b)`
After: rs `tsfn((a, b))` -> js `tsfn([a,b])`
We need change to rs `tsfn(FnArgs { data: (a, b) })`/`tsfn((a, b).into())` -> js `tsfn(a,b)`

Other changes:
1. `Buffer` does not impl `Clone` any more: https://github.com/napi-rs/napi-rs/pull/2462
2. re-export `ctor`: https://github.com/napi-rs/napi-rs/pull/2472

close: https://github.com/web-infra-dev/rspack/issues/9618

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
