### PR TITLE
fix(diagnostic): fix excessively large width causing `format_args` panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,9 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -2733,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -12,7 +12,7 @@ anyhow             = { workspace = true, features = ["backtrace"] }
 cow-utils          = { workspace = true }
 derive_more        = { workspace = true, features = ["debug"] }
 futures            = { workspace = true }
-miette             = { version = "7.2.0", features = ["fancy"] }
+miette             = { version = "7.5.0", features = ["fancy"] }
 once_cell          = { workspace = true }
 owo-colors         = "4.0.0"
 rspack_cacheable   = { workspace = true }

--- a/crates/rspack_error/src/graphical.rs
+++ b/crates/rspack_error/src/graphical.rs
@@ -696,6 +696,12 @@ impl GraphicalReportHandler {
         let num_left = vbar_offset - start;
         let num_right = end - vbar_offset - 1;
         if start < end {
+          let width = start.saturating_sub(highest);
+          // CHANGE:
+          // Rust PR https://github.com/rust-lang/rust/issues/99012 limited format string width and precision to 16 bits, causing panics when dynamic padding exceeds `u16::MAX`.
+          // This fixes exessively large width that exceeds `u16::MAX` by directly printing exceeded width.
+          let pre_width = width.saturating_sub(u16::MAX as usize);
+          underlines.push_str(&format!("{:width$}", "", width = pre_width));
           underlines.push_str(
             &format!(
               "{:width$}{}{}{}",
@@ -709,7 +715,7 @@ impl GraphicalReportHandler {
                 chars.underline
               },
               chars.underline.to_string().repeat(num_right),
-              width = start.saturating_sub(highest),
+              width = width.min(u16::MAX as usize),
             )
             .style(hl.style)
             .to_string(),

--- a/packages/rspack-test-tools/tests/__snapshots__/NewCodeSplitting-stats-output.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/NewCodeSplitting-stats-output.test.js.snap
@@ -64,8 +64,7 @@ Rspack compiled successfully (27eddb11e03f28d2)
 exports[`new code splitting stats output new code splitting stats output/builtin-swc-loader-parse-error should print correct stats for: NewCodeSplittingStatsOutput 1`] = `
 ERROR in ./index.ts
   × Module build failed:
-  ├─▶   ×
-  │     │   x Expected '{', got 'error'
+  ├─▶   ×   x Expected '{', got 'error'
   │     │    ,-[<TEST_TOOLS_ROOT>/tests/statsOutputCases/builtin-swc-loader-parse-error/index.ts<LINE_COL>]
   │     │  1 | export error;
   │     │    :        ^^^^^

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -64,8 +64,7 @@ Rspack compiled successfully (27eddb11e03f28d2)
 exports[`statsOutput statsOutput/builtin-swc-loader-parse-error should print correct stats for 1`] = `
 ERROR in ./index.ts
   × Module build failed:
-  ├─▶   ×
-  │     │   x Expected '{', got 'error'
+  ├─▶   ×   x Expected '{', got 'error'
   │     │    ,-[<TEST_TOOLS_ROOT>/tests/statsOutputCases/builtin-swc-loader-parse-error/index.ts<LINE_COL>]
   │     │  1 | export error;
   │     │    :        ^^^^^

--- a/packages/rspack-test-tools/tests/diagnosticsCases/builtins/recoverable_syntax_error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/builtins/recoverable_syntax_error/stats.err
@@ -1,12 +1,10 @@
 ERROR in ./index.tsx
   × Module build failed:
-  ├─▶   ×
-  │     │   x Expected a semicolon
+  ├─▶   ×   x Expected a semicolon
   │     │    ,-[<TEST_TOOLS_ROOT>/tests/diagnosticsCases/builtins/recoverable_syntax_error/index.tsx<LINE_COL>]
   │     │  1 | let c = <test>() => {}</test>;
   │     │    :                       ^
   │     │    `----
-  │     │
   │     │   x Expression expected
   │     │    ,-[<TEST_TOOLS_ROOT>/tests/diagnosticsCases/builtins/recoverable_syntax_error/index.tsx<LINE_COL>]
   │     │  1 | let c = <test>() => {}</test>;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR fixes the panic when calling `format_args!` with excessively large width (> u16::MAX), which is an constraint introduced in rust PR https://github.com/rust-lang/rust/issues/99012.

This is not an ideal way for handling a minimized source code. The way of printing diagnostics of minimized source remains to be discussed.

closes https://github.com/web-infra-dev/rspack/issues/9971

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
