### PR TITLE
chore: use RefCell instead of Mutex in thread_local!

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -5,11 +5,7 @@
 extern crate napi_derive;
 extern crate rspack_allocator;
 
-use std::{
-  cell::RefCell,
-  pin::Pin,
-  sync::{Arc, Mutex},
-};
+use std::{cell::RefCell, pin::Pin, sync::Arc};
 
 use compiler::{Compiler, CompilerState, CompilerStateGuard};
 use napi::{bindgen_prelude::*, CallContext};
@@ -404,7 +400,7 @@ fn print_error_diagnostic(e: rspack_error::Error, colored: bool) -> String {
 }
 
 thread_local! {
-  static GLOBAL_TRACE_STATE: Mutex<TraceState> = const { Mutex::new(TraceState::Off) };
+  static GLOBAL_TRACE_STATE: RefCell<TraceState> = const { RefCell::new(TraceState::Off) };
 }
 
 /**
@@ -421,7 +417,7 @@ pub fn register_global_trace(
   output: String,
 ) -> anyhow::Result<()> {
   GLOBAL_TRACE_STATE.with(|state| {
-    let mut state = state.lock().expect("Failed to lock GLOBAL_TRACE_STATE");
+    let mut state = state.borrow_mut();
     if let TraceState::Off = *state {
       let mut tracer: Box<dyn Tracer> = match layer.as_str() {
         "chrome" => Box::new(ChromeTracer::default()),
@@ -460,7 +456,7 @@ pub fn register_global_trace(
 #[napi]
 pub fn cleanup_global_trace() {
   GLOBAL_TRACE_STATE.with(|state| {
-    let mut state = state.lock().expect("Failed to lock GLOBAL_TRACE_STATE");
+    let mut state = state.borrow_mut();
     if let TraceState::On(ref mut tracer) = *state {
       tracer.teardown();
     }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

It doesn't make sense to use a `Mutex` in this case, `RefCell` is a lower-cost option. but this probably won't give any performance improvement, since there's no access to `GLOBAL_TRACE_STATE` outside of `register_global_trace` and `cleanup_global_trace`.


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
