### PR TITLE
fix: use exit-hook sync API for tracing

### DIFF
--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -38,7 +38,7 @@ export async function applyProfile(
 	traceLayer: string = defaultRustTraceLayer,
 	traceOutput?: string
 ) {
-	const { asyncExitHook } = await import("exit-hook");
+	const { default: exitHook } = await import("exit-hook");
 	if (traceLayer !== "chrome" && traceLayer !== "logger") {
 		throw new Error(`unsupported trace layer: ${traceLayer}`);
 	}
@@ -64,9 +64,7 @@ export async function applyProfile(
 		traceLayer,
 		traceOutput
 	);
-	asyncExitHook(rspack.experiments.globalTrace.cleanup, {
-		wait: 500
-	});
+	exitHook(rspack.experiments.globalTrace.cleanup);
 }
 
 async function ensureFileDir(outputFilePath: string) {


### PR DESCRIPTION
## Summary

The `wait: 500` option has been introduced for otel and otel has been removed in https://github.com/web-infra-dev/rspack/pull/10067.

This PR uses exit-hook sync API for tracing:

- Faster emitting, no need to wait for 500ms.
- No need to worry about the limitations of asynchronous exit: https://www.npmjs.com/package/exit-hook#asynchronous-exit-notes

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
