### PR TITLE
fix: circularDependencyRspackPlugin should check all cycle

### DIFF
--- a/crates/rspack_plugin_circular_dependencies/src/lib.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/lib.rs
@@ -42,6 +42,8 @@ impl<'a> CycleDetector<'a> {
       &mut vec![initial_module_id],
       &mut cycles,
     );
+    // sort to keep output stable
+    cycles.sort();
     cycles
   }
 

--- a/crates/rspack_plugin_circular_dependencies/src/lib.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/lib.rs
@@ -48,11 +48,11 @@ impl<'a> CycleDetector<'a> {
   fn recurse_dependencies(
     &self,
     current_module_id: ModuleIdentifier,
-    seen_set: &mut IdentifierSet,
+    _seen_set: &mut IdentifierSet,
     current_path: &mut Vec<ModuleIdentifier>,
     found_cycles: &mut Vec<Vec<ModuleIdentifier>>,
   ) {
-    seen_set.insert(current_module_id);
+    // seen_set.insert(current_module_id);
     current_path.push(current_module_id);
     for target_id in self.get_module(&current_module_id).dependencies.keys() {
       // If the current path already contains the dependent module, then it
@@ -72,16 +72,7 @@ impl<'a> CycleDetector<'a> {
         continue;
       }
 
-      // If a module has already been encountered in this traversal, then by
-      // necessity it is either already part of a cycle being detected as
-      // captured above, or it _and all of its dependencies_ are not part of
-      // any cycles involving the current module. If that were not true, then
-      // this module would have already been encountered previously.
-      if seen_set.contains(target_id) {
-        continue;
-      }
-
-      self.recurse_dependencies(*target_id, seen_set, current_path, found_cycles);
+      self.recurse_dependencies(*target_id, _seen_set, current_path, found_cycles);
     }
     current_path.pop();
   }
@@ -320,6 +311,8 @@ impl CircularDependencyRspackPlugin {
       .expect("cwd should be available")
       .to_string_lossy()
       .to_string();
+
+    // remove the root path here.
     let cycle_without_root: Vec<String> = cycle
       .iter()
       .map(|module_path| {

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js
@@ -1,0 +1,1 @@
+import './b.js';

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/b.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/b.js
@@ -1,0 +1,1 @@
+import './c.js';

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/c.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/c.js
@@ -1,0 +1,3 @@
+
+import './d.js';
+import './e.js';

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/d.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/d.js
@@ -1,0 +1,1 @@
+import './a.js';

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/e.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/e.js
@@ -1,0 +1,1 @@
+import './a.js';

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
@@ -7,7 +7,8 @@ module.exports = {
 		aa: "./require-circular/d.js",
 		bb: "./import-circular/index.js",
 		cc: "./no-cycle/index.js",
-		dd: "./ignore-circular/a.js"
+		dd: "./ignore-circular/a.js",
+		ee: "./multiple-circular/a.js"
 	},
 	plugins: [
 		new CircularDependencyRspackPlugin({

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/stats.err
@@ -4,4 +4,10 @@ WARNING in ⚠ Circular dependency detected:
 WARNING in ⚠ Circular dependency detected:
   │  tests/diagnosticsCases/plugins/circular-dependency-plugin/import-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/import-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/import-circular/a.js
 
+WARNING in ⚠ Circular dependency detected:
+  │  tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/c.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/d.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js
+
+WARNING in ⚠ Circular dependency detected:
+  │  tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/c.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/e.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js
+
 ERROR in × Module not found: Can't resolve './' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/plugins/circular-dependency-plugin'


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

In `CircularDependencyRspackPlugin`, we should check all cycle, for example, if we have follow case:

```
// a.js
import './b.js';

// b.js
import './c.js';

// c.js
import './d.js';
import './e.js';

// d.js
import './a.js';

// e.js
import './a.js';
```

In that case, we shoud output two cycle check diagnostic messages:

```output
a.js -> b.js -> c.js -> d.js -> a.js

a.js -> b.js -> c.js -> e.js -> a.js
```

In the algorithm of `CircularDependencyRspackPlugin`'s `fn recurse_dependencies()` we just use a `visited`(`seen_set`) hashmap to filter the duplicate module id, like `c.js` will be recurse twice, so it will not be outputed twice, the output now will be:

```output
a.js -> b.js -> c.js -> d.js -> a.js
```

The behavior is not right as the user's feedback, so we need to move the `visited` hashmap here in the algorithm, just use the simple algorithm here like the answer of https://leetcode.cn/problems/binary-tree-paths/description/.

closes: #9889 

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
