### PR TITLE
refactor: clean dependency template code

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -51,12 +51,12 @@ use crate::{
   ChunkByUkey, ChunkContentHash, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkHashesArtifact,
   ChunkIdsArtifact, ChunkKind, ChunkRenderArtifact, ChunkRenderResult, ChunkUkey,
   CodeGenerationJob, CodeGenerationResult, CodeGenerationResults, CompilationLogger,
-  CompilationLogging, CompilerOptions, DependenciesDiagnosticsArtifact, DependencyId,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
-  Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId, Filename,
-  ImportVarMap, Logger, ModuleFactory, ModuleGraph, ModuleGraphPartial, ModuleIdentifier,
-  ModuleIdsArtifact, PathData, ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpecMap,
-  RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact, SourceType, Stats,
+  CompilationLogging, CompilerOptions, DependenciesDiagnosticsArtifact, DependencyCodeGeneration,
+  DependencyId, DependencyTemplate, DependencyTemplateType, DependencyType, Entry, EntryData,
+  EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId, Filename, ImportVarMap, Logger,
+  ModuleFactory, ModuleGraph, ModuleGraphPartial, ModuleIdentifier, ModuleIdsArtifact, PathData,
+  ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpecMap, RuntimeTemplate,
+  SharedPluginDriver, SideEffectsOptimizeArtifact, SourceType, Stats,
 };
 
 define_hook!(CompilationAddEntry: Series(compilation: &mut Compilation, entry_name: Option<&str>));
@@ -213,8 +213,7 @@ pub struct Compilation {
   pub global_entry: EntryData,
   other_module_graph: Option<ModuleGraphPartial>,
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
-  pub dependency_templates:
-    HashMap<DynamicDependencyTemplateType, Arc<dyn DynamicDependencyTemplate>>,
+  pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
   pub runtime_modules: IdentifierMap<Box<dyn RuntimeModule>>,
   pub runtime_modules_hash: IdentifierMap<RspackHashDigest>,
   pub runtime_modules_code_generation_source: IdentifierMap<BoxSource>,
@@ -2470,18 +2469,18 @@ impl Compilation {
 
   pub fn set_dependency_template(
     &mut self,
-    template_type: DynamicDependencyTemplateType,
-    template: Arc<dyn DynamicDependencyTemplate>,
+    template_type: DependencyTemplateType,
+    template: Arc<dyn DependencyTemplate>,
   ) {
     self.dependency_templates.insert(template_type, template);
   }
 
   pub fn get_dependency_template(
     &self,
-    dep: &dyn DependencyTemplate,
-  ) -> Option<Arc<dyn DynamicDependencyTemplate>> {
+    dep: &dyn DependencyCodeGeneration,
+  ) -> Option<Arc<dyn DependencyTemplate>> {
     dep
-      .dynamic_dependency_template()
+      .dependency_template()
       .and_then(|template_type| self.dependency_templates.get(&template_type).cloned())
   }
 

--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -155,9 +155,9 @@ mod t {
   use crate::{
     compiler::make::cutout::has_module_graph_change::ModuleDeps, AffectType, AsContextDependency,
     BuildInfo, BuildMeta, CodeGenerationResult, Compilation, ConcatenationScope, Context,
-    DependenciesBlock, Dependency, DependencyId, DependencyTemplate, ExportsInfo, FactorizeInfo,
-    FactoryMeta, Module, ModuleDependency, ModuleGraph, ModuleGraphModule, ModuleGraphPartial,
-    ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
+    DependenciesBlock, Dependency, DependencyCodeGeneration, DependencyId, ExportsInfo,
+    FactorizeInfo, FactoryMeta, Module, ModuleDependency, ModuleGraph, ModuleGraphModule,
+    ModuleGraphPartial, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
   };
 
   #[cacheable]
@@ -201,7 +201,7 @@ mod t {
   }
 
   #[cacheable_dyn]
-  impl DependencyTemplate for TestDep {
+  impl DependencyCodeGeneration for TestDep {
     fn apply(
       &self,
       _source: &mut crate::TemplateReplaceSource,

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -15,9 +15,9 @@ use crate::{
   module_graph::{ModuleGraph, ModuleGraphPartial},
   old_cache::Cache as OldCache,
   utils::task_loop::{run_task_loop, Task},
-  BuildDependency, Compilation, CompilationId, CompilerId, CompilerOptions, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, ModuleFactory, ModuleProfile,
-  ResolverFactory, SharedPluginDriver,
+  BuildDependency, Compilation, CompilationId, CompilerId, CompilerOptions, DependencyTemplate,
+  DependencyTemplateType, DependencyType, ModuleFactory, ModuleProfile, ResolverFactory,
+  SharedPluginDriver,
 };
 
 pub struct MakeTaskContext {
@@ -35,8 +35,7 @@ pub struct MakeTaskContext {
   pub cache: Arc<dyn Cache>,
   pub old_cache: Arc<OldCache>,
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
-  pub dependency_templates:
-    HashMap<DynamicDependencyTemplateType, Arc<dyn DynamicDependencyTemplate>>,
+  pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
 
   pub artifact: MakeArtifact,
 }

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -35,7 +35,7 @@ pub fn dependencies_block_update_hash(
   let mg = compilation.get_module_graph();
   for dep_id in deps {
     let dep = mg.dependency_by_id(dep_id).expect("should have dependency");
-    if let Some(dep) = dep.as_dependency_template() {
+    if let Some(dep) = dep.as_dependency_code_generation() {
       dep.update_hash(hasher, compilation, runtime);
     }
   }

--- a/crates/rspack_core/src/dependency/cached_const_dependency.rs
+++ b/crates/rspack_core/src/dependency/cached_const_dependency.rs
@@ -2,7 +2,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_util::ext::DynHash;
 
 use crate::{
-  Compilation, DependencyTemplate, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  Compilation, DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType,
   InitFragmentExt, InitFragmentKey, InitFragmentStage, NormalInitFragment, RuntimeSpec,
   TemplateContext, TemplateReplaceSource,
 };
@@ -28,8 +28,8 @@ impl CachedConstDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for CachedConstDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CachedConstDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CachedConstDependencyTemplate::template_type())
   }
 
@@ -51,15 +51,15 @@ impl DependencyTemplate for CachedConstDependency {
 pub struct CachedConstDependencyTemplate;
 
 impl CachedConstDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("CachedConstDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("CachedConstDependency")
   }
 }
 
-impl DynamicDependencyTemplate for CachedConstDependencyTemplate {
+impl DependencyTemplate for CachedConstDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -2,7 +2,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn, with::AsRefStr};
 use rspack_util::ext::DynHash;
 
 use crate::{
-  Compilation, DependencyTemplate, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  Compilation, DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType,
   RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
@@ -33,8 +33,8 @@ impl ConstDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ConstDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ConstDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ConstDependencyTemplate::template_type())
   }
 
@@ -56,15 +56,15 @@ impl DependencyTemplate for ConstDependency {
 pub struct ConstDependencyTemplate;
 
 impl ConstDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ConstDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ConstDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ConstDependencyTemplate {
+impl DependencyTemplate for ConstDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -9,7 +9,7 @@ use swc_core::ecma::atoms::Atom;
 
 use super::{AffectType, FactorizeInfo};
 use crate::{
-  create_exports_object_referenced, AsContextDependency, AsDependencyTemplate, Context,
+  create_exports_object_referenced, AsContextDependency, AsDependencyCodeGeneration, Context,
   ContextMode, ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyType,
   ExtendedReferencedExport, ImportAttributes, ModuleDependency, ModuleGraph, ModuleLayer,
   ReferencedExport, RuntimeSpec,
@@ -130,5 +130,5 @@ impl ModuleDependency for ContextElementDependency {
   }
 }
 
-impl AsDependencyTemplate for ContextElementDependency {}
+impl AsDependencyCodeGeneration for ContextElementDependency {}
 impl AsContextDependency for ContextElementDependency {}

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -40,19 +40,11 @@ impl TemplateContext<'_, '_, '_> {
 
 pub type TemplateReplaceSource = ReplaceSource<BoxSource>;
 
-clone_trait_object!(DependencyTemplate);
+clone_trait_object!(DependencyCodeGeneration);
 
-// Align with https://github.com/webpack/webpack/blob/671ac29d462e75a10c3fdfc785a4c153e41e749e/lib/DependencyTemplate.js
+// Align with https://github.com/webpack/webpack/blob/671ac29d462e75a10c3fdfc785a4c153e41e749e/lib/DependencyCodeGeneration.js
 #[cacheable_dyn]
-pub trait DependencyTemplate: Debug + DynClone + Sync + Send + AsAny {
-  fn apply(
-    &self,
-    _source: &mut TemplateReplaceSource,
-    _code_generatable_context: &mut TemplateContext,
-  ) {
-    unimplemented!()
-  }
-
+pub trait DependencyCodeGeneration: Debug + DynClone + Sync + Send + AsAny {
   fn update_hash(
     &self,
     _hasher: &mut dyn std::hash::Hasher,
@@ -61,35 +53,35 @@ pub trait DependencyTemplate: Debug + DynClone + Sync + Send + AsAny {
   ) {
   }
 
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     None
   }
 }
 
-pub type BoxDependencyTemplate = Box<dyn DependencyTemplate>;
+pub type BoxDependencyTemplate = Box<dyn DependencyCodeGeneration>;
 
-pub trait AsDependencyTemplate {
-  fn as_dependency_template(&self) -> Option<&dyn DependencyTemplate> {
+pub trait AsDependencyCodeGeneration {
+  fn as_dependency_code_generation(&self) -> Option<&dyn DependencyCodeGeneration> {
     None
   }
 }
 
-impl<T: DependencyTemplate> AsDependencyTemplate for T {
-  fn as_dependency_template(&self) -> Option<&dyn DependencyTemplate> {
+impl<T: DependencyCodeGeneration> AsDependencyCodeGeneration for T {
+  fn as_dependency_code_generation(&self) -> Option<&dyn DependencyCodeGeneration> {
     Some(self)
   }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum DynamicDependencyTemplateType {
-  DependencyType(DependencyType),
-  CustomType(&'static str),
+pub enum DependencyTemplateType {
+  Dependency(DependencyType),
+  Custom(&'static str),
 }
 
-pub trait DynamicDependencyTemplate: Debug + Sync + Send {
+pub trait DependencyTemplate: Debug + Sync + Send {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   );

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -7,7 +7,7 @@ use rspack_error::Diagnostic;
 use rspack_util::{atom::Atom, ext::AsAny};
 
 use super::{
-  dependency_template::AsDependencyTemplate, module_dependency::*, DependencyCategory,
+  dependency_template::AsDependencyCodeGeneration, module_dependency::*, DependencyCategory,
   DependencyId, DependencyLocation, DependencyRange, DependencyType, ExportsSpec,
 };
 use crate::{
@@ -24,7 +24,7 @@ pub enum AffectType {
 
 #[cacheable_dyn]
 pub trait Dependency:
-  AsDependencyTemplate
+  AsDependencyCodeGeneration
   + AsContextDependency
   + AsModuleDependency
   + AsAny

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -2,8 +2,8 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 
 use super::{AffectType, FactorizeInfo};
 use crate::{
-  AsContextDependency, AsDependencyTemplate, Context, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ModuleDependency, ModuleLayer,
+  AsContextDependency, AsDependencyCodeGeneration, Context, Dependency, DependencyCategory,
+  DependencyId, DependencyType, ModuleDependency, ModuleLayer,
 };
 
 #[cacheable]
@@ -111,5 +111,5 @@ impl ModuleDependency for EntryDependency {
   }
 }
 
-impl AsDependencyTemplate for EntryDependency {}
+impl AsDependencyCodeGeneration for EntryDependency {}
 impl AsContextDependency for EntryDependency {}

--- a/crates/rspack_core/src/dependency/loader_import.rs
+++ b/crates/rspack_core/src/dependency/loader_import.rs
@@ -2,8 +2,8 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 
 use super::{AffectType, FactorizeInfo};
 use crate::{
-  AsContextDependency, AsDependencyTemplate, Context, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ModuleDependency,
+  AsContextDependency, AsDependencyCodeGeneration, Context, Dependency, DependencyCategory,
+  DependencyId, DependencyType, ModuleDependency,
 };
 
 #[cacheable]
@@ -51,7 +51,7 @@ impl std::hash::Hash for LoaderImportDependency {
   }
 }
 
-impl AsDependencyTemplate for LoaderImportDependency {}
+impl AsDependencyCodeGeneration for LoaderImportDependency {}
 impl AsContextDependency for LoaderImportDependency {}
 
 #[cacheable_dyn]

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -2,7 +2,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_util::ext::DynHash;
 
 use crate::{
-  Compilation, DependencyTemplate, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  Compilation, DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType,
   RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
@@ -13,8 +13,8 @@ pub struct RuntimeRequirementsDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for RuntimeRequirementsDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for RuntimeRequirementsDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RuntimeRequirementsDependencyTemplate::template_type())
   }
 
@@ -41,15 +41,15 @@ impl RuntimeRequirementsDependency {
 pub struct RuntimeRequirementsDependencyTemplate;
 
 impl RuntimeRequirementsDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("RuntimeRequirementsDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("RuntimeRequirementsDependency")
   }
 }
 
-impl DynamicDependencyTemplate for RuntimeRequirementsDependencyTemplate {
+impl DependencyTemplate for RuntimeRequirementsDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_core/src/dependency/static_exports_dependency.rs
+++ b/crates/rspack_core/src/dependency/static_exports_dependency.rs
@@ -6,7 +6,7 @@ use swc_core::ecma::atoms::Atom;
 
 use super::AffectType;
 use crate::{
-  AsContextDependency, AsDependencyTemplate, AsModuleDependency, Dependency, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, AsModuleDependency, Dependency, DependencyId,
   DependencyType, ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
 };
 
@@ -66,7 +66,7 @@ impl Dependency for StaticExportsDependency {
   }
 }
 
-impl AsDependencyTemplate for StaticExportsDependency {}
+impl AsDependencyCodeGeneration for StaticExportsDependency {}
 impl AsModuleDependency for StaticExportsDependency {}
 
 impl AsContextDependency for StaticExportsDependency {}

--- a/crates/rspack_plugin_asset/src/asset_exports_dependency.rs
+++ b/crates/rspack_plugin_asset/src/asset_exports_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, AsModuleDependency, Dependency, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, AsModuleDependency, Dependency, DependencyId,
   ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
 };
 
@@ -38,6 +38,6 @@ impl Dependency for AssetExportsDependency {
   }
 }
 
-impl AsDependencyTemplate for AssetExportsDependency {}
+impl AsDependencyCodeGeneration for AssetExportsDependency {}
 impl AsModuleDependency for AssetExportsDependency {}
 impl AsContextDependency for AssetExportsDependency {}

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -3,7 +3,7 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyRange, DependencyType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
   RuntimeSpec,
 };
@@ -90,5 +90,5 @@ impl ModuleDependency for CssComposeDependency {
   }
 }
 
-impl AsDependencyTemplate for CssComposeDependency {}
+impl AsDependencyCodeGeneration for CssComposeDependency {}
 impl AsContextDependency for CssComposeDependency {}

--- a/crates/rspack_plugin_css/src/dependency/export.rs
+++ b/crates/rspack_plugin_css/src/dependency/export.rs
@@ -1,7 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, AsModuleDependency, Dependency, DependencyCategory,
-  DependencyId, DependencyType, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec, ExportsSpec,
+  AsContextDependency, AsDependencyCodeGeneration, AsModuleDependency, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ExportNameOrSpec, ExportSpec,
+  ExportsOfExportsSpec, ExportsSpec,
 };
 
 #[cacheable]
@@ -58,6 +59,6 @@ impl Dependency for CssExportDependency {
   }
 }
 
-impl AsDependencyTemplate for CssExportDependency {}
+impl AsDependencyCodeGeneration for CssExportDependency {}
 impl AsContextDependency for CssExportDependency {}
 impl AsModuleDependency for CssExportDependency {}

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -2,9 +2,9 @@ use std::fmt::Display;
 
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
-  FactorizeInfo, ModuleDependency, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, FactorizeInfo,
+  ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -123,8 +123,8 @@ impl Display for CssSupports {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for CssImportDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CssImportDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CssImportDependencyTemplate::template_type())
   }
 }
@@ -135,15 +135,15 @@ impl AsContextDependency for CssImportDependency {}
 #[derive(Debug, Clone, Default)]
 pub struct CssImportDependencyTemplate;
 impl CssImportDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CssImport)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CssImport)
   }
 }
 
-impl DynamicDependencyTemplate for CssImportDependencyTemplate {
+impl DependencyTemplate for CssImportDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     _code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_css/src/dependency/local_ident.rs
+++ b/crates/rspack_plugin_css/src/dependency/local_ident.rs
@@ -1,9 +1,9 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec, ExportsSpec,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  DependencyCodeGeneration, DependencyId, DependencyTemplate, DependencyTemplateType,
+  DependencyType, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec, ExportsSpec, RuntimeSpec,
+  TemplateContext, TemplateReplaceSource,
 };
 use rspack_util::ext::DynHash;
 
@@ -70,8 +70,8 @@ impl Dependency for CssLocalIdentDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for CssLocalIdentDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CssLocalIdentDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CssLocalIdentDependencyTemplate::template_type())
   }
 
@@ -93,15 +93,15 @@ impl AsModuleDependency for CssLocalIdentDependency {}
 pub struct CssLocalIdentDependencyTemplate;
 
 impl CssLocalIdentDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CssLocalIdent)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CssLocalIdent)
   }
 }
 
-impl DynamicDependencyTemplate for CssLocalIdentDependencyTemplate {
+impl DependencyTemplate for CssLocalIdentDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     _code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_css/src/dependency/self_reference.rs
+++ b/crates/rspack_plugin_css/src/dependency/self_reference.rs
@@ -1,9 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExtendedReferencedExport,
+  FactorizeInfo, ModuleDependency, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 use rspack_util::atom::Atom;
 
@@ -88,8 +87,8 @@ impl ModuleDependency for CssSelfReferenceLocalIdentDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for CssSelfReferenceLocalIdentDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CssSelfReferenceLocalIdentDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CssSelfReferenceLocalIdentDependencyTemplate::template_type())
   }
 }
@@ -101,15 +100,15 @@ impl AsContextDependency for CssSelfReferenceLocalIdentDependency {}
 pub struct CssSelfReferenceLocalIdentDependencyTemplate;
 
 impl CssSelfReferenceLocalIdentDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CssSelfReferenceLocalIdent)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CssSelfReferenceLocalIdent)
   }
 }
 
-impl DynamicDependencyTemplate for CssSelfReferenceLocalIdentDependencyTemplate {
+impl DependencyTemplate for CssSelfReferenceLocalIdentDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     _code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -2,9 +2,9 @@ use cow_utils::CowUtils;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, CodeGenerationDataFilename, CodeGenerationDataUrl, Compilation, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, FactorizeInfo, ModuleDependency,
-  ModuleIdentifier, TemplateContext, TemplateReplaceSource,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, FactorizeInfo, ModuleDependency, ModuleIdentifier,
+  TemplateContext, TemplateReplaceSource,
 };
 
 use crate::utils::{css_escape_string, AUTO_PUBLIC_PATH_PLACEHOLDER};
@@ -102,8 +102,8 @@ impl ModuleDependency for CssUrlDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for CssUrlDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CssUrlDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CssUrlDependencyTemplate::template_type())
   }
 }
@@ -115,15 +115,15 @@ impl AsContextDependency for CssUrlDependency {}
 pub struct CssUrlDependencyTemplate;
 
 impl CssUrlDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CssUrl)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CssUrl)
   }
 }
 
-impl DynamicDependencyTemplate for CssUrlDependencyTemplate {
+impl DependencyTemplate for CssUrlDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -500,11 +500,14 @@ impl ParserAndGenerator for CssParserAndGenerator {
             .dependency_by_id(id)
             .expect("should have dependency");
 
-          if let Some(dependency) = dep.as_dependency_template() {
+          if let Some(dependency) = dep.as_dependency_code_generation() {
             if let Some(template) = compilation.get_dependency_template(dependency) {
               template.render(dependency, &mut source, &mut context)
             } else {
-              dependency.apply(&mut source, &mut context)
+              panic!(
+                "Can not find dependency template of {:?}",
+                dependency.dependency_template()
+              );
             }
           }
         });
@@ -542,7 +545,10 @@ impl ParserAndGenerator for CssParserAndGenerator {
             if let Some(template) = compilation.get_dependency_template(dependency.as_ref()) {
               template.render(dependency.as_ref(), &mut source, &mut context)
             } else {
-              dependency.apply(&mut source, &mut context)
+              panic!(
+                "Can not find dependency template of {:?}",
+                dependency.dependency_template()
+              );
             }
           });
         };

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_entry_dependency.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_entry_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AffectType, AsContextDependency, AsDependencyTemplate, Context, Dependency, DependencyId,
+  AffectType, AsContextDependency, AsDependencyCodeGeneration, Context, Dependency, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -73,4 +73,4 @@ impl Dependency for DllEntryDependency {
 
 impl AsContextDependency for DllEntryDependency {}
 
-impl AsDependencyTemplate for DllEntryDependency {}
+impl AsDependencyCodeGeneration for DllEntryDependency {}

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_source_dependency.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_source_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AffectType, AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory,
+  AffectType, AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory,
   DependencyId, DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -62,4 +62,4 @@ impl ModuleDependency for DelegatedSourceDependency {
 
 impl AsContextDependency for DelegatedSourceDependency {}
 
-impl AsDependencyTemplate for DelegatedSourceDependency {}
+impl AsDependencyCodeGeneration for DelegatedSourceDependency {}

--- a/crates/rspack_plugin_extract_css/src/css_dependency.rs
+++ b/crates/rspack_plugin_extract_css/src/css_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  AffectType, AsContextDependency, AsDependencyTemplate, ConnectionState, Dependency,
+  AffectType, AsContextDependency, AsDependencyCodeGeneration, ConnectionState, Dependency,
   DependencyCategory, DependencyId, DependencyRange, DependencyType, FactorizeInfo,
   ModuleDependency, ModuleGraph,
 };
@@ -75,7 +75,7 @@ impl CssDependency {
   }
 }
 
-impl AsDependencyTemplate for CssDependency {}
+impl AsDependencyCodeGeneration for CssDependency {}
 impl AsContextDependency for CssDependency {}
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
@@ -5,8 +5,8 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  DependencyCodeGeneration, DependencyId, DependencyTemplate, DependencyTemplateType,
+  DependencyType, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 use rspack_util::{atom::Atom, json_stringify};
 
@@ -253,8 +253,8 @@ impl AsModuleDependency for AMDDefineDependency {}
 impl AsContextDependency for AMDDefineDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for AMDDefineDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for AMDDefineDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(AMDDefineDependencyTemplate::template_type())
   }
 }
@@ -264,15 +264,15 @@ impl DependencyTemplate for AMDDefineDependency {
 pub struct AMDDefineDependencyTemplate;
 
 impl AMDDefineDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::AmdDefine)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::AmdDefine)
   }
 }
 
-impl DynamicDependencyTemplate for AMDDefineDependencyTemplate {
+impl DependencyTemplate for AMDDefineDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
@@ -4,8 +4,8 @@ use itertools::Itertools;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   module_raw, AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, ModuleDependency, TemplateContext, TemplateReplaceSource,
+  DependencyCodeGeneration, DependencyId, DependencyTemplate, DependencyTemplateType,
+  DependencyType, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 
 use super::amd_require_item_dependency::AMDRequireItemDependency;
@@ -96,8 +96,8 @@ impl AMDRequireArrayDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for AMDRequireArrayDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for AMDRequireArrayDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(AMDRequireArrayDependencyTemplate::template_type())
   }
 }
@@ -111,15 +111,15 @@ impl AsContextDependency for AMDRequireArrayDependency {}
 pub struct AMDRequireArrayDependencyTemplate;
 
 impl AMDRequireArrayDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::AmdRequireArray)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::AmdRequireArray)
   }
 }
 
-impl DynamicDependencyTemplate for AMDRequireArrayDependencyTemplate {
+impl DependencyTemplate for AMDRequireArrayDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   block_promise, AffectType, AsContextDependency, AsModuleDependency, Dependency,
-  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyTemplate,
+  DependencyTemplateType, DependencyType, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -11,7 +11,7 @@ pub struct AMDRequireDependency {
   id: DependencyId,
   outer_range: (u32, u32),
   // In the webpack source code, type annotation of `arrayRange` is non-null.
-  // However, `DependencyTemplate` implementation assumes `arrayRange` can be null in some cases.
+  // However, `DependencyCodeGeneration` implementation assumes `arrayRange` can be null in some cases.
   // So I use Option here.
   array_range: Option<(u32, u32)>,
   function_range: Option<(u32, u32)>,
@@ -63,8 +63,8 @@ impl AsModuleDependency for AMDRequireDependency {}
 impl AsContextDependency for AMDRequireDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for AMDRequireDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for AMDRequireDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(AMDRequireDependencyTemplate::template_type())
   }
 }
@@ -74,15 +74,15 @@ impl DependencyTemplate for AMDRequireDependency {
 pub struct AMDRequireDependencyTemplate;
 
 impl AMDRequireDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::AmdRequire)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::AmdRequire)
   }
 }
 
-impl DynamicDependencyTemplate for AMDRequireDependencyTemplate {
+impl DependencyTemplate for AMDRequireDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_raw, AffectType, AsContextDependency, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
-  FactorizeInfo, ModuleDependency, TemplateContext, TemplateReplaceSource,
+  module_raw, AffectType, AsContextDependency, Dependency, DependencyCategory,
+  DependencyCodeGeneration, DependencyId, DependencyTemplate, DependencyTemplateType,
+  DependencyType, FactorizeInfo, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use rspack_util::atom::Atom;
 
@@ -74,8 +74,8 @@ impl ModuleDependency for AMDRequireItemDependency {
 impl AsContextDependency for AMDRequireItemDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for AMDRequireItemDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for AMDRequireItemDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(AMDRequireItemDependencyTemplate::template_type())
   }
 }
@@ -85,15 +85,15 @@ impl DependencyTemplate for AMDRequireItemDependency {
 pub struct AMDRequireItemDependencyTemplate;
 
 impl AMDRequireItemDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::AmdRequireItem)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::AmdRequireItem)
   }
 }
 
-impl DynamicDependencyTemplate for AMDRequireItemDependencyTemplate {
+impl DependencyTemplate for AMDRequireItemDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
@@ -1,8 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyId,
-  DependencyTemplate, DynamicDependencyTemplate, DynamicDependencyTemplateType, TemplateContext,
-  TemplateReplaceSource,
+  AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyCodeGeneration,
+  DependencyId, DependencyTemplate, DependencyTemplateType, TemplateContext, TemplateReplaceSource,
 };
 
 use super::local_module::LocalModule;
@@ -43,8 +42,8 @@ impl Dependency for LocalModuleDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for LocalModuleDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for LocalModuleDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(LocalModuleDependencyTemplate::template_type())
   }
 }
@@ -58,15 +57,15 @@ impl AsContextDependency for LocalModuleDependency {}
 pub struct LocalModuleDependencyTemplate;
 
 impl LocalModuleDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("LocalModuleDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("LocalModuleDependency")
   }
 }
 
-impl DynamicDependencyTemplate for LocalModuleDependencyTemplate {
+impl DependencyTemplate for LocalModuleDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     _code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
   AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, TemplateContext, TemplateReplaceSource,
+  DependencyCodeGeneration, DependencyId, DependencyTemplate, DependencyTemplateType,
+  DependencyType, TemplateContext, TemplateReplaceSource,
 };
 use rspack_util::atom::Atom;
 
@@ -45,8 +45,8 @@ impl Dependency for UnsupportedDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for UnsupportedDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for UnsupportedDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(UnsupportedDependencyTemplate::template_type())
   }
 }
@@ -60,15 +60,15 @@ impl AsContextDependency for UnsupportedDependency {}
 pub struct UnsupportedDependencyTemplate;
 
 impl UnsupportedDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("UnsupportedDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("UnsupportedDependency")
   }
 }
 
-impl DynamicDependencyTemplate for UnsupportedDependencyTemplate {
+impl DependencyTemplate for UnsupportedDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     _code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -5,11 +5,11 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   module_raw, process_export_info, property_access, AsContextDependency, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, ExportInfoProvided, ExportNameOrSpec,
-  ExportSpec, ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
-  FactorizeInfo, ModuleDependency, ModuleGraph, ModuleIdentifier, Nullable, ReferencedExport,
-  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, ExportInfoProvided, ExportNameOrSpec, ExportSpec,
+  ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport, FactorizeInfo,
+  ModuleDependency, ModuleGraph, ModuleIdentifier, Nullable, ReferencedExport, RuntimeGlobals,
+  RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
 };
 use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
@@ -377,8 +377,8 @@ impl ModuleDependency for CommonJsExportRequireDependency {
 impl AsContextDependency for CommonJsExportRequireDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for CommonJsExportRequireDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CommonJsExportRequireDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsExportRequireDependencyTemplate::template_type())
   }
 }
@@ -388,15 +388,15 @@ impl DependencyTemplate for CommonJsExportRequireDependency {
 pub struct CommonJsExportRequireDependencyTemplate;
 
 impl CommonJsExportRequireDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CjsExportRequire)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CjsExportRequire)
   }
 }
 
-impl DynamicDependencyTemplate for CommonJsExportRequireDependencyTemplate {
+impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -4,10 +4,10 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   property_access, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec, ExportsSpec,
-  InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleGraph, NormalInitFragment,
-  RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsedName,
+  DependencyCodeGeneration, DependencyId, DependencyTemplate, DependencyTemplateType,
+  DependencyType, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec, ExportsSpec, InitFragmentExt,
+  InitFragmentKey, InitFragmentStage, ModuleGraph, NormalInitFragment, RuntimeGlobals,
+  TemplateContext, TemplateReplaceSource, UsedName,
 };
 use swc_core::atoms::Atom;
 
@@ -112,8 +112,8 @@ impl Dependency for CommonJsExportsDependency {
 impl AsModuleDependency for CommonJsExportsDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for CommonJsExportsDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CommonJsExportsDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsExportsDependencyTemplate::template_type())
   }
 }
@@ -125,15 +125,15 @@ impl AsContextDependency for CommonJsExportsDependency {}
 pub struct CommonJsExportsDependencyTemplate;
 
 impl CommonJsExportsDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CjsExports)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CjsExports)
   }
 }
 
-impl DynamicDependencyTemplate for CommonJsExportsDependencyTemplate {
+impl DependencyTemplate for CommonJsExportsDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -4,8 +4,8 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   module_id, property_access, to_normal_comment, AsContextDependency, Dependency,
-  DependencyCategory, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
-  DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType, ExportsType,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsType,
   ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, RuntimeGlobals,
   RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
 };
@@ -129,8 +129,8 @@ impl ModuleDependency for CommonJsFullRequireDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for CommonJsFullRequireDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CommonJsFullRequireDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsFullRequireDependencyTemplate::template_type())
   }
 }
@@ -142,15 +142,15 @@ impl AsContextDependency for CommonJsFullRequireDependency {}
 pub struct CommonJsFullRequireDependencyTemplate;
 
 impl CommonJsFullRequireDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CjsFullRequire)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CjsFullRequire)
   }
 }
 
-impl DynamicDependencyTemplate for CommonJsFullRequireDependencyTemplate {
+impl DependencyTemplate for CommonJsFullRequireDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyLocation,
-  DependencyRange, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, FactorizeInfo, ModuleDependency, SharedSourceMap, TemplateContext,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
+  DependencyType, FactorizeInfo, ModuleDependency, SharedSourceMap, TemplateContext,
   TemplateReplaceSource,
 };
 
@@ -94,8 +94,8 @@ impl ModuleDependency for CommonJsRequireDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for CommonJsRequireDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CommonJsRequireDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsRequireDependencyTemplate::template_type())
   }
 }
@@ -107,15 +107,15 @@ impl AsContextDependency for CommonJsRequireDependency {}
 pub struct CommonJsRequireDependencyTemplate;
 
 impl CommonJsRequireDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CjsRequire)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CjsRequire)
   }
 }
 
-impl DynamicDependencyTemplate for CommonJsRequireDependencyTemplate {
+impl DependencyTemplate for CommonJsRequireDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -3,8 +3,8 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  property_access, AsContextDependency, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  property_access, AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyTemplate, DependencyTemplateType, DependencyType,
   ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, RuntimeGlobals,
   RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName,
 };
@@ -96,8 +96,8 @@ impl ModuleDependency for CommonJsSelfReferenceDependency {
 impl AsContextDependency for CommonJsSelfReferenceDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for CommonJsSelfReferenceDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CommonJsSelfReferenceDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsSelfReferenceDependencyTemplate::template_type())
   }
 }
@@ -107,15 +107,15 @@ impl DependencyTemplate for CommonJsSelfReferenceDependency {
 pub struct CommonJsSelfReferenceDependencyTemplate;
 
 impl CommonJsSelfReferenceDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CjsSelfReference)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CjsSelfReference)
   }
 }
 
-impl DynamicDependencyTemplate for CommonJsSelfReferenceDependencyTemplate {
+impl DependencyTemplate for CommonJsSelfReferenceDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -1,10 +1,10 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   create_exports_object_referenced, create_no_exports_referenced, AsContextDependency, ChunkGraph,
-  Compilation, Dependency, DependencyId, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, FactorizeInfo, InitFragmentKey,
-  InitFragmentStage, ModuleDependency, NormalInitFragment, RuntimeGlobals, RuntimeSpec,
-  TemplateContext, TemplateReplaceSource,
+  Compilation, Dependency, DependencyCodeGeneration, DependencyId, DependencyTemplate,
+  DependencyTemplateType, DependencyType, FactorizeInfo, InitFragmentKey, InitFragmentStage,
+  ModuleDependency, NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource,
 };
 use rspack_util::ext::DynHash;
 
@@ -44,8 +44,8 @@ impl ModuleDependency for ModuleDecoratorDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ModuleDecoratorDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ModuleDecoratorDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ModuleDecoratorDependencyTemplate::template_type())
   }
 
@@ -98,15 +98,15 @@ impl Dependency for ModuleDecoratorDependency {
 pub struct ModuleDecoratorDependencyTemplate;
 
 impl ModuleDecoratorDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::ModuleDecorator)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::ModuleDecorator)
   }
 }
 
-impl DynamicDependencyTemplate for ModuleDecoratorDependencyTemplate {
+impl DependencyTemplate for ModuleDecoratorDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
 
     _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_dependency.rs
@@ -1,9 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   block_promise, AffectType, AsContextDependency, AsModuleDependency, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, RuntimeGlobals, TemplateContext,
-  TemplateReplaceSource,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -56,8 +55,8 @@ impl Dependency for RequireEnsureDependency {
 impl AsModuleDependency for RequireEnsureDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for RequireEnsureDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for RequireEnsureDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireEnsureDependencyTemplate::template_type())
   }
 }
@@ -69,15 +68,15 @@ impl AsContextDependency for RequireEnsureDependency {}
 pub struct RequireEnsureDependencyTemplate;
 
 impl RequireEnsureDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::RequireEnsure)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::RequireEnsure)
   }
 }
 
-impl DynamicDependencyTemplate for RequireEnsureDependencyTemplate {
+impl DependencyTemplate for RequireEnsureDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_item_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_item_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  AffectType, AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory,
+  AffectType, AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory,
   DependencyId, DependencyRange, DependencyType, FactorizeInfo, ModuleDependency,
 };
 use rspack_util::atom::Atom;
@@ -64,6 +64,6 @@ impl ModuleDependency for RequireEnsureItemDependency {
   }
 }
 
-impl AsDependencyTemplate for RequireEnsureItemDependency {}
+impl AsDependencyCodeGeneration for RequireEnsureItemDependency {}
 
 impl AsContextDependency for RequireEnsureItemDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Dependency, DependencyId, DependencyLocation,
-  DependencyRange, DependencyTemplate, DynamicDependencyTemplate, DynamicDependencyTemplateType,
-  RuntimeGlobals, SharedSourceMap, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyCodeGeneration, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, RuntimeGlobals,
+  SharedSourceMap, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -43,8 +43,8 @@ impl AsModuleDependency for RequireHeaderDependency {}
 impl AsContextDependency for RequireHeaderDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for RequireHeaderDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for RequireHeaderDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireHeaderDependencyTemplate::template_type())
   }
 }
@@ -54,15 +54,15 @@ impl DependencyTemplate for RequireHeaderDependency {
 pub struct RequireHeaderDependencyTemplate;
 
 impl RequireHeaderDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("RequireHeaderDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("RequireHeaderDependency")
   }
 }
 
-impl DynamicDependencyTemplate for RequireHeaderDependencyTemplate {
+impl DependencyTemplate for RequireHeaderDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
   ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, RuntimeSpec,
   TemplateContext, TemplateReplaceSource,
 };
@@ -93,8 +93,8 @@ impl ModuleDependency for RequireResolveDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for RequireResolveDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for RequireResolveDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireResolveDependencyTemplate::template_type())
   }
 }
@@ -106,15 +106,15 @@ impl AsContextDependency for RequireResolveDependency {}
 pub struct RequireResolveDependencyTemplate;
 
 impl RequireResolveDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::RequireResolve)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::RequireResolve)
   }
 }
 
-impl DynamicDependencyTemplate for RequireResolveDependencyTemplate {
+impl DependencyTemplate for RequireResolveDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_header_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, SharedSourceMap, TemplateContext, TemplateReplaceSource,
+  AffectType, AsContextDependency, AsModuleDependency, Dependency, DependencyCodeGeneration,
+  DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
+  SharedSourceMap, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -43,8 +43,8 @@ impl AsModuleDependency for RequireResolveHeaderDependency {}
 impl AsContextDependency for RequireResolveHeaderDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for RequireResolveHeaderDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for RequireResolveHeaderDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireResolveHeaderDependencyTemplate::template_type())
   }
 }
@@ -54,15 +54,15 @@ impl DependencyTemplate for RequireResolveHeaderDependency {
 pub struct RequireResolveHeaderDependencyTemplate;
 
 impl RequireResolveHeaderDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("RequireResolveHeaderDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("RequireResolveHeaderDependency")
   }
 }
 
-impl DynamicDependencyTemplate for RequireResolveHeaderDependencyTemplate {
+impl DependencyTemplate for RequireResolveHeaderDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     _code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsModuleDependency, ContextDependency, ContextOptions, Dependency, DependencyCategory,
-  DependencyId, DependencyRange, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, FactorizeInfo, ModuleGraph, TemplateContext,
+  DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, FactorizeInfo, ModuleGraph, TemplateContext,
   TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
@@ -115,8 +115,8 @@ impl ContextDependency for AMDRequireContextDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for AMDRequireContextDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for AMDRequireContextDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(AMDRequireContextDependencyTemplate::template_type())
   }
 }
@@ -128,15 +128,15 @@ impl AsModuleDependency for AMDRequireContextDependency {}
 pub struct AMDRequireContextDependencyTemplate;
 
 impl AMDRequireContextDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::AmdRequireContext)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::AmdRequireContext)
   }
 }
 
-impl DynamicDependencyTemplate for AMDRequireContextDependencyTemplate {
+impl DependencyTemplate for AMDRequireContextDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsModuleDependency, ContextDependency, ContextOptions, Dependency, DependencyCategory,
-  DependencyId, DependencyRange, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, FactorizeInfo, ModuleGraph, TemplateContext,
+  DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, FactorizeInfo, ModuleGraph, TemplateContext,
   TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
@@ -122,8 +122,8 @@ impl ContextDependency for CommonJsRequireContextDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for CommonJsRequireContextDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CommonJsRequireContextDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsRequireContextDependencyTemplate::template_type())
   }
 }
@@ -135,15 +135,15 @@ impl AsModuleDependency for CommonJsRequireContextDependency {}
 pub struct CommonJsRequireContextDependencyTemplate;
 
 impl CommonJsRequireContextDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CommonJSRequireContext)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CommonJSRequireContext)
   }
 }
 
-impl DynamicDependencyTemplate for CommonJsRequireContextDependencyTemplate {
+impl DependencyTemplate for CommonJsRequireContextDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsModuleDependency, ContextDependency, ContextOptions, Dependency, DependencyCategory,
-  DependencyId, DependencyRange, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, FactorizeInfo, ModuleGraph, TemplateContext,
+  DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, FactorizeInfo, ModuleGraph, TemplateContext,
   TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
@@ -122,8 +122,8 @@ impl ContextDependency for ImportContextDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ImportContextDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ImportContextDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportContextDependencyTemplate::template_type())
   }
 }
@@ -135,15 +135,15 @@ impl AsModuleDependency for ImportContextDependency {}
 pub struct ImportContextDependencyTemplate;
 
 impl ImportContextDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::ImportContext)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::ImportContext)
   }
 }
 
-impl DynamicDependencyTemplate for ImportContextDependencyTemplate {
+impl DependencyTemplate for ImportContextDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -1,9 +1,9 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   module_raw, AsModuleDependency, ContextDependency, ContextOptions, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, FactorizeInfo, ModuleGraph,
-  TemplateContext, TemplateReplaceSource,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, FactorizeInfo, ModuleGraph, TemplateContext,
+  TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -113,8 +113,8 @@ impl ContextDependency for ImportMetaContextDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ImportMetaContextDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ImportMetaContextDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportMetaContextDependencyTemplate::template_type())
   }
 }
@@ -126,15 +126,15 @@ impl AsModuleDependency for ImportMetaContextDependency {}
 pub struct ImportMetaContextDependencyTemplate;
 
 impl ImportMetaContextDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::ImportMetaContext)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::ImportMetaContext)
   }
 }
 
-impl DynamicDependencyTemplate for ImportMetaContextDependencyTemplate {
+impl DependencyTemplate for ImportMetaContextDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -1,9 +1,9 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   module_raw, AsModuleDependency, ContextDependency, ContextOptions, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, FactorizeInfo, ModuleGraph,
-  TemplateContext, TemplateReplaceSource,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, FactorizeInfo, ModuleGraph, TemplateContext,
+  TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -113,8 +113,8 @@ impl ContextDependency for RequireContextDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for RequireContextDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for RequireContextDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireContextDependencyTemplate::template_type())
   }
 }
@@ -126,15 +126,15 @@ impl AsModuleDependency for RequireContextDependency {}
 pub struct RequireContextDependencyTemplate;
 
 impl RequireContextDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::RequireContext)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::RequireContext)
   }
 }
 
-impl DynamicDependencyTemplate for RequireContextDependencyTemplate {
+impl DependencyTemplate for RequireContextDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
@@ -1,9 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AffectType, AsModuleDependency, ContextDependency, ContextOptions, ContextTypePrefix, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, FactorizeInfo, TemplateContext,
-  TemplateReplaceSource,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, FactorizeInfo, TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -106,8 +105,8 @@ impl ContextDependency for RequireResolveContextDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for RequireResolveContextDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for RequireResolveContextDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireResolveContextDependencyTemplate::template_type())
   }
 }
@@ -119,15 +118,15 @@ impl AsModuleDependency for RequireResolveContextDependency {}
 pub struct RequireResolveContextDependencyTemplate;
 
 impl RequireResolveContextDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::RequireResolveContext)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::RequireResolveContext)
   }
 }
 
-impl DynamicDependencyTemplate for RequireResolveContextDependencyTemplate {
+impl DependencyTemplate for RequireResolveContextDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  DependencyTemplate, DynamicDependencyTemplate, DynamicDependencyTemplateType, InitFragmentKey,
+  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, InitFragmentKey,
   InitFragmentStage, ModuleGraph, NormalInitFragment, RuntimeGlobals, TemplateContext,
   TemplateReplaceSource, UsageState,
 };
@@ -13,8 +13,8 @@ use swc_core::atoms::Atom;
 pub struct ESMCompatibilityDependency;
 
 #[cacheable_dyn]
-impl DependencyTemplate for ESMCompatibilityDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ESMCompatibilityDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ESMCompatibilityDependencyTemplate::template_type())
   }
 }
@@ -24,15 +24,15 @@ impl DependencyTemplate for ESMCompatibilityDependency {
 pub struct ESMCompatibilityDependencyTemplate;
 
 impl ESMCompatibilityDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ESMCompatibilityDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ESMCompatibilityDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ESMCompatibilityDependencyTemplate {
+impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
   fn render(
     &self,
-    _dep: &dyn DependencyTemplate,
+    _dep: &dyn DependencyCodeGeneration,
     _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -3,10 +3,11 @@ use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_collections::{Identifier, IdentifierSet};
 use rspack_core::{
   property_access, rspack_sources::ReplacementEnforce, AsContextDependency, AsModuleDependency,
-  Compilation, Dependency, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
-  DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType, ESMExportInitFragment,
-  ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph, RuntimeGlobals, RuntimeSpec,
-  SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName, DEFAULT_EXPORT,
+  Compilation, Dependency, DependencyCodeGeneration, DependencyId, DependencyLocation,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
+  ESMExportInitFragment, ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
+  RuntimeGlobals, RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
+  DEFAULT_EXPORT,
 };
 use swc_core::atoms::Atom;
 
@@ -114,8 +115,8 @@ impl AsModuleDependency for ESMExportExpressionDependency {}
 impl AsContextDependency for ESMExportExpressionDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for ESMExportExpressionDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ESMExportExpressionDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ESMExportExpressionDependencyTemplate::template_type())
   }
 }
@@ -125,15 +126,15 @@ impl DependencyTemplate for ESMExportExpressionDependency {
 pub struct ESMExportExpressionDependencyTemplate;
 
 impl ESMExportExpressionDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::EsmExportExpression)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::EsmExportExpression)
   }
 }
 
-impl DynamicDependencyTemplate for ESMExportExpressionDependencyTemplate {
+impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Dependency, DependencyId, DependencyLocation,
-  DependencyRange, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, SharedSourceMap, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyCodeGeneration, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
+  SharedSourceMap, TemplateContext, TemplateReplaceSource,
 };
 
 // Remove `export` label.
@@ -53,8 +53,8 @@ impl Dependency for ESMExportHeaderDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ESMExportHeaderDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ESMExportHeaderDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ESMExportHeaderDependencyTemplate::template_type())
   }
 }
@@ -67,15 +67,15 @@ impl AsContextDependency for ESMExportHeaderDependency {}
 pub struct ESMExportHeaderDependencyTemplate;
 
 impl ESMExportHeaderDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::EsmExportHeader)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::EsmExportHeader)
   }
 }
 
-impl DynamicDependencyTemplate for ESMExportHeaderDependencyTemplate {
+impl DependencyTemplate for ESMExportHeaderDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     _code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -9,15 +9,15 @@ use rspack_collections::IdentifierSet;
 use rspack_core::{
   create_exports_object_referenced, create_no_exports_referenced, filter_runtime, get_exports_type,
   process_export_info, property_access, property_name, string_of_used_name, AsContextDependency,
-  ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory, DependencyCondition,
-  DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
-  DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType, ESMExportInitFragment,
-  ExportInfo, ExportInfoProvided, ExportNameOrSpec, ExportPresenceMode, ExportSpec, ExportsInfo,
-  ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport, FactorizeInfo,
-  ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage, JavascriptParserOptions,
-  ModuleDependency, ModuleGraph, ModuleIdentifier, NormalInitFragment, RuntimeCondition,
-  RuntimeGlobals, RuntimeSpec, SharedSourceMap, Template, TemplateContext, TemplateReplaceSource,
-  UsageState, UsedName,
+  ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
+  DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
+  ESMExportInitFragment, ExportInfo, ExportInfoProvided, ExportNameOrSpec, ExportPresenceMode,
+  ExportSpec, ExportsInfo, ExportsOfExportsSpec, ExportsSpec, ExportsType,
+  ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleIdentifier,
+  NormalInitFragment, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SharedSourceMap, Template,
+  TemplateContext, TemplateReplaceSource, UsageState, UsedName,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -1008,8 +1008,8 @@ pub struct DiscoverActiveExportsFromOtherStarExportsRet<'a> {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ESMExportImportedSpecifierDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ESMExportImportedSpecifierDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ESMExportImportedSpecifierDependencyTemplate::template_type())
   }
 }
@@ -1504,15 +1504,15 @@ fn find_dependency_for_name<'a>(
 pub struct ESMExportImportedSpecifierDependencyTemplate;
 
 impl ESMExportImportedSpecifierDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::EsmExportImportedSpecifier)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::EsmExportImportedSpecifier)
   }
 }
 
-impl DynamicDependencyTemplate for ESMExportImportedSpecifierDependencyTemplate {
+impl DependencyTemplate for ESMExportImportedSpecifierDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -4,11 +4,11 @@ use rspack_cacheable::{
 };
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Dependency, DependencyCategory, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, ESMExportInitFragment,
-  ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph, SharedSourceMap,
-  TemplateContext, TemplateReplaceSource, UsedName,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
+  DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, ESMExportInitFragment, ExportNameOrSpec,
+  ExportsOfExportsSpec, ExportsSpec, ModuleGraph, SharedSourceMap, TemplateContext,
+  TemplateReplaceSource, UsedName,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -90,8 +90,8 @@ impl Dependency for ESMExportSpecifierDependency {
 impl AsModuleDependency for ESMExportSpecifierDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for ESMExportSpecifierDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ESMExportSpecifierDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ESMExportSpecifierDependencyTemplate::template_type())
   }
 }
@@ -103,15 +103,15 @@ impl AsContextDependency for ESMExportSpecifierDependency {}
 pub struct ESMExportSpecifierDependencyTemplate;
 
 impl ESMExportSpecifierDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::EsmExportSpecifier)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::EsmExportSpecifier)
   }
 }
 
-impl DynamicDependencyTemplate for ESMExportSpecifierDependencyTemplate {
+impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -8,12 +8,12 @@ use rspack_collections::IdentifierSet;
 use rspack_core::{
   filter_runtime, import_statement, merge_runtime, AsContextDependency,
   AwaitDependenciesInitFragment, BuildMetaDefaultObject, ConditionalInitFragment, ConnectionState,
-  Dependency, DependencyCategory, DependencyCondition, DependencyConditionFn, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, ErrorSpan, ExportInfoProvided,
-  ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt,
-  InitFragmentKey, InitFragmentStage, ModuleDependency, ModuleGraph, ProvidedExports,
-  RuntimeCondition, RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource,
+  Dependency, DependencyCategory, DependencyCodeGeneration, DependencyCondition,
+  DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, ErrorSpan, ExportInfoProvided, ExportsType,
+  ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, ModuleDependency, ModuleGraph, ProvidedExports, RuntimeCondition, RuntimeSpec,
+  SharedSourceMap, TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -505,8 +505,8 @@ impl ModuleDependency for ESMImportSideEffectDependency {
 impl AsContextDependency for ESMImportSideEffectDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for ESMImportSideEffectDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ESMImportSideEffectDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ESMImportSideEffectDependencyTemplate::template_type())
   }
 }
@@ -516,15 +516,15 @@ impl DependencyTemplate for ESMImportSideEffectDependency {
 pub struct ESMImportSideEffectDependencyTemplate;
 
 impl ESMImportSideEffectDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::EsmImport)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::EsmImport)
   }
 }
 
-impl DynamicDependencyTemplate for ESMImportSideEffectDependencyTemplate {
+impl DependencyTemplate for ESMImportSideEffectDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -6,8 +6,8 @@ use rspack_collections::IdentifierSet;
 use rspack_core::{
   create_exports_object_referenced, export_from_import, get_dependency_used_by_exports_condition,
   get_exports_type, property_access, AsContextDependency, ConnectionState, Dependency,
-  DependencyCategory, DependencyCondition, DependencyId, DependencyLocation, DependencyRange,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  DependencyCategory, DependencyCodeGeneration, DependencyCondition, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
   ExportPresenceMode, ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes,
   JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleReferenceOptions, ReferencedExport,
   RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedByExports,
@@ -283,8 +283,8 @@ impl ModuleDependency for ESMImportSpecifierDependency {
 impl AsContextDependency for ESMImportSpecifierDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for ESMImportSpecifierDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ESMImportSpecifierDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ESMImportSpecifierDependencyTemplate::template_type())
   }
 }
@@ -294,15 +294,15 @@ impl DependencyTemplate for ESMImportSpecifierDependency {
 pub struct ESMImportSpecifierDependencyTemplate;
 
 impl ESMImportSpecifierDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::EsmImportSpecifier)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::EsmImportSpecifier)
   }
 }
 
-impl DynamicDependencyTemplate for ESMImportSpecifierDependencyTemplate {
+impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  Compilation, DependencyId, DependencyTemplate, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, ExternalModuleInitFragment, InitFragmentExt, InitFragmentStage,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  Compilation, DependencyCodeGeneration, DependencyId, DependencyTemplate, DependencyTemplateType,
+  ExternalModuleInitFragment, InitFragmentExt, InitFragmentStage, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource,
 };
 use rspack_util::ext::DynHash;
 
@@ -31,8 +31,8 @@ impl ExternalModuleDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ExternalModuleDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ExternalModuleDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ExternalModuleDependencyTemplate::template_type())
   }
 
@@ -53,15 +53,15 @@ impl DependencyTemplate for ExternalModuleDependency {
 pub struct ExternalModuleDependencyTemplate;
 
 impl ExternalModuleDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ExternalModuleDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ExternalModuleDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ExternalModuleDependencyTemplate {
+impl DependencyTemplate for ExternalModuleDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -4,10 +4,10 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   create_exports_object_referenced, module_namespace_promise, AsContextDependency, Dependency,
-  DependencyCategory, DependencyId, DependencyRange, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, ExportsType, ExtendedReferencedExport,
-  FactorizeInfo, ImportAttributes, ModuleDependency, ModuleGraph, ReferencedExport,
-  TemplateContext, TemplateReplaceSource,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, ExportsType, ExtendedReferencedExport, FactorizeInfo,
+  ImportAttributes, ModuleDependency, ModuleGraph, ReferencedExport, TemplateContext,
+  TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -152,8 +152,8 @@ impl ModuleDependency for ImportDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ImportDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ImportDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportDependencyTemplate::template_type())
   }
 }
@@ -165,15 +165,15 @@ impl AsContextDependency for ImportDependency {}
 pub struct ImportDependencyTemplate;
 
 impl ImportDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::DynamicImport)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::DynamicImport)
   }
 }
 
-impl DynamicDependencyTemplate for ImportDependencyTemplate {
+impl DependencyTemplate for ImportDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -3,9 +3,9 @@ use rspack_cacheable::{
   with::{AsOption, AsPreset, AsVec},
 };
 use rspack_core::{
-  module_namespace_promise, AsContextDependency, Dependency, DependencyCategory, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, FactorizeInfo, ImportAttributes, ModuleDependency,
+  module_namespace_promise, AsContextDependency, Dependency, DependencyCategory,
+  DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, FactorizeInfo, ImportAttributes, ModuleDependency,
   TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
@@ -113,8 +113,8 @@ impl ModuleDependency for ImportEagerDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ImportEagerDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ImportEagerDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportEagerDependencyTemplate::template_type())
   }
 }
@@ -126,15 +126,15 @@ impl AsContextDependency for ImportEagerDependency {}
 pub struct ImportEagerDependencyTemplate;
 
 impl ImportEagerDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ImportEagerDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ImportEagerDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ImportEagerDependencyTemplate {
+impl DependencyTemplate for ImportEagerDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -5,11 +5,11 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   create_exports_object_referenced, module_raw, AsContextDependency, Compilation, Dependency,
-  DependencyCategory, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
-  DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
-  ExtendedReferencedExport, FactorizeInfo, InitFragmentKey, InitFragmentStage, ModuleDependency,
-  ModuleGraph, NormalInitFragment, RuntimeSpec, SharedSourceMap, TemplateContext,
-  TemplateReplaceSource, UsedName,
+  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExtendedReferencedExport,
+  FactorizeInfo, InitFragmentKey, InitFragmentStage, ModuleDependency, ModuleGraph,
+  NormalInitFragment, RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource,
+  UsedName,
 };
 use rspack_util::ext::DynHash;
 use swc_core::atoms::Atom;
@@ -108,8 +108,8 @@ impl ModuleDependency for ProvideDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ProvideDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ProvideDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ProvideDependencyTemplate::template_type())
   }
 
@@ -145,15 +145,15 @@ impl AsContextDependency for ProvideDependency {}
 pub struct ProvideDependencyTemplate;
 
 impl ProvideDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ProvideDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ProvideDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ProvideDependencyTemplate {
+impl DependencyTemplate for ProvideDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -4,7 +4,7 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  DependencyTemplate, DynamicDependencyTemplate, DynamicDependencyTemplateType, ExportProvided,
+  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportProvided,
   TemplateContext, TemplateReplaceSource, UsageState, UsedExports, UsedName,
 };
 use swc_core::ecma::atoms::Atom;
@@ -32,8 +32,8 @@ impl ExportInfoDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ExportInfoDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ExportInfoDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ExportInfoDependencyTemplate::template_type())
   }
 }
@@ -125,15 +125,15 @@ impl ExportInfoDependency {
 pub struct ExportInfoDependencyTemplate;
 
 impl ExportInfoDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ExportInfoDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ExportInfoDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ExportInfoDependencyTemplate {
+impl DependencyTemplate for ExportInfoDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/esm_accept_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/esm_accept_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  import_statement, runtime_condition_expression, DependencyId, DependencyLocation,
-  DependencyRange, DependencyTemplate, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  import_statement, runtime_condition_expression, DependencyCodeGeneration, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
   RuntimeCondition, SharedSourceMap, TemplateContext, TemplateReplaceSource,
 };
 
@@ -38,8 +38,8 @@ impl ESMAcceptDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ESMAcceptDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ESMAcceptDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ESMAcceptDependencyTemplate::template_type())
   }
 }
@@ -49,15 +49,15 @@ impl DependencyTemplate for ESMAcceptDependency {
 pub struct ESMAcceptDependencyTemplate;
 
 impl ESMAcceptDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ESMAcceptDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ESMAcceptDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ESMAcceptDependencyTemplate {
+impl DependencyTemplate for ESMAcceptDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
   FactorizeInfo, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
@@ -78,8 +78,8 @@ impl ModuleDependency for ImportMetaHotAcceptDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ImportMetaHotAcceptDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ImportMetaHotAcceptDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportMetaHotAcceptDependencyTemplate::template_type())
   }
 }
@@ -91,15 +91,15 @@ impl AsContextDependency for ImportMetaHotAcceptDependency {}
 pub struct ImportMetaHotAcceptDependencyTemplate;
 
 impl ImportMetaHotAcceptDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::ImportMetaHotAccept)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::ImportMetaHotAccept)
   }
 }
 
-impl DynamicDependencyTemplate for ImportMetaHotAcceptDependencyTemplate {
+impl DependencyTemplate for ImportMetaHotAcceptDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
   FactorizeInfo, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
@@ -78,8 +78,8 @@ impl ModuleDependency for ImportMetaHotDeclineDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ImportMetaHotDeclineDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ImportMetaHotDeclineDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportMetaHotDeclineDependencyTemplate::template_type())
   }
 }
@@ -91,15 +91,15 @@ impl AsContextDependency for ImportMetaHotDeclineDependency {}
 pub struct ImportMetaHotDeclineDependencyTemplate;
 
 impl ImportMetaHotDeclineDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::ImportMetaHotDecline)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::ImportMetaHotDecline)
   }
 }
 
-impl DynamicDependencyTemplate for ImportMetaHotDeclineDependencyTemplate {
+impl DependencyTemplate for ImportMetaHotDeclineDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
   FactorizeInfo, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
@@ -78,8 +78,8 @@ impl ModuleDependency for ModuleHotAcceptDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ModuleHotAcceptDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ModuleHotAcceptDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ModuleHotAcceptDependencyTemplate::template_type())
   }
 }
@@ -91,15 +91,15 @@ impl AsContextDependency for ModuleHotAcceptDependency {}
 pub struct ModuleHotAcceptDependencyTemplate;
 
 impl ModuleHotAcceptDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::ModuleHotAccept)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::ModuleHotAccept)
   }
 }
 
-impl DynamicDependencyTemplate for ModuleHotAcceptDependencyTemplate {
+impl DependencyTemplate for ModuleHotAcceptDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
   FactorizeInfo, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::Atom;
@@ -78,8 +78,8 @@ impl ModuleDependency for ModuleHotDeclineDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ModuleHotDeclineDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ModuleHotDeclineDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ModuleHotDeclineDependencyTemplate::template_type())
   }
 }
@@ -91,15 +91,15 @@ impl AsContextDependency for ModuleHotDeclineDependency {}
 pub struct ModuleHotDeclineDependencyTemplate;
 
 impl ModuleHotDeclineDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::ModuleHotDecline)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::ModuleHotDecline)
   }
 }
 
-impl DynamicDependencyTemplate for ModuleHotDeclineDependencyTemplate {
+impl DependencyTemplate for ModuleHotDeclineDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -1,9 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyId, DependencyTemplate, DependencyType,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, ExtendedReferencedExport,
-  FactorizeInfo, ModuleDependency, ModuleGraph, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCodeGeneration, DependencyId, DependencyTemplate,
+  DependencyTemplateType, DependencyType, ExtendedReferencedExport, FactorizeInfo,
+  ModuleDependency, ModuleGraph, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -73,8 +72,8 @@ impl ModuleDependency for WebpackIsIncludedDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for WebpackIsIncludedDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for WebpackIsIncludedDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(WebpackIsIncludedDependencyTemplate::template_type())
   }
 }
@@ -84,15 +83,15 @@ impl DependencyTemplate for WebpackIsIncludedDependency {
 pub struct WebpackIsIncludedDependencyTemplate;
 
 impl WebpackIsIncludedDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::WebpackIsIncluded)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::WebpackIsIncluded)
   }
 }
 
-impl DynamicDependencyTemplate for WebpackIsIncludedDependencyTemplate {
+impl DependencyTemplate for WebpackIsIncludedDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  Compilation, DependencyLocation, DependencyRange, DependencyTemplate, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, RuntimeGlobals, RuntimeSpec, SharedSourceMap, TemplateContext,
+  Compilation, DependencyCodeGeneration, DependencyLocation, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, RuntimeGlobals, RuntimeSpec, SharedSourceMap, TemplateContext,
   TemplateReplaceSource,
 };
 use rspack_util::ext::DynHash;
@@ -34,8 +34,8 @@ impl ModuleArgumentDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ModuleArgumentDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ModuleArgumentDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ModuleArgumentDependencyTemplate::template_type())
   }
 
@@ -55,15 +55,15 @@ impl DependencyTemplate for ModuleArgumentDependency {
 pub struct ModuleArgumentDependencyTemplate;
 
 impl ModuleArgumentDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ModuleArgumentDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ModuleArgumentDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ModuleArgumentDependencyTemplate {
+impl DependencyTemplate for ModuleArgumentDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -2,10 +2,9 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::IdentifierSet;
 use rspack_core::{
   filter_runtime, runtime_condition_expression, AsContextDependency, AsModuleDependency,
-  Compilation, ConnectionState, Dependency, DependencyId, DependencyTemplate,
-  DynamicDependencyTemplate, DynamicDependencyTemplateType, ModuleGraph, ModuleIdentifier,
-  RuntimeCondition, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedByExports,
-  UsedName,
+  Compilation, ConnectionState, Dependency, DependencyCodeGeneration, DependencyId,
+  DependencyTemplate, DependencyTemplateType, ModuleGraph, ModuleIdentifier, RuntimeCondition,
+  RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedByExports, UsedName,
 };
 use rspack_util::ext::DynHash;
 
@@ -85,8 +84,8 @@ impl Dependency for PureExpressionDependency {
 impl AsModuleDependency for PureExpressionDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for PureExpressionDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for PureExpressionDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(PureExpressionDependencyTemplate::template_type())
   }
 
@@ -108,15 +107,15 @@ impl AsContextDependency for PureExpressionDependency {}
 pub struct PureExpressionDependencyTemplate;
 
 impl PureExpressionDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("PureExpressionDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("PureExpressionDependency")
   }
 }
 
-impl DynamicDependencyTemplate for PureExpressionDependencyTemplate {
+impl DependencyTemplate for PureExpressionDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -1,9 +1,9 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
   get_dependency_used_by_exports_condition, module_id, AsContextDependency, Dependency,
-  DependencyCategory, DependencyCondition, DependencyId, DependencyRange, DependencyTemplate,
-  DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType, FactorizeInfo,
-  ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsedByExports,
+  DependencyCategory, DependencyCodeGeneration, DependencyCondition, DependencyId, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, FactorizeInfo, ModuleDependency,
+  RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsedByExports,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -90,8 +90,8 @@ impl ModuleDependency for URLDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for URLDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for URLDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(URLDependencyTemplate::template_type())
   }
 }
@@ -103,15 +103,15 @@ impl AsContextDependency for URLDependency {}
 pub struct URLDependencyTemplate;
 
 impl URLDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::NewUrl)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::NewUrl)
   }
 }
 
-impl DynamicDependencyTemplate for URLDependencyTemplate {
+impl DependencyTemplate for URLDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Dependency, DependencyCategory, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyType, DynamicDependencyTemplate,
-  DynamicDependencyTemplateType, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
+  DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -47,8 +47,8 @@ impl Dependency for CreateScriptUrlDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for CreateScriptUrlDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for CreateScriptUrlDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CreateScriptUrlDependencyTemplate::template_type())
   }
 }
@@ -61,15 +61,15 @@ impl AsContextDependency for CreateScriptUrlDependency {}
 pub struct CreateScriptUrlDependencyTemplate;
 
 impl CreateScriptUrlDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::CreateScriptUrl)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::CreateScriptUrl)
   }
 }
 
-impl DynamicDependencyTemplate for CreateScriptUrlDependencyTemplate {
+impl DependencyTemplate for CreateScriptUrlDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -4,8 +4,8 @@ pub use create_script_url_dependency::{
 };
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
+  AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
   ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, RuntimeGlobals,
   RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
@@ -95,8 +95,8 @@ impl ModuleDependency for WorkerDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for WorkerDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for WorkerDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(WorkerDependencyTemplate::template_type())
   }
 
@@ -117,15 +117,15 @@ impl AsContextDependency for WorkerDependency {}
 pub struct WorkerDependencyTemplate;
 
 impl WorkerDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::DependencyType(DependencyType::NewWorker)
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::NewWorker)
   }
 }
 
-impl DynamicDependencyTemplate for WorkerDependencyTemplate {
+impl DependencyTemplate for WorkerDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -82,12 +82,15 @@ impl JavaScriptParserAndGenerator {
       .get_module_graph()
       .dependency_by_id(dependency_id)
       .expect("should have dependency")
-      .as_dependency_template()
+      .as_dependency_code_generation()
     {
       if let Some(template) = compilation.get_dependency_template(dependency) {
         template.render(dependency, source, context)
       } else {
-        dependency.apply(source, context)
+        panic!(
+          "Can not find dependency template of {:?}",
+          dependency.dependency_template()
+        );
       }
     }
   }
@@ -309,7 +312,10 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
           if let Some(template) = compilation.get_dependency_template(dependency.as_ref()) {
             template.render(dependency.as_ref(), &mut source, &mut context)
           } else {
-            dependency.apply(&mut source, &mut context)
+            panic!(
+              "Can not find dependency template of {:?}",
+              dependency.dependency_template()
+            );
           }
         });
       };

--- a/crates/rspack_plugin_json/src/json_exports_dependency.rs
+++ b/crates/rspack_plugin_json/src/json_exports_dependency.rs
@@ -1,8 +1,8 @@
 use json::JsonValue;
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyId,
-  DependencyTemplate, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
+  AsContextDependency, AsModuleDependency, Compilation, Dependency, DependencyCodeGeneration,
+  DependencyId, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
   RuntimeSpec,
 };
 use rspack_util::{ext::DynHash, itoa};
@@ -49,7 +49,7 @@ impl AsModuleDependency for JsonExportsDependency {}
 impl AsContextDependency for JsonExportsDependency {}
 
 #[cacheable_dyn]
-impl DependencyTemplate for JsonExportsDependency {
+impl DependencyCodeGeneration for JsonExportsDependency {
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_lazy_compilation/src/dependency.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency, ModuleFactoryCreateData,
 };
 
@@ -44,7 +44,7 @@ impl ModuleDependency for LazyCompilationDependency {
   }
 }
 
-impl AsDependencyTemplate for LazyCompilationDependency {}
+impl AsDependencyCodeGeneration for LazyCompilationDependency {}
 impl AsContextDependency for LazyCompilationDependency {}
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
+++ b/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
@@ -1,9 +1,9 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType,
-  ExternalRequest, ExternalType, FactorizeInfo, ImportAttributes, ModuleDependency,
-  TemplateContext, TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExternalRequest,
+  ExternalType, FactorizeInfo, ImportAttributes, ModuleDependency, TemplateContext,
+  TemplateReplaceSource,
 };
 use rspack_plugin_javascript::dependency::create_resource_identifier_for_esm_dependency;
 use swc_core::ecma::atoms::Atom;
@@ -101,8 +101,8 @@ impl ModuleDependency for ModernModuleImportDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ModernModuleImportDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ModernModuleImportDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ModernModuleImportDependencyTemplate::template_type())
   }
 }
@@ -113,15 +113,15 @@ impl AsContextDependency for ModernModuleImportDependency {}
 #[derive(Debug, Clone, Default)]
 pub struct ModernModuleImportDependencyTemplate;
 impl ModernModuleImportDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ModernModuleImportDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ModernModuleImportDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ModernModuleImportDependencyTemplate {
+impl DependencyTemplate for ModernModuleImportDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
     _code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_library/src/modern_module/reexport_star_external_dependency.rs
+++ b/crates/rspack_plugin_library/src/modern_module/reexport_star_external_dependency.rs
@@ -1,9 +1,9 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, DynamicDependencyTemplate, DynamicDependencyTemplateType, ExternalRequest,
-  ExternalType, FactorizeInfo, InitFragmentExt, InitFragmentKey, InitFragmentStage,
-  ModuleDependency, NormalInitFragment, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExternalRequest, ExternalType,
+  FactorizeInfo, InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleDependency,
+  NormalInitFragment, TemplateContext, TemplateReplaceSource,
 };
 use rspack_plugin_javascript::dependency::create_resource_identifier_for_esm_dependency;
 use swc_core::ecma::atoms::Atom;
@@ -86,8 +86,8 @@ impl ModuleDependency for ModernModuleReexportStarExternalDependency {
 }
 
 #[cacheable_dyn]
-impl DependencyTemplate for ModernModuleReexportStarExternalDependency {
-  fn dynamic_dependency_template(&self) -> Option<DynamicDependencyTemplateType> {
+impl DependencyCodeGeneration for ModernModuleReexportStarExternalDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ModernModuleReexportStarExternalDependencyTemplate::template_type())
   }
 }
@@ -99,15 +99,15 @@ impl AsContextDependency for ModernModuleReexportStarExternalDependency {}
 pub struct ModernModuleReexportStarExternalDependencyTemplate;
 
 impl ModernModuleReexportStarExternalDependencyTemplate {
-  pub fn template_type() -> DynamicDependencyTemplateType {
-    DynamicDependencyTemplateType::CustomType("ModernModuleReexportStarExternalDependency")
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ModernModuleReexportStarExternalDependency")
   }
 }
 
-impl DynamicDependencyTemplate for ModernModuleReexportStarExternalDependencyTemplate {
+impl DependencyTemplate for ModernModuleReexportStarExternalDependencyTemplate {
   fn render(
     &self,
-    dep: &dyn DependencyTemplate,
+    dep: &dyn DependencyCodeGeneration,
     _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {

--- a/crates/rspack_plugin_mf/src/container/container_entry_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -77,4 +77,4 @@ impl ModuleDependency for ContainerEntryDependency {
 }
 
 impl AsContextDependency for ContainerEntryDependency {}
-impl AsDependencyTemplate for ContainerEntryDependency {}
+impl AsDependencyCodeGeneration for ContainerEntryDependency {}

--- a/crates/rspack_plugin_mf/src/container/container_exposed_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/container_exposed_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -72,4 +72,4 @@ impl ModuleDependency for ContainerExposedDependency {
 }
 
 impl AsContextDependency for ContainerExposedDependency {}
-impl AsDependencyTemplate for ContainerExposedDependency {}
+impl AsDependencyCodeGeneration for ContainerExposedDependency {}

--- a/crates/rspack_plugin_mf/src/container/fallback_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -64,4 +64,4 @@ impl ModuleDependency for FallbackDependency {
 }
 
 impl AsContextDependency for FallbackDependency {}
-impl AsDependencyTemplate for FallbackDependency {}
+impl AsDependencyCodeGeneration for FallbackDependency {}

--- a/crates/rspack_plugin_mf/src/container/fallback_item_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_item_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -57,4 +57,4 @@ impl ModuleDependency for FallbackItemDependency {
 }
 
 impl AsContextDependency for FallbackItemDependency {}
-impl AsDependencyTemplate for FallbackItemDependency {}
+impl AsDependencyCodeGeneration for FallbackItemDependency {}

--- a/crates/rspack_plugin_mf/src/container/remote_to_external_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_to_external_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -57,4 +57,4 @@ impl ModuleDependency for RemoteToExternalDependency {
 }
 
 impl AsContextDependency for RemoteToExternalDependency {}
-impl AsDependencyTemplate for RemoteToExternalDependency {}
+impl AsDependencyCodeGeneration for RemoteToExternalDependency {}

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_fallback_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_fallback_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -57,4 +57,4 @@ impl ModuleDependency for ConsumeSharedFallbackDependency {
 }
 
 impl AsContextDependency for ConsumeSharedFallbackDependency {}
-impl AsDependencyTemplate for ConsumeSharedFallbackDependency {}
+impl AsDependencyCodeGeneration for ConsumeSharedFallbackDependency {}

--- a/crates/rspack_plugin_mf/src/sharing/provide_for_shared_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_for_shared_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -57,4 +57,4 @@ impl ModuleDependency for ProvideForSharedDependency {
 }
 
 impl AsContextDependency for ProvideForSharedDependency {}
-impl AsDependencyTemplate for ProvideForSharedDependency {}
+impl AsDependencyCodeGeneration for ProvideForSharedDependency {}

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
@@ -98,4 +98,4 @@ impl ModuleDependency for ProvideSharedDependency {
 }
 
 impl AsContextDependency for ProvideSharedDependency {}
-impl AsDependencyTemplate for ProvideSharedDependency {}
+impl AsDependencyCodeGeneration for ProvideSharedDependency {}

--- a/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
+++ b/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
@@ -3,7 +3,7 @@ use rspack_cacheable::{
   with::{AsPreset, Unsupported},
 };
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyRange, DependencyType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
   ModuleGraph, RuntimeSpec,
 };
@@ -94,6 +94,6 @@ impl ModuleDependency for WasmImportDependency {
   }
 }
 
-impl AsDependencyTemplate for WasmImportDependency {}
+impl AsDependencyCodeGeneration for WasmImportDependency {}
 
 impl AsContextDependency for WasmImportDependency {}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Remove `DependencyTemplate.apply` and replace its callings with panic
- Rename `DependencyTemplate` to `DependencyCodeGeneration`
- Rename `AsDependencyTemplate` to `AsDependencyCodeGeneration`
- Rename `DynamicDependencyTemplate` and `DynamicDependencyTemplateType` to `DependencyTemplate` and `DependencyTemplateType`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
