### PR TITLE
fix: Vue CSS pseudo class warning in lightningcss

### DIFF
--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -100,10 +100,14 @@ impl LightningCssLoader {
       #[allow(clippy::unwrap_used)]
       let warnings = warnings.read().unwrap();
       for warning in warnings.iter() {
-        if let lightningcss::error::ParserError::SelectorError(
-          lightningcss::error::SelectorError::UnsupportedPseudoClass(pseudo_class),
-        ) = &warning.kind
-        {
+        if matches!(
+          warning.kind,
+          lightningcss::error::ParserError::SelectorError(
+            lightningcss::error::SelectorError::UnsupportedPseudoClass(_)
+          ) | lightningcss::error::ParserError::SelectorError(
+            lightningcss::error::SelectorError::UnsupportedPseudoElement(_)
+          )
+        ) {
           // ignore parsing errors on pseudo class from lightningcss-loader
           // to allow pseudo class in CSS modules and Vue.
           continue;

--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -104,11 +104,9 @@ impl LightningCssLoader {
           lightningcss::error::SelectorError::UnsupportedPseudoClass(pseudo_class),
         ) = &warning.kind
         {
-          // By default, ignore parsing errors on CSS modules from lightningcss-loader.
-          // CSS modules will be handled by downstream loaders.
-          if pseudo_class.as_ref() == "global" || pseudo_class.as_ref() == "local" {
-            continue;
-          }
+          // ignore parsing errors on pseudo class from lightningcss-loader
+          // to allow pseudo class in CSS modules and Vue.
+          continue;
         }
         loader_context.emit_diagnostic(Diagnostic::warn(
           "builtin:lightningcss-loader".to_string(),

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/ignore-css-modules-warning/index.module.css
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/ignore-css-modules-warning/index.module.css
@@ -17,3 +17,7 @@
         background-color: blue;
     }
 }
+
+::v-deep .foo {
+    color: sandybrown;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

fix warning to parse ::v-deep syntax.

relate https://github.com/web-infra-dev/rsbuild/issues/5102

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
