### PR TITLE
fix: truncate width into `u16::MAX` for graphical reporter

### DIFF
--- a/crates/rspack_error/src/graphical.rs
+++ b/crates/rspack_error/src/graphical.rs
@@ -696,12 +696,9 @@ impl GraphicalReportHandler {
         let num_left = vbar_offset - start;
         let num_right = end - vbar_offset - 1;
         if start < end {
-          let width = start.saturating_sub(highest);
           // CHANGE:
           // Rust PR https://github.com/rust-lang/rust/issues/99012 limited format string width and precision to 16 bits, causing panics when dynamic padding exceeds `u16::MAX`.
-          // This fixes exessively large width that exceeds `u16::MAX` by directly printing exceeded width.
-          let pre_width = width.saturating_sub(u16::MAX as usize);
-          underlines.push_str(&format!("{:width$}", "", width = pre_width));
+          let width = start.saturating_sub(highest).min(u16::MAX as usize);
           underlines.push_str(
             &format!(
               "{:width$}{}{}{}",
@@ -715,7 +712,6 @@ impl GraphicalReportHandler {
                 chars.underline
               },
               chars.underline.to_string().repeat(num_right),
-              width = width.min(u16::MAX as usize),
             )
             .style(hl.style)
             .to_string(),


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

closes https://github.com/web-infra-dev/rspack/issues/10150

truncate width into `u16::MAX` for graphical reporter.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
