### PR TITLE
docs: enhance Data URI module and MIME type rules

### DIFF
--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -880,7 +880,7 @@ export type RuleSetRule = {
 	/** Matches all modules that match this resource against the Resource's query. */
 	resourceQuery?: RuleSetCondition;
 
-	/** Matches all modules that match this resource, and will match against the Resource's mimetype. */
+	/** Matches modules based on [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types) instead of file extension. It's primarily useful for data URI module */
 	mimetype?: RuleSetCondition;
 
 	/** Matches all modules that match this resource, and will match against the Resource's scheme. */

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -390,13 +390,13 @@ __webpack_modules__[require.resolveWeak(`./page/${page}`)];
 
 Rspack supports importing Data URI modules using the `import` and `require` syntax.
 
-**import**
+- **import**
 
 ```js
 import DataURI from 'data:text/javascript,export default 42';
 ```
 
-**require**
+- **require**
 
 ```js
 require('data:text/javascript,module.exports = 42');
@@ -414,3 +414,53 @@ const {
 ::: tip
 The Data URI module can be used as a method to implement virtual modules, such as combining with a Loader to dynamically load custom modules at runtime.
 :::
+
+### Built-in rules
+
+Rspack supports these [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types) for data URI modules by default: `application/json`, `text/javascript`, `application/javascript`, `application/node`, and `application/wasm`. This means that when you create data URI modules with these MIME types, Rspack will automatically recognize them.
+
+Rspack's built-in MIME rules are as follows:
+
+```js
+const defaultMimeRules = [
+  {
+    mimetype: 'application/node',
+    type: 'javascript/auto',
+  },
+  {
+    mimetype: 'application/json',
+    type: 'json',
+  },
+  {
+    mimetype: {
+      or: ['text/javascript', 'application/javascript'],
+    },
+    type: 'javascript/esm',
+    // ...
+  },
+  {
+    mimetype: 'application/wasm',
+    type: 'webassembly/async',
+    // ...
+  },
+];
+```
+
+### Custom rules
+
+You can also use [Rule.mimetype](/config/module#rulemimetype) to extend the matching rules for Data URI modules, for example, to add custom loaders for `text/javascript`:
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        mimetype: 'text/javascript',
+        use: [
+          // ...
+        ],
+      },
+    ],
+  },
+};
+```

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -1675,7 +1675,22 @@ export default {
 - **Type:** [`Condition`](/config/module#condition)
 - **Default:** `undefined`
 
-Matches all modules that match this resource, and will match against the Resource's mimetype.
+Matches modules based on [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types) instead of file extension. It's primarily useful for [data URI module](/api/runtime-api/module-methods#data-uri-module).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        mimetype: 'text/javascript',
+        use: [
+          // ...
+        ],
+      },
+    ],
+  },
+};
+```
 
 ### Rule.descriptionData
 

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -389,13 +389,13 @@ __webpack_modules__[require.resolveWeak(`./page/${page}`)];
 
 Rspack 支持使用 `import` 和 `require` 语法导入 Data URI 模块。
 
-**import**
+- **import**
 
 ```js
 import DataURI from 'data:text/javascript,export default 42';
 ```
 
-**require**
+- **require**
 
 ```js
 require('data:text/javascript,module.exports = 42');
@@ -413,3 +413,53 @@ const {
 ::: tip
 Data URI 模块可以被用作虚拟模块（Virtual Modules）的实现方式，如：配合 loader 完成运行时动态加载自定义模块。
 :::
+
+### 自定义 Rules
+
+Rspack 默认支持这些 [MIME 类型](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Guides/MIME_types) 的 data URI 模块：`application/json`、`text/javascript`、`application/javascript`、`application/node` 和 `application/wasm`。这意味着当你使用这些 MIME 类型创建 data URI 模块时，Rspack 会自动识别他们。
+
+Rspack 内置的 MIME rules 如下：
+
+```js
+const defaultMimeRules = [
+  {
+    mimetype: 'application/node',
+    type: 'javascript/auto',
+  },
+  {
+    mimetype: 'application/json',
+    type: 'json',
+  },
+  {
+    mimetype: {
+      or: ['text/javascript', 'application/javascript'],
+    },
+    type: 'javascript/esm',
+    // ...
+  },
+  {
+    mimetype: 'application/wasm',
+    type: 'webassembly/async',
+    // ...
+  },
+];
+```
+
+### 自定义 Rules
+
+你可以也使用 [Rule.mimetype](/config/module#rulemimetype) 来扩展 Data URI 模块的匹配规则，例如为 `text/javascript` 添加自定义的 loaders：
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        mimetype: 'text/javascript',
+        use: [
+          // ...
+        ],
+      },
+    ],
+  },
+};
+```

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -1673,7 +1673,22 @@ export default {
 - **类型：** [`Condition`](/config/module#condition)
 - **默认值：** `undefined`
 
-匹配所有符合这个资源的模块，会和 Resource 的 mimetype 进行匹配。
+根据 [MIME 类型](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Guides/MIME_types)（而非文件扩展名）匹配模块。主要用于 [data URI 模块](/api/runtime-api/module-methods#data-uri-模块)（例如 `data:text/javascript,...`）。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        mimetype: 'text/javascript',
+        use: [
+          // ...
+        ],
+      },
+    ],
+  },
+};
+```
 
 ### Rule.descriptionData
 


### PR DESCRIPTION
## Summary

- Added a new section detailing built-in MIME type rules supported by Rspack, including examples of default MIME type handling for `application/json`, `text/javascript`, etc.
- Provided examples for extending MIME type matching rules using `Rule.mimetype`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
