### PR TITLE
docs: improve Next.js guide

### DIFF
--- a/website/docs/en/blog/announcing-1-3.mdx
+++ b/website/docs/en/blog/announcing-1-3.mdx
@@ -100,11 +100,14 @@ const middleware = rspack.experiments.lazyCompilationMiddleware(
   config.experiments.lazyCompilation,
 );
 
-const server = new DevServer({
-  setupMiddlewares(other) {
-    return [middleware, ...other];
+const server = new DevServer(
+  {
+    setupMiddlewares(other) {
+      return [middleware, ...other];
+    },
   },
-}, compiler);
+  compiler,
+);
 ```
 
 ### AMD supports

--- a/website/docs/en/guide/features/lazy-compilation.mdx
+++ b/website/docs/en/guide/features/lazy-compilation.mdx
@@ -112,12 +112,15 @@ const middleware = experiments.lazyCompilationMiddleware(
   config.experiments.lazyCompilation,
 );
 
-const server = new DevServer({
-  port: 3000,
-  setupMiddlewares(other) {
-    return [middleware, ...other];
+const server = new DevServer(
+  {
+    port: 3000,
+    setupMiddlewares(other) {
+      return [middleware, ...other];
+    },
   },
-}, compiler);
+  compiler,
+);
 
 server.start();
 ```

--- a/website/docs/en/guide/tech/next.mdx
+++ b/website/docs/en/guide/tech/next.mdx
@@ -1,35 +1,57 @@
+import { Tabs, Tab, PackageManagerTabs } from '@theme';
+
 # Next.js
 
-[@next/plugin-rspack](https://www.npmjs.com/package/@next/plugin-rspack) is a community-driven plugin that enables Next.js projects to use Rspack.
+[next-rspack](https://www.npmjs.com/package/next-rspack) is a community-driven plugin that enables Next.js projects to use Rspack as the bundler.
+
+> Example: [next.js/examples/with-rspack](https://github.com/vercel/next.js/tree/canary/examples/with-rspack).
 
 ## Installation
 
-```bash
-pnpm install -D @next/plugin-rspack
-```
+<PackageManagerTabs command="add next-rspack -D" />
 
 ## Usage
 
 Wrap your existing configuration in the project's `next.config.js` or `next.config.ts`:
 
-```ts title="next.config.js"
-const withRspack = require('@next/plugin-rspack');
+<Tabs>
+  <Tab label="next.config.ts">
+
+```ts
+import withRspack from 'next-rspack';
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  /* config options here */
+};
+
+export default withRspack(nextConfig);
+```
+
+  </Tab>
+  <Tab label="next.config.js">
+
+```ts
+const withRspack = require('next-rspack');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // existing configuration
+  /* config options here */
 };
 
 module.exports = withRspack(nextConfig);
 ```
 
+  </Tab>
+</Tabs>
+
 ## Customizing Rspack Configuration
 
-Rspack’s compatibility with webpack, Next.js adopts the same approach as webpack for custom configuration.
+Through Rspack's compatibility with webpack, when using `next-rspack`, you can customize configurations in the same way as you would with webpack.
 
-In `next.config.js`, you can modify Rspack’s configuration by adding the following callback function:
+In `next.config.js`, modify Rspack's configuration by adding the following callback function:
 
-```ts title="next.config.js"
+```js title="next.config.js"
 module.exports = {
   webpack: (
     config,
@@ -41,4 +63,18 @@ module.exports = {
 };
 ```
 
-For more details, see the [Next.js documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/webpack).
+> For more details, see the [Next.js - Custom Webpack Config](https://nextjs.org/docs/app/api-reference/config/next-config-js/webpack).
+
+## Usage with next-compose-plugins
+
+Alternatively, you can use [next-compose-plugins](https://www.npmjs.com/package/next-compose-plugins) to quickly integrate `next-rspack` with other Next.js plugins:
+
+```js title="next.config.js"
+const withPlugins = require('next-compose-plugins');
+const withRspack = require('next-rspack');
+
+module.exports = withPlugins([
+  [withRspack],
+  // your other plugins here
+]);
+```

--- a/website/docs/zh/blog/announcing-1-3.mdx
+++ b/website/docs/zh/blog/announcing-1-3.mdx
@@ -100,11 +100,14 @@ const middleware = rspack.experiments.lazyCompilationMiddleware(
   config.experiments.lazyCompilation,
 );
 
-const server = new DevServer({
-  setupMiddlewares(other) {
-    return [middleware, ...other];
+const server = new DevServer(
+  {
+    setupMiddlewares(other) {
+      return [middleware, ...other];
+    },
   },
-}, compiler);
+  compiler,
+);
 ```
 
 ### 支持 AMD 模块

--- a/website/docs/zh/guide/features/lazy-compilation.mdx
+++ b/website/docs/zh/guide/features/lazy-compilation.mdx
@@ -112,12 +112,15 @@ const middleware = experiments.lazyCompilationMiddleware(
   config.experiments.lazyCompilation,
 );
 
-const server = new DevServer({
-  port: 3000,
-  setupMiddlewares(other) {
-    return [middleware, ...other];
+const server = new DevServer(
+  {
+    port: 3000,
+    setupMiddlewares(other) {
+      return [middleware, ...other];
+    },
   },
-}, compiler);
+  compiler,
+);
 
 server.start();
 ```

--- a/website/docs/zh/guide/tech/next.mdx
+++ b/website/docs/zh/guide/tech/next.mdx
@@ -1,31 +1,53 @@
+import { Tabs, Tab, PackageManagerTabs } from '@theme';
+
 # Next.js
 
-[@next/plugin-rspack](https://www.npmjs.com/package/@next/plugin-rspack) 是一个社区驱动的插件，它允许 Next.js 项目启用 Rspack。
+[next-rspack](https://www.npmjs.com/package/next-rspack) 是一个社区驱动的插件，它允许 Next.js 项目使用 Rspack 作为打包工具。
 
-## 安装插件
+> 示例：[next.js/examples/with-rspack](https://github.com/vercel/next.js/tree/canary/examples/with-rspack)。
 
-```bash
-pnpm install -D @next/plugin-rspack
-```
+## 安装
+
+<PackageManagerTabs command="add next-rspack -D" />
 
 ## 使用
 
 在项目的 `next.config.js` 或 `next.config.ts` 中，对现有配置进行包装：
 
-```ts title="next.config.js"
-const withRspack = require('@next/plugin-rspack');
+<Tabs>
+  <Tab label="next.config.ts">
+
+```ts
+import withRspack from 'next-rspack';
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  /* config options here */
+};
+
+export default withRspack(nextConfig);
+```
+
+  </Tab>
+  <Tab label="next.config.js">
+
+```ts
+const withRspack = require('next-rspack');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  /* 现有配置 */
+  /* config options here */
 };
 
 module.exports = withRspack(nextConfig);
 ```
 
+  </Tab>
+</Tabs>
+
 ## 自定义 Rspack 配置
 
-得益于 Rspack 对 webpack 的兼容性，Next.js 沿用与 webpack 相同的方式进行自定义配置。
+得益于 Rspack 对 webpack 的兼容性，在使用 `next-rspack` 时，可以沿用与 webpack 相同的方式来自定义配置。
 
 在 `next.config.js` 中，通过以下回调函数来修改 Rspack 配置：
 
@@ -41,4 +63,18 @@ module.exports = {
 };
 ```
 
-更多信息请查看 [Next.js 官方文档](https://nextjs.org/docs/app/api-reference/config/next-config-js/webpack)。
+> 更多信息请查看 [Next.js - Custom Webpack Config](https://nextjs.org/docs/app/api-reference/config/next-config-js/webpack)。
+
+## 使用 next-compose-plugins
+
+此外，你可以使用 [next-compose-plugins](https://www.npmjs.com/package/next-compose-plugins) 来快速将 `next-rspack` 与其他 Next.js 插件集成：
+
+```js title="next.config.js"
+const withPlugins = require('next-compose-plugins');
+const withRspack = require('next-rspack');
+
+module.exports = withPlugins([
+  [withRspack],
+  // 其他插件写在这里
+]);
+```


### PR DESCRIPTION
## Summary

- Rename `@next/plugin-rspack` to `next-rspack`.
- Add "Usage with next-compose-plugins" section.
- Add `next.config.ts` example.
- Add example link.
- Format MDX files.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
