### PR TITLE
fix: stablelize order of concated modules

### DIFF
--- a/crates/node_binding/src/module_graph.rs
+++ b/crates/node_binding/src/module_graph.rs
@@ -167,7 +167,7 @@ impl JsModuleGraph {
     let (compilation, module_graph) = self.as_ref()?;
     Ok(
       module_graph
-        .get_outgoing_connections_in_order(&module.identifier)
+        .get_outgoing_deps_in_order(&module.identifier)
         .map(|dependency_id| ModuleGraphConnectionWrapper::new(*dependency_id, compilation))
         .collect::<Vec<_>>(),
     )

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -1598,7 +1598,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       Vec<DependencyId>,
     > = IndexMap::default();
 
-    for dep_id in module_graph.get_outgoing_connections_in_order(&module) {
+    for dep_id in module_graph.get_outgoing_deps_in_order(&module) {
       let dep = module_graph
         .dependency_by_id(dep_id)
         .expect("should have dep");

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -299,7 +299,7 @@ impl ChunkGraph {
     let mut visited_modules = IdentifierSet::default();
     visited_modules.insert(module.identifier());
     for connection in mg
-      .get_outgoing_connections_in_order(&module.identifier())
+      .get_outgoing_deps_in_order(&module.identifier())
       .filter_map(|c| mg.connection_by_dependency_id(c))
     {
       let module_identifier = connection.module_identifier();

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1616,7 +1616,8 @@ impl ConcatenatedModule {
     runtime: Option<&RuntimeSpec>,
     mg: &'a ModuleGraph,
   ) -> Vec<ConnectionWithRuntimeCondition<'a>> {
-    let mut connections = mg.get_outgoing_connections(module_id).collect::<Vec<_>>();
+    let mut connections: Vec<&ModuleGraphConnection> =
+      mg.get_ordered_outgoing_connections(module_id).collect();
     if module_id == root_module_id {
       for c in mg.get_outgoing_connections(&self.id) {
         connections.push(c);

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -820,7 +820,22 @@ impl<'a> ModuleGraph<'a> {
     exports_info.get_export_info(self, export_name)
   }
 
-  pub fn get_outgoing_connections_in_order(
+  pub fn get_ordered_outgoing_connections(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> impl Iterator<Item = &ModuleGraphConnection> {
+    self
+      .module_graph_module_by_identifier(module_identifier)
+      .map(|m| {
+        m.all_dependencies
+          .iter()
+          .filter_map(|dep_id| self.connection_by_dependency_id(dep_id))
+      })
+      .into_iter()
+      .flatten()
+  }
+
+  pub fn get_outgoing_deps_in_order(
     &self,
     module_identifier: &ModuleIdentifier,
   ) -> impl Iterator<Item = &DependencyId> {

--- a/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
@@ -87,7 +87,7 @@ impl CodeSplittingCache {
         let mut visited = IdentifierSet::default();
         let mut active_modules = IdentifierSet::default();
         module_graph
-          .get_outgoing_connections_in_order(&module)
+          .get_outgoing_deps_in_order(&module)
           .filter_map(|dep| module_graph.connection_by_dependency_id(dep))
           .map(|conn| {
             let m = *conn.module_identifier();
@@ -209,7 +209,7 @@ impl CodeSplittingCache {
 
     for module in affected_modules.clone() {
       let outgoings = module_graph
-        .get_outgoing_connections_in_order(&module)
+        .get_outgoing_deps_in_order(&module)
         .filter_map(|dep| module_graph.connection_by_dependency_id(dep))
         .filter(|conn| conn.active_state(&module_graph, None).is_not_false())
         .map(|conn| conn.module_identifier());

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/a.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/b.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/b.js
@@ -1,0 +1,1 @@
+export const b = 1;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/barrel.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/barrel.js
@@ -1,0 +1,7 @@
+export { a } from './a'
+export { b } from './b'
+export { c } from './c'
+export { d } from './d'
+export { e } from './e'
+export { f } from './f'
+export { g } from './g'

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/c.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/c.js
@@ -1,0 +1,1 @@
+export const c = 1;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/d.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/d.js
@@ -1,0 +1,1 @@
+export const d = 1;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/e.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/e.js
@@ -1,0 +1,1 @@
+export const e = 1;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/export-imported.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/export-imported.js
@@ -1,0 +1,1 @@
+export { a, b, c, d, e, f, g } from './barrel'

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/f.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/f.js
@@ -1,0 +1,1 @@
+export const f = 1;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/g.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/g.js
@@ -1,0 +1,1 @@
+export const g = 1;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/index.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/index.js
@@ -1,0 +1,22 @@
+import * as namespace from './export-imported'
+
+// consume
+namespace;
+
+it('should have correct consistent order', () => {
+	const fs = __non_webpack_require__('fs')
+	const path = __non_webpack_require__('path')
+	/** @type {string} */
+	const code = fs.readFileSync(path.resolve(__dirname, './bundle.js')).toString()
+
+	const re = /;\/\/ CONCATENATED MODULE: (.*)\n/g;
+
+	const [a, b, c, d, e, f, g] = [...code.matchAll(re)]
+	expect(a[1]).toBe('./a.js')
+	expect(b[1]).toBe('./b.js')
+	expect(c[1]).toBe('./c.js')
+	expect(d[1]).toBe('./d.js')
+	expect(e[1]).toBe('./e.js')
+	expect(f[1]).toBe('./f.js')
+	expect(g[1]).toBe('./g.js')
+})

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/rspack.config.js
@@ -1,0 +1,21 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	module: {
+		rules: [
+			{
+				test: /\.js/,
+				sideEffects: false
+			}
+		]
+	},
+	output: {
+		filename: "bundle.js"
+	},
+	optimization: {
+		concatenateModules: true,
+		sideEffects: true,
+		moduleIds: "named",
+		minimize: false
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/consistent-concat-order/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["bundle.js"];
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Stablelize the order of concatenated modules.

Iterate `FxHashSet` is not stable, `ModuleConcatenatePlugin` uses `dep.sourceOrder` to ensure the order, however the `sourceOrder` can be the same.

For example:

```
export { a, b } from 'lib';
```

Code above contains 2 [`ExportImportedDependency`](https://webpack-dependencies-visualize.vercel.app/#code=ZXhwb3J0IHsgYSwgYiB9IGZyb20gJ2xpYic7), and they have the same `sourceOrder`. So the sorting algorithm is not safe

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
