### PR TITLE
chore(deps): bump Rslib 0.6.7

### DIFF
--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -27,7 +27,7 @@
     "create-rstack": "1.4.0"
   },
   "devDependencies": {
-    "@rslib/core": "0.6.6",
+    "@rslib/core": "0.6.7",
     "typescript": "^5.7.3"
   },
   "publishConfig": {

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -43,7 +43,7 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
-    "@rslib/core": "0.6.6",
+    "@rslib/core": "0.6.7",
     "@rspack/core": "workspace:*",
     "@types/interpret": "^1.1.3",
     "@types/rechoir": "^0.6.4",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@swc/core": "1.11.21",
     "@swc/types": "0.1.21",
-    "@rslib/core": "0.6.6",
+    "@rslib/core": "0.6.7",
     "@types/graceful-fs": "4.1.9",
     "@types/watchpack": "^2.4.4",
     "@types/webpack-sources": "3.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         version: 1.4.0
     devDependencies:
       '@rslib/core':
-        specifier: 0.6.6
-        version: 0.6.6(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rspack/tracing@1.3.5)(typescript@5.7.3)
+        specifier: 0.6.7
+        version: 0.6.7(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rspack/tracing@1.3.5)(typescript@5.7.3)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -299,8 +299,8 @@ importers:
         version: 1.0.30001715
     devDependencies:
       '@rslib/core':
-        specifier: 0.6.6
-        version: 0.6.6(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rspack/tracing@1.3.5)(typescript@5.7.3)
+        specifier: 0.6.7
+        version: 0.6.7(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rspack/tracing@1.3.5)(typescript@5.7.3)
       '@swc/core':
         specifier: 1.11.21
         version: 1.11.21(@swc/helpers@0.5.15)
@@ -378,8 +378,8 @@ importers:
         version: 17.7.2
     devDependencies:
       '@rslib/core':
-        specifier: 0.6.6
-        version: 0.6.6(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rspack/tracing@1.3.5)(typescript@5.7.3)
+        specifier: 0.6.7
+        version: 0.6.7(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rspack/tracing@1.3.5)(typescript@5.7.3)
       '@rspack/core':
         specifier: workspace:*
         version: link:../rspack
@@ -2750,8 +2750,8 @@ packages:
     peerDependencies:
       '@rsbuild/core': 1.x
 
-  '@rslib/core@0.6.6':
-    resolution: {integrity: sha512-3FtgbYqlFsPgRV8TwW7GjYRJH273fOPw9utcfQqcZIVTuQAhmhr7ZWplpFJWbze2MNP9W234CpbNdRUxfNe3ew==}
+  '@rslib/core@0.6.7':
+    resolution: {integrity: sha512-ti/vE9IVyWXo1QuwtFgK3Enl7mBNKEAUtBJkGZljQgOaJkXWTM0DeHWhpxk2sK4KP9XgaI+7fYsNR/OCcwqqHg==}
     engines: {node: '>=16.7.0'}
     hasBin: true
     peerDependencies:
@@ -6866,8 +6866,8 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
-  rsbuild-plugin-dts@0.6.6:
-    resolution: {integrity: sha512-cN0deqsNMG8Dwmw0MHeFLZWyBuqlT8PhcmUH9qkahMxPRnJCBusnEdVfmRBlXaz+Z24MYX/Z15nCgyydlHInlA==}
+  rsbuild-plugin-dts@0.6.7:
+    resolution: {integrity: sha512-uvGYychYBks67VM7ttXfOvcY2lXSLGrV5uFZ2zJK/O+s4DJ/+oyJ1j6IhIPH191J8zMCaOd/3ftrlq/izVsheA==}
     engines: {node: '>=16.7.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -9912,10 +9912,10 @@ snapshots:
       reduce-configs: 1.1.0
       sass-embedded: 1.86.1
 
-  '@rslib/core@0.6.6(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rspack/tracing@1.3.5)(typescript@5.7.3)':
+  '@rslib/core@0.6.7(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rspack/tracing@1.3.5)(typescript@5.7.3)':
     dependencies:
       '@rsbuild/core': 1.3.9(@rspack/tracing@1.3.5)
-      rsbuild-plugin-dts: 0.6.6(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rsbuild/core@1.3.9(@rspack/tracing@1.3.5))(typescript@5.7.3)
+      rsbuild-plugin-dts: 0.6.7(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rsbuild/core@1.3.9(@rspack/tracing@1.3.5))(typescript@5.7.3)
       tinyglobby: 0.2.13
     optionalDependencies:
       '@microsoft/api-extractor': 7.49.2(@types/node@20.17.30)
@@ -14985,7 +14985,7 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rsbuild-plugin-dts@0.6.6(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rsbuild/core@1.3.9(@rspack/tracing@1.3.5))(typescript@5.7.3):
+  rsbuild-plugin-dts@0.6.7(@microsoft/api-extractor@7.49.2(@types/node@20.17.30))(@rsbuild/core@1.3.9(@rspack/tracing@1.3.5))(typescript@5.7.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.3.9(@rspack/tracing@1.3.5)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

bump Rslib from `v0.6.6` to `v0.6.7` since `v0.6.6` is built based on a canary version of Rspack which contains a reverted PR.

see https://github.com/web-infra-dev/rspack/pull/10126

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
