### PR TITLE
fix(deps): `tinypool` not being able to run on older node versions

### DIFF
--- a/packages/rspack/move-tinypool.js
+++ b/packages/rspack/move-tinypool.js
@@ -9,11 +9,9 @@ const tinypool = require
 	.replace("/package.json", "");
 const dest = path.resolve(__dirname, "./compiled/tinypool");
 
-fs.cpSync(tinypool, path.resolve(__dirname, "./compiled/tinypool"), {
-	recursive: true
-});
+fs.cpSync(tinypool, dest, { recursive: true });
 
 const pkg = JSON.parse(fs.readFileSync(path.join(dest, "package.json")));
-// Removes restirctions on node version (>= 18)
+// Removes restrictions on node version (>= 18)
 delete pkg.engines;
 fs.writeFileSync(path.join(dest, "package.json"), JSON.stringify(pkg, null, 2));

--- a/packages/rspack/move-tinypool.js
+++ b/packages/rspack/move-tinypool.js
@@ -4,12 +4,10 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-const tinypool = require
-	.resolve("tinypool/package.json")
-	.replace("/package.json", "");
+const tinypool = path.dirname(require.resolve("tinypool/package.json"));
 const dest = path.resolve(__dirname, "./compiled/tinypool");
 
-fs.cpSync(tinypool, dest, { recursive: true });
+fs.cpSync(tinypool, dest, { recursive: true, force: true });
 
 const pkg = JSON.parse(fs.readFileSync(path.join(dest, "package.json")));
 // Removes restrictions on node version (>= 18)

--- a/packages/rspack/move-tinypool.js
+++ b/packages/rspack/move-tinypool.js
@@ -1,0 +1,19 @@
+// This script copies the tinypool package from node_modules to the compiled directory.
+// It removes the engines field from package.json and ensures that the package is working under `engine-strict=true` on lower node versions.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const tinypool = require
+	.resolve("tinypool/package.json")
+	.replace("/package.json", "");
+const dest = path.resolve(__dirname, "./compiled/tinypool");
+
+fs.cpSync(tinypool, path.resolve(__dirname, "./compiled/tinypool"), {
+	recursive: true
+});
+
+const pkg = JSON.parse(fs.readFileSync(path.join(dest, "package.json")));
+// Removes restirctions on node version (>= 18)
+delete pkg.engines;
+fs.writeFileSync(path.join(dest, "package.json"), JSON.stringify(pkg, null, 2));

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -26,7 +26,7 @@
     "dev": "pnpm run --stream /^dev:.*/",
     "dev:types": "tsc -w",
     "dev:js": "tsup --watch",
-    "prepare": "prebundle",
+    "prepare": "prebundle && node ./move-tinypool.js",
     "prepare-container-runtime": "node ./scripts/prepare-container-runtime.js",
     "doc-coverage": "tsx ./scripts/check-documentation-coverage.ts",
     "api-extractor": "api-extractor run --verbose",
@@ -69,14 +69,14 @@
     "webpack-dev-server": "5.2.1",
     "webpack-sources": "3.2.3",
     "zod": "^3.24.2",
-    "zod-validation-error": "3.4.0"
+    "zod-validation-error": "3.4.0",
+    "tinypool": "^1.0.2"
   },
   "dependencies": {
     "@module-federation/runtime-tools": "0.11.2",
     "@rspack/binding": "workspace:*",
     "@rspack/lite-tapable": "1.0.1",
-    "caniuse-lite": "^1.0.30001707",
-    "tinypool": "^1.0.2"
+    "caniuse-lite": "^1.0.30001707"
   },
   "peerDependencies": {
     "@rspack/tracing": "^1.x",

--- a/packages/rspack/tsconfig.json
+++ b/packages/rspack/tsconfig.json
@@ -29,6 +29,9 @@
       ],
       "webpack-sources": [
         "../compiled/webpack-sources"
+      ],
+      "tinypool": [
+        "../compiled/tinypool"
       ]
     }
   },

--- a/packages/rspack/tsup.config.ts
+++ b/packages/rspack/tsup.config.ts
@@ -18,6 +18,11 @@ const aliasPlugin = {
 			path: "../package.json",
 			external: true
 		}));
+
+		build.onResolve({ filter: /^tinypool$/ }, () => ({
+			path: "../compiled/tinypool",
+			external: true
+		}));
 	}
 };
 
@@ -50,6 +55,6 @@ export default defineConfig([
 		...commonConfig,
 		entry: {
 			worker: "./src/loader-runner/worker.ts"
-		},
+		}
 	}
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,9 +297,6 @@ importers:
       caniuse-lite:
         specifier: ^1.0.30001707
         version: 1.0.30001707
-      tinypool:
-        specifier: ^1.0.2
-        version: 1.0.2
     devDependencies:
       '@rspack/tracing':
         specifier: workspace:*
@@ -337,6 +334,9 @@ importers:
       prebundle:
         specifier: ^1.2.7
         version: 1.2.7(typescript@5.7.3)
+      tinypool:
+        specifier: ^1.0.2
+        version: 1.0.2
       tsc-alias:
         specifier: ^1.8.13
         version: 1.8.13


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Use pre-compiled `tinypool` to avoid breaking changes to node versions that are lower than 18.

`tinypool` is copied from `node_modules` and removes `engines` field in `package.json`. Tinypool does not have dependencies, so we don't need to prebundle it.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
