### PR TITLE
refactor: convert result with message

### DIFF
--- a/crates/node_binding/src/compilation/mod.rs
+++ b/crates/node_binding/src/compilation/mod.rs
@@ -11,8 +11,8 @@ use rspack_core::{
   rspack_sources::BoxSource, BoxDependency, Compilation, CompilationId, EntryOptions,
   FactorizeInfo, ModuleIdentifier,
 };
-use rspack_error::Diagnostic;
-use rspack_napi::{napi::bindgen_prelude::*, NapiResultExt, OneShotRef};
+use rspack_error::{Diagnostic, ToStringResultToRspackResultExt};
+use rspack_napi::{napi::bindgen_prelude::*, OneShotRef};
 use rspack_plugin_runtime::RuntimeModuleFromJs;
 use rustc_hash::FxHashMap;
 
@@ -75,7 +75,7 @@ impl JsCompilation {
           };
           new_source
         };
-        let new_source = new_source.into_rspack_result()?;
+        let new_source = new_source.to_rspack_result()?;
 
         let new_info: napi::Result<Option<rspack_core::AssetInfo>> = asset_info_update_or_function
           .map(
@@ -90,7 +90,7 @@ impl JsCompilation {
             },
           )
           .transpose();
-        if let Some(new_info) = new_info.into_rspack_result()? {
+        if let Some(new_info) = new_info.to_rspack_result()? {
           original_info.merge_another_asset(new_info);
         }
         Ok((new_source, original_info))

--- a/crates/node_binding/src/error.rs
+++ b/crates/node_binding/src/error.rs
@@ -79,22 +79,16 @@ impl JsRspackError {
   }
 }
 
-pub trait RspackErrorToNapiErrorExt {
-  fn to_napi_error(self) -> napi::Error;
-}
-
-impl<T: ToString> RspackErrorToNapiErrorExt for T {
-  fn to_napi_error(self) -> napi::Error {
-    napi::Error::from_reason(self.to_string())
-  }
-}
-
-pub trait RspackResultToNapiResultExt<T> {
+pub trait RspackResultToNapiResultExt<T, E: ToString> {
   fn to_napi_result(self) -> napi::Result<T>;
+  fn to_napi_result_with_message(self, f: impl FnOnce(E) -> String) -> napi::Result<T>;
 }
 
-impl<T, E: ToString> RspackResultToNapiResultExt<T> for Result<T, E> {
+impl<T, E: ToString> RspackResultToNapiResultExt<T, E> for Result<T, E> {
   fn to_napi_result(self) -> napi::Result<T> {
     self.map_err(|e| napi::Error::from_reason(e.to_string()))
+  }
+  fn to_napi_result_with_message(self, f: impl FnOnce(E) -> String) -> napi::Result<T> {
+    self.map_err(|e| napi::Error::from_reason(f(e)))
   }
 }

--- a/crates/node_binding/src/plugins/js_cleanup_plugin.rs
+++ b/crates/node_binding/src/plugins/js_cleanup_plugin.rs
@@ -5,8 +5,8 @@ use rspack_collections::IdentifierSet;
 use rspack_core::{
   ApplyContext, CompilationRevokedModules, CompilerOptions, ModuleIdentifier, PluginContext,
 };
+use rspack_error::ToStringResultToRspackResultExt;
 use rspack_hook::{plugin, plugin_hook};
-use rspack_napi::NapiResultExt;
 
 pub type CleanupRevokedModulesTsFn = ThreadsafeFunction<
   External<Vec<ModuleIdentifier>>,
@@ -59,6 +59,6 @@ async fn revoked_modules(&self, revoked_modules: &IdentifierSet) -> rspack_error
       revoked_modules.iter().cloned().collect::<Vec<_>>(),
     ))
     .await
-    .into_rspack_result()?;
+    .to_rspack_result()?;
   Ok(())
 }

--- a/crates/node_binding/src/plugins/js_loader/resolver.rs
+++ b/crates/node_binding/src/plugins/js_loader/resolver.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   BoxLoader, Context, Loader, ModuleRuleUseLoader, NormalModuleFactoryResolveLoader, ResolveResult,
   Resolver, Resource, RunnerContext, BUILTIN_LOADER_PREFIX,
 };
-use rspack_error::{error, Result, SerdeResultToRspackResultExt};
+use rspack_error::{error, Result, SerdeResultToRspackResultExt, ToStringResultToRspackResultExt};
 use rspack_hook::plugin_hook;
 use rspack_loader_lightningcss::{config::Config, LIGHTNINGCSS_LOADER_IDENTIFIER};
 use rspack_loader_preact_refresh::PREACT_REFRESH_LOADER_IDENTIFIER;
@@ -133,7 +133,9 @@ pub(crate) async fn resolve_loader(
 
   let resolve_result = resolver
     .resolve(context.as_std_path(), prev.as_str())
-    .map_err(|err| error!("Failed to resolve loader: {prev} in {context}, error: {err:?}"))?;
+    .to_rspack_result_with_message(|e| {
+      format!("Failed to resolve loader: {prev} in {context}, error: {e}")
+    })?;
 
   match resolve_result {
     ResolveResult::Resource(resource) => {

--- a/crates/node_binding/src/raw_options/raw_builtins/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/mod.rs
@@ -25,12 +25,11 @@ use raw_ids::RawOccurrenceChunkIdsPluginOptions;
 use raw_lightning_css_minimizer::RawLightningCssMinimizerRspackPluginOptions;
 use raw_sri::RawSubresourceIntegrityPluginOptions;
 use rspack_core::{BoxPlugin, Plugin, PluginExt};
-use rspack_error::Result;
+use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_ids::{
   DeterministicChunkIdsPlugin, DeterministicModuleIdsPlugin, NamedChunkIdsPlugin,
   NamedModuleIdsPlugin, NaturalChunkIdsPlugin, NaturalModuleIdsPlugin, OccurrenceChunkIdsPlugin,
 };
-use rspack_napi::NapiResultExt;
 use rspack_plugin_asset::AssetPlugin;
 use rspack_plugin_banner::BannerPlugin;
 use rspack_plugin_circular_dependencies::CircularDependencyRspackPlugin;
@@ -602,5 +601,5 @@ impl BuiltinPlugin {
 }
 
 fn downcast_into<T: FromNapiValue + 'static>(o: JsUnknown) -> Result<T> {
-  rspack_napi::downcast_into(o).into_rspack_result()
+  rspack_napi::downcast_into(o).to_rspack_result()
 }

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_lightning_css_minimizer.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_lightning_css_minimizer.rs
@@ -1,5 +1,5 @@
 use napi_derive::napi;
-use rspack_error::Result;
+use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_plugin_lightning_css_minimizer::{
   Draft, MinimizerOptions, NonStandard, PluginOptions, PseudoClasses,
 };
@@ -89,7 +89,7 @@ impl TryFrom<RawLightningCssMinimizerRspackPluginOptions> for PluginOptions {
             rspack_loader_lightningcss::lightningcss::targets::Browsers::from_browserslist(t)
           })
           .transpose()
-          .map_err(|e| rspack_error::error!("Failed to parse browserslist: {}", e))?
+          .to_rspack_result_with_message(|e| format!("Failed to parse browserslist: {}", e))?
           .flatten(),
         include: value.minimizer_options.include,
         exclude: value.minimizer_options.exclude,

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fs, sync::Arc};
 
 use cow_utils::CowUtils;
 use derive_more::Debug;
-use rspack_error::{error, miette::IntoDiagnostic, Result};
+use rspack_error::{error, miette::IntoDiagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_hook::define_hook;
 use rspack_paths::{AssertUtf8, Utf8Path, Utf8PathBuf};
 use rspack_regex::RspackRegex;
@@ -238,9 +238,11 @@ impl ContextModuleFactory {
         for loader_request in loaders {
           let resolve_result = loader_resolver
             .resolve(data.context.as_ref(), loader_request)
-            .map_err(|err| {
-              let context = data.context.to_string();
-              error!("Failed to resolve loader: {loader_request} in {context} {err:?}")
+            .to_rspack_result_with_message(|e| {
+              format!(
+                "Failed to resolve loader: {loader_request} in {} {e}",
+                data.context
+              )
             })?;
           match resolve_result {
             ResolveResult::Resource(resource) => {

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -12,7 +12,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsPreset, Unsupported},
 };
-use rspack_error::error;
+use rspack_error::ToStringResultToRspackResultExt;
 use rspack_util::{atom::Atom, ext::CowExt, MergeFrom};
 
 use crate::{parse_resource, AssetInfo, PathData, ReplaceAllPlaceholder, ResourceParsedData};
@@ -146,11 +146,8 @@ impl LocalFilenameFn for Arc<dyn FilenameFn> {
       .deref()
       .call(path_data, asset_info)
       .await
-      .map_err(|err| {
-        error!(
-          "Failed to render filename function: {}. Did you return the correct filename?",
-          err.to_string()
-        )
+      .to_rspack_result_with_message(|e| {
+        format!("Failed to render filename function: {e}. Did you return the correct filename?")
       })
   }
 }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -33,6 +33,14 @@ pub enum ResolveInnerError {
   RspackResolver(rspack_resolver::ResolveError),
 }
 
+impl fmt::Display for ResolveInnerError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      Self::RspackResolver(error) => write!(f, "{error:?}"),
+    }
+  }
+}
+
 /// Proxy to [rspack_resolver::ResolveOptions]
 pub enum ResolveInnerOptions<'a> {
   RspackResolver(&'a rspack_resolver::ResolveOptions),

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -7,7 +7,7 @@ use std::{
 use cow_utils::CowUtils;
 use itertools::Itertools;
 use rspack_dojang::{Context, Dojang, Operand};
-use rspack_error::{error, miette, Result};
+use rspack_error::{error, miette, Result, ToStringResultToRspackResultExt};
 use serde_json::{Map, Value};
 
 use crate::{Environment, RuntimeGlobals};
@@ -122,7 +122,9 @@ impl RuntimeTemplate {
         )
         // Replace Windows-style line endings (\r\n) with Unix-style (\n) to ensure consistent runtime templates across platforms
         .map(|render| render.cow_replace("\r\n", "\n").to_string())
-        .map_err(|err| error!("Runtime module: failed to render template {key} from: {err}"))
+        .to_rspack_result_with_message(|e| {
+          format!("Runtime module: failed to render template {key} from: {e}")
+        })
     } else {
       Err(error!("Runtime module: Template {key} is not found"))
     }

--- a/crates/rspack_error/src/convert.rs
+++ b/crates/rspack_error/src/convert.rs
@@ -2,17 +2,21 @@ use miette::{miette, LabeledSpan, SourceOffset};
 
 use crate::{AnyhowError, Result};
 
-pub trait ToStringResultToRspackResultExt<T> {
+pub trait ToStringResultToRspackResultExt<T, E: ToString> {
   fn to_rspack_result(self) -> Result<T>;
+  fn to_rspack_result_with_message(self, formatter: impl FnOnce(E) -> String) -> Result<T>;
 }
 
-impl<T, E: ToString> ToStringResultToRspackResultExt<T> for std::result::Result<T, E> {
+impl<T, E: ToString> ToStringResultToRspackResultExt<T, E> for std::result::Result<T, E> {
   fn to_rspack_result(self) -> Result<T> {
     self.map_err(|e| miette!(e.to_string()))
   }
+  fn to_rspack_result_with_message(self, formatter: impl FnOnce(E) -> String) -> Result<T> {
+    self.map_err(|e| miette!(formatter(e)))
+  }
 }
 
-pub trait SerdeResultToRspackResultExt<T>: ToStringResultToRspackResultExt<T> {
+pub trait SerdeResultToRspackResultExt<T> {
   fn to_rspack_result_with_detail(self, content: &str, msg: &str) -> Result<T>;
 }
 
@@ -27,11 +31,11 @@ impl<T> SerdeResultToRspackResultExt<T> for std::result::Result<T, serde_json::E
 }
 
 pub trait AnyhowResultToRspackResultExt<T> {
-  fn to_rspack_result(self) -> Result<T>;
+  fn to_rspack_result_from_anyhow(self) -> Result<T>;
 }
 
 impl<T> AnyhowResultToRspackResultExt<T> for std::result::Result<T, anyhow::Error> {
-  fn to_rspack_result(self) -> Result<T> {
+  fn to_rspack_result_from_anyhow(self) -> Result<T> {
     self.map_err(|e| AnyhowError::from(e).into())
   }
 }

--- a/crates/rspack_loader_lightningcss/src/config.rs
+++ b/crates/rspack_loader_lightningcss/src/config.rs
@@ -3,6 +3,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsOption, AsPreset},
 };
+use rspack_error::ToStringResultToRspackResultExt;
 use serde::Deserialize;
 
 #[cacheable]
@@ -71,7 +72,7 @@ impl TryFrom<RawConfig> for Config {
         .targets
         .map(lightningcss::targets::Browsers::from_browserslist)
         .transpose()
-        .map_err(|err| rspack_error::error!("Failed to parse browserslist: {}", err))?
+        .to_rspack_result_with_message(|e| format!("Failed to parse browserslist: {}", e))?
         .flatten(),
       include: value.include,
       exclude: value.exclude,

--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -183,7 +183,7 @@ impl LightningCssLoader {
             focus_within: pseudo_classes.focus_within.as_deref(),
           }),
       })
-      .map_err(|_| rspack_error::error!("failed to generate css"))?;
+      .to_rspack_result_with_message(|e| format!("failed to generate css: {e}"))?;
 
     if enable_sourcemap {
       let mappings = encode_mappings(source_map.get_mappings().iter().map(|mapping| Mapping {

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -1,6 +1,8 @@
 use std::{fmt::Debug, path::PathBuf, sync::Arc};
 
-use rspack_error::{error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
+use rspack_error::{
+  error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray, ToStringResultToRspackResultExt,
+};
 use rspack_fs::ReadableFileSystem;
 use rspack_sources::SourceMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -51,8 +53,9 @@ async fn process_resource<Context: Send>(
       // use spawn_blocking to avoid block,see https://docs.rs/tokio/latest/src/tokio/fs/read.rs.html#48
       let result = spawn_blocking(move || fs.read(resource_path_owned.as_path()))
         .await
-        .map_err(|e| error!("{e}, spawn task failed"))?;
-      let result = result.map_err(|e| error!("{e}, failed to read {resource_path}"))?;
+        .to_rspack_result_with_message(|e| format!("{e}, spawn task failed"))?;
+      let result =
+        result.to_rspack_result_with_message(|e| format!("{e}, failed to read {resource_path}"))?;
       loader_context.content = Some(Content::from(result));
     } else if !resource_data.get_scheme().is_none() {
       let resource = &resource_data.resource;

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -95,17 +95,17 @@ impl SwcLoader {
 
     let source = content.into_string_lossy();
     let c = SwcCompiler::new(resource_path.into_std_path_buf(), source, swc_options)
-      .to_rspack_result()?;
+      .to_rspack_result_from_anyhow()?;
 
     let built = c
       .parse(None, |_| {
         transformer::transform(&self.options_with_additional.rspack_experiments)
       })
-      .to_rspack_result()?;
+      .to_rspack_result_from_anyhow()?;
 
     let input_source_map = c
       .input_source_map(&built.input_source_map)
-      .to_rspack_result()?;
+      .to_rspack_result_from_anyhow()?;
     let mut codegen_options = ast::CodegenOptions {
       target: Some(built.target),
       minify: Some(built.minify),

--- a/crates/rspack_napi/src/errors.rs
+++ b/crates/rspack_napi/src/errors.rs
@@ -1,29 +1,14 @@
 use std::{ffi::CString, ptr};
 
-use napi::{bindgen_prelude::*, sys::napi_value, Env, Error, Result};
+use napi::{bindgen_prelude::*, sys::napi_value, Env, Error};
 use rspack_error::NodeError;
 
-pub trait NapiErrorExt {
-  fn into_rspack_error(self) -> rspack_error::Error;
-  fn into_rspack_error_with_detail(self, env: &Env) -> rspack_error::Error;
+pub trait NapiErrorToRspackErrorExt {
+  fn to_rspack_error(self, env: &Env) -> rspack_error::Error;
 }
 
-pub trait NapiResultExt<T> {
-  fn into_rspack_result(self) -> rspack_error::Result<T>;
-  fn into_rspack_result_with_detail(self, env: &Env) -> rspack_error::Result<T>;
-}
-
-impl NapiErrorExt for Error {
-  fn into_rspack_error(self) -> rspack_error::Error {
-    (NodeError {
-      reason: self.reason,
-      stack: None,
-      backtrace: "".to_string(),
-      hide_stack: None,
-    })
-    .into()
-  }
-  fn into_rspack_error_with_detail(self, env: &Env) -> rspack_error::Error {
+impl NapiErrorToRspackErrorExt for Error {
+  fn to_rspack_error(self, env: &Env) -> rspack_error::Error {
     let (reason, stack, backtrace, hide_stack) =
       extract_stack_or_message_from_napi_error(env, self);
     (NodeError {
@@ -33,15 +18,6 @@ impl NapiErrorExt for Error {
       hide_stack,
     })
     .into()
-  }
-}
-
-impl<T: 'static> NapiResultExt<T> for Result<T> {
-  fn into_rspack_result(self) -> rspack_error::Result<T> {
-    self.map_err(|e| e.into_rspack_error())
-  }
-  fn into_rspack_result_with_detail(self, env: &Env) -> rspack_error::Result<T> {
-    self.map_err(|e| e.into_rspack_error_with_detail(env))
   }
 }
 

--- a/crates/rspack_napi/src/lib.rs
+++ b/crates/rspack_napi/src/lib.rs
@@ -6,7 +6,7 @@ mod js_values;
 mod utils;
 
 mod errors;
-pub use errors::{NapiErrorExt, NapiResultExt};
+pub use errors::NapiErrorToRspackErrorExt;
 
 mod callback;
 pub use callback::JsCallback;

--- a/crates/rspack_plugin_html/src/asset.rs
+++ b/crates/rspack_plugin_html/src/asset.rs
@@ -349,7 +349,7 @@ pub fn create_favicon_asset(
         CompilationAsset::from(RawBufferSource::from(content).boxed()),
       )
     })
-    .to_rspack_result()
+    .to_rspack_result_from_anyhow()
 }
 
 pub async fn create_html_asset(

--- a/crates/rspack_plugin_schemes/src/file_uri.rs
+++ b/crates/rspack_plugin_schemes/src/file_uri.rs
@@ -2,7 +2,7 @@ use rspack_core::{
   ApplyContext, CompilerOptions, ModuleFactoryCreateData, NormalModuleFactoryResolveForScheme,
   Plugin, PluginContext, ResourceData, Scheme,
 };
-use rspack_error::{error, Result};
+use rspack_error::{error, Result, ToStringResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::AssertUtf8;
 use url::Url;
@@ -19,7 +19,7 @@ async fn normal_module_factory_resolve_for_scheme(
   scheme: &Scheme,
 ) -> Result<Option<bool>> {
   if scheme.is_file() {
-    let url = Url::parse(&resource_data.resource).map_err(|e| error!(e.to_string()))?;
+    let url = Url::parse(&resource_data.resource).to_rspack_result()?;
     let path = url
       .to_file_path()
       .map_err(|_| error!("Failed to get file path of {url}"))?

--- a/crates/rspack_plugin_schemes/src/http_uri/mod.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/mod.rs
@@ -138,7 +138,7 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
   {
     let fetch_result = fetch_content(&resource_data.resource, &self.options)
       .await
-      .to_rspack_result()?;
+      .to_rspack_result_from_anyhow()?;
 
     if let FetchResultType::Content(content_result) = fetch_result {
       return Ok(Some(Content::from(content_result.content().to_vec())));

--- a/crates/rspack_storage/src/fs/mod.rs
+++ b/crates/rspack_storage/src/fs/mod.rs
@@ -335,11 +335,10 @@ mod tests {
 
   #[tokio::test]
   #[cfg_attr(miri, ignore)]
-  async fn should_storage_bridge_fs_work() {
+  async fn should_storage_bridge_fs_work() -> FSResult<()> {
     let fs = BridgeFileSystem(Arc::new(MemoryFileSystem::default()));
 
-    let _ = test_memory_fs(&fs).await.map_err(|e| {
-      panic!("{}", e);
-    });
+    test_memory_fs(&fs).await?;
+    Ok(())
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Convert `Result` with message

---
This pull request focuses on improving error handling and consistency across various modules by replacing custom error conversion methods with a new trait `ToStringResultToRspackResultExt`. The changes span multiple files and touch on different parts of the codebase, including compilation, error handling, plugins, and loaders.


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
