### PR TITLE
test: fix Jest haste module naming collision

### DIFF
--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/managed-paths/test_lib/package.json
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/managed-paths/test_lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test_lib",
+  "name": "managed-paths-test-lib",
   "version": "0.0.1",
   "main": "./file.js"
 }

--- a/packages/rspack-test-tools/tests/cacheCases/snapshot/unmanaged-paths/test_lib/package.json
+++ b/packages/rspack-test-tools/tests/cacheCases/snapshot/unmanaged-paths/test_lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test_lib",
+  "name": "unmanaged-paths-test-lib",
   "version": "0.0.1",
   "main": "./file.js"
 }

--- a/packages/rspack-test-tools/tests/configCases/resolve/pnp-enable/package.json
+++ b/packages/rspack-test-tools/tests/configCases/resolve/pnp-enable/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rspack-pnp-test",
+  "name": "rspack-pnp-enable",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/pnp-disable/package.json
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/pnp-disable/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rspack-pnp-test",
+  "name": "rspack-pnp-disable",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Update package.json#name to fix the Jest haste module naming collision when running the Rspack test cases:

<img width="984" alt="Screenshot 2025-04-20 at 17 25 19" src="https://github.com/user-attachments/assets/a9867454-fdab-4a09-90ba-ce394b7d5957" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
