### PR TITLE
refactor: print diagnostic code in front of message

### DIFF
--- a/crates/rspack_error/src/graphical.rs
+++ b/crates/rspack_error/src/graphical.rs
@@ -222,7 +222,15 @@ impl GraphicalReportHandler {
       .initial_indent(&initial_indent)
       .subsequent_indent(&rest_indent);
 
-    writeln!(f, "{}", textwrap::fill(&diagnostic.to_string(), opts))?;
+    let cause = format!(
+      "{}{}",
+      diagnostic
+        .code()
+        .map(|c| format!("{}: ", c.style(severity_style)))
+        .unwrap_or_default(),
+      diagnostic
+    );
+    writeln!(f, "{}", textwrap::fill(&cause, opts))?;
 
     if !self.with_cause_chain {
       return Ok(());
@@ -303,11 +311,6 @@ impl GraphicalReportHandler {
     if let Some(related) = diagnostic.related() {
       writeln!(f)?;
       for rel in related {
-        match rel.severity() {
-          Some(Severity::Error) | None => write!(f, "Error: ")?,
-          Some(Severity::Warning) => write!(f, "Warning: ")?,
-          Some(Severity::Advice) => write!(f, "Advice: ")?,
-        };
         self.render_header(f, rel)?;
         self.render_causes(f, rel)?;
         let src = rel.source_code().or(parent_src);

--- a/crates/rspack_plugin_circular_dependencies/src/lib.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/lib.rs
@@ -338,11 +338,8 @@ impl CircularDependencyRspackPlugin {
       .collect();
 
     compilation.push_diagnostic(diagnostic_factory(
-      "Circular Dependency".to_string(),
-      format!(
-        "Circular dependency detected:\n {}",
-        cycle_without_root.iter().join(" -> ")
-      ),
+      "CircularDependency".to_string(),
+      format!("detected:\n {}", cycle_without_root.iter().join(" -> ")),
     ));
     Ok(())
   }

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -202,10 +202,7 @@ impl CopyRspackPlugin {
               diagnostics
                 .lock()
                 .expect("failed to obtain lock of `diagnostics`")
-                .push(Diagnostic::error(
-                  "Run copy to fn error".into(),
-                  e.to_string(),
-                ));
+                .push(Diagnostic::error("CopyPlugin".into(), e.to_string()));
               "".to_string()
             }
           };
@@ -526,7 +523,7 @@ impl CopyRspackPlugin {
             .lock()
             .expect("failed to obtain lock of `diagnostics`")
             .push(Diagnostic::error(
-              "CopyRspackPlugin Error".into(),
+              "CopyPlugin".into(),
               format!("unable to locate '{glob_query}' glob"),
             ));
         }
@@ -562,7 +559,7 @@ impl CopyRspackPlugin {
             .lock()
             .expect("failed to obtain lock of `diagnostics`")
             .push(Diagnostic::error(
-              "CopyRspackPlugin Error".into(),
+              "CopyPlugin".into(),
               format!("unable to locate '{glob_query}' glob"),
             ));
           return Ok(None);
@@ -594,7 +591,10 @@ impl CopyRspackPlugin {
         diagnostics
           .lock()
           .expect("failed to obtain lock of `diagnostics`")
-          .push(Diagnostic::error("Glob Error".into(), e.msg.to_string()));
+          .push(Diagnostic::error(
+            "CopyPlugin".into(),
+            format!("glob error, {}", e.msg),
+          ));
 
         Ok(None)
       }
@@ -821,10 +821,7 @@ async fn handle_transform(
       diagnostics
         .lock()
         .expect("failed to obtain lock of `diagnostics`")
-        .push(Diagnostic::error(
-          "Run copy transform fn error".into(),
-          e.to_string(),
-        ));
+        .push(Diagnostic::error("CopyPlugin".into(), e.to_string()));
     }
   }
 }

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -103,7 +103,7 @@ impl CssPlugin {
           .expect("should have module");
 
         Diagnostic::warn(
-          "Conflicting order".into(),
+          "CssPlugin".into(),
           format!(
             "chunk {}\nConflicting order between {} and {}",
             chunk.name().unwrap_or(

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -320,7 +320,7 @@ impl ConsumeSharedPlugin {
           .await
           .map_err(|_e| {
             add_diagnostic(Diagnostic::error(
-              "ModuleNotFoundError".into(),
+              "ConsumeShared".into(),
               format!("resolving fallback for shared module {request}"),
             ))
           })
@@ -472,7 +472,7 @@ async fn additional_tree_runtime_requirements(
 #[async_trait]
 impl Plugin for ConsumeSharedPlugin {
   fn name(&self) -> &'static str {
-    "rspack.ConsumeSharedPlugin"
+    "CosumeShared"
   }
 
   fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_plugin.rs
@@ -114,7 +114,7 @@ impl ProvideSharedPlugin {
     resource_data: &ResourceData,
     mut add_diagnostic: impl FnMut(Diagnostic),
   ) {
-    let title = "rspack.ProvideSharedPlugin";
+    let title = "ProvideShared";
     let error_header = "No version specified and unable to automatically determine one.";
     if let Some(version) = version {
       self.resolved_provide_map.write().await.insert(

--- a/crates/rspack_plugin_size_limits/src/lib.rs
+++ b/crates/rspack_plugin_size_limits/src/lib.rs
@@ -91,7 +91,7 @@ impl SizeLimitsPlugin {
       .map(|&(name, size)| format!("\n  {} ({})", name, format_size(size)))
       .collect::<Vec<String>>()
       .join("");
-    let title = String::from("assets over size limit warning");
+    let title = String::from("SizeLimits");
     let message = format!("asset size limit: The following asset(s) exceed the recommended size limit ({}). This can impact web performance.\nAssets:{}", format_size(limit), asset_list);
 
     Self::add_diagnostic(hints, title, message, diagnostics);
@@ -119,7 +119,7 @@ impl SizeLimitsPlugin {
       })
       .collect::<Vec<_>>()
       .join("");
-    let title = String::from("entrypoints over size limit warning");
+    let title = String::from("SizeLimits");
     let message = format!(
       "entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit ({}). This can impact web performance.\nEntrypoints:{}",
       format_size(limit),

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -113,7 +113,7 @@ async fn handle_compilation(
   ) {
     compilation.push_diagnostic(Diagnostic::error(
       "SubresourceIntegrity".to_string(),
-      "Subresource integrity is not applied to async chunks because the \"output.crossOriginLoading\" option is not set.".to_string(),
+      "SRI is not applied to async chunks because the \"output.crossOriginLoading\" option is not set.".to_string(),
     ));
   }
 

--- a/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
+++ b/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
@@ -90,7 +90,7 @@ async fn seal(&self, compilation: &mut Compilation) -> Result<()> {
     let mut case_modules = set.iter().copied().collect::<Vec<_>>();
     case_modules.sort_unstable();
     diagnostics.push(Diagnostic::warn(
-      "Sensitive Modules Warn".to_string(),
+      "WarnCaseSensitive".to_string(),
       self.create_sensitive_modules_warning(case_modules, &compilation.get_module_graph()),
     ));
   }

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -59,10 +59,9 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
             for export in s {
               match export {
                 Ok(export) => exports.push(export.name.to_string()),
-                Err(err) => diagnostic.push(Diagnostic::error(
-                  "Wasm Export Parse Error".into(),
-                  err.to_string(),
-                )),
+                Err(err) => {
+                  diagnostic.push(Diagnostic::error("WasmParser".into(), err.to_string()))
+                }
               };
             }
           }
@@ -76,20 +75,16 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
                     ty,
                   )));
                 }
-                Err(err) => diagnostic.push(Diagnostic::error(
-                  "Wasm Import Parse Error".into(),
-                  err.to_string(),
-                )),
+                Err(err) => {
+                  diagnostic.push(Diagnostic::error("WasmParser".into(), err.to_string()))
+                }
               }
             }
           }
           _ => {}
         },
         Err(err) => {
-          diagnostic.push(Diagnostic::error(
-            "Wasm Parse Error".into(),
-            err.to_string(),
-          ));
+          diagnostic.push(Diagnostic::error("WasmParser".into(), err.to_string()));
         }
       }
     }

--- a/packages/rspack-test-tools/tests/__snapshots__/NewCodeSplitting-stats-output.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/NewCodeSplitting-stats-output.test.js.snap
@@ -333,11 +333,11 @@ cacheable modules xx KiB
   ./d.js 22 bytes [built] [code generated]
   ./e.js 22 bytes [built] [code generated]
 
-ERROR in × asset size limit: The following asset(s) exceed the recommended size limit (xx KiB). This can impact web performance.Assets:
+ERROR in × SizeLimits: asset size limit: The following asset(s) exceed the recommended size limit (xx KiB). This can impact web performance.Assets:
   │   main.js (xx KiB)
 
 
-ERROR in × entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (xx KiB). This can impact web performance.Entrypoints:
+ERROR in × SizeLimits: entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (xx KiB). This can impact web performance.Entrypoints:
   │   main (xx KiB)
   │       main.js
 

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -333,11 +333,11 @@ cacheable modules xx KiB
   ./d.js 22 bytes [built] [code generated]
   ./e.js 22 bytes [built] [code generated]
 
-ERROR in × asset size limit: The following asset(s) exceed the recommended size limit (xx KiB). This can impact web performance.Assets:
+ERROR in × SizeLimits: asset size limit: The following asset(s) exceed the recommended size limit (xx KiB). This can impact web performance.Assets:
   │   main.js (xx KiB)
 
 
-ERROR in × entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (xx KiB). This can impact web performance.Entrypoints:
+ERROR in × SizeLimits: entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (xx KiB). This can impact web performance.Entrypoints:
   │   main (xx KiB)
   │       main.js
 

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-diagnostic/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-diagnostic/stats.err
@@ -1,18 +1,18 @@
 WARNING in (./basic.js!)
-  ⚠ ModuleWarning: `React` is not defined
+  ⚠ `React` is not defined
 
 WARNING in ./lib.js (./basic.js!./lib.js)
-  ⚠ ModuleWarning: `React` is not defined
+  ⚠ `React` is not defined
 
 ERROR in (./basic.js!)
-  × ModuleError: `React` is not defined
+  × `React` is not defined
 
 ERROR in ./lib.js (./basic.js!./lib.js)
-  × ModuleError: `React` is not defined
+  × `React` is not defined
 
 ERROR in ./some-file.js
  (./with-file.js!) 1:1-4
-  × ModuleError: `React` is not defined
+  × `React` is not defined
    ╭────
  1 │ <div></div>
    ·  ───
@@ -20,14 +20,14 @@ ERROR in ./some-file.js
 
 ERROR in ./some-file.js
 ./lib.js (./with-file.js!./lib.js) 1:1-4
-  × ModuleError: `React` is not defined
+  × `React` is not defined
    ╭────
  1 │ <div></div>
    ·  ───
    ╰────
 
 ERROR in (./with-help.js!) 1:1-4
-  × ModuleError: `React` is not defined
+  × `React` is not defined
    ╭────
  1 │ <div></div>
    ·  ───
@@ -35,14 +35,14 @@ ERROR in (./with-help.js!) 1:1-4
   help: try to import `React`
 
 ERROR in (./with-location.js!) 1:1-4
-  × ModuleError: `React` is not defined
+  × `React` is not defined
    ╭────
  1 │ <div></div>
    ·  ───
    ╰────
 
 ERROR in (./with-multi-byte-char.js!) 1:0-13
-  × ModuleError: Multi-byte character error
+  × Multi-byte character error
    ╭────
  1 │ 👯‍♀️👯‍♀️👯‍♀️👯‍♀️
    · ───
@@ -61,14 +61,14 @@ ERROR in (./with-multi-byte-char.js!)
         │     at xxx
 
 ERROR in (./with-multiple-line.js!) 1:0-2:4
-  × ModuleError: Multiple line error
+  × Multiple line error
    ╭─[1:0]
  1 │ ╭─▶ ~~~~~
  2 │ ╰─▶ ~~~~~
    ╰────
 
 ERROR in (./with-multiple-line.js!) 1:0-2:4
-  × ModuleError: Multiple line error
+  × Multiple line error
    ╭─[1:0]
  1 │ ╭─▶ ~~~~~
  2 │ ├─▶ ~~~~~
@@ -88,7 +88,7 @@ ERROR in (./with-multiple-line.js!)
         │     at xxx
 
 ERROR in (./with-multiple-line.js!) 3:4
-  × ModuleError: Multiple line snippet
+  × Multiple line snippet
    ╭─[3:4]
  1 │ ~~~~~
  2 │ ~~~~~

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/stats.err
@@ -1,13 +1,13 @@
-WARNING in ⚠ Circular dependency detected:
+WARNING in ⚠ CircularDependency: detected:
   │  tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/d.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/e.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/f.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/c.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/d.js
 
-WARNING in ⚠ Circular dependency detected:
+WARNING in ⚠ CircularDependency: detected:
   │  tests/diagnosticsCases/plugins/circular-dependency-plugin/import-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/import-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/import-circular/a.js
 
-WARNING in ⚠ Circular dependency detected:
+WARNING in ⚠ CircularDependency: detected:
   │  tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/c.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/d.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js
 
-WARNING in ⚠ Circular dependency detected:
+WARNING in ⚠ CircularDependency: detected:
   │  tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/c.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/e.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js
 
 ERROR in × Module not found: Can't resolve './' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/plugins/circular-dependency-plugin'

--- a/packages/rspack-test-tools/tests/errorCases/warning-map.js
+++ b/packages/rspack-test-tools/tests/errorCases/warning-map.js
@@ -26,7 +26,7 @@ module.exports = {
 		  "index": 0,
 		  "message": "  ⚠ Module parse warning:\\n  ╰─▶   ⚠ Unsupported feature: require.main.require() is not supported by Rspack.\\n         ╭────\\n       1 │ require.main.require('./file');\\n         · ──────────────────────────────\\n         ╰────\\n      \\n",
 		  "moduleIdentifier": "<TEST_TOOLS_ROOT>/tests/fixtures/errors/require.main.require.js",
-		  "name": "ModuleParseWarning",
+		  "name": "Module parse warning",
 		},
 		]
 	`);

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -618,10 +618,7 @@ export async function runLoaders(
 	loaderContext.experiments = {
 		emitDiagnostic: (diagnostic: Diagnostic) => {
 			const d = Object.assign({}, diagnostic, {
-				message:
-					diagnostic.severity === "warning"
-						? `ModuleWarning: ${diagnostic.message}`
-						: `ModuleError: ${diagnostic.message}`,
+				message: diagnostic.message,
 				moduleIdentifier: context._module.identifier()
 			});
 			compiler._lastCompilation!.__internal__pushDiagnostic(

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -84,13 +84,14 @@ export function concatErrorMsgAndStack(
 		// here we want to treat the almost the same as `Error.stack` just without the stack.
 		// Webpack uses `Error.message`, however it does not contain the `Error.prototype.name`
 		// `xxx` -> `Error: xxx`. So they behave the same even if `hideStack` is set to `true`.
-		err.message = err.stack || err.toString();
+		err.message =
+			err.stack?.replace(`${err.name || "Error"}: `, "") || err.toString();
 	} else {
 		// This is intended to be different than webpack,
 		// here we want to treat the almost the same as `Error.stack` just without the stack.
 		// Webpack uses `Error.message`, however it does not contain the `Error.prototype.name`
 		// `xxx` -> `Error: xxx`. So they behave the same even if `hideStack` is set to `true`.
-		err.message = err.toString();
+		err.message = err.message || err.toString();
 	}
 	// maybe `null`, use `undefined` to compatible with `Option<String>`
 	err.stack = err.stack || undefined;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close https://github.com/web-infra-dev/rspack/issues/9724
perhaps relate to https://github.com/web-infra-dev/rspack/issues/10081

Print diagnostic code in front of message. This enables us to quickly identify the scope where the error lies.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
