### PR TITLE
feat: expose hasChunkEntryDependentChunks on ChunkGraph

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -177,6 +177,7 @@ export declare class JsChunk {
 }
 
 export declare class JsChunkGraph {
+  hasChunkEntryDependentChunks(chunk: JsChunk): boolean
   getChunkModules(chunk: JsChunk): Module[]
   getChunkEntryModules(chunk: JsChunk): Module[]
   getNumberOfEntryModules(chunk: JsChunk): number

--- a/crates/node_binding/src/chunk_graph.rs
+++ b/crates/node_binding/src/chunk_graph.rs
@@ -40,6 +40,16 @@ impl JsChunkGraph {
 
 #[napi]
 impl JsChunkGraph {
+  #[napi(ts_return_type = "boolean")]
+  pub fn has_chunk_entry_dependent_chunks(&self, chunk: &JsChunk) -> Result<bool> {
+    let compilation = self.as_ref()?;
+    Ok(
+      compilation
+        .chunk_graph
+        .has_chunk_entry_dependent_chunks(&chunk.chunk_ukey, &compilation.chunk_group_by_ukey),
+    )
+  }
+
   #[napi(ts_return_type = "Module[]")]
   pub fn get_chunk_modules(&self, chunk: &JsChunk) -> Result<Vec<ModuleObject>> {
     let compilation = self.as_ref()?;

--- a/packages/rspack/src/ChunkGraph.ts
+++ b/packages/rspack/src/ChunkGraph.ts
@@ -17,6 +17,10 @@ export class ChunkGraph {
 		this.#inner = binding;
 	}
 
+	hasChunkEntryDependentChunks(chunk: Chunk): boolean {
+		return this.#inner.hasChunkEntryDependentChunks(Chunk.__to_binding(chunk));
+	}
+
 	getChunkModules(chunk: Chunk): ReadonlyArray<Module> {
 		return this.#inner.getChunkModules(Chunk.__to_binding(chunk));
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
While Webpack provides `hasChunkEntryDependentChunks` method in its `ChunkGraph`, this functionality is missing in Rspack's `JsChunkGraph`. Although we have already implemented the underlying logic in `chunk_graph_chunk.rs`, it hasn't been exposed to the JavaScript interface.

This PR aims to expose this method to support the implementation of `StartupChunkDependenciesRuntimeModule`, which is crucial for fixing chunk splitting issues in Rspeedy.

Related links:
- https://github.com/web-infra-dev/rspack/blob/main/crates/node_binding/binding.d.ts#L179
- https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs#L682
- https://github.com/webpack/webpack/blob/main/lib/ChunkGraph.js#L1243
- https://github.com/webpack/webpack/blob/0f42dc5b8bbfbc71f5550fe1c2e9b2edf38b4c25/lib/runtime/StartupChunkDependenciesPlugin.js#L59
- https://github.com/lynx-family/lynx-stack/pull/705
- https://github.com/lynx-family/lynx-stack/pull/658

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
