### PR TITLE
chore: bump swc version to 22.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,7 +2660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3679,9 +3679,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07852df2dda2f0ab8c3407a6fd19e9389563af11c20f6c299bd07ff9fc96d6ae"
+checksum = "9f0d30c7b8edcf218dd85ceacd8412f0c99a9c36419b81ea7fb97b569316d92a"
 dependencies = [
  "anyhow",
  "browserslist-rs",
@@ -6202,9 +6202,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "swc"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccfeff9af7ffb8fb7243dc698c598e00963486ef5cdeff449abf1cccacef417"
+checksum = "3809091d5035036db41f5212697b10e492a6c97d50bf76839ac52481547a0528"
 dependencies = [
  "anyhow",
  "base64",
@@ -6300,9 +6300,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "8.0.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4a932c152e7142de2d5dba1c393e5523c47cd8fe656e5b0d411954bbaf1810"
+checksum = "7d96ac5d021c7c20acb3073940b4ee59b62989a705f855783c4a452e0737a2e6"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -6332,9 +6332,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "15.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806774262e8cc665d986364c109bdaa91eeadebf71402df6894c7c3c2be92795"
+checksum = "3516918cdce803f6c175aeefefbf3a05b4064eadc2a772f98da63d4282f85497"
 dependencies = [
  "anyhow",
  "base64",
@@ -6385,9 +6385,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "18.0.0"
+version = "22.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6448a3f005d6cd35ae201595669421af9292397e29d04530fa753069c9cf3913"
+checksum = "0ebb37ecf7f5c6c97b2a03ad7fc434d64334f6023affb0d495884e55318bbf94"
 dependencies = [
  "par-core",
  "swc",
@@ -6414,17 +6414,19 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "8.1.0"
+version = "8.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f80679b1afc52ae0663eed0a2539cc3c108d48c287b5601712f9850d9fa9c2"
+checksum = "4062a54522a9c02d2b68cc09282774b87121cd48693b0e67ae8c18b31b709866"
 dependencies = [
  "bitflags 2.6.0",
  "bytecheck 0.8.0",
  "is-macro",
  "num-bigint",
+ "once_cell",
  "phf",
  "rancor",
  "rkyv 0.8.8",
+ "rustc-hash 2.1.0",
  "scoped-tls",
  "serde",
  "string_enum",
@@ -6436,9 +6438,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "8.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f131ade75f9a3cfea38dbce11893f5636b0954de973ad29a2556124322a08372"
+checksum = "b85453d346d0642f296c2b3aa204886a6ae2b9652262c3468d6f4556c1ed020d"
 dependencies = [
  "ascii",
  "compact_str",
@@ -6459,9 +6461,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac2ff0957329e0dfcde86a1ac465382e189bf42a5989720d3476bea78eaa31a"
+checksum = "e99e1931669a67c83e2c2b4375674f6901d1480994a76aa75b23f1389e6c5076"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6682,9 +6684,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "12.0.0"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac89356dc7ab49dc30e9219fdb57cfc35a80aec3c0ae2e12c2a3488f9cfce7dd"
+checksum = "d86c9a647230352f00452699472e16fa76ec54a9e4acfe7fb8c0c93ec3d0ee07"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -6726,9 +6728,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "14.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6c3ea74a80bf1d21bba94f823aa9e90f903b81b345f99c1595faf87d732c63"
+checksum = "996ab0475502825584922ed02a5a457b1538afab511be57ae69434b5eda5762f"
 dependencies = [
  "arrayvec",
  "indexmap 2.7.1",
@@ -6763,10 +6765,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "11.0.0"
+version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e06ecaef86a547831f7f01f342434e4b0d0f363762f8e7a2b84da7a0a5f92e"
+checksum = "aa942372098c7c0e7fd8c584a577378d2f659c934429b8252c4e26fae31d7ea7"
 dependencies = [
+ "arrayvec",
+ "bitflags 2.6.0",
  "either",
  "new_debug_unreachable",
  "num-bigint",
@@ -6786,9 +6790,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6e90087fe511cde69e3648bceb90b04be01236451ced67486371f827d691e1"
+checksum = "dcdb997223f2c92bb31278cf25b37398209fe5ce6a5cf276cf0cdc264386124b"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -6850,9 +6854,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "12.0.0"
+version = "12.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b747f04a004d9b56b903305e4567e1d30c9cd226a8310a29cac06f7ac8173a"
+checksum = "b46e3a36213d78fb4233e596b8a5c81c6cdafe02d03d780eed006c983aa0a724"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.6.0",
@@ -7011,9 +7015,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "13.0.0"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b66c31438de864f9694493d3f3a08744a5604b59df03774d09e0f541f29976c"
+checksum = "d8e7635afe1e1e798d61ff3107b8d27e437e61f243dd226a47fb10724693be66"
 dependencies = [
  "base64",
  "dashmap 5.5.3",
@@ -7121,9 +7125,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "9.1.1"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7938665a5561d6c3e2b796b5b2d0bc9a961d461db960cb5139f12e82b45bb471"
+checksum = "499cf6a20e6acb36f15e22cca18dadc108d7046ae062840b7371ae02eac4dfde"
 dependencies = [
  "anyhow",
  "miette",
@@ -7137,9 +7141,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html"
-version = "14.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e2196c3738ab57e802fd0163442f9ea2a028381f827b527a19791bcfc4a2d8"
+checksum = "3e99deeb8fcdc673fdacf5a5e2bfe0e94657f7961c91d1b8482a8decba662e10"
 dependencies = [
  "swc_html_ast",
  "swc_html_codegen",
@@ -7189,9 +7193,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_minifier"
-version = "14.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8783aeab2a218ebc0f3d9a0033df55b14c945e2122966216ec7b09561c3e8202"
+checksum = "dc72c0c3ef3c780170e3cdfd9214d50d6df6ca96ce07ef0b31201c94202dad0d"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.0",
@@ -7305,9 +7309,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132317a7245b344d654da8cd3c6cdb6fcd72d1e7d028d1085aa679cfb5e9801a"
+checksum = "f59e5549019cd28b972e59d756404aa13dd4b4b3b21dfedc3f871804c6a6cc77"
 dependencies = [
  "anyhow",
  "enumset",
@@ -7317,6 +7321,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",
+ "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_plugin_proxy",
@@ -7367,10 +7372,11 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "11.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8f660e0ab0e92551747a41335ab6a0c7b685885da37f4e8e79ac5737bc4e04"
+checksum = "e8538a8b2e8d8a3ebbf58fe7f933d7b4bb01a291fbd7356352ea255cc15bbc70"
 dependencies = [
+ "bitflags 2.6.0",
  "petgraph 0.7.1",
  "rustc-hash 2.1.0",
  "swc_atoms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,13 +96,13 @@ inventory = { version = "0.3.17" }
 rkyv      = { version = "=0.8.8" }
 
 # Must be pinned with the same swc versions
-swc                 = { version = "=18.0.0" }
+swc                 = { version = "=21.0.0" }
 swc_config          = { version = "=2.0.0" }
-swc_core            = { version = "=18.0.0", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "=14.0.0", default-features = false }
-swc_error_reporters = { version = "=9.1.1" }
-swc_html            = { version = "=14.0.0" }
-swc_html_minifier   = { version = "=14.0.0", default-features = false }
+swc_core            = { version = "=22.4.0", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_minifier   = { version = "=16.0.1", default-features = false }
+swc_error_reporters = { version = "=10.0.0" }
+swc_html            = { version = "=16.0.0" }
+swc_html_minifier   = { version = "=16.0.0", default-features = false }
 swc_node_comments   = { version = "=8.0.0" }
 swc_parallel        = { version = "1.3.0", default-features = false, features = ["rayon"] }
 

--- a/crates/rspack_ast/src/ast/javascript.rs
+++ b/crates/rspack_ast/src/ast/javascript.rs
@@ -9,7 +9,7 @@ use swc_core::{
     visit::{Fold, FoldWith, Visit, VisitMut, VisitMutWith, VisitWith},
   },
 };
-use swc_error_reporters::handler::try_with_handler;
+use swc_error_reporters::{handler::try_with_handler, TWithDiagnosticArray};
 use swc_node_comments::SwcComments;
 
 /// Program is a wrapper for SwcProgram
@@ -177,7 +177,11 @@ impl Ast {
     })
   }
 
-  pub fn transform_with_handler<F, R>(&mut self, cm: Lrc<SourceMap>, f: F) -> Result<R, Error>
+  pub fn transform_with_handler<F, R>(
+    &mut self,
+    cm: Lrc<SourceMap>,
+    f: F,
+  ) -> Result<R, TWithDiagnosticArray<Error>>
   where
     F: FnOnce(&Handler, &mut Program, &Context) -> Result<R, Error>,
   {

--- a/crates/rspack_plugin_swc_js_minimizer/src/minify.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/minify.rs
@@ -314,7 +314,7 @@ struct RspackErrorEmitter {
 }
 
 impl Emitter for RspackErrorEmitter {
-  fn emit(&mut self, db: &swc_core::common::errors::DiagnosticBuilder<'_>) {
+  fn emit(&mut self, db: &mut swc_core::common::errors::DiagnosticBuilder<'_>) {
     let source_file_and_byte_pos = db
       .span
       .primary_span()


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
- Bump swc version to latest
- Only emit help_msg when swc error include `load plugin errors`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
