### PR TITLE
fix(wasm): add wasm fallback in `checkVersion`

### DIFF
--- a/packages/rspack/src/util/bindingVersionCheck.ts
+++ b/packages/rspack/src/util/bindingVersionCheck.ts
@@ -104,7 +104,8 @@ export const checkVersion = () => {
 		);
 
 		const isLocal = readdirSync(BINDING_PKG_DIR).some(
-			item => item === `rspack.${platformArchAbi}.node`
+			item =>
+				item === `rspack.${platformArchAbi}.node` || "rspack.wasm32-wasi.wasm"
 		);
 
 		if (isLocal) {
@@ -112,11 +113,20 @@ export const checkVersion = () => {
 			ADDON_VERSION = BINDING_VERSION;
 		} else {
 			// Fetch addon package if installed from remote
-			ADDON_VERSION = require(
-				require.resolve(`@rspack/binding-${platformArchAbi}/package.json`, {
-					paths: [BINDING_PKG_DIR]
-				})
-			).version;
+			try {
+				ADDON_VERSION = require(
+					require.resolve(`@rspack/binding-${platformArchAbi}/package.json`, {
+						paths: [BINDING_PKG_DIR]
+					})
+				).version;
+			} catch {
+				// Wasm fallback
+				ADDON_VERSION = require(
+					require.resolve("@rspack/binding-wasm32-wasi/package.json", {
+						paths: [BINDING_PKG_DIR]
+					})
+				).version;
+			}
 		}
 	} catch (error: any) {
 		if (error instanceof Error) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This eliminate errors if users only install `@rspack/binding-wasm32-wasi`. Usually users are aware of they are choosing wasm binding so I think we can avoid introducing very detailed messages.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
