### PR TITLE
fix: error when load binding multiple times

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -12,6 +12,8 @@ export type AssetInfo = KnownAssetInfo & Record<string, any>;
 
 export const MODULE_IDENTIFIER_SYMBOL: unique symbol;
 
+export const COMPILATION_HOOKS_MAP_SYMBOL: unique symbol;
+
 export interface Module {
 	[MODULE_IDENTIFIER_SYMBOL]: string;
 	readonly type: string;

--- a/crates/node_binding/scripts/banner.d.ts
+++ b/crates/node_binding/scripts/banner.d.ts
@@ -12,6 +12,8 @@ export type AssetInfo = KnownAssetInfo & Record<string, any>;
 
 export const MODULE_IDENTIFIER_SYMBOL: unique symbol;
 
+export const COMPILATION_HOOKS_MAP_SYMBOL: unique symbol;
+
 export interface Module {
 	[MODULE_IDENTIFIER_SYMBOL]: string;
 	readonly type: string;

--- a/crates/node_binding/src/module.rs
+++ b/crates/node_binding/src/module.rs
@@ -671,6 +671,8 @@ pub type JsBuildMetaDefaultObject = Either<String, JsBuildMetaDefaultObjectRedir
 
 thread_local! {
   pub(crate) static MODULE_IDENTIFIER_SYMBOL: OnceCell<OneShotRef> = Default::default();
+
+  pub(crate) static COMPILATION_HOOKS_MAP_SYMBOL: OnceCell<OneShotRef> = Default::default();
 }
 
 #[module_exports]
@@ -679,6 +681,15 @@ fn init(mut exports: Object, env: Env) -> napi::Result<()> {
   exports.set_named_property("MODULE_IDENTIFIER_SYMBOL", &module_identifier_symbol)?;
   MODULE_IDENTIFIER_SYMBOL.with(|once_cell| {
     once_cell.get_or_init(move || module_identifier_symbol);
+  });
+
+  let compilation_hooks_map_symbol = OneShotRef::new(env.raw(), env.create_symbol(None)?)?;
+  exports.set_named_property(
+    "COMPILATION_HOOKS_MAP_SYMBOL",
+    &compilation_hooks_map_symbol,
+  )?;
+  COMPILATION_HOOKS_MAP_SYMBOL.with(|once_cell| {
+    once_cell.get_or_init(move || compilation_hooks_map_symbol);
   });
 
   Ok(())

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -591,6 +591,8 @@ interface CommonJsConfig extends BaseModuleConfig {
 
 // @public (undocumented)
 export class Compilation {
+    // (undocumented)
+    [binding.COMPILATION_HOOKS_MAP_SYMBOL]: WeakMap<Compilation, NormalModuleCompilationHooks>;
     constructor(compiler: Compiler, inner: JsCompilation);
     // @internal
     __internal__deleteAssetSource(filename: string): void;
@@ -3934,6 +3936,16 @@ type NoParseOptionSingle = string | RegExp | ((request: string) => boolean);
 type NormalizedStatsOptions = KnownNormalizedStatsOptions & Omit<StatsOptions, keyof KnownNormalizedStatsOptions> & Record<string, any>;
 
 export { NormalModule }
+
+// @public (undocumented)
+interface NormalModuleCompilationHooks {
+    // (undocumented)
+    loader: liteTapable.SyncHook<[LoaderContext, Module]>;
+    // (undocumented)
+    readResource: liteTapable.HookMap<liteTapable.AsyncSeriesBailHook<[LoaderContext], string | Buffer>>;
+    // (undocumented)
+    readResourceForScheme: any;
+}
 
 // @public (undocumented)
 type NormalModuleCreateData = binding.JsNormalModuleFactoryCreateModuleArgs & {

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -7,7 +7,7 @@
  * Copyright (c) JS Foundation and other contributors
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
-import type * as binding from "@rspack/binding";
+import * as binding from "@rspack/binding";
 import {
 	type AssetInfo,
 	type Dependency,
@@ -30,6 +30,7 @@ import { Entrypoint } from "./Entrypoint";
 import { cutOffLoaderExecution } from "./ErrorHelpers";
 import type { CodeGenerationResult, Module } from "./Module";
 import ModuleGraph from "./ModuleGraph";
+import type { NormalModuleCompilationHooks } from "./NormalModule";
 import type { NormalModuleFactory } from "./NormalModuleFactory";
 import type { ResolverFactory } from "./ResolverFactory";
 import { JsRspackDiagnostic, type RspackError } from "./RspackError";
@@ -270,6 +271,10 @@ export class Compilation {
 	needAdditionalPass: boolean;
 
 	#addIncludeDispatcher: AddIncludeDispatcher;
+	[binding.COMPILATION_HOOKS_MAP_SYMBOL]: WeakMap<
+		Compilation,
+		NormalModuleCompilationHooks
+	>;
 
 	constructor(compiler: Compiler, inner: JsCompilation) {
 		this.#inner = inner;
@@ -391,6 +396,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this.#addIncludeDispatcher = new AddIncludeDispatcher(
 			inner.addInclude.bind(inner)
 		);
+		this[binding.COMPILATION_HOOKS_MAP_SYMBOL] = new WeakMap();
 	}
 
 	get hash(): Readonly<string | null> {

--- a/packages/rspack/src/NormalModule.ts
+++ b/packages/rspack/src/NormalModule.ts
@@ -2,7 +2,7 @@ import util from "node:util";
 import * as binding from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
 import type { Source } from "webpack-sources";
-import { type Compilation, checkCompilation } from "./Compilation";
+import type { Compilation } from "./Compilation";
 import type { Module } from "./Module";
 import type { LoaderContext } from "./config";
 import { JsSource } from "./util/source";
@@ -38,18 +38,13 @@ Object.defineProperty(binding.NormalModule.prototype, "emitFile", {
 	}
 });
 
-interface NormalModuleCompilationHooks {
+export interface NormalModuleCompilationHooks {
 	loader: liteTapable.SyncHook<[LoaderContext, Module]>;
 	readResourceForScheme: any;
 	readResource: liteTapable.HookMap<
 		liteTapable.AsyncSeriesBailHook<[LoaderContext], string | Buffer>
 	>;
 }
-
-const compilationHooksMap = new WeakMap<
-	Compilation,
-	NormalModuleCompilationHooks
->();
 
 const createFakeHook = <T extends Record<string, any>>(
 	fakeHook: T,
@@ -107,8 +102,14 @@ Object.defineProperty(binding.NormalModule, "getCompilationHooks", {
 	enumerable: true,
 	configurable: true,
 	value(compilation: Compilation): NormalModuleCompilationHooks {
-		checkCompilation(compilation);
+		if (!(binding.COMPILATION_HOOKS_MAP_SYMBOL in compilation)) {
+			throw new TypeError(
+				"The 'compilation' argument must be an instance of Compilation"
+			);
+		}
 
+		const compilationHooksMap =
+			compilation[binding.COMPILATION_HOOKS_MAP_SYMBOL];
 		let hooks = compilationHooksMap.get(compilation);
 		if (hooks === undefined) {
 			hooks = {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This is to resolve the issue where invoking `NormalModule.getCompilationHooks` throws an error when Node.js loads `@rspack/binding` multiple times.

The error occurs because `NormalModule.getCompilationHooks` relies on the `Compilation` class to verify the validity of input parameters. To address this, we now:

1. Add a symbol to the Compilation instance for validation.
2. Move the `compilationHooksMap` into the Compilation instance itself.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
