### PR TITLE
refactor: adjust circularDependencyRspackPlugin compilation api

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1513,10 +1513,10 @@ export interface RawCircularDependencyRspackPluginOptions {
   allowAsyncCycles?: boolean
   exclude?: RegExp
   ignoredConnections?: Array<[string | RegExp, string | RegExp]>
-  onDetected?: (entrypoint: Module, modules: string[], compilation: JsCompilation) => void
-  onIgnored?: (entrypoint: Module, modules: string[], compilation: JsCompilation) => void
-  onStart?: (compilation: JsCompilation) => void
-  onEnd?: (compilation: JsCompilation) => void
+  onDetected?: (entrypoint: Module, modules: string[]) => void
+  onIgnored?: (entrypoint: Module, modules: string[]) => void
+  onStart?: () => void
+  onEnd?: () => void
 }
 
 export interface RawConsumeOptions {

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_circular_dependency.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_circular_dependency.rs
@@ -8,8 +8,6 @@ use rspack_plugin_circular_dependencies::{
 };
 use rspack_regex::RspackRegex;
 
-use crate::JsCompilationWrapper;
-
 fn ignore_pattern_to_entry(
   pattern: Either<String, RspackRegex>,
 ) -> CircularDependencyIgnoredConnectionEntry {
@@ -20,7 +18,7 @@ fn ignore_pattern_to_entry(
 }
 
 type ConnectionPattern = Either<String, RspackRegex>;
-type CycleHookParams = (String, Vec<String>, JsCompilationWrapper);
+type CycleHookParams = (String, Vec<String>);
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
@@ -32,17 +30,17 @@ pub struct RawCircularDependencyRspackPluginOptions {
   #[napi(ts_type = "Array<[string | RegExp, string | RegExp]>")]
   pub ignored_connections: Option<Vec<(ConnectionPattern, ConnectionPattern)>>,
   #[debug(skip)]
-  #[napi(ts_type = "(entrypoint: Module, modules: string[], compilation: JsCompilation) => void")]
+  #[napi(ts_type = "(entrypoint: Module, modules: string[]) => void")]
   pub on_detected: Option<ThreadsafeFunction<FnArgs<CycleHookParams>, ()>>,
   #[debug(skip)]
-  #[napi(ts_type = "(entrypoint: Module, modules: string[], compilation: JsCompilation) => void")]
+  #[napi(ts_type = "(entrypoint: Module, modules: string[]) => void")]
   pub on_ignored: Option<ThreadsafeFunction<FnArgs<CycleHookParams>, ()>>,
   #[debug(skip)]
-  #[napi(ts_type = "(compilation: JsCompilation) => void")]
-  pub on_start: Option<ThreadsafeFunction<JsCompilationWrapper, ()>>,
+  #[napi(ts_type = "() => void")]
+  pub on_start: Option<ThreadsafeFunction<(), ()>>,
   #[debug(skip)]
-  #[napi(ts_type = "(compilation: JsCompilation) => void")]
-  pub on_end: Option<ThreadsafeFunction<JsCompilationWrapper, ()>>,
+  #[napi(ts_type = "() => void")]
+  pub on_end: Option<ThreadsafeFunction<(), ()>>,
 }
 
 impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspackPluginOptions {
@@ -51,11 +49,11 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
     // for the closure compared to the field in the options object.
 
     let on_detected: Option<CycleHandlerFn> = match value.on_detected {
-      Some(callback) => Some(Box::new(move |entrypoint, modules, compilation| {
+      Some(callback) => Some(Box::new(move |entrypoint, modules| {
         let callback = callback.clone();
         Box::pin(async move {
           callback
-            .call_with_sync((entrypoint, modules, JsCompilationWrapper::new(compilation)).into())
+            .call_with_sync((entrypoint, modules).into())
             .await?;
           Ok(())
         })
@@ -63,12 +61,12 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
       _ => None,
     };
     let on_ignored: Option<CycleHandlerFn> = match value.on_ignored {
-      Some(callback) => Some(Box::new(move |entrypoint, modules, compilation| {
+      Some(callback) => Some(Box::new(move |entrypoint, modules| {
         Box::pin({
           let callback = callback.clone();
           async move {
             callback
-              .call_with_sync((entrypoint, modules, JsCompilationWrapper::new(compilation)).into())
+              .call_with_sync((entrypoint, modules).into())
               .await?;
             Ok(())
           }
@@ -77,13 +75,11 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
       _ => None,
     };
     let on_start: Option<CompilationHookFn> = match value.on_start {
-      Some(callback) => Some(Box::new(move |compilation| {
+      Some(callback) => Some(Box::new(move || {
         let callback = callback.clone();
         Box::pin({
           async move {
-            callback
-              .call_with_sync(JsCompilationWrapper::new(compilation))
-              .await?;
+            callback.call_with_sync(()).await?;
             Ok(())
           }
         })
@@ -91,13 +87,11 @@ impl From<RawCircularDependencyRspackPluginOptions> for CircularDependencyRspack
       _ => None,
     };
     let on_end: Option<CompilationHookFn> = match value.on_end {
-      Some(callback) => Some(Box::new(move |compilation| {
+      Some(callback) => Some(Box::new(move || {
         let callback = callback.clone();
         Box::pin({
           async move {
-            callback
-              .call_with_sync(JsCompilationWrapper::new(compilation))
-              .await?;
+            callback.call_with_sync(()).await?;
             Ok(())
           }
         })

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
@@ -14,6 +14,8 @@ module.exports = {
 			failOnError: false,
 			exclude: /ignore-circular/,
 			onStart(_compilation) {
+				expect(typeof _compilation.errors === "object").toBeTruthy();
+				expect(typeof _compilation.errors.push === "function").toBeTruthy();
 				startFn();
 			},
 			onEnd(_compilation) {

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -85,7 +85,7 @@ import { Server as Server_3 } from 'http';
 import { ServerOptions as ServerOptions_2 } from 'https';
 import { ServerResponse as ServerResponse_2 } from 'http';
 import { RawSourceMapDevToolPluginOptions as SourceMapDevToolPluginOptions } from '@rspack/binding';
-import sources = require('../compiled/webpack-sources');
+import sources = require('webpack-sources');
 import { StatSyncFn } from 'fs';
 import { SyncBailHook } from '@rspack/lite-tapable';
 import { SyncHook } from '@rspack/lite-tapable';
@@ -576,15 +576,15 @@ export type ChunkLoadingGlobal = string;
 export type ChunkLoadingType = string | "jsonp" | "import-scripts" | "require" | "async-node" | "import";
 
 // @public (undocumented)
-export const CircularDependencyRspackPlugin: {
-    new (options: CircularDependencyRspackPluginOptions): {
-        name: BuiltinPluginName;
-        _args: [options: CircularDependencyRspackPluginOptions];
-        affectedHooks: "done" | "make" | "compile" | "emit" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler_2): BuiltinPlugin;
-        apply(compiler: Compiler_2): void;
-    };
-};
+export class CircularDependencyRspackPlugin extends RspackBuiltinPlugin {
+    constructor(options: CircularDependencyRspackPluginOptions);
+    // (undocumented)
+    name: BuiltinPluginName;
+    // (undocumented)
+    _options: CircularDependencyRspackPluginOptions;
+    // (undocumented)
+    raw(compiler: Compiler): BuiltinPlugin;
+}
 
 // @public (undocumented)
 export type CircularDependencyRspackPluginOptions = {
@@ -592,10 +592,10 @@ export type CircularDependencyRspackPluginOptions = {
     allowAsyncCycles?: boolean;
     exclude?: RegExp;
     ignoredConnections?: Array<[string | RegExp, string | RegExp]>;
-    onDetected?(entrypoint: Module, modules: string[], compilation: JsCompilation): void;
-    onIgnored?(entrypoint: Module, modules: string[], compilation: JsCompilation): void;
-    onStart?(compilation: JsCompilation): void;
-    onEnd?(compilation: JsCompilation): void;
+    onDetected?(entrypoint: Module, modules: string[], compilation: Compilation): void;
+    onIgnored?(entrypoint: Module, modules: string[], compilation: Compilation): void;
+    onStart?(compilation: Compilation): void;
+    onEnd?(compilation: Compilation): void;
 };
 
 // @public
@@ -5113,7 +5113,7 @@ abstract class RspackBuiltinPlugin implements RspackPluginInstance {
 type RspackConfiguration = Configuration_2;
 
 // @public (undocumented)
-type RspackError = binding.JsRspackError;
+export type RspackError = binding.JsRspackError;
 
 declare namespace rspackExports {
     export {

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -85,7 +85,7 @@ import { Server as Server_3 } from 'http';
 import { ServerOptions as ServerOptions_2 } from 'https';
 import { ServerResponse as ServerResponse_2 } from 'http';
 import { RawSourceMapDevToolPluginOptions as SourceMapDevToolPluginOptions } from '@rspack/binding';
-import sources = require('webpack-sources');
+import sources = require('../compiled/webpack-sources');
 import { StatSyncFn } from 'fs';
 import { SyncBailHook } from '@rspack/lite-tapable';
 import { SyncHook } from '@rspack/lite-tapable';

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -5153,6 +5153,8 @@ declare namespace rspackExports {
         EntryDependency,
         Dependency,
         AsyncDependenciesBlock,
+        RspackError,
+        RspackSeverity,
         ModuleFilenameHelpers,
         Template,
         WebpackError,
@@ -5586,6 +5588,9 @@ export interface RspackPluginInstance {
     // (undocumented)
     apply: (compiler: Compiler) => void;
 }
+
+// @public (undocumented)
+export type RspackSeverity = binding.JsRspackSeverity;
 
 // @public (undocumented)
 export const rspackVersion: string;

--- a/packages/rspack/src/RspackError.ts
+++ b/packages/rspack/src/RspackError.ts
@@ -2,11 +2,12 @@ import type * as binding from "@rspack/binding";
 import { concatErrorMsgAndStack } from "./util";
 
 export type RspackError = binding.JsRspackError;
+export type RspackSeverity = binding.JsRspackSeverity;
 
 export class JsRspackDiagnostic {
 	static __to_binding(
 		error: Error | RspackError,
-		severity: binding.JsRspackSeverity
+		severity: RspackSeverity
 	): binding.JsRspackDiagnostic {
 		return {
 			error: concatErrorMsgAndStack(error),

--- a/packages/rspack/src/builtin-plugin/CircularDependencyRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/CircularDependencyRspackPlugin.ts
@@ -1,10 +1,12 @@
 import {
+	type BuiltinPlugin,
 	BuiltinPluginName,
-	type JsCompilation,
 	type RawCircularDependencyRspackPluginOptions
 } from "@rspack/binding";
+import type { Compilation } from "../Compilation";
+import type { Compiler } from '../Compiler';
 import type { Module } from "../Module";
-import { create } from "./base";
+import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 
 export type CircularDependencyRspackPluginOptions = {
 	/**
@@ -42,7 +44,7 @@ export type CircularDependencyRspackPluginOptions = {
 	onDetected?(
 		entrypoint: Module,
 		modules: string[],
-		compilation: JsCompilation
+		compilation: Compilation
 	): void;
 	/**
 	 * Called once for every detected cycle that was ignored because of a rule,
@@ -51,33 +53,50 @@ export type CircularDependencyRspackPluginOptions = {
 	onIgnored?(
 		entrypoint: Module,
 		modules: string[],
-		compilation: JsCompilation
+		compilation: Compilation
 	): void;
 	/**
 	 * Called before cycle detection begins.
 	 */
-	onStart?(compilation: JsCompilation): void;
+	onStart?(compilation: Compilation): void;
 	/**
 	 * Called after cycle detection finishes.
 	 */
-	onEnd?(compilation: JsCompilation): void;
+	onEnd?(compilation: Compilation): void;
 };
 
-export const CircularDependencyRspackPlugin = create(
-	BuiltinPluginName.CircularDependencyRspackPlugin,
-	(
-		options: CircularDependencyRspackPluginOptions
-	): RawCircularDependencyRspackPluginOptions => {
-		return {
-			allowAsyncCycles: options.allowAsyncCycles,
-			failOnError: options.failOnError,
-			exclude: options.exclude,
-			ignoredConnections: options.ignoredConnections,
-			onDetected: options.onDetected,
-			onIgnored: options.onIgnored,
-			onStart: options.onStart,
-			onEnd: options.onEnd
+export class CircularDependencyRspackPlugin extends RspackBuiltinPlugin {
+	name = BuiltinPluginName.CircularDependencyRspackPlugin;
+	_options: CircularDependencyRspackPluginOptions;
+	
+	constructor(options: CircularDependencyRspackPluginOptions) {
+		super();
+		this._options = options;
+	}
+
+	raw(compiler: Compiler): BuiltinPlugin {
+		const compilation: Compilation = compiler.__internal__get_compilation()!;
+		const { failOnError, allowAsyncCycles, exclude, ignoredConnections } = this._options;
+
+		const rawOptions: RawCircularDependencyRspackPluginOptions = {
+			failOnError,
+			allowAsyncCycles,
+			exclude,
+			ignoredConnections,
+			onDetected: this._options.onDetected ? (entripoint: Module, modules: string[]) => {
+				this._options.onDetected!(entripoint, modules, compilation);
+			} : undefined,
+			onIgnored: this._options.onIgnored ? (entripoint: Module, modules: string[]) => {
+				this._options.onIgnored!(entripoint, modules, compilation);
+			}: undefined,
+			onStart: this._options.onStart ? () => {
+				this._options.onStart!(compilation);
+			}: undefined,
+			onEnd: this._options.onEnd ? () => {
+				this._options.onEnd!(compilation);
+			}: undefined
 		};
-	},
-	"compilation"
-);
+
+		return createBuiltinPlugin(this.name, rawOptions);
+	}
+}

--- a/packages/rspack/src/builtin-plugin/CircularDependencyRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/CircularDependencyRspackPlugin.ts
@@ -4,7 +4,7 @@ import {
 	type RawCircularDependencyRspackPluginOptions
 } from "@rspack/binding";
 import type { Compilation } from "../Compilation";
-import type { Compiler } from '../Compiler';
+import type { Compiler } from "../Compiler";
 import type { Module } from "../Module";
 import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 
@@ -68,33 +68,49 @@ export type CircularDependencyRspackPluginOptions = {
 export class CircularDependencyRspackPlugin extends RspackBuiltinPlugin {
 	name = BuiltinPluginName.CircularDependencyRspackPlugin;
 	_options: CircularDependencyRspackPluginOptions;
-	
+
 	constructor(options: CircularDependencyRspackPluginOptions) {
 		super();
 		this._options = options;
 	}
 
 	raw(compiler: Compiler): BuiltinPlugin {
-		const compilation: Compilation = compiler.__internal__get_compilation()!;
-		const { failOnError, allowAsyncCycles, exclude, ignoredConnections } = this._options;
+		const { failOnError, allowAsyncCycles, exclude, ignoredConnections } =
+			this._options;
 
 		const rawOptions: RawCircularDependencyRspackPluginOptions = {
 			failOnError,
 			allowAsyncCycles,
 			exclude,
 			ignoredConnections,
-			onDetected: this._options.onDetected ? (entripoint: Module, modules: string[]) => {
-				this._options.onDetected!(entripoint, modules, compilation);
-			} : undefined,
-			onIgnored: this._options.onIgnored ? (entripoint: Module, modules: string[]) => {
-				this._options.onIgnored!(entripoint, modules, compilation);
-			}: undefined,
-			onStart: this._options.onStart ? () => {
-				this._options.onStart!(compilation);
-			}: undefined,
-			onEnd: this._options.onEnd ? () => {
-				this._options.onEnd!(compilation);
-			}: undefined
+			onDetected: this._options.onDetected
+				? (entripoint: Module, modules: string[]) => {
+						const compilation: Compilation =
+							compiler.__internal__get_compilation()!;
+						this._options.onDetected!(entripoint, modules, compilation);
+					}
+				: undefined,
+			onIgnored: this._options.onIgnored
+				? (entripoint: Module, modules: string[]) => {
+						const compilation: Compilation =
+							compiler.__internal__get_compilation()!;
+						this._options.onIgnored!(entripoint, modules, compilation);
+					}
+				: undefined,
+			onStart: this._options.onStart
+				? () => {
+						const compilation: Compilation =
+							compiler.__internal__get_compilation()!;
+						this._options.onStart!(compilation);
+					}
+				: undefined,
+			onEnd: this._options.onEnd
+				? () => {
+						const compilation: Compilation =
+							compiler.__internal__get_compilation()!;
+						this._options.onEnd!(compilation);
+					}
+				: undefined
 		};
 
 		return createBuiltinPlugin(this.name, rawOptions);

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -45,6 +45,8 @@ export {
 	AsyncDependenciesBlock
 } from "@rspack/binding";
 
+export type { RspackError, RspackSeverity } from "./RspackError";
+
 // API extractor not working with some re-exports, see: https://github.com/microsoft/fluentui/issues/20694
 import * as ModuleFilenameHelpers from "./lib/ModuleFilenameHelpers";
 export { ModuleFilenameHelpers };


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

In the method https://rspack.dev/zh/plugins/rspack/circular-dependency-rspack-plugin#ondetected , the `compilation` param is `JsCompilation` not `Compilation` in rust side(see docs: https://rspack.dev/api/javascript-api/compilation), which means:

![image](https://github.com/user-attachments/assets/8a62bd20-e8e1-4fc5-8db4-970c8bcfe6e8)

I adjust the `compilation` inject time stage, just inject the `compilation` in the JS side, you can see my code at `packages/src/builtin-plugin/CircularDependencyRspackPlugin.ts`.

So the user can get the `compilation` api at js side:

![image](https://github.com/user-attachments/assets/2a97db27-02eb-4a9b-84ff-287da69875e5)

closes issue: #9877

I add the case at `packages/rspack-test-tools`

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
