### PR TITLE
docs: update config merging guide

### DIFF
--- a/website/docs/en/config/extends.mdx
+++ b/website/docs/en/config/extends.mdx
@@ -11,8 +11,10 @@ Used to extend configurations from other files or packages. This allows you to c
 - **Type:** `string | string[]`
 - **Default:** `undefined`
 
-:::warning
-**This option is not supported via the JavaScript API**: `extends` will have no effect when using the JavaScript API. `@rspack/cli` is required to use this feature.
+:::info
+This option is only supported in [`@rspack/cli`](/api/cli).
+
+If you are using the JavaScript API or other Rspack-based tools, `extends` will not take effect, use [webpack-merge](/config/#webpack-merge) instead.
 :::
 
 ## Basic usage

--- a/website/docs/en/config/index.mdx
+++ b/website/docs/en/config/index.mdx
@@ -230,18 +230,43 @@ export default function (env, argv) {
 
 ## Merge configurations
 
-Use the `merge` function exported by `webpack-merge` to merge multiple configurations.
+Use Rspack's [extends](/config/extends) option or [webpack-merge](https://npmjs.com/package/webpack-merge) package to merge multiple Rspack configurations.
+
+### extends option
+
+When using [@rspack/cli](/api/cli), Rspack provides the `extends` option, allowing you to extend configurations from other files or packages.
+
+```js title="rspack.config.mjs"
+export default {
+  extends: './base.rspack.config.mjs',
+  output: {
+    filename: '[name].bundle.js',
+  },
+};
+```
+
+> This option is only supported in `@rspack/cli`, see [extends](/config/extends) for more usage.
+
+### webpack-merge
+
+`webpack-merge` is a community library for merging multiple webpack configurations, and it can also be used to merge Rspack configurations.
+
+First install `webpack-merge`:
+
+<PackageManagerTabs command="add webpack-merge -D" />
+
+Then you can use its `merge` function to merge configurations:
 
 ```js title="rspack.config.mjs"
 import { merge } from 'webpack-merge';
 
+const isDev = process.env.NODE_ENV === 'development';
 const base = {};
-
 const dev = {
-  plugins: [new DevelopmentSpecifiedPlugin()],
+  plugins: [new SomeDevPlugin()],
 };
 
-export default process.env.NODE_ENV === 'development' ? merge(base, dev) : base;
+export default isDev ? merge(base, dev) : base;
 ```
 
-For more information of `merge`, please refer to [webpack-merge documentation](https://npmjs.com/package/webpack-merge).
+> See [webpack-merge documentation](https://npmjs.com/package/webpack-merge) for more details.

--- a/website/docs/zh/config/extends.mdx
+++ b/website/docs/zh/config/extends.mdx
@@ -11,8 +11,10 @@ import { Tabs, Tab } from '@theme';
 - **类型：** `string | string[]`
 - **默认值：** `undefined`
 
-:::warning
-**此选项在 JavaScript API 中不受支持**：在使用 JavaScript API 时，`extends` 选项将不会生效。使用此功能需要 `@rspack/cli`。
+:::info
+该选项仅在 [@rspack/cli](/api/cli) 中有效。
+
+如果你在使用 JavaScript API，或是其他基于 Rspack 的工具，`extends` 将不会生效，请使用 [webpack-merge](/config/#webpack-merge) 代替。
 :::
 
 ## 基本用法

--- a/website/docs/zh/config/index.mdx
+++ b/website/docs/zh/config/index.mdx
@@ -230,18 +230,43 @@ export default function (env, argv) {
 
 ## 合并配置
 
-使用 `webpack-merge` 导出的 `merge` 函数来合并多个配置。
+使用 Rspack 的 [extends](/config/extends) 选项或者 [webpack-merge](https://npmjs.com/package/webpack-merge) 包来合并多个 Rspack 配置。
+
+### extends 选项
+
+在使用 [@rspack/cli](/api/cli) 时，Rspack 提供了 `extends` 选项，允许你从其他文件或包中扩展配置。
+
+```js title="rspack.config.mjs"
+export default {
+  extends: './base.rspack.config.mjs',
+  output: {
+    filename: '[name].bundle.js',
+  },
+};
+```
+
+> 该选项仅在 `@rspack/cli` 中有效，查看 [extends](/config/extends) 了解更多用法。
+
+### webpack-merge
+
+`webpack-merge` 是一个社区库，用于合并多个 webpack 配置，也能用于合并 Rspack 配置。
+
+首先安装 `webpack-merge`：
+
+<PackageManagerTabs command="add webpack-merge -D" />
+
+然后你就可以使用它的 `merge` 函数来合并配置：
 
 ```js title="rspack.config.mjs"
 import { merge } from 'webpack-merge';
 
+const isDev = process.env.NODE_ENV === 'development';
 const base = {};
-
 const dev = {
-  plugins: [new DevelopmentSpecifiedPlugin()],
+  plugins: [new SomeDevPlugin()],
 };
 
-export default process.env.NODE_ENV === 'development' ? merge(base, dev) : base;
+export default isDev ? merge(base, dev) : base;
 ```
 
-关于 `merge` 的更多信息请查看 [webpack-merge 文档](https://npmjs.com/package/webpack-merge)。
+> 查看 [webpack-merge 文档](https://npmjs.com/package/webpack-merge) 了解更多。


### PR DESCRIPTION
## Summary

Update the configuration merging guide to make the differences between `extends` and `webpack-merge` clearer.

See https://github.com/web-infra-dev/rspack/discussions/10146

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
