### PR TITLE
fix: ignore parsing errors on CSS modules from lightningcss-loader

### DIFF
--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -100,9 +100,19 @@ impl LightningCssLoader {
       #[allow(clippy::unwrap_used)]
       let warnings = warnings.read().unwrap();
       for warning in warnings.iter() {
+        if let lightningcss::error::ParserError::SelectorError(
+          lightningcss::error::SelectorError::UnsupportedPseudoClass(pseudo_class),
+        ) = &warning.kind
+        {
+          // By default, ignore parsing errors on CSS modules from lightningcss-loader.
+          // CSS modules will be handled by downstream loaders.
+          if pseudo_class.as_ref() == "global" || pseudo_class.as_ref() == "local" {
+            continue;
+          }
+        }
         loader_context.emit_diagnostic(Diagnostic::warn(
-          "LightningCSS parse warning".to_string(),
-          format!("{}", warning),
+          "builtin:lightningcss-loader".to_string(),
+          format!("LightningCSS parse warning: {}", warning),
         ));
       }
     }

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/ignore-css-modules-warning/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/ignore-css-modules-warning/index.js
@@ -1,0 +1,1 @@
+import './index.module.css'

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/ignore-css-modules-warning/index.module.css
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/ignore-css-modules-warning/index.module.css
@@ -1,0 +1,19 @@
+:global(.foo) {
+    background-color: red;
+}
+
+:local(.bar) {
+    background-color: blue;
+}
+
+:global {
+    .foo {
+        background-color: red;
+    }
+}
+
+:local {
+    .bar {
+        background-color: blue;
+    }
+}

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/ignore-css-modules-warning/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/ignore-css-modules-warning/rspack.config.js
@@ -5,8 +5,7 @@ class Plugin {
     apply(compiler) {
         compiler.hooks.done.tap("PLUGIN", stats => {
             const json = stats.toJson();
-            expect(json.warnings).toHaveLength(1);
-            expect(json.warnings[0].message).toMatch(/LightningCSS parse warning: Unexpected end of input at/);
+            expect(json.warnings).toHaveLength(0);
         });
     }
 }

--- a/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
@@ -159,7 +159,9 @@ For example, ignore all warnings:
 
 ```js title="rspack.config.mjs"
 export default {
-  ignoreWarnings: [warning => warning.title === 'builtin:lightningcss-loader'],
+  ignoreWarnings: [
+    warning => /LightningCSS parse warning/.test(warning.message),
+  ],
 };
 ```
 

--- a/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
@@ -159,7 +159,9 @@ const loader = {
 
 ```js title="rspack.config.mjs"
 export default {
-  ignoreWarnings: [warning => warning.title === 'builtin:lightningcss-loader'],
+  ignoreWarnings: [
+    warning => /LightningCSS parse warning/.test(warning.message),
+  ],
 };
 ```
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

1. ignore parsing errors on CSS modules from lightningcss-loader. CSS modules will be handled by downstream loaders.
2. improve lightningcss-loader warning message by `LightningCSS parse warning` prefix.
3. fix the document for ignore lightningcss-loader warning message.

Fix #10162

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
