### PR TITLE
fix: sometimes entry chunk hash not changes with full hash runtime modules

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -88,6 +88,7 @@ define_hook!(CompilationOptimizeCodeGeneration: Series(compilation: &mut Compila
 define_hook!(CompilationAfterCodeGeneration: Series(compilation: &mut Compilation));
 define_hook!(CompilationChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash));
 define_hook!(CompilationContentHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hashes: &mut HashMap<SourceType, RspackHash>));
+define_hook!(CompilationDependentFullHash: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> bool);
 define_hook!(CompilationRenderManifest: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, manifest: &mut Vec<RenderManifestEntry>, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationChunkAsset: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, filename: &str));
 define_hook!(CompilationProcessAssets: Series(compilation: &mut Compilation));
@@ -123,6 +124,7 @@ pub struct CompilationHooks {
   pub after_code_generation: CompilationAfterCodeGenerationHook,
   pub chunk_hash: CompilationChunkHashHook,
   pub content_hash: CompilationContentHashHook,
+  pub dependent_full_hash: CompilationDependentFullHashHook,
   pub render_manifest: CompilationRenderManifestHook,
   pub chunk_asset: CompilationChunkAssetHook,
   pub process_assets: CompilationProcessAssetsHook,
@@ -2017,20 +2019,25 @@ impl Compilation {
 
     fn try_process_chunk_hash_results(
       compilation: &mut Compilation,
-      chunk_hash_results: Vec<Result<(ChunkUkey, (RspackHashDigest, ChunkContentHash))>>,
+      chunk_hash_results: Vec<Result<(ChunkUkey, (RspackHashDigest, ChunkContentHash, bool))>>,
+      full_hash_chunks: &mut UkeySet<ChunkUkey>,
     ) -> Result<()> {
       for hash_result in chunk_hash_results {
-        let (chunk_ukey, (chunk_hash, content_hash)) = hash_result?;
+        let (chunk_ukey, (chunk_hash, content_hash, dependent_full_hash)) = hash_result?;
         let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
         chunk.set_hashes(
           &mut compilation.chunk_hashes_artifact,
           chunk_hash,
           content_hash,
         );
+        if dependent_full_hash {
+          full_hash_chunks.insert(chunk_ukey);
+        }
       }
       Ok(())
     }
 
+    let mut full_hash_chunks = UkeySet::default();
     let unordered_runtime_chunks: UkeySet<ChunkUkey> = self.get_chunk_graph_entries().collect();
     let start = logger.time("hashing: hash chunks");
     let other_chunks: Vec<_> = create_hash_chunks
@@ -2048,13 +2055,14 @@ impl Compilation {
       }
     }
     // create hash for other chunks
-    let other_chunks_hash_results: Vec<Result<(ChunkUkey, (RspackHashDigest, ChunkContentHash))>> =
-      join_all(other_chunks.into_iter().map(|chunk| async {
-        let hash_result = self.process_chunk_hash(*chunk, &plugin_driver).await?;
-        Ok((*chunk, hash_result))
-      }))
-      .await;
-    try_process_chunk_hash_results(self, other_chunks_hash_results)?;
+    let other_chunks_hash_results: Vec<
+      Result<(ChunkUkey, (RspackHashDigest, ChunkContentHash, bool))>,
+    > = join_all(other_chunks.into_iter().map(|chunk| async {
+      let hash_result = self.process_chunk_hash(*chunk, &plugin_driver).await?;
+      Ok((*chunk, hash_result))
+    }))
+    .await;
+    try_process_chunk_hash_results(self, other_chunks_hash_results, &mut full_hash_chunks)?;
     logger.time_end(start);
 
     // collect references for runtime chunks
@@ -2091,7 +2099,7 @@ impl Compilation {
       }
     }
     let mut ready_chunks = Vec::new();
-    let mut full_hash_chunks = UkeySet::default();
+
     let mut i = 0;
     while i < runtime_chunks.len() {
       let chunk_ukey = runtime_chunks[i];
@@ -2174,7 +2182,7 @@ impl Compilation {
           .runtime_modules_hash
           .insert(*runtime_module_identifier, digest);
       }
-      let (chunk_hash, content_hash) = self
+      let (chunk_hash, content_hash, _) = self
         .process_chunk_hash(runtime_chunk_ukey, &plugin_driver)
         .await?;
       let chunk = self.chunk_by_ukey.expect_get(&runtime_chunk_ukey);
@@ -2196,10 +2204,10 @@ impl Compilation {
 
     // re-create runtime chunk hash that depend on full hash
     let start = logger.time("hashing: process full hash chunks");
-    for runtime_chunk_ukey in full_hash_chunks {
+    for chunk_ukey in full_hash_chunks {
       for runtime_module_identifier in self
         .chunk_graph
-        .get_chunk_runtime_modules_iterable(&runtime_chunk_ukey)
+        .get_chunk_runtime_modules_iterable(&chunk_ukey)
       {
         let runtime_module = &self.runtime_modules[runtime_module_identifier];
         if runtime_module.full_hash() || runtime_module.dependent_hash() {
@@ -2209,7 +2217,7 @@ impl Compilation {
             .insert(*runtime_module_identifier, digest);
         }
       }
-      let chunk = self.chunk_by_ukey.expect_get(&runtime_chunk_ukey);
+      let chunk = self.chunk_by_ukey.expect_get(&chunk_ukey);
       let new_chunk_hash = {
         let chunk_hash = chunk
           .hash(&self.chunk_hashes_artifact)
@@ -2290,7 +2298,7 @@ impl Compilation {
     &self,
     chunk_ukey: ChunkUkey,
     plugin_driver: &SharedPluginDriver,
-  ) -> Result<(RspackHashDigest, ChunkContentHash)> {
+  ) -> Result<(RspackHashDigest, ChunkContentHash, bool)> {
     let mut hasher = RspackHash::from(&self.options.output);
     if let Some(chunk) = self.chunk_by_ukey.get(&chunk_ukey) {
       chunk.update_hash(&mut hasher, self);
@@ -2313,7 +2321,17 @@ impl Compilation {
       .map(|(t, hasher)| (t, hasher.digest(&self.options.output.hash_digest)))
       .collect();
 
-    Ok((chunk_hash, content_hashes))
+    let dependent_full_hash = plugin_driver
+      .compilation_hooks
+      .dependent_full_hash
+      .call(self, &chunk_ukey)
+      .await?;
+
+    Ok((
+      chunk_hash,
+      content_hashes,
+      dependent_full_hash.unwrap_or(false),
+    ))
   }
 
   #[instrument("Compilation:create_module_hashes", skip_all)]

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -57,6 +57,18 @@ impl Filename {
   pub fn as_str(&self) -> &str {
     self.template().unwrap_or("")
   }
+  pub fn has_hash_placeholder(&self) -> bool {
+    match &self.0 {
+      FilenameKind::Template(atom) => has_hash_placeholder(atom.as_str()),
+      FilenameKind::Fn(_) => true,
+    }
+  }
+  pub fn has_content_hash_placeholder(&self) -> bool {
+    match &self.0 {
+      FilenameKind::Template(atom) => has_content_hash_placeholder(atom.as_str()),
+      FilenameKind::Fn(_) => true,
+    }
+  }
   pub fn template(&self) -> Option<&str> {
     match &self.0 {
       FilenameKind::Template(template) => Some(template.as_str()),
@@ -165,6 +177,16 @@ pub fn has_hash_placeholder(template: &str) -> bool {
       if template[start + offset..].find(']').is_some() {
         return true;
       }
+    }
+  }
+  false
+}
+
+pub fn has_content_hash_placeholder(template: &str) -> bool {
+  let offset = CONTENT_HASH_PLACEHOLDER.len() - 1;
+  if let Some(start) = template.find(&CONTENT_HASH_PLACEHOLDER[..offset]) {
+    if template[start + offset..].find(']').is_some() {
+      return true;
     }
   }
   false

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -17,7 +17,7 @@ use rspack_util::json_stringify;
 
 use crate::{
   generate_entry_startup, get_chunk_output_name, get_relative_path, get_runtime_chunk_output_name,
-  runtime_chunk_has_full_hash, update_hash_for_entry_startup,
+  runtime_chunk_has_hash, update_hash_for_entry_startup,
 };
 
 const PLUGIN_NAME: &str = "rspack.CommonJsChunkFormatPlugin";
@@ -98,7 +98,7 @@ async fn compilation_dependent_full_hash(
 ) -> Result<Option<bool>> {
   let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
   if chunk.has_entry_module(&compilation.chunk_graph)
-    && runtime_chunk_has_full_hash(compilation, chunk_ukey).await?
+    && runtime_chunk_has_hash(compilation, chunk_ukey).await?
   {
     return Ok(Some(true));
   }

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -135,7 +135,7 @@ pub async fn get_runtime_chunk_output_name(
   get_chunk_output_name(runtime_chunk, compilation).await
 }
 
-pub async fn runtime_chunk_has_full_hash(
+pub async fn runtime_chunk_has_hash(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
 ) -> Result<bool> {

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -20,7 +20,7 @@ use rustc_hash::FxHashSet as HashSet;
 use super::update_hash_for_entry_startup;
 use crate::{
   chunk_has_js, get_all_chunks, get_chunk_output_name, get_relative_path,
-  get_runtime_chunk_output_name, runtime_chunk_has_full_hash,
+  get_runtime_chunk_output_name, runtime_chunk_has_hash,
 };
 
 const PLUGIN_NAME: &str = "rspack.ModuleChunkFormatPlugin";
@@ -105,7 +105,7 @@ async fn compilation_dependent_full_hash(
 
   let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
   if chunk.has_entry_module(&compilation.chunk_graph)
-    && runtime_chunk_has_full_hash(compilation, chunk_ukey).await?
+    && runtime_chunk_has_hash(compilation, chunk_ukey).await?
   {
     return Ok(Some(true));
   }

--- a/packages/rspack-test-tools/tests/NewIncremental-watch.test.js
+++ b/packages/rspack-test-tools/tests/NewIncremental-watch.test.js
@@ -20,6 +20,8 @@ describeByWalk(
 	},
 	{
 		source: path.resolve(__dirname, "./watchCases"),
-		dist: path.resolve(__dirname, `./js/new-incremental/watch`)
+		dist: path.resolve(__dirname, `./js/new-incremental/watch`),
+		// TODO: fix this test case
+		exclude: [/runtimeChunkFullHash/]
 	}
 );

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/0/full-hash.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/0/full-hash.js
@@ -1,0 +1,1 @@
+__webpack_hash__;

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/0/index.js
@@ -1,0 +1,5 @@
+import "./full-hash";
+
+it("test", () => {
+  console.log("test");
+});

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/0/index2.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/0/index2.js
@@ -1,0 +1,4 @@
+import "./full-hash";
+
+it("test", () => {
+});

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/1/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/1/index.js
@@ -1,0 +1,3 @@
+it("test", () => {
+  console.log("test1");
+});

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/rspack.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+	mode: "development",
+	entry: {
+		main: "./index.js",
+		entry2: "./index2.js"
+	},
+	output: {
+		chunkLoading: "import",
+		chunkFormat: "module",
+		filename: "[name].[contenthash:8].js",
+		chunkFilename: "[name].[contenthash:8].chunk.js"
+	},
+	optimization: {
+		runtimeChunk: true,
+		minimize: false
+	},
+	experiments: {
+		css: true,
+		outputModule: true
+	}
+};

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkFullHash/test.config.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+let outputPath = "";
+
+module.exports = {
+	findBundle(i, config) {
+		outputPath = config.output.path;
+		return [];
+	},
+	checkStats(i, stats) {
+		const assets = stats.assets;
+		const main = assets.find(i => i.name.startsWith("main."));
+		const runtimeMain = assets.find(i => i.name.startsWith("runtime~main."));
+		const entry2 = assets.find(i => i.name.startsWith("entry2."));
+		const runtimeEntry2 = assets.find(i =>
+			i.name.startsWith("runtime~entry2.")
+		);
+
+		const mainContent = fs.readFileSync(
+			path.join(outputPath, main.name),
+			"utf-8"
+		);
+		const entry2Content = fs.readFileSync(
+			path.join(outputPath, entry2.name),
+			"utf-8"
+		);
+
+		expect(mainContent.includes(runtimeMain.name)).toBe(true);
+		expect(entry2Content.includes(runtimeEntry2.name)).toBe(true);
+
+		return true;
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/9985

In this repro https://github.com/hikerpig/module-runtimechunk-repro, the combination of `chunkFormat: module` and `runtimeChunk: true` causes the entry chunk to import the runtime chunk via `import __webpack_require__ from "./runtime~main.857eaa3b.js";`.

This leads to a situation, when relying on full hash (such as the entry injected by the dev server), during incremental builds in the dev mode, changes of the full hash will cause changes in the content of the runtime chunk. If the filename of the runtime chunk contains `[contenthash]`, then its final filename will change. At this time, due to the above mentioned `import` statement, the content of the entry chunk will also change, and consequently, its `[contenthash]` will change.

However, when rspack calculates the `contenthash` of a chunk, it doesn't take this scenario into account. Because the entry chunk itself has no real relation to these changes, and the import statement is startup code injected during the code generation of the chunk. So when these contents change, the contenthash and chunkhash of the entry chunk in rspack won't change. As a result, the chunk code generation cache takes effect, and the runtime chunk from the previous compilation is referenced.

In Webpack, when adding a runtime module, the runtime module is associated with this chunk. When handling the chunk hash, for normal chunks, it also checks whether they contain full hash modules just like runtime chunks, and then includes the chunk in the hash update process of full hash chunks. However, in rspack, this associative relationship doesn't exist, and the chunk hash only deals with the full hash update of runtime chunks. 

So this PR only applies to the scenarios of `commonjs` and `module` chunkFormats. If they introduce the loading statement of the runtime chunk, then this entry chunk will be added to the full - hash update, causing the cache of this entry chunk to become invalid, thus fixing this issue.

However, in the `new incremental`, `Mutation::ModuleSetHashes` only affects the chunks associated with the module. This causes the chunk hashing process to be skipped, and the problem still persists. I haven't found a good solution to this.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
