### PR TITLE
fix(cli): simplify RSPACK_PROFILE

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -151,7 +151,11 @@ export class RspackCLI {
 			}
 			if (process.env.RSPACK_PROFILE) {
 				const { applyProfile } = await import("./utils/profile.js");
-				await applyProfile(process.env.RSPACK_PROFILE, item);
+				await applyProfile(
+					process.env.RSPACK_PROFILE,
+					process.env.RSPACK_TRACE_LAYER,
+					process.env.RSPACK_TRACE_OUTPUT
+				);
 			}
 			// cli --watch overrides the watch config
 			if (options.watch) {

--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -15,6 +15,7 @@ const defaultRustTraceChromeOutput = path.join(
 	defaultOutputDirname,
 	"./trace.json"
 );
+const defaultRustTraceLoggerOutput = "stdout";
 const overviewTraceFilter = "info";
 const allTraceFilter = "trace";
 const defaultRustTraceLayer = "chrome";
@@ -35,17 +36,29 @@ function resolveLayer(value: string): string {
 export async function applyProfile(
 	filterValue: string,
 	traceLayer: string = defaultRustTraceLayer,
-	traceOutput: string = defaultRustTraceChromeOutput
+	traceOutput?: string
 ) {
 	const { asyncExitHook } = await import("exit-hook");
+	if (traceLayer !== "chrome" && traceLayer !== "logger") {
+		throw new Error(`unsupported trace layer: ${traceLayer}`);
+	}
+	let defaultTraceOutput: string;
+	if (traceLayer === "chrome") {
+		defaultTraceOutput = defaultRustTraceChromeOutput;
+	} else {
+		defaultTraceOutput = defaultRustTraceLoggerOutput;
+	}
+	if (!traceOutput) {
+		// biome-ignore lint/style/noParameterAssign: setting default value makes sense
+		traceOutput = defaultTraceOutput;
+	}
 	const filter = resolveLayer(filterValue);
 	const entries = Object.entries(resolveLayer(filterValue));
 	if (entries.length <= 0) return;
 	await fs.promises.mkdir(defaultOutputDirname);
-	await ensureFileDir(defaultOutputDirname);
-	if (traceLayer !== "chrome" && traceLayer !== "logger") {
-		throw new Error(`unsupported trace layer: ${traceLayer}`);
-	}
+
+	await ensureFileDir(traceOutput);
+
 	await rspack.experiments.globalTrace.register(
 		filter,
 		traceLayer,

--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -1,49 +1,11 @@
-/*
-The full syntax, remember update this when you change something in this file.
-
-`RSPACK_PROFILE='TRACE=filter=trace&output=./rspack.trace&layer=chrome
-											 ^----------------------------------------------: querystring syntax trace options
-																																			^: | is a delimiter for different profile options
-																																			 ^---------------------------------: querystring syntax js cpuprofile options
-																																																				 ^: | is a delimiter for different profile options
-																																																					^------------------------------: querystring syntax stats.logging options
-											 ^-----------: trace filter, default to `trace`, more syntax: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax
-																		^--------------------: trace output, `stderr`, `stdout`, or a file path, default to `./.rspack-profile-${timestamp}/trace.json` for layer `chrome` and default to `stdout` for layer `logger`
-																													^-----------: trace layer, `chrome` or `logger`, default to `chrome`
-
-`RSPACK_PROFILE='TRACE=filter=trace&output=./rspack.trace&layer=chrome' rspack build`: only enable trace
-
-`RSPACK_PROFILE=TRACE rspack build`: only enable trace, and use default options for trace
-`RSPACK_PROFILE=ALL rspack build`: enable all, and use default options
-
-`RSPACK_PROFILE=[rspack_node,rspack_core] rspack build`: enable all, but customize trace filter
-
-*/
-
+/**
+ * `RSPACK_PROFILE=ALL` overview trace events
+ * `RSPACK_PROFILE=OVERVIEW` // all trace event
+ * `RSPACK_PROFILE=warn,tokio::net=info` // trace filter from  https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax
+ */
 import fs from "node:fs";
 import path from "node:path";
-import { URLSearchParams } from "node:url";
-import { type RspackOptions, rspack } from "@rspack/core";
-
-type ParametersOfRegisterGlobalTrace = Parameters<
-	typeof rspack.experiments.globalTrace.register
->;
-type RustTraceOptionsFilter = ParametersOfRegisterGlobalTrace[0];
-type RustTraceOptionsLayer = ParametersOfRegisterGlobalTrace[1];
-type RustTraceOptionsOutput = ParametersOfRegisterGlobalTrace[2];
-type RustTraceOptions = {
-	filter: RustTraceOptionsFilter;
-	layer: RustTraceOptionsLayer;
-	output: RustTraceOptionsOutput;
-};
-type LoggingOutputOptions = string;
-type LoggingOptions = {
-	output: LoggingOutputOptions;
-};
-type ProfileOptions = {
-	TRACE?: RustTraceOptions;
-	LOGGING?: LoggingOptions;
-};
+import { rspack } from "@rspack/core";
 
 const timestamp = Date.now();
 const defaultOutputDirname = path.resolve(
@@ -53,88 +15,45 @@ const defaultRustTraceChromeOutput = path.join(
 	defaultOutputDirname,
 	"./trace.json"
 );
-const defaultRustTraceLoggerOutput = "stdout";
-const defaultRustTraceFilter = "info";
+const overviewTraceFilter = "info";
+const allTraceFilter = "trace";
 const defaultRustTraceLayer = "chrome";
-
-function resolveProfile(value: string): ProfileOptions {
-	if (value.toUpperCase() === "ALL") {
-		return {
-			TRACE: {
-				filter: defaultRustTraceFilter,
-				layer: defaultRustTraceLayer,
-				output: defaultRustTraceChromeOutput
-			}
-		};
+enum TracePreset {
+	OVERVIEW = "OVERVIEW", // contains overview trace events
+	ALL = "ALL" // contains all trace events
+}
+function resolveLayer(value: string): string {
+	if (value === TracePreset.OVERVIEW) {
+		return overviewTraceFilter;
 	}
-	if (value.startsWith("[") && value.endsWith("]")) {
-		return {
-			TRACE: resolveRustTraceOptions(value.slice(1, value.length - 1))
-		};
+	if (value === TracePreset.ALL) {
+		return allTraceFilter;
 	}
-	return value.split("|").reduce<ProfileOptions>((acc, cur) => {
-		const upperCur = cur.toUpperCase();
-		if (upperCur.startsWith("TRACE")) {
-			acc.TRACE = resolveRustTraceOptions(cur.slice(6));
-		}
-		return acc;
-	}, {});
+	return value;
 }
 
-function isSupportedLayer(layer: string): layer is RustTraceOptionsLayer {
-	const SUPPORTED_LAYERS = ["chrome", "logger"];
-	return SUPPORTED_LAYERS.includes(layer);
-}
-
-// TRACE=value
-function resolveRustTraceOptions(value: string): RustTraceOptions {
-	// filter=trace&output=stdout&layer=logger
-	if (value.includes("=")) {
-		const parsed = new URLSearchParams(value);
-		const filter = parsed.get("filter") || defaultRustTraceFilter;
-		const layer = parsed.get("layer") || defaultRustTraceLayer;
-		const output =
-			layer === "chrome"
-				? parsed.get("output") || defaultRustTraceChromeOutput
-				: parsed.get("output") || defaultRustTraceLoggerOutput;
-
-		if (!isSupportedLayer(layer)) {
-			throw new Error(
-				`${layer} is not a valid layer, should be chrome or logger`
-			);
-		}
-		return {
-			filter,
-			layer,
-			output
-		};
-	}
-	// trace
-	return {
-		filter: value || defaultRustTraceFilter,
-		layer: defaultRustTraceLayer,
-		output: defaultRustTraceChromeOutput
-	};
-}
-
-export async function applyProfile(profileValue: string, item: RspackOptions) {
+export async function applyProfile(
+	filterValue: string,
+	traceLayer: string = defaultRustTraceLayer,
+	traceOutput: string = defaultRustTraceChromeOutput
+) {
 	const { asyncExitHook } = await import("exit-hook");
-	const entries = Object.entries(resolveProfile(profileValue));
+	const filter = resolveLayer(filterValue);
+	const entries = Object.entries(resolveLayer(filterValue));
 	if (entries.length <= 0) return;
 	await fs.promises.mkdir(defaultOutputDirname);
-	for (const [kind, value] of entries) {
-		await ensureFileDir(value.output);
-		if (kind === "TRACE" && "filter" in value) {
-			await rspack.experiments.globalTrace.register(
-				value.filter,
-				value.layer,
-				value.output
-			);
-			asyncExitHook(rspack.experiments.globalTrace.cleanup, {
-				wait: 500
-			});
-		}
+	await ensureFileDir(defaultOutputDirname);
+	if (traceLayer !== "chrome" && traceLayer !== "logger") {
+		throw new Error(`unsupported trace layer: ${traceLayer}`);
 	}
+	await rspack.experiments.globalTrace.register(
+		filter,
+		traceLayer,
+		traceOutput
+	);
+	asyncExitHook(rspack.experiments.globalTrace.cleanup, {
+		wait: 500
+	});
 }
 
 async function ensureFileDir(outputFilePath: string) {

--- a/packages/rspack-cli/tests/build/profile/profile.test.ts
+++ b/packages/rspack-cli/tests/build/profile/profile.test.ts
@@ -31,10 +31,6 @@ describe("profile", () => {
 		);
 		expect(exitCode).toBe(0);
 		const dirname = findDefaultOutputDirname();
-		console.log(
-			resolve(dirname, defaultTracePath),
-			fs.existsSync(resolve(dirname, defaultTracePath))
-		);
 		expect(fs.existsSync(resolve(dirname, defaultTracePath))).toBeTruthy();
 	});
 
@@ -50,12 +46,12 @@ describe("profile", () => {
 		expect(fs.existsSync(resolve(dirname, defaultTracePath))).toBeTruthy();
 	});
 
-	it("should filter trace event when use RSPACK_PROFILE=[crate1,crate2]", async () => {
+	it("should filter trace event when use RSPACK_PROFILE=rspack_resolver,rspack", async () => {
 		const { exitCode } = await run(
 			__dirname,
 			[],
 			{},
-			{ RSPACK_PROFILE: "[rspack_core]" }
+			{ RSPACK_PROFILE: "rspack,respack_resolver" }
 		);
 		expect(exitCode).toBe(0);
 		const dirname = findDefaultOutputDirname();
@@ -79,6 +75,7 @@ describe("profile", () => {
 			[],
 			{},
 			{
+				RSPACK_PROFILE: "ALL",
 				RSPACK_TRACE_OUTPUT: customTracePath
 			}
 		);

--- a/packages/rspack-cli/tests/build/profile/profile.test.ts
+++ b/packages/rspack-cli/tests/build/profile/profile.test.ts
@@ -38,12 +38,12 @@ describe("profile", () => {
 		expect(fs.existsSync(resolve(dirname, defaultTracePath))).toBeTruthy();
 	});
 
-	it("should store rust trace file when RSPACK_PROFILE=TRACE enabled", async () => {
+	it("should store rust trace file when RSPACK_PROFILE=OVERVIEW enabled", async () => {
 		const { exitCode } = await run(
 			__dirname,
 			[],
 			{},
-			{ RSPACK_PROFILE: "TRACE" }
+			{ RSPACK_PROFILE: "OVERVIEW" }
 		);
 		expect(exitCode).toBe(0);
 		const dirname = findDefaultOutputDirname();
@@ -79,7 +79,7 @@ describe("profile", () => {
 			[],
 			{},
 			{
-				RSPACK_PROFILE: `TRACE=output=${customTracePath}`
+				RSPACK_TRACE_OUTPUT: customTracePath
 			}
 		);
 		expect(exitCode).toBe(0);
@@ -91,7 +91,10 @@ describe("profile", () => {
 			__dirname,
 			[],
 			{},
-			{ RSPACK_PROFILE: `TRACE=layer=logger&filter=rspack_core::compiler` }
+			{
+				RSPACK_PROFILE: `rspack_core::compiler`,
+				RSPACK_TRACE_LAYER: "logger"
+			}
 		);
 		expect(exitCode).toBe(0);
 		expect(stdout.includes("rspack_core::compiler")).toBe(true);

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -332,7 +332,7 @@ export type { SubresourceIntegrityPluginOptions } from "./builtin-plugin";
 
 ///// Experiments Stuff /////
 import { cleanupGlobalTrace, registerGlobalTrace } from "@rspack/binding";
-import { ChromeTracer } from "./trace";
+import { JavaScriptTracer } from "./trace";
 
 interface Experiments {
 	globalTrace: {
@@ -353,12 +353,14 @@ export const experiments: Experiments = {
 	globalTrace: {
 		async register(filter, layer, output) {
 			registerGlobalTrace(filter, layer, output);
-			ChromeTracer.initChromeTrace(layer, output);
+
+			JavaScriptTracer.initJavaScriptTrace(layer, output);
 		},
 		async cleanup() {
 			// make sure run cleanupGlobalTrace first so we can safely append Node.js trace to it otherwise it will overlap
 			cleanupGlobalTrace();
-			ChromeTracer.cleanupChromeTrace();
+
+			JavaScriptTracer.cleanupJavaScriptTrace();
 		}
 	},
 	RemoveDuplicateModulesPlugin,

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -36,7 +36,7 @@ import {
 	isUseSimpleSourceMap,
 	isUseSourceMap
 } from "../config/adapterRuleUse";
-import { ChromeTracer } from "../trace";
+import { JavaScriptTracer } from "../trace";
 import {
 	concatErrorMsgAndStack,
 	isNil,
@@ -923,7 +923,7 @@ export async function runLoaders(
 		const pitch = loaderState === JsLoaderState.Pitching;
 		const loaderName = extractLoaderName(currentLoaderObject!.request);
 		let result: any;
-		ChromeTracer.startAsync({
+		JavaScriptTracer.startAsync({
 			name: `loader:${pitch ? "pitch" : ""}:${loaderName}`,
 			args: {
 				resourceData: resourceData,
@@ -947,7 +947,7 @@ export async function runLoaders(
 			result = (await runSyncOrAsync(fn, loaderContext, args)) || [];
 		}
 
-		ChromeTracer.endAsync({
+		JavaScriptTracer.endAsync({
 			name: `loader:${pitch ? "pitch" : ""}:${loaderName}`,
 			args: {
 				resourceData,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
The current RSPACK_PROFILE syntax is too complex to understand(`RSPACK_PROFILE='TRACE=filter=trace&output=./rspack.trace&layer=chrome`) cause
* it supports JSCPU | LOGGING | TRACE at same time
* it supports trace layer trace output trace filter at same time
* trace filter itself is already very complex

so this pr try to simplify the RSPACK_PROFILE logic 

* remove JSCPU | LOGGING support: since it's already removed in https://github.com/web-infra-dev/rspack/pull/10071
* separate trace output and trace layer to separate environment RSPACK_TRACE_OUPUT and RSPACK_TRACE_LAYER
* supports two filter preset like turbopack  https://github.com/vercel/next.js/blob/da31ac70afbaf4ddd620ca06e5dbd55ce2d17255/crates/napi/src/next_api/project.rs#L341
    * RSPACK_PROFILE=ALL means contains all trace event
    * RSPACK_PROFILE=OVERVIEW  means contain overview trace event which is default value
    * RSPACK_PROFILE=tokio::net=info any string other than ALL | OVERVIEW will be treated as envFilter string which is described https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax

since RSPACK_PROFILE is a debugging tools which should not be treated as public api, so this change is not treated as breaking change.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
