### PR TITLE
Add minSizeReduction to SplitChunks CacheGroup

### DIFF
--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1305,6 +1305,7 @@ const sharedOptimizationSplitChunksCacheGroup = {
 	name: optimizationSplitChunksName.optional(),
 	filename: filename.optional(),
 	minSize: optimizationSplitChunksSizes.optional(),
+	minSizeReduction: optimizationSplitChunksSizes.optional(),
 	maxSize: optimizationSplitChunksSizes.optional(),
 	maxAsyncSize: optimizationSplitChunksSizes.optional(),
 	maxInitialSize: optimizationSplitChunksSizes.optional(),


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fixes the following error:

Invalid configuration object. Rspack has been initialized using a configuration object that does not match the API schema.
- Unrecognized key(s) in object: 'minSizeReduction' at "optimization.splitChunks.cacheGroups.{group}"

that is caused by valid config:

```
const config = {
  ...
  optimization: {
    splitChunks: {
      ...
      vendor: {
        priority: 5,
        test: /[\\/]node_modules[\\/]/,
        minSize: 20000,
        minSizeReduction: 50000,
        reuseExistingChunk: true,
      },
    }
  }
};
```

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

Both of the following checks didn't seem pertinent:

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
