### PR TITLE
feat(loader-parallel): support `LoaderContext.fs` as `node:fs`

### DIFF
--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -321,6 +321,8 @@ async function loaderImpl(
 		);
 	};
 
+	loaderContext.fs = require("node:fs");
+
 	Object.defineProperty(loaderContext, "request", {
 		enumerable: true,
 		get: () =>

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -2069,7 +2069,7 @@ This configuration only takes effect when [experiments.parallelLoader](/config/e
 
 The loader configuration must comply with the [HTML structured clone algorithm](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist), otherwise transmission will fail.
 
-Currently, Rspack does not support `LoaderContext.fs`, and most methods on `LoaderContext._compilation`, `LoaderContext._compiler`, `LoaderContext._module`.
+Currently, Rspack does not support most of the methods on `LoaderContext._compilation`, `LoaderContext._compiler`, `LoaderContext._module`.
 :::
 
 ### Rule.resolve

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -2067,7 +2067,7 @@ export default {
 
 loader 的配置需要满足 [HTML structured clone algorithm](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist)，否则会发送失败。
 
-目前 rspack 不支持 `LoaderContext.fs`, 以及大多数 `LoaderContext._compilation`, `LoaderContext._compiler`, `LoaderContext._module` 上的方法。
+目前 rspack 不支持大多数 `LoaderContext._compilation`, `LoaderContext._compiler`, `LoaderContext._module` 上的方法。
 :::
 
 ### Rule.resolve


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`Compiler.inputFileSystem` is supposed to be a better choice. But it requires some hassle of wrapping it.
Let's use `node:fs` for now. This is the same as `thread-loader`'s [impl](https://github.com/webpack-contrib/thread-loader/blob/b15157daec07f52c6e5c41f40aff00f277d6d81b/src/worker.js#L160).

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
