### PR TITLE
fix(modern-module): leave non exist dependency to throw on resolve

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-error/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-error/index.js
@@ -1,0 +1,4 @@
+export const main = async () => {
+	const nonExistDep = await import('non_exist_dep') // Not externalized, should throw instead of panic.
+	console.log(nonExistDep)
+}

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-error/rspack.config.js
@@ -1,0 +1,44 @@
+/** @type {import("@rspack/core").Configuration} */
+
+module.exports = {
+	entry: {
+		index: "./index.js"
+	},
+	output: {
+		filename: `[name].js`,
+		chunkFilename: `async.js`,
+		module: true,
+		library: {
+			type: "modern-module"
+		},
+		iife: false,
+		chunkFormat: "module",
+		chunkLoading: "import"
+	},
+	externalsType: "module-import",
+	experiments: {
+		outputModule: true
+	},
+	optimization: {
+		concatenateModules: true,
+		avoidEntryIife: true,
+		minimize: false
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.done.tap("TestPlugin", stats => {
+					const errors = stats.toJson({
+						errors: true,
+						ids: true,
+						moduleTrace: true
+					}).errors;
+					expect(errors.length).toBe(1);
+					expect(errors[0].message).toMatch(
+						/Module not found: Can't resolve 'non_exist_dep' in/
+					);
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix https://github.com/web-infra-dev/rspack/issues/9861.

Skip (directly continue) the dependency if not found, leave it to throw an error in resolve stage, only externalized dep will be processed in the modifed function.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
