### PR TITLE
fix: not evaluate `typeof __dirname` when set to false

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -170,6 +170,14 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'static>> {
+    if parser
+      .compiler_options
+      .node
+      .as_ref()
+      .is_some_and(|node_option| matches!(node_option.dirname, NodeDirnameOption::False))
+    {
+      return None;
+    }
     if ident == DIR_NAME {
       Some(eval::evaluate_to_string(
         get_context(parser.resource_data).as_str().to_string(),

--- a/tests/webpack-test/configCases/parsing/issue-9042/index.js
+++ b/tests/webpack-test/configCases/parsing/issue-9042/index.js
@@ -1,4 +1,4 @@
-it("should not evaluate __dirname or __filename when set to false", function(done) {
+it("should not evaluate __dirname or __filename when set to false", function (done) {
 	if (typeof __dirname !== "undefined") {
 		done.fail();
 	}

--- a/tests/webpack-test/configCases/parsing/issue-9042/test.filter.js
+++ b/tests/webpack-test/configCases/parsing/issue-9042/test.filter.js
@@ -1,2 +1,0 @@
-// TODO: Should create a issue for this test
-module.exports = () => { return false }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should not evaluate `typeof __dirname` when `node.__dirname` is set to false

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
