### PR TITLE
fix: chunk format runtime with entry starts with slash

### DIFF
--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -138,7 +138,7 @@ async fn render_chunk(
       "// load runtime\nvar {} = require({});\n",
       RuntimeGlobals::REQUIRE,
       json_stringify(&get_relative_path(
-        &base_chunk_output_name
+        base_chunk_output_name
           .trim_start_matches("/")
           .trim_start_matches("\\"),
         &runtime_chunk_output_name

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -138,7 +138,9 @@ async fn render_chunk(
       "// load runtime\nvar {} = require({});\n",
       RuntimeGlobals::REQUIRE,
       json_stringify(&get_relative_path(
-        &base_chunk_output_name,
+        &base_chunk_output_name
+          .trim_start_matches("/")
+          .trim_start_matches("\\"),
         &runtime_chunk_output_name
       ))
     )));

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -162,7 +162,7 @@ async fn render_chunk(
     sources.add(RawStringSource::from(format!(
       "import __webpack_require__ from '{}';\n",
       get_relative_path(
-        &base_chunk_output_name
+        base_chunk_output_name
           .trim_start_matches("/")
           .trim_start_matches("\\"),
         &runtime_chunk_output_name

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -161,7 +161,12 @@ async fn render_chunk(
     let runtime_chunk_output_name = get_runtime_chunk_output_name(compilation, chunk_ukey).await?;
     sources.add(RawStringSource::from(format!(
       "import __webpack_require__ from '{}';\n",
-      get_relative_path(&base_chunk_output_name, &runtime_chunk_output_name)
+      get_relative_path(
+        &base_chunk_output_name
+          .trim_start_matches("/")
+          .trim_start_matches("\\"),
+        &runtime_chunk_output_name
+      )
     )));
 
     let entries = compilation

--- a/packages/rspack-test-tools/src/test/creator.ts
+++ b/packages/rspack-test-tools/src/test/creator.ts
@@ -344,10 +344,16 @@ export class BasicCaseCreator<T extends ECompilerType> {
 		testConfig: TTestConfig<T>
 	): boolean | string {
 		const filterPath = path.join(src, "test.filter.js");
-		return (
-			fs.existsSync(filterPath) &&
-			!require(filterPath)(this._options, testConfig)
-		);
+		// no test.filter.js, should not skip
+		if (!fs.existsSync(filterPath)) {
+			return false;
+		}
+		// test.filter.js exists, skip if it returns false|string|array
+		const filtered = require(filterPath)(this._options, testConfig);
+		if (typeof filtered === "string" || Array.isArray(filtered)) {
+			return true;
+		}
+		return !filtered;
 	}
 
 	protected createTester(

--- a/tests/webpack-test/ConfigTestCases.template.js
+++ b/tests/webpack-test/ConfigTestCases.template.js
@@ -477,7 +477,10 @@ const describeCases = config => {
 											let runInNewContext = false;
 											if (
 												options.target === "web" ||
-												options.target === "webworker"
+												options.target === "webworker" ||
+												(Array.isArray(options.target) &&
+													(options.target.includes("web") ||
+														options.target.includes("webworker")))
 											) {
 												baseModuleScope.window = globalContext;
 												baseModuleScope.self = globalContext;

--- a/tests/webpack-test/configCases/asset-modules/build-http/test.filter.js
+++ b/tests/webpack-test/configCases/asset-modules/build-http/test.filter.js
@@ -1,2 +1,1 @@
-// TODO: support function type for buildHttp.allowedUris
-module.exports = () => false;
+module.exports = () => "TODO: support function type for buildHttp.allowedUris";

--- a/tests/webpack-test/configCases/asset-modules/only-entry/test.filter.js
+++ b/tests/webpack-test/configCases/asset-modules/only-entry/test.filter.js
@@ -1,2 +1,1 @@
-// __STATS_I__ is not defined
-module.exports = () => false;
+module.exports = () => "FIXME: generated unexpected main.js";

--- a/tests/webpack-test/configCases/cache-filesystem/multicompiler-mode-cache-3/test.filter.js
+++ b/tests/webpack-test/configCases/cache-filesystem/multicompiler-mode-cache-3/test.filter.js
@@ -1,2 +1,1 @@
-// compiler.options.cache.cacheLocation is undefined
-module.exports = () => false;
+module.exports = () => "NOPLAN: cache of rspack is different with webpack";

--- a/tests/webpack-test/configCases/cache-filesystem/multicompiler-mode-cache-4/test.filter.js
+++ b/tests/webpack-test/configCases/cache-filesystem/multicompiler-mode-cache-4/test.filter.js
@@ -1,2 +1,1 @@
-// compiler.options.cache.cacheLocation is undefined
-module.exports = () => false;
+module.exports = () => "NOPLAN: cache of rspack is different with webpack";

--- a/tests/webpack-test/configCases/chunk-index/issue-18008/test.filter.js
+++ b/tests/webpack-test/configCases/chunk-index/issue-18008/test.filter.js
@@ -1,2 +1,2 @@
 // module.readableIdentifier (from compilation.chunkGraph.getChunkModulesIterable()) is not a function
-module.exports = () => false;
+module.exports = () => "FIXME: missing css ./n.css shared index";

--- a/tests/webpack-test/configCases/clean/lib-manifest-plugin/test.filter.js
+++ b/tests/webpack-test/configCases/clean/lib-manifest-plugin/test.filter.js
@@ -1,2 +1,1 @@
-// missing manifest.json in compilation.getPath(compiler.outputPath, {}); dir
-module.exports = () => false;
+module.exports = () => "FIXME: missing manifest.json in asset files";

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-commonjs/test.filter.js
@@ -1,2 +1,0 @@
-// optimization.runtimeChunk.name not taken into account
-module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-nested-with-deep-entries-esm/test.filter.js
@@ -1,2 +1,0 @@
-// optimization.runtimeChunk.name not taken into account
-module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-commonjs/test.filter.js
@@ -1,2 +1,0 @@
-// optimization.runtimeChunk.name not taken into account
-module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/dynamic-with-deep-entries-esm/test.filter.js
@@ -1,2 +1,0 @@
-// optimization.runtimeChunk.name not taken into account
-module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-commonjs/test.filter.js
@@ -1,2 +1,0 @@
-// optimization.runtimeChunk: "single" not taken into account
-module.exports = () => false;

--- a/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/single-with-deep-entries-esm/test.filter.js
@@ -1,2 +1,0 @@
-// optimization.runtimeChunk: "single" not taken into account
-module.exports = () => false;

--- a/tests/webpack-test/configCases/target/universal/index.js
+++ b/tests/webpack-test/configCases/target/universal/index.js
@@ -12,7 +12,9 @@ it("should circular depend on itself external", () => {
 
 it("work with URL", () => {
 	const url = new URL("./file.png", import.meta.url);
-	expect(/[a-f0-9]{20}\.png/.test(url)).toBe(true);
+	// CHANGE: rspack use 16 length xxhash by default
+	// expect(/[a-f0-9]{20}\.png/.test(url)).toBe(true);
+	expect(/[a-f0-9]{16}\.png/.test(url)).toBe(true);
 });
 
 function test() {

--- a/tests/webpack-test/configCases/target/universal/test.filter.js
+++ b/tests/webpack-test/configCases/target/universal/test.filter.js
@@ -1,2 +1,0 @@
-// For the selected environment is no default ESM chunk format available
-module.exports = () => false;

--- a/tests/webpack-test/configCases/types/filesystems/test.filter.js
+++ b/tests/webpack-test/configCases/types/filesystems/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => false;

--- a/tests/webpack-test/hotCases/css/fetch-priority/test.filter.js
+++ b/tests/webpack-test/hotCases/css/fetch-priority/test.filter.js
@@ -1,2 +1,1 @@
-// TODO: fetch priority for css
-module.exports = () => false
+module.exports = () => false;

--- a/tests/webpack-test/package.json
+++ b/tests/webpack-test/package.json
@@ -6,8 +6,8 @@
   "main": "./dist/index.d.ts",
   "scripts": {
     "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest",
-    "testu": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest -u",
-    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest --json --colors | node scripts/test-metric.js",
+    "testu": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest -u --forceExit",
+    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest --json --colors --forceExit | node scripts/test-metric.js",
     "test:metric:json": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest --logHeapUsage --json"
   },
   "files": [

--- a/tests/webpack-test/watchCases/cache/loader-import-module-progress/test.filter.js
+++ b/tests/webpack-test/watchCases/cache/loader-import-module-progress/test.filter.js
@@ -1,2 +1,1 @@
-// compiler.getCache("ProgressPlugin").getItemCache("counts", null) returns undefined
-module.exports = () => false;
+module.exports = () => "TODO: progress plugin cache not ported to javascript";

--- a/tests/webpack-test/watchCases/cache/loader-load-module-progress/test.filter.js
+++ b/tests/webpack-test/watchCases/cache/loader-load-module-progress/test.filter.js
@@ -1,2 +1,1 @@
-// loaderContext.loadModule is not supported
-module.exports = () => false;
+module.exports = () => "TODO: loaderContext.loadModule is not supported and progress plugin cache not ported to javascript";

--- a/tests/webpack-test/watchCases/cache/max-generation/test.filter.js
+++ b/tests/webpack-test/watchCases/cache/max-generation/test.filter.js
@@ -1,2 +1,2 @@
 // cache.maxGeneration is not supported
-module.exports = () => false
+module.exports = () => "NOPLAN: cache of rspack is different with webpack"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- fix wrong runtime path when entry starts with `/`. for example, when entry is `/entry`, the runtime is `runtime.js`, the generated code should be `./runtime`, but get `../runtime` in rspack.
- enable some webpack test cases that can pass 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
