### PR TITLE
feat(wasm): support `tracing-chrome` in wasm

### DIFF
--- a/crates/rspack_tracing/src/chrome.rs
+++ b/crates/rspack_tracing/src/chrome.rs
@@ -18,7 +18,7 @@ impl Tracer for ChromeTracer {
       .trace_style(TraceStyle::Async)
       .include_args(true)
       .category_fn(Box::new(|_| "rspack".to_string()))
-      .writer(move || trace_writer.writer())
+      .writer(trace_writer.writer())
       .build();
     self.guard = Some(guard);
 

--- a/crates/rspack_tracing/src/chrome.rs
+++ b/crates/rspack_tracing/src/chrome.rs
@@ -13,12 +13,12 @@ pub struct ChromeTracer {
 
 impl Tracer for ChromeTracer {
   fn setup(&mut self, output: &str) -> Option<Layered> {
-    let trace_writer = TraceWriter::from(output);
+    let trace_writer = TraceWriter::from(output.to_owned());
     let (chrome_layer, guard) = ChromeLayerBuilder::new()
       .trace_style(TraceStyle::Async)
       .include_args(true)
       .category_fn(Box::new(|_| "rspack".to_string()))
-      .writer(trace_writer.writer())
+      .writer(move || trace_writer.writer())
       .build();
     self.guard = Some(guard);
 

--- a/crates/rspack_tracing/src/lib.rs
+++ b/crates/rspack_tracing/src/lib.rs
@@ -2,31 +2,29 @@ mod chrome;
 mod stdout;
 mod tracer;
 
-use std::{fs, io, path::Path};
+use std::{fs, io, path::PathBuf};
 
 pub use chrome::ChromeTracer;
 pub use stdout::StdoutTracer;
 pub use tracer::Tracer;
 use tracing_subscriber::fmt::writer::BoxMakeWriter;
-pub(crate) enum TraceWriter<'a> {
+pub(crate) enum TraceWriter {
   Stdout,
   Stderr,
-  File { path: &'a Path },
+  File { path: PathBuf },
 }
 
-impl<'a> From<&'a str> for TraceWriter<'a> {
-  fn from(s: &'a str) -> Self {
-    match s {
+impl From<String> for TraceWriter {
+  fn from(s: String) -> Self {
+    match s.as_str() {
       "stdout" => Self::Stdout,
       "stderr" => Self::Stderr,
-      path => Self::File {
-        path: Path::new(path),
-      },
+      _ => Self::File { path: s.into() },
     }
   }
 }
 
-impl TraceWriter<'_> {
+impl TraceWriter {
   pub fn make_writer(&self) -> BoxMakeWriter {
     match self {
       TraceWriter::Stdout => BoxMakeWriter::new(io::stdout),

--- a/crates/rspack_tracing/src/stdout.rs
+++ b/crates/rspack_tracing/src/stdout.rs
@@ -10,7 +10,7 @@ pub struct StdoutTracer;
 impl Tracer for StdoutTracer {
   fn setup(&mut self, output: &str) -> Option<Layered> {
     use tracing_subscriber::{fmt, prelude::*};
-    let trace_writer = TraceWriter::from(output);
+    let trace_writer = TraceWriter::from(output.to_owned());
     Some(
       fmt::layer()
         .pretty()

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -288,7 +288,7 @@ where
     let out_writer = builder.out_writer;
 
     let handle = std::thread::spawn(move || {
-      let out_writer = out_writer.map_or_else(|| create_default_writer(), |f| f());
+      let out_writer = out_writer.map_or_else(|| create_default_writer() as _, |f| f());
       let mut write = BufWriter::new(out_writer);
       write.write_all(b"[\n").unwrap();
 

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -6,20 +6,20 @@ use std::{
   marker::PhantomData,
   path::Path,
   sync::{
+    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
     mpsc,
     mpsc::Sender,
-    Arc, Mutex,
   },
   thread::JoinHandle,
 };
 
-use serde_json::{json, Value as JsonValue};
-use tracing_core::{field::Field, span, Event, Subscriber};
+use serde_json::{Value as JsonValue, json};
+use tracing_core::{Event, Subscriber, field::Field, span};
 use tracing_subscriber::{
+  Layer,
   layer::Context,
   registry::{LookupSpan, SpanRef},
-  Layer,
 };
 
 thread_local! {

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -6,20 +6,20 @@ use std::{
   marker::PhantomData,
   path::Path,
   sync::{
-    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
     mpsc,
     mpsc::Sender,
+    Arc, Mutex,
   },
   thread::JoinHandle,
 };
 
-use serde_json::{Value as JsonValue, json};
-use tracing_core::{Event, Subscriber, field::Field, span};
+use serde_json::{json, Value as JsonValue};
+use tracing_core::{field::Field, span, Event, Subscriber};
 use tracing_subscriber::{
-  Layer,
   layer::Context,
   registry::{LookupSpan, SpanRef},
+  Layer,
 };
 
 thread_local! {
@@ -98,7 +98,7 @@ where
   /// If `file` could not be opened/created. To handle errors,
   /// open a file and pass it to [`writer`](crate::ChromeLayerBuilder::writer) instead.
   pub fn file<P: AsRef<Path> + Send + 'static>(self, file: P) -> Self {
-    self.writer(|| Box::new(std::fs::File::create(file).expect("Failed to create trace file.")))
+    self.writer(std::fs::File::create(file).expect("Failed to create trace file."))
   }
 
   /// Supply an arbitrary writer to which to write trace contents.
@@ -111,8 +111,8 @@ where
   /// let (layer, guard) = ChromeLayerBuilder::new().writer(std::io::sink()).build();
   /// # tracing_subscriber::registry().with(layer).init();
   /// ```
-  pub fn writer<W: FnOnce() -> Box<dyn Write> + Send + 'static>(mut self, writer: W) -> Self {
-    self.out_writer = Some(Box::new(writer));
+  pub fn writer<W: Write + Send + 'static>(mut self, writer: W) -> Self {
+    self.out_writer = Some(Box::new(|| Box::new(writer)));
     self
   }
 

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -288,10 +288,7 @@ where
     let out_writer = builder.out_writer;
 
     let handle = std::thread::spawn(move || {
-      let out_writer = out_writer.map(|f| f()).unwrap_or_else(|| {
-        let writer = create_default_writer();
-        writer
-      });
+      let out_writer = out_writer.map_or_else(|| create_default_writer(), |f| f());
       let mut write = BufWriter::new(out_writer);
       write.write_all(b"[\n").unwrap();
 

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -459,6 +459,7 @@ class Compiler {
 			this.hooks.afterDone.call(stats!);
 
 			instanceBinding.shutdownAsyncRuntime();
+			instanceBinding.cleanupGlobalTrace();
 			isRuntimeShutdown = true;
 		};
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md. 

-->

## Summary

Debugging wasm is very painful. So I hope this pr could help us find where the wasm crushes or get stuck. There are two things to do:

- [x] `tracing-chrome` send the writer to a isolated thread to write the traces. However, threads in wasm are actually node workers. They can't share file descriptors with each other https://github.com/nodejs/node/issues/30507. The solution is passing a writer creator instead of a writer when building chrome tracer.
- [x] `cleanup` function is called by `exit-hook` and sends an flush message to the tracing thread. This means `cleanup` function is called when there's no active handlers (workers) running, which means the chrome tracing thread is not running. So we may choose another way to call `cleanup`. @hardfist @h-a-n-a Do you have any suggestion? 

This pr can be holding on until there is a good solution.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
