### PR TITLE
refactor: add dynamic dependency template implementation

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -52,8 +52,9 @@ use crate::{
   ChunkIdsArtifact, ChunkKind, ChunkRenderArtifact, ChunkRenderResult, ChunkUkey,
   CodeGenerationJob, CodeGenerationResult, CodeGenerationResults, CompilationLogger,
   CompilationLogging, CompilerOptions, DependenciesDiagnosticsArtifact, DependencyId,
-  DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId,
-  Filename, ImportVarMap, Logger, ModuleFactory, ModuleGraph, ModuleGraphPartial, ModuleIdentifier,
+  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId, Filename,
+  ImportVarMap, Logger, ModuleFactory, ModuleGraph, ModuleGraphPartial, ModuleIdentifier,
   ModuleIdsArtifact, PathData, ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpecMap,
   RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact, SourceType, Stats,
 };
@@ -212,6 +213,8 @@ pub struct Compilation {
   pub global_entry: EntryData,
   other_module_graph: Option<ModuleGraphPartial>,
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
+  pub dependency_templates:
+    HashMap<DynamicDependencyTemplateType, Arc<dyn DynamicDependencyTemplate>>,
   pub runtime_modules: IdentifierMap<Box<dyn RuntimeModule>>,
   pub runtime_modules_hash: IdentifierMap<RspackHashDigest>,
   pub runtime_modules_code_generation_source: IdentifierMap<BoxSource>,
@@ -340,6 +343,7 @@ impl Compilation {
       options,
       other_module_graph: None,
       dependency_factories: Default::default(),
+      dependency_templates: Default::default(),
       runtime_modules: Default::default(),
       runtime_modules_hash: Default::default(),
       runtime_modules_code_generation_source: Default::default(),
@@ -2462,6 +2466,23 @@ impl Compilation {
         )
       })
       .clone()
+  }
+
+  pub fn set_dependency_template(
+    &mut self,
+    template_type: DynamicDependencyTemplateType,
+    template: Arc<dyn DynamicDependencyTemplate>,
+  ) {
+    self.dependency_templates.insert(template_type, template);
+  }
+
+  pub fn get_dependency_template(
+    &self,
+    dep: &dyn DependencyTemplate,
+  ) -> Option<Arc<dyn DynamicDependencyTemplate>> {
+    dep
+      .dynamic_dependency_template()
+      .and_then(|template_type| self.dependency_templates.get(&template_type).cloned())
   }
 
   pub fn built_modules(&self) -> &IdentifierSet {

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -43,13 +43,13 @@ use crate::{
   merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
   reserved_names::RESERVED_NAMES, returning_function, runtime_condition_expression,
   subtract_runtime_condition, to_identifier, AsyncDependenciesBlockIdentifier, BoxDependency,
-  BuildContext, BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, BuildResult,
-  ChunkGraph, ChunkInitFragments, CodeGenerationDataTopLevelDeclarations,
-  CodeGenerationExportsFinalNames, CodeGenerationPublicPathAutoReplace, CodeGenerationResult,
-  Compilation, ConcatenatedModuleIdent, ConcatenationScope, ConnectionState, Context,
-  DependenciesBlock, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
-  ExportInfoProvided, ExportsArgument, ExportsType, FactoryMeta, IdentCollector, LibIdentOptions,
-  MaybeDynamicTargetExportInfoHashKey, Module, ModuleArgument, ModuleDependency, ModuleGraph,
+  BoxDependencyTemplate, BoxModuleDependency, BuildContext, BuildInfo, BuildMeta,
+  BuildMetaDefaultObject, BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments,
+  CodeGenerationDataTopLevelDeclarations, CodeGenerationExportsFinalNames,
+  CodeGenerationPublicPathAutoReplace, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
+  ConcatenationScope, ConnectionState, Context, DependenciesBlock, DependencyId, DependencyType,
+  ErrorSpan, ExportInfoProvided, ExportsArgument, ExportsType, FactoryMeta, IdentCollector,
+  LibIdentOptions, MaybeDynamicTargetExportInfoHashKey, Module, ModuleArgument, ModuleGraph,
   ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleType, Resolve, RuntimeCondition,
   RuntimeGlobals, RuntimeSpec, SourceType, SpanExt, Template, UsageState, UsedName, DEFAULT_EXPORT,
   NAMESPACE_OBJECT_EXPORT,
@@ -71,8 +71,8 @@ pub struct RootModuleContext {
   pub name_for_condition: Option<Box<str>>,
   pub lib_indent: Option<String>,
   pub resolve_options: Option<Arc<Resolve>>,
-  pub code_generation_dependencies: Option<Vec<Box<dyn ModuleDependency>>>,
-  pub presentational_dependencies: Option<Vec<Box<dyn DependencyTemplate>>>,
+  pub code_generation_dependencies: Option<Vec<BoxModuleDependency>>,
+  pub presentational_dependencies: Option<Vec<BoxDependencyTemplate>>,
   pub context: Option<Context>,
   pub layer: Option<ModuleLayer>,
   pub side_effect_connection_state: ConnectionState,
@@ -1383,7 +1383,7 @@ impl Module for ConcatenatedModule {
     self.root_module_ctxt.resolve_options.clone()
   }
 
-  fn get_code_generation_dependencies(&self) -> Option<&[Box<dyn ModuleDependency>]> {
+  fn get_code_generation_dependencies(&self) -> Option<&[BoxModuleDependency]> {
     if let Some(deps) = self
       .root_module_ctxt
       .code_generation_dependencies
@@ -1396,7 +1396,7 @@ impl Module for ConcatenatedModule {
     }
   }
 
-  fn get_presentational_dependencies(&self) -> Option<&[Box<dyn DependencyTemplate>]> {
+  fn get_presentational_dependencies(&self) -> Option<&[BoxDependencyTemplate]> {
     if let Some(deps) = self.root_module_ctxt.presentational_dependencies.as_deref()
       && !deps.is_empty()
     {

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -60,6 +60,10 @@ pub trait DependencyTemplate: Debug + DynClone + Sync + Send + AsAny {
     _runtime: Option<&RuntimeSpec>,
   ) {
   }
+
+  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+    None
+  }
 }
 
 pub type BoxDependencyTemplate = Box<dyn DependencyTemplate>;
@@ -74,4 +78,19 @@ impl<T: DependencyTemplate> AsDependencyTemplate for T {
   fn as_dependency_template(&self) -> Option<&dyn DependencyTemplate> {
     Some(self)
   }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum DynamicDependencyTemplateType {
+  DependencyType(DependencyType),
+  CustomType(String),
+}
+
+pub trait DynamicDependencyTemplate: Debug + Sync + Send {
+  fn render(
+    &self,
+    dep: &dyn DependencyTemplate,
+    source: &mut TemplateReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  );
 }

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -6,7 +6,7 @@ use rspack_sources::{BoxSource, ReplaceSource};
 use rspack_util::ext::AsAny;
 
 use crate::{
-  ChunkInitFragments, CodeGenerationData, Compilation, ConcatenationScope, Module,
+  ChunkInitFragments, CodeGenerationData, Compilation, ConcatenationScope, DependencyType, Module,
   ModuleInitFragments, RuntimeGlobals, RuntimeSpec,
 };
 

--- a/crates/rspack_core/src/dependency/module_dependency.rs
+++ b/crates/rspack_core/src/dependency/module_dependency.rs
@@ -62,3 +62,5 @@ impl<T: ModuleDependency> AsModuleDependency for T {
     Some(self)
   }
 }
+
+pub type BoxModuleDependency = Box<dyn ModuleDependency>;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -28,10 +28,10 @@ use serde::Serialize;
 
 use crate::{
   concatenated_module::ConcatenatedModule, dependencies_block::dependencies_block_update_hash,
-  AsyncDependenciesBlock, BoxDependency, ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation,
-  CompilationAsset, CompilationId, CompilerId, CompilerOptions, ConcatenationScope,
-  ConnectionState, Context, ContextModule, DependenciesBlock, DependencyId, DependencyTemplate,
-  ExportInfoProvided, ExternalModule, ModuleDependency, ModuleGraph, ModuleLayer, ModuleType,
+  AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BoxModuleDependency, ChunkGraph,
+  ChunkUkey, CodeGenerationResult, Compilation, CompilationAsset, CompilationId, CompilerId,
+  CompilerOptions, ConcatenationScope, ConnectionState, Context, ContextModule, DependenciesBlock,
+  DependencyId, ExportInfoProvided, ExternalModule, ModuleGraph, ModuleLayer, ModuleType,
   NormalModule, RawModule, Resolve, ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver,
   SourceType,
 };
@@ -327,11 +327,11 @@ pub trait Module:
   /// depends on the code generation results of dependencies which are returned by this function.
   /// e.g `Css` module may rely on the code generation result of `CssUrlDependency` to re-direct
   /// the url of the referenced assets.
-  fn get_code_generation_dependencies(&self) -> Option<&[Box<dyn ModuleDependency>]> {
+  fn get_code_generation_dependencies(&self) -> Option<&[BoxModuleDependency]> {
     None
   }
 
-  fn get_presentational_dependencies(&self) -> Option<&[Box<dyn DependencyTemplate>]> {
+  fn get_presentational_dependencies(&self) -> Option<&[BoxDependencyTemplate]> {
     None
   }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -35,13 +35,12 @@ use crate::{
   contextify,
   diagnostics::{CapturedLoaderError, ModuleBuildError},
   get_context, impl_module_meta_info, module_update_hash, AsyncDependenciesBlockIdentifier,
-  BoxLoader, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult, ChunkGraph,
-  CodeGenerationResult, Compilation, ConcatenationScope, ConnectionState, Context,
-  DependenciesBlock, DependencyId, DependencyTemplate, FactoryMeta, GenerateContext,
-  GeneratorOptions, LibIdentOptions, Module, ModuleDependency, ModuleGraph, ModuleIdentifier,
-  ModuleLayer, ModuleType, OutputOptions, ParseContext, ParseResult, ParserAndGenerator,
-  ParserOptions, Resolve, RspackLoaderRunnerPlugin, RunnerContext, RuntimeGlobals, RuntimeSpec,
-  SourceType,
+  BoxDependencyTemplate, BoxLoader, BoxModule, BoxModuleDependency, BuildContext, BuildInfo,
+  BuildMeta, BuildResult, ChunkGraph, CodeGenerationResult, Compilation, ConcatenationScope,
+  ConnectionState, Context, DependenciesBlock, DependencyId, FactoryMeta, GenerateContext,
+  GeneratorOptions, LibIdentOptions, Module, ModuleGraph, ModuleIdentifier, ModuleLayer,
+  ModuleType, OutputOptions, ParseContext, ParseResult, ParserAndGenerator, ParserOptions, Resolve,
+  RspackLoaderRunnerPlugin, RunnerContext, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
 #[cacheable]
@@ -143,8 +142,8 @@ pub struct NormalModule {
   #[cacheable(with=Skip)]
   diagnostics: Vec<Diagnostic>,
 
-  code_generation_dependencies: Option<Vec<Box<dyn ModuleDependency>>>,
-  presentational_dependencies: Option<Vec<Box<dyn DependencyTemplate>>>,
+  code_generation_dependencies: Option<Vec<BoxModuleDependency>>,
+  presentational_dependencies: Option<Vec<BoxDependencyTemplate>>,
 
   factory_meta: Option<FactoryMeta>,
   build_info: BuildInfo,
@@ -262,23 +261,19 @@ impl NormalModule {
     &mut self.parser_and_generator
   }
 
-  pub fn code_generation_dependencies(&self) -> &Option<Vec<Box<dyn ModuleDependency>>> {
+  pub fn code_generation_dependencies(&self) -> &Option<Vec<BoxModuleDependency>> {
     &self.code_generation_dependencies
   }
 
-  pub fn code_generation_dependencies_mut(
-    &mut self,
-  ) -> &mut Option<Vec<Box<dyn ModuleDependency>>> {
+  pub fn code_generation_dependencies_mut(&mut self) -> &mut Option<Vec<BoxModuleDependency>> {
     &mut self.code_generation_dependencies
   }
 
-  pub fn presentational_dependencies(&self) -> &Option<Vec<Box<dyn DependencyTemplate>>> {
+  pub fn presentational_dependencies(&self) -> &Option<Vec<BoxDependencyTemplate>> {
     &self.presentational_dependencies
   }
 
-  pub fn presentational_dependencies_mut(
-    &mut self,
-  ) -> &mut Option<Vec<Box<dyn DependencyTemplate>>> {
+  pub fn presentational_dependencies_mut(&mut self) -> &mut Option<Vec<BoxDependencyTemplate>> {
     &mut self.presentational_dependencies
   }
 
@@ -706,7 +701,7 @@ impl Module for NormalModule {
     self.resolve_options.clone()
   }
 
-  fn get_code_generation_dependencies(&self) -> Option<&[Box<dyn ModuleDependency>]> {
+  fn get_code_generation_dependencies(&self) -> Option<&[BoxModuleDependency]> {
     if let Some(deps) = self.code_generation_dependencies.as_deref()
       && !deps.is_empty()
     {
@@ -716,7 +711,7 @@ impl Module for NormalModule {
     }
   }
 
-  fn get_presentational_dependencies(&self) -> Option<&[Box<dyn DependencyTemplate>]> {
+  fn get_presentational_dependencies(&self) -> Option<&[BoxDependencyTemplate]> {
     if let Some(deps) = self.presentational_dependencies.as_deref()
       && !deps.is_empty()
     {

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -11,10 +11,10 @@ use rustc_hash::FxHashMap;
 use swc_core::common::Span;
 
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BoxLoader, BuildInfo, BuildMeta, ChunkGraph,
-  CodeGenerationData, Compilation, CompilerOptions, ConcatenationScope, Context,
-  DependencyTemplate, Module, ModuleDependency, ModuleGraph, ModuleIdentifier, ModuleLayer,
-  ModuleType, NormalModule, ParserOptions, RuntimeGlobals, RuntimeSpec, SourceType,
+  AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BoxLoader, BoxModuleDependency,
+  BuildInfo, BuildMeta, ChunkGraph, CodeGenerationData, Compilation, CompilerOptions,
+  ConcatenationScope, Context, Module, ModuleGraph, ModuleIdentifier, ModuleLayer, ModuleType,
+  NormalModule, ParserOptions, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
 #[derive(Debug)]
@@ -67,8 +67,8 @@ impl SideEffectsBailoutItemWithSpan {
 pub struct ParseResult {
   pub dependencies: Vec<BoxDependency>,
   pub blocks: Vec<Box<AsyncDependenciesBlock>>,
-  pub presentational_dependencies: Vec<Box<dyn DependencyTemplate>>,
-  pub code_generation_dependencies: Vec<Box<dyn ModuleDependency>>,
+  pub presentational_dependencies: Vec<BoxDependencyTemplate>,
+  pub code_generation_dependencies: Vec<BoxModuleDependency>,
   pub source: BoxSource,
   pub side_effects_bailout: Option<SideEffectsBailoutItem>,
 }

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -14,9 +14,9 @@ use rspack_core::{
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   remove_bom,
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
-  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, Compilation, ConstDependency,
-  CssExportsConvention, Dependency, DependencyId, DependencyRange, DependencyTemplate,
-  DependencyType, GenerateContext, LocalIdentName, Module, ModuleDependency, ModuleGraph,
+  BoxDependencyTemplate, BoxModuleDependency, BuildMetaDefaultObject, BuildMetaExportsType,
+  ChunkGraph, Compilation, ConstDependency, CssExportsConvention, Dependency, DependencyId,
+  DependencyRange, DependencyType, GenerateContext, LocalIdentName, Module, ModuleGraph,
   ModuleIdentifier, ModuleInitFragments, ModuleType, NormalModule, ParseContext, ParseResult,
   ParserAndGenerator, RuntimeGlobals, RuntimeSpec, SourceType, TemplateContext, UsageState,
 };
@@ -154,8 +154,8 @@ impl ParserAndGenerator for CssParserAndGenerator {
 
     let mut diagnostics: Vec<Box<dyn Diagnostic + Send + Sync + 'static>> = vec![];
     let mut dependencies: Vec<Box<dyn Dependency>> = vec![];
-    let mut presentational_dependencies: Vec<Box<dyn DependencyTemplate>> = vec![];
-    let mut code_generation_dependencies: Vec<Box<dyn ModuleDependency>> = vec![];
+    let mut presentational_dependencies: Vec<BoxDependencyTemplate> = vec![];
+    let mut code_generation_dependencies: Vec<BoxModuleDependency> = vec![];
 
     let (deps, warnings) = css_module_lexer::collect_dependencies(&source_code, mode);
     for dependency in deps {
@@ -499,8 +499,13 @@ impl ParserAndGenerator for CssParserAndGenerator {
           let dep = module_graph
             .dependency_by_id(id)
             .expect("should have dependency");
+
           if let Some(dependency) = dep.as_dependency_template() {
-            dependency.apply(&mut source, &mut context)
+            if let Some(template) = compilation.get_dependency_template(dependency) {
+              template.render(dependency, &mut source, &mut context)
+            } else {
+              dependency.apply(&mut source, &mut context)
+            }
           }
         });
 
@@ -533,9 +538,13 @@ impl ParserAndGenerator for CssParserAndGenerator {
         }
 
         if let Some(dependencies) = module.get_presentational_dependencies() {
-          dependencies
-            .iter()
-            .for_each(|dependency| dependency.apply(&mut source, &mut context));
+          dependencies.iter().for_each(|dependency| {
+            if let Some(template) = compilation.get_dependency_template(dependency.as_ref()) {
+              template.render(dependency.as_ref(), &mut source, &mut context)
+            } else {
+              dependency.apply(&mut source, &mut context)
+            }
+          });
         };
 
         generate_context.concatenation_scope = context.concatenation_scope.take();

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -160,7 +160,7 @@ impl DependencyTemplate for ImportDependency {
 impl AsContextDependency for ImportDependency {}
 
 #[cacheable]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ImportDependencyTemplate;
 
 impl ImportDependencyTemplate {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -182,15 +182,15 @@ impl DynamicDependencyTemplate for ImportDependencyTemplate {
       .expect("ImportDependencyTemplate can only be applied to ImportDependency");
     let range = dep.range().expect("ImportDependency should have range");
     let module_graph = code_generatable_context.compilation.get_module_graph();
-    let block = module_graph.get_parent_block(&dep.id());
+    let block = module_graph.get_parent_block(dep.id());
     source.replace(
       range.start,
       range.end,
       module_namespace_promise(
         code_generatable_context,
-        &dep.id(),
+        dep.id(),
         block,
-        &dep.request(),
+        dep.request(),
         dep.dependency_type().as_str(),
         false,
       )

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -61,10 +61,10 @@ pub struct ImportDependency {
   pub request: Atom,
   pub range: DependencyRange,
   #[cacheable(with=AsOption<AsVec<AsPreset>>)]
-  referenced_exports: Option<Vec<Atom>>,
-  attributes: Option<ImportAttributes>,
-  resource_identifier: String,
-  factorize_info: FactorizeInfo,
+  pub referenced_exports: Option<Vec<Atom>>,
+  pub attributes: Option<ImportAttributes>,
+  pub resource_identifier: String,
+  pub factorize_info: FactorizeInfo,
 }
 
 impl ImportDependency {
@@ -152,22 +152,46 @@ impl ModuleDependency for ImportDependency {
 
 #[cacheable_dyn]
 impl DependencyTemplate for ImportDependency {
-  fn apply(
+  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+    Some(ImportDependencyTemplate::template_type())
+  }
+}
+
+impl AsContextDependency for ImportDependency {}
+
+#[cacheable]
+#[derive(Debug)]
+pub struct ImportDependencyTemplate;
+
+impl ImportDependencyTemplate {
+  pub fn template_type() -> DynamicDependencyTemplateType {
+    DynamicDependencyTemplateType::DependencyType(DependencyType::DynamicImport)
+  }
+}
+
+impl DynamicDependencyTemplate for ImportDependencyTemplate {
+  fn render(
     &self,
+    dep: &dyn DependencyTemplate,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<ImportDependency>()
+      .expect("ImportDependencyTemplate can only be applied to ImportDependency");
+    let range = dep.range().expect("ImportDependency should have range");
     let module_graph = code_generatable_context.compilation.get_module_graph();
-    let block = module_graph.get_parent_block(&self.id);
+    let block = module_graph.get_parent_block(&dep.id());
     source.replace(
-      self.range.start,
-      self.range.end,
+      range.start,
+      range.end,
       module_namespace_promise(
         code_generatable_context,
-        &self.id,
+        &dep.id(),
         block,
-        &self.request,
-        self.dependency_type().as_str(),
+        &dep.request(),
+        dep.dependency_type().as_str(),
         false,
       )
       .as_str(),
@@ -175,5 +199,3 @@ impl DependencyTemplate for ImportDependency {
     );
   }
 }
-
-impl AsContextDependency for ImportDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -5,8 +5,9 @@ use rspack_cacheable::{
 use rspack_core::{
   create_exports_object_referenced, module_namespace_promise, AsContextDependency, Dependency,
   DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes, ModuleDependency,
-  ModuleGraph, ReferencedExport, TemplateContext, TemplateReplaceSource,
+  DynamicDependencyTemplate, DynamicDependencyTemplateType, ExportsType, ExtendedReferencedExport,
+  FactorizeInfo, ImportAttributes, ModuleDependency, ModuleGraph, ReferencedExport,
+  TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
   },
   esm_import_specifier_dependency::ESMImportSpecifierDependency,
   external_module_dependency::ExternalModuleDependency,
-  import_dependency::ImportDependency,
+  import_dependency::{ImportDependency, ImportDependencyTemplate},
   import_eager_dependency::ImportEagerDependency,
   provide_dependency::ProvideDependency,
 };

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -84,7 +84,11 @@ impl JavaScriptParserAndGenerator {
       .expect("should have dependency")
       .as_dependency_template()
     {
-      dependency.apply(source, context)
+      if let Some(template) = compilation.get_dependency_template(dependency) {
+        template.render(dependency, source, context)
+      } else {
+        dependency.apply(source, context)
+      }
     }
   }
 }
@@ -301,9 +305,13 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       });
 
       if let Some(dependencies) = module.get_presentational_dependencies() {
-        dependencies
-          .iter()
-          .for_each(|dependency| dependency.apply(&mut source, &mut context));
+        dependencies.iter().for_each(|dependency| {
+          if let Some(template) = compilation.get_dependency_template(dependency.as_ref()) {
+            template.render(dependency.as_ref(), &mut source, &mut context)
+          } else {
+            dependency.apply(&mut source, &mut context)
+          }
+        });
       };
 
       module

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -107,7 +107,7 @@ async fn compilation(
   );
   compilation.set_dependency_template(
     ImportDependencyTemplate::template_type(),
-    Arc::new(ImportDependencyTemplate {}),
+    Arc::new(ImportDependencyTemplate::default()),
   );
   compilation.set_dependency_factory(
     DependencyType::DynamicImportEager,

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -15,7 +15,10 @@ use rspack_hash::RspackHash;
 use rspack_hook::plugin_hook;
 use rustc_hash::FxHashMap;
 
-use crate::{parser_and_generator::JavaScriptParserAndGenerator, JsPlugin, JsPluginInner};
+use crate::{
+  dependency::ImportDependencyTemplate, parser_and_generator::JavaScriptParserAndGenerator,
+  JsPlugin, JsPluginInner,
+};
 
 #[plugin_hook(CompilerCompilation for JsPlugin)]
 async fn compilation(
@@ -101,6 +104,10 @@ async fn compilation(
   compilation.set_dependency_factory(
     DependencyType::DynamicImport,
     params.normal_module_factory.clone(),
+  );
+  compilation.set_dependency_template(
+    ImportDependencyTemplate::template_type(),
+    Arc::new(ImportDependencyTemplate {}),
   );
   compilation.set_dependency_factory(
     DependencyType::DynamicImportEager,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -9,9 +9,9 @@ use std::{borrow::Cow, fmt::Display, rc::Rc, sync::Arc};
 use bitflags::bitflags;
 pub use call_hooks_name::CallHooksName;
 use rspack_core::{
-  AdditionalData, AsyncDependenciesBlock, BoxDependency, BuildInfo, BuildMeta, CompilerOptions,
-  DependencyTemplate, JavascriptParserOptions, JavascriptParserUrl, ModuleIdentifier, ModuleLayer,
-  ModuleType, ResourceData, SpanExt,
+  AdditionalData, AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo,
+  BuildMeta, CompilerOptions, JavascriptParserOptions, JavascriptParserUrl, ModuleIdentifier,
+  ModuleLayer, ModuleType, ResourceData, SpanExt,
 };
 use rspack_error::miette::Diagnostic;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -209,7 +209,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) errors: Vec<Box<dyn Diagnostic + Send + Sync>>,
   pub(crate) warning_diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>>,
   pub dependencies: Vec<BoxDependency>,
-  pub(crate) presentational_dependencies: Vec<Box<dyn DependencyTemplate>>,
+  pub(crate) presentational_dependencies: Vec<BoxDependencyTemplate>,
   // Vec<Box<T: Sized>> makes sense if T is a large type (see #3530, 1st comment).
   // #3530: https://github.com/rust-lang/rust-clippy/issues/3530
   #[allow(clippy::vec_box)]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Currently, for scenarios such as Rstest and Rslib, there may be a need to customize the generated code of dependencies. By dynamically injecting a `DependencyTemplate` to override the default `DependencyTemplate` implementation of the dependency, it is possible to completely reuse the parser hooks and other processes of the dependency while only intervening in the generation of the code, thus reducing development costs. This is quite useful for implementing mocks in the bundleless mode of Rstest and for handling some module interop code in rslib.

### Webpack's implementation
- Mount dependency templates on the compilation.
- Register the dependency templates of dependencies in various plugins.
- During code generation, obtain the dependency template corresponding to the dependency from the compilation and then render the dependency.

### Adding and Saving
And in Rspack, there should be a `dependency_templates` field on `Compilation`, which is used to find the corresponding dependency template through the dependency.

```rust
pub dependency_templates: HashMap<DynamicDependencyTemplateType, Arc<dyn DynamicDependencyTemplate>>,
```

In the `compiler.hooks.compilation` of each plugin, the dependencies within the plugin will be registered on the compilation:

```rust
compilation.set_dependency_template(
    ImportDependencyTemplate::template_type(),
    Arc::new(ImportDependencyTemplate::default()),
);
```

### Dependency Modification
- Move the logic of the `apply` method currently on the `DependencyTemplate` trait to an independent struct
- Some internal attributes need to be changed to public
-  For the `dependency`, need to manually downcast to obtain the specific type, and the default type is `DependencyTemplate`
- Need a new method to obtain the template type. If it is a `Dependency` trait, it can be encapsulated from `dependencyType`. However, a few presentational dependencies do not implement the `Dependency` trait but only implement the `DependencyTemplate` trait. Therefore, a unique template type needs to be manually generated with string

### Code Generation
Since there are a large number of `Dependency`s, during the transformation process, both methods will be compatible:
1. If the `dynamic_dependency_template()` on the `DependencyTemplate` trait is implemented to obtain the template type and the previously registered `dependency template` implementation can be retrieved from the `compilation`, then use it for rendering.
2. If the above method fails to obtain, use the existing `dependency.apply` for rendering.

After all `dependency` refactoring is completed, the compatibility code at the rendering point will be deleted. During the refactoring, the `apply` method on the `dependency` that has implemented the `dependency template` will only have `unreachable!()`.

```rust
if let Some(template) = compilation.get_dependency_template(dependency) {
    template.render(dependency, source, context)
} else {
    dependency.apply(source, context)
}
``` 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
