### PR TITLE
feat(wasm): limit tokio `max_blocking_threads` to  1

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -335,6 +335,22 @@ enum TraceState {
   Off,
 }
 
+#[cfg(target_family = "wasm")]
+const _: () = {
+  #[used]
+  #[link_section = ".init_array"]
+  static __CTOR: unsafe extern "C" fn() = init;
+
+  unsafe extern "C" fn init() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+      .max_blocking_threads(1)
+      .enable_all()
+      .build()
+      .expect("Create tokio runtime failed");
+    create_custom_tokio_runtime(rt);
+  }
+};
+
 #[cfg(not(target_family = "wasm"))]
 #[napi::ctor::ctor(crate_path = ::napi::ctor)]
 fn init() {


### PR DESCRIPTION
## Summary

There are not many blocking tasks in rspack now, so set this to 1 to avoid creating too many workers.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
