### PR TITLE
fix: async entry should have unique runtime

### DIFF
--- a/crates/node_binding/rspack.wasi.cjs
+++ b/crates/node_binding/rspack.wasi.cjs
@@ -65,8 +65,6 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
     worker.onmessage = ({ data }) => {
       __wasmCreateOnMessageForFsProxy(__nodeFs)(data)
     }
-    worker.ref = () => {}
-    worker.unref();
     return worker
   },
   overwriteImports(importObject) {

--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -503,6 +503,7 @@ impl CodeSplitter {
         let entry_options = block
           .get_group_options()
           .and_then(|option| option.entry_options());
+        let is_entry = entry_options.is_some();
         let should_create = chunk_loading || entry_options.is_some();
         let block = module_graph
           .block_by_id(&block_id)
@@ -525,9 +526,15 @@ impl CodeSplitter {
           {
             // already created with name, let old_runtime = root.get_runtime();
             let old_runtime = root.get_runtime();
-            let new_runtime = merge_runtime(&runtime, old_runtime);
-            self.module_deps.entry(new_runtime.clone()).or_default();
-            root.set_runtime(new_runtime.clone());
+            let new_runtime = if is_entry {
+              // async entrypoint has unique runtime, do not merge runtime
+              old_runtime.clone()
+            } else {
+              let new_runtime = merge_runtime(&runtime, old_runtime);
+              self.module_deps.entry(new_runtime.clone()).or_default();
+              root.set_runtime(new_runtime.clone());
+              new_runtime
+            };
 
             match root {
               CreateChunkRoot::Entry(_, options, _) => {
@@ -577,9 +584,15 @@ impl CodeSplitter {
           } else if let Some(root) = roots.get_mut(&block_id) {
             // already created
             let old_runtime = root.get_runtime();
-            let new_runtime = merge_runtime(&runtime, old_runtime);
-            self.module_deps.entry(new_runtime.clone()).or_default();
-            root.set_runtime(new_runtime.clone());
+            let new_runtime = if is_entry {
+              // async entrypoint has unique runtime, do not merge runtime
+              old_runtime.clone()
+            } else {
+              let new_runtime = merge_runtime(&runtime, old_runtime);
+              self.module_deps.entry(new_runtime.clone()).or_default();
+              root.set_runtime(new_runtime.clone());
+              new_runtime
+            };
             Cow::Owned(new_runtime)
           } else {
             let rt = if let Some(entry_options) = entry_options {
@@ -1516,6 +1529,7 @@ Or do you want to use the entrypoints '{name}' and '{entry_runtime}' independent
     self.set_order_index_and_group_index(compilation);
 
     errors.sort_unstable_by_key(|err| err.message());
+
     compilation.extend_diagnostics(errors);
 
     if enable_incremental {

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/a.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/a.js
@@ -1,0 +1,2 @@
+import './worker'
+it('should compile', () => {})

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/b.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/b.js
@@ -1,0 +1,2 @@
+import './worker'
+it('should compile', () => {})

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/rspack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		a: "./a.js",
+		b: "./b.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	target: "web"
+};

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["a.js", "b.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/test.filter.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/test.filter.js
@@ -1,0 +1,5 @@
+var supportsWorker = require("../../../../dist/helper/legacy/supportsWorker");
+
+module.exports = function (config) {
+	return supportsWorker();
+};

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/worker-impl.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/worker-impl.js
@@ -1,0 +1,2 @@
+// access runtime id, if this worker has multiple runtime, it will panic
+globalThis.currentRuntimeId = __webpack_runtime_id__

--- a/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/worker.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-loading/issue-9840/worker.js
@@ -1,0 +1,1 @@
+new Worker(new URL("./worker-impl.js", import.meta.url));


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #9840 

AsyncEntrypoint has unique runtime, should not merge runtime when analyze module graph.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
