### PR TITLE
feat: rsdoctor module object add issuerPath property

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -975,6 +975,7 @@ export interface JsRsdoctorModule {
   modules: Array<number>
   belongModules: Array<number>
   chunks: Array<number>
+  issuerPath: Array<number>
 }
 
 export interface JsRsdoctorModuleGraph {

--- a/crates/node_binding/src/rsdoctor.rs
+++ b/crates/node_binding/src/rsdoctor.rs
@@ -45,9 +45,9 @@ impl From<RsdoctorModule> for JsRsdoctorModule {
       belong_modules: value.belong_modules.into_iter().collect::<Vec<_>>(),
       issuer_path: value
         .issuer_path
-        .unwrap_or_default() // Handle the Option
+        .unwrap_or_default()
         .into_iter()
-        .filter_map(|i| i.ukey) // Access the `ukey` field
+        .filter_map(|i| i.ukey)
         .collect::<Vec<_>>(),
     }
   }

--- a/crates/node_binding/src/rsdoctor.rs
+++ b/crates/node_binding/src/rsdoctor.rs
@@ -26,6 +26,7 @@ pub struct JsRsdoctorModule {
   pub modules: Vec<i32>,
   pub belong_modules: Vec<i32>,
   pub chunks: Vec<i32>,
+  pub issuer_path: Vec<i32>,
 }
 
 impl From<RsdoctorModule> for JsRsdoctorModule {
@@ -42,6 +43,12 @@ impl From<RsdoctorModule> for JsRsdoctorModule {
       modules: value.modules.into_iter().collect::<Vec<_>>(),
       chunks: value.chunks.into_iter().collect::<Vec<_>>(),
       belong_modules: value.belong_modules.into_iter().collect::<Vec<_>>(),
+      issuer_path: value
+        .issuer_path
+        .unwrap_or_default() // Handle the Option
+        .into_iter()
+        .filter_map(|i| i.ukey) // Access the `ukey` field
+        .collect::<Vec<_>>(),
     }
   }
 }

--- a/crates/rspack_plugin_rsdoctor/src/data.rs
+++ b/crates/rspack_plugin_rsdoctor/src/data.rs
@@ -29,6 +29,11 @@ pub type VariableUkey = i32;
 pub type SideEffectUkey = i32;
 
 #[derive(Debug, Default)]
+pub struct RsdoctorStatsModuleIssuer {
+  pub ukey: Option<ModuleUkey>,
+}
+
+#[derive(Debug, Default)]
 pub struct RsdoctorModule {
   pub ukey: ModuleUkey,
   pub identifier: Identifier,
@@ -41,6 +46,7 @@ pub struct RsdoctorModule {
   pub chunks: HashSet<ChunkUkey>,
   pub modules: HashSet<ModuleUkey>,
   pub belong_modules: HashSet<ModuleUkey>,
+  pub issuer_path: Option<Vec<RsdoctorStatsModuleIssuer>>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -71,6 +71,7 @@ pub fn collect_modules(
           modules: HashSet::default(),
           belong_modules: HashSet::default(),
           chunks,
+          issuer_path: None,
         },
       )
     })

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -28,6 +28,7 @@ use crate::{
   },
   EntrypointUkey, ModuleUkey, RsdoctorAssetPatch, RsdoctorChunkGraph, RsdoctorModuleGraph,
   RsdoctorModuleIdsPatch, RsdoctorModuleSourcesPatch, RsdoctorPluginHooks,
+  RsdoctorStatsModuleIssuer,
 };
 
 pub type SendModuleGraph =
@@ -303,7 +304,30 @@ async fn optimize_chunk_modules(&self, compilation: &mut Compilation) -> Result<
     }
   }
 
-  // 5. collect chunk modules
+  // 5. Rsdoctor module add issuer_path
+  for module in module_graph.modules() {
+    let mut issuer_path = Vec::new();
+    let (module_id, _) = module;
+    let mut current_issuer = module_graph.get_issuer(&module_id);
+
+    while let Some(i) = current_issuer {
+      if let Some(rsd_module) = rsd_modules.get_mut(&i.identifier()) {
+        let module_ukey = rsd_module.ukey;
+
+        issuer_path.push(RsdoctorStatsModuleIssuer {
+          ukey: Some(module_ukey),
+        });
+      }
+
+      current_issuer = module_graph.get_issuer(&i.identifier());
+    }
+
+    if let Some(rsd_module) = rsd_modules.get_mut(&module_id) {
+      rsd_module.issuer_path = Some(issuer_path);
+    }
+  }
+
+  // 6. collect chunk modules
   let chunk_modules =
     collect_chunk_modules(chunk_by_ukey, &MODULE_UKEY_MAP, chunk_graph, &module_graph);
 

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
@@ -29,11 +29,14 @@ module.exports = {
 						);
 						expect(concatenateModules.length).toBe(1);
 						expect(normalModules.length).toBe(4);
-						const issuerPathList = normalModules.map(module => {
-							return module.issuerPath.length > 0;
-						});
 
-						expect(issuerPathList).toEqual([true, true, true, false]);
+						// test for issuerPath
+						const issuerPathList = normalModules
+							.filter(module => module.issuerPath.length)
+							.map(module => module.issuerPath.length);
+						[1, 2, 3].forEach(value => {
+							expect(issuerPathList).toContain(value);
+						});
 
 						const entryModule = modules.find(
 							module => module.isEntry && module.kind === "concatenated"

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
@@ -30,10 +30,10 @@ module.exports = {
 						expect(concatenateModules.length).toBe(1);
 						expect(normalModules.length).toBe(4);
 						const issuerPathList = normalModules.map(module => {
-							return module.issuerPath.length;
+							return module.issuerPath.length > 0;
 						});
 
-						expect(issuerPathList).toEqual([3, 1, 2, 0]);
+						expect(issuerPathList).toEqual([true, true, true, false]);
 
 						const entryModule = modules.find(
 							module => module.isEntry && module.kind === "concatenated"

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
@@ -29,6 +29,11 @@ module.exports = {
 						);
 						expect(concatenateModules.length).toBe(1);
 						expect(normalModules.length).toBe(4);
+						const issuerPathList = normalModules.map(module => {
+							return module.issuerPath.length;
+						});
+
+						expect(issuerPathList).toEqual([3, 1, 2, 0]);
 
 						const entryModule = modules.find(
 							module => module.isEntry && module.kind === "concatenated"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

feat: rsdoctor module object add issuerPath properry.


## Summary
This pull request introduces several changes to the `rsdoctor` module in the `rspack` project, primarily focusing on adding support for tracking the issuer path of modules. The most important changes include the addition of the `issuer_path` field to the `RsdoctorModule` and `JsRsdoctorModule` structs, and the corresponding logic to populate this field.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
