### PR TITLE
fix: inner graph block scopes

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use rspack_core::{Dependency, SpanExt, UsedByExports};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::{
@@ -17,7 +19,7 @@ use crate::{
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
 pub enum InnerGraphMapSetValue {
-  TopLevel(Atom),
+  TopLevel(TopLevelSymbol),
   Str(Atom),
 }
 
@@ -35,7 +37,7 @@ impl From<InnerGraphMapUsage> for InnerGraphMapSetValue {
 impl InnerGraphMapSetValue {
   pub(crate) fn to_atom(&self) -> &Atom {
     match self {
-      InnerGraphMapSetValue::TopLevel(v) => v,
+      InnerGraphMapSetValue::TopLevel(v) => &v.name,
       InnerGraphMapSetValue::Str(v) => v,
     }
   }
@@ -51,7 +53,7 @@ pub enum InnerGraphMapValue {
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum InnerGraphMapUsage {
-  TopLevel(Atom),
+  TopLevel(TopLevelSymbol),
   Value(Atom),
   True,
 }
@@ -61,15 +63,31 @@ pub struct InnerGraphPlugin {
 }
 
 pub static TOP_LEVEL_SYMBOL: &str = "inner graph top level symbol";
+static TOP_LEVEL_SYMBOL_ID: AtomicUsize = AtomicUsize::new(1);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) struct TopLevelSymbol {
+  id: usize,
   name: Atom,
 }
 
 impl TopLevelSymbol {
   pub fn new(name: Atom) -> Self {
-    Self { name }
+    Self {
+      name,
+      id: TOP_LEVEL_SYMBOL_ID.fetch_add(1, Ordering::Relaxed),
+    }
+  }
+
+  pub fn global() -> Self {
+    Self {
+      name: Atom::from(""),
+      id: 0,
+    }
+  }
+
+  fn is_global(&self) -> bool {
+    self.name.is_empty() && self.id == 0
   }
 }
 
@@ -90,7 +108,7 @@ impl InnerGraphPlugin {
       let symbol = TopLevelSymbol::downcast(tag_info.data.clone().expect("should have data"));
       let usage = parser.inner_graph.get_top_level_symbol();
       parser.inner_graph.add_usage(
-        symbol.name,
+        symbol,
         match usage {
           Some(atom) => InnerGraphMapUsage::TopLevel(atom),
           None => InnerGraphMapUsage::True,
@@ -105,9 +123,7 @@ impl InnerGraphPlugin {
       .statement_with_top_level_symbol
       .get(stmt_span)
     {
-      parser
-        .inner_graph
-        .set_top_level_symbol(Some(v.name.clone()));
+      parser.inner_graph.set_top_level_symbol(Some(v.clone()));
 
       if let Some(pure_part) = parser.inner_graph.statement_pure_part.get(stmt_span) {
         let pure_part_start = pure_part.real_lo();
@@ -136,7 +152,7 @@ impl InnerGraphPlugin {
     }
     let state: &mut super::state::InnerGraphState = &mut parser.inner_graph;
     let mut non_terminal = HashSet::from_iter(state.inner_graph.keys().cloned());
-    let mut processed: HashMap<Atom, HashSet<InnerGraphMapSetValue>> = HashMap::default();
+    let mut processed: HashMap<TopLevelSymbol, HashSet<InnerGraphMapSetValue>> = HashMap::default();
 
     while !non_terminal.is_empty() {
       let mut keys_to_remove = vec![];
@@ -201,11 +217,11 @@ impl InnerGraphPlugin {
         if is_terminal {
           keys_to_remove.push(key.clone());
           // We use `""` to represent global_key
-          if key.is_empty() {
-            let global_value = state.inner_graph.get(&Atom::from("")).cloned();
+          if key.is_global() {
+            let global_value = state.inner_graph.get(&TopLevelSymbol::global()).cloned();
             if let Some(global_value) = global_value {
               for (key, value) in state.inner_graph.iter_mut() {
-                if !key.is_empty() && value != &InnerGraphMapValue::True {
+                if !key.is_global() && value != &InnerGraphMapValue::True {
                   if global_value == InnerGraphMapValue::True {
                     *value = InnerGraphMapValue::True;
                   } else {
@@ -265,7 +281,7 @@ impl InnerGraphPlugin {
       .map(TopLevelSymbol::downcast)
       .unwrap_or_else(|| Self::tag_top_level_symbol(parser, name));
 
-    parser.inner_graph.add_usage(symbol.name, usage);
+    parser.inner_graph.add_usage(symbol, usage);
   }
 
   pub fn on_usage(parser: &mut JavascriptParser, on_usage_callback: UsageCallback) {
@@ -514,8 +530,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
       .statement_with_top_level_symbol
       .get(&stmt_span)
     {
-      let v = v.clone();
-      parser.inner_graph.set_top_level_symbol(Some(v.name));
+      parser.inner_graph.set_top_level_symbol(Some(v.clone()));
 
       if let Some(pure_part) = parser.inner_graph.statement_pure_part.get(&stmt_span) {
         let pure_part_start = pure_part.real_lo();
@@ -567,9 +582,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
       .get(&class_decl_or_expr.span())
       && is_pure_expression(super_class, self.unresolved_context, parser.comments)
     {
-      parser
-        .inner_graph
-        .set_top_level_symbol(Some(v.name.clone()));
+      parser.inner_graph.set_top_level_symbol(Some(v.clone()));
 
       let expr_span = super_class.span();
 
@@ -628,8 +641,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
       if !element.is_static()
         || is_pure_class_member(element, self.unresolved_context, parser.comments)
       {
-        let atom = v.name.clone();
-        parser.inner_graph.set_top_level_symbol(Some(atom));
+        parser.inner_graph.set_top_level_symbol(Some(v.clone()));
         if !matches!(element, ClassMember::Method(_)) && element.is_static() {
           Self::on_usage(
             parser,
@@ -666,9 +678,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
       .decl_with_top_level_symbol
       .get(&decl.span())
     {
-      parser
-        .inner_graph
-        .set_top_level_symbol(Some(v.name.clone()));
+      parser.inner_graph.set_top_level_symbol(Some(v.clone()));
 
       if parser.inner_graph.pure_declarators.contains(&decl.span) {
         // class Foo extends Bar {}

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 
 use rspack_core::UsedByExports;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use swc_core::{common::Span, ecma::atoms::Atom};
+use swc_core::common::Span;
 
 use super::plugin::TopLevelSymbol;
 use crate::{
@@ -16,9 +16,9 @@ pub type UsageCallback = Box<dyn Fn(&mut JavascriptParser, Option<UsedByExports>
 
 #[derive(Default)]
 pub struct InnerGraphState {
-  pub(crate) inner_graph: HashMap<Atom, InnerGraphMapValue>,
-  pub(crate) usage_callback_map: HashMap<Atom, Vec<UsageCallback>>,
-  current_top_level_symbol: Option<Atom>,
+  pub(crate) inner_graph: HashMap<TopLevelSymbol, InnerGraphMapValue>,
+  pub(crate) usage_callback_map: HashMap<TopLevelSymbol, Vec<UsageCallback>>,
+  current_top_level_symbol: Option<TopLevelSymbol>,
   enable: bool,
 
   pub(crate) statement_with_top_level_symbol: HashMap<Span, TopLevelSymbol>,
@@ -47,11 +47,11 @@ impl InnerGraphState {
     self.enable
   }
 
-  pub fn set_top_level_symbol(&mut self, symbol: Option<Atom>) {
+  pub fn set_top_level_symbol(&mut self, symbol: Option<TopLevelSymbol>) {
     self.current_top_level_symbol = symbol;
   }
 
-  pub fn get_top_level_symbol(&self) -> Option<Atom> {
+  pub fn get_top_level_symbol(&self) -> Option<TopLevelSymbol> {
     if self.is_enabled() {
       self.current_top_level_symbol.clone()
     } else {
@@ -59,7 +59,7 @@ impl InnerGraphState {
     }
   }
 
-  pub fn add_usage(&mut self, symbol: Atom, usage: InnerGraphMapUsage) {
+  pub fn add_usage(&mut self, symbol: TopLevelSymbol, usage: InnerGraphMapUsage) {
     if !self.is_enabled() {
       return;
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
@@ -1,7 +1,7 @@
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet;
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, TopLevelSymbol};
 use crate::visitors::JavascriptParser;
 
 pub struct JavascriptMetaInfoPlugin;
@@ -17,7 +17,7 @@ impl JavascriptParserPlugin for JavascriptMetaInfoPlugin {
       parser.build_info.module_concatenation_bailout = Some("eval()".into());
       if let Some(top_level_symbol) = parser.inner_graph.get_top_level_symbol() {
         parser.inner_graph.add_usage(
-          "".to_string().into(),
+          TopLevelSymbol::global(),
           super::InnerGraphMapUsage::TopLevel(top_level_symbol),
         );
       } else {

--- a/tests/webpack-test/configCases/inner-graph/blockScopes/test.filter.js
+++ b/tests/webpack-test/configCases/inner-graph/blockScopes/test.filter.js
@@ -1,2 +1,0 @@
-// TODO: Should create a issue for this test
-module.exports = () => { return "FIXME: used exports is not as expected" }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix inner graph block scope variables analysis
- Use TopLevelSymbol as inner graph map keys which align with [webpack](https://github.com/webpack/webpack/blob/main/lib/optimize/InnerGraph.js#L342-L349)


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
