### PR TITLE
chore: improve tracing

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -702,9 +702,8 @@ impl Compilation {
     );
     Ok(())
   }
-
+  #[instrument("Compilation:emit_asset",skip_all, fields(filename = filename))]
   pub fn emit_asset(&mut self, filename: String, asset: CompilationAsset) {
-    tracing::trace!("Emit asset {}", filename);
     if let Some(mut original) = self.assets.remove(&filename)
       && let Some(original_source) = &original.source
       && let Some(asset_source) = asset.get_source()

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -386,8 +386,6 @@ impl Compiler {
       .call(&mut self.compilation)
       .await
   }
-
-  #[instrument(skip_all, fields(filename = filename))]
   async fn emit_asset(
     &self,
     output_path: &Utf8Path,

--- a/crates/rspack_tracing/src/chrome.rs
+++ b/crates/rspack_tracing/src/chrome.rs
@@ -17,6 +17,7 @@ impl Tracer for ChromeTracer {
     let (chrome_layer, guard) = ChromeLayerBuilder::new()
       .trace_style(tracing_chrome::TraceStyle::Async)
       .include_args(true)
+      .category_fn(Box::new(|_| "rspack".to_string()))
       .writer(trace_writer.writer())
       .build();
     self.guard = Some(guard);
@@ -40,6 +41,7 @@ impl<S> Filter<S> for FilterEvent {
     meta: &tracing::Metadata<'_>,
     _cx: &tracing_subscriber::layer::Context<'_, S>,
   ) -> bool {
-    !meta.is_event()
+    // filter out swc related tracing because it's too much noisy for info level now
+    !meta.is_event() && !meta.target().contains("swc")
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
improve tracing readability by following ways
* filter out swc related tracing: swc use info level trace for ast visitor which is too verbose now, so disable it by default, we can turn it on if swc use trace level to trace ast visitor
* unify cat for perftto: perfetto will split tracing data according to cat(It seems a weird behavior for legacy chrome event), we can use track_id to separate meaningful trace in the future(which is suggested by perfetto)
* fix emit_asset trace: remove unnecessary trace event for emit_asset
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
## result
* before
* after
![image](https://github.com/user-attachments/assets/01b0ef36-3083-44c0-bcff-33e442b72f39)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
