### PR TITLE
perf(hash): avoid heap allocations in hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-url"
@@ -2660,7 +2660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4414,7 +4414,6 @@ dependencies = [
 name = "rspack_hash"
 version = "0.2.0"
 dependencies = [
- "data-encoding",
  "md4",
  "rspack_cacheable",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,9 +325,6 @@ opt-level = "s"
 [profile.release.package.wasmparser]
 opt-level = "s"
 
-[profile.release.package.data-encoding]
-opt-level = "s"
-
 [profile.release.package.jsonc-parser]
 opt-level = "s"
 

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -117,7 +117,7 @@ pub trait ParserAndGenerator: Send + Sync + Debug + AsAny {
     _runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
     Ok(RspackHashDigest::new(
-      vec![],
+      &[],
       &compilation.options.output.hash_digest,
     ))
   }

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -125,7 +125,7 @@ impl Module for SelfModule {
   ) -> Result<RspackHashDigest> {
     // do nothing, since this is self reference, the module itself (parent module of this self module) should take effects
     Ok(RspackHashDigest::new(
-      vec![],
+      &[],
       &compilation.options.output.hash_digest,
     ))
   }

--- a/crates/rspack_hash/Cargo.toml
+++ b/crates/rspack_hash/Cargo.toml
@@ -7,7 +7,6 @@ repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.2.0"
 
 [dependencies]
-data-encoding    = { version = "2.6.0" }
 md4              = "0.10.2"
 rspack_cacheable = { workspace = true }
 smol_str         = { workspace = true }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

There are currently 3 unnecessary heap allocations in hash. This PR will remove as many of them as possible.

Since `md4` output is larger than `smol_str` capacity, a heap allocation still occurs when using `md4`. We use `xxhash` by default, so no further optimization is done here.

`data-encoding` is suitable for size-sensitive scenarios, but because it shares an impl with encodings such as base64, it is not usually inlined. here we replace it with our own simple impl.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
