### PR TITLE
perf: skip UTF-8 validation if JS loader returned a string

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -851,7 +851,11 @@ export interface JsLoaderContext {
   loaderIndex: number
   loaderState: Readonly<JsLoaderState>
   __internal__error?: JsRspackError
-  __internal__tracingCarrier?: Record<string, string>
+  /**
+   * UTF-8 hint for `content`
+   * - Some(true): `content` is a `UTF-8` encoded sequence
+   */
+  __internal__utf8Hint?: boolean
 }
 
 export interface JsLoaderItem {

--- a/crates/node_binding/src/plugins/js_loader/context.rs
+++ b/crates/node_binding/src/plugins/js_loader/context.rs
@@ -112,8 +112,10 @@ pub struct JsLoaderContext {
   #[napi(js_name = "__internal__error")]
   pub error: Option<JsRspackError>,
 
-  #[napi(js_name = "__internal__tracingCarrier")]
-  pub carrier: Option<HashMap<String, String>>,
+  /// UTF-8 hint for `content`
+  /// - Some(true): `content` is a `UTF-8` encoded sequence
+  #[napi(js_name = "__internal__utf8Hint")]
+  pub utf8_hint: Option<bool>,
 }
 
 impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
@@ -123,9 +125,6 @@ impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
     cx: &mut rspack_core::LoaderContext<RunnerContext>,
   ) -> std::result::Result<Self, Self::Error> {
     let module = unsafe { cx.context.module.as_ref() };
-
-    #[allow(unused_mut)]
-    let mut carrier = HashMap::new();
 
     #[allow(clippy::unwrap_used)]
     Ok(JsLoaderContext {
@@ -178,7 +177,7 @@ impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
       loader_index: cx.loader_index,
       loader_state: cx.state().into(),
       error: None,
-      carrier: Some(carrier),
+      utf8_hint: None,
     })
   }
 }

--- a/crates/node_binding/src/plugins/js_loader/scheduler.rs
+++ b/crates/node_binding/src/plugins/js_loader/scheduler.rs
@@ -119,12 +119,31 @@ pub(crate) fn merge_loader_context(
 
   let content = match from.content {
     Either::A(_) => None,
-    Either::B(c) => Some(rspack_core::Content::from(Into::<Vec<u8>>::into(c))),
+    Either::B(c) => {
+      // perf: Ignore UTF-8 check when JavaScript passed in an UTF-8 encoded value
+      let content = if let Some(utf8_hint) = from.utf8_hint
+        && utf8_hint
+      {
+        rspack_core::Content::from(
+          // SAFETY: UTF-8 passed from JavaScript loader runner should ensure it does not pass non-UTF-8 encoded sequence when `utf_hint` is set to `true`. This invariant should be followed on the JavaScript side.
+          unsafe { String::from_utf8_unchecked(c.into()) },
+        )
+      } else {
+        rspack_core::Content::from(Into::<Vec<u8>>::into(c))
+      };
+
+      Some(content)
+    }
   };
   let source_map = from
     .source_map
     .as_ref()
-    .map(|s| rspack_core::rspack_sources::SourceMap::from_slice(s))
+    .map(|s| {
+      rspack_core::rspack_sources::SourceMap::from_json(
+        // SAFETY: `sourceMap` is serialized by JavaScript from a JSON object. This is an invariant should be followed on the JavaScript side.
+        unsafe { str::from_utf8_unchecked(s) },
+      )
+    })
     .transpose()
     .to_rspack_result()?;
   let additional_data = from.additional_data.take().map(|data| {

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -1070,6 +1070,7 @@ export async function runLoaders(
 				context.content = isNil(content) ? null : toBuffer(content);
 				context.sourceMap = JsSourceMap.__to_binding(sourceMap);
 				context.additionalData = additionalData || undefined;
+				context.__internal__utf8Hint = typeof content === "string";
 
 				break;
 			}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Skip `UTF-8` validation on the Rust side in normal module build if the last loader returned a string. Also removes source map `UTF-8` validation as it's always `UTF-8` encoded.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or not required).
