### PR TITLE
refactor: clean dependency template code

### DIFF
--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -210,10 +210,6 @@ mod t {
       todo!()
     }
 
-    fn dependency_id(&self) -> Option<DependencyId> {
-      None
-    }
-
     fn update_hash(
       &self,
       _hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_core/src/dependency/cached_const_dependency.rs
+++ b/crates/rspack_core/src/dependency/cached_const_dependency.rs
@@ -46,10 +46,6 @@ impl DependencyTemplate for CachedConstDependency {
     source.replace(self.start, self.end, &self.identifier, None);
   }
 
-  fn dependency_id(&self) -> Option<crate::DependencyId> {
-    None
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -47,10 +47,6 @@ impl DependencyTemplate for ConstDependency {
     source.replace(self.start, self.end, self.content.as_ref(), None);
   }
 
-  fn dependency_id(&self) -> Option<crate::DependencyId> {
-    None
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -6,7 +6,7 @@ use rspack_sources::{BoxSource, ReplaceSource};
 use rspack_util::ext::AsAny;
 
 use crate::{
-  ChunkInitFragments, CodeGenerationData, Compilation, ConcatenationScope, DependencyId, Module,
+  ChunkInitFragments, CodeGenerationData, Compilation, ConcatenationScope, Module,
   ModuleInitFragments, RuntimeGlobals, RuntimeSpec,
 };
 
@@ -51,10 +51,6 @@ pub trait DependencyTemplate: Debug + DynClone + Sync + Send + AsAny {
     _code_generatable_context: &mut TemplateContext,
   ) {
     unimplemented!()
-  }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    None
   }
 
   fn update_hash(

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -47,18 +47,23 @@ clone_trait_object!(DependencyTemplate);
 pub trait DependencyTemplate: Debug + DynClone + Sync + Send + AsAny {
   fn apply(
     &self,
-    source: &mut TemplateReplaceSource,
-    code_generatable_context: &mut TemplateContext,
-  );
+    _source: &mut TemplateReplaceSource,
+    _code_generatable_context: &mut TemplateContext,
+  ) {
+    unimplemented!()
+  }
 
-  fn dependency_id(&self) -> Option<DependencyId>;
+  fn dependency_id(&self) -> Option<DependencyId> {
+    None
+  }
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
-    compilation: &Compilation,
-    runtime: Option<&RuntimeSpec>,
-  );
+    _hasher: &mut dyn std::hash::Hasher,
+    _compilation: &Compilation,
+    _runtime: Option<&RuntimeSpec>,
+  ) {
+  }
 }
 
 pub type BoxDependencyTemplate = Box<dyn DependencyTemplate>;

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -24,10 +24,6 @@ impl DependencyTemplate for RuntimeRequirementsDependency {
       .insert(self.runtime_requirements);
   }
 
-  fn dependency_id(&self) -> Option<crate::DependencyId> {
-    None
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_asset/src/asset_exports_dependency.rs
+++ b/crates/rspack_plugin_asset/src/asset_exports_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyId,
-  DependencyTemplate, ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyId, DependencyTemplate,
+  ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph, TemplateContext,
+  TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -53,13 +53,5 @@ impl DependencyTemplate for AssetExportsDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }

--- a/crates/rspack_plugin_asset/src/asset_exports_dependency.rs
+++ b/crates/rspack_plugin_asset/src/asset_exports_dependency.rs
@@ -50,8 +50,4 @@ impl DependencyTemplate for AssetExportsDependency {
     _code_generatable_context: &mut TemplateContext,
   ) {
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }

--- a/crates/rspack_plugin_css/src/dependency/export.rs
+++ b/crates/rspack_plugin_css/src/dependency/export.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, ExportNameOrSpec, ExportSpec,
-  ExportsOfExportsSpec, ExportsSpec, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyCategory, DependencyId,
+  DependencyTemplate, DependencyType, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec,
+  ExportsSpec, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -72,15 +72,6 @@ impl DependencyTemplate for CssExportDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
-    // No DependencyTemplate::apply, no need to update hash
   }
 }
 

--- a/crates/rspack_plugin_css/src/dependency/export.rs
+++ b/crates/rspack_plugin_css/src/dependency/export.rs
@@ -69,10 +69,6 @@ impl DependencyTemplate for CssExportDependency {
     // TODO: currently our css module implementation is different from `webpack`, so we do
     // nothing here. ref: https://github.com/webpack/webpack/blob/b9fb99c63ca433b24233e0bbc9ce336b47872c08/lib/dependencies/CssExportDependency.js#L85-L86
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for CssExportDependency {}

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -2,9 +2,9 @@ use std::fmt::Display;
 
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency, RuntimeSpec,
-  TemplateContext, TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
+  DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency, TemplateContext,
+  TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -134,14 +134,6 @@ impl DependencyTemplate for CssImportDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -131,10 +131,6 @@ impl DependencyTemplate for CssImportDependency {
   ) {
     source.replace(self.range.start, self.range.end, "", None);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for CssImportDependency {}

--- a/crates/rspack_plugin_css/src/dependency/local_ident.rs
+++ b/crates/rspack_plugin_css/src/dependency/local_ident.rs
@@ -78,10 +78,6 @@ impl DependencyTemplate for CssLocalIdentDependency {
     source.replace(self.start, self.end, &escape_css(&self.local_ident), None);
   }
 
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_css/src/dependency/self_reference.rs
+++ b/crates/rspack_plugin_css/src/dependency/self_reference.rs
@@ -102,10 +102,6 @@ impl DependencyTemplate for CssSelfReferenceLocalIdentDependency {
       );
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for CssSelfReferenceLocalIdentDependency {}

--- a/crates/rspack_plugin_css/src/dependency/self_reference.rs
+++ b/crates/rspack_plugin_css/src/dependency/self_reference.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency, RuntimeSpec,
+  TemplateContext, TemplateReplaceSource,
 };
 use rspack_util::atom::Atom;
 
@@ -105,14 +105,6 @@ impl DependencyTemplate for CssSelfReferenceLocalIdentDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -3,8 +3,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, CodeGenerationDataFilename, CodeGenerationDataUrl, Compilation, Dependency,
   DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  FactorizeInfo, ModuleDependency, ModuleIdentifier, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource,
+  FactorizeInfo, ModuleDependency, ModuleIdentifier, TemplateContext, TemplateReplaceSource,
 };
 
 use crate::utils::{css_escape_string, AUTO_PUBLIC_PATH_PLACEHOLDER};
@@ -126,14 +125,6 @@ impl DependencyTemplate for CssUrlDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -122,10 +122,6 @@ impl DependencyTemplate for CssUrlDependency {
       source.replace(self.range.start, self.range.end, &content, None);
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for CssUrlDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
@@ -4,8 +4,8 @@ use rspack_cacheable::{
   with::{AsOption, AsPreset},
 };
 use rspack_core::{
-  AffectType, AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, RuntimeGlobals, RuntimeSpec, TemplateContext,
+  AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
+  DependencyId, DependencyTemplate, DependencyType, RuntimeGlobals, TemplateContext,
   TemplateReplaceSource,
 };
 use rspack_util::{atom::Atom, json_stringify};
@@ -294,14 +294,6 @@ impl DependencyTemplate for AMDDefineDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
@@ -291,10 +291,6 @@ impl DependencyTemplate for AMDDefineDependency {
       panic!("Implementation error");
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for AMDDefineDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
@@ -105,10 +105,6 @@ impl DependencyTemplate for AMDRequireArrayDependency {
     let content = self.get_content(code_generatable_context);
     source.replace(self.range.0, self.range.1, &content, None);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for AMDRequireArrayDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
@@ -3,9 +3,9 @@ use std::borrow::Cow;
 use itertools::Itertools;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  module_raw, AffectType, AsContextDependency, AsModuleDependency, Compilation, Dependency,
-  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ModuleDependency,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  module_raw, AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
+  DependencyId, DependencyTemplate, DependencyType, ModuleDependency, TemplateContext,
+  TemplateReplaceSource,
 };
 
 use super::amd_require_item_dependency::AMDRequireItemDependency;
@@ -108,14 +108,6 @@ impl DependencyTemplate for AMDRequireArrayDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
@@ -183,10 +183,6 @@ impl DependencyTemplate for AMDRequireDependency {
       source.replace(function_range.1, self.outer_range.1, &end_block, None);
     };
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for AMDRequireDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
@@ -1,8 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  block_promise, AffectType, AsContextDependency, AsModuleDependency, Compilation, Dependency,
+  block_promise, AffectType, AsContextDependency, AsModuleDependency, Dependency,
   DependencyCategory, DependencyId, DependencyTemplate, DependencyType, RuntimeGlobals,
-  RuntimeSpec,
 };
 
 #[cacheable]
@@ -187,14 +186,6 @@ impl DependencyTemplate for AMDRequireDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_raw, AffectType, AsContextDependency, Compilation, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency, RuntimeSpec,
-  TemplateContext, TemplateReplaceSource,
+  module_raw, AffectType, AsContextDependency, Dependency, DependencyCategory, DependencyId,
+  DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency, TemplateContext,
+  TemplateReplaceSource,
 };
 use rspack_util::atom::Atom;
 
@@ -75,14 +75,6 @@ impl DependencyTemplate for AMDRequireItemDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
@@ -72,10 +72,6 @@ impl DependencyTemplate for AMDRequireItemDependency {
     );
     source.replace(range.0, range.1, &content, None);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AffectType, AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyId,
-  DependencyTemplate, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyId,
+  DependencyTemplate, TemplateContext, TemplateReplaceSource,
 };
 
 use super::local_module::LocalModule;
@@ -63,14 +63,6 @@ impl DependencyTemplate for LocalModuleDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
@@ -60,10 +60,6 @@ impl DependencyTemplate for LocalModuleDependency {
       source.replace(range.0, range.1, &module_instance, None);
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for LocalModuleDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
@@ -56,10 +56,6 @@ impl DependencyTemplate for UnsupportedDependency {
     );
     source.replace(self.range.0, self.range.1, &content, None);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for UnsupportedDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
@@ -1,8 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  AffectType, AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource,
+  AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
+  DependencyId, DependencyTemplate, DependencyType, TemplateContext, TemplateReplaceSource,
 };
 use rspack_util::atom::Atom;
 
@@ -60,14 +59,6 @@ impl DependencyTemplate for UnsupportedDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -440,10 +440,6 @@ impl DependencyTemplate for CommonJsExportRequireDependency {
       panic!("Unexpected type");
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -4,7 +4,7 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  module_raw, process_export_info, property_access, AsContextDependency, Compilation, Dependency,
+  module_raw, process_export_info, property_access, AsContextDependency, Dependency,
   DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
   ExportInfoProvided, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec, ExportsSpec, ExportsType,
   ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleIdentifier,
@@ -443,14 +443,6 @@ impl DependencyTemplate for CommonJsExportRequireDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -234,10 +234,6 @@ impl DependencyTemplate for CommonJsExportsDependency {
       panic!("Unexpected base type");
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for CommonJsExportsDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -3,11 +3,11 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  property_access, AsContextDependency, AsModuleDependency, Compilation, Dependency,
-  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ExportNameOrSpec,
-  ExportSpec, ExportsOfExportsSpec, ExportsSpec, InitFragmentExt, InitFragmentKey,
-  InitFragmentStage, ModuleGraph, NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource, UsedName,
+  property_access, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
+  DependencyId, DependencyTemplate, DependencyType, ExportNameOrSpec, ExportSpec,
+  ExportsOfExportsSpec, ExportsSpec, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  ModuleGraph, NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  UsedName,
 };
 use swc_core::atoms::Atom;
 
@@ -237,14 +237,6 @@ impl DependencyTemplate for CommonJsExportsDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -177,10 +177,6 @@ impl DependencyTemplate for CommonJsFullRequireDependency {
 
     source.replace(self.range.start, self.range.end, &require_expr, None);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for CommonJsFullRequireDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -3,7 +3,7 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec, Skip},
 };
 use rspack_core::{
-  module_id, property_access, to_normal_comment, AsContextDependency, Compilation, Dependency,
+  module_id, property_access, to_normal_comment, AsContextDependency, Dependency,
   DependencyCategory, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyType, ExportsType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
   ModuleGraph, RuntimeGlobals, RuntimeSpec, SharedSourceMap, TemplateContext,
@@ -180,14 +180,6 @@ impl DependencyTemplate for CommonJsFullRequireDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -112,10 +112,6 @@ impl DependencyTemplate for CommonJsRequireDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for CommonJsRequireDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  module_id, AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo,
-  ModuleDependency, RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyLocation,
+  DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency,
+  SharedSourceMap, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -115,14 +115,6 @@ impl DependencyTemplate for CommonJsRequireDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -155,8 +155,4 @@ impl DependencyTemplate for CommonJsSelfReferenceDependency {
       None,
     )
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -3,7 +3,7 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  property_access, AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId,
+  property_access, AsContextDependency, Dependency, DependencyCategory, DependencyId,
   DependencyTemplate, DependencyType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
   ModuleGraph, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName,
 };
@@ -158,13 +158,5 @@ impl DependencyTemplate for CommonJsSelfReferenceDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -88,10 +88,6 @@ impl DependencyTemplate for ModuleDecoratorDependency {
     )));
   }
 
-  fn dependency_id(&self) -> Option<rspack_core::DependencyId> {
-    None
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_dependency.rs
@@ -103,10 +103,6 @@ impl DependencyTemplate for RequireEnsureDependency {
     }
   }
 
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
-
   fn update_hash(
     &self,
     _hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
@@ -60,8 +60,4 @@ impl DependencyTemplate for RequireHeaderDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
@@ -1,8 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, RuntimeGlobals, RuntimeSpec,
-  SharedSourceMap, TemplateContext,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyId, DependencyLocation,
+  DependencyRange, DependencyTemplate, RuntimeGlobals, SharedSourceMap, TemplateContext,
 };
 
 #[cacheable]
@@ -64,13 +63,5 @@ impl DependencyTemplate for RequireHeaderDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  module_id, AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyType, ExtendedReferencedExport, FactorizeInfo,
-  ModuleDependency, ModuleGraph, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
+  DependencyTemplate, DependencyType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
+  ModuleGraph, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -114,14 +114,6 @@ impl DependencyTemplate for RequireResolveDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -111,10 +111,6 @@ impl DependencyTemplate for RequireResolveDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for RequireResolveDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_header_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  AffectType, AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, RuntimeSpec, SharedSourceMap,
-  TemplateContext, TemplateReplaceSource,
+  AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, SharedSourceMap, TemplateContext,
+  TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -59,13 +59,5 @@ impl DependencyTemplate for RequireResolveHeaderDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_header_dependency.rs
@@ -56,8 +56,4 @@ impl DependencyTemplate for RequireResolveHeaderDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
@@ -128,10 +128,6 @@ impl DependencyTemplate for AMDRequireContextDependency {
       Some(&self.range),
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for AMDRequireContextDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsModuleDependency, Compilation, ContextDependency, ContextOptions, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  FactorizeInfo, ModuleGraph, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  AsModuleDependency, ContextDependency, ContextOptions, Dependency, DependencyCategory,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo, ModuleGraph,
+  TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -131,14 +131,6 @@ impl DependencyTemplate for AMDRequireContextDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -135,10 +135,6 @@ impl DependencyTemplate for CommonJsRequireContextDependency {
       self.value_range.as_ref(),
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for CommonJsRequireContextDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsModuleDependency, Compilation, ContextDependency, ContextOptions, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  FactorizeInfo, ModuleGraph, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  AsModuleDependency, ContextDependency, ContextOptions, Dependency, DependencyCategory,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo, ModuleGraph,
+  TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -138,14 +138,6 @@ impl DependencyTemplate for CommonJsRequireContextDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -135,10 +135,6 @@ impl DependencyTemplate for ImportContextDependency {
       Some(&self.value_range),
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for ImportContextDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsModuleDependency, Compilation, ContextDependency, ContextOptions, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  FactorizeInfo, ModuleGraph, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  AsModuleDependency, ContextDependency, ContextOptions, Dependency, DependencyCategory,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo, ModuleGraph,
+  TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -138,14 +138,6 @@ impl DependencyTemplate for ImportContextDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  module_raw, AsModuleDependency, Compilation, ContextDependency, ContextOptions, Dependency,
+  module_raw, AsModuleDependency, ContextDependency, ContextOptions, Dependency,
   DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  FactorizeInfo, ModuleGraph, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  FactorizeInfo, ModuleGraph, TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -136,14 +136,6 @@ impl DependencyTemplate for ImportMetaContextDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -133,10 +133,6 @@ impl DependencyTemplate for ImportMetaContextDependency {
     );
     source.replace(self.range.start, self.range.end, &content, None);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for ImportMetaContextDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  module_raw, AsModuleDependency, Compilation, ContextDependency, ContextOptions, Dependency,
+  module_raw, AsModuleDependency, ContextDependency, ContextOptions, Dependency,
   DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  FactorizeInfo, ModuleGraph, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  FactorizeInfo, ModuleGraph, TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -136,14 +136,6 @@ impl DependencyTemplate for RequireContextDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -133,10 +133,6 @@ impl DependencyTemplate for RequireContextDependency {
     );
     source.replace(self.range.start, self.range.end, &content, None);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for RequireContextDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
@@ -113,10 +113,6 @@ impl DependencyTemplate for RequireResolveContextDependency {
   ) {
     context_dependency_template_as_id(self, source, code_generatable_context, &self.range);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for RequireResolveContextDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
@@ -1,9 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AffectType, AsModuleDependency, Compilation, ContextDependency, ContextOptions,
-  ContextTypePrefix, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, FactorizeInfo, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource,
+  AffectType, AsModuleDependency, ContextDependency, ContextOptions, ContextTypePrefix, Dependency,
+  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
+  FactorizeInfo, TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -117,14 +116,6 @@ impl DependencyTemplate for RequireResolveContextDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -1,8 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  Compilation, DependencyTemplate, InitFragmentKey, InitFragmentStage, ModuleGraph,
-  NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
-  UsageState,
+  DependencyTemplate, InitFragmentKey, InitFragmentStage, ModuleGraph, NormalInitFragment,
+  RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsageState,
 };
 use swc_core::atoms::Atom;
 
@@ -75,17 +74,5 @@ impl DependencyTemplate for ESMCompatibilityDependency {
         Some(format!("\n__webpack_async_result__();\n}} catch(e) {{ __webpack_async_result__(e); }} }}{});", if module.build_meta().has_top_level_await { ", 1" } else { "" })),
       )));
     }
-  }
-
-  fn dependency_id(&self) -> Option<rspack_core::DependencyId> {
-    None
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -256,12 +256,4 @@ impl DependencyTemplate for ESMExportExpressionDependency {
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
   }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
-  }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -252,8 +252,4 @@ impl DependencyTemplate for ESMExportExpressionDependency {
       );
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
@@ -70,10 +70,6 @@ impl DependencyTemplate for ESMExportHeaderDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for ESMExportHeaderDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, DependencyType, RuntimeSpec,
-  SharedSourceMap, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyId, DependencyLocation,
+  DependencyRange, DependencyTemplate, DependencyType, SharedSourceMap, TemplateContext,
+  TemplateReplaceSource,
 };
 
 // Remove `export` label.
@@ -73,14 +73,6 @@ impl DependencyTemplate for ESMExportHeaderDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -1038,10 +1038,6 @@ impl DependencyTemplate for ESMExportImportedSpecifierDependency {
       self.add_export_fragments(code_generatable_context, mode);
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -9,14 +9,14 @@ use rspack_collections::IdentifierSet;
 use rspack_core::{
   create_exports_object_referenced, create_no_exports_referenced, filter_runtime, get_exports_type,
   process_export_info, property_access, property_name, string_of_used_name, AsContextDependency,
-  Compilation, ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
-  DependencyCondition, DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange,
-  DependencyTemplate, DependencyType, ESMExportInitFragment, ExportInfo, ExportInfoProvided,
-  ExportNameOrSpec, ExportPresenceMode, ExportSpec, ExportsInfo, ExportsOfExportsSpec, ExportsSpec,
-  ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt,
-  InitFragmentKey, InitFragmentStage, JavascriptParserOptions, ModuleDependency, ModuleGraph,
-  ModuleIdentifier, NormalInitFragment, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
-  SharedSourceMap, Template, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
+  ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory, DependencyCondition,
+  DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
+  DependencyType, ESMExportInitFragment, ExportInfo, ExportInfoProvided, ExportNameOrSpec,
+  ExportPresenceMode, ExportSpec, ExportsInfo, ExportsOfExportsSpec, ExportsSpec, ExportsType,
+  ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleIdentifier,
+  NormalInitFragment, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SharedSourceMap, Template,
+  TemplateContext, TemplateReplaceSource, UsageState, UsedName,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -1041,14 +1041,6 @@ impl DependencyTemplate for ESMExportImportedSpecifierDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -4,10 +4,10 @@ use rspack_cacheable::{
 };
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyCategory,
-  DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyType,
-  ESMExportInitFragment, ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
-  RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyCategory, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyType, ESMExportInitFragment,
+  ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph, SharedSourceMap,
+  TemplateContext, TemplateReplaceSource, UsedName,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -135,14 +135,6 @@ impl DependencyTemplate for ESMExportSpecifierDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -132,10 +132,6 @@ impl DependencyTemplate for ESMExportSpecifierDependency {
       )));
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ESMExportSpecifierDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -523,10 +523,6 @@ impl DependencyTemplate for ESMImportSideEffectDependency {
     }
     esm_import_dependency_apply(self, self.source_order, code_generatable_context);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ESMImportSideEffectDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -7,9 +7,9 @@ use rspack_cacheable::{
 use rspack_collections::IdentifierSet;
 use rspack_core::{
   filter_runtime, import_statement, merge_runtime, AsContextDependency,
-  AwaitDependenciesInitFragment, BuildMetaDefaultObject, Compilation, ConditionalInitFragment,
-  ConnectionState, Dependency, DependencyCategory, DependencyCondition, DependencyConditionFn,
-  DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyType, ErrorSpan,
+  AwaitDependenciesInitFragment, BuildMetaDefaultObject, ConditionalInitFragment, ConnectionState,
+  Dependency, DependencyCategory, DependencyCondition, DependencyConditionFn, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyType, ErrorSpan,
   ExportInfoProvided, ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes,
   InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleDependency, ModuleGraph,
   ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap, TemplateContext,
@@ -526,14 +526,6 @@ impl DependencyTemplate for ESMImportSideEffectDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{
 use rspack_collections::IdentifierSet;
 use rspack_core::{
   create_exports_object_referenced, export_from_import, get_dependency_used_by_exports_condition,
-  get_exports_type, property_access, AsContextDependency, Compilation, ConnectionState, Dependency,
+  get_exports_type, property_access, AsContextDependency, ConnectionState, Dependency,
   DependencyCategory, DependencyCondition, DependencyId, DependencyLocation, DependencyRange,
   DependencyTemplate, DependencyType, ExportPresenceMode, ExportsType, ExtendedReferencedExport,
   FactorizeInfo, ImportAttributes, JavascriptParserOptions, ModuleDependency, ModuleGraph,
@@ -232,14 +232,6 @@ impl DependencyTemplate for ESMImportSpecifierDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -229,10 +229,6 @@ impl DependencyTemplate for ESMImportSpecifierDependency {
       source.replace(self.range.start, self.range.end, export_expr.as_str(), None);
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
@@ -53,10 +53,6 @@ impl DependencyTemplate for ExternalModuleDependency {
     chunk_init_fragments.push(fragment.boxed());
   }
 
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -3,11 +3,10 @@ use rspack_cacheable::{
   with::{AsOption, AsPreset, AsVec},
 };
 use rspack_core::{
-  create_exports_object_referenced, module_namespace_promise, AsContextDependency, Compilation,
-  Dependency, DependencyCategory, DependencyId, DependencyRange, DependencyTemplate,
-  DependencyType, ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes,
-  ModuleDependency, ModuleGraph, ReferencedExport, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource,
+  create_exports_object_referenced, module_namespace_promise, AsContextDependency, Dependency,
+  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
+  ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes, ModuleDependency,
+  ModuleGraph, ReferencedExport, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -178,14 +177,6 @@ impl DependencyTemplate for ImportDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -174,10 +174,6 @@ impl DependencyTemplate for ImportDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ImportDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -3,9 +3,9 @@ use rspack_cacheable::{
   with::{AsOption, AsPreset, AsVec},
 };
 use rspack_core::{
-  module_namespace_promise, AsContextDependency, Compilation, Dependency, DependencyCategory,
-  DependencyId, DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo,
-  ImportAttributes, ModuleDependency, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  module_namespace_promise, AsContextDependency, Dependency, DependencyCategory, DependencyId,
+  DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo, ImportAttributes,
+  ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -138,14 +138,6 @@ impl DependencyTemplate for ImportEagerDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -135,10 +135,6 @@ impl DependencyTemplate for ImportEagerDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ImportEagerDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -149,10 +149,6 @@ impl DependencyTemplate for ProvideDependency {
     source.replace(self.range.start, self.range.end, &self.identifier, None);
   }
 
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -4,8 +4,8 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  Compilation, DependencyTemplate, ExportProvided, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource, UsageState, UsedExports, UsedName,
+  DependencyTemplate, ExportProvided, TemplateContext, TemplateReplaceSource, UsageState,
+  UsedExports, UsedName,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -41,18 +41,6 @@ impl DependencyTemplate for ExportInfoDependency {
       value.unwrap_or("undefined".to_owned()).as_str(),
       None,
     );
-  }
-
-  fn dependency_id(&self) -> Option<rspack_core::DependencyId> {
-    None
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/esm_accept_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/esm_accept_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  import_statement, runtime_condition_expression, Compilation, DependencyId, DependencyLocation,
-  DependencyRange, DependencyTemplate, RuntimeCondition, RuntimeSpec, SharedSourceMap,
-  TemplateContext, TemplateReplaceSource,
+  import_statement, runtime_condition_expression, DependencyId, DependencyLocation,
+  DependencyRange, DependencyTemplate, RuntimeCondition, SharedSourceMap, TemplateContext,
+  TemplateReplaceSource,
 };
 
 use crate::dependency::import_emitted_runtime;
@@ -123,17 +123,5 @@ impl DependencyTemplate for ESMAcceptDependency {
         None,
       );
     }
-  }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    None
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -97,10 +97,6 @@ impl DependencyTemplate for ImportMetaHotAcceptDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ImportMetaHotAcceptDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_id, AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
+  DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency, TemplateContext,
+  TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -100,14 +100,6 @@ impl DependencyTemplate for ImportMetaHotAcceptDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -97,10 +97,6 @@ impl DependencyTemplate for ImportMetaHotDeclineDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ImportMetaHotDeclineDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_id, AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
+  DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency, TemplateContext,
+  TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -100,14 +100,6 @@ impl DependencyTemplate for ImportMetaHotDeclineDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -97,10 +97,6 @@ impl DependencyTemplate for ModuleHotAcceptDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ModuleHotAcceptDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_id, AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
+  DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency, TemplateContext,
+  TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -100,14 +100,6 @@ impl DependencyTemplate for ModuleHotAcceptDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_id, AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
+  DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency, TemplateContext,
+  TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -100,14 +100,6 @@ impl DependencyTemplate for ModuleHotDeclineDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -97,10 +97,6 @@ impl DependencyTemplate for ModuleHotDeclineDependency {
       None,
     );
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ModuleHotDeclineDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, Compilation, Dependency, DependencyId, DependencyTemplate, DependencyType,
+  AsContextDependency, Dependency, DependencyId, DependencyTemplate, DependencyType,
   ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, RuntimeSpec,
   TemplateContext, TemplateReplaceSource,
 };
@@ -96,13 +96,5 @@ impl DependencyTemplate for WebpackIsIncludedDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -93,8 +93,4 @@ impl DependencyTemplate for WebpackIsIncludedDependency {
 
     source.replace(self.start, self.end, included.to_string().as_str(), None);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -63,10 +63,6 @@ impl DependencyTemplate for ModuleArgumentDependency {
     source.replace(self.range.start, self.range.end, content.as_str(), None);
   }
 
-  fn dependency_id(&self) -> Option<rspack_core::DependencyId> {
-    None
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -115,10 +115,6 @@ impl DependencyTemplate for PureExpressionDependency {
     }
   }
 
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -1,9 +1,9 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  get_dependency_used_by_exports_condition, module_id, AsContextDependency, Compilation,
-  Dependency, DependencyCategory, DependencyCondition, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, FactorizeInfo, ModuleDependency, RuntimeGlobals, RuntimeSpec,
-  TemplateContext, TemplateReplaceSource, UsedByExports,
+  get_dependency_used_by_exports_condition, module_id, AsContextDependency, Dependency,
+  DependencyCategory, DependencyCondition, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyType, FactorizeInfo, ModuleDependency, RuntimeGlobals, TemplateContext,
+  TemplateReplaceSource, UsedByExports,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -137,14 +137,6 @@ impl DependencyTemplate for URLDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -134,10 +134,6 @@ impl DependencyTemplate for URLDependency {
       );
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for URLDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
@@ -64,10 +64,6 @@ impl DependencyTemplate for CreateScriptUrlDependency {
     );
     source.insert(self.range_path.end, ")", None);
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsModuleDependency for CreateScriptUrlDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyCategory,
-  DependencyId, DependencyRange, DependencyTemplate, DependencyType, RuntimeGlobals, RuntimeSpec,
-  TemplateContext, TemplateReplaceSource,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyCategory, DependencyId,
+  DependencyRange, DependencyTemplate, DependencyType, RuntimeGlobals, TemplateContext,
+  TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -67,14 +67,6 @@ impl DependencyTemplate for CreateScriptUrlDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -141,10 +141,6 @@ impl DependencyTemplate for WorkerDependency {
     );
   }
 
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_json/src/json_exports_dependency.rs
+++ b/crates/rspack_plugin_json/src/json_exports_dependency.rs
@@ -57,10 +57,6 @@ impl DependencyTemplate for JsonExportsDependency {
   ) {
   }
 
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
-
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
+++ b/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId, DependencyRange,
+  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
   DependencyTemplate, DependencyType, ExternalRequest, ExternalType, FactorizeInfo,
-  ImportAttributes, ModuleDependency, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  ImportAttributes, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use rspack_plugin_javascript::dependency::create_resource_identifier_for_esm_dependency;
 use swc_core::ecma::atoms::Atom;
@@ -138,14 +138,6 @@ impl DependencyTemplate for ModernModuleImportDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
+++ b/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
@@ -135,10 +135,6 @@ impl DependencyTemplate for ModernModuleImportDependency {
       );
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ModernModuleImportDependency {}

--- a/crates/rspack_plugin_library/src/modern_module/reexport_star_external_dependency.rs
+++ b/crates/rspack_plugin_library/src/modern_module/reexport_star_external_dependency.rs
@@ -1,9 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, ExternalRequest, ExternalType, FactorizeInfo,
-  InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleDependency, NormalInitFragment,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, ExternalRequest, ExternalType, FactorizeInfo, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, ModuleDependency, NormalInitFragment, TemplateContext, TemplateReplaceSource,
 };
 use rspack_plugin_javascript::dependency::create_resource_identifier_for_esm_dependency;
 use swc_core::ecma::atoms::Atom;
@@ -117,14 +116,6 @@ impl DependencyTemplate for ModernModuleReexportStarExternalDependency {
 
   fn dependency_id(&self) -> Option<DependencyId> {
     Some(self.id)
-  }
-
-  fn update_hash(
-    &self,
-    _hasher: &mut dyn std::hash::Hasher,
-    _compilation: &Compilation,
-    _runtime: Option<&RuntimeSpec>,
-  ) {
   }
 }
 

--- a/crates/rspack_plugin_library/src/modern_module/reexport_star_external_dependency.rs
+++ b/crates/rspack_plugin_library/src/modern_module/reexport_star_external_dependency.rs
@@ -113,10 +113,6 @@ impl DependencyTemplate for ModernModuleReexportStarExternalDependency {
       );
     }
   }
-
-  fn dependency_id(&self) -> Option<DependencyId> {
-    Some(self.id)
-  }
 }
 
 impl AsContextDependency for ModernModuleReexportStarExternalDependency {}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Remove empty `update_hash` methods when implement `DependencyTemplate`. Just use the default implementation.
- Remove `dependency_id` on `DependencyTemplate` which is never used

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
