### PR TITLE
fix: support license plugin when enable concatenated

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -77,6 +77,7 @@ export declare class Chunks {
 }
 
 export declare class ConcatenatedModule {
+  get rootModule(): Module
   get modules(): Module[]
   _originalSource(): JsCompatSource | undefined
   nameForCondition(): string | undefined
@@ -98,6 +99,7 @@ export declare class ContextModule {
 }
 
 export declare class Dependency {
+  get _parentModule(): Module | undefined
   get type(): string
   get category(): string
   get request(): string | undefined

--- a/crates/node_binding/src/dependency.rs
+++ b/crates/node_binding/src/dependency.rs
@@ -71,7 +71,7 @@ impl Dependency {
     let module_graph = compilation.get_module_graph();
     let parent_module = module_graph
       .get_parent_module(dependency.id())
-      .and_then(|m| compilation.module_by_identifier(&m))
+      .and_then(|m| compilation.module_by_identifier(m))
       .map(|m| ModuleObject::with_ref(m.as_ref(), compilation.compiler_id()));
     Ok(parent_module)
   }

--- a/crates/node_binding/src/modules/concatenated_module.rs
+++ b/crates/node_binding/src/modules/concatenated_module.rs
@@ -29,6 +29,18 @@ impl ConcatenatedModule {
 
 #[napi]
 impl ConcatenatedModule {
+  #[napi(getter, ts_return_type = "Module")]
+  pub fn root_module(&mut self) -> napi::Result<ModuleObject> {
+    let (compilation, module) = self.as_ref()?;
+    let root_module = compilation
+      .module_by_identifier(&module.get_root())
+      .expect("Root module should exist");
+    Ok(ModuleObject::with_ref(
+      root_module.as_ref(),
+      compilation.compiler_id(),
+    ))
+  }
+
   #[napi(getter, ts_return_type = "Module[]")]
   pub fn modules(&mut self) -> napi::Result<Vec<ModuleObject>> {
     let (compilation, module) = self.as_ref()?;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/8924
- add [`Dependency._parentModule`](https://github.com/codepunkt/webpack-license-plugin/blob/main/src/WebpackModuleFileIterator.ts#L30)
- add [`ConcatenatedModule.rootModule`](https://github.com/codepunkt/webpack-license-plugin/blob/main/src/WebpackModuleFileIterator.ts#L17)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
