### PR TITLE
fix: copy zod types instead of bundling them

### DIFF
--- a/packages/rspack/prebundle.config.mjs
+++ b/packages/rspack/prebundle.config.mjs
@@ -9,7 +9,10 @@ const __dirname = dirname(__filename);
 /** @type {import('prebundle').Config} */
 export default {
 	dependencies: [
-		"zod",
+		{
+			name: "zod",
+			copyDts: true
+		},
 		"graceful-fs",
 		{
 			name: "watchpack",

--- a/packages/rspack/src/builtin-loader/swc/pluginImport.ts
+++ b/packages/rspack/src/builtin-loader/swc/pluginImport.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 type RawStyleConfig = {
 	styleLibraryDirectory?: string;

--- a/packages/rspack/src/builtin-plugin/IgnorePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/IgnorePlugin.ts
@@ -2,7 +2,7 @@ import {
 	BuiltinPluginName,
 	type RawIgnorePluginOptions
 } from "@rspack/binding";
-import z from "zod";
+import { z } from "zod";
 
 import { validate } from "../util/validate";
 import { create } from "./base";

--- a/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
@@ -25,7 +25,7 @@ import {
 	RegisterJsTapKind
 } from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
-import z from "zod";
+import { z } from "zod";
 import { type Compilation, checkCompilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import type { CreatePartialRegisters } from "../taps/types";

--- a/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
@@ -8,7 +8,7 @@ import {
 	type RawSubresourceIntegrityPluginOptions
 } from "@rspack/binding";
 import type { AsyncSeriesWaterfallHook } from "@rspack/lite-tapable";
-import z from "zod";
+import { z } from "zod";
 import type { Compilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import type { CrossOriginLoading } from "../config/types";

--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 import { Compilation } from "../../Compilation";
 import { validate } from "../../util/validate";
 

--- a/packages/rspack/src/config/utils.ts
+++ b/packages/rspack/src/config/utils.ts
@@ -1,4 +1,4 @@
-import z, {
+import {
 	type DIRTY,
 	INVALID,
 	type IssueData,
@@ -17,7 +17,8 @@ import z, {
 	type ZodTypeDef,
 	ZodUnion,
 	type ZodUnionOptions,
-	addIssueToContext
+	addIssueToContext,
+	z
 } from "zod";
 import type { RspackOptions } from "./types";
 

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1,6 +1,6 @@
 import nodePath from "node:path";
 import type { AssetInfo, RawFuncUseCtx } from "@rspack/binding";
-import z, { type SyncParseReturnType, ZodIssueCode } from "zod";
+import { type SyncParseReturnType, ZodIssueCode, z } from "zod";
 import { Chunk } from "../Chunk";
 import { ChunkGraph } from "../ChunkGraph";
 import type { Compilation, PathData } from "../Compilation";

--- a/packages/rspack/src/lib/DllPlugin.ts
+++ b/packages/rspack/src/lib/DllPlugin.ts
@@ -8,7 +8,7 @@
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
 
-import z from "zod";
+import { z } from "zod";
 import type { Compiler } from "../Compiler";
 import { LibManifestPlugin } from "../builtin-plugin";
 import { DllEntryPlugin } from "../builtin-plugin/DllEntryPlugin";

--- a/packages/rspack/src/lib/DllReferencePlugin.ts
+++ b/packages/rspack/src/lib/DllReferencePlugin.ts
@@ -9,7 +9,7 @@
  */
 
 import type { JsBuildMeta } from "@rspack/binding";
-import z from "zod";
+import { z } from "zod";
 import type { CompilationParams } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import { DllReferenceAgencyPlugin } from "../builtin-plugin";


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

In https://github.com/web-infra-dev/rspack/pull/9899, I use default import to import `zod` to make types clear like below.

![image](https://github.com/user-attachments/assets/ac3b6807-782e-41b0-8d54-3fceec66781a)

But if user use named import in daily development, the types will be emitted like:

![image](https://github.com/user-attachments/assets/30bad587-9039-48cb-bc05-dcf70b7fa0c0)

And there exists an ast-grep issue when we try to redirect the import path, see https://github.com/ast-grep/ast-grep/issues/1959

Since the named import is the recommended one, so this PR, we use named import to import zod uniformly, and modify the prebundle script to copy the dts file directly instead of using `rollup-plugin-dts` for bundling to avoid the ast-grep issue and make the types simple and clear.

> BTW, zod use namespace and `rollup-plugin-dts` has some issues for namespace support, so we just use copy when prebundle.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
