### PR TITLE
fix: use name instead of identifier in CircularDependencyRspackPlugin

### DIFF
--- a/crates/rspack_plugin_circular_dependencies/src/lib.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/lib.rs
@@ -321,13 +321,18 @@ impl CircularDependencyRspackPlugin {
     // remove the root path here.
     let cycle_without_root: Vec<String> = cycle
       .iter()
-      .map(|module_path| {
-        module_path
-          .to_string()
-          .cow_replace(&cwd, "")
-          .trim_start_matches('/')
-          .trim_start_matches('\\')
-          .to_string()
+      .map(|module_identifier| {
+        compilation
+          .module_by_identifier(module_identifier)
+          .map(|module| {
+            module
+              .readable_identifier(&compilation.options.context)
+              .to_string()
+              .cow_replace(&cwd, "")
+              .trim_start_matches('/')
+              .trim_start_matches('\\')
+              .to_string()
+          })
       })
       .collect();
 

--- a/crates/rspack_plugin_circular_dependencies/src/lib.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/lib.rs
@@ -321,7 +321,7 @@ impl CircularDependencyRspackPlugin {
     // remove the root path here.
     let cycle_without_root: Vec<String> = cycle
       .iter()
-      .map(|module_identifier| {
+      .filter_map(|module_identifier| {
         compilation
           .module_by_identifier(module_identifier)
           .map(|module| {

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/loader.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/loader.js
@@ -1,0 +1,4 @@
+// This is a noop loader that is used to test the circular dependency plugin.
+module.exports = function loader(source) {
+  return source;
+}

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
@@ -8,7 +8,22 @@ module.exports = {
 		bb: "./import-circular/index.js",
 		cc: "./no-cycle/index.js",
 		dd: "./ignore-circular/a.js",
-		ee: "./multiple-circular/a.js"
+		ee: "./multiple-circular/a.js",
+		ff: {
+			import: "./multiple-circular/a.js",
+			layer: "f"
+		}
+	},
+	experiments: {
+		layers: true
+	},
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				loader: "./loader.js"
+			}
+		]
 	},
 	plugins: [
 		new CircularDependencyRspackPlugin({

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/stats.err
@@ -1,13 +1,19 @@
 WARNING in ⚠ Circular dependency detected:
-  │  tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/d.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/e.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/f.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/c.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/require-circular/d.js
+  │  ./require-circular/d.js -> ./require-circular/e.js -> ./require-circular/f.js -> ./require-circular/a.js -> ./require-circular/b.js -> ./require-circular/c.js -> ./require-circular/d.js
 
 WARNING in ⚠ Circular dependency detected:
-  │  tests/diagnosticsCases/plugins/circular-dependency-plugin/import-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/import-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/import-circular/a.js
+  │  ./import-circular/a.js -> ./import-circular/b.js -> ./import-circular/a.js
 
 WARNING in ⚠ Circular dependency detected:
-  │  tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/c.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/d.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js
+  │  ./multiple-circular/a.js -> ./multiple-circular/b.js -> ./multiple-circular/c.js -> ./multiple-circular/d.js -> ./multiple-circular/a.js
 
 WARNING in ⚠ Circular dependency detected:
-  │  tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/b.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/c.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/e.js -> tests/diagnosticsCases/plugins/circular-dependency-plugin/multiple-circular/a.js
+  │  ./multiple-circular/a.js -> ./multiple-circular/b.js -> ./multiple-circular/c.js -> ./multiple-circular/e.js -> ./multiple-circular/a.js
+
+WARNING in ⚠ Circular dependency detected:
+  │  ./multiple-circular/a.js -> ./multiple-circular/b.js -> ./multiple-circular/c.js -> ./multiple-circular/d.js -> ./multiple-circular/a.js
+
+WARNING in ⚠ Circular dependency detected:
+  │  ./multiple-circular/a.js -> ./multiple-circular/b.js -> ./multiple-circular/c.js -> ./multiple-circular/e.js -> ./multiple-circular/a.js
 
 ERROR in × Module not found: Can't resolve './' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/plugins/circular-dependency-plugin'


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Use `module.readable_identifier` instead of plain `ModuleIdentifier`.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: #10378 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
