### PR TITLE
fix: should ensure cache exist when incremental rebuild chunk graph

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -1766,7 +1766,13 @@ pub fn code_split(compilation: &mut Compilation) -> Result<()> {
 
   let module_graph: &ModuleGraph<'_> = &compilation.get_module_graph();
 
-  let mut splitter = if let Some(mutations) = mutations {
+  let mut splitter = if !compilation
+    .code_splitting_cache
+    .new_code_splitter
+    .module_ordinal
+    .is_empty()
+    && let Some(mutations) = mutations
+  {
     let mut affected = mutations.get_affected_modules_with_module_graph(module_graph);
     let removed = mutations.iter().filter_map(|mutation| match mutation {
       Mutation::ModuleRemove { module } => Some(*module),

--- a/packages/rspack-test-tools/tests/cacheCases/common/basic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/cacheCases/common/basic/rspack.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	experiments: {
 		cache: {
 			type: "persistent"
-		}
+		},
+		incremental: true
 	}
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Persistant cache may clear caches, so if we want to incremental rebuild, not only ensure incremental config, but also make sure we have caches

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
