### PR TITLE
chore: rollback rust to nightly 2025-03-26

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,4 +3,4 @@ profile = "default"
 # Use nightly for better access to the latest Rust features.
 # This date is aligned to stable release dates.
 # stable-2025-04-03 -> v1.86.0
-channel = "nightly-2025-04-03"
+channel = "nightly-2025-03-26"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

There is a bug in rust latest nightly version: https://github.com/rust-lang/rust/issues/139110 and seems caused by https://github.com/rust-lang/rust/pull/138824
So rollback to `nightly-2025-03-26` which is just a day before that pr

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
