### PR TITLE
fix: CI mulit rust cache file with the same cache key

### DIFF
--- a/.github/actions/cache/restore/action.yml
+++ b/.github/actions/cache/restore/action.yml
@@ -16,7 +16,7 @@ inputs:
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
-    value: ${{ steps.github-cache.outputs.cache-hit || steps.local-cache.outputs.cache-hit }}
+    value: ${{ steps.github-cache.outputs.cache-hit =='true' || steps.local-cache.outputs.cache-hit == 'true' }}
 
 runs:
   using: composite

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -40,7 +40,7 @@ runs:
       uses: ./.github/actions/cache/restore
       with:
         path: ~/.rustup/toolchains
-        key: rustup-cache-2-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
+        key: rustup-cache-v2-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
 
     # install components for nightly toolchain
     - name: Install
@@ -60,7 +60,7 @@ runs:
       if: ${{ inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       with:
         path: ~/.rustup/toolchains
-        key: rustup-cache-2-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
+        key: rustup-cache-v2-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
 
     - name: Cargo cache
       uses: ./.github/actions/rustup/cargo

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -59,7 +59,7 @@ runs:
       uses: ./.github/actions/cache/save
       if: ${{ inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       with:
-        path: ~/.rustup/toolchains/${{ steps.get-toolchain.outputs.toolchain }}*
+        path: ~/.rustup/toolchains
         key: rustup-cache-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
 
     - name: Cargo cache

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -40,7 +40,7 @@ runs:
       uses: ./.github/actions/cache/restore
       with:
         path: ~/.rustup/toolchains
-        key: rustup-cache-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
+        key: rustup-cache-2-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
 
     # install components for nightly toolchain
     - name: Install
@@ -60,7 +60,7 @@ runs:
       if: ${{ inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       with:
         path: ~/.rustup/toolchains
-        key: rustup-cache-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
+        key: rustup-cache-2-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
 
     - name: Cargo cache
       uses: ./.github/actions/rustup/cargo


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- fix cache-hit in composition action; `cache-hit` is string.
ref https://github.com/actions/cache/blob/main/src/restoreImpl.ts#L79C1-L80C1

- if you use cahce save/restore api, the key and path parameter should be the same.
- add version segement in key to, isolate old un-rebased PR

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
