### PR TITLE
chore: disable hook macro tracing by default

### DIFF
--- a/crates/rspack_macros/src/plugin.rs
+++ b/crates/rspack_macros/src/plugin.rs
@@ -1,4 +1,3 @@
-use proc_macro2::Span;
 use quote::quote;
 use syn::{
   parse::{Parse, ParseStream, Parser},
@@ -182,10 +181,10 @@ pub fn expand_fn(args: HookArgs, input: syn::ItemFn) -> proc_macro::TokenStream 
 
   let inner_ident = plugin_inner_ident(&name);
 
-  let tracing_name = syn::LitStr::new(&format!("{}:{}", &name, &fn_ident), Span::call_site());
+  let tracing_name = syn::LitStr::new(&format!("{}:{}", &name, &fn_ident), name.span());
   let tracing_annotation = tracing
     .map(|bool_lit| bool_lit.value)
-    .unwrap_or(true)
+    .unwrap_or_default()
     .then(|| {
       quote! {
         #[::rspack_hook::__macro_helper::tracing::instrument(name = #tracing_name, skip_all)]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

How to enable:

`define_hook!(CompilerThisCompilation: Series(compilation: &mut Compilation, params: &mut CompilationParams), tracing = true);`

`#[plugin_hook(NormalModuleFactoryBeforeResolve for IgnorePlugin, tracing = true)]`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
