### PR TITLE
fix: worker alias with module

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -527,7 +527,8 @@ impl NormalModuleFactory {
       ));
     }
 
-    let resolved_resolve_options = self.calculate_resolve_options(&resolved_module_rules);
+    let resolved_resolve_options =
+      self.calculate_resolve_options(&resolved_module_rules, dependency_category);
     let (resolved_parser_options, resolved_generator_options) =
       self.calculate_parser_and_generator_options(&resolved_module_rules);
     let (resolved_parser_options, resolved_generator_options) = self
@@ -650,7 +651,11 @@ impl NormalModuleFactory {
     Ok(rules)
   }
 
-  fn calculate_resolve_options(&self, module_rules: &[&ModuleRuleEffect]) -> Option<Arc<Resolve>> {
+  fn calculate_resolve_options(
+    &self,
+    module_rules: &[&ModuleRuleEffect],
+    dependency_type: DependencyCategory,
+  ) -> Option<Arc<Resolve>> {
     let mut resolved: Option<Resolve> = None;
     for rule in module_rules {
       if let Some(rule_resolve) = &rule.resolve {
@@ -661,7 +666,9 @@ impl NormalModuleFactory {
         }
       }
     }
-    resolved.map(Arc::new)
+    resolved
+      .map(|r| r.merge_by_dependency(dependency_type))
+      .map(Arc::new)
   }
 
   fn calculate_side_effects(&self, module_rules: &[&ModuleRuleEffect]) -> Option<bool> {

--- a/packages/rspack-test-tools/src/case/config.ts
+++ b/packages/rspack-test-tools/src/case/config.ts
@@ -27,7 +27,11 @@ const creator = new BasicCaseCreator({
 			name,
 			runable: true,
 			compilerType: ECompilerType.Rspack,
-			configFiles: ["rspack.config.js", "webpack.config.js"]
+			configFiles: [
+				"rspack.config.cjs",
+				"rspack.config.js",
+				"webpack.config.js"
+			]
 		})
 	],
 	runner: MultipleRunnerFactory,

--- a/packages/rspack-test-tools/src/case/new-code-splitting.ts
+++ b/packages/rspack-test-tools/src/case/new-code-splitting.ts
@@ -43,7 +43,11 @@ const configCreator = new BasicCaseCreator({
 			name,
 			runable: true,
 			compilerType: ECompilerType.Rspack,
-			configFiles: ["rspack.config.js", "webpack.config.js"]
+			configFiles: [
+				"rspack.config.cjs",
+				"rspack.config.js",
+				"webpack.config.js"
+			]
 		});
 		return [processor];
 	},

--- a/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/index.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/index.js
@@ -1,0 +1,13 @@
+function createWorker() {
+  return new Worker(new URL('./worker.js', import.meta.url));
+}
+
+new Map(), createWorker;
+
+const fs = require("fs");
+const path = require("path");
+
+it("should compile", () => {
+  const worker = fs.readFileSync(path.resolve(__dirname, "worker.js"), "utf-8");
+  expect(worker).toContain("this is a fake node_modules");
+});

--- a/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/node_modules/corejs/modules/esnext.map.update.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/node_modules/corejs/modules/esnext.map.update.js
@@ -1,0 +1,4 @@
+console.log("this is a fake node_modules");
+
+module.exports = {
+}

--- a/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/node_modules/corejs/package.json
+++ b/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/node_modules/corejs/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "corejs",
+  "version": "3.41.0",
+  "private": true,
+  "type": "commonjs"
+}

--- a/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/package.json
+++ b/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "rspack-worker-alias",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/rspack.config.cjs
+++ b/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/rspack.config.cjs
@@ -1,0 +1,29 @@
+const path = require('path');
+
+module.exports = {
+  optimization: {
+    chunkIds: "named",
+    moduleIds: "named",
+    splitChunks: false
+  },
+  output: {
+    chunkFilename: "worker.js",
+  },
+  node: {
+    __dirname: false,
+    __filename: false,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        type: 'javascript/auto',
+        resolve: {
+          alias: {
+            'somefakemodule': path.resolve(__dirname, "./node_modules/corejs")
+          }
+        }
+      },
+    ]
+  }
+};

--- a/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/worker.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/worker-alias/worker.js
@@ -1,0 +1,3 @@
+require("somefakemodule/modules/esnext.map.update");
+
+new Map();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/9940

The resolve options which is stored in normal module should include the part of `byDependency`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
