### PR TITLE
fix(types): export PitchLoaderDefinitionFunction type

### DIFF
--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -37,6 +37,7 @@ import {
 	type LoaderContext,
 	type LoaderDefinition,
 	type LoaderDefinitionFunction,
+	type PitchLoaderDefinitionFunction,
 	createRawModuleRuleUses
 } from "./adapterRuleUse";
 import type {
@@ -70,7 +71,12 @@ import type {
 	StatsValue
 } from "./types";
 
-export type { LoaderContext, LoaderDefinition, LoaderDefinitionFunction };
+export type {
+	LoaderContext,
+	LoaderDefinition,
+	LoaderDefinitionFunction,
+	PitchLoaderDefinitionFunction
+};
 
 // invariant: `options` is normalized with default value applied
 export const getRawOptions = (


### PR DESCRIPTION
## Summary

When building a loader I noticed that `PitchLoaderDefinitionFunction` is not exported from `@rspack/core` so I updated the code to fix that. I see some JSDoc comments reference that type so this is technically a fix for those. Example:

https://github.com/web-infra-dev/rspack/blob/87ff2360a85d17d754868c112f7c77d7ec85e2a7/tests/webpack-test/configCases/css/css-auto/loader.js#L1-L2

Thanks!

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
