### PR TITLE
fix: should regenerate runtime chunk hash when using get chunk filename runtime module

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -505,6 +505,23 @@ impl ChunkGraph {
     false
   }
 
+  pub fn has_chunk_dependent_hash_modules(
+    &self,
+    chunk: &ChunkUkey,
+    runtime_modules: &IdentifierMap<Box<dyn RuntimeModule>>,
+  ) -> bool {
+    let cgc = self.expect_chunk_graph_chunk(chunk);
+    for runtime_module in &cgc.runtime_modules {
+      let runtime_module = runtime_modules
+        .get(runtime_module)
+        .expect("should have runtime_module");
+      if runtime_module.dependent_hash() {
+        return true;
+      }
+    }
+    false
+  }
+
   pub fn set_chunk_runtime_requirements(
     compilation: &mut Compilation,
     chunk_ukey: ChunkUkey,

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -166,9 +166,12 @@ pub async fn runtime_chunk_has_hash(
   }
 
   if filename.has_content_hash_placeholder()
-    && compilation
+    && (compilation
       .chunk_graph
       .has_chunk_full_hash_modules(&runtime_chunk_ukey, &compilation.runtime_modules)
+      || compilation
+        .chunk_graph
+        .has_chunk_dependent_hash_modules(&runtime_chunk_ukey, &compilation.runtime_modules))
   {
     return Ok(true);
   }

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -104,11 +104,15 @@ async fn compilation_dependent_full_hash(
   }
 
   let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
-  if chunk.has_entry_module(&compilation.chunk_graph)
-    && runtime_chunk_has_hash(compilation, chunk_ukey).await?
-  {
+
+  if !chunk.has_entry_module(&compilation.chunk_graph) {
+    return Ok(None);
+  }
+
+  if runtime_chunk_has_hash(compilation, chunk_ukey).await? {
     return Ok(Some(true));
   }
+
   Ok(None)
 }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -384,10 +384,4 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
   fn attach(&mut self, chunk: ChunkUkey) {
     self.chunk = Some(chunk);
   }
-
-  // different with webpack
-  // webpack use dependentHash
-  fn full_hash(&self) -> bool {
-    true
-  }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -384,4 +384,10 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
   fn attach(&mut self, chunk: ChunkUkey) {
     self.chunk = Some(chunk);
   }
+
+  // different with webpack
+  // webpack use dependentHash
+  fn full_hash(&self) -> bool {
+    true
+  }
 }

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/0/dependent-hash.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/0/dependent-hash.js
@@ -1,0 +1,1 @@
+__webpack_get_script_filename__;

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/0/index.js
@@ -1,0 +1,5 @@
+import "./dependent-hash";
+
+it("test", () => {
+  console.log("test");
+});

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/0/index2.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/0/index2.js
@@ -1,0 +1,4 @@
+import "./dependent-hash";
+
+it("test", () => {
+});

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/0/warnings.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/0/warnings.js
@@ -1,0 +1,3 @@
+module.exports = process.env.RSPACK_INCREMENTAL_WATCH_TEST
+  ? [[/Chunks that dependent on full hash requires calculating the hashes of all chunks, which is a global effect/, /`incremental.chunksHashes` has been overridden to false/]]
+  : [];

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/1/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/1/index.js
@@ -1,0 +1,3 @@
+it("test", () => {
+  console.log("test1");
+});

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/rspack.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+	mode: "development",
+	entry: {
+		main: "./index.js",
+		entry2: "./index2.js"
+	},
+	output: {
+		chunkLoading: "import",
+		chunkFormat: "module",
+		filename: "[name].[contenthash:8].js",
+		chunkFilename: "[name].[contenthash:8].chunk.js"
+	},
+	optimization: {
+		runtimeChunk: true,
+		minimize: false
+	},
+	experiments: {
+		css: true,
+		outputModule: true
+	}
+};

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkGetChunkFilename/test.config.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+let outputPath = "";
+
+module.exports = {
+	findBundle(i, config) {
+		outputPath = config.output.path;
+		return [];
+	},
+	checkStats(i, stats) {
+		const assets = stats.assets;
+		const main = assets.find(i => i.name.startsWith("main."));
+		const runtimeMain = assets.find(i => i.name.startsWith("runtime~main."));
+		const entry2 = assets.find(i => i.name.startsWith("entry2."));
+		const runtimeEntry2 = assets.find(i =>
+			i.name.startsWith("runtime~entry2.")
+		);
+
+		const mainContent = fs.readFileSync(
+			path.join(outputPath, main.name),
+			"utf-8"
+		);
+		const entry2Content = fs.readFileSync(
+			path.join(outputPath, entry2.name),
+			"utf-8"
+		);
+
+		expect(mainContent.includes(runtimeMain.name)).toBe(true);
+		expect(entry2Content.includes(runtimeEntry2.name)).toBe(true);
+
+		return true;
+	}
+};

--- a/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkHash/0/warnings.js
+++ b/packages/rspack-test-tools/tests/watchCases/hashes/runtimeChunkHash/0/warnings.js
@@ -1,0 +1,3 @@
+module.exports = process.env.RSPACK_INCREMENTAL_WATCH_TEST
+  ? [[/Chunks that dependent on full hash requires calculating the hashes of all chunks, which is a global effect/, /`incremental.chunksHashes` has been overridden to false/]]
+  : [];


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

another case of https://github.com/web-infra-dev/rspack/pull/9986

The GetChunkFilenameRuntimeModule may include some chunks that change after rebuilding. So this runtime module should depend on their hashes. Changing of their hashes may lead to the change of runtime chunk. And then the generated code of entry which uses `chunkFormat: "module"` should also change.

In webpack, it uses a `dependentHash` flag too handle this. But I think we can just reuse `fullhash` to handle this.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
