### PR TITLE
fix: plugin compilation hooks leak

### DIFF
--- a/crates/node_binding/src/plugins/js_hooks_plugin.rs
+++ b/crates/node_binding/src/plugins/js_hooks_plugin.rs
@@ -3,7 +3,8 @@ use std::fmt;
 use async_trait::async_trait;
 use napi::{Env, Result};
 use rspack_core::{
-  ApplyContext, Compilation, CompilationParams, CompilerCompilation, CompilerOptions, PluginContext,
+  ApplyContext, Compilation, CompilationId, CompilationParams, CompilerCompilation,
+  CompilerOptions, PluginContext,
 };
 use rspack_hook::{plugin, plugin_hook, Hook as _};
 use rspack_plugin_html::HtmlRspackPlugin;
@@ -330,7 +331,7 @@ impl rspack_core::Plugin for JsHooksAdapterPlugin {
     Ok(())
   }
 
-  fn clear_cache(&self) {
+  fn clear_cache(&self, _id: CompilationId) {
     self.register_compiler_this_compilation_taps.clear_cache();
     self.register_compiler_compilation_taps.clear_cache();
     self.register_compiler_make_taps.clear_cache();

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -203,7 +203,7 @@ impl Compiler {
     self.old_cache.end_idle();
     // TODO: clear the outdated cache entries in resolver,
     // TODO: maybe it's better to use external entries.
-    self.plugin_driver.clear_cache();
+    self.plugin_driver.clear_cache(self.compilation.id());
 
     fast_set(
       &mut self.compilation,

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -39,7 +39,7 @@ impl Compiler {
       //   .old_cache
       //   .set_modified_files(all_files.into_iter().collect());
 
-      self.plugin_driver.clear_cache();
+      self.plugin_driver.clear_cache(self.compilation.id());
 
       let mut new_compilation = Compilation::new(
         self.id,

--- a/crates/rspack_core/src/plugin/mod.rs
+++ b/crates/rspack_core/src/plugin/mod.rs
@@ -7,7 +7,7 @@ pub use context::*;
 pub use plugin_driver::*;
 use rspack_error::Result;
 
-use crate::CompilerOptions;
+use crate::{compiler::CompilationId, CompilerOptions};
 
 #[async_trait::async_trait]
 pub trait Plugin: fmt::Debug + Send + Sync {
@@ -23,7 +23,7 @@ pub trait Plugin: fmt::Debug + Send + Sync {
     Ok(())
   }
 
-  fn clear_cache(&self) {}
+  fn clear_cache(&self, _id: CompilationId) {}
 }
 
 pub type BoxPlugin = Box<dyn Plugin>;

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -5,9 +5,9 @@ use rspack_error::Diagnostic;
 use rspack_util::fx_hash::FxDashMap;
 
 use crate::{
-  ApplyContext, BoxedParserAndGeneratorBuilder, CompilationHooks, CompilerHooks, CompilerOptions,
-  ConcatenatedModuleHooks, ContextModuleFactoryHooks, ModuleType, NormalModuleFactoryHooks,
-  NormalModuleHooks, Plugin, PluginContext, ResolverFactory,
+  ApplyContext, BoxedParserAndGeneratorBuilder, CompilationHooks, CompilationId, CompilerHooks,
+  CompilerOptions, ConcatenatedModuleHooks, ContextModuleFactoryHooks, ModuleType,
+  NormalModuleFactoryHooks, NormalModuleHooks, Plugin, PluginContext, ResolverFactory,
 };
 
 #[derive(Debug)]
@@ -76,10 +76,10 @@ impl PluginDriver {
     std::mem::take(&mut diagnostic)
   }
 
-  pub fn clear_cache(&self) {
+  pub fn clear_cache(&self, id: CompilationId) {
     self.resolver_factory.clear_cache();
     for plugin in &self.plugins {
-      plugin.clear_cache();
+      plugin.clear_cache(id);
     }
   }
 }

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -290,6 +290,10 @@ impl Plugin for HtmlRspackPlugin {
       .tap(process_assets::new(self));
     Ok(())
   }
+
+  fn clear_cache(&self, id: CompilationId) {
+    COMPILATION_HOOKS_MAP.remove(&id);
+  }
 }
 
 fn create_error_html(err: &str) -> String {

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -6,10 +6,10 @@ use rspack_core::{
   rspack_sources::{BoxSource, CachedSource, SourceExt},
   AssetInfo, CachedConstDependencyTemplate, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationChunkHash, CompilationContentHash,
-  CompilationParams, CompilationRenderManifest, CompilerCompilation, CompilerOptions,
-  ConstDependencyTemplate, DependencyType, IgnoreErrorModuleFactory, ModuleGraph, ModuleType,
-  ParserAndGenerator, PathData, Plugin, PluginContext, RenderManifestEntry, RuntimeGlobals,
-  RuntimeRequirementsDependencyTemplate, SelfModuleFactory, SourceType,
+  CompilationId, CompilationParams, CompilationRenderManifest, CompilerCompilation,
+  CompilerOptions, ConstDependencyTemplate, DependencyType, IgnoreErrorModuleFactory, ModuleGraph,
+  ModuleType, ParserAndGenerator, PathData, Plugin, PluginContext, RenderManifestEntry,
+  RuntimeGlobals, RuntimeRequirementsDependencyTemplate, SelfModuleFactory, SourceType,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hash::RspackHash;
@@ -622,6 +622,10 @@ impl Plugin for JsPlugin {
       });
 
     Ok(())
+  }
+
+  fn clear_cache(&self, id: CompilationId) {
+    crate::plugin::COMPILATION_HOOKS_MAP.remove(&id);
   }
 }
 

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -77,6 +77,10 @@ impl Plugin for RealContentHashPlugin {
       .tap(process_assets::new(self));
     Ok(())
   }
+
+  fn clear_cache(&self, id: CompilationId) {
+    COMPILATION_HOOKS_MAP.remove(&id);
+  }
 }
 
 async fn inner_impl(compilation: &mut Compilation) -> Result<()> {

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -486,4 +486,8 @@ impl Plugin for RsdoctorPlugin {
 
     Ok(())
   }
+
+  fn clear_cache(&self, id: CompilationId) {
+    COMPILATION_HOOKS_MAP.remove(&id);
+  }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -551,4 +551,8 @@ impl Plugin for RuntimePlugin {
       .tap(runtime_requirements_in_tree::new(self));
     Ok(())
   }
+
+  fn clear_cache(&self, id: CompilationId) {
+    COMPILATION_HOOKS_MAP.remove(&id);
+  }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This PR removes the hooks in plugin's `COMPILATION_HOOKS_MAP` when `clear_cache` to avoid leak memory when rebuild.

Strictly speaking this is not semantically correct, since this is not a cache, and it is also hard to track hooks usage. There should be a better management mechanism in future. but for now, this is a simple fix.


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
