### PR TITLE
fix(template-react-ts): work with newer Node

### DIFF
--- a/packages/create-rspack/template-react-js/package.json
+++ b/packages/create-rspack/template-react-js/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/plugin-react-refresh": "^1.4.1",
+    "@rspack/plugin-react-refresh": "^1.4.3",
     "@types/react": "^19.1.3",
     "@types/react-dom": "^19.1.3",
     "react-refresh": "^0.17.0"

--- a/packages/create-rspack/template-react-js/rspack.config.mjs
+++ b/packages/create-rspack/template-react-js/rspack.config.mjs
@@ -2,13 +2,13 @@ import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "@rspack/cli";
 import { rspack } from "@rspack/core";
-import RefreshPlugin from "@rspack/plugin-react-refresh";
+import { ReactRefreshRspackPlugin } from "@rspack/plugin-react-refresh";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV === "development";
 
 // Target browsers, see: https://github.com/browserslist/browserslist
-const targets = ["last 2 versions", "> 0.2%",  "not dead",  "Firefox ESR"];
+const targets = ["last 2 versions", "> 0.2%", "not dead", "Firefox ESR"];
 
 export default defineConfig({
 	context: __dirname,
@@ -54,7 +54,7 @@ export default defineConfig({
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
 		}),
-		isDev ? new RefreshPlugin() : null
+		isDev ? new ReactRefreshRspackPlugin() : null
 	].filter(Boolean),
 	optimization: {
 		minimizer: [

--- a/packages/create-rspack/template-react-ts/package.json
+++ b/packages/create-rspack/template-react-ts/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/plugin-react-refresh": "^1.4.1",
+    "@rspack/plugin-react-refresh": "^1.4.3",
     "@types/react": "^19.1.3",
     "@types/react-dom": "^19.1.3",
     "react-refresh": "^0.17.0",

--- a/packages/create-rspack/template-react-ts/rspack.config.ts
+++ b/packages/create-rspack/template-react-ts/rspack.config.ts
@@ -1,14 +1,13 @@
 import { defineConfig } from "@rspack/cli";
 import { rspack } from "@rspack/core";
-import * as RefreshPlugin from "@rspack/plugin-react-refresh";
+import { ReactRefreshRspackPlugin } from "@rspack/plugin-react-refresh";
 
 const isDev = process.env.NODE_ENV === "development";
 
 // Target browsers, see: https://github.com/browserslist/browserslist
-const targets = ["last 2 versions", "> 0.2%",  "not dead",  "Firefox ESR"];
+const targets = ["last 2 versions", "> 0.2%", "not dead", "Firefox ESR"];
 
 export default defineConfig({
-	context: __dirname,
 	entry: {
 		main: "./src/main.tsx"
 	},
@@ -51,7 +50,7 @@ export default defineConfig({
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
 		}),
-		isDev ? new RefreshPlugin() : null
+		isDev ? new ReactRefreshRspackPlugin() : null
 	].filter(Boolean),
 	optimization: {
 		minimizer: [

--- a/packages/create-rspack/template-vue-js/rspack.config.mjs
+++ b/packages/create-rspack/template-vue-js/rspack.config.mjs
@@ -7,10 +7,9 @@ import { VueLoaderPlugin } from "vue-loader";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Target browsers, see: https://github.com/browserslist/browserslist
-const targets = ["last 2 versions", "> 0.2%",  "not dead",  "Firefox ESR"];
+const targets = ["last 2 versions", "> 0.2%", "not dead", "Firefox ESR"];
 
 export default defineConfig({
-	context: __dirname,
 	entry: {
 		main: "./src/main.js"
 	},

--- a/packages/create-rspack/template-vue-ts/rspack.config.ts
+++ b/packages/create-rspack/template-vue-ts/rspack.config.ts
@@ -3,10 +3,9 @@ import { type RspackPluginFunction, rspack } from "@rspack/core";
 import { VueLoaderPlugin } from "vue-loader";
 
 // Target browsers, see: https://github.com/browserslist/browserslist
-const targets = ["last 2 versions", "> 0.2%",  "not dead",  "Firefox ESR"];
+const targets = ["last 2 versions", "> 0.2%", "not dead", "Firefox ESR"];
 
 export default defineConfig({
-	context: __dirname,
 	entry: {
 		main: "./src/main.ts"
 	},

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -71,7 +71,7 @@
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
     "@rspack/plugin-preact-refresh": "1.1.2",
-    "@rspack/plugin-react-refresh": "^1.4.1",
+    "@rspack/plugin-react-refresh": "^1.4.3",
     "@rspack/test-tools": "workspace:*",
     "@swc/helpers": "0.5.17",
     "@swc/plugin-remove-console": "^7.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: workspace:*
         version: link:../../rspack
       '@rspack/plugin-react-refresh':
-        specifier: ^1.4.1
-        version: 1.4.2(react-refresh@0.17.0)
+        specifier: ^1.4.3
+        version: 1.4.3(react-refresh@0.17.0)
       '@types/react':
         specifier: ^19.1.3
         version: 19.1.3
@@ -197,8 +197,8 @@ importers:
         specifier: workspace:*
         version: link:../../rspack
       '@rspack/plugin-react-refresh':
-        specifier: ^1.4.1
-        version: 1.4.2(react-refresh@0.17.0)
+        specifier: ^1.4.3
+        version: 1.4.3(react-refresh@0.17.0)
       '@types/react':
         specifier: ^19.1.3
         version: 19.1.3
@@ -493,8 +493,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2(@prefresh/core@1.5.2(preact@10.23.2))(@prefresh/utils@1.2.0)
       '@rspack/plugin-react-refresh':
-        specifier: ^1.4.1
-        version: 1.4.2(react-refresh@0.17.0)
+        specifier: ^1.4.3
+        version: 1.4.3(react-refresh@0.17.0)
       '@rspack/test-tools':
         specifier: workspace:*
         version: 'link:'
@@ -662,8 +662,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack
       '@rspack/plugin-react-refresh':
-        specifier: ^1.4.1
-        version: 1.4.2(react-refresh@0.17.0)
+        specifier: ^1.4.3
+        version: 1.4.3(react-refresh@0.17.0)
       '@types/react':
         specifier: ^19.1.3
         version: 19.1.3
@@ -692,8 +692,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1(@rspack/core@packages+rspack)(@types/express@4.17.21)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
       '@rspack/plugin-react-refresh':
-        specifier: ^1.4.1
-        version: 1.4.2(react-refresh@0.17.0)
+        specifier: ^1.4.3
+        version: 1.4.3(react-refresh@0.17.0)
       '@swc/helpers':
         specifier: 0.5.17
         version: 0.5.17
@@ -2747,8 +2747,8 @@ packages:
       '@prefresh/core': ^1.5.0
       '@prefresh/utils': ^1.2.0
 
-  '@rspack/plugin-react-refresh@1.4.2':
-    resolution: {integrity: sha512-SZetmR5PdWbBal9ln4U0MAWaZyAsZlZ2u+EGkZcVtKklW7Bil77QQs00cwS303JsXWnxyeTHDAAf0fzaWbltgQ==}
+  '@rspack/plugin-react-refresh@1.4.3':
+    resolution: {integrity: sha512-wZx4vWgy5oMEvgyNGd/oUKcdnKaccYWHCRkOqTdAPJC3WcytxhTX+Kady8ERurSBiLyQpoMiU3Iyd+F1Y2Arbw==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
       webpack-hot-middleware: 2.x
@@ -9587,7 +9587,7 @@ snapshots:
   '@rsbuild/plugin-react@1.3.1(@rsbuild/core@1.3.16)':
     dependencies:
       '@rsbuild/core': 1.3.16
-      '@rspack/plugin-react-refresh': 1.4.2(react-refresh@0.17.0)
+      '@rspack/plugin-react-refresh': 1.4.3(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
       - webpack-hot-middleware
@@ -9755,7 +9755,7 @@ snapshots:
       '@prefresh/core': 1.5.2(preact@10.23.2)
       '@prefresh/utils': 1.2.0
 
-  '@rspack/plugin-react-refresh@1.4.2(react-refresh@0.17.0)':
+  '@rspack/plugin-react-refresh@1.4.3(react-refresh@0.17.0)':
     dependencies:
       error-stack-parser: 2.1.4
       html-entities: 2.6.0

--- a/tests/bench/package.json
+++ b/tests/bench/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "bench",
-    "private": true,
-    "license": "MIT",
-    "type": "module",
-    "scripts": {
-        "bench": "vitest bench --run"
-    },
-    "devDependencies": {
-        "@codspeed/vitest-plugin": "^4.0.1",
-        "@rspack/cli": "workspace:*",
-        "@rspack/core": "workspace:*",
-        "@rspack/plugin-react-refresh": "^1.4.1",
-        "@types/react": "^19.1.3",
-        "@types/react-dom": "^19.1.3",
-        "vitest": "^3.1.3"
-    },
-    "dependencies": {
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
-    }
+  "name": "bench",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "bench": "vitest bench --run"
+  },
+  "devDependencies": {
+    "@codspeed/vitest-plugin": "^4.0.1",
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*",
+    "@rspack/plugin-react-refresh": "^1.4.3",
+    "@types/react": "^19.1.3",
+    "@types/react-dom": "^19.1.3",
+    "vitest": "^3.1.3"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  }
 }

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -13,7 +13,7 @@
     "core-js": "3.42.0",
     "@rspack/core": "workspace:*",
     "@rspack/dev-server": "1.1.1",
-    "@rspack/plugin-react-refresh": "^1.4.1",
+    "@rspack/plugin-react-refresh": "^1.4.3",
     "@swc/helpers": "0.5.17",
     "@types/fs-extra": "11.0.4",
     "babel-loader": "^10.0.0",


### PR DESCRIPTION

Summary:
On my machine running Node v23.11.0, running this example fails with two errors:
1. `__dirname` is undefined
2. `RefreshPlugin` is an object instead of a class

This commit fixes both of these errors.

Test Plan:
1. use Node v23.11.0
2. run `pnpm create rspack@latest`
3. select react-typescript config
4. run `pnpm run dev`

Before this commit: it doesn't work
After this commit: it works
