### PR TITLE
fix(incremental): dynamic add entries with infer async modules

### DIFF
--- a/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/0/index0.js
+++ b/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/0/index0.js
@@ -1,0 +1,6 @@
+import a from "./module"
+
+it("should have correct entrypoints", function() {
+  expect(Object.keys(__STATS__.entrypoints)).toEqual(["bundle0"]);
+  expect(a).toBe(1)
+})

--- a/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/0/module.js
+++ b/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/0/module.js
@@ -1,0 +1,2 @@
+import a from "./tla.js"
+export default a;

--- a/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/0/tla.js
+++ b/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/0/tla.js
@@ -1,0 +1,2 @@
+const a = await Promise.resolve(1);
+export default a;

--- a/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/1/index0.js
+++ b/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/1/index0.js
@@ -1,0 +1,6 @@
+import a from "./module"
+
+it("should have correct entrypoints", function() {
+  expect(Object.keys(__STATS__.entrypoints)).toEqual(["bundle0", "bundle1"]);
+  expect(a).toBe(1)
+})

--- a/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/1/index1.js
+++ b/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/1/index1.js
@@ -1,0 +1,5 @@
+import a from "./module"
+
+it("should have correct output for new added entry with top-level-await", function() {
+  expect(a).toBe(1)
+})

--- a/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/rspack.config.js
@@ -1,0 +1,26 @@
+const path = require("path");
+const fs = require("fs");
+
+let compiler;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: async () => {
+		const context = compiler.context;
+		const files = await fs.promises.readdir(context);
+		let entries = files.filter(f => f.startsWith("index"));
+		entries.sort();
+		return entries.reduce((acc, e, i) => {
+			acc[`bundle${i}`] = path.resolve(context, e);
+			return acc;
+		}, {});
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		function (c) {
+			compiler = c;
+		}
+	]
+};

--- a/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/async-modules/dynamic-entries/test.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	findBundle(i, options, step) {
+		if (step === "0") {
+			return ["bundle0.js"];
+		}
+		if (step === "1") {
+			return ["bundle0.js", "bundle1.js"];
+		}
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

In the test case, before the affected modules for infer async modules is the added entry: `index1`, this cause the wrong generated code for `index1`, to fix this, we need also add the `index1`'s outgoing modules, and there outgoing modules, to the affected modules, but this would cause very bad performance (too may modules when iterate with `get_outgoing_connections`), so we just fallback to use all modules here since the infer async modules is not slow in the whole compilation, it's too hard to write a correct and performance well incremental infer async modules

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
