### PR TITLE
fix: set watchpack limit before loading watchpack

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -46,8 +46,6 @@ export class RspackCLI {
 		callback?: (e: Error | null, res?: Stats | MultiStats) => void
 	) {
 		process.env.RSPACK_CONFIG_VALIDATE ??= "loose";
-		process.env.WATCHPACK_WATCHER_LIMIT =
-			process.env.WATCHPACK_WATCHER_LIMIT || "20";
 
 		let config = await this.loadConfig(options);
 		config = await this.buildConfig(config, options, rspackCommand);

--- a/packages/rspack/src/index.ts
+++ b/packages/rspack/src/index.ts
@@ -1,3 +1,4 @@
+import "./setupEnv";
 import * as rspackExports from "./exports";
 import { rspack as rspackFn } from "./rspack";
 // add exports on rspack() function

--- a/packages/rspack/src/setupEnv.ts
+++ b/packages/rspack/src/setupEnv.ts
@@ -1,0 +1,11 @@
+import os from "node:os";
+
+// There is a node.js bug on MacOS which causes closing file watchers to be really slow.
+// This limits the number of watchers to mitigate the issue.
+// https://github.com/nodejs/node/issues/29949
+if (
+	os.platform() === "darwin" &&
+	process.env.WATCHPACK_WATCHER_LIMIT === undefined
+) {
+	process.env.WATCHPACK_WATCHER_LIMIT = "20";
+}


### PR DESCRIPTION
## Summary

We tried setting WATCHPACK_WATCHER_LIMIT by default in the Rspack CLI (https://github.com/web-infra-dev/rspack/pull/5486), but I found that this did not work because watchpack was loaded earlier than the WATCHPACK_WATCHER_LIMIT was set in the Rspack CLI.

![image](https://github.com/user-attachments/assets/9e6648b5-f197-45eb-b347-2a4fb16232e6)

This PR fixes the issue by setting WATCHPACK_WATCHER_LIMIT earlier in Rspack core.

Also submitted a PR to the watchpack repo: https://github.com/webpack/watchpack/pull/249, if that gets merged we can remove this.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
