### PR TITLE
docs: add tree shaking prerequisites and pure annotation

### DIFF
--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -142,7 +142,7 @@ type LazyCompilationOptions =
     };
 ```
 
-:::Tip
+:::tip
 Check out the [guide](/guide/features/lazy-compilation) for a quick start.
 :::
 

--- a/website/docs/en/guide/optimization/tree-shaking.mdx
+++ b/website/docs/en/guide/optimization/tree-shaking.mdx
@@ -1,19 +1,37 @@
 # Tree shaking
 
-Rspack supports tree shaking, a terminology widely used within the JavaScript ecosystem defined as the removal of unused code, commonly referred to as "dead code." Dead code arises when certain exports from a module are not used and they lack side effects, allowing such pieces to be safely deleted to reduce the final output size.
+Rspack supports [tree shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking), a terminology widely used within the JavaScript ecosystem defined as the removal of unused code, commonly referred to as "dead code." Dead code arises when certain exports from a module are not used and they lack side effects, allowing such pieces to be safely deleted to reduce the final output size.
 
-Upon setting the `mode` to `production`, Rspack by default enables a series of optimizations related to tree shaking, including:
+## What is tree shaking
+
+You can imagine your application as a tree. The source code and libraries you actually use represent the green, living leaves of the tree. Dead code represents the brown, dead leaves of the tree that are consumed by autumn. In order to get rid of the dead leaves, you have to shake the tree, causing them to fall.
+
+Note that Rspack does not directly remove dead code but labels unused exports as potential "dead code". These labels can then be recognized and processed by subsequent compression tools. As such, if [minimize](/config/optimization#optimizationminimize) features are disabled, no actual code removal will be observable.
+
+:::tip What is dead code
+[Dead code](https://en.wikipedia.org/wiki/Dead_code) refers to a piece of code that is no longer executed, typically due to refactoring, optimization, or logical errors. These codes may be remnants of previous versions or codes that will never be executed under certain conditions.
+:::
+
+## Prerequisites
+
+To effectively leverage tree shaking, you need to:
+
+- Set Rspack's [mode](/config/mode) to `production` to enable related optimizations.
+  - When performing a production build, `mode` defaults to `production`.
+- Use ES modules syntax (i.e., `import` and `export`).
+  - When using compilers like SWC or Babel, ensure they don't transform ES modules syntax to CommonJS.
+  - For example, in [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env), set the `modules` option to `false`.
+
+## Configurations
+
+When the [mode](/config/mode) is set to `production`, Rspack enables a series of optimizations related to tree shaking, including:
 
 - [usedExports](/config/optimization#optimizationusedexports): Checks whether module exports are utilized, allowing the removal of unused exports.
 - [sideEffects](/config/optimization#optimizationsideeffects): Assesses modules for side effects. Modules without side effects can be optimized further via re-exports.
 - [providedExports](/config/optimization#optimizationprovidedExports): Analyzes all exports and their sources of re-exportation.
 - [innerGraph](/config/optimization#optimizationsinnergraph): Tracks the transmission of variables, enhancing the accuracy of determining whether exports are indeed used.
 
-Below are examples to illustrate how these configuration options function.
-
-:::info
-Note that Rspack does not directly remove dead code but labels unused exports as potential "dead code." These labels can then be recognized and processed by subsequent compression tools. As such, if compression features are turned off, no actual code removal will be observable. For enhanced readability, pseudocode might be used to demonstrate the effects of code removal.
-:::
+Below are examples to illustrate how these configuration options function. For the sake of clarity, we will use pseudocode to demonstrate the effects of code removal.
 
 Let's understand this mechanism better through an example, assuming `src/main.js` as the project's entry point:
 
@@ -119,3 +137,20 @@ export const foo = 42;
 ```
 
 In this context, because `value` is eventually used, the `foo` it depends on is retained.
+
+## Pure annotation
+
+Using the `/*#__PURE__*/` annotation to tell Rspack that a function call is side-effect-free (pure) . It can be put in front of function calls to mark them as side-effect-free.
+
+When the initial value in a variable declaration of an unused variable is considered as side-effect-free (pure), it is getting marked as dead code, not executed and dropped by the minimizer.
+
+```js
+/*#__PURE__*/ double(55);
+```
+
+:::tip
+
+- Arguments passed to the function are not being marked by the annotation and may need to be marked individually.
+- This behavior is enabled when [optimization.innerGraph](/config/optimization#optimizationinnergraph) is set to true.
+
+:::

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -142,8 +142,8 @@ type LazyCompilationOptions =
     };
 ```
 
-:::Tip
-[参考指南](/guide/features/lazy-compilation)来让你快速上手。
+:::tip
+参考 [指南](/guide/features/lazy-compilation) 来快速上手。
 :::
 
 开启懒编译，这对提高多入口应用（MPA）或大型单页面应用（SPA）的 dev 启动性能会非常有帮助。例如你有二十个入口，只有访问到的入口才会进行构建，或者如果项目中存在非常多的 `import()`，每一个 `import()` 所指向的模块都只有在被真正访问到时，才进行构建。

--- a/website/docs/zh/guide/optimization/tree-shaking.mdx
+++ b/website/docs/zh/guide/optimization/tree-shaking.mdx
@@ -4,20 +4,38 @@ import WebpackLicense from '@components/WebpackLicense';
 
 # Tree shaking
 
-Rspack 支持 tree shaking 功能，这是一个在 JavaScript 生态中广泛使用的术语，主要用于去除未被访问的代码，俗称“死代码”。当一个模块的某些导出未被使用且不存在副作用时，这部分代码就可以被安全地删除，以减小最终产物的体积。
+Rspack 支持 [tree shaking](https://developer.mozilla.org/zh-CN/docs/Glossary/Tree_shaking) 功能，这是一个在 JavaScript 生态中广泛使用的术语，主要用于去除未被访问的代码，俗称“死代码”。当一个模块的某些导出未被使用且不存在副作用时，这部分代码就可以被安全地删除，以减小最终产物的体积。
 
-在设置 `mode` 为 `production` 后，Rspack 会默认启用一系列与 tree shaking 相关的优化措施。
+## 什么是 tree shaking
+
+你可以将应用程序想象成一棵树。绿色表示实际用到的源码和库，是树上活的树叶。灰色表示未引用代码，是秋天树上枯萎的树叶。为了除去死去的树叶，你必须摇动（shake）这棵树，使它们落下。
+
+需要注意的是，Rspack 本身不直接删除死代码，而是标记未使用的导出为潜在的"死代码"。这些代码能被后续的压缩工具识别并处理。因此，如果 [压缩功能](/config/optimization#optimizationminimize) 被关闭，你将不会看到代码有任何实际的删除效果。
+
+:::tip 什么是死代码
+[死代码（dead code）](https://en.wikipedia.org/wiki/Dead_code) 是指程序中一段已经不会被执行的代码，通常是因为重构、优化或者逻辑错误导致的。这些代码可能是之前版本的遗留物，或者某些条件下永远不会被执行的代码。
+:::
+
+## 前置条件
+
+为了有效利用 tree shaking 功能，你需要：
+
+- 将 Rspack 的 [mode](/config/mode) 设置为 `production` 以启用相关优化。
+  - 在执行生产环境构建时，`mode` 默认为 `production`。
+- 使用 ES modules 语法（即 `import` 和 `export`）。
+  - 在 SWC 或 Babel 等编译器时，确保它们没有将 ES modules 语法转换为 CommonJS。
+  - 例如在 [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env) 中，需要将 `modules` 选项设置为 `false`。
+
+## 配置项
+
+当 [mode](/config/mode) 被设置为 `production` 时，Rspack 会默认启用一系列与 tree shaking 相关的优化措施，包括：
 
 - [usedExports](/config/optimization#optimizationusedexports) 检查模块导出是否被使用到，没被使用到的导出可以被移除。
 - [sideEffects](/config/optimization#optimizationsideeffects) 检查模块是否包含副作用，如果不包含副作用可以被重导出优化。
 - [providedExports](/config/optimization#optimizationprovidedExports) 分析模块的所有导出和重导出来源。
 - [innerGraph](/config/optimization#optimizationsinnergraph) 追踪变量的传递，更加准确地判断导出是否真的被使用到。
 
-下面有一些例子来说明各个配置项的作用。
-
-:::info
-需要注意的是，Rspack 本身不直接删除死代码，而是标记未使用的导出为可能的“死代码”。这些代码能被后续的压缩工具识别并处理。因此，如果压缩功能被关闭，你将不会看到代码有任何实际的删除效果。为了增强文档的可读性，我们可能会使用伪代码来展示代码的删除效果。
-:::
+下面有一些例子来说明各个配置项的作用，为了增强文档的可读性，我们会使用伪代码来展示代码的删除效果。
 
 让我们通过一个例子来更好地理解这一机制，假设 `src/main.js` 是项目的入口文件：
 
@@ -123,3 +141,20 @@ export const foo = 42;
 ```
 
 在这种情况下，由于 `value` 最终被使用，它所依赖的 `foo` 也得以保留。
+
+## Pure 注解
+
+通过 `/*#__PURE__*/` 注解可以告诉 Rspack 某个函数调用无副作用。它可以被放到函数调用之前，用来标记此函数调用是无副作用的。
+
+如果一个没被使用的变量定义的初始值被认为是无副作用的，它会被标记为死代码，不会被执行且会被压缩工具清除掉。
+
+```js
+/*#__PURE__*/ double(55);
+```
+
+:::tip
+
+- 传入函数的参数无法被这个注释所标记，需要单独对每一个参数进行标记。
+- 当 [optimization.innerGraph](/config/optimization#optimizationinnergraph) 被设置成 `true` 时这个行为将被启用。
+
+:::


### PR DESCRIPTION
## Summary

- Expanded the tree-shaking guide with new sections, including "What is tree shaking," "Prerequisites," and "Pure annotation.
- Fixed the incorrect casing of the `:::Tip` directive to `:::tip`:

<img width="514" alt="Screenshot 2025-05-12 at 16 41 43" src="https://github.com/user-attachments/assets/85981d29-7778-48ad-a46d-fbcc672dff9f" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
