### PR TITLE
docs: add next.js guide to sidebar

### DIFF
--- a/website/docs/en/guide/tech/_meta.json
+++ b/website/docs/en/guide/tech/_meta.json
@@ -6,7 +6,8 @@
   "react",
   "preact",
   "vue",
+  "next",
+  "nestjs",
   "solid",
-  "svelte",
-  "nestjs"
+  "svelte"
 ]

--- a/website/docs/en/guide/tech/next.mdx
+++ b/website/docs/en/guide/tech/next.mdx
@@ -4,9 +4,13 @@ import { Tabs, Tab, PackageManagerTabs } from '@theme';
 
 [next-rspack](https://www.npmjs.com/package/next-rspack) is a community-driven plugin that enables Next.js projects to use Rspack as the bundler.
 
-> Example: [next.js/examples/with-rspack](https://github.com/vercel/next.js/tree/canary/examples/with-rspack).
+:::tip
+See the [Rspack joins the Next.js ecosystem](/blog/rspack-next-partner) blog post to learn more details.
+:::
 
 ## Installation
+
+Install the `next-rspack` package:
 
 <PackageManagerTabs command="add next-rspack -D" />
 
@@ -44,6 +48,8 @@ module.exports = withRspack(nextConfig);
 
   </Tab>
 </Tabs>
+
+> Example: [next.js/examples/with-rspack](https://github.com/vercel/next.js/tree/canary/examples/with-rspack).
 
 ## Customizing Rspack Configuration
 

--- a/website/docs/zh/guide/tech/_meta.json
+++ b/website/docs/zh/guide/tech/_meta.json
@@ -6,7 +6,8 @@
   "react",
   "preact",
   "vue",
+  "next",
+  "nestjs",
   "solid",
-  "svelte",
-  "nestjs"
+  "svelte"
 ]

--- a/website/docs/zh/guide/tech/next.mdx
+++ b/website/docs/zh/guide/tech/next.mdx
@@ -4,9 +4,13 @@ import { Tabs, Tab, PackageManagerTabs } from '@theme';
 
 [next-rspack](https://www.npmjs.com/package/next-rspack) 是一个社区驱动的插件，它允许 Next.js 项目使用 Rspack 作为打包工具。
 
-> 示例：[next.js/examples/with-rspack](https://github.com/vercel/next.js/tree/canary/examples/with-rspack)。
+:::tip
+查看 [Rspack joins the Next.js ecosystem](https://rspack.dev/blog/rspack-next-partner) 博客文章了解更多。
+:::
 
 ## 安装
+
+安装 `next-rspack` 包：
 
 <PackageManagerTabs command="add next-rspack -D" />
 
@@ -44,6 +48,8 @@ module.exports = withRspack(nextConfig);
 
   </Tab>
 </Tabs>
+
+> 示例：[next.js/examples/with-rspack](https://github.com/vercel/next.js/tree/canary/examples/with-rspack)。
 
 ## 自定义 Rspack 配置
 


### PR DESCRIPTION
## Summary

- Add next.js guide to sidebar
- Add blog post link

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
