### PR TITLE
feat: persistent cache snapshot save file hash by default

### DIFF
--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -3,13 +3,11 @@ mod strategy;
 
 use std::{path::Path, sync::Arc};
 
-use futures::future::join_all;
 use rspack_cacheable::{from_bytes, to_bytes};
 use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
 use rspack_paths::{ArcPath, AssertUtf8};
 use rustc_hash::FxHashSet as HashSet;
-use tokio::task::spawn_blocking;
 
 pub use self::option::{PathMatcher, SnapshotOptions};
 use self::strategy::{Strategy, StrategyHelper, ValidateResult};
@@ -24,7 +22,7 @@ const SCOPE: &str = "snapshot";
 /// through the generated `Strategy`
 #[derive(Debug)]
 pub struct Snapshot {
-  options: SnapshotOptions,
+  options: Arc<SnapshotOptions>,
   fs: Arc<dyn ReadableFileSystem>,
   storage: Arc<dyn Storage>,
 }
@@ -36,56 +34,65 @@ impl Snapshot {
     storage: Arc<dyn Storage>,
   ) -> Self {
     Self {
-      options,
+      options: Arc::new(options),
       fs,
       storage,
     }
   }
 
-  #[tracing::instrument("Cache::Snapshot::add", skip_all)]
-  pub async fn add(&self, paths: impl Iterator<Item = &Path>) {
-    let default_strategy = StrategyHelper::compile_time();
-    let helper = StrategyHelper::new(self.fs.clone());
-
-    // TODO merge package version file
-    join_all(paths.map(|path| async {
-      let utf8_path = path.assert_utf8();
-      // check path exists
-      let fs = self.fs.clone();
-      let utf8_path_clone = utf8_path.to_owned();
-      let metadata_has_error =
-        spawn_blocking(move || fs.clone().metadata_sync(&utf8_path_clone).is_err())
-          .await
-          .unwrap_or(true);
-      if metadata_has_error {
-        return;
+  async fn calc_strategy(
+    options: &Arc<SnapshotOptions>,
+    helper: &Arc<StrategyHelper>,
+    path: &ArcPath,
+  ) -> Option<Strategy> {
+    let path_str = path.to_string_lossy();
+    if options.is_immutable_path(&path_str) {
+      return None;
+    }
+    if options.is_managed_path(&path_str) {
+      if let Some(v) = helper.package_version(path).await {
+        return Some(v);
       }
-      // TODO directory path should check all sub file
-      let path_str = utf8_path.as_str();
-      if self.options.is_immutable_path(path_str) {
-        return;
-      }
-      if self.options.is_managed_path(path_str) {
-        if let Some(v) = helper.package_version(path).await {
-          self.storage.set(
-            SCOPE,
-            path.as_os_str().as_encoded_bytes().to_vec(),
-            to_bytes::<_, ()>(&v, &()).expect("should to bytes success"),
-          );
-          return;
-        }
-      }
-      // compiler time
-      self.storage.set(
-        SCOPE,
-        path.as_os_str().as_encoded_bytes().to_vec(),
-        to_bytes::<_, ()>(&default_strategy, &()).expect("should to bytes success"),
-      );
-    }))
-    .await;
+    }
+    if let Some(h) = helper.path_hash(path).await {
+      return Some(h);
+    }
+    Some(helper.compile_time())
   }
 
-  pub fn remove(&self, paths: impl Iterator<Item = &Path>) {
+  #[tracing::instrument("Cache::Snapshot::add", skip_all)]
+  pub async fn add(&self, paths: impl Iterator<Item = ArcPath>) {
+    let helper = Arc::new(StrategyHelper::new(self.fs.clone()));
+    // TODO merge package version file
+    paths
+      .map(|path| {
+        let helper = helper.clone();
+        let fs = self.fs.clone();
+        let options = self.options.clone();
+        async move {
+          let utf8_path = path.assert_utf8();
+          // check path exists
+          let metadata_has_error = fs.metadata(utf8_path).await.is_err();
+          if metadata_has_error {
+            return None;
+          }
+
+          let strategy = Self::calc_strategy(&options, &helper, &path).await?;
+          Some((
+            path.as_os_str().as_encoded_bytes().to_vec(),
+            to_bytes::<_, ()>(&strategy, &()).expect("should to bytes success"),
+          ))
+        }
+      })
+      .fut_consume(|data| {
+        if let Some((key, value)) = data {
+          self.storage.set(SCOPE, key, value);
+        }
+      })
+      .await;
+  }
+
+  pub fn remove(&self, paths: impl Iterator<Item = ArcPath>) {
     for item in paths {
       self
         .storage
@@ -134,12 +141,13 @@ mod tests {
   use std::sync::Arc;
 
   use rspack_fs::{MemoryFileSystem, WritableFileSystem};
+  use rspack_paths::ArcPath;
 
   use super::{super::storage::MemoryStorage, PathMatcher, Snapshot, SnapshotOptions};
 
   macro_rules! p {
     ($tt:tt) => {
-      std::path::Path::new($tt)
+      ArcPath::from(std::path::Path::new($tt))
     };
   }
 
@@ -207,10 +215,10 @@ mod tests {
 
     let (modified_paths, deleted_paths) = snapshot.calc_modified_paths().await.unwrap();
     assert!(deleted_paths.is_empty());
-    assert!(!modified_paths.contains(p!("/constant")));
-    assert!(modified_paths.contains(p!("/file1")));
-    assert!(modified_paths.contains(p!("/node_modules/project/file1")));
-    assert!(!modified_paths.contains(p!("/node_modules/lib/file1")));
+    assert!(!modified_paths.contains(&p!("/constant")));
+    assert!(modified_paths.contains(&p!("/file1")));
+    assert!(modified_paths.contains(&p!("/node_modules/project/file1")));
+    assert!(!modified_paths.contains(&p!("/node_modules/lib/file1")));
 
     fs.write(
       "/node_modules/lib/package.json".into(),
@@ -221,9 +229,9 @@ mod tests {
     snapshot.add([p!("/file1")].into_iter()).await;
     let (modified_paths, deleted_paths) = snapshot.calc_modified_paths().await.unwrap();
     assert!(deleted_paths.is_empty());
-    assert!(!modified_paths.contains(p!("/constant")));
-    assert!(!modified_paths.contains(p!("/file1")));
-    assert!(modified_paths.contains(p!("/node_modules/project/file1")));
-    assert!(modified_paths.contains(p!("/node_modules/lib/file1")));
+    assert!(!modified_paths.contains(&p!("/constant")));
+    assert!(!modified_paths.contains(&p!("/file1")));
+    assert!(modified_paths.contains(&p!("/node_modules/project/file1")));
+    assert!(modified_paths.contains(&p!("/node_modules/lib/file1")));
   }
 }

--- a/crates/rspack_core/src/cache/persistent/snapshot/option.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/option.rs
@@ -1,7 +1,7 @@
 use rspack_regex::RspackRegex;
 
 /// Use string or regex to match path
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub enum PathMatcher {
   String(String),
   Regexp(RspackRegex),
@@ -17,7 +17,7 @@ impl PathMatcher {
 }
 
 /// Snapshot options
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Hash)]
 pub struct SnapshotOptions {
   /// immutable paths, snapshot will ignore them
   immutable_paths: Vec<PathMatcher>,

--- a/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
@@ -1,4 +1,5 @@
 use std::{
+  hash::{Hash, Hasher},
   path::Path,
   sync::Arc,
   time::{SystemTime, UNIX_EPOCH},
@@ -8,6 +9,7 @@ use dashmap::DashMap;
 use rspack_cacheable::cacheable;
 use rspack_fs::ReadableFileSystem;
 use rspack_paths::{ArcPath, AssertUtf8};
+use rustc_hash::FxHasher;
 
 /// Snapshot check strategy
 #[cacheable]
@@ -21,8 +23,14 @@ pub enum Strategy {
 
   /// Check by compile time
   ///
-  /// This strategy will compare the compile time and the file update time
+  /// This strategy will compare the compile time and the file update time.
   CompileTime(u64),
+
+  /// Check by file hash
+  ///
+  /// This strategy will first compare the compile time and the file update time,
+  /// and then compare the file hash if the file has been updated.
+  PathHash { compile_time: u64, hash: u64 },
 }
 
 /// Validate Result
@@ -39,13 +47,19 @@ pub enum ValidateResult {
 pub struct StrategyHelper {
   fs: Arc<dyn ReadableFileSystem>,
   package_version_cache: DashMap<ArcPath, Option<String>>,
+  compile_time: u64,
 }
 
 impl StrategyHelper {
   pub fn new(fs: Arc<dyn ReadableFileSystem>) -> Self {
+    let now = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .expect("get current time failed")
+      .as_millis() as u64;
     Self {
       fs,
       package_version_cache: Default::default(),
+      compile_time: now,
     }
   }
 
@@ -66,11 +80,7 @@ impl StrategyHelper {
     }
 
     let mut res = None;
-    if let Ok(content) = self
-      .fs
-      .async_read(&path.join("package.json").assert_utf8())
-      .await
-    {
+    if let Ok(content) = self.fs.read(&path.join("package.json").assert_utf8()).await {
       if let Ok(mut package_json) =
         serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(&content)
       {
@@ -90,13 +100,21 @@ impl StrategyHelper {
     res
   }
 
+  /// get path file content hash
+  async fn content_hash(&self, path: &Path) -> Option<u64> {
+    // currently only supports files
+    // TODO add cache if directory hash is supported
+    let Ok(content) = self.fs.read(path.assert_utf8()).await else {
+      return None;
+    };
+    let mut hasher = FxHasher::default();
+    content.hash(&mut hasher);
+    Some(hasher.finish())
+  }
+
   /// get current time as compile time strategy
-  pub fn compile_time() -> Strategy {
-    let now = SystemTime::now()
-      .duration_since(UNIX_EPOCH)
-      .expect("get current time failed")
-      .as_millis() as u64;
-    Strategy::CompileTime(now)
+  pub fn compile_time(&self) -> Strategy {
+    Strategy::CompileTime(self.compile_time)
   }
   /// get path file package version strategy
   pub async fn package_version(&self, path: &Path) -> Option<Strategy> {
@@ -105,30 +123,49 @@ impl StrategyHelper {
       .await
       .map(Strategy::PackageVersion)
   }
+  /// get path file hash strategy
+  pub async fn path_hash(&self, path: &Path) -> Option<Strategy> {
+    let hash = self.content_hash(path).await?;
+    Some(Strategy::PathHash {
+      compile_time: self.compile_time,
+      hash,
+    })
+  }
 
   /// validate path file by target strategy
   pub async fn validate(&self, path: &Path, strategy: &Strategy) -> ValidateResult {
+    let Some(modified_time) = self.modified_time(path).await else {
+      return ValidateResult::Deleted;
+    };
     match strategy {
       Strategy::PackageVersion(version) => {
-        if let Some(ref cur_version) = self.package_version_with_cache(path).await {
-          if cur_version == version {
-            ValidateResult::NoChanged
-          } else {
-            ValidateResult::Modified
-          }
+        let Some(ref cur_version) = self.package_version_with_cache(path).await else {
+          return ValidateResult::Deleted;
+        };
+        if cur_version == version {
+          ValidateResult::NoChanged
         } else {
-          ValidateResult::Deleted
+          ValidateResult::Modified
         }
       }
       Strategy::CompileTime(compile_time) => {
-        if let Some(ref modified_time) = self.modified_time(path).await {
-          if modified_time > compile_time {
-            ValidateResult::Modified
-          } else {
-            ValidateResult::NoChanged
-          }
+        if &modified_time > compile_time {
+          ValidateResult::Modified
         } else {
-          ValidateResult::Deleted
+          ValidateResult::NoChanged
+        }
+      }
+      Strategy::PathHash { compile_time, hash } => {
+        if &modified_time < compile_time {
+          return ValidateResult::NoChanged;
+        }
+        let Some(file_hash) = self.content_hash(path).await else {
+          return ValidateResult::Deleted;
+        };
+        if &file_hash == hash {
+          ValidateResult::NoChanged
+        } else {
+          ValidateResult::Modified
         }
       }
     }
@@ -139,135 +176,187 @@ impl StrategyHelper {
 mod tests {
   use std::{path::Path, sync::Arc};
 
-  use rspack_fs::{MemoryFileSystem, ReadableFileSystem, WritableFileSystem};
+  use rspack_fs::{MemoryFileSystem, WritableFileSystem};
 
   use super::{Strategy, StrategyHelper, ValidateResult};
 
   #[tokio::test]
-  async fn should_strategy_works() {
+  async fn compile_time() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    let helper = StrategyHelper::new(fs.clone());
+    let compile_time_1 = helper.compile_time();
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let compile_time_2 = helper.compile_time();
+    assert_eq!(compile_time_1, compile_time_2);
+  }
+
+  #[tokio::test]
+  async fn package_version() {
     let fs = Arc::new(MemoryFileSystem::default());
     fs.create_dir_all("/packages/p1".into()).await.unwrap();
-    fs.create_dir_all("/packages/p2".into()).await.unwrap();
     fs.write(
       "/packages/p1/package.json".into(),
+      r#"{"version": "1.2.0"}"#.as_bytes(),
+    )
+    .await
+    .unwrap();
+
+    let helper = StrategyHelper::new(fs.clone());
+    assert_eq!(
+      helper
+        .package_version(Path::new("/packages/p1/file.js"))
+        .await,
+      Some(Strategy::PackageVersion("1.2.0".into()))
+    );
+    assert_eq!(
+      helper
+        .package_version(Path::new("/packages/p2/file.js"))
+        .await,
+      None
+    );
+  }
+
+  #[tokio::test]
+  async fn path_hash() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    fs.create_dir_all("/".into()).await.unwrap();
+    fs.write("/hash.js".into(), "abc".as_bytes()).await.unwrap();
+
+    let helper = StrategyHelper::new(fs.clone());
+    assert_eq!(helper.path_hash(Path::new("/not_exist.js")).await, None);
+
+    let hash1 = helper.path_hash(Path::new("/hash.js")).await;
+    fs.write("/hash.js".into(), "abc".as_bytes()).await.unwrap();
+    let hash2 = helper.path_hash(Path::new("/hash.js")).await;
+    assert_eq!(hash1, hash2);
+
+    fs.write("/hash.js".into(), "abcd".as_bytes())
+      .await
+      .unwrap();
+    let hash3 = helper.path_hash(Path::new("/hash.js")).await;
+    assert_ne!(hash1, hash3);
+  }
+
+  #[tokio::test]
+  async fn validate_compile_time() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    fs.create_dir_all("/".into()).await.unwrap();
+    fs.write("/file1.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let helper = StrategyHelper::new(fs.clone());
+    let strategy = helper.compile_time();
+    assert!(matches!(
+      helper.validate(Path::new("/file1.js"), &strategy).await,
+      ValidateResult::NoChanged
+    ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.write("/file1.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
+    assert!(matches!(
+      helper.validate(Path::new("/file1.js"), &strategy).await,
+      ValidateResult::Modified
+    ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.remove_file("/file1.js".into()).await.unwrap();
+    assert!(matches!(
+      helper.validate(Path::new("/file1.js"), &strategy).await,
+      ValidateResult::Deleted
+    ));
+  }
+
+  #[tokio::test]
+  async fn validate_package_version() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    fs.create_dir_all("/packages/lib".into()).await.unwrap();
+    fs.write(
+      "/packages/lib/package.json".into(),
       r#"{"version": "1.0.0"}"#.as_bytes(),
     )
     .await
     .unwrap();
+    fs.write("/packages/lib/file.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
+
+    let strategy = Strategy::PackageVersion("1.0.0".into());
+    let helper = StrategyHelper::new(fs.clone());
+    assert!(matches!(
+      helper
+        .validate(Path::new("/packages/lib/file.js"), &strategy)
+        .await,
+      ValidateResult::NoChanged
+    ));
+
+    helper.package_version_cache.clear();
     fs.write(
-      "/packages/p2/package.json".into(),
-      r#"{"version": "1.1.0"}"#.as_bytes(),
+      "/packages/lib/package.json".into(),
+      r#"{"version": "1.2.0"}"#.as_bytes(),
     )
     .await
     .unwrap();
-    fs.write("/file1".into(), "abc".as_bytes()).await.unwrap();
-
-    // compile_time
-    let Strategy::CompileTime(time1) = StrategyHelper::compile_time() else {
-      unreachable!()
-    };
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    let Strategy::CompileTime(time2) = StrategyHelper::compile_time() else {
-      unreachable!()
-    };
-    assert!(time1 < time2);
-
-    let helper = StrategyHelper::new(fs.clone());
-    // modified_time
-    assert_eq!(
-      helper.modified_time(Path::new("/file1")).await,
-      Some(fs.metadata("/file1".into()).await.unwrap().mtime_ms)
-    );
-    assert!(helper.modified_time(Path::new("/file2")).await.is_none());
-
-    // package_version_with_cache
-    assert_eq!(
-      helper
-        .package_version_with_cache(Path::new("/packages/p1/file"))
-        .await
-        .unwrap(),
-      "1.0.0"
-    );
-    assert_eq!(
-      helper
-        .package_version_with_cache(Path::new("/packages/p2/file"))
-        .await
-        .unwrap(),
-      "1.1.0"
-    );
-    assert_eq!(
-      helper
-        .package_version_with_cache(Path::new("/packages/p2/dir1/dir2/dir3/file"))
-        .await
-        .unwrap(),
-      "1.1.0"
-    );
-    assert!(helper
-      .package_version_with_cache(Path::new("/file1"))
-      .await
-      .is_none());
-    assert!(helper
-      .package_version_with_cache(Path::new("/file2"))
-      .await
-      .is_none());
-
-    // package_version
-    assert_eq!(
-      helper
-        .package_version(Path::new("/packages/p1/file"))
-        .await
-        .unwrap(),
-      Strategy::PackageVersion("1.0.0".into())
-    );
-    assert_eq!(
-      helper
-        .package_version(Path::new("/packages/p2/file"))
-        .await
-        .unwrap(),
-      Strategy::PackageVersion("1.1.0".into())
-    );
-    assert_eq!(
-      helper
-        .package_version(Path::new("/packages/p2/dir1/dir2/dir3/file"))
-        .await
-        .unwrap(),
-      Strategy::PackageVersion("1.1.0".into())
-    );
-    assert!(helper.package_version(Path::new("/file1")).await.is_none());
-    assert!(helper.package_version(Path::new("/file2")).await.is_none());
-
-    // validate
-    let now = StrategyHelper::compile_time();
     assert!(matches!(
-      helper.validate(Path::new("/file1"), &now).await,
-      ValidateResult::NoChanged
-    ));
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    fs.write("/file1".into(), "abcd".as_bytes()).await.unwrap();
-    assert!(matches!(
-      helper.validate(Path::new("/file1"), &now).await,
+      helper
+        .validate(Path::new("/packages/lib/file.js"), &strategy)
+        .await,
       ValidateResult::Modified
     ));
+
+    helper.package_version_cache.clear();
+    fs.remove_file("/packages/lib/package.json".into())
+      .await
+      .unwrap();
     assert!(matches!(
-      helper.validate(Path::new("/file2"), &now).await,
+      helper
+        .validate(Path::new("/packages/lib/file.js"), &strategy)
+        .await,
       ValidateResult::Deleted
     ));
+  }
 
-    let version = Strategy::PackageVersion("1.0.0".into());
+  #[tokio::test]
+  async fn validate_path_hash() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    fs.create_dir_all("/".into()).await.unwrap();
+    fs.write("/file1.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let helper = StrategyHelper::new(fs.clone());
+    let strategy = helper.path_hash(Path::new("/file1.js")).await.unwrap();
     assert!(matches!(
-      helper
-        .validate(Path::new("/packages/p1/file1"), &version)
-        .await,
+      helper.validate(Path::new("/file1.js"), &strategy).await,
       ValidateResult::NoChanged
     ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.write("/file1.js".into(), "abc".as_bytes())
+      .await
+      .unwrap();
     assert!(matches!(
-      helper
-        .validate(Path::new("/packages/p2/file1"), &version)
-        .await,
+      helper.validate(Path::new("/file1.js"), &strategy).await,
+      ValidateResult::NoChanged
+    ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.write("/file1.js".into(), "abcd".as_bytes())
+      .await
+      .unwrap();
+    assert!(matches!(
+      helper.validate(Path::new("/file1.js"), &strategy).await,
       ValidateResult::Modified
     ));
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    fs.remove_file("/file1.js".into()).await.unwrap();
     assert!(matches!(
-      helper.validate(Path::new("/file2"), &version).await,
+      helper.validate(Path::new("/file1.js"), &strategy).await,
       ValidateResult::Deleted
     ));
   }

--- a/crates/rspack_core/src/cache/persistent/storage/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/storage/mod.rs
@@ -12,7 +12,7 @@ use rspack_storage::{BridgeFileSystem, PackStorage, PackStorageOptions};
 ///
 /// This enum contains all of supported storage options.
 /// Since MemoryStorage is only used in unit test, there is no need to add it here.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub enum StorageOptions {
   FileSystem { directory: PathBuf },
 }

--- a/crates/rspack_fs/src/memory_fs.rs
+++ b/crates/rspack_fs/src/memory_fs.rs
@@ -271,10 +271,6 @@ impl ReadableFileSystem for MemoryFileSystem {
     Ok(path.assert_utf8())
   }
 
-  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>> {
-    ReadableFileSystem::read(self, file).await
-  }
-
   async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>> {
     self._read_dir(dir)
   }
@@ -460,23 +456,23 @@ mod tests {
 
     // read
     assert!(
-      ReadableFileSystem::async_read(&fs, Utf8Path::new("/a/temp/file2"))
+      ReadableFileSystem::read(&fs, Utf8Path::new("/a/temp/file2"))
         .await
         .is_err()
     );
     assert!(
-      ReadableFileSystem::async_read(&fs, Utf8Path::new("/a/file1/file2"))
+      ReadableFileSystem::read(&fs, Utf8Path::new("/a/file1/file2"))
         .await
         .is_err()
     );
     assert_eq!(
-      ReadableFileSystem::async_read(&fs, Utf8Path::new("/a/file1"))
+      ReadableFileSystem::read(&fs, Utf8Path::new("/a/file1"))
         .await
         .unwrap(),
       file_content
     );
     assert_eq!(
-      ReadableFileSystem::async_read(&fs, Utf8Path::new("/a/file2"))
+      ReadableFileSystem::read(&fs, Utf8Path::new("/a/file2"))
         .await
         .unwrap(),
       file_content

--- a/crates/rspack_fs/src/native_fs.rs
+++ b/crates/rspack_fs/src/native_fs.rs
@@ -210,10 +210,6 @@ impl ReadableFileSystem for NativeFileSystem {
     Ok(path.assert_utf8())
   }
 
-  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>> {
-    tokio::fs::read(file).await.to_fs_result()
-  }
-
   async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>> {
     self.read_dir_sync(dir)
   }
@@ -279,10 +275,6 @@ impl ReadableFileSystem for NativeFileSystem {
       }
     }
     Ok(path_buf)
-  }
-
-  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>> {
-    fs::read(file).to_fs_result()
   }
 
   async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>> {

--- a/crates/rspack_fs/src/read.rs
+++ b/crates/rspack_fs/src/read.rs
@@ -25,9 +25,4 @@ pub trait ReadableFileSystem: Debug + Send + Sync {
   /// Returns a Vec of entry names in the directory
   async fn read_dir(&self, dir: &Utf8Path) -> Result<Vec<String>>;
   fn read_dir_sync(&self, dir: &Utf8Path) -> Result<Vec<String>>;
-
-  /// Read the entire contents of a file into a bytes vector.
-  ///
-  /// Error: This function will return an error if path does not already exist.
-  async fn async_read(&self, file: &Utf8Path) -> Result<Vec<u8>>;
 }

--- a/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
+++ b/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
@@ -40,7 +40,7 @@ export class HotUpdatePlugin {
 		let content =
 			contents[index] === undefined ? contents.at(-1) || "" : contents[index];
 		let command = "";
-		const matchResult = content.match(/^<(.+?)>(.*)/);
+		const matchResult = content.match(/^<(.+?)>([\w\W]*)$/);
 		if (matchResult) {
 			command = matchResult[1];
 			content = matchResult[2];

--- a/packages/rspack-test-tools/src/helper/plugins/hot-update.ts
+++ b/packages/rspack-test-tools/src/helper/plugins/hot-update.ts
@@ -4,9 +4,15 @@ import type { TUpdateOptions } from "../../type";
 export class TestHotUpdatePlugin {
 	constructor(private updateOptions: TUpdateOptions) {}
 	apply(compiler: Compiler) {
+		let isRebuild = false;
 		compiler.hooks.beforeRun.tap("TestHotUpdatePlugin", () => {
-			compiler.modifiedFiles = new Set(this.updateOptions.changedFiles);
+			if (isRebuild) {
+				compiler.modifiedFiles = new Set(this.updateOptions.changedFiles);
+			} else {
+				compiler.modifiedFiles = new Set();
+			}
 			this.updateOptions.changedFiles = [];
+			isRebuild = true;
 		});
 
 		compiler.hooks.compilation.tap("TestHotUpdatePlugin", compilation => {

--- a/packages/rspack-test-tools/tests/cacheCases/common/update-file/file.js
+++ b/packages/rspack-test-tools/tests/cacheCases/common/update-file/file.js
@@ -1,0 +1,9 @@
+export default 1;
+---
+export default 2;
+---
+export default 2;
+---
+<force_write>export default 2;
+---
+export default 3;

--- a/packages/rspack-test-tools/tests/cacheCases/common/update-file/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/common/update-file/index.js
@@ -1,0 +1,21 @@
+import value from "./file";
+
+it("should basic test work", async () => {
+	if (COMPILER_INDEX == 0) {
+		expect(value).toBe(1);
+		await NEXT_HMR();
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 2) {
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 3) {
+		expect(value).toBe(3);
+	}
+});

--- a/packages/rspack-test-tools/tests/cacheCases/common/update-file/loader.js
+++ b/packages/rspack-test-tools/tests/cacheCases/common/update-file/loader.js
@@ -1,0 +1,5 @@
+module.exports = function (content) {
+	const options = this.getOptions();
+	options.files.push(this.resourcePath);
+	return content;
+};

--- a/packages/rspack-test-tools/tests/cacheCases/common/update-file/rspack.config.js
+++ b/packages/rspack-test-tools/tests/cacheCases/common/update-file/rspack.config.js
@@ -1,0 +1,49 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: /file\.js$/,
+				loader: "./loader.js",
+				options: {
+					files: []
+				}
+			}
+		]
+	},
+	experiments: {
+		cache: {
+			type: "persistent"
+		},
+		incremental: true
+	},
+	plugins: [
+		{
+			updateIndex: 0,
+			apply(compiler) {
+				compiler.hooks.done.tap("Test", () => {
+					const options = compiler.options.module.rules[0].options;
+					console.log("options", options.files, this.updateIndex);
+					if (this.updateIndex == 0) {
+						expect(options.files.length).toBe(1);
+					}
+					if (this.updateIndex == 1) {
+						expect(options.files.length).toBe(1);
+					}
+					if (this.updateIndex == 2) {
+						expect(options.files.length).toBe(0);
+					}
+					if (this.updateIndex == 3) {
+						expect(options.files.length).toBe(0);
+					}
+					if (this.updateIndex == 4) {
+						expect(options.files.length).toBe(1);
+					}
+					options.files = [];
+					this.updateIndex++;
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The persistent cache snapshot will store the compile times and use them to calculate which files were modified when hot start. However, this strategy is invalid in scenarios such as CI because the update time of all files will be refreshed.

This PR will make snapshot store both compile time and file hash, and when calculate modified files the file hash will be compared when the file modification time has been updated.

This PR will introduce some performance regression due to the addition of hash calculations, and I manually benchmarked the performance of snapshot generation in cold start.

| Name | File Count | Hash Count | Before | After |
| -- | -- | -- | -- | -- |
| Docusaurus | 4059 | 2143 | 22.32ms | 73.274ms |
| Large real project | 44905 | 8891 | 106.189ms | 365.41ms |

As can be seen from the table above, this takes three times longer than before, and the main time consumption occurs in file IO. This is currently acceptable in large real projects.

PS. For hot start, it will take 3 times longer if you update a lot of files like in CI, otherwise it will be the same as before. HMR will create snapshots incrementally so the performance impact is smaller.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
