### PR TITLE
docs: redirect rspack.org to rspack.dev

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -1,1 +1,4 @@
 /en / 200
+
+# Redirect rspack.org to rspack.dev
+https://rspack.org/* https://rspack.dev/:splat 301!


### PR DESCRIPTION
## Summary

Redirect rspack.org to rspack.dev to ensure that users access the same domain name.

See: https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
