### PR TITLE
fix: ThreadsafeOneShotRef prevents event loop destroy

### DIFF
--- a/crates/rspack_napi/src/js_values/threadsafe_one_shot_value_ref.rs
+++ b/crates/rspack_napi/src/js_values/threadsafe_one_shot_value_ref.rs
@@ -90,6 +90,7 @@ impl ThreadsafeOneShotRef {
         },
         "Failed to create threadsafe function"
       )?;
+      check_status!(unsafe { sys::napi_unref_threadsafe_function(env, ts_fn) })?;
       DELETE_REF_TS_FN.store(ts_fn, Ordering::Relaxed);
     }
 
@@ -111,7 +112,11 @@ impl Drop for ThreadsafeOneShotRef {
     } else {
       let ts_fn = DELETE_REF_TS_FN.load(Ordering::Relaxed);
       unsafe {
-        let _ = napi_call_threadsafe_function(ts_fn, self.napi_ref.cast(), 0);
+        let _ = napi_call_threadsafe_function(
+          ts_fn,
+          self.napi_ref.cast(),
+          sys::ThreadsafeFunctionCallMode::nonblocking,
+        );
       }
     }
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

ThreadsafeOneShotRef use ThreadsafeFunction to delete ref when struct drop not in node thread.

We should unref ThreadsafeFunction before create ThreadsafeFunction, avoid it prevents event loop destroy.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
