### PR TITLE
fix: AMD parser plugin replaced define plugin values mutiple times

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
@@ -183,7 +183,7 @@ impl AMDDefineDependencyParserPlugin {
       for option in options.iter() {
         let result = self.process_item(parser, call_expr, option, &None);
         if result.is_none() {
-          self.process_context(parser, call_expr, param);
+          self.process_context(parser, call_expr, option);
         }
       }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
@@ -114,7 +114,7 @@ impl AMDRequireDependenciesBlockParserPlugin {
       for option in options.iter() {
         let result = self.process_item(parser, block_deps, call_expr, option);
         if result.is_none() {
-          self.process_context(parser, block_deps, call_expr, param);
+          self.process_context(parser, block_deps, call_expr, option);
         }
       }
 

--- a/tests/webpack-test/configCases/parsing/issue-8293/test.filter.js
+++ b/tests/webpack-test/configCases/parsing/issue-8293/test.filter.js
@@ -1,2 +1,0 @@
-// TODO: Should create a issue for this test
-module.exports = () => { return "FIXME: missing expected substring" }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix AMD parser plugin replaced define plugin values mutiple times


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
