### PR TITLE
fix: should call `compiler.close` when having errors

### DIFF
--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -122,18 +122,12 @@ export class BuildCommand implements RspackCommand {
 
 				compiler.run(
 					(error: Error | null, stats: Stats | MultiStats | undefined) => {
-						// If there is a compilation error, the close method should not be called,
-						// Otherwise Rspack may generate invalid caches.
-						if (error || stats?.hasErrors()) {
+						compiler.close(closeErr => {
+							if (closeErr) {
+								logger.error(closeErr);
+							}
 							errorHandler(error, stats);
-						} else {
-							compiler.close(closeErr => {
-								if (closeErr) {
-									logger.error(closeErr);
-								}
-								errorHandler(error, stats);
-							});
-						}
+						});
 					}
 				);
 			}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/9699

Persistent cache of rspack is implemented in Rust and should always call `compiler.close` after building.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
