### PR TITLE
fix: import module entry dependency resolve options

### DIFF
--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1341,6 +1341,7 @@ fn get_resolve_defaults(
   let mut by_dependency: Vec<(Cow<'static, str>, Resolve)> = vec![
     ("wasm".into(), esm_deps()),
     ("esm".into(), esm_deps()),
+    ("loaderImport".into(), esm_deps()),
     (
       "url".into(),
       Resolve {
@@ -1357,6 +1358,7 @@ fn get_resolve_defaults(
     ),
     ("commonjs".into(), cjs_deps()),
     ("amd".into(), cjs_deps()),
+    ("loader".into(), cjs_deps()),
     ("unknown".into(), cjs_deps()),
   ];
 

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -298,6 +298,54 @@ CompilerOptions {
                         enforce_extension: None,
                         pnp: None,
                     },
+                    "loaderImport": Resolve {
+                        extensions: Some(
+                            [
+                                ".js",
+                                ".json",
+                                ".wasm",
+                            ],
+                        ),
+                        alias: None,
+                        prefer_relative: None,
+                        prefer_absolute: None,
+                        symlinks: None,
+                        main_files: None,
+                        main_fields: Some(
+                            [
+                                "browser",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        condition_names: Some(
+                            [
+                                "import",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        tsconfig: None,
+                        modules: None,
+                        fallback: None,
+                        fully_specified: None,
+                        exports_fields: None,
+                        extension_alias: None,
+                        alias_fields: Some(
+                            [
+                                [
+                                    "browser",
+                                ],
+                            ],
+                        ),
+                        roots: None,
+                        restrictions: None,
+                        imports_fields: None,
+                        by_dependency: None,
+                        description_files: None,
+                        enforce_extension: None,
+                        pnp: None,
+                    },
                     "url": Resolve {
                         extensions: None,
                         alias: None,
@@ -423,6 +471,54 @@ CompilerOptions {
                         pnp: None,
                     },
                     "amd": Resolve {
+                        extensions: Some(
+                            [
+                                ".js",
+                                ".json",
+                                ".wasm",
+                            ],
+                        ),
+                        alias: None,
+                        prefer_relative: None,
+                        prefer_absolute: None,
+                        symlinks: None,
+                        main_files: None,
+                        main_fields: Some(
+                            [
+                                "browser",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        condition_names: Some(
+                            [
+                                "require",
+                                "module",
+                                "...",
+                            ],
+                        ),
+                        tsconfig: None,
+                        modules: None,
+                        fallback: None,
+                        fully_specified: None,
+                        exports_fields: None,
+                        extension_alias: None,
+                        alias_fields: Some(
+                            [
+                                [
+                                    "browser",
+                                ],
+                            ],
+                        ),
+                        roots: None,
+                        restrictions: None,
+                        imports_fields: None,
+                        by_dependency: None,
+                        description_files: None,
+                        enforce_extension: None,
+                        pnp: None,
+                    },
+                    "loader": Resolve {
                         extensions: Some(
                             [
                                 ".js",

--- a/crates/rspack_core/src/dependency/dependency_category.rs
+++ b/crates/rspack_core/src/dependency/dependency_category.rs
@@ -32,6 +32,7 @@ impl From<&str> for DependencyCategory {
       "css-export" => Self::CssExport,
       "css-compose" => Self::CssCompose,
       "css-local-ident" => Self::CssLocalIdent,
+      "loaderImport" => Self::LoaderImport,
       "worker" => Self::Worker,
       "unknown" => Self::Unknown,
       _ => unimplemented!("DependencyCategory {}", value),
@@ -53,7 +54,7 @@ impl DependencyCategory {
       DependencyCategory::CssLocalIdent => "css-local-ident",
       DependencyCategory::Wasm => "wasm",
       DependencyCategory::Worker => "worker",
-      DependencyCategory::LoaderImport => "loader import",
+      DependencyCategory::LoaderImport => "loaderImport",
     }
   }
 }

--- a/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
@@ -406,6 +406,46 @@ Object {
           ...,
         ],
       },
+      loader: Object {
+        aliasFields: Array [
+          browser,
+        ],
+        conditionNames: Array [
+          require,
+          module,
+          ...,
+        ],
+        extensions: Array [
+          .js,
+          .json,
+          .wasm,
+        ],
+        mainFields: Array [
+          browser,
+          module,
+          ...,
+        ],
+      },
+      loaderImport: Object {
+        aliasFields: Array [
+          browser,
+        ],
+        conditionNames: Array [
+          import,
+          module,
+          ...,
+        ],
+        extensions: Array [
+          .js,
+          .json,
+          .wasm,
+        ],
+        mainFields: Array [
+          browser,
+          module,
+          ...,
+        ],
+      },
       unknown: Object {
         aliasFields: Array [
           browser,

--- a/packages/rspack-test-tools/tests/defaultsCases/target_/electron-main.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/target_/electron-main.js
@@ -105,6 +105,20 @@ module.exports = {
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
+		@@ ... @@
+		-           "browser",
+		@@ ... @@
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
+		@@ ... @@
+		-           "browser",
+		@@ ... @@
 		-       "browser",
 		+       "node",
 		+       "electron",

--- a/packages/rspack-test-tools/tests/defaultsCases/target_/electron-preload.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/target_/electron-preload.js
@@ -103,6 +103,20 @@ module.exports = {
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
+		@@ ... @@
+		-           "browser",
+		@@ ... @@
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
+		@@ ... @@
+		-           "browser",
+		@@ ... @@
 		+       "node",
 		@@ ... @@
 		+       "electron",

--- a/packages/rspack-test-tools/tests/defaultsCases/target_/node.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/target_/node.js
@@ -100,6 +100,20 @@ module.exports = {
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
+		@@ ... @@
+		-           "browser",
+		@@ ... @@
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
+		@@ ... @@
+		-           "browser",
+		@@ ... @@
 		-       "browser",
 		+       "node",
 		@@ ... @@

--- a/packages/rspack-test-tools/tests/defaultsCases/target_/nwjs.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/target_/nwjs.js
@@ -99,6 +99,20 @@ module.exports = {
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
+		@@ ... @@
+		-           "browser",
+		@@ ... @@
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
+		@@ ... @@
+		-           "browser",
+		@@ ... @@
 		+       "node",
 		@@ ... @@
 		+       "nwjs",

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -1094,6 +1094,7 @@ const getResolveDefaults = ({
 		byDependency: {
 			wasm: esmDeps(),
 			esm: esmDeps(),
+			loaderImport: esmDeps(),
 			url: {
 				preferRelative: true
 			},
@@ -1104,7 +1105,7 @@ const getResolveDefaults = ({
 			commonjs: cjsDeps(),
 			amd: cjsDeps(),
 			// for backward-compat: loadModule
-			// loader: cjsDeps(),
+			loader: cjsDeps(),
 			// for backward-compat: Custom Dependency and getResolve without dependencyType
 			unknown: cjsDeps()
 		}

--- a/tests/webpack-test/configCases/concatenate-modules/import-module/test.filter.js
+++ b/tests/webpack-test/configCases/concatenate-modules/import-module/test.filter.js
@@ -1,3 +1,0 @@
-module.exports = () => {
-	return 'https://github.com/web-infra-dev/rspack/issues/8447';
-};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/8447

The import module entry dependency's category is `loaderImport`, and it is missed in by depenedency of default resolve options. This make the resolve options inconsistent with other modules.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
