### PR TITLE
fix: should walk for worker args

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -347,6 +347,9 @@ impl JavascriptParserPlugin for WorkerPlugin {
           if let Some(callee) = call_expr.callee.as_expr() {
             parser.walk_expression(callee);
           }
+          if let Some(arg) = call_expr.args.get(1) {
+            parser.walk_expression(&arg.expr);
+          }
           true
         },
       );
@@ -382,6 +385,9 @@ impl JavascriptParserPlugin for WorkerPlugin {
             if let Some(callee) = call_expr.callee.as_expr() {
               parser.walk_expression(callee);
             }
+            if let Some(arg) = call_expr.args.get(1) {
+              parser.walk_expression(&arg.expr);
+            }
             true
           },
         );
@@ -402,6 +408,9 @@ impl JavascriptParserPlugin for WorkerPlugin {
         );
         if let Some(callee) = call_expr.callee.as_expr() {
           parser.walk_expression(callee);
+        }
+        if let Some(arg) = call_expr.args.get(1) {
+          parser.walk_expression(&arg.expr);
         }
         true
       },
@@ -437,6 +446,11 @@ impl JavascriptParserPlugin for WorkerPlugin {
               parsed_options,
             );
             parser.walk_expression(&new_expr.callee);
+            if let Some(args) = &new_expr.args
+              && let Some(arg) = args.get(1)
+            {
+              parser.walk_expression(&arg.expr);
+            }
             true
           });
       }
@@ -458,6 +472,11 @@ impl JavascriptParserPlugin for WorkerPlugin {
           parsed_options,
         );
         parser.walk_expression(&new_expr.callee);
+        if let Some(args) = &new_expr.args
+          && let Some(arg) = args.get(1)
+        {
+          parser.walk_expression(&arg.expr);
+        }
         true
       })
   }

--- a/packages/rspack-test-tools/tests/normalCases/worker/specifier-in-worker-args/config.js
+++ b/packages/rspack-test-tools/tests/normalCases/worker/specifier-in-worker-args/config.js
@@ -1,0 +1,1 @@
+export const workerData = "MyWorkerData";

--- a/packages/rspack-test-tools/tests/normalCases/worker/specifier-in-worker-args/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/worker/specifier-in-worker-args/index.js
@@ -1,0 +1,16 @@
+import { Worker } from "worker_threads";
+import * as config from "./config";
+
+it("should compile", async () => {
+	const worker = new Worker(new URL("./worker", import.meta.url), {
+		workerData: config.workerData,
+	});
+	worker.postMessage("ok");
+	const result = await new Promise(resolve => {
+		worker.on("message", data => {
+			resolve(data);
+		});
+	});
+	expect(result).toBe(config.workerData);
+	await worker.terminate();
+});

--- a/packages/rspack-test-tools/tests/normalCases/worker/specifier-in-worker-args/worker.js
+++ b/packages/rspack-test-tools/tests/normalCases/worker/specifier-in-worker-args/worker.js
@@ -1,0 +1,5 @@
+import { parentPort, workerData } from "worker_threads";
+
+parentPort.on("message", ()=> {
+	parentPort.postMessage(workerData);
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix the case: 

```js
import { something } from "./anotherFile"
new Worker(..., { workerData: something }) // some import specifier used in the second argument
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
