### PR TITLE
fix: should rename __webpack_require__ pat in parameters

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -219,7 +219,11 @@ impl JavascriptParserPlugin for CompatibilityPlugin {
     deps.push(ConstDependency::new(
       ident.span.real_lo(),
       ident.span.real_hi(),
-      name.into(),
+      if parser.in_short_hand {
+        format!("{}: {}", ident.sym, name.clone()).into()
+      } else {
+        name.clone().into()
+      },
       None,
     ));
     for dep in deps {

--- a/packages/rspack-test-tools/tests/configCases/plugins/compatibility-plugin/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/compatibility-plugin/index.js
@@ -6,4 +6,8 @@ it("compatibility plugin", async () => {
 	const context = require('./c.js');
 	const { __webpack_require__ } = context;
 	expect(__webpack_require__).toBe(1);
+
+	(function f({ __webpack_require__ }) {
+		expect(__webpack_require__).toBe(1);
+	})({ __webpack_require__ })
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

```js
const __webpack_require__ = 1;
call({ __webpack_require__ })
```

After

```js
const __webpack_require_rename__ = 1;
call({ __webpack_require__: __webpack_require_rename__ })
```

The parameter is not visited by `pattern` hook, instead, it uses `identifier` hook, so we should also rename it in `identifier` hook

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
