### PR TITLE
fix(pnp):  resolved wrong description file in yarn pnp mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3378,9 +3378,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "pnp"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cda59e692c332a953b19dcfe863b45344ce8bfc9027e229f3a732e3d61c50a"
+checksum = "b4efb966c09f2fd5359294a357e14819277b4f0ce5981449b289bdd334b86699"
 dependencies = [
  "arca",
  "byteorder",
@@ -5189,9 +5189,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b92170acee801d0d79f73efafd8e51c4d039161e4c3152889dbd7f032d996c"
+checksum = "b7026b3b6b4d18ad1896163a15db0202f0fe99fd26b4601dc4945e6142b2a1cd"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ quote            = { version = "1.0.38" }
 rayon            = { version = "1.10.0" }
 regex            = { version = "1.11.1" }
 ropey            = "1.6.1"
-rspack_resolver  = { features = ["package_json_raw_json_api"], version = "0.5.4" }
+rspack_resolver  = { features = ["package_json_raw_json_api"], version = "0.5.5" }
 rspack_sources   = { version = "0.4.8" }
 rustc-hash       = { version = "2.1.0" }
 serde            = { version = "1.0.217" }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
close https://github.com/web-infra-dev/rspack/issues/9967

the root cause is pnp-rs return wrong file_type when querying zip cached path.
Solved by update pnp-rs in rspack resolver.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
