### PR TITLE
chore: release v1.3.5

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "binding.js",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-wasm32-wasi",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.wasi.cjs",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-x64-msvc",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-x64-msvc.node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "description": "The fast Rust-based web bundler with webpack-compatible API",
   "private": true,

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "CLI for rspack",
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/test-tools",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "description": "Test tools for rspack",
   "main": "dist/index.js",

--- a/packages/rspack-tracing/package.json
+++ b/packages/rspack-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/tracing",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "module",
   "description": "Internal tracing package for rspack",
   "homepage": "https://rspack.dev",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "The fast Rust-based web bundler with webpack-compatible API",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at release/v1.3.5 -->

## What's Changed
### Performance Improvements ⚡
* perf: js module loaders getter by @SyMind in https://github.com/web-infra-dev/rspack/pull/9955
### Exciting New Features 🎉
* feat: adapter rspack-resolver async api by @stormslowly in https://github.com/web-infra-dev/rspack/pull/9747
* feat: rspack cacheable noop feature by @jerrykingxyz in https://github.com/web-infra-dev/rspack/pull/9990
* feat: resolver restriction support regex by @SyMind in https://github.com/web-infra-dev/rspack/pull/9885
### Bug Fixes 🐞
* fix: stablelize order of concated modules by @JSerFeng in https://github.com/web-infra-dev/rspack/pull/9968
* fix: jsonpChunksLoadingWithCallback code format by @1714080902120 in https://github.com/web-infra-dev/rspack/pull/9923
* fix: lightningcss loader report error by default by @SyMind in https://github.com/web-infra-dev/rspack/pull/9979
* fix: external with properties array list in module format by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9980
* fix: external module to pass webpack test cases by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9981
* fix: hmr wasm filename by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/10010
* fix: sometimes entry chunk hash not changes with full hash runtime modules by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9986
* fix(wasm): align trait methods for `native_fs` by @CPunisher in https://github.com/web-infra-dev/rspack/pull/9999
* fix: incorrect type signatures on Hash's digest and update methods by @hulin32 in https://github.com/web-infra-dev/rspack/pull/9608
* fix: error when load binding multiple times by @SyMind in https://github.com/web-infra-dev/rspack/pull/10018
* fix(incremental): dynamic add entries with infer async modules by @ahabhgk in https://github.com/web-infra-dev/rspack/pull/10019
* fix: covert optional import meta property to `undefined` by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/10030
* fix: worker alias with module by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/10021
### Document Updates 📖
* docs: add rspack & next.js partner annoucement by @hardfist in https://github.com/web-infra-dev/rspack/pull/9962
* docs: update blog tile and description on the list page by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/9969
* docs: add next.js guide to sidebar by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/9970
* docs: translate Next.js blog to Chinese by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/9974
* docs: improve clarity in documentation by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/9977
* docs: add dependency in glossary by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9972
* docs: add a standalone ecosystem page by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10004
### Other Changes
* ci: split reusable-build.yml by @jerrykingxyz in https://github.com/web-infra-dev/rspack/pull/9941
* chore: release v1.3.4 by @ahabhgk in https://github.com/web-infra-dev/rspack/pull/9950
* refactor: dynamic templates of javascript esm dependencies by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9945
* refactor: dynamic templates of JavaScript amd and cjs dependencies
 by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9948
* refactor: dynamic templates of javascript remain depenendencies by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9958
* chore(deps): update github-actions by @renovate in https://github.com/web-infra-dev/rspack/pull/9951
* refactor: dynamic templates of all dependencies by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9960
* refactor: clean dependency template code by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9961
* test: not to print unnecessary message when testing by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9963
* ci: add lynx-stack to ecosystem-ci by @colinaaa in https://github.com/web-infra-dev/rspack/pull/9964
* chore: use async trace style for chrome tracing by @hardfist in https://github.com/web-infra-dev/rspack/pull/9965
* chore: remove unused scripts by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/9973
* ci: update lynx infra artifact action by @jerrykingxyz in https://github.com/web-infra-dev/rspack/pull/9975
* ci: use node v22 in ecosystem-ci by @colinaaa in https://github.com/web-infra-dev/rspack/pull/9966
* chore: use RefCell instead of Mutex in thread_local! by @quininer in https://github.com/web-infra-dev/rspack/pull/9978
* chore: improve tracing by @hardfist in https://github.com/web-infra-dev/rspack/pull/9989
* refactor: remove useless code by @jerrykingxyz in https://github.com/web-infra-dev/rspack/pull/9992
* chore(deps): update dependency @rspack/plugin-react-refresh to ^1.2.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10000
* chore(deps): update dependency prebundle to ^1.3.3 by @renovate in https://github.com/web-infra-dev/rspack/pull/10001
* chore: add more tracing data by @hardfist in https://github.com/web-infra-dev/rspack/pull/9994
* chore(deps): update rspress to 2.0.0-alpha.11 by @SoonIter in https://github.com/web-infra-dev/rspack/pull/10027

## New Contributors
* @1714080902120 made their first contribution in https://github.com/web-infra-dev/rspack/pull/9923

**Full Changelog**: https://github.com/web-infra-dev/rspack/compare/v1.3.4...v1.3.5