### PR TITLE
fix(core): remove filename fn in sync js api

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -251,10 +251,10 @@ export declare class JsCompilation {
   getErrors(): Array<JsRspackError>
   getWarnings(): Array<JsRspackError>
   getStats(): JsStats
-  getAssetPath(filename: JsFilename, data: JsPathData): string
-  getAssetPathWithInfo(filename: JsFilename, data: JsPathData): PathWithInfo
-  getPath(filename: JsFilename, data: JsPathData): string
-  getPathWithInfo(filename: JsFilename, data: JsPathData): PathWithInfo
+  getAssetPath(filename: string, data: JsPathData): string
+  getAssetPathWithInfo(filename: string, data: JsPathData): PathWithInfo
+  getPath(filename: string, data: JsPathData): string
+  getPathWithInfo(filename: string, data: JsPathData): PathWithInfo
   addFileDependencies(deps: Array<string>): void
   addContextDependencies(deps: Array<string>): void
   addMissingDependencies(deps: Array<string>): void
@@ -265,7 +265,7 @@ export declare class JsCompilation {
    * Using async and mutable reference to `Compilation` at the same time would likely to cause data races.
    */
   rebuildModule(moduleIdentifiers: Array<string>, f: any): void
-  importModule(request: string, layer: string | undefined | null, publicPath: JsFilename | undefined | null, baseUri: string | undefined | null, originalModule: string | undefined | null, originalModuleContext: string | undefined | null, callback: any): void
+  importModule(request: string, layer: string | undefined | null, publicPath: string | undefined | null, baseUri: string | undefined | null, originalModule: string | undefined | null, originalModuleContext: string | undefined | null, callback: any): void
   get entries(): JsEntries
   addRuntimeModule(chunk: JsChunk, runtimeModule: JsAddingRuntimeModule): void
   get moduleGraph(): JsModuleGraph

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -265,7 +265,7 @@ export declare class JsCompilation {
    * Using async and mutable reference to `Compilation` at the same time would likely to cause data races.
    */
   rebuildModule(moduleIdentifiers: Array<string>, f: any): void
-  importModule(request: string, layer: string | undefined | null, publicPath: string | undefined | null, baseUri: string | undefined | null, originalModule: string | undefined | null, originalModuleContext: string | undefined | null, callback: any): void
+  importModule(request: string, layer: string | undefined | null, publicPath: JsFilename | undefined | null, baseUri: string | undefined | null, originalModule: string | undefined | null, originalModuleContext: string | undefined | null, callback: any): void
   get entries(): JsEntries
   addRuntimeModule(chunk: JsChunk, runtimeModule: JsAddingRuntimeModule): void
   get moduleGraph(): JsModuleGraph

--- a/crates/node_binding/src/compilation/mod.rs
+++ b/crates/node_binding/src/compilation/mod.rs
@@ -22,7 +22,7 @@ use rspack_napi::{napi::bindgen_prelude::*, OneShotRef, WeakRef};
 use rspack_plugin_runtime::RuntimeModuleFromJs;
 use rustc_hash::FxHashMap;
 
-use super::{JsFilename, PathWithInfo};
+use super::PathWithInfo;
 use crate::{
   entry::JsEntryOptions, utils::callbackify, AssetInfo, EntryDependency, JsAddingRuntimeModule,
   JsAsset, JsChunk, JsChunkGraph, JsChunkGroupWrapper, JsChunkWrapper, JsCompatSource,
@@ -501,7 +501,7 @@ impl JsCompilation {
   }
 
   #[napi]
-  pub fn get_asset_path(&self, filename: JsFilename, data: JsPathData) -> Result<String> {
+  pub fn get_asset_path(&self, filename: String, data: JsPathData) -> Result<String> {
     let compilation = self.as_ref()?;
     #[allow(clippy::disallowed_methods)]
     futures::executor::block_on(compilation.get_asset_path(&filename.into(), data.to_path_data()))
@@ -511,7 +511,7 @@ impl JsCompilation {
   #[napi]
   pub fn get_asset_path_with_info(
     &self,
-    filename: JsFilename,
+    filename: String,
     data: JsPathData,
   ) -> Result<PathWithInfo> {
     let compilation = self.as_ref()?;
@@ -525,7 +525,7 @@ impl JsCompilation {
   }
 
   #[napi]
-  pub fn get_path(&self, filename: JsFilename, data: JsPathData) -> Result<String> {
+  pub fn get_path(&self, filename: String, data: JsPathData) -> Result<String> {
     let compilation = self.as_ref()?;
     #[allow(clippy::disallowed_methods)]
     futures::executor::block_on(compilation.get_path(&filename.into(), data.to_path_data()))
@@ -533,7 +533,7 @@ impl JsCompilation {
   }
 
   #[napi]
-  pub fn get_path_with_info(&self, filename: JsFilename, data: JsPathData) -> Result<PathWithInfo> {
+  pub fn get_path_with_info(&self, filename: String, data: JsPathData) -> Result<PathWithInfo> {
     let compilation = self.as_ref()?;
 
     let mut asset_info = rspack_core::AssetInfo::default();
@@ -631,7 +631,7 @@ impl JsCompilation {
     reference: Reference<JsCompilation>,
     request: String,
     layer: Option<String>,
-    public_path: Option<JsFilename>,
+    public_path: Option<String>,
     base_uri: Option<String>,
     original_module: Option<String>,
     original_module_context: Option<String>,

--- a/crates/node_binding/src/compilation/mod.rs
+++ b/crates/node_binding/src/compilation/mod.rs
@@ -25,7 +25,7 @@ use rustc_hash::FxHashMap;
 use super::PathWithInfo;
 use crate::{
   entry::JsEntryOptions, utils::callbackify, AssetInfo, EntryDependency, JsAddingRuntimeModule,
-  JsAsset, JsChunk, JsChunkGraph, JsChunkGroupWrapper, JsChunkWrapper, JsCompatSource,
+  JsAsset, JsChunk, JsChunkGraph, JsChunkGroupWrapper, JsChunkWrapper, JsCompatSource, JsFilename,
   JsModuleGraph, JsPathData, JsRspackDiagnostic, JsRspackError, JsStats,
   JsStatsOptimizationBailout, ModuleObject, RspackResultToNapiResultExt, ToJsCompatSource,
   COMPILER_REFERENCES,
@@ -631,7 +631,7 @@ impl JsCompilation {
     reference: Reference<JsCompilation>,
     request: String,
     layer: Option<String>,
-    public_path: Option<String>,
+    public_path: Option<JsFilename>,
     base_uri: Option<String>,
     original_module: Option<String>,
     original_module_context: Option<String>,

--- a/examples/basic/rspack.config.cjs
+++ b/examples/basic/rspack.config.cjs
@@ -2,5 +2,9 @@ module.exports = {
 	context: __dirname,
 	entry: {
 		main: "./index.js"
-	}
+	},
+	output: {
+		publicPath: () => { }
+	},
+	stats: { all: true }
 };

--- a/examples/basic/rspack.config.cjs
+++ b/examples/basic/rspack.config.cjs
@@ -2,9 +2,5 @@ module.exports = {
 	context: __dirname,
 	entry: {
 		main: "./index.js"
-	},
-	output: {
-		publicPath: () => { }
-	},
-	stats: { all: true }
+	}
 };

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -43,7 +43,6 @@ import {
 } from "./Stats";
 import type { EntryOptions, EntryPlugin } from "./builtin-plugin";
 import type {
-	Filename,
 	OutputNormalized,
 	RspackOptionsNormalized,
 	RspackPluginInstance,
@@ -898,7 +897,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		);
 	}
 
-	getPath(filename: Filename, data: PathData = {}) {
+	getPath(filename: string, data: PathData = {}) {
 		const pathData: JsPathData = { ...data };
 		if (data.contentHashType && data.chunk?.contentHash) {
 			pathData.contentHash = data.chunk.contentHash[data.contentHashType];
@@ -906,7 +905,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		return this.#inner.getPath(filename, pathData);
 	}
 
-	getPathWithInfo(filename: Filename, data: PathData = {}) {
+	getPathWithInfo(filename: string, data: PathData = {}) {
 		const pathData: JsPathData = { ...data };
 		if (data.contentHashType && data.chunk?.contentHash) {
 			pathData.contentHash = data.chunk.contentHash[data.contentHashType];
@@ -914,7 +913,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		return this.#inner.getPathWithInfo(filename, pathData);
 	}
 
-	getAssetPath(filename: Filename, data: PathData = {}) {
+	getAssetPath(filename: string, data: PathData = {}) {
 		const pathData: JsPathData = { ...data };
 		if (data.contentHashType && data.chunk?.contentHash) {
 			pathData.contentHash = data.chunk.contentHash[data.contentHashType];
@@ -922,7 +921,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		return this.#inner.getAssetPath(filename, pathData);
 	}
 
-	getAssetPathWithInfo(filename: Filename, data: PathData = {}) {
+	getAssetPathWithInfo(filename: string, data: PathData = {}) {
 		const pathData: JsPathData = { ...data };
 		if (data.contentHashType && data.chunk?.contentHash) {
 			pathData.contentHash = data.chunk.contentHash[data.contentHashType];

--- a/packages/rspack/src/RspackError.ts
+++ b/packages/rspack/src/RspackError.ts
@@ -23,3 +23,12 @@ export class NonErrorEmittedError extends Error {
 		this.message = `(Emitted value instead of an instance of Error) ${error}`;
 	}
 }
+
+export class DeadlockRiskError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "DeadlockRiskError";
+		// hide the stack trace for this error
+		this.stack = "";
+	}
+}

--- a/packages/rspack/src/Stats.ts
+++ b/packages/rspack/src/Stats.ts
@@ -10,6 +10,7 @@
 import type * as binding from "@rspack/binding";
 
 import type { Compilation } from "./Compilation";
+import { DeadlockRiskError } from "./RspackError";
 import type { StatsOptions, StatsValue } from "./config";
 import type { StatsCompilation } from "./stats/statsFactoryUtils";
 
@@ -114,6 +115,10 @@ export class Stats {
 				getInner: this.#getInnerByCompilation.bind(this)
 			});
 		} catch (e) {
+			if (e instanceof DeadlockRiskError) {
+				throw e;
+			}
+			// FIXME: shouldn't swallow error
 			console.warn(
 				`Failed to get stats due to error: ${(e as Error)?.message}, are you trying to access the stats from the previous compilation?`
 			);
@@ -156,6 +161,10 @@ export class Stats {
 				getInner: this.#getInnerByCompilation.bind(this)
 			});
 		} catch (e) {
+			if (e instanceof DeadlockRiskError) {
+				throw e;
+			}
+			// FIXME: shouldn't swallow error
 			console.warn(
 				`Failed to get stats due to error: ${(e as Error)?.message}, are you trying to access the stats from the previous compilation?`
 			);

--- a/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
@@ -19,6 +19,7 @@ import type {
 import type { Chunk } from "../Chunk";
 import type { NormalizedStatsOptions } from "../Compilation";
 import type { Compiler } from "../Compiler";
+import { DeadlockRiskError } from "../RspackError";
 import type { StatsOptions } from "../config";
 import {
 	LogType,
@@ -857,6 +858,11 @@ const SIMPLE_EXTRACTORS: SimpleExtractors = {
 			object.builtAt = compilation.endTime;
 		},
 		publicPath: (object, compilation) => {
+			if (typeof compilation.outputOptions.publicPath === "function") {
+				throw new DeadlockRiskError(
+					"publicPath as function can't be used with stats.publicPath=true, which may cause deadlock risk, consider setting stats.publicPath=false in rspack config"
+				);
+			}
 			object.publicPath = compilation.getPath(
 				compilation.outputOptions.publicPath || ""
 			);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
calling filename function in sync js api will definitely cause deadlock so it's never working before, remove filename fn support to avoid deadlock risk for users. more background in https://github.com/web-infra-dev/rspack/discussions/3642
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
