### PR TITLE
fix: should enforce orphan:false for concatenated module

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/stats-orphan/esm-for-concate.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/stats-orphan/esm-for-concate.js
@@ -1,0 +1,1 @@
+export default 42

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/stats-orphan/index.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/stats-orphan/index.js
@@ -1,0 +1,9 @@
+import value from './esm-for-concate'
+
+it('should check stats', () => {
+	expect(value).toBe(42)
+	const module = __STATS__.modules.find(m => {
+		return m.identifier.replaceAll('\\', '/').includes('configCases/concatenate-modules/stats-orphan/index.js')
+	})
+	expect(module.orphan).toBe(false)
+})

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/stats-orphan/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/stats-orphan/rspack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	mode: "development",
+	entry: {
+		main: "./index.js"
+	},
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	},
+	stats: {
+		modules: true
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

should enforce orphan:false for concatenated module, as the modules actually connected in chunk graph. Webpack is the same

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
