### PR TITLE
docs: fix the wrong container syntax

### DIFF
--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -541,7 +541,7 @@ export default {
 
 Cache versions, different versions of caches are isolated from each other.
 
-:::tip title="Persistent cache invalidation"
+:::tip Persistent cache invalidation
 
 In addition to [buildDependencies](#cachebuilddependencies) and [version](#cacheversion) configurations that affect persistent cache invalidation, Rspack also invalidates persistent cache when the following fields change.
 
@@ -792,7 +792,7 @@ After enabling this feature, Rspack can build remote resources that start with t
 
 By default, Rspack will generate `rspack.lock` and `rspack.lock.data` in the [context](/config/context) folder as the locations of the Lockfile and the cache respectively. You can also configure them through `lockfileLocation` and `cacheLocation`.
 
-:::Note
+:::note
 You should commit the files at `lockfileLocation` and `cacheLocation` to the version control system so that no network requests will be made during the production build.
 :::
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -542,7 +542,7 @@ export default {
 
 缓存数据的版本，不同版本缓存相互隔离。
 
-:::tip title="持久化缓存失效"
+:::tip 持久化缓存失效
 
 除了 [buildDependencies](#cachebuilddependencies) 和 [version](#cacheversion) 配置会影响持久化缓存失效，Rspack 还会在以下字段变化时使持久化缓存失效。
 


### PR DESCRIPTION

## Summary

These grammars are not supported by Rspress, but in surprising coincidence, it worked.

just standardize them

https://github.com/web-infra-dev/rspress/blob/415cefcdf2772f1e6442ead732e28b6f5eb55bd0/packages/plugin-container-syntax/src/remarkPlugin.ts

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
