### PR TITLE
perf: import node inspector dynamically

### DIFF
--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -355,7 +355,7 @@ interface Experiments {
 export const experiments: Experiments = {
 	globalTrace: {
 		async register(filter, layer, output) {
-			JavaScriptTracer.initJavaScriptTrace(layer, output);
+			await JavaScriptTracer.initJavaScriptTrace(layer, output);
 			registerGlobalTrace(filter, layer, output);
 			// lazy init cpuProfiler to make sure js and rust's timestamp is much aligned
 			JavaScriptTracer.initCpuProfiler();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Import node inspector module dynamically to:

- Be compatible with Node.js that has been built with the [--without-inspector](https://github.com/nodejs/node/blob/5f252a45bc4db17b1ba41a747a2dc1a63ed7dbae/configure.py#L899C22-L899C41) flag.
- Improve startup performance.

Related issue:

https://github.com/web-infra-dev/rsbuild/issues/5193#issuecomment-2862026133

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
