### PR TITLE
feat: custom prefix for lazy compilation

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3296,6 +3296,7 @@ export type LazyCompilationOptions = {
     test?: RegExp | ((module: Module) => boolean);
     client?: string;
     serverUrl?: string;
+    prefix?: string;
 };
 
 // @public

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -79,7 +79,12 @@ export const lazyCompilationMiddleware = (
 			: options.test
 	).apply(compiler);
 
-	return lazyCompilationMiddlewareInternal(compiler, activeModules, filesByKey, lazyCompilationPrefix);
+	return lazyCompilationMiddlewareInternal(
+		compiler,
+		activeModules,
+		filesByKey,
+		lazyCompilationPrefix
+	);
 };
 
 // used for reuse code, do not export this

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2492,6 +2492,11 @@ export type LazyCompilationOptions = {
 	 * environment you need to explicitly specify a specific path.
 	 */
 	serverUrl?: string;
+	/**
+	 * Customize the prefix used for lazy compilation endpoint.
+	 * @default "/lazy-compilation-using-"
+	 */
+	prefix?: string;
 };
 
 /**

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1441,7 +1441,8 @@ const lazyCompilationOptions = z.object({
 		.or(z.function().args(z.custom<Module>()).returns(z.boolean()))
 		.optional(),
 	client: z.string().optional(),
-	serverUrl: z.string().optional()
+	serverUrl: z.string().optional(),
+	prefix: z.string().optional()
 }) satisfies z.ZodType<t.LazyCompilationOptions>;
 
 const incremental = z.strictObject({

--- a/tests/e2e/cases/lazy-compilation/custom-prefix/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/custom-prefix/index.test.ts
@@ -16,6 +16,9 @@ test("should use custom prefix for lazy compilation", async ({ page }) => {
   const response = await responsePromise;
   expect(response.status()).toBe(200);
 
+  // Wait for the component to appear with a more reliable wait
+  await page.waitForSelector('div:has-text("Component")', { timeout: 5000 });
+
   // Check that the component was loaded and displayed
   const component_count = await page.getByText("Component").count();
   expect(component_count).toBe(1);

--- a/tests/e2e/cases/lazy-compilation/custom-prefix/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/custom-prefix/index.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@/fixtures";
+
+test("should use custom prefix for lazy compilation", async ({ page }) => {
+  // Wait for a request with custom prefix
+  const responsePromise = page.waitForResponse(
+    response =>
+      response.url().includes("/custom-lazy-endpoint-") &&
+      response.request().method() === "GET",
+    { timeout: 5000 }
+  );
+
+  // Click the button that triggers dynamic import
+  await page.getByText("Click me").click();
+
+  // Wait for response with custom prefix
+  const response = await responsePromise;
+  expect(response.status()).toBe(200);
+
+  // Check that the component was loaded and displayed
+  const component_count = await page.getByText("Component").count();
+  expect(component_count).toBe(1);
+
+  // Verify that the request was made using the custom prefix
+  expect(response.url()).toContain("/custom-lazy-endpoint-");
+});

--- a/tests/e2e/cases/lazy-compilation/custom-prefix/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/custom-prefix/rspack.config.js
@@ -1,0 +1,23 @@
+const { rspack } = require("@rspack/core");
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+  context: __dirname,
+  entry: {
+    main: "./src/index.js"
+  },
+  stats: "none",
+  mode: "development",
+  plugins: [new rspack.HtmlRspackPlugin()],
+  experiments: {
+    lazyCompilation: {
+      entries: true,
+      imports: true,
+      // Set custom prefix for lazy compilation
+      prefix: "/custom-lazy-endpoint-"
+    }
+  },
+  devServer: {
+    hot: true
+  }
+};

--- a/tests/e2e/cases/lazy-compilation/custom-prefix/src/component.js
+++ b/tests/e2e/cases/lazy-compilation/custom-prefix/src/component.js
@@ -1,0 +1,3 @@
+const component = document.createElement("div");
+component.textContent = "Component";
+document.body.appendChild(component);

--- a/tests/e2e/cases/lazy-compilation/custom-prefix/src/index.js
+++ b/tests/e2e/cases/lazy-compilation/custom-prefix/src/index.js
@@ -3,6 +3,8 @@ button.textContent = "Click me";
 document.body.appendChild(button);
 
 button.addEventListener("click", () => {
+  // Dynamic import already contains code that adds component to the page
+  // Just use import() and make sure the module is loaded
   import("./component.js").then(() => {
     console.log("Component loaded");
   });

--- a/tests/e2e/cases/lazy-compilation/custom-prefix/src/index.js
+++ b/tests/e2e/cases/lazy-compilation/custom-prefix/src/index.js
@@ -1,0 +1,9 @@
+const button = document.createElement("button");
+button.textContent = "Click me";
+document.body.appendChild(button);
+
+button.addEventListener("click", () => {
+  import("./component.js").then(() => {
+    console.log("Component loaded");
+  });
+});

--- a/tests/e2e/cases/lazy-compilation/default-prefix/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/default-prefix/index.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@/fixtures";
+
+test("should use default prefix for lazy compilation", async ({ page }) => {
+  // Wait for a request with default prefix
+  const responsePromise = page.waitForResponse(
+    response =>
+      response.url().includes("/lazy-compilation-using-") &&
+      response.request().method() === "GET",
+    { timeout: 5000 }
+  );
+
+  // Click the button that triggers dynamic import
+  await page.getByText("Click me").click();
+
+  // Wait for response with default prefix
+  const response = await responsePromise;
+  expect(response.status()).toBe(200);
+
+  // Check that the component was loaded and displayed
+  const component_count = await page.getByText("Component").count();
+  expect(component_count).toBe(1);
+
+  // Verify that the request was made using the default prefix
+  expect(response.url()).toContain("/lazy-compilation-using-");
+});

--- a/tests/e2e/cases/lazy-compilation/default-prefix/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/default-prefix/index.test.ts
@@ -16,6 +16,9 @@ test("should use default prefix for lazy compilation", async ({ page }) => {
   const response = await responsePromise;
   expect(response.status()).toBe(200);
 
+  // Wait for the component to appear with a more reliable wait
+  await page.waitForSelector('div:has-text("Component")', { timeout: 5000 });
+
   // Check that the component was loaded and displayed
   const component_count = await page.getByText("Component").count();
   expect(component_count).toBe(1);

--- a/tests/e2e/cases/lazy-compilation/default-prefix/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/default-prefix/rspack.config.js
@@ -1,0 +1,22 @@
+const { rspack } = require("@rspack/core");
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+  context: __dirname,
+  entry: {
+    main: "./src/index.js"
+  },
+  stats: "none",
+  mode: "development",
+  plugins: [new rspack.HtmlRspackPlugin()],
+  experiments: {
+    lazyCompilation: {
+      entries: true,
+      imports: true
+      // Using default prefix (not specifying prefix option)
+    }
+  },
+  devServer: {
+    hot: true
+  }
+};

--- a/tests/e2e/cases/lazy-compilation/default-prefix/src/component.js
+++ b/tests/e2e/cases/lazy-compilation/default-prefix/src/component.js
@@ -1,0 +1,3 @@
+const component = document.createElement("div");
+component.textContent = "Component";
+document.body.appendChild(component);

--- a/tests/e2e/cases/lazy-compilation/default-prefix/src/index.js
+++ b/tests/e2e/cases/lazy-compilation/default-prefix/src/index.js
@@ -3,6 +3,8 @@ button.textContent = "Click me";
 document.body.appendChild(button);
 
 button.addEventListener("click", () => {
+  // Dynamic import already contains code that adds component to the page
+  // Just use import() and make sure the module is loaded
   import("./component.js").then(() => {
     console.log("Component loaded");
   });

--- a/tests/e2e/cases/lazy-compilation/default-prefix/src/index.js
+++ b/tests/e2e/cases/lazy-compilation/default-prefix/src/index.js
@@ -1,0 +1,9 @@
+const button = document.createElement("button");
+button.textContent = "Click me";
+document.body.appendChild(button);
+
+button.addEventListener("click", () => {
+  import("./component.js").then(() => {
+    console.log("Component loaded");
+  });
+});

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -134,6 +134,11 @@ type LazyCompilationOptions =
        * Tells the client the server path that needs to be requested.
        */
       serverUrl?: string;
+      /**
+       * Customize the prefix used for lazy compilation endpoint.
+       * @default "/lazy-compilation-using-"
+       */
+      prefix?: string;
     };
 ```
 
@@ -194,6 +199,23 @@ export default {
   experiments: {
     lazyCompilation: {
       serverUrl: 'http://localhost:3000',
+    },
+  },
+};
+```
+
+### lazyCompilation.prefix
+
+- **Type:** `string`
+- **Default:** `'/lazy-compilation-using-'`
+
+Customize the prefix used for lazy compilation endpoint. By default, the lazy compilation middleware uses the `/lazy-compilation-using-` prefix for handling requests.
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    lazyCompilation: {
+      prefix: '/custom-lazy-endpoint-',
     },
   },
 };

--- a/website/docs/en/guide/features/lazy-compilation.mdx
+++ b/website/docs/en/guide/features/lazy-compilation.mdx
@@ -143,9 +143,9 @@ export default defineConfig({
       entries: true,
       imports: true,
       // Customize the lazy compilation endpoint prefix
-      prefix: '/custom-lazy-endpoint-'
-    }
-  }
+      prefix: '/custom-lazy-endpoint-',
+    },
+  },
 });
 ```
 

--- a/website/docs/en/guide/features/lazy-compilation.mdx
+++ b/website/docs/en/guide/features/lazy-compilation.mdx
@@ -129,3 +129,24 @@ server.start();
 
 - `compiler`: The current [Compiler](/api/javascript-api/compiler) instance
 - `options`: The lazy compilation options, same as [experiments.lazyCompilation](/config/experiments#experimentslazycompilation)
+
+## Customizing lazy compilation endpoint
+
+By default, the lazy compilation middleware uses the `/lazy-compilation-using-` prefix for handling requests. If you need to customize this prefix, you can use the `prefix` option:
+
+```js title="rspack.config.mjs"
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
+  experiments: {
+    lazyCompilation: {
+      entries: true,
+      imports: true,
+      // Customize the lazy compilation endpoint prefix
+      prefix: '/custom-lazy-endpoint-'
+    }
+  }
+});
+```
+
+This is particularly useful when you're integrating with an existing system that has specific routing requirements or when you need to avoid prefix conflicts.

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -133,6 +133,11 @@ type LazyCompilationOptions =
        * 自定义服务端路径
        */
       serverUrl?: string;
+      /**
+       * 自定义懒编译端点的前缀
+       * @default "/lazy-compilation-using-"
+       */
+      prefix?: string;
     };
 ```
 
@@ -195,6 +200,23 @@ export default {
   experiments: {
     lazyCompilation: {
       serverUrl: 'http://localhost:3000',
+    },
+  },
+};
+```
+
+### lazyCompilation.prefix
+
+- **类型：** `string`
+- **默认值：** `'/lazy-compilation-using-'`
+
+自定义懒编译端点的前缀。默认情况下，懒编译中间件使用 `/lazy-compilation-using-` 前缀来处理请求。
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    lazyCompilation: {
+      prefix: '/custom-lazy-endpoint-',
     },
   },
 };

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -210,7 +210,7 @@ export default {
 - **类型：** `string`
 - **默认值：** `'/lazy-compilation-using-'`
 
-自定义懒编译端点的前缀。默认情况下，懒编译中间件使用 `/lazy-compilation-using-` 前缀来处理请求。
+自定义懒编译请求前缀。默认情况下，懒编译中间件使用 `/lazy-compilation-using-` 前缀来处理请求。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/guide/features/lazy-compilation.mdx
+++ b/website/docs/zh/guide/features/lazy-compilation.mdx
@@ -143,9 +143,9 @@ export default defineConfig({
       entries: true,
       imports: true,
       // 自定义懒编译端点前缀
-      prefix: '/custom-lazy-endpoint-'
-    }
-  }
+      prefix: '/custom-lazy-endpoint-',
+    },
+  },
 });
 ```
 

--- a/website/docs/zh/guide/features/lazy-compilation.mdx
+++ b/website/docs/zh/guide/features/lazy-compilation.mdx
@@ -129,3 +129,24 @@ server.start();
 
 - `compiler`: 当前的 [Compiler](/api/javascript-api/compiler) 实例
 - `options`: 懒编译的配置，与 [experiments.lazyCompilation](/config/experiments#experimentslazycompilation) 相同
+
+## 自定义懒编译端点
+
+默认情况下，懒编译中间件使用 `/lazy-compilation-using-` 前缀来处理请求。如果你需要自定义这个前缀，可以使用 `prefix` 选项：
+
+```js title="rspack.config.mjs"
+import { defineConfig } from '@rspack/cli';
+
+export default defineConfig({
+  experiments: {
+    lazyCompilation: {
+      entries: true,
+      imports: true,
+      // 自定义懒编译端点前缀
+      prefix: '/custom-lazy-endpoint-'
+    }
+  }
+});
+```
+
+这在你需要与具有特定路由要求的现有系统集成，或者需要避免前缀冲突时特别有用。


### PR DESCRIPTION
## Summary

This PR adds a new option to customize the URL prefix used for lazy compilation endpoints. Currently, the lazy compilation middleware uses a hardcoded `/lazy-compilation-using-` prefix for its endpoints, without any way to customize it.

This change adds a new `prefix` option to the `LazyCompilationOptions` type, allowing users to specify a custom prefix. When this option is provided, the middleware will use the custom prefix instead of the default one. This is particularly useful for:

1. Avoiding URL routing conflicts in complex setups
2. Integrating with existing systems that have specific URL requirements
3. Keeping consistent URL patterns across different parts of an application

The implementation maintains backward compatibility by using the default prefix when the custom prefix isn't specified.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
