### PR TITLE
fix: the modules order cross render manifest and content hash should be equal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,7 +4784,6 @@ dependencies = [
  "rspack_hash",
  "rspack_hook",
  "rspack_paths",
- "rspack_plugin_css",
  "rspack_plugin_javascript",
  "rspack_plugin_runtime",
  "rspack_util",

--- a/crates/rspack_plugin_extract_css/Cargo.toml
+++ b/crates/rspack_plugin_extract_css/Cargo.toml
@@ -16,7 +16,6 @@ rspack_error             = { workspace = true }
 rspack_hash              = { workspace = true }
 rspack_hook              = { workspace = true }
 rspack_paths             = { workspace = true }
-rspack_plugin_css        = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
 rspack_plugin_runtime    = { workspace = true }
 rspack_util              = { workspace = true }

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -592,10 +592,10 @@ async fn content_hash(
   }
   let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
 
-  let used_modules =
-    rspack_plugin_css::CssPlugin::get_modules_in_order(chunk, rendered_modules, compilation)
-      .0
-      .into_iter();
+  let used_modules = self
+    .sort_modules(chunk, &rendered_modules, compilation, &module_graph)
+    .0
+    .into_iter();
 
   let mut hasher = hashes
     .entry(SOURCE_TYPE[0])


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

When identical modules exist across different chunks:
* Their content hashes are equal .
* However, due to different module ordering in the render manifest, the final emitted content might differ, causing conflicts.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
