### PR TITLE
ci: use node v22 in ecosystem-ci

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -156,6 +156,8 @@ jobs:
 
       - name: Pnpm Setup
         uses: ./.github/actions/pnpm/setup
+        with:
+          node-version: "22"
 
       - name: Pnpm Install
         uses: ./.github/actions/pnpm/install-dependencies


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix the EcoSystem CI failure as noted [here](https://github.com/web-infra-dev/rspack/actions/runs/14358129696/job/40253930696), caused by lynx-family/lynx-stack requiring Node.js v22.

It seems reasonable to update all tests to use Node.js v22 since it is LTS now.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
