### PR TITLE
fix(core): fix async event tracing showing in perfetto

### DIFF
--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -278,7 +278,11 @@ impl NormalModule {
     &mut self.presentational_dependencies
   }
 
-  #[tracing::instrument("NormalModule:build_hash", skip_all)]
+  #[tracing::instrument(
+    "NormalModule:build_hash", skip_all,fields(
+    id2 = self.resource_data.resource.as_str()
+  )
+)]
   fn init_build_hash(
     &self,
     output_options: &OutputOptions,
@@ -364,6 +368,7 @@ impl Module for NormalModule {
   #[tracing::instrument("NormalModule:build", skip_all, fields(
     module.resource = self.resource_resolved_data().resource.as_str(),
     module.identifier = self.identifier().as_str(),
+    id2 = self.resource_data.resource.as_str(),
     module.loaders = ?self.loaders.iter().map(|l| l.identifier().as_str()).collect::<Vec<_>>())
   )]
   async fn build(
@@ -407,7 +412,10 @@ impl Module for NormalModule {
       },
       build_context.fs.clone(),
     )
-    .instrument(info_span!("NormalModule:run_loaders"))
+    .instrument(info_span!(
+      "NormalModule:run_loaders",
+      id2 = self.resource_data.resource.as_str(),
+    ))
     .await;
     let (mut loader_result, ds) = match loader_result {
       Ok(r) => r.split_into_parts(),

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -147,7 +147,9 @@ pub const SWC_LOADER_IDENTIFIER: &str = "builtin:swc-loader";
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Loader<RunnerContext> for SwcLoader {
-  #[tracing::instrument("SwcLoader:run", skip_all)]
+  #[tracing::instrument("loader:builtin-swc", skip_all, fields(
+    id2 =loader_context.resource(),
+  ))]
   async fn run(&self, loader_context: &mut LoaderContext<RunnerContext>) -> Result<()> {
     #[allow(unused_mut)]
     let mut inner = || self.loader_impl(loader_context);

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -111,6 +111,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
 
   #[tracing::instrument("JavaScriptParser:parse", skip_all,fields(
     resource = parse_context.resource_data.resource.as_str(),
+    id2 = parse_context.resource_data.resource.as_str(),
   ))]
   async fn parse<'a>(
     &mut self,

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -6,20 +6,20 @@ use std::{
   marker::PhantomData,
   path::Path,
   sync::{
+    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
     mpsc,
     mpsc::Sender,
-    Arc, Mutex,
   },
   thread::JoinHandle,
 };
 
-use serde_json::{json, Value as JsonValue};
-use tracing_core::{field::Field, span, Event, Subscriber};
+use serde_json::{Value as JsonValue, json};
+use tracing_core::{Event, Subscriber, field::Field, span};
 use tracing_subscriber::{
+  Layer,
   layer::Context,
   registry::{LookupSpan, SpanRef},
-  Layer,
 };
 
 thread_local! {

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -6,20 +6,20 @@ use std::{
   marker::PhantomData,
   path::Path,
   sync::{
-    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
     mpsc,
     mpsc::Sender,
+    Arc, Mutex,
   },
   thread::JoinHandle,
 };
 
-use serde_json::{Value as JsonValue, json};
-use tracing_core::{Event, Subscriber, field::Field, span};
+use serde_json::{json, Value as JsonValue};
+use tracing_core::{field::Field, span, Event, Subscriber};
 use tracing_subscriber::{
-  Layer,
   layer::Context,
   registry::{LookupSpan, SpanRef},
+  Layer,
 };
 
 thread_local! {
@@ -347,7 +347,7 @@ where
           for (tid, name) in thread_names.iter() {
             let entry = json!({
                 "ph": "M",
-                "pid": 1,
+                "pid": 1, // fake pid for separate perfetto overview track
                 "name": "thread_name",
                 "tid": *tid,
                 "args": {
@@ -415,7 +415,7 @@ where
             if !call_args.is_empty() {
               // use id2 for perfetto to split span
               if let Some(id2) = call_args.get("id2") {
-                entry["pid"] = json!(2);
+                entry["pid"] = json!(2); // fake pid for separate perfetto detail track
                 entry["id2"]["local"] = id2.clone();
                 if let Some(obj) = entry["id2"].as_object_mut() {
                   obj.remove("global");

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -925,12 +925,15 @@ export async function runLoaders(
 		const loaderName = extractLoaderName(currentLoaderObject!.request);
 		let result: any;
 		JavaScriptTracer.startAsync({
-			name: `loader:${pitch ? "pitch" : ""}:${loaderName}`,
-			args: {
-				resourceData: resourceData,
-				"loader.request": currentLoaderObject?.request
+			name: `loader:${pitch ? "pitch:" : ""}${loaderName}`,
+			id2: {
+				local: resource // use id2.local to bind to span for same module
 			},
-			cat: "rspack"
+			cat: "rspack",
+			args: {
+				resource: resource,
+				"loader.request": currentLoaderObject?.request
+			}
 		});
 		if (parallelism) {
 			result =
@@ -947,14 +950,16 @@ export async function runLoaders(
 				convertArgs(args, !!currentLoaderObject?.raw);
 			result = (await runSyncOrAsync(fn, loaderContext, args)) || [];
 		}
-
 		JavaScriptTracer.endAsync({
-			name: `loader:${pitch ? "pitch" : ""}:${loaderName}`,
+			name: `loader:${pitch ? "pitch:" : ""}${loaderName}`,
 			args: {
-				resourceData,
+				resource: resource,
 				"loader.request": currentLoaderObject?.request
 			},
-			cat: "rspack"
+			cat: "rspack",
+			id2: {
+				local: resource
+			}
 		});
 		return result;
 	};

--- a/packages/rspack/src/trace/index.ts
+++ b/packages/rspack/src/trace/index.ts
@@ -111,7 +111,7 @@ export class JavaScriptTracer {
 	static getCommonEv() {
 		return {
 			tid: 1,
-			pid: 1,
+			pid: 2, // fake pid for detailed track
 			ts: this.getTs()
 		};
 	}

--- a/packages/rspack/src/trace/index.ts
+++ b/packages/rspack/src/trace/index.ts
@@ -8,9 +8,13 @@ export interface ChromeEvent {
 	ts?: number;
 	pid?: number;
 	tid?: number;
-	id?: number;
+	id?: number; // updated to allow string id
 	args?: {
 		[key: string]: any;
+	};
+	id2?: {
+		local?: string;
+		global?: string;
 	};
 }
 // this is a tracer for nodejs
@@ -56,8 +60,9 @@ export class JavaScriptTracer {
 					name: "Profile",
 					cat: "disabled-by-default-v8.cpu_profiler",
 					ph: "P",
+					id: 1,
 					...this.getCommonEv(),
-					pid: process.pid,
+					pid: 3, // separate process id for cpu profile
 					args: {
 						data: {
 							startTime: 0 // use offset time to align with other trace data
@@ -67,9 +72,10 @@ export class JavaScriptTracer {
 				this.pushEvent({
 					name: "ProfileChunk",
 					ph: "P",
+					id: 1,
 					cat: "disabled-by-default-v8.cpu_profiler",
 					...this.getCommonEv(),
-					pid: process.pid,
+					pid: 3,
 					args: {
 						data: {
 							cpuProfile: cpu_profile,
@@ -104,9 +110,8 @@ export class JavaScriptTracer {
 	// get common chrome event
 	static getCommonEv() {
 		return {
-			tid: process.pid, // node doesn't expose tid so use pid
-			pid: process.pid,
-			id: 1,
+			tid: 1,
+			pid: 1,
 			ts: this.getTs()
 		};
 	}

--- a/scripts/build-npm.cjs
+++ b/scripts/build-npm.cjs
@@ -80,7 +80,7 @@ const NPM = path.resolve(__dirname, "../npm");
 try {
 	// Error tolerant if the directory already exists
 	fs.mkdirSync(NPM);
-} catch (e) { }
+} catch (e) {}
 
 // Releasing bindings
 const releasingPackages = [];
@@ -128,7 +128,7 @@ for (const binding of bindings) {
 	const output = path.join(NPM, platformArchABI);
 	try {
 		fs.mkdirSync(output);
-	} catch (e) { }
+	} catch (e) {}
 
 	const coreJson = require(
 		path.resolve(__dirname, "../packages/rspack/package.json")


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
### `id2`
It's harder for trace viewer(like perfetto) to explain overlap async event with same `name` and `id` and `cat`
```json
[
  {
    "name": "parse",
    "ph": "b",
    "ts": 0,
    "id": "1",
    "pid": 1,
    "tid": 1
  },
  {
    "name": "parse",
    "ph": "e",
    "ts": 4000,
    "id": "1",
    "pid": 1,
    "tid": 1
  },
  {
    "name": "parse",
    "ph": "b",
    "ts": 2000,
    "id": "1",
    "pid": 1,
    "tid": 1
  },
  {
    "name": "parse",
    "ph": "e",
    "ts": 5000,
    "id": "1",
    "pid": 1,
    "tid": 1
  }
]
```
it can explain the json in two different ways
* first
![image](https://github.com/user-attachments/assets/3dc42e23-12ad-43cc-8ead-9fe0ca526d89)
* second
![image](https://github.com/user-attachments/assets/f2e20da9-3637-4eda-a942-89e82a4d3b94)
chrome trace event supports use ["id2"](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.l7g30knytzzc) to different span, so we use "id2" instead to control how perfetto show overlap, it's not only useful to specify range but also can bind span with different name into same flamechart(we choose to bind all build phase tracing to resource for better view)
### Separate Build Overview and Build Detail Track
since the tracing contains too much information(especially for module.build phase which contains thousands of async events for large projects), it looks better that we split track to overview track(which covers important phase of compilation) and detail track(which covers detailed info about all module build process, we may add more detailed track like for code splitting and memory in the future)

![image](https://github.com/user-attachments/assets/4bad2d7b-c98b-428d-8292-9b289e783d5c)


### Know Limitations
* Perfetto UI: It seems perfetto's UI is not perfect for showing large async events which may be harder to read for too many build events for large projects compared with turbopack's trace viewer, but we can still search in it and we can build our own trace viewer in the future if https://github.com/google/perfetto/issues/1333 is not supported
* trace.json limitation: the current usage of trace.json is kind of hacky, since trace.json itself is second class support(legacy) in perfetto, we may switch to perfetto proto if trace.json doesn't meet more needs in the future.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
