### PR TITLE
fix: compilation.chuks not corresponds to a unique jsobect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4347,6 +4347,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "once_cell",
  "ropey",
  "rspack_allocator",
  "rspack_cacheable",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -47,6 +47,7 @@ derive_more        = { workspace = true, features = ["debug"] }
 futures            = { workspace = true }
 glob               = { workspace = true }
 heck               = { workspace = true }
+once_cell          = { workspace = true }
 rspack_cacheable   = { workspace = true }
 rspack_ids         = { workspace = true }
 rspack_napi_macros = { workspace = true }

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -70,6 +70,12 @@ export declare class AsyncDependenciesBlock {
   get blocks(): AsyncDependenciesBlock[]
 }
 
+export declare class Chunks {
+  get size(): number
+  _values(): JsChunk[]
+  _has(chunk: JsChunk): boolean
+}
+
 export declare class ConcatenatedModule {
   get modules(): Module[]
   _originalSource(): JsCompatSource | undefined
@@ -203,7 +209,7 @@ export declare class JsCompilation {
   get modules(): Array<Module>
   get builtModules(): Array<Module>
   getOptimizationBailout(): Array<JsStatsOptimizationBailout>
-  getChunks(): JsChunk[]
+  get chunks(): Chunks
   getNamedChunkKeys(): Array<string>
   getNamedChunk(name: string): JsChunk | null
   getNamedChunkGroupKeys(): Array<string>

--- a/crates/node_binding/rspack.wasi-browser.js
+++ b/crates/node_binding/rspack.wasi-browser.js
@@ -61,6 +61,7 @@ const {
   },
 })
 export const AsyncDependenciesBlock = __napiModule.exports.AsyncDependenciesBlock
+export const Chunks = __napiModule.exports.Chunks
 export const ConcatenatedModule = __napiModule.exports.ConcatenatedModule
 export const ContextModule = __napiModule.exports.ContextModule
 export const Dependency = __napiModule.exports.Dependency

--- a/crates/node_binding/rspack.wasi.cjs
+++ b/crates/node_binding/rspack.wasi.cjs
@@ -86,6 +86,7 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
 })
 
 module.exports.AsyncDependenciesBlock = __napiModule.exports.AsyncDependenciesBlock
+module.exports.Chunks = __napiModule.exports.Chunks
 module.exports.ConcatenatedModule = __napiModule.exports.ConcatenatedModule
 module.exports.ContextModule = __napiModule.exports.ContextModule
 module.exports.Dependency = __napiModule.exports.Dependency

--- a/crates/node_binding/src/compilation/chunks.rs
+++ b/crates/node_binding/src/compilation/chunks.rs
@@ -1,0 +1,60 @@
+use napi::{
+  bindgen_prelude::{Object, ToNapiValue, WeakReference},
+  Env, NapiValue,
+};
+use rspack_core::Compilation;
+
+use crate::{JsChunk, JsChunkWrapper, JsCompilation};
+
+#[napi]
+pub struct Chunks {
+  compiler_reference: WeakReference<JsCompilation>,
+}
+
+impl Chunks {
+  pub fn new(compiler_reference: WeakReference<JsCompilation>) -> Self {
+    Self { compiler_reference }
+  }
+
+  fn as_ref(&self) -> napi::Result<&Compilation> {
+    match self.compiler_reference.get() {
+        Some(wrapped_value) => Ok(wrapped_value.as_ref()?),
+        None => Err(napi::Error::from_reason(
+          "Unable to access compilation.chunks now. The Compilation has been garbage collected by JavaScript."
+        )),
+      }
+  }
+
+  pub fn get_jsobject(self, env: &Env) -> napi::Result<Object> {
+    let raw_env = env.raw();
+    let napi_val = unsafe { ToNapiValue::to_napi_value(raw_env, self)? };
+    Ok(unsafe { Object::from_raw_unchecked(raw_env, napi_val) })
+  }
+}
+
+#[napi]
+impl Chunks {
+  #[napi(getter)]
+  pub fn size(&self) -> napi::Result<u32> {
+    let compilation = self.as_ref()?;
+    Ok(compilation.chunk_by_ukey.len() as u32)
+  }
+
+  #[napi(js_name = "_values", ts_return_type = "JsChunk[]")]
+  pub fn values(&self) -> napi::Result<Vec<JsChunkWrapper>> {
+    let compilation = self.as_ref()?;
+    Ok(
+      compilation
+        .chunk_by_ukey
+        .keys()
+        .map(|chunk_ukey| JsChunkWrapper::new(*chunk_ukey, compilation))
+        .collect::<Vec<_>>(),
+    )
+  }
+
+  #[napi(js_name = "_has")]
+  pub fn has(&self, chunk: &JsChunk) -> napi::Result<bool> {
+    let compilation = self.as_ref()?;
+    Ok(compilation.chunk_by_ukey.contains(&chunk.chunk_ukey))
+  }
+}

--- a/crates/rspack_napi/src/js_values/weak_ref.rs
+++ b/crates/rspack_napi/src/js_values/weak_ref.rs
@@ -16,12 +16,11 @@ pub struct WeakRef {
 impl WeakRef {
   pub fn new(env: napi_env, object: &mut Object) -> Result<Self> {
     let mut raw_ref = ptr::null_mut();
-    check_status!(unsafe { sys::napi_create_reference(env, object.raw(), 1, &mut raw_ref) })?;
+    check_status!(unsafe { sys::napi_create_reference(env, object.raw(), 0, &mut raw_ref) })?;
 
     let deleted = Rc::new(Cell::new(false));
     let deleted_clone = deleted.clone();
-    object.add_finalizer((), (), move |_ctx| unsafe {
-      sys::napi_delete_reference(env, raw_ref);
+    object.add_finalizer((), (), move |_ctx| {
       deleted_clone.set(true);
     })?;
 

--- a/crates/rspack_napi/src/lib.rs
+++ b/crates/rspack_napi/src/lib.rs
@@ -26,4 +26,5 @@ pub mod napi {
 
 pub use js_values::{
   one_shot_instance_ref::*, one_shot_value_ref::*, threadsafe_one_shot_value_ref::*, value_ref::*,
+  weak_ref::*,
 };

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/compilation-chunks-instance/index.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/compilation-chunks-instance/index.js
@@ -1,0 +1,1 @@
+global.bar = "bar";

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/compilation-chunks-instance/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/compilation-chunks-instance/rspack.config.js
@@ -1,0 +1,20 @@
+class Plugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Test", compilation => {
+			const chunks = compilation.chunks;
+
+			compilation.hooks.processAssets.tap("Test", () => {
+				expect(chunks).toBe(compilation.chunks);
+				expect(chunks.size).toBe(1);
+			});
+		});
+	}
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		main: "./index.js"
+	},
+	plugins: [new Plugin()]
+};

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -648,8 +648,6 @@ export class Compilation {
     // @internal
     __internal__getAssetSource(filename: string): Source | void;
     // @internal
-    __internal__getChunks(): Chunk[];
-    // @internal
     __internal__hasAsset(name: string): boolean;
     // @internal
     __internal__pushDiagnostic(diagnostic: ExternalObject<"Diagnostic">): void;

--- a/packages/rspack/src/Chunks.ts
+++ b/packages/rspack/src/Chunks.ts
@@ -1,0 +1,67 @@
+import { Chunks } from "@rspack/binding";
+import { Chunk } from "./Chunk";
+
+Object.defineProperty(Chunks.prototype, "values", {
+	enumerable: true,
+	configurable: true,
+	value(this: Chunks): SetIterator<Chunk> {
+		return this._values()
+			.map(binding => Chunk.__from_binding(binding))
+			.values();
+	}
+});
+
+Object.defineProperty(Chunks.prototype, Symbol.iterator, {
+	enumerable: true,
+	configurable: true,
+	value(this: Chunks): SetIterator<Chunk> {
+		return this.values();
+	}
+});
+
+Object.defineProperty(Chunks.prototype, "keys", {
+	enumerable: true,
+	configurable: true,
+	value(this: Chunks): SetIterator<Chunk> {
+		return this.values();
+	}
+});
+
+Object.defineProperty(Chunks.prototype, "forEach", {
+	enumerable: true,
+	configurable: true,
+	value(
+		callbackfn: (value: Chunk, value2: Chunk, set: ReadonlySet<Chunk>) => void,
+		thisArg?: any
+	): void {
+		return this.values().forEach(callbackfn, thisArg);
+	}
+});
+
+Object.defineProperty(Chunks.prototype, "has", {
+	enumerable: true,
+	configurable: true,
+	value(this: Chunks, value: Chunk): boolean {
+		return this._has(Chunk.__to_binding(value));
+	}
+});
+
+declare module "@rspack/binding" {
+	interface Chunks {
+		[Symbol.iterator](): SetIterator<Chunk>;
+		entries(): SetIterator<[Chunk, Chunk]>;
+		values(): SetIterator<Chunk>;
+		keys(): SetIterator<Chunk>;
+		forEach(
+			callbackfn: (
+				value: Chunk,
+				value2: Chunk,
+				set: ReadonlySet<Chunk>
+			) => void,
+			thisArg?: any
+		): void;
+		has(value: Chunk): boolean;
+	}
+}
+
+export default Chunks;

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -60,6 +60,8 @@ import { createFakeCompilationDependencies } from "./util/fake";
 import type { InputFileSystem } from "./util/fs";
 import type Hash from "./util/hash";
 import { JsSource } from "./util/source";
+// patch chunks
+import "./Chunks";
 
 export type Assets = Record<string, Source>;
 export interface Asset {
@@ -461,7 +463,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	}
 
 	get chunks(): ReadonlySet<Chunk> {
-		return new Set(this.__internal__getChunks());
+		return this.#inner.chunks;
 	}
 
 	/**
@@ -1177,17 +1179,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	 */
 	__internal__hasAsset(name: string): boolean {
 		return this.#inner.hasAsset(name);
-	}
-
-	/**
-	 * Note: This is not a webpack public API, maybe removed in future.
-	 *
-	 * @internal
-	 */
-	__internal__getChunks(): Chunk[] {
-		return this.#inner
-			.getChunks()
-			.map(binding => Chunk.__from_binding(binding));
 	}
 
 	/**


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fix #9953

compilation.chunks should always to point a unique jsobject.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
