### PR TITLE
chore(deps): remove loader-utils v2

### DIFF
--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -57,7 +57,6 @@
     "jest-diff": "^29.7.0",
     "jest-snapshot": "29.7.0",
     "jsdom": "^26.1.0",
-    "loader-utils": "^2.0.4",
     "memfs": "4.17.0",
     "path-serializer": "0.4.0",
     "pretty-format": "29.7.0",

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/inline-pitching/pitching-loader.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/inline-pitching/pitching-loader.js
@@ -1,8 +1,6 @@
-const { stringifyRequest } = require("loader-utils");
-
-module.exports = function () {};
+module.exports = function () { };
 module.exports.pitch = function (remainingRequest, precedingRequest, data) {
-	return `import { lib } from ${stringifyRequest(this, `!!${remainingRequest}`)}
+	return `import { lib } from ${JSON.stringify(this.utils.contextify(this.context, `!!${remainingRequest}`))}
 export const lib2 = "lib2";
 export { lib }`;
 };

--- a/packages/rspack-test-tools/tests/configCases/loader/rspack-issue-4838/node_modules/loader1.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/rspack-issue-4838/node_modules/loader1.js
@@ -1,6 +1,3 @@
-const { stringifyRequest } = require("loader-utils");
-const path = require("path");
-
 /** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	const opts = this.getOptions();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,9 +455,6 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
-      loader-utils:
-        specifier: ^2.0.4
-        version: 2.0.4
       memfs:
         specifier: 4.17.0
         version: 4.17.0
@@ -887,9 +884,6 @@ importers:
       less-loader:
         specifier: ^12.2.0
         version: 12.2.0(@rspack/core@packages+rspack)(less@4.3.0)(webpack@5.99.7(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      loader-utils:
-        specifier: ^2.0.4
-        version: 2.0.4
       memfs:
         specifier: ^4.17.0
         version: 4.17.0

--- a/tests/webpack-test/cases/loaders/issue-10725/loader.js
+++ b/tests/webpack-test/cases/loaders/issue-10725/loader.js
@@ -1,5 +1,3 @@
-const { getRemainingRequest, stringifyRequest } = require("loader-utils");
-
 const loaderPath = require.resolve("./loader");
 
 /** @type {import("@rspack/core").LoaderDefinition} */
@@ -14,9 +12,9 @@ export default answer;
 
 	const matchResource = `${this.resourcePath}.js`;
 	const loader = `${loaderPath}?load`;
-	const remaining = getRemainingRequest(this);
+	const remaining = this.remainingRequest;
 	const request = JSON.parse(
-		stringifyRequest(this, `${matchResource}!=!${loader}!${remaining}`)
+		this.utils.contextify(this.context, `${matchResource}!=!${loader}!${remaining}`)
 	);
 
 	this.async();

--- a/tests/webpack-test/cases/wasm/two-files-loader/wrapper-loader.js
+++ b/tests/webpack-test/cases/wasm/two-files-loader/wrapper-loader.js
@@ -1,12 +1,7 @@
-const stringifyRequest = require("loader-utils").stringifyRequest;
-
 /** @type {import("@rspack/core").PitchLoaderDefinitionFunction} */
 module.exports.pitch = function (remainingRequest) {
 	return `
-	import { getString as _getString, memory } from ${stringifyRequest(
-		this,
-		`${this.resourcePath}.wat!=!${remainingRequest}`
-	)};
+	import { getString as _getString, memory } from ${JSON.stringify(this.utils.contextify(this.context, `${this.resourcePath}.wat!=!${remainingRequest}`))};
 
 	export function getString() {
 		const strBuf = new Uint8Array(memory.buffer, _getString());

--- a/tests/webpack-test/cases/wasm/two-files-loader/wrapper-loader2.js
+++ b/tests/webpack-test/cases/wasm/two-files-loader/wrapper-loader2.js
@@ -1,12 +1,7 @@
-const stringifyRequest = require("loader-utils").stringifyRequest;
-
 /** @type {import("@rspack/core").PitchLoaderDefinitionFunction} */
 module.exports.pitch = function (remainingRequest) {
 	return `
-	import { getString as _getString, memory } from ${stringifyRequest(
-		this,
-		`${this.resourcePath}.wasm!=!wast-loader!${remainingRequest}`
-	)};
+	import { getString as _getString, memory } from ${JSON.stringify(this.utils.contextify(this.context, `${this.resourcePath}.wasm!=!wast-loader!${remainingRequest}`))};
 
 	export function getString() {
 		const strBuf = new Uint8Array(memory.buffer, _getString());

--- a/tests/webpack-test/configCases/loaders/issue-3320/node_modules/any-loader.js
+++ b/tests/webpack-test/configCases/loaders/issue-3320/node_modules/any-loader.js
@@ -1,8 +1,6 @@
-var loaderUtils = require('loader-utils');
-
-module.exports = function(source) {
+module.exports = function (source) {
 	var loaderContext = this;
-	var options = loaderUtils.getOptions(loaderContext);
+	var options = this.getOptions(loaderContext);
 
 	return "module.exports=" + JSON.stringify(options.foo);
 }

--- a/tests/webpack-test/package.json
+++ b/tests/webpack-test/package.json
@@ -27,7 +27,6 @@
     "is-ci": "4.1.0",
     "less": "4.3.0",
     "less-loader": "^12.2.0",
-    "loader-utils": "^2.0.4",
     "memfs": "^4.17.0",
     "mime-types": "^3.0.1",
     "mini-svg-data-uri": "^1.4.4",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`stringifyRequest` and `getRemainingRequest` has been removed in `loader-utils` v3, we can just remove `loader-utils` v2 and use Rspack built-in methods instead.

- close https://github.com/web-infra-dev/rspack/pull/9654
- https://github.com/webpack/loader-utils/releases/tag/v3.0.0

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
