### PR TITLE
fix(core): temporarily disable lightningcss warning

### DIFF
--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -17,7 +17,7 @@ use rspack_core::{
   rspack_sources::{encode_mappings, Mapping, OriginalLocation, SourceMap},
   Loader, LoaderContext, RunnerContext,
 };
-use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
+use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_loader_runner::{Identifiable, Identifier};
 use tokio::sync::Mutex;
 
@@ -95,29 +95,31 @@ impl LightningCssLoader {
       flags: parser_flags,
     };
     let stylesheet = StyleSheet::parse(&content_str, option.clone()).to_rspack_result()?;
+    // FIXME: Disable the warnings for now, cause it cause too much positive-negative warnings,
+    // enable when we have a better way to handle it.
 
-    if let Some(warnings) = warnings {
-      #[allow(clippy::unwrap_used)]
-      let warnings = warnings.read().unwrap();
-      for warning in warnings.iter() {
-        if matches!(
-          warning.kind,
-          lightningcss::error::ParserError::SelectorError(
-            lightningcss::error::SelectorError::UnsupportedPseudoClass(_)
-          ) | lightningcss::error::ParserError::SelectorError(
-            lightningcss::error::SelectorError::UnsupportedPseudoElement(_)
-          )
-        ) {
-          // ignore parsing errors on pseudo class from lightningcss-loader
-          // to allow pseudo class in CSS modules and Vue.
-          continue;
-        }
-        loader_context.emit_diagnostic(Diagnostic::warn(
-          "builtin:lightningcss-loader".to_string(),
-          format!("LightningCSS parse warning: {}", warning),
-        ));
-      }
-    }
+    // if let Some(warnings) = warnings {
+    //   #[allow(clippy::unwrap_used)]
+    //   let warnings = warnings.read().unwrap();
+    //   for warning in warnings.iter() {
+    //     if matches!(
+    //       warning.kind,
+    //       lightningcss::error::ParserError::SelectorError(
+    //         lightningcss::error::SelectorError::UnsupportedPseudoClass(_)
+    //       ) | lightningcss::error::ParserError::SelectorError(
+    //         lightningcss::error::SelectorError::UnsupportedPseudoElement(_)
+    //       )
+    //     ) {
+    //       // ignore parsing errors on pseudo class from lightningcss-loader
+    //       // to allow pseudo class in CSS modules and Vue.
+    //       continue;
+    //     }
+    //     loader_context.emit_diagnostic(Diagnostic::warn(
+    //       "builtin:lightningcss-loader".to_string(),
+    //       format!("LightningCSS parse warning: {}", warning),
+    //     ));
+    //   }
+    // }
 
     let mut stylesheet = to_static(
       stylesheet,

--- a/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
@@ -22,4 +22,4 @@ rspack_hook  = { workspace = true }
 rspack_util  = { workspace = true }
 
 [package.metadata.cargo-shear]
-ignored = ["tracing"]
+ignored = ["tracing", "ropey"]

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -20,10 +20,7 @@ use rspack_core::{
   },
   ChunkUkey, Compilation, CompilationChunkHash, CompilationProcessAssets, Plugin,
 };
-use rspack_error::{
-  miette, Diagnostic, DiagnosticKind, Result, RspackSeverity, ToStringResultToRspackResultExt,
-  TraceableError,
-};
+use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::asset_condition::AssetConditions;
@@ -250,27 +247,30 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
               }),
             })
             .to_rspack_result()?;
-          let warnings = warnings.read().expect("should lock");
-          all_warnings.write().expect("should lock").extend(
-            warnings.iter().map(|e| {
-              if let Some(loc) = &e.loc {
-                let rope = ropey::Rope::from_str(&input);
-                let start = rope.line_to_byte(loc.line as usize) + loc.column as usize - 1;
-                let end = start;
-                Diagnostic::from(Box::new(TraceableError::from_file(
-                  input.clone(),
-                  start,
-                  end,
-                  "LightningCSS minimize warning".to_string(),
-                  e.to_string(),
-                )
-                .with_kind(DiagnosticKind::Css)
-                .with_severity(RspackSeverity::Warn)) as Box<dyn miette::Diagnostic + Send + Sync>)
-              } else {
-                Diagnostic::warn("LightningCSS minimize warning".to_string(), e.to_string())
-              }
-            }),
-          );
+          // FIXME: Disable the warnings for now, cause it cause too much positive-negative warnings,
+          // enable when we have a better way to handle it.
+
+          // let warnings = warnings.read().expect("should lock");
+          // all_warnings.write().expect("should lock").extend(
+          //   warnings.iter().map(|e| {
+          //     if let Some(loc) = &e.loc {
+          //       let rope = ropey::Rope::from_str(&input);
+          //       let start = rope.line_to_byte(loc.line as usize) + loc.column as usize - 1;
+          //       let end = start;
+          //       Diagnostic::from(Box::new(TraceableError::from_file(
+          //         input.clone(),
+          //         start,
+          //         end,
+          //         "LightningCSS minimize warning".to_string(),
+          //         e.to_string(),
+          //       )
+          //       .with_kind(DiagnosticKind::Css)
+          //       .with_severity(RspackSeverity::Warn)) as Box<dyn miette::Diagnostic + Send + Sync>)
+          //     } else {
+          //       Diagnostic::warn("LightningCSS minimize warning".to_string(), e.to_string())
+          //     }
+          //   }),
+          // );
           result
         };
 

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/report-warning/test.filter.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/report-warning/test.filter.js
@@ -1,0 +1,3 @@
+
+// temporarily disable this test
+module.exports = () => { return false }

--- a/packages/rspack-test-tools/tests/diagnosticsCases/minimize/lightning-css-invalid/test.filter.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/minimize/lightning-css-invalid/test.filter.js
@@ -1,0 +1,3 @@
+
+// temporarily disable this test
+module.exports = () => { return false }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
temporarily disable lightningcss warning cause it contains too much positive-negative warnings
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
