### PR TITLE
fix(html): not to override plugin options when using multiple instances

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -500,6 +500,7 @@ export interface JsAdditionalTreeRuntimeRequirementsResult {
 export interface JsAfterEmitData {
   outputName: string
   compilationId: number
+  uid?: number
 }
 
 export interface JsAfterResolveData {
@@ -519,6 +520,7 @@ export interface JsAfterTemplateExecutionData {
   bodyTags: Array<JsHtmlPluginTag>
   outputName: string
   compilationId: number
+  uid?: number
 }
 
 export interface JsAlterAssetTagGroupsData {
@@ -527,6 +529,7 @@ export interface JsAlterAssetTagGroupsData {
   publicPath: string
   outputName: string
   compilationId: number
+  uid?: number
 }
 
 export interface JsAlterAssetTagsData {
@@ -534,6 +537,7 @@ export interface JsAlterAssetTagsData {
   outputName: string
   publicPath: string
   compilationId: number
+  uid?: number
 }
 
 export interface JsAsset {
@@ -561,12 +565,14 @@ export interface JsBeforeAssetTagGenerationData {
   assets: JsHtmlPluginAssets
   outputName: string
   compilationId: number
+  uid?: number
 }
 
 export interface JsBeforeEmitData {
   html: string
   outputName: string
   compilationId: number
+  uid?: number
 }
 
 export interface JsBeforeResolveArgs {
@@ -1838,6 +1844,7 @@ export interface RawHtmlRspackPluginOptions {
   meta?: Record<string, Record<string, string>>
   hash?: boolean
   base?: RawHtmlRspackPluginBaseOptions
+  uid?: number
 }
 
 export interface RawHttpExternalsRspackPluginOptions {

--- a/crates/node_binding/src/html.rs
+++ b/crates/node_binding/src/html.rs
@@ -121,6 +121,7 @@ pub struct JsBeforeAssetTagGenerationData {
   pub assets: JsHtmlPluginAssets,
   pub output_name: String,
   pub compilation_id: u32,
+  pub uid: Option<u32>,
 }
 
 impl From<JsBeforeAssetTagGenerationData> for BeforeAssetTagGenerationData {
@@ -129,6 +130,7 @@ impl From<JsBeforeAssetTagGenerationData> for BeforeAssetTagGenerationData {
       assets: value.assets.into(),
       output_name: value.output_name,
       compilation_id: CompilationId(value.compilation_id),
+      uid: value.uid,
     }
   }
 }
@@ -139,6 +141,7 @@ impl From<BeforeAssetTagGenerationData> for JsBeforeAssetTagGenerationData {
       assets: value.assets.into(),
       output_name: value.output_name,
       compilation_id: value.compilation_id.0,
+      uid: value.uid,
     }
   }
 }
@@ -200,6 +203,7 @@ pub struct JsAlterAssetTagsData {
   pub output_name: String,
   pub public_path: String,
   pub compilation_id: u32,
+  pub uid: Option<u32>,
 }
 
 impl From<AlterAssetTagsData> for JsAlterAssetTagsData {
@@ -209,6 +213,7 @@ impl From<AlterAssetTagsData> for JsAlterAssetTagsData {
       output_name: value.output_name,
       public_path: value.public_path,
       compilation_id: value.compilation_id.0,
+      uid: value.uid,
     }
   }
 }
@@ -220,6 +225,7 @@ impl From<JsAlterAssetTagsData> for AlterAssetTagsData {
       output_name: value.output_name,
       public_path: value.public_path,
       compilation_id: CompilationId(value.compilation_id),
+      uid: value.uid,
     }
   }
 }
@@ -231,6 +237,7 @@ pub struct JsAlterAssetTagGroupsData {
   pub public_path: String,
   pub output_name: String,
   pub compilation_id: u32,
+  pub uid: Option<u32>,
 }
 
 impl From<AlterAssetTagGroupsData> for JsAlterAssetTagGroupsData {
@@ -249,6 +256,7 @@ impl From<AlterAssetTagGroupsData> for JsAlterAssetTagGroupsData {
       public_path: value.public_path,
       output_name: value.output_name,
       compilation_id: value.compilation_id.0,
+      uid: value.uid,
     }
   }
 }
@@ -269,6 +277,7 @@ impl From<JsAlterAssetTagGroupsData> for AlterAssetTagGroupsData {
       public_path: value.public_path,
       output_name: value.output_name,
       compilation_id: CompilationId(value.compilation_id),
+      uid: value.uid,
     }
   }
 }
@@ -280,6 +289,7 @@ pub struct JsAfterTemplateExecutionData {
   pub body_tags: Vec<JsHtmlPluginTag>,
   pub output_name: String,
   pub compilation_id: u32,
+  pub uid: Option<u32>,
 }
 
 impl From<AfterTemplateExecutionData> for JsAfterTemplateExecutionData {
@@ -298,6 +308,7 @@ impl From<AfterTemplateExecutionData> for JsAfterTemplateExecutionData {
         .collect::<Vec<_>>(),
       output_name: value.output_name,
       compilation_id: value.compilation_id.0,
+      uid: value.uid,
     }
   }
 }
@@ -318,6 +329,7 @@ impl From<JsAfterTemplateExecutionData> for AfterTemplateExecutionData {
         .collect::<Vec<_>>(),
       output_name: value.output_name,
       compilation_id: CompilationId(value.compilation_id),
+      uid: value.uid,
     }
   }
 }
@@ -327,6 +339,7 @@ pub struct JsBeforeEmitData {
   pub html: String,
   pub output_name: String,
   pub compilation_id: u32,
+  pub uid: Option<u32>,
 }
 
 impl From<BeforeEmitData> for JsBeforeEmitData {
@@ -335,6 +348,7 @@ impl From<BeforeEmitData> for JsBeforeEmitData {
       html: value.html,
       output_name: value.output_name,
       compilation_id: value.compilation_id.0,
+      uid: value.uid,
     }
   }
 }
@@ -345,6 +359,7 @@ impl From<JsBeforeEmitData> for BeforeEmitData {
       html: value.html,
       output_name: value.output_name,
       compilation_id: CompilationId(value.compilation_id),
+      uid: value.uid,
     }
   }
 }
@@ -353,6 +368,7 @@ impl From<JsBeforeEmitData> for BeforeEmitData {
 pub struct JsAfterEmitData {
   pub output_name: String,
   pub compilation_id: u32,
+  pub uid: Option<u32>,
 }
 
 impl From<AfterEmitData> for JsAfterEmitData {
@@ -360,6 +376,7 @@ impl From<AfterEmitData> for JsAfterEmitData {
     Self {
       output_name: value.output_name,
       compilation_id: value.compilation_id.0,
+      uid: value.uid,
     }
   }
 }
@@ -369,6 +386,7 @@ impl From<JsAfterEmitData> for AfterEmitData {
     Self {
       output_name: value.output_name,
       compilation_id: CompilationId(value.compilation_id),
+      uid: value.uid,
     }
   }
 }

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_html.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_html.rs
@@ -58,6 +58,7 @@ pub struct RawHtmlRspackPluginOptions {
   pub meta: Option<HashMap<String, HashMap<String, String>>>,
   pub hash: Option<bool>,
   pub base: Option<RawHtmlRspackPluginBaseOptions>,
+  pub uid: Option<u32>,
 }
 
 impl From<RawHtmlRspackPluginOptions> for HtmlRspackPluginOptions {
@@ -118,6 +119,7 @@ impl From<RawHtmlRspackPluginOptions> for HtmlRspackPluginOptions {
       meta: value.meta,
       hash: value.hash,
       base: value.base.map(|v| v.into()),
+      uid: value.uid,
     }
   }
 }

--- a/crates/rspack_plugin_html/src/config.rs
+++ b/crates/rspack_plugin_html/src/config.rs
@@ -176,6 +176,8 @@ pub struct HtmlRspackPluginOptions {
   pub meta: Option<HashMap<String, HashMap<String, String>>>,
   pub hash: Option<bool>,
   pub base: Option<HtmlRspackPluginBaseOptions>,
+  /// uid is used to identify the plugin instance on javascript side
+  pub uid: Option<u32>,
 }
 
 fn default_filename() -> Vec<String> {
@@ -215,6 +217,7 @@ impl Default for HtmlRspackPluginOptions {
       meta: None,
       hash: None,
       base: None,
+      uid: None,
     }
   }
 }

--- a/crates/rspack_plugin_html/src/drive.rs
+++ b/crates/rspack_plugin_html/src/drive.rs
@@ -11,6 +11,7 @@ pub struct BeforeAssetTagGenerationData {
   pub assets: HtmlPluginAssets,
   pub output_name: String,
   pub compilation_id: CompilationId,
+  pub uid: Option<u32>,
 }
 
 #[derive(Clone, Debug)]
@@ -19,6 +20,7 @@ pub struct AlterAssetTagsData {
   pub output_name: String,
   pub public_path: String,
   pub compilation_id: CompilationId,
+  pub uid: Option<u32>,
 }
 
 #[derive(Clone, Debug)]
@@ -28,6 +30,7 @@ pub struct AlterAssetTagGroupsData {
   pub public_path: String,
   pub output_name: String,
   pub compilation_id: CompilationId,
+  pub uid: Option<u32>,
 }
 
 #[derive(Clone, Debug)]
@@ -37,6 +40,7 @@ pub struct AfterTemplateExecutionData {
   pub body_tags: Vec<HtmlPluginTag>,
   pub output_name: String,
   pub compilation_id: CompilationId,
+  pub uid: Option<u32>,
 }
 
 #[derive(Clone, Debug)]
@@ -44,12 +48,14 @@ pub struct BeforeEmitData {
   pub html: String,
   pub output_name: String,
   pub compilation_id: CompilationId,
+  pub uid: Option<u32>,
 }
 
 #[derive(Clone, Debug)]
 pub struct AfterEmitData {
   pub output_name: String,
   pub compilation_id: CompilationId,
+  pub uid: Option<u32>,
 }
 
 define_hook!(HtmlPluginBeforeAssetTagGeneration: SeriesWaterfall(data: BeforeAssetTagGenerationData) -> BeforeAssetTagGenerationData);

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -86,6 +86,7 @@ async fn generate_html(
       assets: assets_info.0,
       output_name: html_file_name.as_str().to_string(),
       compilation_id: compilation.id(),
+      uid: config.uid,
     })
     .await?;
 
@@ -99,6 +100,7 @@ async fn generate_html(
       public_path: public_path.clone(),
       output_name: html_file_name.as_str().to_string(),
       compilation_id: compilation.id(),
+      uid: config.uid,
     })
     .await?;
 
@@ -113,6 +115,7 @@ async fn generate_html(
       public_path: public_path.clone(),
       output_name: html_file_name.as_str().to_string(),
       compilation_id: compilation.id(),
+      uid: config.uid,
     })
     .await?;
 
@@ -137,6 +140,7 @@ async fn generate_html(
       body_tags: alter_asset_tag_groups_data.body_tags,
       output_name: html_file_name.as_str().to_string(),
       compilation_id: compilation.id(),
+      uid: config.uid,
     })
     .await?;
 
@@ -237,6 +241,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         html,
         output_name: output_file_name.as_str().to_string(),
         compilation_id: compilation.id(),
+        uid: config.uid,
       })
       .await?;
 
@@ -266,6 +271,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       .call(AfterEmitData {
         output_name: html_asset.0.to_string(),
         compilation_id: compilation.id(),
+        uid: config.uid,
       })
       .await?;
   }

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-custom-options/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-custom-options/index.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+const path = require("path");
+
+it("html template content", () => {
+	const htmlPath = path.join(__dirname, "./index.html");
+	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
+	expect(htmlContent.includes("<div>production</div>")).toBe(true);
+});
+

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-custom-options/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-custom-options/rspack.config.js
@@ -1,0 +1,31 @@
+const { rspack } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			templateContent:
+				"<!DOCTYPE html><html><body><div><%= env %></div></body></html>",
+			templateParameters: {
+				env: "production"
+			},
+			filename: "index.html",
+			customOptions: {
+				property: "value"
+			}
+		}),
+		{
+			apply: compiler => {
+				compiler.hooks.thisCompilation.tap("HtmlRspackPlugin", compilation => {
+					const hooks =
+						rspack.HtmlRspackPlugin.getCompilationHooks(compilation);
+					hooks.beforeEmit.tap("HtmlRspackPlugin", htmlPluginData => {
+						expect(htmlPluginData.plugin.options.customOptions.property).toBe(
+							"value"
+						);
+					});
+				});
+			}
+		}
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-multiple-options/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-multiple-options/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+it("html template content", () => {
+	const htmlPath = path.join(__dirname, "./index.html");
+	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
+	expect(htmlContent.includes("<div>production</div>")).toBe(true);
+});
+
+it("html template content", () => {
+	const htmlPath = path.join(__dirname, "./index2.html");
+	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
+	expect(htmlContent.includes("<div>development</div>")).toBe(true);
+});

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-multiple-options/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-multiple-options/rspack.config.js
@@ -1,0 +1,42 @@
+const { rspack } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			templateContent:
+				"<!DOCTYPE html><html><body><div><%= env %></div></body></html>",
+			templateParameters: {
+				env: "production"
+			},
+			filename: "index.html"
+		}),
+		new rspack.HtmlRspackPlugin({
+			templateContent:
+				"<!DOCTYPE html><html><body><div><%= env %></div></body></html>",
+			templateParameters: {
+				env: "development"
+			},
+			filename: "index2.html"
+		}),
+		{
+			apply: compiler => {
+				compiler.hooks.thisCompilation.tap("HtmlRspackPlugin", compilation => {
+					const hooks =
+						rspack.HtmlRspackPlugin.getCompilationHooks(compilation);
+					let index = 0;
+					hooks.beforeEmit.tap("HtmlRspackPlugin", htmlPluginData => {
+						if (index === 0) {
+							expect(htmlPluginData.plugin.options.filename).toBe("index.html");
+						} else {
+							expect(htmlPluginData.plugin.options.filename).toBe(
+								"index2.html"
+							);
+						}
+						index++;
+					});
+				});
+			}
+		}
+	]
+};

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3005,7 +3005,6 @@ export type HotUpdateMainFilename = FilenameTemplate;
 export const HtmlRspackPlugin: typeof HtmlRspackPluginImpl & {
     getHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
     getCompilationHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
-    getCompilationOptions: (compilation: Compilation) => HtmlRspackPluginOptions | void;
     createHtmlTagObject: (tagName: string, attributes?: Record<string, string | boolean>, innerHTML?: string | undefined) => JsHtmlPluginTag;
     version: number;
 };
@@ -3015,7 +3014,9 @@ type HtmlRspackPluginHooks = {
     beforeAssetTagGeneration: liteTapable.AsyncSeriesWaterfallHook<[
     JsBeforeAssetTagGenerationData & ExtraPluginHookData
     ]>;
-    alterAssetTags: liteTapable.AsyncSeriesWaterfallHook<[JsAlterAssetTagsData]>;
+    alterAssetTags: liteTapable.AsyncSeriesWaterfallHook<[
+    JsAlterAssetTagsData & ExtraPluginHookData
+    ]>;
     alterAssetTagGroups: liteTapable.AsyncSeriesWaterfallHook<[
     JsAlterAssetTagGroupsData & ExtraPluginHookData
     ]>;
@@ -3063,6 +3064,7 @@ export type HtmlRspackPluginOptions = {
     favicon?: string;
     meta?: Record<string, string | Record<string, string>>;
     hash?: boolean;
+    [key: string]: any;
 };
 
 // @public (undocumented)

--- a/packages/rspack/src/builtin-plugin/html-plugin/hooks.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/hooks.ts
@@ -23,7 +23,9 @@ export type HtmlRspackPluginHooks = {
 	beforeAssetTagGeneration: liteTapable.AsyncSeriesWaterfallHook<
 		[JsBeforeAssetTagGenerationData & ExtraPluginHookData]
 	>;
-	alterAssetTags: liteTapable.AsyncSeriesWaterfallHook<[JsAlterAssetTagsData]>;
+	alterAssetTags: liteTapable.AsyncSeriesWaterfallHook<
+		[JsAlterAssetTagsData & ExtraPluginHookData]
+	>;
 	alterAssetTagGroups: liteTapable.AsyncSeriesWaterfallHook<
 		[JsAlterAssetTagGroupsData & ExtraPluginHookData]
 	>;

--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -113,6 +113,11 @@ export type HtmlRspackPluginOptions = {
 	 * If `true` then append a unique Rspack compilation hash to all included scripts and CSS files. This is useful for cache busting.
 	 */
 	hash?: boolean;
+
+	/**
+	 * Any other options will be passed by hooks.
+	 */
+	[key: string]: any;
 };
 
 const templateFilenameFunction = z
@@ -120,7 +125,7 @@ const templateFilenameFunction = z
 	.args(z.string())
 	.returns(z.string());
 
-const pluginOptionsSchema = z.strictObject({
+const pluginOptionsSchema = z.object({
 	filename: z.string().or(templateFilenameFunction).optional(),
 	template: z
 		.string()
@@ -167,22 +172,31 @@ export function validateHtmlPluginOptions(options: HtmlRspackPluginOptions) {
 	return validate(options, pluginOptionsSchema);
 }
 
-export const getPluginOptions = (compilation: Compilation) => {
+export const getPluginOptions = (compilation: Compilation, uid: number) => {
 	if (!(compilation instanceof Compilation)) {
 		throw new TypeError(
 			"The 'compilation' argument must be an instance of Compilation"
 		);
 	}
-	return compilationOptionsMap.get(compilation);
+	return compilationOptionsMap.get(compilation)?.[uid];
 };
 
 export const setPluginOptions = (
 	compilation: Compilation,
+	uid: number,
 	options: HtmlRspackPluginOptions
 ) => {
-	compilationOptionsMap.set(compilation, options);
+	const optionsMap = compilationOptionsMap.get(compilation) || {};
+	optionsMap[uid] = options;
+	compilationOptionsMap.set(compilation, optionsMap);
 };
 
-export const cleanPluginOptions = (compilation: Compilation) => {
-	compilationOptionsMap.delete(compilation);
+export const cleanPluginOptions = (compilation: Compilation, uid: number) => {
+	const optionsMap = compilationOptionsMap.get(compilation) || {};
+	delete optionsMap[uid];
+	if (Object.keys(optionsMap).length === 0) {
+		compilationOptionsMap.delete(compilation);
+	} else {
+		compilationOptionsMap.set(compilation, optionsMap);
+	}
 };

--- a/packages/rspack/src/builtin-plugin/html-plugin/taps.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/taps.ts
@@ -1,10 +1,14 @@
 import * as binding from "@rspack/binding";
 import type { CreatePartialRegisters } from "../../taps/types";
+import { type HtmlRspackPluginOptions, getPluginOptions } from "./options";
 import { HtmlRspackPlugin } from "./plugin";
 
 export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 	`HtmlPlugin`
 > = (getCompiler, createTap, createMapTap) => {
+	const getOptions = (uid: number): HtmlRspackPluginOptions => {
+		return getPluginOptions(getCompiler().__internal__get_compilation()!, uid)!;
+	};
 	return {
 		registerHtmlPluginBeforeAssetTagGenerationTaps: createTap(
 			binding.RegisterJsTapKind.HtmlPluginBeforeAssetTagGeneration,
@@ -15,17 +19,15 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsBeforeAssetTagGenerationData) {
-					const compilationId = data.compilationId;
+					const { compilationId, uid } = data;
 					const res = await queried.promise({
 						...data,
 						plugin: {
-							options:
-								HtmlRspackPlugin.getCompilationOptions(
-									getCompiler().__internal__get_compilation()!
-								) || {}
+							options: getOptions(uid!)
 						}
 					});
 					res.compilationId = compilationId;
+					res.uid = uid;
 					return res;
 				};
 			}
@@ -39,9 +41,15 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsAlterAssetTagsData) {
-					const compilationId = data.compilationId;
-					const res = await queried.promise(data);
+					const { compilationId, uid } = data;
+					const res = await queried.promise({
+						...data,
+						plugin: {
+							options: getOptions(uid!)
+						}
+					});
 					res.compilationId = compilationId;
+					res.uid = uid;
 					return res;
 				};
 			}
@@ -55,17 +63,15 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsAlterAssetTagGroupsData) {
-					const compilationId = data.compilationId;
+					const { compilationId, uid } = data;
 					const res = await queried.promise({
 						...data,
 						plugin: {
-							options:
-								HtmlRspackPlugin.getCompilationOptions(
-									getCompiler().__internal__get_compilation()!
-								) || {}
+							options: getOptions(uid!)
 						}
 					});
 					res.compilationId = compilationId;
+					res.uid = uid;
 					return res;
 				};
 			}
@@ -79,14 +85,11 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsAfterTemplateExecutionData) {
-					const compilationId = data.compilationId;
+					const { compilationId, uid } = data;
 					const res = await queried.promise({
 						...data,
 						plugin: {
-							options:
-								HtmlRspackPlugin.getCompilationOptions(
-									getCompiler().__internal__get_compilation()!
-								) || {}
+							options: getOptions(uid!)
 						}
 					});
 					res.compilationId = compilationId;
@@ -103,17 +106,15 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsBeforeEmitData) {
-					const compilationId = data.compilationId;
+					const { compilationId, uid } = data;
 					const res = await queried.promise({
 						...data,
 						plugin: {
-							options:
-								HtmlRspackPlugin.getCompilationOptions(
-									getCompiler().__internal__get_compilation()!
-								) || {}
+							options: getOptions(uid!)
 						}
 					});
 					res.compilationId = compilationId;
+					res.uid = uid;
 					return res;
 				};
 			}
@@ -127,17 +128,15 @@ export const createHtmlPluginHooksRegisters: CreatePartialRegisters<
 			},
 			function (queried) {
 				return async function (data: binding.JsAfterEmitData) {
-					const compilationId = data.compilationId;
+					const { compilationId, uid } = data;
 					const res = await queried.promise({
 						...data,
 						plugin: {
-							options:
-								HtmlRspackPlugin.getCompilationOptions(
-									getCompiler().__internal__get_compilation()!
-								) || {}
+							options: getOptions(uid!)
 						}
 					});
 					res.compilationId = compilationId;
+					res.uid = uid;
 					return res;
 				};
 			}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Using `compilationId` to obtain plugin options will lead to overriding when using multiple plugin instances.
- add uid to plugin options to make sure the javascript side can obtain the correct one when calling hooks
- allow passing extra plugin options. The csp plugin depends on this feature.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
