### PR TITLE
fix: print rspack version instead of webpack's (fix #10189)

### DIFF
--- a/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
@@ -833,8 +833,8 @@ const SIMPLE_EXTRACTORS: SimpleExtractors = {
 			object.hash = statsCompilation.hash;
 		},
 		version: object => {
-			object.version = RSPACK_VERSION;
-			object.rspackVersion = WEBPACK_VERSION;
+			object.version = WEBPACK_VERSION;
+			object.rspackVersion = RSPACK_VERSION;
 		},
 		env: (object, _compilation, _context, { _env }) => {
 			object.env = _env;


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/rspack/pull/10121 introduced a bug that makes rspack print webpack's version number rather than rspack's version number in `rspack serve` and `rspack build` (as reported in https://github.com/web-infra-dev/rspack/issues/10189).

This PR fixes it.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
