### PR TITLE
fix(core): fix relative http import failed

### DIFF
--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -183,6 +183,7 @@ impl NormalModule {
     resource_data: Arc<ResourceData>,
     resolve_options: Option<Arc<Resolve>>,
     loaders: Vec<BoxLoader>,
+    context: Option<Context>,
   ) -> Self {
     let module_type = module_type.into();
     let id = Self::create_id(&module_type, layer.as_ref(), &request);
@@ -190,7 +191,7 @@ impl NormalModule {
       blocks: Vec::new(),
       dependencies: Vec::new(),
       id: ModuleIdentifier::from(id.as_ref()),
-      context: Box::new(get_context(&resource_data)),
+      context: Box::new(context.unwrap_or_else(|| get_context(&resource_data))),
       request,
       user_request,
       raw_request,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -564,9 +564,10 @@ impl NormalModuleFactory {
         raw_request,
         request,
         user_request,
-        resource_resolve_data: resource_data,
         match_resource: match_resource_data.as_ref().map(|d| d.resource.clone()),
         side_effects: resolved_side_effects,
+        context: resource_data.context.clone(),
+        resource_resolve_data: resource_data,
       };
       if let Some(plugin_result) = self
         .plugin_driver
@@ -607,6 +608,7 @@ impl NormalModuleFactory {
         Arc::new(create_data.resource_resolve_data.clone()),
         resolved_resolve_options,
         loaders,
+        create_data.context.clone().map(|x| x.into()),
       )
       .boxed()
     };
@@ -934,6 +936,7 @@ pub struct NormalModuleCreateData {
   pub resource_resolve_data: ResourceData,
   pub match_resource: Option<String>,
   pub side_effects: Option<bool>,
+  pub context: Option<String>,
 }
 
 #[test]

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -125,6 +125,7 @@ pub struct ResourceData {
   pub parameters: Option<String>,
   pub encoding: Option<String>,
   pub encoded_content: Option<String>,
+  pub context: Option<String>,
   #[cacheable(with=AsInner)]
   pub(crate) scheme: OnceCell<Scheme>,
 }
@@ -142,7 +143,14 @@ impl ResourceData {
       encoding: None,
       encoded_content: None,
       scheme: OnceCell::new(),
+      context: None,
     }
+  }
+  pub fn set_context(&mut self, context: Option<String>) {
+    self.context = context;
+  }
+  pub fn get_context(&self) -> Option<&String> {
+    self.context.as_ref()
   }
 
   pub fn get_scheme(&self) -> &Scheme {

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -444,6 +444,7 @@ mod test {
       parameters: None,
       encoding: None,
       encoded_content: None,
+      context: None,
     });
 
     // Ignore error: Final loader didn't return a Buffer or String
@@ -547,6 +548,7 @@ mod test {
       parameters: None,
       encoding: None,
       encoded_content: None,
+      context: None,
     });
 
     run_loaders(
@@ -592,6 +594,7 @@ mod test {
       parameters: None,
       encoding: None,
       encoded_content: None,
+      context: None,
     });
 
     #[cacheable]

--- a/crates/rspack_plugin_schemes/src/http_uri/http_cache.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/http_cache.rs
@@ -40,7 +40,7 @@ pub struct FetchResultMeta {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ContentFetchResult {
-  entry: LockfileEntry,
+  pub(crate) entry: LockfileEntry,
   content: Vec<u8>,
   meta: FetchResultMeta,
 }
@@ -53,10 +53,11 @@ impl ContentFetchResult {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RedirectFetchResult {
-  location: String,
+  pub(crate) location: String,
   meta: FetchResultMeta,
 }
 
+#[derive(Debug)]
 pub enum FetchResultType {
   Content(ContentFetchResult),
   #[allow(dead_code)]

--- a/crates/rspack_plugin_schemes/src/http_uri/mod.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/mod.rs
@@ -4,7 +4,7 @@ mod lockfile;
 use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
-use http_cache::{fetch_content, FetchResultType};
+use http_cache::{fetch_content, ContentFetchResult, FetchResultType};
 pub use http_cache::{HttpClient, HttpResponse};
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -13,7 +13,7 @@ use rspack_core::{
   NormalModuleFactoryResolveForScheme, NormalModuleFactoryResolveInScheme,
   NormalModuleReadResource, Plugin, PluginContext, ResourceData, Scheme,
 };
-use rspack_error::{AnyhowResultToRspackResultExt, Result};
+use rspack_error::{miette, AnyhowResultToRspackResultExt, Result};
 use rspack_fs::WritableFileSystem;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::asset_condition::{AssetCondition, AssetConditions};
@@ -27,7 +27,21 @@ static EXTERNAL_HTTP_REQUEST: Lazy<Regex> =
 pub struct HttpUriPlugin {
   options: HttpUriPluginOptions,
 }
-
+// recursively handle http redirect
+async fn resolve_content(
+  url: &str,
+  options: &HttpUriPluginOptions,
+) -> miette::Result<ContentFetchResult> {
+  let result = fetch_content(url, options)
+    .await
+    .to_rspack_result_from_anyhow()?;
+  match result {
+    FetchResultType::Content(content) => Ok(content),
+    FetchResultType::Redirect(redirect) => {
+      Box::pin(resolve_content(&redirect.location, options)).await
+    }
+  }
+}
 impl HttpUriPlugin {
   pub fn new(options: HttpUriPluginOptions) -> Self {
     Self::new_inner(options)
@@ -38,6 +52,10 @@ impl HttpUriPlugin {
     url: &Url,
     mimetype: Option<String>,
   ) -> Result<bool> {
+    let resolved_result = resolve_content(url.as_str(), &self.options).await?;
+
+    let context = get_resource_context(&resolved_result.entry.resolved);
+    resource_data.set_context(context);
     resource_data.set_resource(url.to_string());
     resource_data.set_path(url.origin().ascii_serialization() + url.path());
     if let Some(query) = url.query() {
@@ -133,16 +151,13 @@ async fn resolve_in_scheme(
 
 #[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
 async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
+  dbg!(&resource_data);
   if (resource_data.get_scheme().is_http() || resource_data.get_scheme().is_https())
     && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
   {
-    let fetch_result = fetch_content(&resource_data.resource, &self.options)
-      .await
-      .to_rspack_result_from_anyhow()?;
+    let content_result = resolve_content(&resource_data.resource, &self.options).await?;
 
-    if let FetchResultType::Content(content_result) = fetch_result {
-      return Ok(Some(Content::from(content_result.content().to_vec())));
-    }
+    return Ok(Some(Content::from(content_result.content().to_vec())));
   }
   Ok(None)
 }
@@ -203,5 +218,46 @@ impl HttpUriOptionsAllowedUris {
       AssetCondition::String(s) => s.to_string(),
       AssetCondition::Regexp(r) => r.to_source_string(),
     }
+  }
+}
+
+// align with https://github.com/webpack/webpack/blob/dec18718be5dfba28f067fb3827dd620a1f33667/lib/schemes/HttpUriPlugin.js#L1154
+// set
+fn get_resource_context(result_entry_resolved: &str) -> Option<String> {
+  // Parse the resolved URL
+  if let Ok(base_url) = Url::parse(result_entry_resolved) {
+    // Resolve the relative path "." against the base URL
+    if let Ok(resolved_url) = base_url.join(".") {
+      // Convert the resolved URL to a string
+      let mut href = resolved_url.to_string();
+
+      // Remove the trailing slash if it exists
+      if href.ends_with('/') {
+        href.pop();
+      }
+
+      // Return the context as a string
+      return Some(href);
+    }
+  }
+
+  // Return None if parsing or joining fails
+  None
+}
+#[cfg(test)]
+mod test {
+  use crate::http_uri::get_resource_context;
+
+  #[test]
+  fn test_get_resource_context() {
+    assert_eq!(
+      get_resource_context("https://www.unpkg.com/react-dom@18.3.1/index.js"),
+      Some("https://www.unpkg.com/react-dom@18.3.1".to_string())
+    );
+    assert_eq!(
+      get_resource_context("https://www.unpkg.com/react-dom@18.3.1/"),
+      Some("https://www.unpkg.com/react-dom@18.3.1".to_string())
+    );
+    // FIXME: add more test cases
   }
 }

--- a/crates/rspack_plugin_schemes/src/http_uri/mod.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/mod.rs
@@ -151,7 +151,6 @@ async fn resolve_in_scheme(
 
 #[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
 async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
-  dbg!(&resource_data);
   if (resource_data.get_scheme().is_http() || resource_data.get_scheme().is_https())
     && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
   {

--- a/tests/webpack-examples/build-http/webpack.config.js
+++ b/tests/webpack-examples/build-http/webpack.config.js
@@ -2,13 +2,16 @@ module.exports = {
 	// enable debug logging to see network requests!
 	// stats: {
 	// 	loggingDebug: /HttpUriPlugin/
-	// },
+	// },cd
 	experiments: {
-		// buildHttp: [
-		// 	"https://cdn.esm.sh/",
-		// 	"https://cdn.skypack.dev/",
-		// 	"https://jspm.dev/",
-		// 	/^https:\/\/unpkg\.com\/.+\?module$/
-		// ]
+
+		buildHttp: {
+			allowedUris: [
+				"https://cdn.esm.sh/",
+				"https://cdn.skypack.dev/",
+				"https://jspm.dev/",
+				/^https:\/\/unpkg\.com\/.+\?module$/
+			]
+		}
 	}
 };

--- a/tests/webpack-examples/build-http/webpack.config.js
+++ b/tests/webpack-examples/build-http/webpack.config.js
@@ -2,7 +2,7 @@ module.exports = {
 	// enable debug logging to see network requests!
 	// stats: {
 	// 	loggingDebug: /HttpUriPlugin/
-	// },cd
+	// },
 	experiments: {
 
 		buildHttp: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
support build http-import with relative import 
* support context in resource_data to handle relative import in http scheme
* change fetch from 'recirect': 'manual' to align with http.get's behavior( fetch will auto redirect by default which will cause never return 30x for redirect request)
* enable example/build-http case(which is ignored before)
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
