### PR TITLE
docs: add a standalone ecosystem page

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -972,8 +972,8 @@ importers:
   website:
     dependencies:
       '@rstack-dev/doc-ui':
-        specifier: 1.7.3
-        version: 1.7.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 1.7.4
+        version: 1.7.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       axios:
         specifier: ^1.8.4
         version: 1.8.4
@@ -3141,8 +3141,8 @@ packages:
     resolution: {integrity: sha512-mV9urKnzf/1T/ufzHHnCPnxQJW7ffl7x+l62jm8xK0H4l8sNqLpLt0FekASmf4w5wNCAEpYHjciemzECc755fA==}
     engines: {node: '>=14.17.6'}
 
-  '@rstack-dev/doc-ui@1.7.3':
-    resolution: {integrity: sha512-rWJgZoe2bG9dMLjRUMjifU3SyF2JR/73fkPVJfUfp34xZS8fnOYVBEvHJkKuBwKOzFwEthz0nbO5mDu+kaGpuQ==}
+  '@rstack-dev/doc-ui@1.7.4':
+    resolution: {integrity: sha512-hv2yN06dOwftQqRGIuXk7ij1phkdEFCg9qYEOCz0s2dTAtjmI4OaYlLLyAM1m2ip6/ivx8i726fKgUD+Noen2Q==}
 
   '@rushstack/node-core-library@5.11.0':
     resolution: {integrity: sha512-I8+VzG9A0F3nH2rLpPd7hF8F7l5Xb7D+ldrWVZYegXM6CsKkvWc670RlgK3WX8/AseZfXA/vVrh0bpXe2Y2UDQ==}
@@ -5103,8 +5103,8 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  framer-motion@12.5.0:
-    resolution: {integrity: sha512-buPlioFbH9/W7rDzYh1C09AuZHAk2D1xTA1BlounJ2Rb9aRg84OXexP0GLd+R83v0khURdMX7b5MKnGTaSg5iA==}
+  framer-motion@12.6.5:
+    resolution: {integrity: sha512-MKvnWov0paNjvRJuIy6x418w23tFqRfS6CXHhZrCiSEpXVlo/F+usr8v4/3G6O0u7CpsaO1qop+v4Ip7PRCBqQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -6362,11 +6362,11 @@ packages:
   module-details-from-path@1.0.3:
     resolution: {integrity: sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==}
 
-  motion-dom@12.5.0:
-    resolution: {integrity: sha512-uH2PETDh7m+Hjd1UQQ56yHqwn83SAwNjimNPE/kC+Kds0t4Yh7+29rfo5wezVFpPOv57U4IuWved5d1x0kNhbQ==}
+  motion-dom@12.6.5:
+    resolution: {integrity: sha512-jpM9TQLXzYMWMJ7Ec7sAj0iis8oIuu6WvjI3yNKJLdrZyrsI/b2cRInDVL8dCl683zQQq19DpL9cSMP+k8T1NA==}
 
-  motion-utils@12.5.0:
-    resolution: {integrity: sha512-+hFFzvimn0sBMP9iPxBa9OtRX35ZQ3py0UHnb8U29VD+d8lQ8zH3dTygJWqK7av2v6yhg7scj9iZuvTS0f4+SA==}
+  motion-utils@12.6.5:
+    resolution: {integrity: sha512-IsOeKsOF+FWBhxQEDFBO6ZYC8/jlidmVbbLpe9/lXSA9j9kzGIMUuIBx2SZY+0reAS0DjZZ1i7dJp4NHrjocPw==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -10611,9 +10611,9 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rstack-dev/doc-ui@1.7.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@rstack-dev/doc-ui@1.7.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      framer-motion: 12.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      framer-motion: 12.6.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -12755,10 +12755,10 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  framer-motion@12.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  framer-motion@12.6.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      motion-dom: 12.5.0
-      motion-utils: 12.5.0
+      motion-dom: 12.6.5
+      motion-utils: 12.6.5
       tslib: 2.8.1
     optionalDependencies:
       react: 19.0.0
@@ -14545,11 +14545,11 @@ snapshots:
 
   module-details-from-path@1.0.3: {}
 
-  motion-dom@12.5.0:
+  motion-dom@12.6.5:
     dependencies:
-      motion-utils: 12.5.0
+      motion-utils: 12.6.5
 
-  motion-utils@12.5.0: {}
+  motion-utils@12.6.5: {}
 
   mri@1.2.0: {}
 

--- a/website/components/Tag.scss
+++ b/website/components/Tag.scss
@@ -9,11 +9,11 @@
 
   .ant-tag-geekblue {
     color: #a8c1f8;
-    border: 1px solid rgba(168, 193, 248, 0.6);
+    border: 1px solid rgba(168, 193, 248, 0.4);
   }
 
   .ant-tag-purple {
     color: #cda8f0;
-    border: 1px solid rgba(205, 168, 240, 0.6);
+    border: 1px solid rgba(205, 168, 240, 0.4);
   }
 }

--- a/website/components/Tag.scss
+++ b/website/components/Tag.scss
@@ -1,0 +1,19 @@
+.ant-tag {
+  border: none;
+}
+
+.dark {
+  .ant-tag {
+    background-color: transparent;
+  }
+
+  .ant-tag-geekblue {
+    color: #a8c1f8;
+    border: 1px solid rgba(168, 193, 248, 0.6);
+  }
+
+  .ant-tag-purple {
+    color: #cda8f0;
+    border: 1px solid rgba(205, 168, 240, 0.6);
+  }
+}

--- a/website/components/Tag.tsx
+++ b/website/components/Tag.tsx
@@ -1,0 +1,4 @@
+import { Tag } from '@rstack-dev/doc-ui/antd';
+import './Tag.scss';
+
+export { Tag };

--- a/website/docs/en/guide/start/_meta.json
+++ b/website/docs/en/guide/start/_meta.json
@@ -1,1 +1,1 @@
-["introduction", "quick-start"]
+["introduction", "quick-start", "ecosystem"]

--- a/website/docs/en/guide/start/ecosystem.mdx
+++ b/website/docs/en/guide/start/ecosystem.mdx
@@ -1,0 +1,75 @@
+# Ecosystem
+
+## Rstack toolchain
+
+Rstack is a high-performance, unified JavaScript toolchain based on Rspack, developed and maintained by the Rspack team.
+
+### Rsbuild
+
+[Rsbuild](https://github.com/web-infra-dev/rsbuild) is a high-performance build tool powered by Rspack. It provides a set of thoughtfully designed default build configs, offering an out-of-the-box development experience and can fully unleash the performance advantages of Rspack.
+
+### Rspress
+
+[Rspress](https://github.com/web-infra-dev/rspress) is a static site generator based on Rsbuild, React and MDX. It comes with a default documentation theme, and you can quickly build a documentation site with Rspress. You can also customize the theme to meet your personalized static site needs, such as blog sites, product homepages, etc.
+
+### Rslib
+
+[Rslib](https://github.com/web-infra-dev/rslib) is a library development tool based on Rsbuild, which reuses the carefully designed build configuration and plugin system of Rsbuild. It allows developers to create JavaScript libraries in a simple and intuitive way.
+
+### Rsdoctor
+
+[Rsdoctor](https://github.com/web-infra-dev/rsdoctor) is a build analyzer that can visually display the build process, such as compilation time, code changes before and after compilation, module reference relationships, duplicate modules, etc.
+
+### Rstest
+
+[Rstest](https://github.com/web-infra-dev/rstest) is a testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.
+
+## Angular Rspack
+
+[Angular Rspack](https://github.com/nrwl/angular-rspack) is a set of plugins and tools to make it easy and straightforward to build Angular applications with Rspack and Rsbuild.
+
+## Docusaurus
+
+[Docusaurus](https://docusaurus.io/) is a project for building, deploying, and maintaining open source project websites easily.
+
+Docusaurus v3.6 supports Rspack as the bundler, see [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster) for details.
+
+## Modern.js
+
+[Modern.js](https://modernjs.dev/en/) is a Rspack-based progressive React framework that supports nested routes, SSR, and provides out-of-the-box CSS solutions such as styled components and Tailwind CSS.
+
+## Next.js
+
+[Next.js](https://nextjs.org/) is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations.
+
+Rspack team and Next.js team have partnered to provide the `next-rspack` plugin. This plugin allows you to use Rspack as the bundler for Next.js, see [Next.js guide](/guide/tech/next) for details.
+
+## Nuxt
+
+[Nuxt](https://nuxt.com/) is a free and open-source framework with an intuitive and extendable way to create type-safe, performant and production-grade full-stack web applications and websites with Vue.js.
+
+Nuxt v3.14 introduces a new first-class Nuxt builder for Rspack, see [Nuxt 3.14](https://nuxt.com/blog/v3-14) for details.
+
+## Nx
+
+[Nx](https://nx.dev/) is a powerful open-source build system that provides tools and techniques for enhancing developer productivity, optimizing CI performance, and maintaining code quality.
+
+Rspack team and Nx team have collaborated to provide the [Rspack Nx plugin](https://nx.dev/nx-api/rspack). This plugin contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
+
+## Rspeedy
+
+[Rspeedy](https://lynxjs.org/rspeedy/) is an Rspack-based build tool designed specifically for Lynx applications. [Lynx](https://lynxjs.org/) is a family of technologies empowering developers to use their existing web skills to create truly native UIs for both mobile and web from a single codebase.
+
+## Re.Pack
+
+[Re.Pack](https://github.com/callstack/repack) is a build tool for building your React Native application.
+
+Re.Pack v5 uses Rspack and React Native community CLI's plugin system to allow you to bundle your application using Rspack and easily switch from Metro.
+
+## Storybook
+
+[Storybook Rsbuild](https://storybook.rsbuild.dev/) allows you to use Rsbuild as the build tool for Storybook, and provides UI framework integrations like React and Vue.
+
+## More
+
+Visit [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) to discover more projects within the Rspack ecosystem.

--- a/website/docs/en/guide/start/ecosystem.mdx
+++ b/website/docs/en/guide/start/ecosystem.mdx
@@ -37,7 +37,7 @@ Rstack is a high-performance, unified JavaScript toolchain based on Rspack, deve
 
 [Rstest](https://github.com/web-infra-dev/rstest) is a testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.
 
-## Community projects
+## Community integrations
 
 ### Angular Rspack
 
@@ -51,16 +51,16 @@ Rstack is a high-performance, unified JavaScript toolchain based on Rspack, deve
 <Tag color="geekblue">Static site generator</Tag>
 <Tag color="purple">React</Tag>
 
-[Docusaurus](https://docusaurus.io/) is a project for building, deploying, and maintaining open source project websites easily.
+[Docusaurus](https://docusaurus.io/) is a static site generator for building, deploying, and maintaining open source project websites easily.
 
-Docusaurus v3.6 supports Rspack as the bundler, see [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster) for details.
+Docusaurus supports Rspack as the bundler since v3.6, see [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster) for details.
 
 ### Modern.js
 
 <Tag color="geekblue">Web framework</Tag>
 <Tag color="purple">React</Tag>
 
-[Modern.js](https://modernjs.dev/en/) is a Rspack-based progressive React framework that supports nested routes, SSR, and provides out-of-the-box CSS solutions such as styled components and Tailwind CSS.
+[Modern.js](https://modernjs.dev/en/) is a Rsbuild-based progressive React framework that supports nested routes, SSR, and provides out-of-the-box CSS solutions such as styled components and Tailwind CSS.
 
 ### Next.js
 

--- a/website/docs/en/guide/start/ecosystem.mdx
+++ b/website/docs/en/guide/start/ecosystem.mdx
@@ -1,3 +1,5 @@
+import { Tag } from '@components/Tag';
+
 # Ecosystem
 
 ## Rstack toolchain
@@ -6,67 +8,106 @@ Rstack is a high-performance, unified JavaScript toolchain based on Rspack, deve
 
 ### Rsbuild
 
+<Tag color="geekblue">Build tool</Tag>
+
 [Rsbuild](https://github.com/web-infra-dev/rsbuild) is a high-performance build tool powered by Rspack. It provides a set of thoughtfully designed default build configs, offering an out-of-the-box development experience and can fully unleash the performance advantages of Rspack.
 
 ### Rspress
+
+<Tag color="geekblue">Static site generator</Tag>
+<Tag color="purple">React</Tag>
 
 [Rspress](https://github.com/web-infra-dev/rspress) is a static site generator based on Rsbuild, React and MDX. It comes with a default documentation theme, and you can quickly build a documentation site with Rspress. You can also customize the theme to meet your personalized static site needs, such as blog sites, product homepages, etc.
 
 ### Rslib
 
+<Tag color="geekblue">Library development tool</Tag>
+
 [Rslib](https://github.com/web-infra-dev/rslib) is a library development tool based on Rsbuild, which reuses the carefully designed build configuration and plugin system of Rsbuild. It allows developers to create JavaScript libraries in a simple and intuitive way.
 
 ### Rsdoctor
+
+<Tag color="geekblue">Build analyzer</Tag>
 
 [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) is a build analyzer that can visually display the build process, such as compilation time, code changes before and after compilation, module reference relationships, duplicate modules, etc.
 
 ### Rstest
 
+<Tag color="geekblue">Testing framework</Tag>
+
 [Rstest](https://github.com/web-infra-dev/rstest) is a testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.
 
-## Angular Rspack
+## Community projects
+
+### Angular Rspack
+
+<Tag color="geekblue">Build tool</Tag>
+<Tag color="purple">Angular</Tag>
 
 [Angular Rspack](https://github.com/nrwl/angular-rspack) is a set of plugins and tools to make it easy and straightforward to build Angular applications with Rspack and Rsbuild.
 
-## Docusaurus
+### Docusaurus
+
+<Tag color="geekblue">Static site generator</Tag>
+<Tag color="purple">React</Tag>
 
 [Docusaurus](https://docusaurus.io/) is a project for building, deploying, and maintaining open source project websites easily.
 
 Docusaurus v3.6 supports Rspack as the bundler, see [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster) for details.
 
-## Modern.js
+### Modern.js
+
+<Tag color="geekblue">Web framework</Tag>
+<Tag color="purple">React</Tag>
 
 [Modern.js](https://modernjs.dev/en/) is a Rspack-based progressive React framework that supports nested routes, SSR, and provides out-of-the-box CSS solutions such as styled components and Tailwind CSS.
 
-## Next.js
+### Next.js
+
+<Tag color="geekblue">Web framework</Tag>
+<Tag color="purple">React</Tag>
 
 [Next.js](https://nextjs.org/) is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations.
 
 Rspack team and Next.js team have partnered to provide the `next-rspack` plugin. This plugin allows you to use Rspack as the bundler for Next.js, see [Next.js guide](/guide/tech/next) for details.
 
-## Nuxt
+### Nuxt
+
+<Tag color="geekblue">Web framework</Tag>
+<Tag color="purple">Vue</Tag>
 
 [Nuxt](https://nuxt.com/) is a free and open-source framework with an intuitive and extendable way to create type-safe, performant and production-grade full-stack web applications and websites with Vue.js.
 
 Nuxt v3.14 introduces a new first-class Nuxt builder for Rspack, see [Nuxt 3.14](https://nuxt.com/blog/v3-14) for details.
 
-## Nx
+### Nx
+
+<Tag color="geekblue">Build system</Tag>
+<Tag color="purple">Monorepo</Tag>
 
 [Nx](https://nx.dev/) is a powerful open-source build system that provides tools and techniques for enhancing developer productivity, optimizing CI performance, and maintaining code quality.
 
 Rspack team and Nx team have collaborated to provide the [Rspack Nx plugin](https://nx.dev/nx-api/rspack). This plugin contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
 
-## Rspeedy
+### Rspeedy
+
+<Tag color="geekblue">Build tool</Tag>
+<Tag color="purple">Lynx</Tag>
 
 [Rspeedy](https://lynxjs.org/rspeedy/) is an Rspack-based build tool designed specifically for Lynx applications. [Lynx](https://lynxjs.org/) is a family of technologies empowering developers to use their existing web skills to create truly native UIs for both mobile and web from a single codebase.
 
-## Re.Pack
+### Re.Pack
+
+<Tag color="geekblue">Build tool</Tag>
+<Tag color="purple">React Native</Tag>
 
 [Re.Pack](https://github.com/callstack/repack) is a build tool for building your React Native application.
 
 Re.Pack v5 uses Rspack and React Native community CLI's plugin system to allow you to bundle your application using Rspack and easily switch from Metro.
 
-## Storybook
+### Storybook
+
+<Tag color="geekblue">UI development</Tag>
 
 [Storybook Rsbuild](https://storybook.rsbuild.dev/) allows you to use Rsbuild as the build tool for Storybook, and provides UI framework integrations like React and Vue.
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -6,7 +6,12 @@ Get up to speed quickly with a new Rspack based project.
 
 - [Create a new project](#create-a-new-project): Use the CLI to create a brand-new Rspack or Rsbuild project.
 - [Migrating from existing projects](#migrating-from-existing-projects): Migrate from a webpack-based project to Rspack.
-- [Ecosystem](#ecosystem): Discover projects within the Rspack community ecosystem.
+
+## Ecosystem
+
+As a low-level bundler, Rspack has a rich ecosystem that includes various frameworks, tools, and solutions. These ecosystem projects cover different aspects from frameworks to development tools, meeting diverse development needs across scenarios and providing an out-of-the-box experience.
+
+See the [Ecosystem](/guide/start/ecosystem) page to explore these ecosystem projects.
 
 ## Setup environment
 
@@ -145,67 +150,3 @@ npx install-rspack --version latest # Install the latest version
 npx install-rspack --version canary # Install the canary version
 npx install-rspack --version 1.0.0-canary-d614005-20250101082730 # Install the specified canary version
 ```
-
-## Ecosystem
-
-### Rspress
-
-[Rspress](https://rspress.dev) is a static site generator based on Rsbuild, React and MDX. It comes with a default documentation theme, and you can quickly build a documentation site with Rspress. You can also customize the theme to meet your personalized static site needs, such as blog sites, product homepages, etc.
-
-### Rslib
-
-[Rslib](https://github.com/web-infra-dev/rslib) is a library development tool based on Rsbuild, which reuses the carefully designed build configuration and plugin system of Rsbuild. It allows developers to create JavaScript libraries in a simple and intuitive way.
-
-### Rsdoctor
-
-[Rsdoctor](https://rsdoctor.dev/) is a build analyzer that can visually display the build process, such as compilation time, code changes before and after compilation, module reference relationships, duplicate modules, etc.
-
-### Rspeedy
-
-[Rspeedy](https://lynxjs.org/rspeedy/) is an Rspack-based build tool designed specifically for Lynx applications. [Lynx](https://lynxjs.org/) is a family of technologies empowering developers to use their existing web skills to create truly native UIs for both mobile and web from a single codebase.
-
-### Modern.js
-
-[Modern.js](https://modernjs.dev/en/) is a Rspack-based progressive React framework that supports nested routes, SSR, and provides out-of-the-box CSS solutions such as styled components and Tailwind CSS.
-
-### Next.js
-
-[Next.js](https://nextjs.org/) is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations.
-
-Rspack team and Next.js team have partnered to provide the `next-rspack` plugin. This plugin allows you to use Rspack as the bundler for Next.js, see [Next.js guide](/guide/tech/next) for details.
-
-### Nx
-
-[Nx](https://nx.dev/) is a powerful open-source build system that provides tools and techniques for enhancing developer productivity, optimizing CI performance, and maintaining code quality.
-
-Rspack team and Nx team have collaborated to provide the [Rspack Nx plugin](https://nx.dev/nx-api/rspack). This plugin contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
-
-### Docusaurus
-
-[Docusaurus](https://docusaurus.io/) is a project for building, deploying, and maintaining open source project websites easily.
-
-Docusaurus v3.6 supports Rspack as the bundler, see [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster) for details.
-
-### Storybook
-
-[Storybook Rsbuild](https://storybook.rsbuild.dev/) allows you to use Rsbuild as the build tool for Storybook, and provides UI framework integrations like React and Vue.
-
-### Nuxt
-
-[Nuxt](https://nuxt.com/) is a free and open-source framework with an intuitive and extendable way to create type-safe, performant and production-grade full-stack web applications and websites with Vue.js.
-
-Nuxt v3.14 introduces a new first-class Nuxt builder for Rspack, see [Nuxt 3.14](https://nuxt.com/blog/v3-14) for details.
-
-### Re.Pack
-
-[Re.Pack](https://github.com/callstack/repack) is a build tool for building your React Native application.
-
-Re.Pack v5 uses Rspack and React Native community CLI's plugin system to allow you to bundle your application using Rspack and easily switch from Metro.
-
-### Angular Rspack
-
-[Angular Rspack](https://github.com/nrwl/angular-rspack) is a set of plugins and tools to make it easy and straightforward to build Angular applications with Rspack and Rsbuild.
-
-### More
-
-Visit [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) to discover more projects within the Rspack ecosystem.

--- a/website/docs/zh/guide/start/_meta.json
+++ b/website/docs/zh/guide/start/_meta.json
@@ -1,1 +1,1 @@
-["introduction", "quick-start"]
+["introduction", "quick-start", "ecosystem"]

--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -1,3 +1,5 @@
+import { Tag } from '@components/Tag';
+
 # 生态
 
 ## Rstack 工具链
@@ -6,67 +8,97 @@ Rstack 是基于 Rspack 的高性能、一体化 JavaScript 工具链，由 Rspa
 
 ### Rsbuild
 
+<Tag color="geekblue">构建工具</Tag>
+
 [Rsbuild](https://github.com/web-infra-dev/rsbuild) 是由 Rspack 驱动的高性能构建工具，它默认包含了一套精心设计的构建配置，提供开箱即用的开发体验，并能够充分发挥出 Rspack 的性能优势。
 
 ### Rspress
+
+<Tag color="geekblue">静态站点生成器</Tag> <Tag color="purple">React</Tag>
 
 [Rspress](https://github.com/web-infra-dev/rspress) 是一个基于 Rsbuild、React 和 MDX 的静态站点生成器，内置了一套默认的文档主题，你可以通过 Rspress 来快速搭建一个文档站点，同时也可以自定义主题，来满足个性化静态站需求，比如博客站、产品主页等。
 
 ### Rslib
 
+<Tag color="geekblue">库开发工具</Tag>
+
 [Rslib](https://github.com/web-infra-dev/rslib) 是一个基于 Rsbuild 的 npm 库开发工具，它复用了 Rsbuild 精心设计的构建配置和插件系统，使开发者能够以简单直观的方式创建 JavaScript 库。
 
 ### Rsdoctor
+
+<Tag color="geekblue">构建分析工具</Tag>
 
 [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) 是一个针对 Rspack 的构建分析工具，可以直观地展示构建过程，例如编译时间、编译前后的代码变化、模块引用关系、重复模块等。如果你需要排查构建产物或构建时编译问题，可以使用 Rsdoctor。
 
 ### Rstest
 
+<Tag color="geekblue">测试框架</Tag>
+
 [Rstest](https://github.com/web-infra-dev/rstest) 是一个基于 Rspack 的测试框架，它为 Rspack 生态提供了全面、一流的支持，能够轻松集成到现有的 Rspack 项目中。
 
-## Angular Rspack
+## 社区项目
+
+### Angular Rspack
+
+<Tag color="geekblue">构建工具</Tag> <Tag color="purple">Angular</Tag>
 
 [Angular Rspack](https://github.com/nrwl/angular-rspack) 是一套工具链和插件集合，能够让你简单直接地使用 Rspack 和 Rsbuild 构建 Angular 应用。
 
-## Docusaurus
+### Docusaurus
+
+<Tag color="geekblue">静态站点生成器</Tag> <Tag color="purple">React</Tag>
 
 [Docusaurus](https://docusaurus.io/) 是一个用于快速构建、部署和维护开源项目网站的工具。
 
 Docusaurus v3.6 支持使用 Rspack 作为打包工具，详见 [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster)。
 
-## Modern.js
+### Modern.js
+
+<Tag color="geekblue">Web 框架</Tag> <Tag color="purple">React</Tag>
 
 [Modern.js](https://modernjs.dev/) 是一个基于 Rspack 实现的渐进式 React 框架，支持嵌套路由、服务器端渲染（SSR）和模块联邦，并提供开箱即用的 CSS 解决方案。
 
-## Next.js
+### Next.js
+
+<Tag color="geekblue">Web 框架</Tag> <Tag color="purple">React</Tag>
 
 [Next.js](https://nextjs.org/) 是一个用于构建全栈 Web 应用的 React 框架。它允许你使用 React 组件构建用户界面，并使用 Next.js 进行额外功能和优化。
 
 Rspack 团队与 Next.js 团队合作提供了 `next-rspack` 插件。该插件允许你使用 Rspack 作为 Next.js 的打包工具，详见 [Next.js 指南](/guide/tech/next)。
 
-## Nuxt
+### Nuxt
+
+<Tag color="geekblue">Web 框架</Tag> <Tag color="purple">Vue</Tag>
 
 [Nuxt](https://nuxt.com/) 是一个开源框架，提供了直观且可扩展的方式来使用 Vue.js 创建类型安全、高性能和生产级的全栈 Web 应用程序和网站。
 
 Nuxt v3.14 引入了对 Rspack 的官方支持，详见 [Nuxt 3.14](https://nuxt.com/blog/v3-14)。
 
-## Nx
+### Nx
+
+<Tag color="geekblue">构建系统</Tag> <Tag color="purple">Monorepo</Tag>
 
 [Nx](https://nx.dev/) 是一个强大的开源构建系统，提供了工具来提升生产力、优化 CI 性能和维护代码质量。
 
 Rspack 团队与 Nx 团队合作提供了 [Rspack Nx 插件](https://nx.dev/nx-api/rspack)。该插件包含在 Nx Workspace 中管理 Rspack 项目的执行器、生成器和实用工具。
 
-## Rspeedy
+### Rspeedy
+
+<Tag color="geekblue">构建工具</Tag> <Tag color="purple">Lynx</Tag>
 
 [Rspeedy](https://lynxjs.org/rspeedy/) 是一个基于 Rspack 的构建工具，专门为 Lynx 应用设计。[Lynx](https://lynxjs.org/) 是一套帮助 Web 开发者复用现有经验、通过一份代码同时构建移动端原生界面与 Web 端界面的技术方案。
 
-## Re.Pack
+### Re.Pack
+
+<Tag color="geekblue">构建工具</Tag> <Tag color="purple">React Native</Tag>
 
 [Re.Pack](https://github.com/callstack/repack) 是一个用于开发 React Native 应用的构建工具。
 
 Re.Pack v5 使用 Rspack 和 React Native 社区 CLI 的插件系统，允许你使用 Rspack 打包你的应用，并轻松切换到 Metro。
 
-## Storybook
+### Storybook
+
+<Tag color="geekblue">UI 开发</Tag>
 
 [Storybook Rsbuild](https://storybook.rsbuild.dev/) 允许你使用 Rsbuild 作为 Storybook 的构建工具，并提供了 React 和 Vue 等 UI 框架的集成。
 

--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -1,0 +1,75 @@
+# 生态
+
+## Rstack 工具链
+
+Rstack 是基于 Rspack 的高性能、一体化 JavaScript 工具链，由 Rspack 团队开发和维护。
+
+### Rsbuild
+
+[Rsbuild](https://github.com/web-infra-dev/rsbuild) 是由 Rspack 驱动的高性能构建工具，它默认包含了一套精心设计的构建配置，提供开箱即用的开发体验，并能够充分发挥出 Rspack 的性能优势。
+
+### Rspress
+
+[Rspress](https://github.com/web-infra-dev/rspress) 是一个基于 Rsbuild、React 和 MDX 的静态站点生成器，内置了一套默认的文档主题，你可以通过 Rspress 来快速搭建一个文档站点，同时也可以自定义主题，来满足个性化静态站需求，比如博客站、产品主页等。
+
+### Rslib
+
+[Rslib](https://github.com/web-infra-dev/rslib) 是一个基于 Rsbuild 的 npm 库开发工具，它复用了 Rsbuild 精心设计的构建配置和插件系统，使开发者能够以简单直观的方式创建 JavaScript 库。
+
+### Rsdoctor
+
+[Rsdoctor](https://github.com/web-infra-dev/rsdoctor) 是一个针对 Rspack 的构建分析工具，可以直观地展示构建过程，例如编译时间、编译前后的代码变化、模块引用关系、重复模块等。如果你需要排查构建产物或构建时编译问题，可以使用 Rsdoctor。
+
+### Rstest
+
+[Rstest](https://github.com/web-infra-dev/rstest) 是一个基于 Rspack 的测试框架，它为 Rspack 生态提供了全面、一流的支持，能够轻松集成到现有的 Rspack 项目中。
+
+## Angular Rspack
+
+[Angular Rspack](https://github.com/nrwl/angular-rspack) 是一套工具链和插件集合，能够让你简单直接地使用 Rspack 和 Rsbuild 构建 Angular 应用。
+
+## Docusaurus
+
+[Docusaurus](https://docusaurus.io/) 是一个用于快速构建、部署和维护开源项目网站的工具。
+
+Docusaurus v3.6 支持使用 Rspack 作为打包工具，详见 [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster)。
+
+## Modern.js
+
+[Modern.js](https://modernjs.dev/) 是一个基于 Rspack 实现的渐进式 React 框架，支持嵌套路由、服务器端渲染（SSR）和模块联邦，并提供开箱即用的 CSS 解决方案。
+
+## Next.js
+
+[Next.js](https://nextjs.org/) 是一个用于构建全栈 Web 应用的 React 框架。它允许你使用 React 组件构建用户界面，并使用 Next.js 进行额外功能和优化。
+
+Rspack 团队与 Next.js 团队合作提供了 `next-rspack` 插件。该插件允许你使用 Rspack 作为 Next.js 的打包工具，详见 [Next.js 指南](/guide/tech/next)。
+
+## Nuxt
+
+[Nuxt](https://nuxt.com/) 是一个开源框架，提供了直观且可扩展的方式来使用 Vue.js 创建类型安全、高性能和生产级的全栈 Web 应用程序和网站。
+
+Nuxt v3.14 引入了对 Rspack 的官方支持，详见 [Nuxt 3.14](https://nuxt.com/blog/v3-14)。
+
+## Nx
+
+[Nx](https://nx.dev/) 是一个强大的开源构建系统，提供了工具来提升生产力、优化 CI 性能和维护代码质量。
+
+Rspack 团队与 Nx 团队合作提供了 [Rspack Nx 插件](https://nx.dev/nx-api/rspack)。该插件包含在 Nx Workspace 中管理 Rspack 项目的执行器、生成器和实用工具。
+
+## Rspeedy
+
+[Rspeedy](https://lynxjs.org/rspeedy/) 是一个基于 Rspack 的构建工具，专门为 Lynx 应用设计。[Lynx](https://lynxjs.org/) 是一套帮助 Web 开发者复用现有经验、通过一份代码同时构建移动端原生界面与 Web 端界面的技术方案。
+
+## Re.Pack
+
+[Re.Pack](https://github.com/callstack/repack) 是一个用于开发 React Native 应用的构建工具。
+
+Re.Pack v5 使用 Rspack 和 React Native 社区 CLI 的插件系统，允许你使用 Rspack 打包你的应用，并轻松切换到 Metro。
+
+## Storybook
+
+[Storybook Rsbuild](https://storybook.rsbuild.dev/) 允许你使用 Rsbuild 作为 Storybook 的构建工具，并提供了 React 和 Vue 等 UI 框架的集成。
+
+## 更多
+
+访问 [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) 来发现更多 Rspack 生态中的项目。

--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -36,7 +36,7 @@ Rstack 是基于 Rspack 的高性能、一体化 JavaScript 工具链，由 Rspa
 
 [Rstest](https://github.com/web-infra-dev/rstest) 是一个基于 Rspack 的测试框架，它为 Rspack 生态提供了全面、一流的支持，能够轻松集成到现有的 Rspack 项目中。
 
-## 社区项目
+## 社区集成
 
 ### Angular Rspack
 
@@ -48,15 +48,15 @@ Rstack 是基于 Rspack 的高性能、一体化 JavaScript 工具链，由 Rspa
 
 <Tag color="geekblue">静态站点生成器</Tag> <Tag color="purple">React</Tag>
 
-[Docusaurus](https://docusaurus.io/) 是一个用于快速构建、部署和维护开源项目网站的工具。
+[Docusaurus](https://docusaurus.io/) 是一个用于快速构建、部署和维护开源项目网站的静态站点生成器。
 
-Docusaurus v3.6 支持使用 Rspack 作为打包工具，详见 [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster)。
+Docusaurus 从 v3.6 开始支持使用 Rspack 作为打包工具，详见 [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster)。
 
 ### Modern.js
 
 <Tag color="geekblue">Web 框架</Tag> <Tag color="purple">React</Tag>
 
-[Modern.js](https://modernjs.dev/) 是一个基于 Rspack 实现的渐进式 React 框架，支持嵌套路由、服务器端渲染（SSR）和模块联邦，并提供开箱即用的 CSS 解决方案。
+[Modern.js](https://modernjs.dev/) 是一个基于 Rsbuild 实现的渐进式 React 框架，支持嵌套路由、服务器端渲染（SSR）和模块联邦，并提供开箱即用的 CSS 解决方案。
 
 ### Next.js
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -6,7 +6,12 @@ import { PackageManagerTabs } from '@theme';
 
 - [创建新项目](#创建新项目)：使用 CLI 创建一个全新的 Rspack 或 Rsbuild 项目。
 - [从现有项目迁移](#从现有项目迁移)：从一个基于 webpack 的项目迁移到 Rspack。
-- [生态](#生态)：发现 Rspack 社区生态中的项目。
+
+## 生态
+
+作为一个底层打包工具，Rspack 拥有丰富的技术生态，包含多种框架、工具和解决方案。这些生态项目涵盖了从框架到开发工具的各个方面，能够满足不同场景下的开发需求，提供开箱即用的体验。
+
+查看 [生态](/guide/start/ecosystem) 页面来探索这些生态项目。
 
 ## 环境准备
 
@@ -145,67 +150,3 @@ npx install-rspack --version latest # 安装当前的 latest 版本
 npx install-rspack --version canary # 安装当前的 canary 版本
 npx install-rspack --version 1.0.0-canary-d614005-20250101082730 # 安装指定的 canary 版本
 ```
-
-## 生态
-
-### Rspress
-
-[Rspress](https://rspress.dev) 是一个基于 Rsbuild、React 和 MDX 的静态站点生成器，内置了一套默认的文档主题，你可以通过 Rspress 来快速搭建一个文档站点，同时也可以自定义主题，来满足个性化静态站需求，比如博客站、产品主页等。
-
-### Rslib
-
-[Rslib](https://github.com/web-infra-dev/rslib) 是一个基于 Rsbuild 的 npm 库开发工具，它复用了 Rsbuild 精心设计的构建配置和插件系统，使开发者能够以简单直观的方式创建 JavaScript 库。
-
-### Rsdoctor
-
-[Rsdoctor](https://rsdoctor.dev/) 是一个针对 Rspack 的构建分析工具，可以直观地展示构建过程，例如编译时间、编译前后的代码变化、模块引用关系、重复模块等。如果你需要排查构建产物或构建时编译问题，可以使用 Rsdoctor。
-
-### Rspeedy
-
-[Rspeedy](https://lynxjs.org/rspeedy/) 是一个基于 Rspack 的构建工具，专门为 Lynx 应用设计。[Lynx](https://lynxjs.org/) 是一套帮助 Web 开发者复用现有经验、通过一份代码同时构建移动端原生界面与 Web 端界面的技术方案。
-
-### Modern.js
-
-[Modern.js](https://modernjs.dev/) 是一个基于 Rspack 实现的渐进式 React 框架，支持嵌套路由、服务器端渲染（SSR）和模块联邦，并提供开箱即用的 CSS 解决方案。
-
-### Next.js
-
-[Next.js](https://nextjs.org/) 是一个用于构建全栈 Web 应用的 React 框架。它允许你使用 React 组件构建用户界面，并使用 Next.js 进行额外功能和优化。
-
-Rspack 团队与 Next.js 团队合作提供了 `next-rspack` 插件。该插件允许你使用 Rspack 作为 Next.js 的打包工具，详见 [Next.js 指南](/guide/tech/next)。
-
-### Nx
-
-[Nx](https://nx.dev/) 是一个强大的开源构建系统，提供了工具来提升生产力、优化 CI 性能和维护代码质量。
-
-Rspack 团队与 Nx 团队合作提供了 [Rspack Nx 插件](https://nx.dev/nx-api/rspack)。该插件包含在 Nx Workspace 中管理 Rspack 项目的执行器、生成器和实用工具。
-
-### Docusaurus
-
-[Docusaurus](https://docusaurus.io/) 是一个用于快速构建、部署和维护开源项目网站的工具。
-
-Docusaurus v3.6 支持使用 Rspack 作为打包工具，详见 [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster)。
-
-### Storybook
-
-[Storybook Rsbuild](https://storybook.rsbuild.dev/) 允许你使用 Rsbuild 作为 Storybook 的构建工具，并提供了 React 和 Vue 等 UI 框架的集成。
-
-### Nuxt
-
-[Nuxt](https://nuxt.com/) 是一个开源框架，提供了直观且可扩展的方式来使用 Vue.js 创建类型安全、高性能和生产级的全栈 Web 应用程序和网站。
-
-Nuxt v3.14 引入了对 Rspack 的官方支持，详见 [Nuxt 3.14](https://nuxt.com/blog/v3-14)。
-
-### Re.Pack
-
-[Re.Pack](https://github.com/callstack/repack) 是一个用于开发 React Native 应用的构建工具。
-
-Re.Pack v5 使用 Rspack 和 React Native 社区 CLI 的插件系统，允许你使用 Rspack 打包你的应用，并轻松切换到 Metro。
-
-### Angular Rspack
-
-[Angular Rspack](https://github.com/nrwl/angular-rspack) 是一套工具链和插件集合，能够让你简单直接地使用 Rspack 和 Rsbuild 构建 Angular 应用。
-
-### 更多
-
-访问 [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) 来发现更多 Rspack 生态中的项目。

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@rstack-dev/doc-ui": "1.7.3",
+    "@rstack-dev/doc-ui": "1.7.4",
     "axios": "^1.8.4",
     "markdown-to-jsx": "^7.7.4",
     "mermaid": "^11.6.0",


### PR DESCRIPTION
## Summary

- Add a standalone ecosystem page to better showcase the projects in the Rspack ecosystem.
- Add tags to more clearly distinguish project types.
- Add a brief introduction for Rstack.

Preview:

![image](https://github.com/user-attachments/assets/2f1c65c8-487f-4890-8fa5-e4616a4d5ede)


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
