### PR TITLE
fix: failed to resolve tinypool when using parallel loader

### DIFF
--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -16,7 +16,7 @@ const externalAlias = ({ request }: { request?: string }, callback) => {
 	}
 
 	if (new RegExp(/^tinypool$/).test(request!)) {
-		return callback(null, "../compiled/tinypool");
+		return callback(null, "../compiled/tinypool/dist/index.js");
 	}
 
 	return callback();


### PR DESCRIPTION
## Summary

Fix failed to resolve tinypool when using parallel loader:

<img width="1208" alt="Screenshot 2025-04-15 at 22 47 25" src="https://github.com/user-attachments/assets/abd45efe-ce33-4f9d-8f51-f1555c6aac6b" />

The tinypool is imported with `import()` and directory import is not supported in this case. We should import the full module path.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
