### PR TITLE
fix: missing context depenendency

### DIFF
--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -320,9 +320,13 @@ impl ContextModuleFactory {
           Default::default(),
         )
         .boxed();
+        data.add_file_dependencies(file_dependencies);
+        data.add_missing_dependencies(missing_dependencies);
         return Ok((ModuleFactoryResult::new_with_module(raw_module), None));
       }
       Err(err) => {
+        data.add_file_dependencies(file_dependencies);
+        data.add_missing_dependencies(missing_dependencies);
         return Err(err);
       }
     };

--- a/packages/rspack-test-tools/tests/configCases/context/missing-dependency/errors.js
+++ b/packages/rspack-test-tools/tests/configCases/context/missing-dependency/errors.js
@@ -1,0 +1,1 @@
+module.exports = [/Can't resolve '\.\/lang'/];

--- a/packages/rspack-test-tools/tests/configCases/context/missing-dependency/index.js
+++ b/packages/rspack-test-tools/tests/configCases/context/missing-dependency/index.js
@@ -1,0 +1,6 @@
+const lang = ["en", "fr", "es", "de", "it", "ja", "zh", "ru", "pt", "ar"];
+
+for (const l of lang) {
+  require(`./lang/${l}`);
+}
+

--- a/packages/rspack-test-tools/tests/configCases/context/missing-dependency/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/context/missing-dependency/rspack.config.js
@@ -1,0 +1,16 @@
+const path = require("node:path");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.done.tap("DonePlugin", stats => {
+					expect(Array.from(stats.compilation.missingDependencies)).toEqual([
+						path.resolve(__dirname, "./lang")
+					]);
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/5536

Removed context directory should be add to missing dependencies of watcher.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
