### PR TITLE
docs: correct SWC API examples

### DIFF
--- a/website/docs/en/api/javascript-api/swc.mdx
+++ b/website/docs/en/api/javascript-api/swc.mdx
@@ -1,6 +1,6 @@
 # SWC API
 
-Rspack uses [SWC](https://swc.rs/) under the hood to transform and minify JavaScript code, and experimentally exposes some SWC JavaScript APIs through `rspack.experiments.swc`. This allows you to directly call SWC functions like `transform` or `minify` without installing the additional [@swc/core](https://www.npmjs.com/package/@swc/core) package.
+Rspack uses [SWC](https://swc.rs/) under the hood to transform and minify JavaScript code, and experimentally exposes some SWC JavaScript APIs through `rspack.experiments.swc`. This allows you to directly call SWC methods like `transform` or `minify` without installing the additional [@swc/core](https://www.npmjs.com/package/@swc/core) package.
 
 ## Examples
 
@@ -10,15 +10,16 @@ Here is a simple example demonstrating how to transform JavaScript code using Rs
 import { rspack } from '@rspack/core';
 
 const { swc } = rspack.experiments;
+const sourceCode = 'const a: number = 10;';
 
 swc
-  .transform('const a: number = 10;', {
+  .transform(sourceCode, {
     filename: 'main.ts',
     jsc: {
       parser: {
         syntax: 'typescript',
       },
-      target: 'es5',
+      // ...other options
     },
   })
   .then(result => {
@@ -29,7 +30,7 @@ swc
 In addition to using the `swc` API directly, you can also use it in loaders or plugins to help with code transform or minify.
 
 ```js title="my-loader.mjs"
-export default function (source) {
+export default function myLoader(source) {
   const { swc } = this._compiler.rspack.experiments;
   const customCode = `
     const a = 10;
@@ -42,12 +43,11 @@ export default function (source) {
   swc
     .minify(customCode, {
       compress: true,
-      keep_classnames: true,
-      safari10: true,
       sourceMap: true,
+      // ...other options
     })
-    .then(minifiedCode => {
-      callback(null, `${minifiedCode}\n${source}`);
+    .then(result => {
+      callback(null, `${result.code}\n${source}`);
     });
 }
 ```

--- a/website/docs/zh/api/javascript-api/swc.mdx
+++ b/website/docs/zh/api/javascript-api/swc.mdx
@@ -10,15 +10,16 @@ Rspack 底层使用 [SWC](https://swc.rs/) 来转换和压缩 JavaScript 代码�
 import { rspack } from '@rspack/core';
 
 const { swc } = rspack.experiments;
+const sourceCode = 'const a: number = 10;';
 
 swc
-  .transform('const a: number = 10;', {
+  .transform(sourceCode, {
     filename: 'main.ts',
     jsc: {
       parser: {
         syntax: 'typescript',
       },
-      target: 'es5',
+      // ...other options
     },
   })
   .then(result => {
@@ -29,7 +30,7 @@ swc
 你也可以在 loader 或 plugin 中使用这些 API，来帮助你进行代码转换或压缩。
 
 ```js title="my-loader.mjs"
-export default function (source) {
+export default function myLoader(source) {
   const { swc } = this._compiler.rspack.experiments;
   const customCode = `
     const a = 10;
@@ -42,12 +43,11 @@ export default function (source) {
   swc
     .minify(customCode, {
       compress: true,
-      keep_classnames: true,
-      safari10: true,
       sourceMap: true,
+      // ...other options
     })
-    .then(minifiedCode => {
-      callback(null, `${minifiedCode}\n${source}`);
+    .then(result => {
+      callback(null, `${result.code}\n${source}`);
     });
 }
 ```


### PR DESCRIPTION
## Summary

Correct SWC API examples, the `minifiedCode` is an object and should be `result.code`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
