### PR TITLE
fix: more stable named chunk ids

### DIFF
--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -52,6 +52,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
       compare_chunks_natural(
         chunk_graph,
         &module_graph,
+        &compilation.chunk_group_by_ukey,
         &compilation.module_ids_artifact,
         a,
         b,

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -12,8 +12,8 @@ use itertools::{
 use regex::Regex;
 use rspack_collections::DatabaseItem;
 use rspack_core::{
-  compare_runtime, BoxModule, Chunk, ChunkGraph, ChunkUkey, Compilation, ModuleGraph,
-  ModuleIdentifier, ModuleIdsArtifact,
+  compare_runtime, BoxModule, Chunk, ChunkGraph, ChunkGroupByUkey, ChunkUkey, Compilation,
+  ModuleGraph, ModuleIdentifier, ModuleIdsArtifact,
 };
 use rspack_util::{
   comparators::{compare_ids, compare_numbers},
@@ -363,7 +363,7 @@ fn compare_chunks_by_modules(
   let a_modules = chunk_graph.get_ordered_chunk_modules(&a.ukey(), module_graph);
   let b_modules = chunk_graph.get_ordered_chunk_modules(&b.ukey(), module_graph);
 
-  let eq = a_modules
+  let ordering = a_modules
     .into_iter()
     .zip_longest(b_modules)
     .find_map(|pair| match pair {
@@ -386,18 +386,27 @@ fn compare_chunks_by_modules(
     })
     .unwrap_or(Ordering::Equal);
 
-  // 2 chunks are exactly the same, we have to compare
-  // the ukey to get stable results
-  if matches!(eq, Ordering::Equal) {
-    return a.ukey().cmp(&b.ukey());
-  }
+  ordering
+}
 
-  eq
+fn compare_chunks_by_groups(
+  chunk_group_by_ukey: &ChunkGroupByUkey,
+  a: &Chunk,
+  b: &Chunk,
+) -> Ordering {
+  let a_groups = a
+    .get_sorted_groups_iter(chunk_group_by_ukey)
+    .map(|group| chunk_group_by_ukey.expect_get(group).index);
+  let b_groups = b
+    .get_sorted_groups_iter(chunk_group_by_ukey)
+    .map(|group| chunk_group_by_ukey.expect_get(group).index);
+  a_groups.cmp_by(b_groups, |a, b| a.cmp(&b))
 }
 
 pub fn compare_chunks_natural(
   chunk_graph: &ChunkGraph,
   module_graph: &ModuleGraph,
+  chunk_group_by_ukey: &ChunkGroupByUkey,
   module_ids: &ModuleIdsArtifact,
   a: &Chunk,
   b: &Chunk,
@@ -412,5 +421,10 @@ pub fn compare_chunks_natural(
     return runtime_ordering;
   }
 
-  compare_chunks_by_modules(chunk_graph, module_graph, module_ids, a, b)
+  let modules_ordering = compare_chunks_by_modules(chunk_graph, module_graph, module_ids, a, b);
+  if modules_ordering != Ordering::Equal {
+    return modules_ordering;
+  }
+
+  compare_chunks_by_groups(chunk_group_by_ukey, a, b)
 }

--- a/crates/rspack_ids/src/lib.rs
+++ b/crates/rspack_ids/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(iter_intersperse)]
+#![feature(iter_order_by)]
 #![feature(let_chains)]
 
 mod deterministic_module_ids_plugin;

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -112,12 +112,12 @@ fn assign_named_chunk_ids(
       });
       let mut i = 0;
       for item in items {
-        let mut formatted_name = format!("{name}-{}", itoa!(i));
+        let mut formatted_name = format!("{name}{}", itoa!(i));
         while name_to_items_keys.contains(&formatted_name)
           && used_ids.contains_key(formatted_name.as_str())
         {
           i += 1;
-          formatted_name = format!("{name}-{}", itoa!(i));
+          formatted_name = format!("{name}{}", itoa!(i));
         }
         let name: ChunkId = formatted_name.into();
         if ChunkGraph::set_chunk_id(chunk_ids, item, name.clone())

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -104,6 +104,7 @@ fn assign_named_chunk_ids(
         compare_chunks_natural(
           chunk_graph,
           &module_graph,
+          &compilation.chunk_group_by_ukey,
           &compilation.module_ids_artifact,
           a,
           b,
@@ -111,12 +112,12 @@ fn assign_named_chunk_ids(
       });
       let mut i = 0;
       for item in items {
-        let mut formatted_name = format!("{name}{}", itoa!(i));
+        let mut formatted_name = format!("{name}-{}", itoa!(i));
         while name_to_items_keys.contains(&formatted_name)
           && used_ids.contains_key(formatted_name.as_str())
         {
           i += 1;
-          formatted_name = format!("{name}{}", itoa!(i));
+          formatted_name = format!("{name}-{}", itoa!(i));
         }
         let name: ChunkId = formatted_name.into();
         if ChunkGraph::set_chunk_id(chunk_ids, item, name.clone())
@@ -135,6 +136,7 @@ fn assign_named_chunk_ids(
     compare_chunks_natural(
       chunk_graph,
       &module_graph,
+      &compilation.chunk_group_by_ukey,
       &compilation.module_ids_artifact,
       a,
       b,

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -95,12 +95,12 @@ fn assign_named_module_ids(
       items.sort_unstable_by(|a, b| compare_ids(a, b));
       let mut i = 0;
       for item in items {
-        let mut formatted_name = format!("{name}-{}", itoa!(i));
+        let mut formatted_name = format!("{name}{}", itoa!(i));
         while name_to_items_keys.contains(&formatted_name)
           && used_ids.contains_key(&formatted_name.as_str().into())
         {
           i += 1;
-          formatted_name = format!("{name}-{}", itoa!(i));
+          formatted_name = format!("{name}{}", itoa!(i));
         }
         let name: ModuleId = formatted_name.into();
         if ChunkGraph::set_module_id(module_ids, item, name.clone())

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -95,12 +95,12 @@ fn assign_named_module_ids(
       items.sort_unstable_by(|a, b| compare_ids(a, b));
       let mut i = 0;
       for item in items {
-        let mut formatted_name = format!("{name}{}", itoa!(i));
+        let mut formatted_name = format!("{name}-{}", itoa!(i));
         while name_to_items_keys.contains(&formatted_name)
           && used_ids.contains_key(&formatted_name.as_str().into())
         {
           i += 1;
-          formatted_name = format!("{name}{}", itoa!(i));
+          formatted_name = format!("{name}-{}", itoa!(i));
         }
         let name: ModuleId = formatted_name.into();
         if ChunkGraph::set_module_id(module_ids, item, name.clone())

--- a/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
@@ -21,7 +21,16 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     .chunk_by_ukey
     .values()
     .map(|chunk| chunk as &Chunk)
-    .sorted_unstable_by(|a, b| compare_chunks_natural(chunk_graph, module_graph, module_ids, a, b))
+    .sorted_unstable_by(|a, b| {
+      compare_chunks_natural(
+        chunk_graph,
+        module_graph,
+        &compilation.chunk_group_by_ukey,
+        module_ids,
+        a,
+        b,
+      )
+    })
     .map(|chunk| chunk.ukey())
     .collect::<Vec<_>>();
 

--- a/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
@@ -72,6 +72,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<
       compare_chunks_natural(
         chunk_graph,
         module_graph,
+        &compilation.chunk_group_by_ukey,
         &compilation.module_ids_artifact,
         a,
         b,

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
@@ -1,8 +1,8 @@
-node_modules_cell_index_js-XXX-0.bundle0.js
+node_modules_cell_index_js-XXX0.bundle0.js
 
 ::
 
-exports.ids = ['node_modules_cell_index_js-_861a-0'];
+exports.ids = ['node_modules_cell_index_js-_861a0'];
 exports.modules = {
 "./node_modules/cell/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
 const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
@@ -15,13 +15,12 @@ module.exports.cell = function(cell) {
 
 };
 ;
-
 ==============================================================
-node_modules_cell_index_js-XXX-1.bundle0.js
+node_modules_cell_index_js-XXX1.bundle0.js
 
 ::
 
-exports.ids = ['node_modules_cell_index_js-_861a-1'];
+exports.ids = ['node_modules_cell_index_js-_861a1'];
 exports.modules = {
 "./node_modules/cell/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
 const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
@@ -34,13 +33,12 @@ module.exports.cell = function(cell) {
 
 };
 ;
-
 ==============================================================
-node_modules_row_index_js-XXX-0.bundle0.js
+node_modules_row_index_js-XXX0.bundle0.js
 
 ::
 
-exports.ids = ['node_modules_row_index_js-_b2e2-0'];
+exports.ids = ['node_modules_row_index_js-_b2e20'];
 exports.modules = {
 "./node_modules/row/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
 const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")
@@ -54,13 +52,12 @@ module.exports.row = function(cells) {
 
 };
 ;
-
 ==============================================================
-node_modules_row_index_js-XXX-1.bundle0.js
+node_modules_row_index_js-XXX1.bundle0.js
 
 ::
 
-exports.ids = ['node_modules_row_index_js-_b2e2-1'];
+exports.ids = ['node_modules_row_index_js-_b2e21'];
 exports.modules = {
 "./node_modules/row/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
 const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")
@@ -74,5 +71,4 @@ module.exports.row = function(cells) {
 
 };
 ;
-
 ==============================================================

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
@@ -1,0 +1,78 @@
+node_modules_cell_index_js-XXX-0.bundle0.js
+
+::
+
+exports.ids = ['node_modules_cell_index_js-_861a-0'];
+exports.modules = {
+"./node_modules/cell/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
+const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
+
+module.exports.cell = function(cell) {
+    return tmpl(`<td>CELL</td>`, { CELL: cell })
+}
+
+}),
+
+};
+;
+
+==============================================================
+node_modules_cell_index_js-XXX-1.bundle0.js
+
+::
+
+exports.ids = ['node_modules_cell_index_js-_861a-1'];
+exports.modules = {
+"./node_modules/cell/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
+const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
+
+module.exports.cell = function(cell) {
+    return tmpl(`<td>CELL</td>`, { CELL: cell })
+}
+
+}),
+
+};
+;
+
+==============================================================
+node_modules_row_index_js-XXX-0.bundle0.js
+
+::
+
+exports.ids = ['node_modules_row_index_js-_b2e2-0'];
+exports.modules = {
+"./node_modules/row/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
+const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")
+const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
+
+module.exports.row = function(cells) {
+    return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })
+}
+
+}),
+
+};
+;
+
+==============================================================
+node_modules_row_index_js-XXX-1.bundle0.js
+
+::
+
+exports.ids = ['node_modules_row_index_js-_b2e2-1'];
+exports.modules = {
+"./node_modules/row/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
+const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")
+const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
+
+module.exports.row = function(cells) {
+    return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })
+}
+
+}),
+
+};
+;
+
+==============================================================

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/index.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/index.js
@@ -1,0 +1,19 @@
+export default async () => {
+	const { test } = await import(/* webpackMode: "eager" */'./module')
+
+	test()
+};
+
+it("should have stable chunkIds and chunk content", async () => {
+	const fs = __non_webpack_require__("fs");
+	const path = __non_webpack_require__("path");
+	const files = (await fs.promises.readdir(__dirname)).filter(file => file.startsWith("node_modules_cell_index_js-") || file.startsWith("node_modules_row_index_js-"));
+	let snapshot = "";
+	for (const file of files) {
+		const key = file.replace(/(.*)-(.*)-(\d\.bundle0\.js)/, "$1-XXX-$3");
+		const content = await fs.promises.readFile(path.resolve(__dirname, file), "utf-8");
+		snapshot += `${key}\n\n::\n\n${content}\n`;
+		snapshot += '==============================================================\n';
+	}
+	expect(snapshot).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'snapshot.txt'));
+})

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/index.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/index.js
@@ -10,7 +10,7 @@ it("should have stable chunkIds and chunk content", async () => {
 	const files = (await fs.promises.readdir(__dirname)).filter(file => file.startsWith("node_modules_cell_index_js-") || file.startsWith("node_modules_row_index_js-"));
 	let snapshot = "";
 	for (const file of files) {
-		const key = file.replace(/(.*)-(.*)-(\d\.bundle0\.js)/, "$1-XXX-$3");
+		const key = file.replace(/(.*)-(.*)(\d\.bundle0\.js)/, "$1-XXX$3");
 		const content = await fs.promises.readFile(path.resolve(__dirname, file), "utf-8");
 		snapshot += `${key}\n\n::\n\n${content}\n`;
 		snapshot += '==============================================================\n';

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/module.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/module.js
@@ -1,0 +1,5 @@
+import { table } from 'table'
+
+export function test() {
+    expect(table([['1']])).toBe('<table><tr><td>1</td></tr></table>')
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/cell/index.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/cell/index.js
@@ -1,0 +1,5 @@
+const { tmpl } = require('templater')
+
+module.exports.cell = function(cell) {
+    return tmpl(`<td>CELL</td>`, { CELL: cell })
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/cell/package.json
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/cell/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "row",
+    "version": "1.0.0",
+    "dependencies": {
+        "cell": "=1.0.0",
+        "templater": "=1.0.0"
+    }
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/row/index.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/row/index.js
@@ -1,0 +1,6 @@
+const { cell } = require('cell')
+const { tmpl } = require('templater')
+
+module.exports.row = function(cells) {
+    return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/row/package.json
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/row/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "row",
+    "version": "1.0.0",
+    "dependencies": {
+        "cell": "=1.0.0",
+        "templater": "=1.0.0"
+    }
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/table/index.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/table/index.js
@@ -1,0 +1,6 @@
+const { row } = require('row')
+const { tmpl } = require('templater')
+
+module.exports.table = function(rows) {
+    return tmpl('<table>ROWS</table>', { ROWS: rows.map(r => row(r)).join('\n') })
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/table/package.json
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/table/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "table",
+    "version": "1.0.0",
+    "dependencies": {
+        "row": "=1.0.0",
+        "templater": "=1.0.0"
+    }
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/templater/index.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/templater/index.js
@@ -1,0 +1,6 @@
+module.exports.tmpl = function(str, params) {
+    Object.keys(params).forEach((k) => {
+        str = str.replace(new RegExp(k, 'g'), params[k])
+    })
+    return str
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/templater/package.json
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/node_modules/templater/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "templater",
+    "version": "1.0.0"
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/package.json
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "engines": {
+    "node": ">=10.13.0"
+  },
+  "dependencies": {
+    "table": "=2.0.0"
+  }
+}

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/webpack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/webpack.config.js
@@ -1,0 +1,28 @@
+const webpack = require("@rspack/core");
+const { ModuleFederationPluginV1: ModuleFederationPlugin } = webpack.container;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		moduleIds: "named",
+		chunkIds: "named"
+	},
+	plugins: [
+		new ModuleFederationPlugin({
+			shared: {
+				table: {
+					requiredVersion: "=1.0.0"
+				},
+				cell: {
+					requiredVersion: "=1.0.0"
+				},
+				row: {
+					requiredVersion: "=1.0.0"
+				},
+				templater: {
+					requiredVersion: "=1.0.0"
+				}
+			}
+		})
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Make named chunk ids more stable, comparing with chunk ukey in not stable enough, so we compare their groups index instead

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
