### PR TITLE
refactor: simplify fs code

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -327,7 +327,7 @@ export declare class JsModuleGraph {
 }
 
 export declare class JsResolver {
-  resolveSync(path: string, request: string): JsResourceData | false
+  resolve(path: string, request: string): Promise<JsResourceData | false>
   withOptions(raw?: RawResolveOptionsWithDependencyType | undefined | null): JsResolver
 }
 

--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -9,7 +9,6 @@ use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
 use rspack_paths::{ArcPath, AssertUtf8};
 use rustc_hash::FxHashSet as HashSet;
-use tokio::task::spawn_blocking;
 
 pub use self::option::{PathMatcher, SnapshotOptions};
 use self::strategy::{Strategy, StrategyHelper, ValidateResult};
@@ -53,10 +52,7 @@ impl Snapshot {
       // check path exists
       let fs = self.fs.clone();
       let utf8_path_clone = utf8_path.to_owned();
-      let metadata_has_error =
-        spawn_blocking(move || fs.clone().metadata_sync(&utf8_path_clone).is_err())
-          .await
-          .unwrap_or(true);
+      let metadata_has_error = fs.clone().metadata(&utf8_path_clone).await.is_err();
       if metadata_has_error {
         return;
       }

--- a/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
@@ -66,11 +66,7 @@ impl StrategyHelper {
     }
 
     let mut res = None;
-    if let Ok(content) = self
-      .fs
-      .async_read(&path.join("package.json").assert_utf8())
-      .await
-    {
+    if let Ok(content) = self.fs.read(&path.join("package.json").assert_utf8()).await {
       if let Ok(mut package_json) =
         serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(&content)
       {

--- a/crates/rspack_fs/src/memory_fs.rs
+++ b/crates/rspack_fs/src/memory_fs.rs
@@ -271,10 +271,6 @@ impl ReadableFileSystem for MemoryFileSystem {
     Ok(path.assert_utf8())
   }
 
-  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>> {
-    ReadableFileSystem::read(self, file).await
-  }
-
   async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>> {
     self._read_dir(dir)
   }
@@ -460,23 +456,23 @@ mod tests {
 
     // read
     assert!(
-      ReadableFileSystem::async_read(&fs, Utf8Path::new("/a/temp/file2"))
+      ReadableFileSystem::read(&fs, Utf8Path::new("/a/temp/file2"))
         .await
         .is_err()
     );
     assert!(
-      ReadableFileSystem::async_read(&fs, Utf8Path::new("/a/file1/file2"))
+      ReadableFileSystem::read(&fs, Utf8Path::new("/a/file1/file2"))
         .await
         .is_err()
     );
     assert_eq!(
-      ReadableFileSystem::async_read(&fs, Utf8Path::new("/a/file1"))
+      ReadableFileSystem::read(&fs, Utf8Path::new("/a/file1"))
         .await
         .unwrap(),
       file_content
     );
     assert_eq!(
-      ReadableFileSystem::async_read(&fs, Utf8Path::new("/a/file2"))
+      ReadableFileSystem::read(&fs, Utf8Path::new("/a/file2"))
         .await
         .unwrap(),
       file_content

--- a/crates/rspack_fs/src/native_fs.rs
+++ b/crates/rspack_fs/src/native_fs.rs
@@ -230,10 +230,6 @@ impl ReadableFileSystem for NativeFileSystem {
     }
   }
 
-  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>> {
-    tokio::fs::read(file).await.to_fs_result()
-  }
-
   async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>> {
     let mut res = vec![];
     let mut read_dir = tokio::fs::read_dir(dir).await.to_fs_result()?;

--- a/crates/rspack_fs/src/read.rs
+++ b/crates/rspack_fs/src/read.rs
@@ -25,9 +25,4 @@ pub trait ReadableFileSystem: Debug + Send + Sync {
   /// Returns a Vec of entry names in the directory
   async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>>;
   fn read_dir_sync(&self, dir: &Utf8Path) -> Result<Vec<String>>;
-
-  /// Read the entire contents of a file into a bytes vector.
-  ///
-  /// Error: This function will return an error if path does not already exist.
-  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>>;
 }

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -4,7 +4,6 @@ use rspack_error::{error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray
 use rspack_fs::ReadableFileSystem;
 use rspack_sources::SourceMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use tokio::task::spawn_blocking;
 
 use crate::{
   content::{AdditionalData, Content, ResourceData},
@@ -48,11 +47,10 @@ async fn process_resource<Context: Send>(
       && !resource_path.as_str().is_empty()
     {
       let resource_path_owned = resource_path.to_owned();
-      // use spawn_blocking to avoid block,see https://docs.rs/tokio/latest/src/tokio/fs/read.rs.html#48
-      let result = spawn_blocking(move || fs.read_sync(resource_path_owned.as_path()))
+      let result = fs
+        .read(resource_path_owned.as_path())
         .await
-        .map_err(|e| error!("{e}, spawn task failed"))?;
-      let result = result.map_err(|e| error!("{e}, failed to read {resource_path}"))?;
+        .map_err(|e| error!("{e}, failed to read {resource_path}"))?;
       loader_context.content = Some(Content::from(result));
     } else if !resource_data.get_scheme().is_none() {
       let resource = &resource_data.resource;

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4753,8 +4753,6 @@ class Resolver {
     // (undocumented)
     resolve(context: object, path: string, request: string, resolveContext: ResolveContext, callback: ResolveCallback): void;
     // (undocumented)
-    resolveSync(context: object, path: string, request: string): string | false;
-    // (undocumented)
     withOptions({ dependencyCategory, resolveToContext, ...resolve }: ResolveOptionsWithDependencyType_2): Resolver;
 }
 

--- a/packages/rspack/src/Resolver.ts
+++ b/packages/rspack/src/Resolver.ts
@@ -27,12 +27,6 @@ export class Resolver {
 		this.binding = binding;
 	}
 
-	resolveSync(context: object, path: string, request: string): string | false {
-		const data = this.binding.resolveSync(path, request);
-		if (data === false) return data;
-		return data.resource;
-	}
-
 	resolve(
 		context: object,
 		path: string,
@@ -41,12 +35,16 @@ export class Resolver {
 		callback: ResolveCallback
 	): void {
 		try {
-			const data = this.binding.resolveSync(path, request);
-			if (data === false) {
-				callback(null, false);
-				return;
-			}
-			callback(null, data.resource, data);
+			this.binding.resolve(path, request).then(
+				data => {
+					if (data === false) {
+						callback(null, false);
+						return;
+					}
+					callback(null, data.resource, data);
+				},
+				err => callback(err as ErrorWithDetails)
+			);
 		} catch (err) {
 			callback(err as ErrorWithDetails);
 		}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

small refactors:

- refactor: change `JsResolver::resolve_sync` to `JsResolver::resolve`, making it async
   because `JsResolver::resolve_sync` is a napi function, and on the js side, it's only exposed in a callback-style API
- refactor: remove some unnecessary `spawn_blocking`
    Since` ReadableFileSystem` already provides asynchronous methods, there's no need to use `spawn_blocking` anymore.
- refactor: remove `ReadableFileSystem::read_async` as it's duplicated

changes that may cause regression:

- refactor: use non-blocking fs in `impl ReadableFileSystem for NativeFileSystem`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

I have run `cargo test --lib --bins --examples --tests --benches --all-targets` and `./x test ci` in my local, It passed.

<img width="1513" alt="image" src="https://github.com/user-attachments/assets/d0045d2b-c2c0-4e8c-9f06-bd70ffd148d4" />
