### PR TITLE
feat(compiler-builder): support `browserslist` as the target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4000,6 +4000,7 @@ name = "rspack"
 version = "0.2.0"
 dependencies = [
  "bitflags 2.6.0",
+ "browserslist-rs",
  "enum-tag",
  "indexmap 2.7.1",
  "insta",

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -16,19 +16,20 @@ loader_swc            = ["rspack_loader_swc"]
 loaders               = ["loader_lightningcss", "loader_preact_refresh", "loader_react_refresh", "loader_swc"]
 
 [dependencies]
-bitflags     = { workspace = true }
-enum-tag     = { workspace = true }
-indexmap     = { workspace = true, features = ["rayon"] }
-regex        = { workspace = true }
-rspack_core  = { workspace = true }
-rspack_error = { workspace = true }
-rspack_fs    = { workspace = true }
-rspack_hash  = { workspace = true }
-rspack_ids   = { workspace = true }
-rspack_paths = { workspace = true }
-rspack_regex = { workspace = true }
-rustc-hash   = { workspace = true }
-serde_json   = { workspace = true }
+bitflags        = { workspace = true }
+browserslist-rs = { workspace = true }
+enum-tag        = { workspace = true }
+indexmap        = { workspace = true, features = ["rayon"] }
+regex           = { workspace = true }
+rspack_core     = { workspace = true }
+rspack_error    = { workspace = true }
+rspack_fs       = { workspace = true }
+rspack_hash     = { workspace = true }
+rspack_ids      = { workspace = true }
+rspack_paths    = { workspace = true }
+rspack_regex    = { workspace = true }
+rustc-hash      = { workspace = true }
+serde_json      = { workspace = true }
 
 # Plugins
 rspack_plugin_asset                   = { workspace = true }

--- a/crates/rspack/src/builder/browserslist_target.rs
+++ b/crates/rspack/src/builder/browserslist_target.rs
@@ -1,0 +1,508 @@
+use std::collections::HashMap;
+
+use browserslist::Opts;
+
+use super::target::TargetProperties;
+
+// Macro for defining HashMaps with less boilerplate
+macro_rules! hashmap {
+    ($( $key: expr => $val: expr ),* $(,)?) => {{
+         let mut map = ::std::collections::HashMap::new();
+         $( map.insert($key, $val); )*
+         map
+    }}
+}
+
+/// Configuration parsed from input string and context directory
+#[derive(Debug, Default)]
+pub struct BrowserslistHandlerConfig<'a> {
+  /// Optional absolute path to config file
+  pub config_path: Option<String>,
+  /// Optional environment name
+  pub env: Option<String>,
+  /// Optional query string
+  pub query: Option<String>,
+  /// Context directory path, used for Browserslist Opts.path to locate config
+  pub context: &'a str,
+}
+
+/// Parse input string and context directory (as &str) to extract config path, env, or query.
+/// The context is stored in the returned struct for later use.
+///
+/// # Arguments
+///
+/// * `input` - Optional input string, e.g. absolute config path with optional env suffix, or query string
+/// * `context` - Context directory as &str, used to set context path for config searching
+///
+/// # Returns
+///
+/// * `BrowserslistHandlerConfig` struct with parsed fields and context path
+pub fn parse<'a>(input: Option<&str>, context: &'a str) -> BrowserslistHandlerConfig<'a> {
+  let Some(input) = input else {
+    return BrowserslistHandlerConfig {
+      context,
+      ..Default::default()
+    };
+  };
+
+  // Regex pattern matches:
+  // group 1: absolute path (optionally Windows drive letter)
+  // group 2: optional env suffix after colon
+  // same as JS: /^(?:((?:[A-Z]:)?[/\\].*?))?(?::(.+?))?$/i
+  let re = regex::Regex::new(r"^(?:((?:[A-Z]:)?[/\\].*?))?(?::(.+?))?$")
+    .expect("Should initialize browserlist regex");
+
+  if let Some(caps) = re.captures(input) {
+    let config_path = caps.get(1).map(|m| m.as_str().to_string());
+    let env = caps.get(2).map(|m| m.as_str().to_string());
+
+    if config_path.is_some() {
+      return BrowserslistHandlerConfig {
+        config_path,
+        env,
+        query: None,
+        context,
+      };
+    }
+  }
+
+  // If input is not absolute path with optional env, treat as query string
+  BrowserslistHandlerConfig {
+    config_path: None,
+    env: None,
+    query: Some(input.to_string()),
+    context,
+  }
+}
+
+/// Loads the browsers list based on the input and context.
+pub fn load(input: Option<&str>, context: &str) -> Option<Vec<String>> {
+  let BrowserslistHandlerConfig {
+    config_path,
+    env,
+    query,
+    context,
+  } = parse(input, context);
+
+  let mut opts = Opts::default();
+  if let Some(config) = config_path {
+    opts.config = Some(config);
+  } else {
+    opts.path = Some(context.to_string());
+  }
+  if let Some(e) = env {
+    opts.env = Some(e);
+  }
+
+  match if let Some(q) = query {
+    browserslist::resolve(vec![q], &opts)
+  } else {
+    browserslist::execute(&opts)
+  } {
+    Ok(browsers) => Some(browsers.into_iter().map(|d| d.to_string()).collect()),
+    Err(_) => None,
+  }
+}
+
+/// Represents a version requirement, which can be a major version or a major-minor version pair.
+enum VersionRequirement {
+  Major(u32),
+  MajorMinor(u32, u32),
+}
+
+impl VersionRequirement {
+  /// Checks if the given major and minor versions meet the version requirement.
+  fn matches(&self, major: u32, minor: u32) -> bool {
+    match self {
+      VersionRequirement::Major(r_major) => major >= *r_major,
+      VersionRequirement::MajorMinor(r_major, r_minor) => {
+        if major == *r_major {
+          minor >= *r_minor
+        } else {
+          major > *r_major
+        }
+      }
+    }
+  }
+}
+
+/// Parses a version string into a (major, minor) tuple.
+fn parse_version(version: &str) -> (u32, u32) {
+  let parts: Vec<&str> = version.split('.').collect();
+  let major = parts.first().and_then(|v| v.parse().ok()).unwrap_or(0);
+  let minor = parts.get(1).and_then(|v| v.parse().ok()).unwrap_or(0);
+  (major, minor)
+}
+
+/// Checks if all browsers in the list meet the version requirements.
+fn raw_checker(browsers: &[String], versions: &HashMap<&str, VersionRequirement>) -> bool {
+  browsers.iter().all(|b| {
+    let mut parts = b.split_whitespace();
+    let name = parts.next().unwrap_or("");
+    let version_str = parts.next().unwrap_or("");
+    if name.is_empty() {
+      return false;
+    }
+    let required = match versions.get(name) {
+      Some(r) => r,
+      None => return false,
+    };
+    let (major, minor) = if version_str == "TP" {
+      (u32::MAX, u32::MAX)
+    } else if version_str.contains('-') {
+      let first = version_str.split('-').next().unwrap_or("0");
+      parse_version(first)
+    } else {
+      parse_version(version_str)
+    };
+    required.matches(major, minor)
+  })
+}
+
+/// Resolves target properties based on the provided browser list.
+pub fn resolve(browsers: Vec<String>) -> TargetProperties {
+  let any_node = browsers.iter().any(|b| b.starts_with("node "));
+  let any_browser = browsers.iter().any(|b| !b.starts_with("node "));
+
+  let browser_property = if !any_browser {
+    Some(false)
+  } else if any_node {
+    None
+  } else {
+    Some(true)
+  };
+  let node_property = if !any_node {
+    Some(false)
+  } else if any_browser {
+    None
+  } else {
+    Some(true)
+  };
+
+  let es6_dynamic_import_versions = hashmap! {
+      "chrome" => VersionRequirement::Major(63),
+      "and_chr" => VersionRequirement::Major(63),
+      "edge" => VersionRequirement::Major(79),
+      "firefox" => VersionRequirement::Major(67),
+      "and_ff" => VersionRequirement::Major(67),
+      "opera" => VersionRequirement::Major(50),
+      "op_mob" => VersionRequirement::Major(46),
+      "safari" => VersionRequirement::MajorMinor(11, 1),
+      "ios_saf" => VersionRequirement::MajorMinor(11, 3),
+      "samsung" => VersionRequirement::MajorMinor(8, 2),
+      "android" => VersionRequirement::Major(63),
+      "and_qq" => VersionRequirement::MajorMinor(10, 4),
+      "baidu" => VersionRequirement::MajorMinor(13, 18),
+      "and_uc" => VersionRequirement::MajorMinor(15, 5),
+      "kaios" => VersionRequirement::MajorMinor(3, 0),
+      "node" => VersionRequirement::MajorMinor(12, 17),
+  };
+
+  let es6_dynamic_import = raw_checker(&browsers, &es6_dynamic_import_versions);
+
+  TargetProperties {
+    r#const: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(49),
+          "and_chr" => VersionRequirement::Major(49),
+          "edge" => VersionRequirement::Major(12),
+          "firefox" => VersionRequirement::Major(36),
+          "and_ff" => VersionRequirement::Major(36),
+          "opera" => VersionRequirement::Major(36),
+          "op_mob" => VersionRequirement::Major(36),
+          "safari" => VersionRequirement::MajorMinor(10, 0),
+          "ios_saf" => VersionRequirement::MajorMinor(10, 0),
+          "samsung" => VersionRequirement::MajorMinor(5, 0),
+          "android" => VersionRequirement::Major(37),
+          "and_qq" => VersionRequirement::MajorMinor(10, 4),
+          "baidu" => VersionRequirement::MajorMinor(13, 18),
+          "and_uc" => VersionRequirement::MajorMinor(12, 12),
+          "kaios" => VersionRequirement::MajorMinor(2, 5),
+          "node" => VersionRequirement::MajorMinor(6, 0),
+      },
+    )),
+    arrow_function: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(45),
+          "and_chr" => VersionRequirement::Major(45),
+          "edge" => VersionRequirement::Major(12),
+          "firefox" => VersionRequirement::Major(39),
+          "and_ff" => VersionRequirement::Major(39),
+          "opera" => VersionRequirement::Major(32),
+          "op_mob" => VersionRequirement::Major(32),
+          "safari" => VersionRequirement::MajorMinor(10, 0),
+          "ios_saf" => VersionRequirement::MajorMinor(10, 0),
+          "samsung" => VersionRequirement::MajorMinor(5, 0),
+          "android" => VersionRequirement::Major(45),
+          "and_qq" => VersionRequirement::MajorMinor(10, 4),
+          "baidu" => VersionRequirement::MajorMinor(7, 12),
+          "and_uc" => VersionRequirement::MajorMinor(12, 12),
+          "kaios" => VersionRequirement::MajorMinor(2, 5),
+          "node" => VersionRequirement::MajorMinor(6, 0),
+      },
+    )),
+    for_of: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(38),
+          "and_chr" => VersionRequirement::Major(38),
+          "edge" => VersionRequirement::Major(12),
+          "firefox" => VersionRequirement::Major(51),
+          "and_ff" => VersionRequirement::Major(51),
+          "opera" => VersionRequirement::Major(25),
+          "op_mob" => VersionRequirement::Major(25),
+          "safari" => VersionRequirement::MajorMinor(7, 0),
+          "ios_saf" => VersionRequirement::MajorMinor(7, 0),
+          "samsung" => VersionRequirement::MajorMinor(3, 0),
+          "android" => VersionRequirement::Major(38),
+          "kaios" => VersionRequirement::MajorMinor(3, 0),
+          "node" => VersionRequirement::MajorMinor(0, 12),
+      },
+    )),
+    destructuring: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(49),
+          "and_chr" => VersionRequirement::Major(49),
+          "edge" => VersionRequirement::Major(14),
+          "firefox" => VersionRequirement::Major(41),
+          "and_ff" => VersionRequirement::Major(41),
+          "opera" => VersionRequirement::Major(36),
+          "op_mob" => VersionRequirement::Major(36),
+          "safari" => VersionRequirement::MajorMinor(8, 0),
+          "ios_saf" => VersionRequirement::MajorMinor(8, 0),
+          "samsung" => VersionRequirement::MajorMinor(5, 0),
+          "android" => VersionRequirement::Major(49),
+          "kaios" => VersionRequirement::MajorMinor(2, 5),
+          "node" => VersionRequirement::MajorMinor(6, 0),
+      },
+    )),
+    big_int_literal: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(67),
+          "and_chr" => VersionRequirement::Major(67),
+          "edge" => VersionRequirement::Major(79),
+          "firefox" => VersionRequirement::Major(68),
+          "and_ff" => VersionRequirement::Major(68),
+          "opera" => VersionRequirement::Major(54),
+          "op_mob" => VersionRequirement::Major(48),
+          "safari" => VersionRequirement::MajorMinor(14, 0),
+          "ios_saf" => VersionRequirement::MajorMinor(14, 0),
+          "samsung" => VersionRequirement::MajorMinor(9, 2),
+          "android" => VersionRequirement::Major(67),
+          "and_qq" => VersionRequirement::MajorMinor(13, 1),
+          "baidu" => VersionRequirement::MajorMinor(13, 18),
+          "and_uc" => VersionRequirement::MajorMinor(15, 5),
+          "kaios" => VersionRequirement::MajorMinor(3, 0),
+          "node" => VersionRequirement::MajorMinor(10, 4),
+      },
+    )),
+    module: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(61),
+          "and_chr" => VersionRequirement::Major(61),
+          "edge" => VersionRequirement::Major(16),
+          "firefox" => VersionRequirement::Major(60),
+          "and_ff" => VersionRequirement::Major(60),
+          "opera" => VersionRequirement::Major(48),
+          "op_mob" => VersionRequirement::Major(45),
+          "safari" => VersionRequirement::MajorMinor(10, 1),
+          "ios_saf" => VersionRequirement::MajorMinor(10, 3),
+          "samsung" => VersionRequirement::MajorMinor(8, 0),
+          "android" => VersionRequirement::Major(61),
+          "and_qq" => VersionRequirement::MajorMinor(10, 4),
+          "baidu" => VersionRequirement::MajorMinor(13, 18),
+          "and_uc" => VersionRequirement::MajorMinor(15, 5),
+          "kaios" => VersionRequirement::MajorMinor(3, 0),
+          "node" => VersionRequirement::MajorMinor(12, 17),
+      },
+    )),
+    dynamic_import: Some(es6_dynamic_import),
+    dynamic_import_in_worker: Some(es6_dynamic_import && !any_node),
+    global_this: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(71),
+          "and_chr" => VersionRequirement::Major(71),
+          "edge" => VersionRequirement::Major(79),
+          "firefox" => VersionRequirement::Major(65),
+          "and_ff" => VersionRequirement::Major(65),
+          "opera" => VersionRequirement::Major(58),
+          "op_mob" => VersionRequirement::Major(50),
+          "safari" => VersionRequirement::MajorMinor(12, 1),
+          "ios_saf" => VersionRequirement::MajorMinor(12, 2),
+          "samsung" => VersionRequirement::MajorMinor(10, 1),
+          "android" => VersionRequirement::Major(71),
+          "kaios" => VersionRequirement::MajorMinor(3, 0),
+          "node" => VersionRequirement::Major(12),
+      },
+    )),
+    optional_chaining: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(80),
+          "and_chr" => VersionRequirement::Major(80),
+          "edge" => VersionRequirement::Major(80),
+          "firefox" => VersionRequirement::Major(74),
+          "and_ff" => VersionRequirement::Major(79),
+          "opera" => VersionRequirement::Major(67),
+          "op_mob" => VersionRequirement::Major(64),
+          "safari" => VersionRequirement::MajorMinor(13, 1),
+          "ios_saf" => VersionRequirement::MajorMinor(13, 4),
+          "samsung" => VersionRequirement::Major(13),
+          "android" => VersionRequirement::Major(80),
+          "kaios" => VersionRequirement::MajorMinor(3, 0),
+          "node" => VersionRequirement::Major(14),
+      },
+    )),
+    template_literal: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(41),
+          "and_chr" => VersionRequirement::Major(41),
+          "edge" => VersionRequirement::Major(13),
+          "firefox" => VersionRequirement::Major(34),
+          "and_ff" => VersionRequirement::Major(34),
+          "opera" => VersionRequirement::Major(29),
+          "op_mob" => VersionRequirement::Major(64),
+          "safari" => VersionRequirement::MajorMinor(9, 1),
+          "ios_saf" => VersionRequirement::Major(9),
+          "samsung" => VersionRequirement::Major(4),
+          "android" => VersionRequirement::Major(41),
+          "and_qq" => VersionRequirement::MajorMinor(10, 4),
+          "baidu" => VersionRequirement::MajorMinor(7, 12),
+          "and_uc" => VersionRequirement::MajorMinor(12, 12),
+          "kaios" => VersionRequirement::MajorMinor(2, 5),
+          "node" => VersionRequirement::Major(4),
+      },
+    )),
+    async_function: Some(raw_checker(
+      &browsers,
+      &hashmap! {
+          "chrome" => VersionRequirement::Major(55),
+          "and_chr" => VersionRequirement::Major(55),
+          "edge" => VersionRequirement::Major(15),
+          "firefox" => VersionRequirement::Major(52),
+          "and_ff" => VersionRequirement::Major(52),
+          "opera" => VersionRequirement::Major(42),
+          "op_mob" => VersionRequirement::Major(42),
+          "safari" => VersionRequirement::Major(11),
+          "ios_saf" => VersionRequirement::Major(11),
+          "samsung" => VersionRequirement::MajorMinor(6, 2),
+          "android" => VersionRequirement::Major(55),
+          "and_qq" => VersionRequirement::MajorMinor(13, 1),
+          "baidu" => VersionRequirement::MajorMinor(13, 18),
+          "and_uc" => VersionRequirement::MajorMinor(15, 5),
+          "kaios" => VersionRequirement::Major(3),
+          "node" => VersionRequirement::MajorMinor(7, 6),
+      },
+    )),
+    browser: browser_property,
+    electron: Some(false),
+    node: node_property,
+    nwjs: Some(false),
+    web: browser_property,
+    webworker: Some(false),
+
+    document: browser_property,
+    fetch_wasm: browser_property,
+    global: node_property,
+    import_scripts: Some(false),
+    import_scripts_in_worker: Some(true),
+    node_builtins: node_property,
+    node_prefix_for_core_modules: Some(
+      node_property.unwrap_or(false)
+        && !browsers.iter().any(|b| b.starts_with("node 15"))
+        && raw_checker(
+          &browsers,
+          &hashmap! { "node" => VersionRequirement::MajorMinor(14, 18) },
+        ),
+    ),
+    require: node_property,
+    ..Default::default()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use insta::assert_debug_snapshot;
+
+  use super::*;
+  #[test]
+  fn test() {
+    let context = std::env::current_dir()
+      .unwrap()
+      .to_str()
+      .unwrap()
+      .to_string();
+
+    // Example: Load browsers list, pass query string or None for default config
+    let browsers = load(Some("last 2 versions, not dead"), &context).unwrap_or_default();
+
+    println!("browsers: {browsers:?}");
+
+    // Resolve target properties
+    let properties = resolve(browsers);
+
+    println!("prop: {properties:#?}")
+  }
+
+  #[test]
+  fn test_browserslist_targets_snapshots() {
+    let tests = vec![
+      vec!["ie 11"],
+      vec!["ie_mob 11"],
+      vec!["edge 79"],
+      vec!["android 4"],
+      vec!["android 4.1"],
+      vec!["android 4.4.3-4.4.4"],
+      vec!["android 81"],
+      vec!["chrome 80"],
+      vec!["and_chr 80"],
+      vec!["firefox 68"],
+      vec!["and_ff 68"],
+      vec!["opera 54"],
+      vec!["op_mob 54"],
+      vec!["safari 10"],
+      vec!["safari TP"],
+      vec!["safari 11"],
+      vec!["safari 12.0"],
+      vec!["safari 12.1"],
+      vec!["safari 13"],
+      vec!["ios_saf 12.0-12.1"],
+      vec!["samsung 4"],
+      vec!["samsung 9.2"],
+      vec!["samsung 11.1-11.2"],
+      vec!["op_mini all"],
+      vec!["bb 10"],
+      vec!["node 0.10.0"],
+      vec!["node 0.12.0"],
+      vec!["node 10.0.0"],
+      vec!["node 10.17.0"],
+      vec!["node 12.19.0"],
+      vec!["and_uc 12.12"],
+      vec!["and_qq 10.4"],
+      vec!["kaios 2.5"],
+      vec!["baidu 7.12"],
+      vec!["firefox 80", "chrome 80"],
+      vec!["chrome 80", "node 12.19.0"],
+      vec!["unknown 50"],
+    ];
+
+    let mut results = vec![];
+
+    for test_case in tests {
+      let input: Vec<String> = test_case.iter().map(|s| s.to_string()).collect();
+
+      let targets = resolve(input.clone());
+
+      results.push((test_case, targets));
+    }
+
+    assert_debug_snapshot!(results);
+  }
+}

--- a/crates/rspack/src/builder/browserslist_target.rs
+++ b/crates/rspack/src/builder/browserslist_target.rs
@@ -496,7 +496,7 @@ mod tests {
     let mut results = vec![];
 
     for test_case in tests {
-      let input: Vec<String> = test_case.iter().map(|s| s.to_string()).collect();
+      let input: Vec<String> = test_case.iter().map(|s| (*s).to_string()).collect();
 
       let targets = resolve(input.clone());
 

--- a/crates/rspack/src/builder/snapshots/rspack__builder__browserslist_target__tests__browserslist_targets_snapshots.snap
+++ b/crates/rspack/src/builder/snapshots/rspack__builder__browserslist_target__tests__browserslist_targets_snapshots.snap
@@ -1,0 +1,3248 @@
+---
+source: crates/rspack/src/builder/browserslist_target.rs
+expression: results
+---
+[
+    (
+        [
+            "ie 11",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "ie_mob 11",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "edge 79",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "android 4",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "android 4.1",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "android 4.4.3-4.4.4",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "android 81",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                true,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "chrome 80",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                true,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "and_chr 80",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                true,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "firefox 68",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "and_ff 68",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "opera 54",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "op_mob 54",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "safari 10",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "safari TP",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                true,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "safari 11",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "safari 12.0",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "safari 12.1",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "safari 13",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "ios_saf 12.0-12.1",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "samsung 4",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "samsung 9.2",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "samsung 11.1-11.2",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "op_mini all",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "bb 10",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "node 0.10.0",
+        ],
+        TargetProperties {
+            web: Some(
+                false,
+            ),
+            browser: Some(
+                false,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                true,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                true,
+            ),
+            node_builtins: Some(
+                true,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                false,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                false,
+            ),
+            global: Some(
+                true,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "node 0.12.0",
+        ],
+        TargetProperties {
+            web: Some(
+                false,
+            ),
+            browser: Some(
+                false,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                true,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                true,
+            ),
+            node_builtins: Some(
+                true,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                false,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                false,
+            ),
+            global: Some(
+                true,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "node 10.0.0",
+        ],
+        TargetProperties {
+            web: Some(
+                false,
+            ),
+            browser: Some(
+                false,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                true,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                true,
+            ),
+            node_builtins: Some(
+                true,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                false,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                false,
+            ),
+            global: Some(
+                true,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "node 10.17.0",
+        ],
+        TargetProperties {
+            web: Some(
+                false,
+            ),
+            browser: Some(
+                false,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                true,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                true,
+            ),
+            node_builtins: Some(
+                true,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                false,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                false,
+            ),
+            global: Some(
+                true,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "node 12.19.0",
+        ],
+        TargetProperties {
+            web: Some(
+                false,
+            ),
+            browser: Some(
+                false,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                true,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                true,
+            ),
+            node_builtins: Some(
+                true,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                false,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                false,
+            ),
+            global: Some(
+                true,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "and_uc 12.12",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "and_qq 10.4",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "kaios 2.5",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "baidu 7.12",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+    (
+        [
+            "firefox 80",
+            "chrome 80",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                true,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                true,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "chrome 80",
+            "node 12.19.0",
+        ],
+        TargetProperties {
+            web: None,
+            browser: None,
+            webworker: Some(
+                false,
+            ),
+            node: None,
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: None,
+            node_builtins: None,
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: None,
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: None,
+            global: None,
+            global_this: Some(
+                true,
+            ),
+            big_int_literal: Some(
+                true,
+            ),
+            const: Some(
+                true,
+            ),
+            arrow_function: Some(
+                true,
+            ),
+            for_of: Some(
+                true,
+            ),
+            destructuring: Some(
+                true,
+            ),
+            dynamic_import: Some(
+                true,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                true,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                true,
+            ),
+            async_function: Some(
+                true,
+            ),
+        },
+    ),
+    (
+        [
+            "unknown 50",
+        ],
+        TargetProperties {
+            web: Some(
+                true,
+            ),
+            browser: Some(
+                true,
+            ),
+            webworker: Some(
+                false,
+            ),
+            node: Some(
+                false,
+            ),
+            electron: Some(
+                false,
+            ),
+            nwjs: Some(
+                false,
+            ),
+            electron_main: None,
+            electron_preload: None,
+            electron_renderer: None,
+            require: Some(
+                false,
+            ),
+            node_builtins: Some(
+                false,
+            ),
+            node_prefix_for_core_modules: Some(
+                false,
+            ),
+            document: Some(
+                true,
+            ),
+            import_scripts: Some(
+                false,
+            ),
+            import_scripts_in_worker: Some(
+                true,
+            ),
+            fetch_wasm: Some(
+                true,
+            ),
+            global: Some(
+                false,
+            ),
+            global_this: Some(
+                false,
+            ),
+            big_int_literal: Some(
+                false,
+            ),
+            const: Some(
+                false,
+            ),
+            arrow_function: Some(
+                false,
+            ),
+            for_of: Some(
+                false,
+            ),
+            destructuring: Some(
+                false,
+            ),
+            dynamic_import: Some(
+                false,
+            ),
+            dynamic_import_in_worker: Some(
+                false,
+            ),
+            module: Some(
+                false,
+            ),
+            optional_chaining: Some(
+                false,
+            ),
+            template_literal: Some(
+                false,
+            ),
+            async_function: Some(
+                false,
+            ),
+        },
+    ),
+]

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -97,22 +97,22 @@ CompilerOptions {
         script_type: "",
         environment: Environment {
             const: Some(
-                true,
+                false,
             ),
             arrow_function: Some(
-                true,
+                false,
             ),
             node_prefix_for_core_modules: Some(
-                true,
+                false,
             ),
             async_function: Some(
-                true,
+                false,
             ),
             big_int_literal: Some(
-                true,
+                false,
             ),
             destructuring: Some(
-                true,
+                false,
             ),
             document: Some(
                 true,
@@ -121,17 +121,19 @@ CompilerOptions {
                 false,
             ),
             for_of: Some(
-                true,
+                false,
             ),
-            global_this: None,
+            global_this: Some(
+                false,
+            ),
             module: Some(
                 false,
             ),
             optional_chaining: Some(
-                true,
+                false,
             ),
             template_literal: Some(
-                true,
+                false,
             ),
             dynamic_import_in_worker: Some(
                 false,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Supports using `browserslist` as the target.

### Ceveat

`browserslist_rs` did not export `load_config`, this causes a difference between webpack and rspack. In webpack, if the bundler is not able to find a config, then it will fallback to target `web`. In rspack, it fallbacks to the default browserslist query instead.


Tests are being reviewed by my eyes to align with webpack's `target-browserslist` unit tests. Nevertheless, there could be some cases that I'm not aware of. Please file an issue if you find one.

Snapshot of `crates/rspack/tests/snapshots/defaults__default_options.snap` has been changed due to the previous reason.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or not required).
