### PR TITLE
docs: update banner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://assets.rspack.dev/rspack/rspack-banner-plain-dark.png">
-  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner-plain-light.png">
+  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner.png">
 </picture>
 
 # Rspack

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,5 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://assets.rspack.dev/rspack/rspack-banner-plain-dark.png">
-  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner-plain-light.png">
+  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner.png">
 </picture>
 
 # Rspack

--- a/crates/node_binding/README.md
+++ b/crates/node_binding/README.md
@@ -1,6 +1,5 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://assets.rspack.dev/rspack/rspack-banner-plain-dark.png">
-  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner-plain-light.png">
+  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner.png">
 </picture>
 
 # @rspack/binding

--- a/packages/create-rspack/README.md
+++ b/packages/create-rspack/README.md
@@ -1,6 +1,5 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://assets.rspack.dev/rspack/rspack-banner-plain-dark.png">
-  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner-plain-light.png">
+  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner.png">
 </picture>
 
 # create-rspack

--- a/packages/rspack-cli/README.md
+++ b/packages/rspack-cli/README.md
@@ -1,6 +1,5 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://assets.rspack.dev/rspack/rspack-banner-plain-dark.png">
-  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner-plain-light.png">
+  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner.png">
 </picture>
 
 # @rspack/cli

--- a/packages/rspack-test-tools/README.md
+++ b/packages/rspack-test-tools/README.md
@@ -1,6 +1,5 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://assets.rspack.dev/rspack/rspack-banner-plain-dark.png">
-  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner-plain-light.png">
+  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner.png">
 </picture>
 
 # @rspack/test-tools

--- a/packages/rspack/README.md
+++ b/packages/rspack/README.md
@@ -1,6 +1,5 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://assets.rspack.dev/rspack/rspack-banner-plain-dark.png">
-  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner-plain-light.png">
+  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner.png">
 </picture>
 
 # @rspack/core

--- a/scripts/build-npm.cjs
+++ b/scripts/build-npm.cjs
@@ -80,7 +80,7 @@ const NPM = path.resolve(__dirname, "../npm");
 try {
 	// Error tolerant if the directory already exists
 	fs.mkdirSync(NPM);
-} catch (e) {}
+} catch (e) { }
 
 // Releasing bindings
 const releasingPackages = [];
@@ -128,7 +128,7 @@ for (const binding of bindings) {
 	const output = path.join(NPM, platformArchABI);
 	try {
 		fs.mkdirSync(output);
-	} catch (e) {}
+	} catch (e) { }
 
 	const coreJson = require(
 		path.resolve(__dirname, "../packages/rspack/package.json")
@@ -159,8 +159,7 @@ for (const binding of bindings) {
 	fs.writeFileSync(`${output}/${pkgJson.main}`, binary);
 
 	const README = `<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://assets.rspack.dev/rspack/rspack-banner-plain-dark.png">
-  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner-plain-light.png">
+  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner.png">
 </picture>
 
 # ${pkgJson.name}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,6 +1,5 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://assets.rspack.dev/rspack/rspack-banner-plain-dark.png">
-  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner-plain-light.png">
+  <img alt="Rspack Banner" src="https://assets.rspack.dev/rspack/rspack-banner.png">
 </picture>
 
 # rspack-e2e


### PR DESCRIPTION
## Summary

This PR updates the banner image in README files to align with other Rstack projects.

- before:

![image](https://github.com/user-attachments/assets/d9b8464d-0c93-4df8-9896-8ac84a765017)

- after:

![image](https://github.com/user-attachments/assets/d68f52d3-e64f-4d1c-8228-ca14fd811bf4)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
