### PR TITLE
perf(core): remove json-parse-even-better-errors dependency

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -56,7 +56,6 @@
     "cross-env": "^7.0.3",
     "enhanced-resolve": "5.18.1",
     "graceful-fs": "^4.2.11",
-    "json-parse-even-better-errors": "^3.0.2",
     "prebundle": "^1.3.3",
     "tsx": "^4.19.3",
     "typescript": "^5.7.3",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -53,7 +53,6 @@
     "@types/watchpack": "^2.4.4",
     "@types/webpack-sources": "3.2.3",
     "browserslist": "^4.24.4",
-    "cross-env": "^7.0.3",
     "enhanced-resolve": "5.18.1",
     "graceful-fs": "^4.2.11",
     "prebundle": "^1.3.3",

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -644,10 +644,11 @@ export async function runLoaders(
 		if (typeof options === "string") {
 			if (options.startsWith("{") && options.endsWith("}")) {
 				try {
-					const parseJson = require("json-parse-even-better-errors");
-					options = parseJson(options);
+					options = JSON.parse(options);
 				} catch (e: any) {
-					throw new Error(`Cannot parse string options: ${e.message}`);
+					throw new Error(
+						`JSON parsing failed for loader's string options: ${e.message}`
+					);
 				}
 			} else {
 				options = querystring.parse(options);

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -380,10 +380,11 @@ async function loaderImpl(
 		if (typeof options === "string") {
 			if (options.startsWith("{") && options.endsWith("}")) {
 				try {
-					const parseJson = require("json-parse-even-better-errors");
-					options = parseJson(options);
+					options = JSON.parse(options);
 				} catch (e: any) {
-					throw new Error(`Cannot parse string options: ${e.message}`);
+					throw new Error(
+						`JSON parsing failed for loader's string options: ${e.message}`
+					);
 				}
 			} else {
 				options = querystring.parse(options);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,9 +319,6 @@ importers:
       browserslist:
         specifier: ^4.24.4
         version: 4.24.4
-      cross-env:
-        specifier: ^7.0.3
-        version: 7.0.3
       enhanced-resolve:
         specifier: 5.18.1
         version: 5.18.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,9 +328,6 @@ importers:
       graceful-fs:
         specifier: ^4.2.11
         version: 4.2.11(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
-      json-parse-even-better-errors:
-        specifier: ^3.0.2
-        version: 3.0.2
       prebundle:
         specifier: ^1.3.3
         version: 1.3.3(typescript@5.7.3)
@@ -5891,10 +5888,6 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-
-  json-parse-even-better-errors@3.0.2:
-    resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -13829,8 +13822,6 @@ snapshots:
   jsesc@3.0.2: {}
 
   json-parse-even-better-errors@2.3.1: {}
-
-  json-parse-even-better-errors@3.0.2: {}
 
   json-schema-traverse@0.4.1: {}
 


### PR DESCRIPTION
## Summary

This PR removes the `json-parse-even-better-errors` dependency to remove ~100 loc from the `dist/index.js`.

I think this package can be removed due to two reasons:

1. The "loader string option parsing error" is a rare case, and I think few users will encounter this error.
2. `json-parse-even-better-errors` does not seem to improve the readability of the error, but makes the log more complicated:

```js
import jsonParse from "json-parse-even-better-errors";

const invalidJson = "{foo:1,bar:2,baz:`}";

try {
  console.log("=== JSON.parse ===");
  JSON.parse(invalidJson);
} catch (e) {
  console.log(e);
  console.log('\n');
}

try {
  console.log("=== json-parse-even-better-errors ===");
  jsonParse(invalidJson);
} catch (e) {
  console.log(e);
}
```

![image](https://github.com/user-attachments/assets/c37d5241-0b46-4ed8-89a6-8eabcf6e3599)
 
## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
