### PR TITLE
chore: 🔧 use less docker in self hosted runner

### DIFF
--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -170,13 +170,9 @@ jobs:
       # WASM
       - name: Build wasm32-wasip1-threads with linux in Docker
         if: ${{ inputs.target == 'wasm32-wasip1-threads' }}
-        uses: ./.github/actions/docker/linux-build
-        with:
-          image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
-          target: ${{ inputs.target }}
-          profile: ${{ inputs.profile }}
-          plugin: false
-          pre: unset CC_x86_64_unknown_linux_gnu && unset CC # for jemallocator to compile
+        run: | 
+          unset CC_x86_64_unknown_linux_gnu && unset CC # for jemallocator to compile
+          DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads pnpm --filter @rspack/binding build:release --profile ${{ inputs.profile }}
 
       - name: Upload artifact
         uses: ./.github/actions/artifact/upload

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -48,8 +48,17 @@ jobs:
           NODE_BIN_PATH=$(dirname $(which node))
           echo "path=$NODE_BIN_PATH" >> $GITHUB_OUTPUT
 
+      - name: Run e2e (Self-Hosted)
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: |
+          export PATH=${{ steps.calculate-node-bin-path.outputs.path }}:$PATH
+          pnpm run build:js
+          pnpm run prepare:test:e2e
+          pnpm run test:e2e
+
       - name: Run e2e
         uses: ./.github/actions/docker/run
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           # Jammy uses ubuntu 22.04
           # If this is to change, make sure to upgrade the ubuntu version in GitHub Actions

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:hot": "pnpm --filter \"@rspack/*\" test:hot",
     "test:unit": "pnpm --parallel --filter \"@rspack/*\" test",
     "test:e2e": "pnpm --filter \"e2e-test\" test",
+    "prepare:test:e2e": "pnpm --filter \"e2e-test\" playwright install --with-deps",
     "test:ci": "cross-env NODE_OPTIONS=--max_old_space_size=8192 pnpm run build:js && pnpm run test:unit && pnpm test:webpack",
     "test:webpack": "pnpm --filter \"webpack-test\" test:metric",
     "doc-coverage": "pnpm --filter \"@rspack/core\" doc-coverage",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:hot": "pnpm --filter \"@rspack/*\" test:hot",
     "test:unit": "pnpm --parallel --filter \"@rspack/*\" test",
     "test:e2e": "pnpm --filter \"e2e-test\" test",
-    "prepare:test:e2e": "pnpm --filter \"e2e-test\" playwright install --with-deps",
+    "prepare:test:e2e": "pnpm --filter \"e2e-test\" prepare:test",
     "test:ci": "cross-env NODE_OPTIONS=--max_old_space_size=8192 pnpm run build:js && pnpm run test:unit && pnpm test:webpack",
     "test:webpack": "pnpm --filter \"webpack-test\" test:metric",
     "doc-coverage": "pnpm --filter \"@rspack/core\" doc-coverage",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.8",
   "scripts": {
+    "prepare:test": "playwright install --with-deps",
     "test": "playwright test",
     "test:CI": "CI=1 npm run test"
   },


### PR DESCRIPTION
## Summary
to avoid network error while running jobs in docker

1. build wasm in runner directly, no need to run in docker
2. run e2e test in self hosted runner, it takes similar time while in docker


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
