### PR TITLE
fix(parallel-loader): should not pass options for which loaders are not set to `parallel`

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/parallel-option/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/parallel-option/rspack.config.js
@@ -9,6 +9,12 @@ module.exports = {
 				test: /lib\.js/,
 				use: [
 					{
+						loader: "./unclonable.js",
+						options: {
+							notclonable() {}
+						}
+					},
+					{
 						loader: "./loader-in-worker.js",
 						parallel: true,
 						options: {}

--- a/packages/rspack-test-tools/tests/configCases/loader-parallel/parallel-option/unclonable.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-parallel/parallel-option/unclonable.js
@@ -1,0 +1,3 @@
+module.exports = function(content) {
+	return content
+}

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -744,8 +744,17 @@ export async function runLoaders(
 			rootContext: loaderContext.context!,
 			loaderIndex: loaderContext.loaderIndex,
 			loaders: loaderContext.loaders.map(item => {
+				let options = item.options;
+				// Do not pass options into worker, if it's not prepared to be executed
+				// in the worker thread.
+				//
+				// Aligns yielding strategy within the worker.
+				if (!item.parallel || item.request.startsWith(BUILTIN_LOADER_PREFIX)) {
+					options = undefined;
+				}
 				return {
 					...item,
+					options,
 					pitch: undefined,
 					normal: undefined,
 					normalExecuted: item.normalExecuted,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Worker threads would execute loaders until it's not set to `parallel` or it's a builtin loader that should be yielded to rust.
Previously, loader runner would pass loaders with `options` into worker thread without checking if the loader enabled `parallel`. In this PR, only `options` of which loader is set to `parallel` are passed. 

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or not required).
