### PR TITLE
fix: simplify trace implementation by removing unused code

### DIFF
--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -7,22 +7,15 @@ import fs from "node:fs";
 import path from "node:path";
 import { rspack } from "@rspack/core";
 
-const timestamp = Date.now();
-const defaultOutputDirname = path.resolve(
-	`.rspack-profile-${timestamp}-${process.pid}`
-);
-const defaultRustTraceChromeOutput = path.join(
-	defaultOutputDirname,
-	"./trace.json"
-);
-const defaultRustTraceLoggerOutput = "stdout";
 const overviewTraceFilter = "info";
 const allTraceFilter = "trace";
 const defaultRustTraceLayer = "chrome";
+
 enum TracePreset {
 	OVERVIEW = "OVERVIEW", // contains overview trace events
 	ALL = "ALL" // contains all trace events
 }
+
 function resolveLayer(value: string): string {
 	if (value === TracePreset.OVERVIEW) {
 		return overviewTraceFilter;
@@ -39,26 +32,34 @@ export async function applyProfile(
 	traceOutput?: string
 ) {
 	const { asyncExitHook } = await import("exit-hook");
+
 	if (traceLayer !== "chrome" && traceLayer !== "logger") {
 		throw new Error(`unsupported trace layer: ${traceLayer}`);
 	}
-	let defaultTraceOutput: string;
-	if (traceLayer === "chrome") {
-		defaultTraceOutput = defaultRustTraceChromeOutput;
-	} else {
-		defaultTraceOutput = defaultRustTraceLoggerOutput;
-	}
+
 	if (!traceOutput) {
+		const timestamp = Date.now();
+		const defaultOutputDir = path.resolve(
+			`.rspack-profile-${timestamp}-${process.pid}`
+		);
+		const defaultRustTraceChromeOutput = path.join(
+			defaultOutputDir,
+			"./trace.json"
+		);
+		const defaultRustTraceLoggerOutput = "stdout";
+
+		const defaultTraceOutput =
+			traceLayer === "chrome"
+				? defaultRustTraceChromeOutput
+				: defaultRustTraceLoggerOutput;
+
 		// biome-ignore lint/style/noParameterAssign: setting default value makes sense
 		traceOutput = defaultTraceOutput;
 	}
+
 	const filter = resolveLayer(filterValue);
-	const entries = Object.entries(resolveLayer(filterValue));
-	if (entries.length <= 0) return;
-	await fs.promises.mkdir(defaultOutputDirname);
 
 	await ensureFileDir(traceOutput);
-
 	await rspack.experiments.globalTrace.register(
 		filter,
 		traceLayer,

--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -44,7 +44,7 @@ export async function applyProfile(
 		);
 		const defaultRustTraceChromeOutput = path.join(
 			defaultOutputDir,
-			"./trace.json"
+			"trace.json"
 		);
 		const defaultRustTraceLoggerOutput = "stdout";
 
@@ -73,5 +73,4 @@ export async function applyProfile(
 async function ensureFileDir(outputFilePath: string) {
 	const dir = path.dirname(outputFilePath);
 	await fs.promises.mkdir(dir, { recursive: true });
-	return dir;
 }

--- a/packages/rspack-cli/tests/build/profile/profile.test.ts
+++ b/packages/rspack-cli/tests/build/profile/profile.test.ts
@@ -3,20 +3,19 @@ import { resolve } from "path";
 import { run } from "../../utils/test-utils";
 
 const defaultTracePath = "./trace.json";
-const customTracePath = "./custom/trace";
+const customTracePath = "./custom/trace.json";
 
 function findDefaultOutputDirname() {
 	const files = fs.readdirSync(__dirname);
 	const file = files.filter(file => file.startsWith(".rspack-profile"));
-	expect(file.length).toBe(1);
-	return resolve(__dirname, file[0]);
+	return file.length > 0 ? resolve(__dirname, file[0]) : null;
 }
 
 describe("profile", () => {
 	afterEach(() => {
 		const dirname = findDefaultOutputDirname();
 		[dirname, resolve(__dirname, customTracePath)].forEach(p => {
-			if (fs.existsSync(p)) {
+			if (p && fs.existsSync(p)) {
 				fs.rmSync(p, { recursive: true });
 			}
 		});

--- a/packages/rspack-cli/tests/utils/test-utils.ts
+++ b/packages/rspack-cli/tests/utils/test-utils.ts
@@ -10,7 +10,7 @@ const fs = require("fs");
 const execa = require("execa");
 const { exec } = require("child_process");
 const { node: execaNode } = execa;
-const { Writable } = require("readable-stream");
+const { Writable } = require("node:stream");
 const concat = require("concat-stream");
 
 const RSPACK_PATH = path.resolve(__dirname, "../../bin/rspack.js");


### PR DESCRIPTION
## Summary

1. Remove `entries > 0` check, because `resolveLayer` returns a non-empty string rather than an object.

```diff
- const entries = Object.entries(resolveLayer(filterValue));
- if (entries.length <= 0) return;
```

2. Remove duplicated `mkdir`, it has the same function as `await ensureFileDir(traceOutput);`.

```diff
- await fs.promises.mkdir(defaultOutputDirname);
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
