### PR TITLE
test: should not report on wrong case when error

### DIFF
--- a/packages/rspack-test-tools/src/case/new-incremental.ts
+++ b/packages/rspack-test-tools/src/case/new-incremental.ts
@@ -75,7 +75,7 @@ function getWatchCreator(options: WatchNewIncrementalOptions) {
 				description: (name, index) => {
 					return index === 0
 						? `${name} should compile`
-						: `should compile the next step ${index}`;
+						: `should compile step ${index}`;
 				},
 				describe: false,
 				steps: ({ name, src, temp }) => {

--- a/packages/rspack-test-tools/src/case/watch.ts
+++ b/packages/rspack-test-tools/src/case/watch.ts
@@ -12,7 +12,7 @@ const creator = new BasicCaseCreator({
 	description: (name, index) => {
 		return index === 0
 			? `${name} should compile`
-			: `should compile the next step ${index}`;
+			: `should compile step ${index}`;
 	},
 	describe: false,
 	steps: ({ name, src, temp }) => {

--- a/packages/rspack-test-tools/src/processor/basic.ts
+++ b/packages/rspack-test-tools/src/processor/basic.ts
@@ -97,6 +97,9 @@ export class BasicProcessor<T extends ECompilerType> implements ITestProcessor {
 		}
 
 		for (const bundle of bundles!) {
+			if (!bundle) {
+				continue;
+			}
 			const runnerFactory = context.getRunnerFactory(this._options.name);
 			if (!runnerFactory) {
 				throw new Error(`Test case ${this._options.name} is not runable`);

--- a/packages/rspack-test-tools/src/test/creator.ts
+++ b/packages/rspack-test-tools/src/test/creator.ts
@@ -126,13 +126,12 @@ export class BasicCaseCreator<T extends ECompilerType> {
 		});
 		const ender = this.registerConcurrentTask(name, starter!);
 		const env = this.createConcurrentEnv();
-		let bailout = false;
 		for (let index = 0; index < tester.total; index++) {
 			let stepSignalResolve = null;
-			let stepSignalReject = null;
-			const stepSignal = new Promise((resolve, reject) => {
+			const stepSignal = new Promise<Error>((resolve, reject) => {
 				stepSignalResolve = resolve;
-				stepSignalReject = reject;
+			}).catch(e => {
+				// prevent unhandled rejection
 			});
 			const description =
 				typeof this._options.description === "function"
@@ -142,42 +141,53 @@ export class BasicCaseCreator<T extends ECompilerType> {
 						: "should pass";
 			it(
 				description,
-				async () => {
-					await stepSignal;
+				cb => {
+					stepSignal.then((e: Error | void) => {
+						cb(e);
+					});
 				},
 				this._options.timeout || 180000
 			);
 
-			chain = chain.then(async () => {
-				try {
-					if (bailout) {
-						throw `Case "${name}" step ${index + 1} bailout because ${tester.step + 1} failed`;
+			chain = chain.then(
+				async () => {
+					try {
+						env.clear();
+						await tester.compile();
+						await tester.check(env);
+						await env.run();
+						const context = tester.getContext();
+						if (!tester.next() && context.hasError()) {
+							const errors = context
+								.getError()
+								.map(i => `${i.stack}`.split("\n").join("\t\n"))
+								.join("\n\n");
+							throw new Error(
+								`Case "${name}" failed at step ${tester.step + 1}:\n${errors}`
+							);
+						}
+						stepSignalResolve!();
+					} catch (e) {
+						stepSignalResolve!(e);
+						return Promise.reject();
 					}
-					env.clear();
-					await tester.compile();
-					await tester.check(env);
-					await env.run();
-					const context = tester.getContext();
-					if (!tester.next() && context.hasError()) {
-						bailout = true;
-						const errors = context
-							.getError()
-							.map(i => `${i.stack}`.split("\n").join("\t\n"))
-							.join("\n\n");
-						throw new Error(
-							`Case "${name}" failed at step ${tester.step + 1}:\n${errors}`
-						);
-					}
+				},
+				e => {
+					// bailout
 					stepSignalResolve!();
-				} catch (e) {
-					stepSignalReject!(e);
+					return Promise.reject();
 				}
-			});
+			);
 		}
 
-		chain.finally(() => {
-			ender();
-		});
+		chain
+			.catch(e => {
+				// bailout error
+				// prevent unhandled rejection
+			})
+			.finally(() => {
+				ender();
+			});
 
 		afterAll(async () => {
 			await tester.resume();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should add `.catch` to runner tasks of concurrent test cases. To prevent the error being thrown to `unhandledRejection` which will be captured by jest and attach to currently running test cases.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
