### PR TITLE
feat: improve lightningcss minimize warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4825,6 +4825,7 @@ dependencies = [
  "parcel_sourcemap",
  "rayon",
  "regex",
+ "ropey",
  "rspack_core",
  "rspack_error",
  "rspack_hash",

--- a/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
@@ -12,6 +12,7 @@ lightningcss     = { workspace = true, features = ["sourcemap", "browserslist"] 
 parcel_sourcemap = { workspace = true }
 rayon            = { workspace = true }
 regex            = { workspace = true }
+ropey            = { workspace = true }
 tracing          = { workspace = true }
 
 rspack_core  = { workspace = true }

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -20,7 +20,10 @@ use rspack_core::{
   },
   ChunkUkey, Compilation, CompilationChunkHash, CompilationProcessAssets, Plugin,
 };
-use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
+use rspack_error::{
+  miette, Diagnostic, DiagnosticKind, Result, RspackSeverity, ToStringResultToRspackResultExt,
+  TraceableError,
+};
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::asset_condition::AssetConditions;
@@ -143,7 +146,7 @@ async fn chunk_hash(
 async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let options = &self.options;
   let minimizer_options = &self.options.minimizer_options;
-  let all_warnings: RwLock<Vec<_>> = Default::default();
+  let all_warnings: RwLock<Vec<Diagnostic>> = Default::default();
   compilation
     .assets_mut()
     .par_iter_mut()
@@ -250,7 +253,22 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
           let warnings = warnings.read().expect("should lock");
           all_warnings.write().expect("should lock").extend(
             warnings.iter().map(|e| {
-              Diagnostic::warn("LightningCSS minimize warning".to_string(), e.to_string())
+              if let Some(loc) = &e.loc {
+                let rope = ropey::Rope::from_str(&input);
+                let start = rope.line_to_byte(loc.line as usize) + loc.column as usize - 1;
+                let end = start;
+                Diagnostic::from(Box::new(TraceableError::from_file(
+                  input.clone(),
+                  start,
+                  end,
+                  "LightningCSS minimize warning".to_string(),
+                  e.to_string(),
+                )
+                .with_kind(DiagnosticKind::Css)
+                .with_severity(RspackSeverity::Warn)) as Box<dyn miette::Diagnostic + Send + Sync>)
+              } else {
+                Diagnostic::warn("LightningCSS minimize warning".to_string(), e.to_string())
+              }
             }),
           );
           result

--- a/packages/rspack-test-tools/tests/diagnosticsCases/minimize/lightning-css-invalid/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/minimize/lightning-css-invalid/stats.err
@@ -1,7 +1,39 @@
-WARNING in ⚠ Unknown at rule: @apply at main.css<LINE_COL>
+WARNING in ⚠ LightningCSS minimize warning: Unknown at rule: @apply at main.css<LINE_COL>
+   ╭─[5:6]
+ 3 │ - type: css/auto
+ 4 │ */
+ 5 │ @apply {
+   ·       ▲
+ 6 │ }
+ 7 │ 
+   ╰────
 
-WARNING in ⚠ Unexpected end of input at main.css<LINE_COL>
+WARNING in ⚠ LightningCSS minimize warning: Unexpected end of input at main.css<LINE_COL>
+    ╭─[13:7]
+ 11 │ 
+ 12 │ .b {
+ 13 │   color; blue;
+    ·        ▲
+ 14 │ }
+ 15 │ 
+    ╰────
 
-WARNING in ⚠ Unexpected end of input at main.css<LINE_COL>
+WARNING in ⚠ LightningCSS minimize warning: Unexpected end of input at main.css<LINE_COL>
+    ╭─[13:13]
+ 11 │ 
+ 12 │ .b {
+ 13 │   color; blue;
+    ·              ▲
+ 14 │ }
+ 15 │ 
+    ╰────
 
-WARNING in ⚠ Unexpected token Delim('<') at main.css<LINE_COL>
+WARNING in ⚠ LightningCSS minimize warning: Unexpected token Delim('<') at main.css<LINE_COL>
+    ╭─[16:2]
+ 14 │ }
+ 15 │ 
+ 16 │ .c<>c {
+    ·   ▲
+ 17 │   color: green;
+ 18 │ }
+    ╰────


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

improve lightningcss minimize warning

before

```
WARNING in ⚠ Unexpected end of input at main.css<LINE_COL>
```
after

```
WARNING in ⚠ LightningCSS minimize warning: Unexpected end of input at main.css<LINE_COL>
    ╭─[13:13]
 11 │ 
 12 │ .b {
 13 │   color; blue;
    ·              ▲
 14 │ }
 15 │ 
    ╰────
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
