### PR TITLE
fix(cli): remove JSCPU & LOGGING support

### DIFF
--- a/packages/rspack-cli/tests/build/profile/profile.test.ts
+++ b/packages/rspack-cli/tests/build/profile/profile.test.ts
@@ -3,11 +3,7 @@ import { resolve } from "path";
 import { run } from "../../utils/test-utils";
 
 const defaultTracePath = "./trace.json";
-const defaultJSCPUPath = "./jscpuprofile.json";
-const defaultLoggingPath = "./logging.json";
 const customTracePath = "./custom/trace";
-const customJSCPUPath = "./custom/jscpuprofile";
-const customLoggingPath = "./custom/logging";
 
 function findDefaultOutputDirname() {
 	const files = fs.readdirSync(__dirname);
@@ -19,12 +15,7 @@ function findDefaultOutputDirname() {
 describe("profile", () => {
 	afterEach(() => {
 		const dirname = findDefaultOutputDirname();
-		[
-			dirname,
-			resolve(__dirname, customTracePath),
-			resolve(__dirname, customJSCPUPath),
-			resolve(__dirname, customLoggingPath)
-		].forEach(p => {
+		[dirname, resolve(__dirname, customTracePath)].forEach(p => {
 			if (fs.existsSync(p)) {
 				fs.rmSync(p, { recursive: true });
 			}
@@ -45,20 +36,6 @@ describe("profile", () => {
 			fs.existsSync(resolve(dirname, defaultTracePath))
 		);
 		expect(fs.existsSync(resolve(dirname, defaultTracePath))).toBeTruthy();
-		expect(fs.existsSync(resolve(dirname, defaultJSCPUPath))).toBeTruthy();
-		expect(fs.existsSync(resolve(dirname, defaultLoggingPath))).toBeTruthy();
-	});
-
-	it("should store js cpu profile file when RSPACK_PROFILE=JSCPU enabled", async () => {
-		const { exitCode } = await run(
-			__dirname,
-			[],
-			{},
-			{ RSPACK_PROFILE: "JSCPU" }
-		);
-		expect(exitCode).toBe(0);
-		const dirname = findDefaultOutputDirname();
-		expect(fs.existsSync(resolve(dirname, defaultJSCPUPath))).toBeTruthy();
 	});
 
 	it("should store rust trace file when RSPACK_PROFILE=TRACE enabled", async () => {
@@ -114,13 +91,11 @@ describe("profile", () => {
 			[],
 			{},
 			{
-				RSPACK_PROFILE: `TRACE=output=${customTracePath}|JSCPU=output=${customJSCPUPath}|LOGGING=output=${customLoggingPath}`
+				RSPACK_PROFILE: `TRACE=output=${customTracePath}`
 			}
 		);
 		expect(exitCode).toBe(0);
 		expect(fs.existsSync(resolve(__dirname, customTracePath))).toBeTruthy();
-		expect(fs.existsSync(resolve(__dirname, customJSCPUPath))).toBeTruthy();
-		expect(fs.existsSync(resolve(__dirname, customLoggingPath))).toBeTruthy();
 	});
 
 	it("should be able to use logger trace layer and default output should be stdout", async () => {

--- a/packages/rspack-cli/tests/build/profile/profile.test.ts
+++ b/packages/rspack-cli/tests/build/profile/profile.test.ts
@@ -50,18 +50,6 @@ describe("profile", () => {
 		expect(fs.existsSync(resolve(dirname, defaultTracePath))).toBeTruthy();
 	});
 
-	it("should store logging file when RSPACK_PROFILE=LOGGING enabled", async () => {
-		const { exitCode } = await run(
-			__dirname,
-			[],
-			{},
-			{ RSPACK_PROFILE: "LOGGING" }
-		);
-		expect(exitCode).toBe(0);
-		const dirname = findDefaultOutputDirname();
-		expect(fs.existsSync(resolve(dirname, defaultLoggingPath))).toBeTruthy();
-	});
-
 	it("should filter trace event when use RSPACK_PROFILE=[crate1,crate2]", async () => {
 		const { exitCode } = await run(
 			__dirname,

--- a/website/docs/en/contribute/development/profiling.md
+++ b/website/docs/en/contribute/development/profiling.md
@@ -104,27 +104,6 @@ Rspack’s Rust code usually runs in the tokio thread. Select the tokio thread t
 
 ![Rust Profiling](https://assets.rspack.dev/rspack/assets/profiling-rust.png)
 
-### Node.js profiling
-
-If we find that the performance bottleneck is on the JS side (e.g. js loader), then we need to further analyse the js side, and we can use Nodejs Profiling to analyse. for example
-
-```bash
-node --cpu-prof {rspack_bin_path} -c rspack.config.js
-```
-
-or
-
-```bash
-RSPACK_PROFILE=JSCPU rspack build
-```
-
-this will generates a cpu profile like `CPU.20230522.154658.14577.0.001.cpuprofile`, and we can use speedscope to visualize the profile, for example
-
-```bash
-npm install -g speedscope
-speedscope CPU.20230522.154658.14577.0.001.cpuprofile
-```
-
 ### Rsdoctor timeline
 
 If we want to analyze the time cost of loaders and plugins or the compilation behavior of loaders, we can use Rsdoctor to view:

--- a/website/docs/en/guide/optimization/profile.mdx
+++ b/website/docs/en/guide/optimization/profile.mdx
@@ -16,11 +16,9 @@ The Rspack CLI supports the use of the `RSPACK_PROFILE` environment variable for
 $ RSPACK_PROFILE=ALL rspack build
 ```
 
-This command will generate a `.rspack-profile-${timestamp}-${pid}` folder in the current folder, and it will contain `logging.json`, `trace.json` and `jscpuprofile.json` files:
+This command will generate a `.rspack-profile-${timestamp}-${pid}` folder in the current folder, and it will contain `trace.json`:
 
 - `trace.json`: The time spent on each phase of the Rust side is recorded at a granular level using [tracing](https://github.com/tokio-rs/tracing) and can be viewed using [ui.perfetto.dev](https://ui.perfetto.dev/)
-- `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/)
-- `logging.json`: Includes some logging information that keeps a coarse-grained record of how long each phase of the build took
 
 ## Performance bottlenecks
 

--- a/website/docs/zh/contribute/development/profiling.md
+++ b/website/docs/zh/contribute/development/profiling.md
@@ -106,27 +106,6 @@ Rspack 的 Rust 代码通常执行在 tokio 线程里，选择 tokio 线程就�
 
 ![Rust Profiling](https://assets.rspack.dev/rspack/assets/profiling-rust.png)
 
-### Nodejs profiling
-
-如果我们发现性能瓶颈在 JS 端（比如 js loader），那么我们需要进一步分析 js 端，可以使用 Nodejs Profiling 来分析。例如
-
-```bash
-node --cpu-prof {rspack_bin_path} -c rspack.config.js
-```
-
-或者
-
-```bash
-RSPACK_PROFILE=JSCPU rspack build
-```
-
-这将生成一个 cpu 配置文件，例如 `CPU.20230522.154658.14577.0.001.cpuprofile`，并且我们可以使用 speedscope 来可视化 profile，例如
-
-```bash
-npm install -g speedscope
-speedscope CPU.20230522.154658.14577.0.001.cpuprofile
-```
-
 ### Rsdoctor timeline
 
 如果你需要分析 Loader 和 Plugin 耗时或者 Loader 的编译行为，可以利用 Rsdoctor 来查看：

--- a/website/docs/zh/guide/optimization/profile.mdx
+++ b/website/docs/zh/guide/optimization/profile.mdx
@@ -18,11 +18,9 @@ Rspack CLI 支持使用 `RSPACK_PROFILE` 环境变量来进行构建性能分析
 $ RSPACK_PROFILE=ALL rspack build
 ```
 
-执行该命令后会在当前目录下生成一个 `.rspack-profile-${timestamp}-${pid}` 文件夹，该文件夹下会包含 `logging.json`、`trace.json` 和 `jscpuprofile.json` 三个文件：
+执行该命令后会在当前目录下生成一个 `.rspack-profile-${timestamp}-${pid}` 文件夹，该文件夹下会包含 `trace.json`：
 
 - `trace.json`：使用 [tracing](https://github.com/tokio-rs/tracing) 细粒度地记录了 Rust 侧各个阶段的耗时，可以使用 [ui.perfetto.dev](https://ui.perfetto.dev/) 进行查看
-- `jscpuprofile.json`：使用 [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) 细粒度地记录了 JavaScript 侧的各个阶段的耗时，可以使用 [speedscope.app](https://www.speedscope.app/) 进行查看
-- `logging.json`：包含一些日志信息，粗粒度地记录了构建的各个阶段耗时
 
 ## 性能瓶颈
 

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -73,8 +73,6 @@ JavaScript
 jerrykingxyz
 jkzing
 jscexperimentalplugins
-JSCPU
-jscpuprofile
 jserfeng
 kaffi
 kuaishou


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
remove RSPACK_PROFILE=JSCPU and RSPACK_PROFILE=LOGGING support
both function are covered by TRACE now see https://github.com/web-infra-dev/rspack/pull/10009
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
