### PR TITLE
fix: should union available modules when depend on multiple entry

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/available_modules.rs
+++ b/crates/rspack_core/src/build_chunk_graph/available_modules.rs
@@ -51,13 +51,21 @@ pub fn remove_available_modules(
   let mut pending = HashSet::<usize>::default();
   let module_graph = compilation.get_module_graph();
 
+  let mut entry_with_depend_on = HashSet::<usize>::default();
+
   let mut stack = roots
     .iter()
     .filter(|root| {
-      let is_entry_without_depend_on = chunk_incomings[**root].is_empty() && matches!(&chunks[**root].1.chunk_desc, ChunkDesc::Entry(box EntryChunkDesc{initial, ..}) if *initial);
+      let is_entry = matches!(&chunks[**root].1.chunk_desc, ChunkDesc::Entry(box EntryChunkDesc{initial, ..}) if *initial);
+      let is_entry_without_depend_on = is_entry && chunk_incomings[**root].is_empty();
       if is_entry_without_depend_on {
         pending.insert(**root);
       }
+
+      if is_entry && !chunk_incomings[**root].is_empty() {
+        entry_with_depend_on.insert(**root);
+      }
+
       is_entry_without_depend_on
     })
     .map(|root| (AvailableModules::default(), *root, false))
@@ -73,6 +81,8 @@ pub fn remove_available_modules(
         // if already calculated
         let res = if force_continue {
           Cow::Borrowed(curr)
+        } else if entry_with_depend_on.contains(&chunk_index) {
+          Cow::Owned(curr.union(&parent_available_modules))
         } else {
           Cow::Owned(curr.intersect(&parent_available_modules))
         };
@@ -165,7 +175,13 @@ pub fn remove_available_modules(
       !in_parent
     });
 
-    if removed.is_empty() {
+    if let ChunkDesc::Entry(box entry_chunk) = chunk {
+      entry_chunk.entry_modules.retain(|m| {
+        !available.is_module_available(*ordinal_by_modules.get(m).expect("should have module"))
+      });
+    }
+
+    if removed.is_empty() || entry_with_depend_on.contains(&chunk_index) {
       continue;
     }
 

--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -139,7 +139,7 @@ pub struct EntryChunkDesc {
   options: EntryOptions,
   modules_ordinal: AvailableModules,
   entry: Option<String>,
-  entry_modules: Vec<ModuleIdentifier>,
+  pub entry_modules: Vec<ModuleIdentifier>,
   chunk_modules: IdentifierSet,
 
   pre_order_indices: IdentifierMap<usize>,

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/async.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/async.js
@@ -1,0 +1,1 @@
+export default 42

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/main.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/main.js
@@ -1,0 +1,9 @@
+import v1 from './vendor1'
+import v2 from './vendor2'
+
+import('./async')
+
+it('should not contain vendor1 and vendor2 in current chunk', (done) => {
+	expect(v1).toBe('vendor1')
+	expect(v2).toBe('vendor2')
+})

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/rspack.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+	entry: {
+		vendor1: "./vendor1.js",
+		vendor2: "./vendor2.js",
+		main: {
+			dependOn: ["vendor1", "vendor2"],
+			import: "./main.js"
+		}
+	},
+	target: "web",
+	node: {
+		__dirname: false
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		moduleIds: "named",
+		chunkIds: "named"
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["vendor2.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/vendor1.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/vendor1.js
@@ -1,0 +1,1 @@
+export default 'vendor1'

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/vendor2.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/depend-on-multiple-entry/vendor2.js
@@ -1,0 +1,10 @@
+export default 'vendor2'
+
+it('should not contain vendor1 vendor2 in file', () => {
+	const path = __non_webpack_require__('path')
+	const fs = __non_webpack_require__('fs')
+
+	const code = fs.readFileSync(path.resolve(__dirname, './main.js'), 'utf-8')
+	expect(code).not.toContain('"./vendor1.js":')
+	expect(code).not.toContain('"./vendor2.js":')
+})


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close #10261

Available modules should be intersection for async chunks' parents, and should be union for entries' parents.

Using dependOn will make the entry loading after all parents loaded, so all modules in parents are available at that time, should union their available modules.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
