### PR TITLE
ci: lock cargo shear version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
         with:
           shared-key: check
       - uses: cargo-bins/cargo-binstall@63aaa5c1932cebabc34eceda9d92a70215dcead6 # v1.12.3
-      - run: cargo binstall --no-confirm cargo-shear --force
+      - run: cargo binstall --no-confirm cargo-shear@1.1.12 --force
       - run: cargo shear
 
   rust_test:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The latest version of cargo shear (1.1.14) depends on GLIBC 2.38, which is not available on ubuntu 22. This PR will lock the shear version.

![image](https://github.com/user-attachments/assets/f6efa80f-1770-4e16-8ca9-e7075a434bc1)


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
