### PR TITLE
fix: allow the SRI plugin to be used without passing options

### DIFF
--- a/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
@@ -113,7 +113,7 @@ export class SubresourceIntegrityPlugin extends NativeSubresourceIntegrityPlugin
 	private integrities: Map<string, string> = new Map();
 	private options: SubresourceIntegrityPluginOptions;
 	private validateError: Error | null = null;
-	constructor(options: SubresourceIntegrityPluginOptions) {
+	constructor(options: SubresourceIntegrityPluginOptions = {}) {
 		let validateError: Error | null = null;
 		if (typeof options !== "object") {
 			throw new Error("SubResourceIntegrity: argument must be an object");


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

allow the SRI plugin to be used without passing options, use `{}` by default

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
