### PR TITLE
feat: support full options for EvalSourceMapDevToolPlugin

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -2372,24 +2372,6 @@ export interface RawSizeLimitsPluginOptions {
   maxEntrypointSize?: number
 }
 
-export interface RawSourceMapDevToolPluginOptions {
-  append?: (false | null) | string | Function
-  columns?: boolean
-  fallbackModuleFilenameTemplate?: string | ((info: RawModuleFilenameTemplateFnCtx) => string)
-  fileContext?: string
-  filename?: (false | null) | string
-  module?: boolean
-  moduleFilenameTemplate?: string | ((info: RawModuleFilenameTemplateFnCtx) => string)
-  namespace?: string
-  noSources?: boolean
-  publicPath?: string
-  sourceRoot?: string
-  test?: string | RegExp | (string | RegExp)[]
-  include?: string | RegExp | (string | RegExp)[]
-  exclude?: string | RegExp | (string | RegExp)[]
-  debugIds?: boolean
-}
-
 export interface RawSplitChunkSizes {
   sizes: Record<string, number>
 }
@@ -2582,6 +2564,24 @@ export interface RegisterJsTaps {
  * In the wasm runtime, the `park` threads will hang there until the tokio::Runtime is shutdown.
  */
 export declare function shutdownAsyncRuntime(): void
+
+export interface SourceMapDevToolPluginOptions {
+  append?: (false | null) | string | Function
+  columns?: boolean
+  fallbackModuleFilenameTemplate?: string | ((info: RawModuleFilenameTemplateFnCtx) => string)
+  fileContext?: string
+  filename?: (false | null) | string
+  module?: boolean
+  moduleFilenameTemplate?: string | ((info: RawModuleFilenameTemplateFnCtx) => string)
+  namespace?: string
+  noSources?: boolean
+  publicPath?: string
+  sourceRoot?: string
+  test?: string | RegExp | (string | RegExp)[]
+  include?: string | RegExp | (string | RegExp)[]
+  exclude?: string | RegExp | (string | RegExp)[]
+  debugIds?: boolean
+}
 
 /**
  * Start the async runtime manually.

--- a/crates/node_binding/src/raw_options/raw_builtins/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/mod.rs
@@ -42,7 +42,6 @@ use rspack_plugin_css::CssPlugin;
 use rspack_plugin_devtool::{
   EvalDevToolModulePlugin, EvalSourceMapDevToolPlugin, SourceMapDevToolModuleOptionsPlugin,
   SourceMapDevToolModuleOptionsPluginOptions, SourceMapDevToolPlugin,
-  SourceMapDevToolPluginOptions,
 };
 use rspack_plugin_dll::{
   DllEntryPlugin, DllReferenceAgencyPlugin, FlagAllModulesAsUsedPlugin, LibManifestPlugin,
@@ -116,8 +115,8 @@ use crate::{
   entry::JsEntryPluginOptions, plugins::JsLoaderRspackPlugin, JsLoaderRunnerGetter,
   RawContextReplacementPluginOptions, RawDynamicEntryPluginOptions,
   RawEvalDevToolModulePluginOptions, RawExternalItemWrapper, RawExternalsPluginOptions,
-  RawHttpExternalsRspackPluginOptions, RawRsdoctorPluginOptions, RawSourceMapDevToolPluginOptions,
-  RawSplitChunksOptions,
+  RawHttpExternalsRspackPluginOptions, RawRsdoctorPluginOptions, RawSplitChunksOptions,
+  SourceMapDevToolPluginOptions,
 };
 
 #[napi(string_enum)]
@@ -479,8 +478,8 @@ impl BuiltinPlugin {
       }
       BuiltinPluginName::AssetModulesPlugin => plugins.push(AssetPlugin::default().boxed()),
       BuiltinPluginName::SourceMapDevToolPlugin => {
-        let options: SourceMapDevToolPluginOptions =
-          downcast_into::<RawSourceMapDevToolPluginOptions>(self.options)
+        let options: rspack_plugin_devtool::SourceMapDevToolPluginOptions =
+          downcast_into::<SourceMapDevToolPluginOptions>(self.options)
             .map_err(|report| napi::Error::from_reason(report.to_string()))?
             .into();
         plugins.push(
@@ -493,8 +492,8 @@ impl BuiltinPlugin {
         plugins.push(SourceMapDevToolPlugin::new(options).boxed());
       }
       BuiltinPluginName::EvalSourceMapDevToolPlugin => {
-        let options: SourceMapDevToolPluginOptions =
-          downcast_into::<RawSourceMapDevToolPluginOptions>(self.options)
+        let options: rspack_plugin_devtool::SourceMapDevToolPluginOptions =
+          downcast_into::<SourceMapDevToolPluginOptions>(self.options)
             .map_err(|report| napi::Error::from_reason(report.to_string()))?
             .into();
         plugins.push(

--- a/crates/node_binding/src/raw_options/raw_devtool.rs
+++ b/crates/node_binding/src/raw_options/raw_devtool.rs
@@ -9,7 +9,6 @@ use rspack_core::PathData;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_devtool::{
   Append, EvalDevToolModulePluginOptions, ModuleFilenameTemplate, ModuleFilenameTemplateFnCtx,
-  SourceMapDevToolPluginOptions,
 };
 
 use crate::{into_asset_conditions, RawAssetConditions};
@@ -98,7 +97,7 @@ fn normalize_raw_module_filename_template(
 }
 
 #[napi(object, object_to_js = false)]
-pub struct RawSourceMapDevToolPluginOptions {
+pub struct SourceMapDevToolPluginOptions {
   #[napi(ts_type = "(false | null) | string | Function")]
   pub append: Option<RawAppend>,
   pub columns: Option<bool>,
@@ -123,8 +122,8 @@ pub struct RawSourceMapDevToolPluginOptions {
   pub debug_ids: Option<bool>,
 }
 
-impl From<RawSourceMapDevToolPluginOptions> for SourceMapDevToolPluginOptions {
-  fn from(opts: RawSourceMapDevToolPluginOptions) -> Self {
+impl From<SourceMapDevToolPluginOptions> for rspack_plugin_devtool::SourceMapDevToolPluginOptions {
+  fn from(opts: SourceMapDevToolPluginOptions) -> Self {
     let append = opts.append.map(normalize_raw_append);
     let filename = opts.filename.and_then(|raw| match raw {
       Either3::A(_) | Either3::B(_) => None,

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -84,7 +84,7 @@ import { Server as Server_2 } from 'tls';
 import { Server as Server_3 } from 'http';
 import { ServerOptions as ServerOptions_2 } from 'https';
 import { ServerResponse as ServerResponse_2 } from 'http';
-import { RawSourceMapDevToolPluginOptions as SourceMapDevToolPluginOptions } from '@rspack/binding';
+import { SourceMapDevToolPluginOptions } from '@rspack/binding';
 import sources = require('../compiled/webpack-sources');
 import { StatSyncFn } from 'fs';
 import { SyncBailHook } from '@rspack/lite-tapable';

--- a/packages/rspack/src/builtin-plugin/EvalSourceMapDevToolPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EvalSourceMapDevToolPlugin.ts
@@ -1,24 +1,13 @@
 import {
 	BuiltinPluginName,
-	type RawSourceMapDevToolPluginOptions
+	type SourceMapDevToolPluginOptions
 } from "@rspack/binding";
 
 import { create } from "./base";
 
 export const EvalSourceMapDevToolPlugin = create(
 	BuiltinPluginName.EvalSourceMapDevToolPlugin,
-	(
-		options: RawSourceMapDevToolPluginOptions
-	): RawSourceMapDevToolPluginOptions => {
-		return {
-			filename: options.filename || undefined,
-			append: options.append,
-			namespace: options.namespace ?? "",
-			columns: options.columns ?? true,
-			noSources: options.noSources ?? false,
-			publicPath: options.publicPath,
-			module: options.module
-		};
-	},
+	(options: SourceMapDevToolPluginOptions): SourceMapDevToolPluginOptions =>
+		options,
 	"compilation"
 );

--- a/packages/rspack/src/builtin-plugin/SourceMapDevToolPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SourceMapDevToolPlugin.ts
@@ -1,14 +1,14 @@
 import {
 	BuiltinPluginName,
-	type RawSourceMapDevToolPluginOptions
+	type SourceMapDevToolPluginOptions
 } from "@rspack/binding";
 
 import { create } from "./base";
 
-export type { RawSourceMapDevToolPluginOptions as SourceMapDevToolPluginOptions };
+export type { SourceMapDevToolPluginOptions };
 
 export const SourceMapDevToolPlugin = create(
 	BuiltinPluginName.SourceMapDevToolPlugin,
-	(options: RawSourceMapDevToolPluginOptions) => options,
+	(options: SourceMapDevToolPluginOptions) => options,
 	"compilation"
 );


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

The EvalSourceMapDevToolPlugin on the Rust side supports all configuration options, but the JS side previously passed only a subset of these settings to Rust. Now, it will forward all configuration options.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
