### PR TITLE
fix(wasm): avoid passing fd across threads

### DIFF
--- a/crates/rspack_tracing/src/chrome.rs
+++ b/crates/rspack_tracing/src/chrome.rs
@@ -18,7 +18,7 @@ impl Tracer for ChromeTracer {
       .trace_style(TraceStyle::Async)
       .include_args(true)
       .category_fn(Box::new(|_| "rspack".to_string()))
-      .writer(trace_writer.writer())
+      .writer(move || trace_writer.writer())
       .build();
     self.guard = Some(guard);
 

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -6,20 +6,20 @@ use std::{
   marker::PhantomData,
   path::Path,
   sync::{
+    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
     mpsc,
     mpsc::Sender,
-    Arc, Mutex,
   },
   thread::JoinHandle,
 };
 
-use serde_json::{json, Value as JsonValue};
-use tracing_core::{field::Field, span, Event, Subscriber};
+use serde_json::{Value as JsonValue, json};
+use tracing_core::{Event, Subscriber, field::Field, span};
 use tracing_subscriber::{
+  Layer,
   layer::Context,
   registry::{LookupSpan, SpanRef},
-  Layer,
 };
 
 thread_local! {

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -108,7 +108,9 @@ where
   /// ```rust
   /// # use rspack_tracing_chrome::ChromeLayerBuilder;
   /// # use tracing_subscriber::prelude::*;
-  /// let (layer, guard) = ChromeLayerBuilder::new().writer(std::io::sink()).build();
+  /// let (layer, guard) = ChromeLayerBuilder::new()
+  ///   .writer(|| Box::new(std::io::sink()))
+  ///   .build();
   /// # tracing_subscriber::registry().with(layer).init();
   /// ```
   pub fn writer<W: FnOnce() -> Box<dyn Write> + Send + 'static>(mut self, writer: W) -> Self {

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -6,20 +6,20 @@ use std::{
   marker::PhantomData,
   path::Path,
   sync::{
-    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
     mpsc,
     mpsc::Sender,
+    Arc, Mutex,
   },
   thread::JoinHandle,
 };
 
-use serde_json::{Value as JsonValue, json};
-use tracing_core::{Event, Subscriber, field::Field, span};
+use serde_json::{json, Value as JsonValue};
+use tracing_core::{field::Field, span, Event, Subscriber};
 use tracing_subscriber::{
-  Layer,
   layer::Context,
   registry::{LookupSpan, SpanRef},
+  Layer,
 };
 
 thread_local! {
@@ -98,7 +98,7 @@ where
   /// If `file` could not be opened/created. To handle errors,
   /// open a file and pass it to [`writer`](crate::ChromeLayerBuilder::writer) instead.
   pub fn file<P: AsRef<Path> + Send + 'static>(self, file: P) -> Self {
-    self.writer(std::fs::File::create(file).expect("Failed to create trace file."))
+    self.writer(|| Box::new(std::fs::File::create(file).expect("Failed to create trace file.")))
   }
 
   /// Supply an arbitrary writer to which to write trace contents.
@@ -111,8 +111,8 @@ where
   /// let (layer, guard) = ChromeLayerBuilder::new().writer(std::io::sink()).build();
   /// # tracing_subscriber::registry().with(layer).init();
   /// ```
-  pub fn writer<W: Write + Send + 'static>(mut self, writer: W) -> Self {
-    self.out_writer = Some(Box::new(|| Box::new(writer)));
+  pub fn writer<W: FnOnce() -> Box<dyn Write> + Send + 'static>(mut self, writer: W) -> Self {
+    self.out_writer = Some(Box::new(writer));
     self
   }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Related: https://github.com/web-infra-dev/rspack/pull/10246

Sorry, I made a mistake in https://github.com/web-infra-dev/rspack/pull/10246/commits/464b1814350b553bfd12391d489cc2a78c3a91ce, which passes the fd across threads.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
