### PR TITLE
ci: fix rustup download target failed

### DIFF
--- a/.github/actions/docker/linux-build/action.yml
+++ b/.github/actions/docker/linux-build/action.yml
@@ -51,9 +51,6 @@ runs:
           ${{ inputs.post }}
         options: |
           -e CARGO_INCREMENTAL=0 \
-          -v ~/.cargo/registry/index:/usr/local/cargo/registry/index \
-          -v ~/.cargo/registry/cache:/usr/local/cargo/registry/cache \
-          -v ~/.cargo/git/db:/usr/local/cargo/git/db \
-          -v ~/.rustup/toolchains:/usr/local/rustup/toolchains \
-          -v /tmp:/tmp \
+          -v ~/.cargo:/usr/local/cargo \
+          -v ~/.rustup:/usr/local/rustup \
           ${{ inputs.options }} \


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The release build will mount ~/.rustup/toolchains to docker environment, and it will make rustup install target failed because of can not create hard link between two different file system.

```
could not rename component file from '/usr/local/rustup/tmp/pwqudzloviho19iy_dir/cargo/bin/cargo' to '/usr/local/rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo': Invalid cross-device link (os error 18)
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
