### PR TITLE
feat(swc): enhance TransformOutput with diagnostics

### DIFF
--- a/crates/rspack_javascript_compiler/src/compiler/mod.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/mod.rs
@@ -6,7 +6,7 @@ pub mod stringify;
 pub mod transform;
 
 use rspack_sources::SourceMap;
-use swc_core::common::{Globals, SourceMap as SwcSourceMap, GLOBALS};
+use swc_core::common::{GLOBALS, Globals, SourceMap as SwcSourceMap};
 
 #[derive(Default)]
 /// JavaScriptCompiler is a struct that represents a JavaScript compiler instance.

--- a/crates/rspack_javascript_compiler/src/compiler/mod.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/mod.rs
@@ -6,7 +6,7 @@ pub mod stringify;
 pub mod transform;
 
 use rspack_sources::SourceMap;
-use swc_core::common::{GLOBALS, Globals, SourceMap as SwcSourceMap};
+use swc_core::common::{Globals, SourceMap as SwcSourceMap, GLOBALS};
 
 #[derive(Default)]
 /// JavaScriptCompiler is a struct that represents a JavaScript compiler instance.
@@ -32,6 +32,19 @@ impl JavaScriptCompiler {
 
 #[derive(Debug)]
 pub struct TransformOutput {
+  /// The transformed code
   pub code: String,
+
+  /// The source map for the transformed code
   pub map: Option<SourceMap>,
+
+  /// The warning diagnostics for the transformed code
+  pub diagnostics: Vec<String>,
+}
+
+impl TransformOutput {
+  pub fn with_diagnostics(mut self, diagnostics: Vec<String>) -> Self {
+    self.diagnostics = diagnostics;
+    self
+  }
 }

--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -1,22 +1,23 @@
 use std::sync::Arc;
 
-use rspack_error::{Error, miette::IntoDiagnostic};
-use rspack_sources::{Mapping, OriginalLocation, encode_mappings};
+use rspack_error::{miette::IntoDiagnostic, Error};
+use rspack_sources::{encode_mappings, Mapping, OriginalLocation};
 use rustc_hash::FxHashMap;
 use swc_core::{
   base::{config::JsMinifyFormatOptions, sourcemap},
   common::{
-    BytePos, FileName, SourceMap as SwcSourceMap, comments::Comments,
-    source_map::SourceMapGenConfig,
+    comments::Comments, source_map::SourceMapGenConfig, BytePos, FileName,
+    SourceMap as SwcSourceMap,
   },
   ecma::{
     ast::{EsVersion, Ident, Program as SwcProgram},
     atoms::Atom,
     codegen::{
-      self, Emitter, Node,
+      self,
       text_writer::{self, WriteJs},
+      Emitter, Node,
     },
-    visit::{Visit, VisitWith, noop_visit_type},
+    visit::{noop_visit_type, Visit, VisitWith},
   },
 };
 
@@ -209,7 +210,11 @@ impl JavaScriptCompiler {
       None
     };
 
-    Ok(TransformOutput { code: src, map })
+    Ok(TransformOutput {
+      code: src,
+      map,
+      diagnostics: Default::default(),
+    })
   }
 }
 

--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -1,23 +1,22 @@
 use std::sync::Arc;
 
-use rspack_error::{miette::IntoDiagnostic, Error};
-use rspack_sources::{encode_mappings, Mapping, OriginalLocation};
+use rspack_error::{Error, miette::IntoDiagnostic};
+use rspack_sources::{Mapping, OriginalLocation, encode_mappings};
 use rustc_hash::FxHashMap;
 use swc_core::{
   base::{config::JsMinifyFormatOptions, sourcemap},
   common::{
-    comments::Comments, source_map::SourceMapGenConfig, BytePos, FileName,
-    SourceMap as SwcSourceMap,
+    BytePos, FileName, SourceMap as SwcSourceMap, comments::Comments,
+    source_map::SourceMapGenConfig,
   },
   ecma::{
     ast::{EsVersion, Ident, Program as SwcProgram},
     atoms::Atom,
     codegen::{
-      self,
+      self, Emitter, Node,
       text_writer::{self, WriteJs},
-      Emitter, Node,
     },
-    visit::{noop_visit_type, Visit, VisitWith},
+    visit::{Visit, VisitWith, noop_visit_type},
   },
 };
 

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -12,31 +12,32 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use base64::prelude::*;
 use indoc::formatdoc;
 use jsonc_parser::parse_to_serde_value;
-use rspack_error::{miette::MietteDiagnostic, AnyhowResultToRspackResultExt, Error};
+use rspack_error::{AnyhowResultToRspackResultExt, Error, miette::MietteDiagnostic};
 use rspack_util::{itoa, source_map::SourceMapKind, swc::minify_file_comments};
 use serde_json::error::Category;
-use swc_config::{merge::Merge, IsModule};
+use swc_config::{IsModule, merge::Merge};
 pub use swc_core::base::config::Options as SwcOptions;
 use swc_core::{
   base::{
+    BoolOr,
     config::{
       BuiltInput, Config, ConfigFile, InputSourceMap, JsMinifyCommentOption, JsMinifyFormatOptions,
       Rc, RootMode, SourceMapsConfig,
     },
-    sourcemap, BoolOr,
+    sourcemap,
   },
   common::{
+    FileName, GLOBALS, Mark, SourceFile, SourceMap,
     comments::{Comments, SingleThreadedComments},
     errors::Handler,
-    FileName, Mark, SourceFile, SourceMap, GLOBALS,
   },
   ecma::{
     ast::{EsVersion, Pass, Program},
-    parser::{parse_file_as_module, parse_file_as_program, parse_file_as_script, Syntax},
+    parser::{Syntax, parse_file_as_module, parse_file_as_program, parse_file_as_script},
     transforms::base::helpers::{self, Helpers},
   },
 };
@@ -44,8 +45,8 @@ use swc_error_reporters::handler::try_with_handler;
 use url::Url;
 
 use super::{
-  stringify::{PrintOptions, SourceMapConfig},
   JavaScriptCompiler, TransformOutput,
+  stringify::{PrintOptions, SourceMapConfig},
 };
 
 impl JavaScriptCompiler {

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -12,32 +12,31 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use anyhow::{Context, bail};
+use anyhow::{bail, Context};
 use base64::prelude::*;
 use indoc::formatdoc;
 use jsonc_parser::parse_to_serde_value;
-use rspack_error::{AnyhowResultToRspackResultExt, Error, miette::MietteDiagnostic};
+use rspack_error::{miette::MietteDiagnostic, AnyhowResultToRspackResultExt, Error};
 use rspack_util::{itoa, source_map::SourceMapKind, swc::minify_file_comments};
 use serde_json::error::Category;
-use swc_config::{IsModule, merge::Merge};
+use swc_config::{merge::Merge, IsModule};
 pub use swc_core::base::config::Options as SwcOptions;
 use swc_core::{
   base::{
-    BoolOr,
     config::{
       BuiltInput, Config, ConfigFile, InputSourceMap, JsMinifyCommentOption, JsMinifyFormatOptions,
       Rc, RootMode, SourceMapsConfig,
     },
-    sourcemap,
+    sourcemap, BoolOr,
   },
   common::{
-    FileName, GLOBALS, Mark, SourceFile, SourceMap,
     comments::{Comments, SingleThreadedComments},
     errors::Handler,
+    FileName, Mark, SourceFile, SourceMap, GLOBALS,
   },
   ecma::{
     ast::{EsVersion, Pass, Program},
-    parser::{Syntax, parse_file_as_module, parse_file_as_program, parse_file_as_script},
+    parser::{parse_file_as_module, parse_file_as_program, parse_file_as_script, Syntax},
     transforms::base::helpers::{self, Helpers},
   },
 };
@@ -45,8 +44,8 @@ use swc_error_reporters::handler::try_with_handler;
 use url::Url;
 
 use super::{
-  JavaScriptCompiler, TransformOutput,
   stringify::{PrintOptions, SourceMapConfig},
+  JavaScriptCompiler, TransformOutput,
 };
 
 impl JavaScriptCompiler {
@@ -314,7 +313,7 @@ impl<'a> JavaScriptTransformer<'a> {
       .input_source_map(&built_input.input_source_map)
       .to_rspack_result_from_anyhow()?;
 
-    let program = self.transform_with_built_input(built_input)?;
+    let (program, diagnostics) = self.transform_with_built_input(built_input)?;
     let format_opt = JsMinifyFormatOptions {
       inline_script: false,
       ascii_only: true,
@@ -331,7 +330,10 @@ impl<'a> JavaScriptTransformer<'a> {
       format: &format_opt,
     };
 
-    self.javascript_compiler.print(&program, print_options)
+    self
+      .javascript_compiler
+      .print(&program, print_options)
+      .map(|o| o.with_diagnostics(diagnostics))
   }
 
   fn parse_js(
@@ -420,13 +422,20 @@ impl<'a> JavaScriptTransformer<'a> {
   fn transform_with_built_input(
     &self,
     built_input: BuiltInput<impl Pass>,
-  ) -> Result<Program, Error> {
+  ) -> Result<(Program, Vec<String>), Error> {
     let program = built_input.program;
     let mut pass = built_input.pass;
+    let mut diagnostics = vec![];
     let program = self.run(|| {
       helpers::HELPERS.set(&self.helpers, || {
-        let result = try_with_handler(self.cm.clone(), Default::default(), |_handler| {
-          Ok(program.apply(&mut pass))
+        let result = try_with_handler(self.cm.clone(), Default::default(), |handler| {
+          // Apply external plugin passes to the Program AST.
+          // External plugins may emit warnings or inject helpers,
+          // so we need a handler to properly process them.
+          let program = program.apply(&mut pass);
+          diagnostics.extend(handler.take_diagnostics());
+
+          Ok(program)
         });
 
         result.map_err(|err| {
@@ -476,7 +485,9 @@ impl<'a> JavaScriptTransformer<'a> {
       );
     }
 
-    program.map_err(|e| e.into())
+    program
+      .map(|program| (program, diagnostics))
+      .map_err(|e| e.into())
   }
 
   pub fn input_source_map(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
The Swc plugin emit warn diagnostics will ignore by swc before, according to this PR https://github.com/swc-project/swc/pull/10027, swc will return a diagnostics. So we can emit diagnostics to loaderContext.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
