### PR TITLE
fix(storage): should flush writer when flushing file mtime

### DIFF
--- a/crates/rspack_storage/src/pack/strategy/split/util.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/util.rs
@@ -240,7 +240,9 @@ pub mod test_pack_utils {
 
   pub async fn flush_file_mtime(path: &Utf8Path, fs: Arc<dyn FileSystem>) -> Result<()> {
     let content = fs.read_file(path).await?.read_to_end().await?;
-    fs.write_file(path).await?.write_all(&content).await?;
+    let mut writer = fs.write_file(path).await?;
+    writer.write_all(&content).await?;
+    writer.flush().await?;
 
     Ok(())
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should flush the file writer when testing rspack_storage otherwise the files will not be found

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
