### PR TITLE
chore: use async trace style for chrome tracing

### DIFF
--- a/crates/rspack_tracing/src/chrome.rs
+++ b/crates/rspack_tracing/src/chrome.rs
@@ -15,6 +15,7 @@ impl Tracer for ChromeTracer {
   fn setup(&mut self, output: &str) -> Option<Layered> {
     let trace_writer = TraceWriter::from(output);
     let (chrome_layer, guard) = ChromeLayerBuilder::new()
+      .trace_style(tracing_chrome::TraceStyle::Async)
       .include_args(true)
       .writer(trace_writer.writer())
       .build();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
since most of rspack task is async task, async trace style is much readable than thread trace style
* async style
![image](https://github.com/user-attachments/assets/4d3fe9f8-1487-41e5-bf36-f87290df3a59)
* thread style
![image](https://github.com/user-attachments/assets/71a31845-b7a1-45eb-aaa2-cc8c314d57e6)


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
