### PR TITLE
fix: process warnings multiple times

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -351,8 +351,6 @@ export declare class JsResolverFactory {
 
 export declare class JsStats {
   toJson(jsOptions: JsStatsOptions): JsStatsCompilation
-  hasWarnings(): boolean
-  hasErrors(): boolean
   getLogging(acceptedTypes: number): Array<JsStatsLogging>
 }
 
@@ -1358,6 +1356,7 @@ export interface JsStatsSize {
 
 export interface JsStatsWarning {
   moduleDescriptor?: JsModuleDescriptor
+  name?: string
   message: string
   chunkName?: string
   chunkEntry?: boolean

--- a/crates/node_binding/src/stats.rs
+++ b/crates/node_binding/src/stats.rs
@@ -184,6 +184,7 @@ impl<'a> From<rspack_core::StatsError<'a>> for JsStatsError<'a> {
 pub struct JsStatsWarning<'a> {
   #[napi(ts_type = "JsModuleDescriptor")]
   pub module_descriptor: Option<JsModuleDescriptorWrapper<'a>>,
+  pub name: Option<String>,
   pub message: String,
   pub chunk_name: Option<&'a str>,
   pub chunk_entry: Option<bool>,
@@ -206,6 +207,7 @@ impl<'a> From<rspack_core::StatsWarning<'a>> for JsStatsWarning<'a> {
         }
         .into()
       }),
+      name: stats.name,
       message: stats.message,
       file: stats.file.map(|f| f.as_str()),
       chunk_name: stats.chunk_name,
@@ -1248,16 +1250,6 @@ impl JsStats {
         .collect::<Vec<_>>();
       unsafe { ToNapiValue::to_napi_value(env.raw(), val) }
     })
-  }
-
-  #[napi]
-  pub fn has_warnings(&self) -> bool {
-    !self.inner.get_warnings(|warnings| warnings.is_empty())
-  }
-
-  #[napi]
-  pub fn has_errors(&self) -> bool {
-    !self.inner.get_errors(|warnings| warnings.is_empty())
   }
 
   #[napi]

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -673,6 +673,7 @@ impl Stats<'_> {
         );
 
         StatsWarning {
+          name: d.code().map(|c| c.to_string()),
           message: diagnostic_displayer
             .emit_diagnostic(d)
             .expect("should print diagnostics"),

--- a/crates/rspack_core/src/stats/struct.rs
+++ b/crates/rspack_core/src/stats/struct.rs
@@ -57,6 +57,7 @@ pub struct StatsError<'a> {
 
 #[derive(Debug)]
 pub struct StatsWarning<'a> {
+  pub name: Option<String>,
   pub message: String,
   pub module_identifier: Option<ModuleIdentifier>,
   pub module_name: Option<Cow<'a, str>>,

--- a/packages/rspack-test-tools/tests/errorCases/warning-test-push.js
+++ b/packages/rspack-test-tools/tests/errorCases/warning-test-push.js
@@ -29,7 +29,7 @@ module.exports = {
 		      "moduleIdentifier": "<TEST_TOOLS_ROOT>/tests/fixtures/errors/require.main.require.js",
 		      "moduleName": "./require.main.require.js",
 		      "moduleTrace": Array [],
-		      "stack": undefined,
+		      "stack": "ModuleParseWarning:   ⚠ Module parse warning:\\n  ╰─▶   ⚠ Unsupported feature: require.main.require() is not supported by Rspack.\\n         ╭────\\n       1 │ require.main.require('./file');\\n         · ──────────────────────────────\\n         ╰────\\n      \\n\\n    at warningFromStatsWarning (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at Array.map (<anonymous>)\\n    at context.cachedGetWarnings (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at warnings (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at SyncBailHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at SyncBailHook.callStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at SyncBailHook.call (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>\\n    at StatsFactory._forEachLevel (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at StatsFactory._create (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at StatsFactory.create (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at Stats.toJson (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at ErrorProcessor.check (<TEST_TOOLS_ROOT>/dist/processor/error.js<LINE_COL>)\\n    at run (<TEST_TOOLS_ROOT>/dist/test/simple.js<LINE_COL>)\\n    at Object.<anonymous> (<TEST_TOOLS_ROOT>/dist/case/error.js<LINE_COL>)",
 		    },
 		  ],
 		}

--- a/packages/rspack-test-tools/tests/errorCases/warning-test-splice-2.js
+++ b/packages/rspack-test-tools/tests/errorCases/warning-test-splice-2.js
@@ -29,7 +29,7 @@ module.exports = {
 		      "moduleIdentifier": "<TEST_TOOLS_ROOT>/tests/fixtures/errors/require.main.require.js",
 		      "moduleName": "./require.main.require.js",
 		      "moduleTrace": Array [],
-		      "stack": undefined,
+		      "stack": "ModuleParseWarning:   ⚠ Module parse warning:\\n  ╰─▶   ⚠ Unsupported feature: require.main.require() is not supported by Rspack.\\n         ╭────\\n       1 │ require.main.require('./file');\\n         · ──────────────────────────────\\n         ╰────\\n      \\n\\n    at warningFromStatsWarning (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at Array.map (<anonymous>)\\n    at context.cachedGetWarnings (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at warnings (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at SyncBailHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at SyncBailHook.callStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at SyncBailHook.call (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>\\n    at StatsFactory._forEachLevel (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at StatsFactory._create (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at StatsFactory.create (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at Stats.toJson (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at ErrorProcessor.check (<TEST_TOOLS_ROOT>/dist/processor/error.js<LINE_COL>)\\n    at run (<TEST_TOOLS_ROOT>/dist/test/simple.js<LINE_COL>)\\n    at Object.<anonymous> (<TEST_TOOLS_ROOT>/dist/case/error.js<LINE_COL>)",
 		    },
 		  ],
 		}

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -794,7 +794,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	get warnings(): RspackError[] {
 		const inner = this.#inner;
 		type WarnType = Error | RspackError;
-		const processWarningsHook = this.hooks.processWarnings;
 		const warnings = inner.getWarnings();
 		const proxyMethod = [
 			{
@@ -804,16 +803,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					thisArg: Array<WarnType>,
 					warns: WarnType[]
 				) {
-					return Reflect.apply(
-						target,
-						thisArg,
-						processWarningsHook.call(warns as any).map(warn => {
-							inner.pushDiagnostic(
-								JsRspackDiagnostic.__to_binding(warn, JsRspackSeverity.Warn)
-							);
-							return warn;
-						})
-					);
+					for (const warn of warns) {
+						inner.pushDiagnostic(
+							JsRspackDiagnostic.__to_binding(warn, JsRspackSeverity.Warn)
+						);
+					}
+					return Reflect.apply(target, thisArg, warns);
 				}
 			},
 			{
@@ -840,18 +835,14 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					thisArg: Array<WarnType>,
 					warns: WarnType[]
 				) {
-					const warnings = processWarningsHook.call(warns as any);
 					inner.spliceDiagnostic(
 						0,
 						0,
-						warnings.map(warn => {
-							return JsRspackDiagnostic.__to_binding(
-								warn,
-								JsRspackSeverity.Warn
-							);
-						})
+						warns.map(warn =>
+							JsRspackDiagnostic.__to_binding(warn, JsRspackSeverity.Warn)
+						)
 					);
-					return Reflect.apply(target, thisArg, warnings);
+					return Reflect.apply(target, thisArg, warns);
 				}
 			},
 			{
@@ -861,10 +852,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					thisArg: Array<WarnType>,
 					[startIdx, delCount, ...warns]: [number, number, ...WarnType[]]
 				) {
-					warns = processWarningsHook.call(warns as any);
-					const warnList = warns.map(warn => {
-						return JsRspackDiagnostic.__to_binding(warn, JsRspackSeverity.Warn);
-					});
+					const warnList = warns.map(warn =>
+						JsRspackDiagnostic.__to_binding(warn, JsRspackSeverity.Warn)
+					);
 					inner.spliceDiagnostic(startIdx, startIdx + delCount, warnList);
 					return Reflect.apply(target, thisArg, [
 						startIdx,

--- a/packages/rspack/src/Stats.ts
+++ b/packages/rspack/src/Stats.ts
@@ -63,12 +63,21 @@ export class Stats {
 		return this.compilation.endTime;
 	}
 
-	hasErrors() {
-		return this.#inner.hasErrors();
+	hasErrors(): boolean {
+		return (
+			this.#compilation.errors.length > 0 ||
+			this.#compilation.children.some(child => child.getStats().hasErrors())
+		);
 	}
 
-	hasWarnings() {
-		return this.#inner.hasWarnings();
+	hasWarnings(): boolean {
+		const warnings = this.#compilation.hooks.processWarnings.call(
+			this.#compilation.warnings
+		);
+		return (
+			warnings.length > 0 ||
+			this.#compilation.children.some(child => child.getStats().hasWarnings())
+		);
 	}
 
 	toJson(opts?: StatsValue, forToString?: boolean): StatsCompilation {

--- a/packages/rspack/src/stats/statsFactoryUtils.ts
+++ b/packages/rspack/src/stats/statsFactoryUtils.ts
@@ -723,3 +723,12 @@ export const errorsSpaceLimit = (errors: StatsError[], max: number) => {
 		filtered
 	};
 };
+
+export const warningFromStatsWarning = (
+	warning: binding.JsStatsWarning
+): Error => {
+	const res = new Error(warning.message);
+	res.name = warning.name || "StatsWarning";
+	Object.assign(res, warning);
+	return res;
+};

--- a/tests/webpack-test/statsCases/ignore-warnings/test.filter.js
+++ b/tests/webpack-test/statsCases/ignore-warnings/test.filter.js
@@ -1,5 +1,0 @@
-const { FilteredStatus } = require("../../lib/util/filterUtil");
-
-module.exports = () => {
-	return [FilteredStatus.PARTIAL_PASS, "check the consistency with webpack "];
-};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix the wired behavior of  ignore warnings plugin in https://github.com/web-infra-dev/rspack/issues/10266
- not to process warning multiple times
- should create a error instance instead of plain object

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
