### PR TITLE
docs: fix render of note title and file name

### DIFF
--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -464,7 +464,7 @@ type ExperimentCacheOptions =
 
 Control experimental caching behavior. This will only work if [config.cache](/config/cache) is set to `true`.
 
-:::info title="Note"
+:::info Note
 In production mode, the default value of `config.cache` is `false`, which will cause this configuration item invalid. It is recommended to directly configure `config.cache` to `true`.
 :::
 

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -15,9 +15,7 @@ The `externals` configuration option provides a way of excluding dependencies fr
 
 For example, to include [jQuery](https://jquery.com/) from a CDN instead of bundling it:
 
-**index.html**
-
-```html
+```html title="index.html"
 <script
   src="https://code.jquery.com/jquery-3.1.0.js"
   integrity="sha256-slogkvB1K3VOkzAI8QITxV3VzpOnkeNVsKvtkYLMjfk="

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -465,7 +465,7 @@ type ExperimentCacheOptions =
 
 控制实验性的缓存行为，此配置依赖全局开启缓存，需配置 [config.cache](/config/cache) 为 `true` 才有效。
 
-:::info title="Note"
+:::info Note
 production 模式下 `config.cache` 默认值为 `false`，这会导致此配置项失效，建议直接配置 `config.cache` 为 `true`。
 :::
 

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -15,9 +15,7 @@ import { Stability } from '../../../components/ApiMeta';
 
 例如，从 CDN 引入 [jQuery](https://jquery.com/)，而不是把它打包：
 
-**index.html**
-
-```html
+```html title="index.html"
 <script
   src="https://code.jquery.com/jquery-3.1.0.js"
   integrity="sha256-slogkvB1K3VOkzAI8QITxV3VzpOnkeNVsKvtkYLMjfk="


### PR DESCRIPTION
## Summary

I noticed that the note title is displayed incorrectly and the file name is not attached to the code block in the config documentation. I have fixed it for both languages.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
