### PR TITLE
test: cacheCases update dynamic file by write

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -155,9 +155,9 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
     // (undocumented)
     afterAll(context: ITestContext): Promise<void>;
     // (undocumented)
-    build(context: ITestContext): Promise<void>;
-    // (undocumented)
     protected _cacheOptions: ICacheProcessorOptions<T>;
+    // (undocumented)
+    config(context: ITestContext): Promise<void>;
     // (undocumented)
     static defaultOptions<T extends ECompilerType>(this: CacheProcessor<T>, context: ITestContext): TCompilerOptions<T>;
     // (undocumented)
@@ -169,7 +169,7 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
     // (undocumented)
     protected runner: ITestRunner | null;
     // (undocumented)
-    protected updateOptions: TUpdateOptions;
+    protected updatePlugin: HotUpdatePlugin;
 }
 
 // @public (undocumented)
@@ -226,7 +226,7 @@ export class ConfigProcessor<T extends ECompilerType> extends MultiTaskProcessor
 export function createBuiltinCase(name: string, src: string, dist: string): void;
 
 // @public (undocumented)
-export function createCacheCase(name: string, src: string, dist: string, target: TCompilerOptions<ECompilerType.Rspack>["target"]): void;
+export function createCacheCase(name: string, src: string, dist: string, target: TCompilerOptions<ECompilerType.Rspack>["target"], temp: string): void;
 
 // @public (undocumented)
 export function createCompilerCase(name: string, src: string, dist: string, testConfig: string): void;
@@ -597,6 +597,21 @@ export class HotStepRunnerFactory<T extends ECompilerType> extends HotRunnerFact
 }
 
 // @public (undocumented)
+class HotUpdatePlugin {
+    constructor(projectDir: string, tempDir: string);
+    // (undocumented)
+    apply(compiler: Compiler): void;
+    // (undocumented)
+    getTotalUpdates(): number;
+    // (undocumented)
+    getUpdateIndex(): number;
+    // (undocumented)
+    goNext(): Promise<void>;
+    // (undocumented)
+    initialize(): Promise<void>;
+}
+
+// @public (undocumented)
 export interface IBasicCaseCreatorOptions<T extends ECompilerType> {
     // (undocumented)
     [key: string]: unknown;
@@ -694,7 +709,11 @@ export interface IBuiltinProcessorOptions<T extends ECompilerType> extends Omit<
 // @public (undocumented)
 export interface ICacheProcessorOptions<T extends ECompilerType> extends Omit<IBasicProcessorOptions<T>, "runable"> {
     // (undocumented)
+    sourceDir: string;
+    // (undocumented)
     target: TCompilerOptions<T>["target"];
+    // (undocumented)
+    tempDir: string;
 }
 
 // @public (undocumented)

--- a/packages/rspack-test-tools/src/case/cache.ts
+++ b/packages/rspack-test-tools/src/case/cache.ts
@@ -18,9 +18,11 @@ function getCreator(target: TTarget) {
 				clean: true,
 				describe: true,
 				target,
-				steps: ({ name, target }) => [
+				steps: ({ name, src, target, temp }) => [
 					new CacheProcessor({
 						name,
+						sourceDir: src,
+						tempDir: temp!,
 						target: target as TTarget,
 						compilerType: ECompilerType.Rspack,
 						configFiles: ["rspack.config.js", "webpack.config.js"]
@@ -38,8 +40,9 @@ export function createCacheCase(
 	name: string,
 	src: string,
 	dist: string,
-	target: TCompilerOptions<ECompilerType.Rspack>["target"]
+	target: TCompilerOptions<ECompilerType.Rspack>["target"],
+	temp: string
 ) {
 	const creator = getCreator(target);
-	creator.create(name, src, dist);
+	creator.create(name, src, dist, temp);
 }

--- a/packages/rspack-test-tools/src/helper/hot-update/index.ts
+++ b/packages/rspack-test-tools/src/helper/hot-update/index.ts
@@ -1,0 +1,1 @@
+export { HotUpdatePlugin } from "./plugin";

--- a/packages/rspack-test-tools/src/helper/hot-update/loader.ts
+++ b/packages/rspack-test-tools/src/helper/hot-update/loader.ts
@@ -1,0 +1,29 @@
+export default function (c: string) {
+	let content = c;
+	if (content.includes("NEXT_HMR")) {
+		content = `
+			${content}
+			let __hmr_children__ = [...module.children];
+      let __hmr_used_exports__ = __hmr_children__.reduce((res, child) => {
+        if (__webpack_module_cache__[child]) {
+          res[child] = __webpack_module_cache__[child].exports;
+        }
+				return res;
+			}, {});
+			module.hot.accept(__hmr_children__, () => {
+				__hmr_children__.forEach((child) => {
+					const reexports = __webpack_require__(child);
+          for (let key in reexports) {
+            if (!__hmr_used_exports__[child]) { continue; }
+						Object.defineProperty(__hmr_used_exports__[child], key, {
+							configurable: true,
+							enumerable: true,
+							get: () => reexports[key]
+						});
+					}
+				});
+			});
+		`;
+	}
+	return content.replace(/NEXT_HMR/g, "NEXT_HMR.bind(null, module)");
+}

--- a/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
+++ b/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { Compiler } from "@rspack/core";
+
+async function loopFile(
+	dir: string,
+	callback: (filePath: string, content: string) => void
+) {
+	const children = await fs.readdir(dir);
+	await Promise.all(
+		children.map(async filename => {
+			const filePath = path.join(dir, filename);
+			const stat = await fs.stat(filePath);
+			if (stat.isFile()) {
+				const content = await fs.readFile(filePath);
+				callback(filePath, content.toString());
+			} else if (stat.isDirectory()) {
+				return loopFile(filePath, callback);
+			}
+		})
+	);
+}
+
+const PLUGIN_NAME = "HotUpdatePlugin";
+
+export class HotUpdatePlugin {
+	private initialized = false;
+	private updateIndex = 0;
+	private files: Record<string, string[]> = {};
+	constructor(
+		private projectDir: string,
+		private tempDir: string
+	) {}
+
+	private getModifiedFiles() {
+		return Object.keys(this.files);
+	}
+	private getContent(filePath: string, index: number) {
+		const contents = this.files[filePath] || [];
+		let content =
+			contents[index] === undefined ? contents.at(-1) || "" : contents[index];
+		let command = "";
+		const matchResult = content.match(/^<(.+?)>(.*)/);
+		if (matchResult) {
+			command = matchResult[1];
+			content = matchResult[2];
+		}
+		return {
+			content,
+			command
+		};
+	}
+	private async updateFiles() {
+		await Promise.all(
+			this.getModifiedFiles().map(async filePath => {
+				const { content, command } = this.getContent(
+					filePath,
+					this.updateIndex
+				);
+				// match command
+				if (command === "delete") {
+					await fs.unlink(filePath);
+					return;
+				}
+				if (command === "force_write") {
+					await fs.writeFile(filePath, content);
+					return;
+				}
+				// default
+				const { content: oldContent } = this.getContent(
+					filePath,
+					this.updateIndex - 1
+				);
+				if (content === oldContent) {
+					return;
+				}
+				await fs.writeFile(filePath, content);
+			})
+		);
+	}
+
+	async initialize() {
+		if (this.initialized) {
+			return;
+		}
+		this.initialized = true;
+		await fs.rmdir(this.tempDir, { recursive: true });
+		await fs.cp(this.projectDir, this.tempDir, { recursive: true });
+		await loopFile(this.tempDir, (filePath, content) => {
+			const contents = content.split(/---+\r?\n/g);
+			if (contents.length > 1) {
+				this.files[filePath] = contents;
+			}
+		});
+		await this.updateFiles();
+	}
+
+	getUpdateIndex() {
+		return this.updateIndex;
+	}
+	getTotalUpdates() {
+		return Object.values(this.files).reduce((max, item) => {
+			return Math.max(max, item.length);
+		}, 0);
+	}
+	async goNext() {
+		this.updateIndex++;
+		await this.updateFiles();
+	}
+
+	apply(compiler: Compiler) {
+		const options = compiler.options;
+		options.context = this.tempDir;
+		options.module.rules ??= [];
+		options.module.rules.push({
+			test: /\.(js|css|json)/,
+			use: [
+				{
+					loader: path.resolve(__dirname, "./loader.js")
+				}
+			]
+		});
+		let isRebuild = false;
+		compiler.hooks.beforeRun.tap(PLUGIN_NAME, () => {
+			compiler.modifiedFiles = new Set(
+				isRebuild ? this.getModifiedFiles() : []
+			);
+			isRebuild = true;
+		});
+
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.additionalTreeRuntimeRequirements.tap(
+				PLUGIN_NAME,
+				(_chunk: any, set: any) => {
+					set.add(compiler.webpack.RuntimeGlobals.moduleCache);
+				}
+			);
+			compilation.hooks.runtimeModule.tap(
+				PLUGIN_NAME,
+				(module: any, _set: any) => {
+					if (module.constructorName === "DefinePropertyGettersRuntimeModule") {
+						module.source.source = Buffer.from(
+							`
+										__webpack_require__.d = function (exports, definition) {
+												for (var key in definition) {
+														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
+														}
+												}
+										};
+										`,
+							"utf-8"
+						);
+					}
+				}
+			);
+		});
+	}
+}

--- a/packages/rspack-test-tools/src/helper/util/refreshModifyTime.ts
+++ b/packages/rspack-test-tools/src/helper/util/refreshModifyTime.ts
@@ -1,6 +1,0 @@
-import { readFile, writeFile } from "fs-extra";
-
-export async function refreshModifyTime(file: string) {
-	const data = await readFile(file);
-	await writeFile(file, data);
-}

--- a/packages/rspack-test-tools/src/processor/cache.ts
+++ b/packages/rspack-test-tools/src/processor/cache.ts
@@ -1,33 +1,28 @@
 import path from "node:path";
 import { rspack } from "@rspack/core";
-import { removeSync } from "fs-extra";
 
-import { TestHotUpdatePlugin } from "../helper/plugins";
+import { HotUpdatePlugin } from "../helper/hot-update";
 import {
 	ECompilerType,
 	type ITestContext,
 	type ITestEnv,
 	type ITestRunner,
-	type TCompilerOptions,
-	type TUpdateOptions
+	type TCompilerOptions
 } from "../type";
 import { BasicProcessor, type IBasicProcessorOptions } from "./basic";
 
 export interface ICacheProcessorOptions<T extends ECompilerType>
 	extends Omit<IBasicProcessorOptions<T>, "runable"> {
 	target: TCompilerOptions<T>["target"];
+	tempDir: string;
+	sourceDir: string;
 }
 
 export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
-	protected updateOptions: TUpdateOptions;
+	protected updatePlugin: HotUpdatePlugin;
 	protected runner: ITestRunner | null = null;
 
 	constructor(protected _cacheOptions: ICacheProcessorOptions<T>) {
-		const fakeUpdateLoaderOptions: TUpdateOptions = {
-			updateIndex: 0,
-			totalUpdates: 1,
-			changedFiles: []
-		};
 		super({
 			defaultOptions: CacheProcessor.defaultOptions,
 			overrideOptions: CacheProcessor.overrideOptions,
@@ -35,34 +30,22 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
 			runable: true,
 			..._cacheOptions
 		});
-		this.updateOptions = fakeUpdateLoaderOptions;
+		this.updatePlugin = new HotUpdatePlugin(
+			_cacheOptions.sourceDir,
+			_cacheOptions.tempDir
+		);
 	}
 
-	async build(context: ITestContext): Promise<void> {
-		// clear cache directory first time.
-		const experiments =
-			this.getCompiler(context).getOptions().experiments || {};
-		let directory = "";
-		if (
-			"cache" in experiments &&
-			typeof experiments.cache === "object" &&
-			experiments.cache.type === "persistent"
-		) {
-			directory = experiments.cache.storage?.directory || directory;
-		}
-		removeSync(
-			path.resolve(context.getSource(), directory || "node_modules/.cache")
-		);
-
-		await super.build(context);
+	async config(context: ITestContext) {
+		await this.updatePlugin.initialize();
+		this._options.configFiles = this._options.configFiles?.map(item => {
+			return path.resolve(this._cacheOptions.tempDir, item);
+		});
+		super.config(context);
 	}
 
 	async run(env: ITestEnv, context: ITestContext) {
-		context.setValue(
-			this._options.name,
-			"hotUpdateContext",
-			this.updateOptions
-		);
+		context.setValue(this._options.name, "hotUpdateContext", this.updatePlugin);
 		await super.run(env, context);
 	}
 
@@ -99,12 +82,11 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
 
 	async afterAll(context: ITestContext) {
 		await super.afterAll(context);
-		if (
-			this.updateOptions.updateIndex + 1 !==
-			this.updateOptions.totalUpdates
-		) {
+		const updateIndex = this.updatePlugin.getUpdateIndex();
+		const totalUpdates = this.updatePlugin.getTotalUpdates();
+		if (updateIndex + 1 !== totalUpdates) {
 			throw new Error(
-				`Should run all hot steps (${this.updateOptions.updateIndex + 1} / ${this.updateOptions.totalUpdates}): ${this._options.name}`
+				`Should run all hot steps (${updateIndex + 1} / ${totalUpdates}): ${this._options.name}`
 			);
 		}
 	}
@@ -114,7 +96,7 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
 		context: ITestContext
 	): TCompilerOptions<T> {
 		const options = {
-			context: context.getSource(),
+			context: this._cacheOptions.tempDir,
 			mode: "production",
 			cache: true,
 			devtool: false,
@@ -158,6 +140,8 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
 			options.entry = "./index.js";
 		}
 
+		// rewrite context to temp dir
+		options.context = this._cacheOptions.tempDir;
 		options.module ??= {};
 		for (const cssModuleType of ["css/auto", "css/module", "css"] as const) {
 			options.module!.generator ??= {};
@@ -165,20 +149,10 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
 			options.module!.generator[cssModuleType]!.exportsOnly ??=
 				this._cacheOptions.target === "async-node";
 		}
-		options.module.rules ??= [];
-		options.module.rules.push({
-			test: /\.(js|css|json)/,
-			use: [
-				{
-					loader: path.resolve(__dirname, "../helper/loaders/hot-update.js"),
-					options: this.updateOptions
-				}
-			]
-		});
 		if (this._cacheOptions.compilerType === ECompilerType.Rspack) {
 			options.plugins ??= [];
 			(options as TCompilerOptions<ECompilerType.Rspack>).plugins!.push(
-				new TestHotUpdatePlugin(this.updateOptions)
+				this.updatePlugin
 			);
 		}
 		if (!global.printLogger) {

--- a/packages/rspack-test-tools/tests/Cache.test.js
+++ b/packages/rspack-test-tools/tests/Cache.test.js
@@ -3,12 +3,13 @@ process.env.RSPACK_CONFIG_VALIDATE = "loose-silent";
 
 const path = require("path");
 const { describeByWalk, createCacheCase } = require("@rspack/test-tools");
+const tempDir = path.resolve(__dirname, `./js/temp`);
 
 // Run tests rspack-test-tools/tests/cacheCases in target async-node
 describeByWalk(
 	"cache",
 	(name, src, dist) => {
-		createCacheCase(name, src, dist, "async-node");
+		createCacheCase(name, src, dist, "async-node", path.join(tempDir, name));
 	},
 	{
 		source: path.resolve(__dirname, "./cacheCases"),


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Currently, CacheCases uses a loader to switch file contents during HMR, which doesn't work when we want to test file modifications or file hash changes.

* This PR upgrades the test flow of CacheCases:
1. Copy the working test directory to a temporary directory
2. Scan dynamic files and write target content
3. Run test cases in a temporary directory
4. Write dynamic file content when rebuilding

* support a command write style to allow delete file or force_write content

``` text
export default 1
---
<delete> // delete the file
---
export default 1 // create the file
---
export default 2  // write file
---
export default 2 // skip write file (not update file modify time)
---
<force_write>export default 2 // force wirte file(will update file modifiy time)
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
