### PR TITLE
fix: compilation chunks for each is undefined

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/compilation-chunks-instance/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/compilation-chunks-instance/rspack.config.js
@@ -6,6 +6,15 @@ class Plugin {
 			compilation.hooks.processAssets.tap("Test", () => {
 				expect(chunks).toBe(compilation.chunks);
 				expect(chunks.size).toBe(1);
+
+				const chunk = Array.from(chunks)[0];
+				const mockFn = jest.fn((value, value2, set) => {
+					expect(value).toBe(chunk);
+					expect(value2).toBe(chunk);
+					expect(set).toBe(chunks);
+				});
+				chunks.forEach(mockFn);
+				expect(mockFn).toHaveBeenCalledTimes(1);
 			});
 		});
 	}

--- a/packages/rspack/src/Chunks.ts
+++ b/packages/rspack/src/Chunks.ts
@@ -31,10 +31,14 @@ Object.defineProperty(Chunks.prototype, "forEach", {
 	enumerable: true,
 	configurable: true,
 	value(
+		this: Chunks,
 		callbackfn: (value: Chunk, value2: Chunk, set: ReadonlySet<Chunk>) => void,
 		thisArg?: any
 	): void {
-		return this.values().forEach(callbackfn, thisArg);
+		for (const binding of this._values()) {
+			const chunk = Chunk.__from_binding(binding);
+			callbackfn.call(thisArg, chunk, chunk, this);
+		}
 	}
 });
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: compilation chunks for each is undefined

before node 22, there is not forEach function in `SetIterator<T>`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
