### PR TITLE
fix(wasm): copy data to `ArrayBuffer` when decoding `SharedArrayBuffer`

### DIFF
--- a/packages/rspack/src/loader-runner/utils.ts
+++ b/packages/rspack/src/loader-runner/utils.ts
@@ -10,7 +10,10 @@ import loadLoaderRaw from "./loadLoader";
 const decoder = new TextDecoder();
 
 function utf8BufferToString(buf: Uint8Array) {
-	const str = decoder.decode(buf);
+	// The provided ArrayBufferView value must not be shared.
+	const str = decoder.decode(
+		buf.buffer instanceof SharedArrayBuffer ? Buffer.from(buf) : buf
+	);
 	if (str.charCodeAt(0) === 0xfeff) {
 		return str.slice(1);
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Reason: 
1. Wasm memory is a large `SharedArrayBuffer`
2. `TextDecoder` in browser doesn't allow to decode data in `SharedArrayBuffer`
```js
sab = new SharedArrayBuffer(8);
buf = new Uint8Array(sab);
new TextDecoder().decode(buf); // Uncaught TypeError: Failed to execute 'decode' on 'TextDecoder': The provided ArrayBufferView value must not be shared.
```
3. Stackblitz wraps the `TextDecoder` in browser as its Node.js implementation

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
