### PR TITLE
fix: clever merge resolve options

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -331,8 +331,6 @@ impl NormalModuleFactory {
           dependency_type: &dependency_type,
           dependency_category: &dependency_category,
           span: dependency_source_span,
-          // take the options is safe here, because it
-          // is not used in after_resolve hooks
           resolve_options: data.resolve_options.clone(),
           resolve_to_context: false,
           optional: dependency_optional,
@@ -527,8 +525,7 @@ impl NormalModuleFactory {
       ));
     }
 
-    let resolved_resolve_options =
-      self.calculate_resolve_options(&resolved_module_rules, dependency_category);
+    let resolved_resolve_options = self.calculate_resolve_options(&resolved_module_rules);
     let (resolved_parser_options, resolved_generator_options) =
       self.calculate_parser_and_generator_options(&resolved_module_rules);
     let (resolved_parser_options, resolved_generator_options) = self
@@ -651,11 +648,7 @@ impl NormalModuleFactory {
     Ok(rules)
   }
 
-  fn calculate_resolve_options(
-    &self,
-    module_rules: &[&ModuleRuleEffect],
-    dependency_type: DependencyCategory,
-  ) -> Option<Arc<Resolve>> {
+  fn calculate_resolve_options(&self, module_rules: &[&ModuleRuleEffect]) -> Option<Arc<Resolve>> {
     let mut resolved: Option<Resolve> = None;
     for rule in module_rules {
       if let Some(rule_resolve) = &rule.resolve {
@@ -666,9 +659,7 @@ impl NormalModuleFactory {
         }
       }
     }
-    resolved
-      .map(|r| r.merge_by_dependency(dependency_type))
-      .map(Arc::new)
+    resolved.map(Arc::new)
   }
 
   fn calculate_side_effects(&self, module_rules: &[&ModuleRuleEffect]) -> Option<bool> {

--- a/crates/rspack_core/src/options/resolve/clever_merge.rs
+++ b/crates/rspack_core/src/options/resolve/clever_merge.rs
@@ -2312,10 +2312,14 @@ mod test {
   #[test]
   fn test_merge_resolver_options_20() {
     let first = Resolve {
+      alias: Some(vec![].into()),
+      fallback: Some(vec![].into()),
       extension_alias: Some(vec![]),
       by_dependency: Some(ByDependency::from_iter([(
         "x".into(),
         Resolve {
+          alias: Some(vec![].into()),
+          fallback: Some(vec![].into()),
           extension_alias: Some(vec![]),
           ..Default::default()
         },
@@ -2324,6 +2328,14 @@ mod test {
     };
 
     let second = Resolve {
+      alias: Some(vec![("fakemodule".to_string(), vec!["realmodule".into()])].into()),
+      fallback: Some(
+        vec![(
+          "fallbackmodule".to_string(),
+          vec!["fallbacktomodule".into()],
+        )]
+        .into(),
+      ),
       extension_alias: Some(vec![(".js".to_string(), vec![".ts".to_string()])]),
       ..Default::default()
     };
@@ -2331,6 +2343,14 @@ mod test {
     pretty_assertions::assert_eq!(
       merge_resolve(first, second),
       Resolve {
+        alias: Some(vec![("fakemodule".to_string(), vec!["realmodule".into()])].into()),
+        fallback: Some(
+          vec![(
+            "fallbackmodule".to_string(),
+            vec!["fallbacktomodule".into()],
+          )]
+          .into(),
+        ),
         extension_alias: Some(vec![(".js".to_string(), vec![".ts".to_string()])]),
         ..Default::default()
       }

--- a/crates/rspack_core/src/options/resolve/clever_merge.rs
+++ b/crates/rspack_core/src/options/resolve/clever_merge.rs
@@ -111,12 +111,13 @@ fn parse_resolve(resolve: Resolve) -> ResolveWithEntry {
   let mut by_dependency = by_dependency;
 
   macro_rules! update_by_value {
-    ($ident: ident) => {
+    ($ident: ident, $should_insert_by_value_key: expr) => {
       let mut $ident = LinkedHashMap::new();
       let by_values_key: Vec<_> = by_dependency.0.keys().cloned().collect();
       for by_value_key in &by_values_key {
         let obj = by_dependency.0.get_mut(by_value_key).expect("");
-        if obj.$ident.is_some() {
+        let should_insert_by_value_key = $should_insert_by_value_key(obj.$ident.as_ref());
+        if should_insert_by_value_key {
           $ident.insert(by_value_key.clone(), std::mem::take(&mut obj.$ident));
         }
         if by_value_key == "default" {
@@ -132,26 +133,35 @@ fn parse_resolve(resolve: Resolve) -> ResolveWithEntry {
       }
     };
   }
-  update_by_value!(extensions);
-  update_by_value!(alias);
-  update_by_value!(prefer_relative);
-  update_by_value!(prefer_absolute);
-  update_by_value!(symlinks);
-  update_by_value!(main_files);
-  update_by_value!(main_fields);
-  update_by_value!(condition_names);
-  update_by_value!(modules);
-  update_by_value!(fallback);
-  update_by_value!(fully_specified);
-  update_by_value!(exports_fields);
-  update_by_value!(imports_fields);
-  update_by_value!(description_files);
-  update_by_value!(enforce_extension);
-  update_by_value!(extension_alias);
-  update_by_value!(alias_fields);
-  update_by_value!(restrictions);
-  update_by_value!(roots);
-  update_by_value!(tsconfig);
+  update_by_value!(extensions, |i: Option<&_>| i.is_some());
+  update_by_value!(
+    alias,
+    |i: Option<&Alias>| matches!(i, Some(Alias::MergeAlias(i)) if !i.is_empty())
+  );
+  update_by_value!(prefer_relative, |i: Option<&_>| i.is_some());
+  update_by_value!(prefer_absolute, |i: Option<&_>| i.is_some());
+  update_by_value!(symlinks, |i: Option<&_>| i.is_some());
+  update_by_value!(main_files, |i: Option<&_>| i.is_some());
+  update_by_value!(main_fields, |i: Option<&_>| i.is_some());
+  update_by_value!(condition_names, |i: Option<&_>| i.is_some());
+  update_by_value!(modules, |i: Option<&_>| i.is_some());
+  update_by_value!(
+    fallback,
+    |i: Option<&Alias>| matches!(i, Some(Alias::MergeAlias(i)) if !i.is_empty())
+  );
+  update_by_value!(fully_specified, |i: Option<&_>| i.is_some());
+  update_by_value!(exports_fields, |i: Option<&_>| i.is_some());
+  update_by_value!(imports_fields, |i: Option<&_>| i.is_some());
+  update_by_value!(description_files, |i: Option<&_>| i.is_some());
+  update_by_value!(enforce_extension, |i: Option<&_>| i.is_some());
+  update_by_value!(
+    extension_alias,
+    |i: Option<&ExtensionAlias>| matches!(i, Some(i) if !i.is_empty())
+  );
+  update_by_value!(alias_fields, |i: Option<&_>| i.is_some());
+  update_by_value!(restrictions, |i: Option<&_>| i.is_some());
+  update_by_value!(roots, |i: Option<&_>| i.is_some());
+  update_by_value!(tsconfig, |i: Option<&_>| i.is_some());
 
   res
 }
@@ -2294,6 +2304,34 @@ mod test {
       merge_resolve(first, second),
       Resolve {
         extensions: string_list(&[]),
+        ..Default::default()
+      }
+    )
+  }
+
+  #[test]
+  fn test_merge_resolver_options_20() {
+    let first = Resolve {
+      extension_alias: Some(vec![]),
+      by_dependency: Some(ByDependency::from_iter([(
+        "x".into(),
+        Resolve {
+          extension_alias: Some(vec![]),
+          ..Default::default()
+        },
+      )])),
+      ..Default::default()
+    };
+
+    let second = Resolve {
+      extension_alias: Some(vec![(".js".to_string(), vec![".ts".to_string()])]),
+      ..Default::default()
+    };
+
+    pretty_assertions::assert_eq!(
+      merge_resolve(first, second),
+      Resolve {
+        extension_alias: Some(vec![(".js".to_string(), vec![".ts".to_string()])]),
         ..Default::default()
       }
     )

--- a/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/index.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/index.js
@@ -1,0 +1,5 @@
+import { a } from 'pkg';
+
+it("should resolve to correct module", () => {
+  expect(a).toBe(1);
+})

--- a/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/node_modules/pkg/lib/a.native.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/node_modules/pkg/lib/a.native.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/node_modules/pkg/lib/index.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/node_modules/pkg/lib/index.js
@@ -1,0 +1,1 @@
+export { a } from './a';

--- a/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/node_modules/pkg/lib/package.json
+++ b/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/node_modules/pkg/lib/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/node_modules/pkg/package.json
+++ b/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/node_modules/pkg/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pkg",
+  "main": "lib/index.js"
+}

--- a/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/warnings.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/warnings.js
@@ -1,0 +1,4 @@
+module.exports = [
+  /No required version specified and unable to automatically determine one/,
+  /No version specified and unable to automatically determine one/,
+]

--- a/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/webpack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/mf-by-dependency-esm/webpack.config.js
@@ -1,0 +1,48 @@
+const rspack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				type: "javascript/auto",
+				test: /\.js$/,
+				use: {
+					loader: "builtin:swc-loader",
+					options: {
+						jsc: {
+							parser: {
+								syntax: "ecmascript",
+								jsx: true,
+								exportDefaultFrom: true
+							}
+						},
+						module: {
+							type: "commonjs",
+							strict: false,
+							strictMode: false,
+							noInterop: false,
+							lazy: false,
+							allowTopLevelThis: true,
+							ignoreDynamic: true
+						}
+					}
+				}
+			}
+		]
+	},
+	resolve: {
+		extensions: [".native.js", ".js"]
+	},
+	plugins: [
+		new rspack.container.ModuleFederationPluginV1({
+			name: "test",
+			shared: {
+				pkg: {
+					singleton: true,
+					eager: true
+				}
+			}
+		})
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/10215

which is introduced by https://github.com/web-infra-dev/rspack/pull/10021, a wrong fix about merge resolve options by dependency, the real cause is the bug on `clever_merge`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
