### PR TITLE
fix: css local ident name with empty unique name

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/basic-include/__snapshot__/bundle0.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/basic-include/__snapshot__/bundle0.css.txt
@@ -1,5 +1,5 @@
 body {
-  & .-_6ec1c834ac8cc99e-used {
+  & ._6ec1c834ac8cc99e-used {
     color: #00f;
   }
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-auto/__snapshot__/index.module.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-auto/__snapshot__/index.module.css.txt
@@ -1,3 +1,3 @@
 Object {
-  "style": "-_6ec1c834ac8cc99e-style",
+  "style": "_6ec1c834ac8cc99e-style",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-composes-preprocessers/__snapshot__/index.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-composes-preprocessers/__snapshot__/index.css.txt
@@ -1,6 +1,6 @@
 Object {
-  "class": "-bd00b1e0e0954270-class -a700d75440d0c95b-lessClass",
-  "ghi": "-bd00b1e0e0954270-ghi",
-  "other": "-bd00b1e0e0954270-other -_59c82bab3b83825a-scssClass",
-  "otherClassName": "-bd00b1e0e0954270-otherClassName globalClassName",
+  "class": "bd00b1e0e0954270-class a700d75440d0c95b-lessClass",
+  "ghi": "bd00b1e0e0954270-ghi",
+  "other": "bd00b1e0e0954270-other _59c82bab3b83825a-scssClass",
+  "otherClassName": "bd00b1e0e0954270-otherClassName globalClassName",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-composes-sass/__snapshot__/index.scss.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-composes-sass/__snapshot__/index.scss.txt
@@ -1,3 +1,3 @@
 Object {
-  "bar": "-_6f71ebaec3a61562-bar -d2e32b33f9cd5760-foo",
+  "bar": "_6f71ebaec3a61562-bar d2e32b33f9cd5760-foo",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-composes/__snapshot__/index.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-composes/__snapshot__/index.css.txt
@@ -1,4 +1,4 @@
 Object {
-  "simple-bar": "-bd00b1e0e0954270-simple-bar -e631de715f468814-imported-simple",
-  "simple-foo": "-bd00b1e0e0954270-simple-foo -e631de715f468814-imported-simple",
+  "simple-bar": "bd00b1e0e0954270-simple-bar e631de715f468814-imported-simple",
+  "simple-foo": "bd00b1e0e0954270-simple-foo e631de715f468814-imported-simple",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-dedupe/__snapshot__/source.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-dedupe/__snapshot__/source.css.txt
@@ -1,4 +1,4 @@
 Object {
-  "backButton": "-_1f9dde4a2b9fd39e-backButton -_3c0cdf795e5ee8e4-secondaryButton -_542ff2973456bd9e-button",
-  "nextButton": "-_1f9dde4a2b9fd39e-nextButton -_7fe530a949364eca-primaryButton -_542ff2973456bd9e-button",
+  "backButton": "_1f9dde4a2b9fd39e-backButton _3c0cdf795e5ee8e4-secondaryButton _542ff2973456bd9e-button",
+  "nextButton": "_1f9dde4a2b9fd39e-nextButton _7fe530a949364eca-primaryButton _542ff2973456bd9e-button",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-exports-only/__snapshot__/index.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-exports-only/__snapshot__/index.css.txt
@@ -1,4 +1,4 @@
 Object {
-  "simple-bar": "-bd00b1e0e0954270-simple-bar -e631de715f468814-imported-simple",
-  "simple-foo": "-bd00b1e0e0954270-simple-foo -e631de715f468814-imported-simple",
+  "simple-bar": "bd00b1e0e0954270-simple-bar e631de715f468814-imported-simple",
+  "simple-foo": "bd00b1e0e0954270-simple-foo e631de715f468814-imported-simple",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-camelCase/__snapshot__/index.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-camelCase/__snapshot__/index.css.txt
@@ -1,9 +1,9 @@
 Object {
-  "btn--info_is-disabled_1": "-bd00b1e0e0954270-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "-bd00b1e0e0954270-btn-info_is-disabled",
-  "btnInfoIsDisabled": "-bd00b1e0e0954270-btn-info_is-disabled",
-  "btnInfoIsDisabled1": "-bd00b1e0e0954270-btn--info_is-disabled_1",
-  "fooBar": "-bd00b1e0e0954270-foo_bar",
-  "foo_bar": "-bd00b1e0e0954270-foo_bar",
-  "simple": "-bd00b1e0e0954270-simple",
+  "btn--info_is-disabled_1": "bd00b1e0e0954270-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "bd00b1e0e0954270-btn-info_is-disabled",
+  "btnInfoIsDisabled": "bd00b1e0e0954270-btn-info_is-disabled",
+  "btnInfoIsDisabled1": "bd00b1e0e0954270-btn--info_is-disabled_1",
+  "fooBar": "bd00b1e0e0954270-foo_bar",
+  "foo_bar": "bd00b1e0e0954270-foo_bar",
+  "simple": "bd00b1e0e0954270-simple",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-camelCaseOnly/__snapshot__/index.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-camelCaseOnly/__snapshot__/index.css.txt
@@ -1,6 +1,6 @@
 Object {
-  "btnInfoIsDisabled": "-bd00b1e0e0954270-btn-info_is-disabled",
-  "btnInfoIsDisabled1": "-bd00b1e0e0954270-btn--info_is-disabled_1",
-  "fooBar": "-bd00b1e0e0954270-foo_bar",
-  "simple": "-bd00b1e0e0954270-simple",
+  "btnInfoIsDisabled": "bd00b1e0e0954270-btn-info_is-disabled",
+  "btnInfoIsDisabled1": "bd00b1e0e0954270-btn--info_is-disabled_1",
+  "fooBar": "bd00b1e0e0954270-foo_bar",
+  "simple": "bd00b1e0e0954270-simple",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-dashes/__snapshot__/index.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-locals-convention-dashes/__snapshot__/index.css.txt
@@ -1,9 +1,9 @@
 Object {
-  "btn--info_is-disabled_1": "-bd00b1e0e0954270-btn--info_is-disabled_1",
-  "btn-info-is-disabled": "-bd00b1e0e0954270-btn-info_is-disabled",
-  "btn-info-is-disabled-1": "-bd00b1e0e0954270-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "-bd00b1e0e0954270-btn-info_is-disabled",
-  "foo-bar": "-bd00b1e0e0954270-foo_bar",
-  "foo_bar": "-bd00b1e0e0954270-foo_bar",
-  "simple": "-bd00b1e0e0954270-simple",
+  "btn--info_is-disabled_1": "bd00b1e0e0954270-btn--info_is-disabled_1",
+  "btn-info-is-disabled": "bd00b1e0e0954270-btn-info_is-disabled",
+  "btn-info-is-disabled-1": "bd00b1e0e0954270-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "bd00b1e0e0954270-btn-info_is-disabled",
+  "foo-bar": "bd00b1e0e0954270-foo_bar",
+  "foo_bar": "bd00b1e0e0954270-foo_bar",
+  "simple": "bd00b1e0e0954270-simple",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-pseudo/__snapshot__/index.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-pseudo/__snapshot__/index.css.txt
@@ -1,9 +1,9 @@
 Object {
-  "bar": "-bd00b1e0e0954270-bar",
-  "bav": "-bd00b1e0e0954270-bav",
-  "foo": "-bd00b1e0e0954270-foo",
-  "four": "-bd00b1e0e0954270-four",
-  "one": "-bd00b1e0e0954270-one",
-  "three": "-bd00b1e0e0954270-three",
-  "two": "-bd00b1e0e0954270-two",
+  "bar": "bd00b1e0e0954270-bar",
+  "bav": "bd00b1e0e0954270-bav",
+  "foo": "bd00b1e0e0954270-foo",
+  "four": "bd00b1e0e0954270-four",
+  "one": "bd00b1e0e0954270-one",
+  "three": "bd00b1e0e0954270-three",
+  "two": "bd00b1e0e0954270-two",
 }

--- a/packages/rspack-test-tools/tests/configCases/builtins/css-modules-simple/__snapshot__/index.module.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/builtins/css-modules-simple/__snapshot__/index.module.css.txt
@@ -1,3 +1,3 @@
 Object {
-  "style": "-_6ec1c834ac8cc99e-style",
+  "style": "_6ec1c834ac8cc99e-style",
 }

--- a/packages/rspack-test-tools/tests/configCases/css/override-exports/index.js
+++ b/packages/rspack-test-tools/tests/configCases/css/override-exports/index.js
@@ -2,9 +2,9 @@ import * as classes from "./index.module.css";
 
 it("should have correct classes", function () {
 	expect(classes).toEqual(nsObj({
-		base: "-_index_module_css-base",
-		first: "-_index_module_css-first -_index_module_css-base",
-		second: "-_index_module_css-second -_index_module_css-base",
-		container: "-_index_module_css-container",
+		base: "_index_module_css-base",
+		first: "_index_module_css-first _index_module_css-base",
+		second: "_index_module_css-second _index_module_css-base",
+		container: "_index_module_css-container",
 	}))
 });

--- a/packages/rspack-test-tools/tests/configCases/mangle-exports/skipping-mangle-css-modules/index.js
+++ b/packages/rspack-test-tools/tests/configCases/mangle-exports/skipping-mangle-css-modules/index.js
@@ -6,5 +6,5 @@ it("should not mangle css module", () => {
   // Using this to trigger a none provided export
   test.res;
 
-  expect(test.test).toBe("-_6ec1c834ac8cc99e-test");
+  expect(test.test).toBe("_6ec1c834ac8cc99e-test");
 });

--- a/packages/rspack-test-tools/tests/defaultsCases/experiments/future-defaults.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/experiments/future-defaults.js
@@ -83,13 +83,13 @@ module.exports = {
 		+         "esModule": true,
 		+         "exportsConvention": "as-is",
 		+         "exportsOnly": false,
-		+         "localIdentName": "[uniqueName]-[id]-[local]",
+		+         "localIdentName": "[id]-[local]",
 		+       },
 		+       "css/module": Object {
 		+         "esModule": true,
 		+         "exportsConvention": "as-is",
 		+         "exportsOnly": false,
-		+         "localIdentName": "[uniqueName]-[id]-[local]",
+		+         "localIdentName": "[id]-[local]",
 		+       },
 		@@ ... @@
 		+         },

--- a/packages/rspack-test-tools/tests/hotCases/css/css-modules/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-modules/__snapshots__/web/1.snap.txt
@@ -1,9 +1,11 @@
 # Case css-modules: Step 1
 
 ## Changed Files
+
 - index.module.css
 
 ## Asset Files
+
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 802
@@ -16,19 +18,20 @@
 {"c":["main"],"r":[],"m":[]}
 ```
 
-
 ## Update
-
 
 ### main.LAST_HASH.hot-update.js
 
 #### Changed Modules
+
 - ./index.module.css
 
 #### Changed Runtime Modules
+
 - webpack/runtime/get_full_hash
 
 #### Changed Content
+
 ```js
 "use strict";
 self["webpackHotUpdate"]("main", {
@@ -38,7 +41,7 @@ self["webpackHotUpdate"]("main", {
   \**************************/
 (function (module, __unused_webpack_exports, __webpack_require__) {
 var exports = {
-  "a": "-_index_module_css-a",
+  "a": "_index_module_css-a",
 };
 // only invalidate when locals change
 var stringified_exports = JSON.stringify(exports);

--- a/packages/rspack-test-tools/tests/hotCases/css/css-modules/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/css/css-modules/__snapshots__/web/1.snap.txt
@@ -1,14 +1,12 @@
 # Case css-modules: Step 1
 
 ## Changed Files
-
 - index.module.css
 
 ## Asset Files
-
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 802
+- Update: main.LAST_HASH.hot-update.js, size: 801
 
 ## Manifest
 
@@ -18,20 +16,19 @@
 {"c":["main"],"r":[],"m":[]}
 ```
 
+
 ## Update
+
 
 ### main.LAST_HASH.hot-update.js
 
 #### Changed Modules
-
 - ./index.module.css
 
 #### Changed Runtime Modules
-
 - webpack/runtime/get_full_hash
 
 #### Changed Content
-
 ```js
 "use strict";
 self["webpackHotUpdate"]("main", {

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -104,7 +104,8 @@ export const applyRspackOptionsDefaults = (
 		asyncWebAssembly: options.experiments.asyncWebAssembly!,
 		css: options.experiments.css,
 		targetProperties,
-		mode: options.mode
+		mode: options.mode,
+		uniqueName: options.output.uniqueName
 	});
 
 	applyOutputDefaults(options.output, {
@@ -305,12 +306,14 @@ const applyModuleDefaults = (
 		asyncWebAssembly,
 		css,
 		targetProperties,
-		mode
+		mode,
+		uniqueName
 	}: {
 		asyncWebAssembly: boolean;
 		css?: boolean;
 		targetProperties: any;
 		mode?: Mode;
+		uniqueName?: string;
 	}
 ) => {
 	assertNotNill(module.parser);
@@ -374,11 +377,11 @@ const applyModuleDefaults = (
 			!targetProperties || !targetProperties.document
 		);
 		D(module.generator["css/auto"], "exportsConvention", "as-is");
-		D(
-			module.generator["css/auto"],
-			"localIdentName",
-			"[uniqueName]-[id]-[local]"
-		);
+		const localIdentName =
+			uniqueName && uniqueName.length > 0
+				? "[uniqueName]-[id]-[local]"
+				: "[id]-[local]";
+		D(module.generator["css/auto"], "localIdentName", localIdentName);
 		D(module.generator["css/auto"], "esModule", true);
 
 		F(module.generator, "css/module", () => ({}));
@@ -389,11 +392,7 @@ const applyModuleDefaults = (
 			!targetProperties || !targetProperties.document
 		);
 		D(module.generator["css/module"], "exportsConvention", "as-is");
-		D(
-			module.generator["css/module"],
-			"localIdentName",
-			"[uniqueName]-[id]-[local]"
-		);
+		D(module.generator["css/module"], "localIdentName", localIdentName);
 		D(module.generator["css/module"], "esModule", true);
 	}
 

--- a/tests/webpack-test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1,112 +1,154 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ConfigTestCases css css-modules-no-space exported tests should allow to create css modules 1`] = `
+Object {
+  "class": "_style_module_css-class",
+}
+`;
+
+exports[`ConfigTestCases css css-modules-no-space exported tests should allow to create css modules 2`] = `
+"/* #region \\"./style.module.css\\" */
+/*
+- type: css/auto
+*/
+._style_module_css-no-space {
+	.class {
+		color: red;
+	}
+
+	.class {
+		color: red;
+	}
+
+	._style_module_css-class {
+		color: red;
+	}
+
+	._style_module_css-class {
+		color: red;
+	}
+
+	#_style_module_css-hash {
+		color: red;
+	}
+
+	{
+		color: red;
+	}
+}
+
+/* #endregion \\"./style.module.css\\" */
+
+"
+`;
+
 exports[`ConfigTestCases css escape-unescape exported tests should work with URLs in CSS: classes 1`] = `
 Object {
-  "#": "-_style_modules_css-#",
-  "##": "-_style_modules_css-##",
-  "#.#.#": "-_style_modules_css-#.#.#",
-  "#fake-id": "-_style_modules_css-#fake-id",
-  "++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.": "-_style_modules_css-++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.",
-  "-a-b-c-": "-_style_modules_css--a-b-c-",
-  "-a0-34a___f": "-_style_modules_css--a0-34a___f",
-  ".": "-_style_modules_css-.",
-  "123": "-_style_modules_css-123",
-  "1a2b3c": "-_style_modules_css-1a2b3c",
-  ":)": "-_style_modules_css-:)",
-  ":\`(": "-_style_modules_css-:\`(",
-  ":hover": "-_style_modules_css-:hover",
-  ":hover:focus:active": "-_style_modules_css-:hover:focus:active",
-  "<><<<>><>": "-_style_modules_css-<><<<>><>",
-  "<p>": "-_style_modules_css-<p>",
-  "?": "-_style_modules_css-?",
-  "@": "-_style_modules_css-@",
-  "B&W?": "-_style_modules_css-B&W?",
-  "[attr=value]": "-_style_modules_css-[attr=value]",
-  "_": "-_style_modules_css-_",
-  "_test": "-_style_modules_css-_test",
-  "class": "-_style_modules_css-class",
-  "className": "-_style_modules_css-className",
-  "f!o!o": "-_style_modules_css-f!o!o",
-  "f'o'o": "-_style_modules_css-f'o'o",
-  "f*o*o": "-_style_modules_css-f*o*o",
-  "f+o+o": "-_style_modules_css-f+o+o",
-  "f/o/o": "-_style_modules_css-f/o/o",
-  "f@oo": "-_style_modules_css-f@oo",
-  "f\\\\o\\\\o": "-_style_modules_css-f\\\\o\\\\o",
-  "foo.bar": "-_style_modules_css-foo.bar",
-  "foo/bar": "-_style_modules_css-foo/bar",
-  "foo/bar/baz": "-_style_modules_css-foo/bar/baz",
-  "foo\\\\bar": "-_style_modules_css-foo\\\\bar",
-  "foo\\\\bar\\\\baz": "-_style_modules_css-foo\\\\bar\\\\baz",
-  "f~o~o": "-_style_modules_css-f~o~o",
-  "m_x_@": "-_style_modules_css-m_x_@",
-  "someId": "-_style_modules_css-someId",
-  "subClass": "-_style_modules_css-subClass",
-  "test": "-_style_modules_css-test",
-  "{}": "-_style_modules_css-{}",
-  "©": "-_style_modules_css-©",
-  "“‘’”": "-_style_modules_css-“‘’”",
-  "⌘⌥": "-_style_modules_css-⌘⌥",
-  "☺☃": "-_style_modules_css-☺☃",
-  "♥": "-_style_modules_css-♥",
-  "𝄞♪♩♫♬": "-_style_modules_css-𝄞♪♩♫♬",
-  "💩": "-_style_modules_css-💩",
-  "😍": "-_style_modules_css-😍",
+  "#": "_style_modules_css-#",
+  "##": "_style_modules_css-##",
+  "#.#.#": "_style_modules_css-#.#.#",
+  "#fake-id": "_style_modules_css-#fake-id",
+  "++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.": "_style_modules_css-++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.",
+  "-a-b-c-": "_style_modules_css--a-b-c-",
+  "-a0-34a___f": "_style_modules_css--a0-34a___f",
+  ".": "_style_modules_css-.",
+  "123": "_style_modules_css-123",
+  "1a2b3c": "_style_modules_css-1a2b3c",
+  ":)": "_style_modules_css-:)",
+  ":\`(": "_style_modules_css-:\`(",
+  ":hover": "_style_modules_css-:hover",
+  ":hover:focus:active": "_style_modules_css-:hover:focus:active",
+  "<><<<>><>": "_style_modules_css-<><<<>><>",
+  "<p>": "_style_modules_css-<p>",
+  "?": "_style_modules_css-?",
+  "@": "_style_modules_css-@",
+  "B&W?": "_style_modules_css-B&W?",
+  "[attr=value]": "_style_modules_css-[attr=value]",
+  "_": "_style_modules_css-_",
+  "_test": "_style_modules_css-_test",
+  "class": "_style_modules_css-class",
+  "className": "_style_modules_css-className",
+  "f!o!o": "_style_modules_css-f!o!o",
+  "f'o'o": "_style_modules_css-f'o'o",
+  "f*o*o": "_style_modules_css-f*o*o",
+  "f+o+o": "_style_modules_css-f+o+o",
+  "f/o/o": "_style_modules_css-f/o/o",
+  "f@oo": "_style_modules_css-f@oo",
+  "f\\\\o\\\\o": "_style_modules_css-f\\\\o\\\\o",
+  "foo.bar": "_style_modules_css-foo.bar",
+  "foo/bar": "_style_modules_css-foo/bar",
+  "foo/bar/baz": "_style_modules_css-foo/bar/baz",
+  "foo\\\\bar": "_style_modules_css-foo\\\\bar",
+  "foo\\\\bar\\\\baz": "_style_modules_css-foo\\\\bar\\\\baz",
+  "f~o~o": "_style_modules_css-f~o~o",
+  "m_x_@": "_style_modules_css-m_x_@",
+  "someId": "_style_modules_css-someId",
+  "subClass": "_style_modules_css-subClass",
+  "test": "_style_modules_css-test",
+  "{}": "_style_modules_css-{}",
+  "©": "_style_modules_css-©",
+  "“‘’”": "_style_modules_css-“‘’”",
+  "⌘⌥": "_style_modules_css-⌘⌥",
+  "☺☃": "_style_modules_css-☺☃",
+  "♥": "_style_modules_css-♥",
+  "𝄞♪♩♫♬": "_style_modules_css-𝄞♪♩♫♬",
+  "💩": "_style_modules_css-💩",
+  "😍": "_style_modules_css-😍",
 }
 `;
 
 exports[`ConfigTestCases css escape-unescape exported tests should work with URLs in CSS: classes 2`] = `
 Object {
-  "#": "-_style_modules_css-#",
-  "##": "-_style_modules_css-##",
-  "#.#.#": "-_style_modules_css-#.#.#",
-  "#fake-id": "-_style_modules_css-#fake-id",
-  "++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.": "-_style_modules_css-++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.",
-  "-a-b-c-": "-_style_modules_css--a-b-c-",
-  "-a0-34a___f": "-_style_modules_css--a0-34a___f",
-  ".": "-_style_modules_css-.",
-  "123": "-_style_modules_css-123",
-  "1a2b3c": "-_style_modules_css-1a2b3c",
-  ":)": "-_style_modules_css-:)",
-  ":\`(": "-_style_modules_css-:\`(",
-  ":hover": "-_style_modules_css-:hover",
-  ":hover:focus:active": "-_style_modules_css-:hover:focus:active",
-  "<><<<>><>": "-_style_modules_css-<><<<>><>",
-  "<p>": "-_style_modules_css-<p>",
-  "?": "-_style_modules_css-?",
-  "@": "-_style_modules_css-@",
-  "B&W?": "-_style_modules_css-B&W?",
-  "[attr=value]": "-_style_modules_css-[attr=value]",
-  "_": "-_style_modules_css-_",
-  "_test": "-_style_modules_css-_test",
-  "class": "-_style_modules_css-class",
-  "className": "-_style_modules_css-className",
-  "f!o!o": "-_style_modules_css-f!o!o",
-  "f'o'o": "-_style_modules_css-f'o'o",
-  "f*o*o": "-_style_modules_css-f*o*o",
-  "f+o+o": "-_style_modules_css-f+o+o",
-  "f/o/o": "-_style_modules_css-f/o/o",
-  "f@oo": "-_style_modules_css-f@oo",
-  "f\\\\o\\\\o": "-_style_modules_css-f\\\\o\\\\o",
-  "foo.bar": "-_style_modules_css-foo.bar",
-  "foo/bar": "-_style_modules_css-foo/bar",
-  "foo/bar/baz": "-_style_modules_css-foo/bar/baz",
-  "foo\\\\bar": "-_style_modules_css-foo\\\\bar",
-  "foo\\\\bar\\\\baz": "-_style_modules_css-foo\\\\bar\\\\baz",
-  "f~o~o": "-_style_modules_css-f~o~o",
-  "m_x_@": "-_style_modules_css-m_x_@",
-  "someId": "-_style_modules_css-someId",
-  "subClass": "-_style_modules_css-subClass",
-  "test": "-_style_modules_css-test",
-  "{}": "-_style_modules_css-{}",
-  "©": "-_style_modules_css-©",
-  "“‘’”": "-_style_modules_css-“‘’”",
-  "⌘⌥": "-_style_modules_css-⌘⌥",
-  "☺☃": "-_style_modules_css-☺☃",
-  "♥": "-_style_modules_css-♥",
-  "𝄞♪♩♫♬": "-_style_modules_css-𝄞♪♩♫♬",
-  "💩": "-_style_modules_css-💩",
-  "😍": "-_style_modules_css-😍",
+  "#": "_style_modules_css-#",
+  "##": "_style_modules_css-##",
+  "#.#.#": "_style_modules_css-#.#.#",
+  "#fake-id": "_style_modules_css-#fake-id",
+  "++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.": "_style_modules_css-++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.",
+  "-a-b-c-": "_style_modules_css--a-b-c-",
+  "-a0-34a___f": "_style_modules_css--a0-34a___f",
+  ".": "_style_modules_css-.",
+  "123": "_style_modules_css-123",
+  "1a2b3c": "_style_modules_css-1a2b3c",
+  ":)": "_style_modules_css-:)",
+  ":\`(": "_style_modules_css-:\`(",
+  ":hover": "_style_modules_css-:hover",
+  ":hover:focus:active": "_style_modules_css-:hover:focus:active",
+  "<><<<>><>": "_style_modules_css-<><<<>><>",
+  "<p>": "_style_modules_css-<p>",
+  "?": "_style_modules_css-?",
+  "@": "_style_modules_css-@",
+  "B&W?": "_style_modules_css-B&W?",
+  "[attr=value]": "_style_modules_css-[attr=value]",
+  "_": "_style_modules_css-_",
+  "_test": "_style_modules_css-_test",
+  "class": "_style_modules_css-class",
+  "className": "_style_modules_css-className",
+  "f!o!o": "_style_modules_css-f!o!o",
+  "f'o'o": "_style_modules_css-f'o'o",
+  "f*o*o": "_style_modules_css-f*o*o",
+  "f+o+o": "_style_modules_css-f+o+o",
+  "f/o/o": "_style_modules_css-f/o/o",
+  "f@oo": "_style_modules_css-f@oo",
+  "f\\\\o\\\\o": "_style_modules_css-f\\\\o\\\\o",
+  "foo.bar": "_style_modules_css-foo.bar",
+  "foo/bar": "_style_modules_css-foo/bar",
+  "foo/bar/baz": "_style_modules_css-foo/bar/baz",
+  "foo\\\\bar": "_style_modules_css-foo\\\\bar",
+  "foo\\\\bar\\\\baz": "_style_modules_css-foo\\\\bar\\\\baz",
+  "f~o~o": "_style_modules_css-f~o~o",
+  "m_x_@": "_style_modules_css-m_x_@",
+  "someId": "_style_modules_css-someId",
+  "subClass": "_style_modules_css-subClass",
+  "test": "_style_modules_css-test",
+  "{}": "_style_modules_css-{}",
+  "©": "_style_modules_css-©",
+  "“‘’”": "_style_modules_css-“‘’”",
+  "⌘⌥": "_style_modules_css-⌘⌥",
+  "☺☃": "_style_modules_css-☺☃",
+  "♥": "_style_modules_css-♥",
+  "𝄞♪♩♫♬": "_style_modules_css-𝄞♪♩♫♬",
+  "💩": "_style_modules_css-💩",
+  "😍": "_style_modules_css-😍",
 }
 `;
 
@@ -116,126 +158,126 @@ Array [
 /*
 - type: css/auto
 */
-.-_style_modules_css-class {
+._style_modules_css-class {
 	color: red;
 }
 
-.-_style_modules_css-class {
+._style_modules_css-class {
 	background: blue;
 }
 
-.-_style_modules_css-test {
+._style_modules_css-test {
 	background: red;
 }
 
-.-_style_modules_css-_test {
+._style_modules_css-_test {
 	background: blue;
 }
 
-.-_style_modules_css-className {
+._style_modules_css-className {
 	background: red;
 }
 
-#-_style_modules_css-someId {
+#_style_modules_css-someId {
 	background: green;
 }
 
-.-_style_modules_css-className .-_style_modules_css-subClass {
+._style_modules_css-className ._style_modules_css-subClass {
 	color: green;
 }
 
-#-_style_modules_css-someId .-_style_modules_css-subClass {
+#_style_modules_css-someId ._style_modules_css-subClass {
 	color: blue;
 }
 
-.-_style_modules_css--a0-34a___f {
+._style_modules_css--a0-34a___f {
 	color: red;
 }
 
-.-_style_modules_css-m_x_\\\\@ {
+._style_modules_css-m_x_\\\\@ {
 	margin-left: auto !important;
 	margin-right: auto !important;
 }
 
-.-_style_modules_css-B\\\\&W\\\\? {
+._style_modules_css-B\\\\&W\\\\? {
 	margin-left: auto !important;
 	margin-right: auto !important;
 }
 
 /* matches elements with class=\\":\`(\\" */
-.-_style_modules_css-\\\\:\\\\\`\\\\( {
+._style_modules_css-\\\\:\\\\\`\\\\( {
 	color: aqua;
 }
 
 /* matches elements with class=\\"1a2b3c\\" */
-.-_style_modules_css-1a2b3c {
+._style_modules_css-1a2b3c {
 	color: aliceblue;
 }
 
 /* matches the element with id=\\"#fake-id\\" */
-#-_style_modules_css-\\\\#fake-id {
+#_style_modules_css-\\\\#fake-id {
 	color: antiquewhite;
 }
 
 /* matches the element with id=\\"-a-b-c-\\" */
-#-_style_modules_css--a-b-c- {
+#_style_modules_css--a-b-c- {
 	color: azure;
 }
 
 /* matches the element with id=\\"©\\" */
-#-_style_modules_css-© {
+#_style_modules_css-© {
 	color: black;
 }
 
-.-_style_modules_css-♥ { background: lime; }
-.-_style_modules_css-© { background: lime; }
-.-_style_modules_css-\\\\😍 { background: lime; }
-.-_style_modules_css-“‘’” { background: lime; }
-.-_style_modules_css-☺☃ { background: lime; }
-.-_style_modules_css-⌘⌥ { background: lime; }
-.-_style_modules_css-\\\\𝄞♪♩♫♬ { background: lime; }
-.-_style_modules_css-\\\\💩 { background: lime; }
-.-_style_modules_css-\\\\? { background: lime; }
-.-_style_modules_css-\\\\@ { background: lime; }
-.-_style_modules_css-\\\\. { background: lime; }
-.-_style_modules_css-\\\\:\\\\) { background: lime; }
-.-_style_modules_css-\\\\:\\\\\`\\\\( { background: lime; }
-.-_style_modules_css-123 { background: lime; }
-.-_style_modules_css-1a2b3c { background: lime; }
-.-_style_modules_css-\\\\<p\\\\> { background: lime; }
-.-_style_modules_css-\\\\<\\\\>\\\\<\\\\<\\\\<\\\\>\\\\>\\\\<\\\\> { background: lime; }
-.-_style_modules_css-\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\[\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\>\\\\+\\\\<\\\\<\\\\<\\\\<-\\\\]\\\\>\\\\+\\\\+\\\\.\\\\>\\\\+\\\\.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\.\\\\+\\\\+\\\\+\\\\.\\\\>\\\\+\\\\+\\\\.\\\\<\\\\<\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\>\\\\.\\\\+\\\\+\\\\+\\\\.------\\\\.--------\\\\.\\\\>\\\\+\\\\.\\\\>\\\\. { background: lime; }
-.-_style_modules_css-\\\\# { background: lime; }
-.-_style_modules_css-\\\\#\\\\# { background: lime; }
-.-_style_modules_css-\\\\#\\\\.\\\\#\\\\.\\\\# { background: lime; }
-.-_style_modules_css-_ { background: lime; }
-.-_style_modules_css-\\\\{\\\\} { background: lime; }
-.-_style_modules_css-\\\\#fake-id { background: lime; }
-.-_style_modules_css-foo\\\\.bar { background: lime; }
-.-_style_modules_css-\\\\:hover { background: lime; }
-.-_style_modules_css-\\\\:hover\\\\:focus\\\\:active { background: lime; }
-.-_style_modules_css-\\\\[attr\\\\=value\\\\] { background: lime; }
-.-_style_modules_css-f\\\\/o\\\\/o { background: lime; }
-.-_style_modules_css-f\\\\\\\\o\\\\\\\\o { background: lime; }
-.-_style_modules_css-f\\\\*o\\\\*o { background: lime; }
-.-_style_modules_css-f\\\\!o\\\\!o { background: lime; }
-.-_style_modules_css-f\\\\'o\\\\'o { background: lime; }
-.-_style_modules_css-f\\\\~o\\\\~o { background: lime; }
-.-_style_modules_css-f\\\\+o\\\\+o { background: lime; }
+._style_modules_css-♥ { background: lime; }
+._style_modules_css-© { background: lime; }
+._style_modules_css-\\\\😍 { background: lime; }
+._style_modules_css-“‘’” { background: lime; }
+._style_modules_css-☺☃ { background: lime; }
+._style_modules_css-⌘⌥ { background: lime; }
+._style_modules_css-\\\\𝄞♪♩♫♬ { background: lime; }
+._style_modules_css-\\\\💩 { background: lime; }
+._style_modules_css-\\\\? { background: lime; }
+._style_modules_css-\\\\@ { background: lime; }
+._style_modules_css-\\\\. { background: lime; }
+._style_modules_css-\\\\:\\\\) { background: lime; }
+._style_modules_css-\\\\:\\\\\`\\\\( { background: lime; }
+._style_modules_css-123 { background: lime; }
+._style_modules_css-1a2b3c { background: lime; }
+._style_modules_css-\\\\<p\\\\> { background: lime; }
+._style_modules_css-\\\\<\\\\>\\\\<\\\\<\\\\<\\\\>\\\\>\\\\<\\\\> { background: lime; }
+._style_modules_css-\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\[\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\>\\\\+\\\\<\\\\<\\\\<\\\\<-\\\\]\\\\>\\\\+\\\\+\\\\.\\\\>\\\\+\\\\.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\.\\\\+\\\\+\\\\+\\\\.\\\\>\\\\+\\\\+\\\\.\\\\<\\\\<\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\>\\\\.\\\\+\\\\+\\\\+\\\\.------\\\\.--------\\\\.\\\\>\\\\+\\\\.\\\\>\\\\. { background: lime; }
+._style_modules_css-\\\\# { background: lime; }
+._style_modules_css-\\\\#\\\\# { background: lime; }
+._style_modules_css-\\\\#\\\\.\\\\#\\\\.\\\\# { background: lime; }
+._style_modules_css-_ { background: lime; }
+._style_modules_css-\\\\{\\\\} { background: lime; }
+._style_modules_css-\\\\#fake-id { background: lime; }
+._style_modules_css-foo\\\\.bar { background: lime; }
+._style_modules_css-\\\\:hover { background: lime; }
+._style_modules_css-\\\\:hover\\\\:focus\\\\:active { background: lime; }
+._style_modules_css-\\\\[attr\\\\=value\\\\] { background: lime; }
+._style_modules_css-f\\\\/o\\\\/o { background: lime; }
+._style_modules_css-f\\\\\\\\o\\\\\\\\o { background: lime; }
+._style_modules_css-f\\\\*o\\\\*o { background: lime; }
+._style_modules_css-f\\\\!o\\\\!o { background: lime; }
+._style_modules_css-f\\\\'o\\\\'o { background: lime; }
+._style_modules_css-f\\\\~o\\\\~o { background: lime; }
+._style_modules_css-f\\\\+o\\\\+o { background: lime; }
 
-.-_style_modules_css-foo\\\\/bar {
+._style_modules_css-foo\\\\/bar {
 	background: hotpink;
 }
 
-.-_style_modules_css-foo\\\\\\\\bar {
+._style_modules_css-foo\\\\\\\\bar {
 	background: hotpink;
 }
 
-.-_style_modules_css-foo\\\\/bar\\\\/baz {
+._style_modules_css-foo\\\\/bar\\\\/baz {
 	background: hotpink;
 }
 
-.-_style_modules_css-foo\\\\\\\\bar\\\\\\\\baz {
+._style_modules_css-foo\\\\\\\\bar\\\\\\\\baz {
 	background: hotpink;
 }
 
@@ -249,7 +291,7 @@ details {
 	background-color: var(--main-bg-color-\\\\@2);
 }
 
-@keyframes -_style_modules_css-f\\\\@oo { from { color: red; } to { color: blue; } }
+@keyframes _style_modules_css-f\\\\@oo { from { color: red; } to { color: blue; } }
 
 /* #endregion \\"./style.modules.css\\" */
 
@@ -263,126 +305,126 @@ Array [
 /*
 - type: css/auto
 */
-.-_style_modules_css-class {
+._style_modules_css-class {
 	color: red;
 }
 
-.-_style_modules_css-class {
+._style_modules_css-class {
 	background: blue;
 }
 
-.-_style_modules_css-test {
+._style_modules_css-test {
 	background: red;
 }
 
-.-_style_modules_css-_test {
+._style_modules_css-_test {
 	background: blue;
 }
 
-.-_style_modules_css-className {
+._style_modules_css-className {
 	background: red;
 }
 
-#-_style_modules_css-someId {
+#_style_modules_css-someId {
 	background: green;
 }
 
-.-_style_modules_css-className .-_style_modules_css-subClass {
+._style_modules_css-className ._style_modules_css-subClass {
 	color: green;
 }
 
-#-_style_modules_css-someId .-_style_modules_css-subClass {
+#_style_modules_css-someId ._style_modules_css-subClass {
 	color: blue;
 }
 
-.-_style_modules_css--a0-34a___f {
+._style_modules_css--a0-34a___f {
 	color: red;
 }
 
-.-_style_modules_css-m_x_\\\\@ {
+._style_modules_css-m_x_\\\\@ {
 	margin-left: auto !important;
 	margin-right: auto !important;
 }
 
-.-_style_modules_css-B\\\\&W\\\\? {
+._style_modules_css-B\\\\&W\\\\? {
 	margin-left: auto !important;
 	margin-right: auto !important;
 }
 
 /* matches elements with class=\\":\`(\\" */
-.-_style_modules_css-\\\\:\\\\\`\\\\( {
+._style_modules_css-\\\\:\\\\\`\\\\( {
 	color: aqua;
 }
 
 /* matches elements with class=\\"1a2b3c\\" */
-.-_style_modules_css-1a2b3c {
+._style_modules_css-1a2b3c {
 	color: aliceblue;
 }
 
 /* matches the element with id=\\"#fake-id\\" */
-#-_style_modules_css-\\\\#fake-id {
+#_style_modules_css-\\\\#fake-id {
 	color: antiquewhite;
 }
 
 /* matches the element with id=\\"-a-b-c-\\" */
-#-_style_modules_css--a-b-c- {
+#_style_modules_css--a-b-c- {
 	color: azure;
 }
 
 /* matches the element with id=\\"©\\" */
-#-_style_modules_css-© {
+#_style_modules_css-© {
 	color: black;
 }
 
-.-_style_modules_css-♥ { background: lime; }
-.-_style_modules_css-© { background: lime; }
-.-_style_modules_css-\\\\😍 { background: lime; }
-.-_style_modules_css-“‘’” { background: lime; }
-.-_style_modules_css-☺☃ { background: lime; }
-.-_style_modules_css-⌘⌥ { background: lime; }
-.-_style_modules_css-\\\\𝄞♪♩♫♬ { background: lime; }
-.-_style_modules_css-\\\\💩 { background: lime; }
-.-_style_modules_css-\\\\? { background: lime; }
-.-_style_modules_css-\\\\@ { background: lime; }
-.-_style_modules_css-\\\\. { background: lime; }
-.-_style_modules_css-\\\\:\\\\) { background: lime; }
-.-_style_modules_css-\\\\:\\\\\`\\\\( { background: lime; }
-.-_style_modules_css-123 { background: lime; }
-.-_style_modules_css-1a2b3c { background: lime; }
-.-_style_modules_css-\\\\<p\\\\> { background: lime; }
-.-_style_modules_css-\\\\<\\\\>\\\\<\\\\<\\\\<\\\\>\\\\>\\\\<\\\\> { background: lime; }
-.-_style_modules_css-\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\[\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\>\\\\+\\\\<\\\\<\\\\<\\\\<-\\\\]\\\\>\\\\+\\\\+\\\\.\\\\>\\\\+\\\\.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\.\\\\+\\\\+\\\\+\\\\.\\\\>\\\\+\\\\+\\\\.\\\\<\\\\<\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\>\\\\.\\\\+\\\\+\\\\+\\\\.------\\\\.--------\\\\.\\\\>\\\\+\\\\.\\\\>\\\\. { background: lime; }
-.-_style_modules_css-\\\\# { background: lime; }
-.-_style_modules_css-\\\\#\\\\# { background: lime; }
-.-_style_modules_css-\\\\#\\\\.\\\\#\\\\.\\\\# { background: lime; }
-.-_style_modules_css-_ { background: lime; }
-.-_style_modules_css-\\\\{\\\\} { background: lime; }
-.-_style_modules_css-\\\\#fake-id { background: lime; }
-.-_style_modules_css-foo\\\\.bar { background: lime; }
-.-_style_modules_css-\\\\:hover { background: lime; }
-.-_style_modules_css-\\\\:hover\\\\:focus\\\\:active { background: lime; }
-.-_style_modules_css-\\\\[attr\\\\=value\\\\] { background: lime; }
-.-_style_modules_css-f\\\\/o\\\\/o { background: lime; }
-.-_style_modules_css-f\\\\\\\\o\\\\\\\\o { background: lime; }
-.-_style_modules_css-f\\\\*o\\\\*o { background: lime; }
-.-_style_modules_css-f\\\\!o\\\\!o { background: lime; }
-.-_style_modules_css-f\\\\'o\\\\'o { background: lime; }
-.-_style_modules_css-f\\\\~o\\\\~o { background: lime; }
-.-_style_modules_css-f\\\\+o\\\\+o { background: lime; }
+._style_modules_css-♥ { background: lime; }
+._style_modules_css-© { background: lime; }
+._style_modules_css-\\\\😍 { background: lime; }
+._style_modules_css-“‘’” { background: lime; }
+._style_modules_css-☺☃ { background: lime; }
+._style_modules_css-⌘⌥ { background: lime; }
+._style_modules_css-\\\\𝄞♪♩♫♬ { background: lime; }
+._style_modules_css-\\\\💩 { background: lime; }
+._style_modules_css-\\\\? { background: lime; }
+._style_modules_css-\\\\@ { background: lime; }
+._style_modules_css-\\\\. { background: lime; }
+._style_modules_css-\\\\:\\\\) { background: lime; }
+._style_modules_css-\\\\:\\\\\`\\\\( { background: lime; }
+._style_modules_css-123 { background: lime; }
+._style_modules_css-1a2b3c { background: lime; }
+._style_modules_css-\\\\<p\\\\> { background: lime; }
+._style_modules_css-\\\\<\\\\>\\\\<\\\\<\\\\<\\\\>\\\\>\\\\<\\\\> { background: lime; }
+._style_modules_css-\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\[\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\>\\\\+\\\\+\\\\+\\\\>\\\\+\\\\<\\\\<\\\\<\\\\<-\\\\]\\\\>\\\\+\\\\+\\\\.\\\\>\\\\+\\\\.\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\.\\\\+\\\\+\\\\+\\\\.\\\\>\\\\+\\\\+\\\\.\\\\<\\\\<\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\+\\\\.\\\\>\\\\.\\\\+\\\\+\\\\+\\\\.------\\\\.--------\\\\.\\\\>\\\\+\\\\.\\\\>\\\\. { background: lime; }
+._style_modules_css-\\\\# { background: lime; }
+._style_modules_css-\\\\#\\\\# { background: lime; }
+._style_modules_css-\\\\#\\\\.\\\\#\\\\.\\\\# { background: lime; }
+._style_modules_css-_ { background: lime; }
+._style_modules_css-\\\\{\\\\} { background: lime; }
+._style_modules_css-\\\\#fake-id { background: lime; }
+._style_modules_css-foo\\\\.bar { background: lime; }
+._style_modules_css-\\\\:hover { background: lime; }
+._style_modules_css-\\\\:hover\\\\:focus\\\\:active { background: lime; }
+._style_modules_css-\\\\[attr\\\\=value\\\\] { background: lime; }
+._style_modules_css-f\\\\/o\\\\/o { background: lime; }
+._style_modules_css-f\\\\\\\\o\\\\\\\\o { background: lime; }
+._style_modules_css-f\\\\*o\\\\*o { background: lime; }
+._style_modules_css-f\\\\!o\\\\!o { background: lime; }
+._style_modules_css-f\\\\'o\\\\'o { background: lime; }
+._style_modules_css-f\\\\~o\\\\~o { background: lime; }
+._style_modules_css-f\\\\+o\\\\+o { background: lime; }
 
-.-_style_modules_css-foo\\\\/bar {
+._style_modules_css-foo\\\\/bar {
 	background: hotpink;
 }
 
-.-_style_modules_css-foo\\\\\\\\bar {
+._style_modules_css-foo\\\\\\\\bar {
 	background: hotpink;
 }
 
-.-_style_modules_css-foo\\\\/bar\\\\/baz {
+._style_modules_css-foo\\\\/bar\\\\/baz {
 	background: hotpink;
 }
 
-.-_style_modules_css-foo\\\\\\\\bar\\\\\\\\baz {
+._style_modules_css-foo\\\\\\\\bar\\\\\\\\baz {
 	background: hotpink;
 }
 
@@ -396,7 +438,7 @@ details {
 	background-color: var(--main-bg-color-\\\\@2);
 }
 
-@keyframes -_style_modules_css-f\\\\@oo { from { color: red; } to { color: blue; } }
+@keyframes _style_modules_css-f\\\\@oo { from { color: red; } to { color: blue; } }
 
 /* #endregion \\"./style.modules.css\\" */
 
@@ -412,18 +454,18 @@ Object {
 
 exports[`ConfigTestCases css large exported tests should allow to create css modules: prod 1`] = `
 Object {
-  "placeholder": "-_6d72b53b84605386-placeholder-gray-700",
+  "placeholder": "_6d72b53b84605386-placeholder-gray-700",
 }
 `;
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 1`] = `
 Object {
-  "btn--info_is-disabled_1": "-_style_module_css-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "-_style_module_css-btn-info_is-disabled",
+  "btn--info_is-disabled_1": "_style_module_css-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_style_module_css-btn-info_is-disabled",
   "foo": "bar",
-  "foo_bar": "-_style_module_css-foo_bar",
+  "foo_bar": "_style_module_css-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "-_style_module_css-simple",
+  "simple": "_style_module_css-simple",
 }
 `;
 
@@ -506,12 +548,12 @@ Object {
 
 exports[`ConfigTestCases css local-ident-name exported tests should have correct local ident for css export locals 9`] = `
 Object {
-  "btn--info_is-disabled_1": "-_style_module_css-btn--info_is-disabled_1",
-  "btn-info_is-disabled": "-_style_module_css-btn-info_is-disabled",
+  "btn--info_is-disabled_1": "_style_module_css-btn--info_is-disabled_1",
+  "btn-info_is-disabled": "_style_module_css-btn-info_is-disabled",
   "foo": "bar",
-  "foo_bar": "-_style_module_css-foo_bar",
+  "foo_bar": "_style_module_css-foo_bar",
   "my-btn-info_is-disabled": "value",
-  "simple": "-_style_module_css-simple",
+  "simple": "_style_module_css-simple",
 }
 `;
 

--- a/tests/webpack-test/configCases/css/build-http/test.filter.js
+++ b/tests/webpack-test/configCases/css/build-http/test.filter.js
@@ -1,2 +1,1 @@
-// TODO: support function type for buildHttp.allowedUris
-module.exports = () => false;
+module.exports = () => "TODO: support function type for buildHttp.allowedUris";

--- a/tests/webpack-test/configCases/css/cjs-module-syntax/index.js
+++ b/tests/webpack-test/configCases/css/cjs-module-syntax/index.js
@@ -4,8 +4,8 @@ it("should able to require the css module as commonjs", () => {
 	const style = require("./style.module.css");
 	const interoperatedStyle = _interopRequireDefault(require("./style.module.css"));
 
-	expect(style).toEqual({ foo: '-_style_module_css-foo' });
-	expect(style).not.toEqual(nsObj({ foo: '-_style_module_css-foo' }));
+	expect(style).toEqual({ foo: '_style_module_css-foo' });
+	expect(style).not.toEqual(nsObj({ foo: '_style_module_css-foo' }));
 	expect(style.__esModule).toEqual(undefined);
-	expect(interoperatedStyle.default.foo).toEqual("-_style_module_css-foo");
+	expect(interoperatedStyle.default.foo).toEqual("_style_module_css-foo");
 });

--- a/tests/webpack-test/configCases/css/css-auto/index.js
+++ b/tests/webpack-test/configCases/css/css-auto/index.js
@@ -11,7 +11,7 @@ it("should correctly compile css/auto", () => {
 	expect(style.getPropertyValue("background")).toBe(" #f00");
 	expect(style1.class).toBe("_style1_module_less-class");
 	expect(style2.class).toBe("_style2_modules_less-class");
-	expect(style3.class).toBe("_style3_module_less_loader_js_style3_module_js-class");
-	expect(style4.class).toBe("_style4_module_less_loader_js_style4_js-class");
-	expect(style5.class).toBe("_style5_module_css_loader_js_style4_js-class");
+	// expect(style3.class).toBe("_style3_module_less_loader_js_style3_module_js-class");
+	// expect(style4.class).toBe("_style4_module_less_loader_js_style4_js-class");
+	// expect(style5.class).toBe("_style5_module_css_loader_js_style4_js-class");
 });

--- a/tests/webpack-test/configCases/css/css-auto/test.filter.js
+++ b/tests/webpack-test/configCases/css/css-auto/test.filter.js
@@ -1,2 +1,6 @@
-// css class is prefixed with an unexpected '-'
-module.exports = () => false;
+const { FilteredStatus } = require("../../../lib/util/filterUtil");
+
+module.exports = () => [
+  FilteredStatus.PARTIAL_PASS,
+  "FIXME: ident name not contain loader path"
+];

--- a/tests/webpack-test/configCases/css/css-modules-in-node/test.filter.js
+++ b/tests/webpack-test/configCases/css/css-modules-in-node/test.filter.js
@@ -1,2 +1,3 @@
 // do not support webpack.ids.DeterministicModuleIdsPlugin
-module.exports = () => false;
+// TODO: Should create a issue for this test
+module.exports = () => "TODO: DeterministicModuleIdsPlugin is not exposed";

--- a/tests/webpack-test/configCases/css/css-modules-no-space/test.filter.js
+++ b/tests/webpack-test/configCases/css/css-modules-no-space/test.filter.js
@@ -1,2 +1,0 @@
-// Mismatched warnings in format and number
-module.exports = () => false;

--- a/tests/webpack-test/configCases/css/css-modules-no-space/warnings.js
+++ b/tests/webpack-test/configCases/css/css-modules-no-space/warnings.js
@@ -1,10 +1,19 @@
+// module.exports = [
+// 	[/Missing whitespace after ':global' in ':global\.class \{/],
+// 	[
+// 		/Missing whitespace after ':global' in ':global\/\*\* test \*\*\/\.class \{/
+// 	],
+// 	[/Missing whitespace after ':local' in ':local\.class \{'/],
+// 	[/Missing whitespace after ':local' in ':local\/\*\* test \*\*\/\.class \{'/],
+// 	[/Missing whitespace after ':local' in ':local\/\*\* test \*\*\/#hash \{'/],
+// 	[/Missing whitespace after ':local' in ':local\/\*\* test \*\*\/\{/]
+// ];
+
+
 module.exports = [
-	[/Missing whitespace after ':global' in ':global\.class \{/],
-	[
-		/Missing whitespace after ':global' in ':global\/\*\* test \*\*\/\.class \{/
-	],
-	[/Missing whitespace after ':local' in ':local\.class \{'/],
-	[/Missing whitespace after ':local' in ':local\/\*\* test \*\*\/\.class \{'/],
-	[/Missing whitespace after ':local' in ':local\/\*\* test \*\*\/#hash \{'/],
-	[/Missing whitespace after ':local' in ':local\/\*\* test \*\*\/\{/]
+	[/Missing trailing whitespace/, /:global\.class/],
+	[/Missing trailing whitespace/, /:global\/\*\* test \*\*\/\.class/],
+	[/Missing trailing whitespace/, /:local\.class/],
+	[/Missing trailing whitespace/, /:local\/\*\* test \*\*\/\.class/],
+	[/Missing trailing whitespace/, /:local\/\*\* test \*\*\/#hash/],
 ];

--- a/tests/webpack-test/configCases/css/css-modules/test.filter.js
+++ b/tests/webpack-test/configCases/css/css-modules/test.filter.js
@@ -1,2 +1,1 @@
-// do not support webpack.ids.DeterministicModuleIdsPlugin
-module.exports = () => false;
+module.exports = () => "TODO: DeterministicModuleIdsPlugin and SyncModuleIdsPlugin are not exposed";

--- a/tests/webpack-test/configCases/css/css-types/index.js
+++ b/tests/webpack-test/configCases/css/css-types/index.js
@@ -10,7 +10,7 @@ it("should not parse css modules in type: css", () => {
     const links = document.getElementsByTagName("link");
     const css = links[1].sheet.css;
 
-	expect(css).toMatch(/\:local\(\.foo\)/);
+    expect(css).toMatch(/\:local\(\.foo\)/);
     expect(css).toMatch(/\:global\(\.bar\)/);
 });
 
@@ -21,26 +21,27 @@ it("should compile type: css/module", () => {
     expect(style1.class1).toBe('_style1_local_css-class1');
 });
 
-it("should compile type: css/global", (done) => {
-    const element = document.createElement(".class3");
-    const style = getComputedStyle(element);
-    expect(style.getPropertyValue("color")).toBe(" red");
-    expect(style2.class4).toBe('_style2_global_css-class4');
-    done()
-});
+// CHANGE: not support css/global
+// it("should compile type: css/global", (done) => {
+//     const element = document.createElement(".class3");
+//     const style = getComputedStyle(element);
+//     expect(style.getPropertyValue("color")).toBe(" red");
+//     expect(style2.class4).toBe('_style2_global_css-class4');
+//     done()
+// });
 
 it("should not parse css modules in type: css/auto", () => {
-	const style = getComputedStyle(document.body);
-	expect(style.getPropertyValue("background")).toBe(" red");
-	const links = document.getElementsByTagName("link");
-	const css = links[1].sheet.css;
-	expect(css).toMatch(/\:local\(\.baz\)/);
-	expect(css).toMatch(/\:global\(\.qux\)/);
+    const style = getComputedStyle(document.body);
+    expect(style.getPropertyValue("background")).toBe(" red");
+    const links = document.getElementsByTagName("link");
+    const css = links[1].sheet.css;
+    expect(css).toMatch(/\:local\(\.baz\)/);
+    expect(css).toMatch(/\:global\(\.qux\)/);
 });
 
 it("should parse css modules in type: css/auto", () => {
-	const element = document.createElement(".class3");
-	const style = getComputedStyle(element);
-	expect(style.getPropertyValue("color")).toBe(" red");
-	expect(style3.class3).toBe('_style4_modules_css-class3');
+    const element = document.createElement(".class3");
+    const style = getComputedStyle(element);
+    expect(style.getPropertyValue("color")).toBe(" red");
+    expect(style3.class3).toBe('_style4_modules_css-class3');
 });

--- a/tests/webpack-test/configCases/css/css-types/test.filter.js
+++ b/tests/webpack-test/configCases/css/css-types/test.filter.js
@@ -1,2 +1,6 @@
-// Cannot find module './style2.global.css'
-module.exports = () => false;
+const { FilteredStatus } = require("../../../lib/util/filterUtil");
+
+module.exports = () => [
+  FilteredStatus.PARTIAL_PASS,
+  "TODO: support module type css/global"
+];

--- a/tests/webpack-test/configCases/css/css-types/webpack.config.js
+++ b/tests/webpack-test/configCases/css/css-types/webpack.config.js
@@ -14,7 +14,9 @@ module.exports = {
 			},
 			{
 				test: /\.global\.css$/i,
-				type: "css/global"
+				// CHANGE: not support css/global
+				// type: "css/global"
+				type: "css/auto"
 			},
 			{
 				test: /\.auto\.css$/i,

--- a/tests/webpack-test/configCases/css/default-exports-parser-options/index.js
+++ b/tests/webpack-test/configCases/css/default-exports-parser-options/index.js
@@ -3,16 +3,16 @@ import style2 from "./style.module.css?default";
 import { foo } from "./style.module.css?named";
 
 it("should able to import with default and named exports", () => {
-	expect(style1.default).toEqual(nsObj({ foo: '-_style_module_css_namespace-foo' }));
-	expect(style1.foo).toEqual("-_style_module_css_namespace-foo");
-	expect(style2).toEqual(nsObj({ foo: '-_style_module_css_default-foo' }));
-	expect(foo).toEqual("-_style_module_css_named-foo");
+	expect(style1.default).toEqual(nsObj({ foo: '_style_module_css_namespace-foo' }));
+	expect(style1.foo).toEqual("_style_module_css_namespace-foo");
+	expect(style2).toEqual(nsObj({ foo: '_style_module_css_default-foo' }));
+	expect(foo).toEqual("_style_module_css_named-foo");
 });
 
 it("should able to import with different default and namex dynamic export", (done) => {
 	import("./style.module.css?namespace").then((style1) => {
-		expect(style1.default).toEqual(nsObj({ foo: '-_style_module_css_namespace-foo' }));
-		expect(style1.foo).toEqual('-_style_module_css_namespace-foo');
+		expect(style1.default).toEqual(nsObj({ foo: '_style_module_css_namespace-foo' }));
+		expect(style1.foo).toEqual('_style_module_css_namespace-foo');
 
 		done();
 	}, done)

--- a/tests/webpack-test/configCases/css/exports-convention/test.filter.js
+++ b/tests/webpack-test/configCases/css/exports-convention/test.filter.js
@@ -1,2 +1,1 @@
-// Failed to convert JavaScript value `function exportsConvention(..) ` into rust type `String` on RawCssModuleGeneratorOptions.exportsConvention
-module.exports = () => false;
+module.exports = () => "TODO: support function type exportsConvention";

--- a/tests/webpack-test/configCases/css/exports-in-node/index.js
+++ b/tests/webpack-test/configCases/css/exports-in-node/index.js
@@ -8,7 +8,7 @@ it("should allow to import a css module", () => {
 			a: "a",
 			abc: "a b c",
 			comments: "abc      def",
-			"white space": "abc\n\tdef",
+			whitespace: "abc\n\tdef",
 			default: "default"
 		})
 	);
@@ -18,14 +18,14 @@ it("should allow to import a css module", () => {
 });
 
 it("should allow to dynamic import a css module", done => {
-	import("../exports/style.module.css").then(x => {
+	import("../pseudo-export/style.module.css").then(x => {
 		try {
 			expect(x).toEqual(
 				nsObj({
 					a: "a",
 					abc: "a b c",
 					comments: "abc      def",
-					"white space": "abc\n\tdef",
+					whitespace: "abc\n\tdef",
 					default: "default"
 				})
 			);
@@ -37,14 +37,14 @@ it("should allow to dynamic import a css module", done => {
 });
 
 it("should allow to reexport a css module", done => {
-	import("../exports/reexported").then(x => {
+	import("../pseudo-export/reexported").then(x => {
 		try {
 			expect(x).toEqual(
 				nsObj({
 					a: "a",
 					abc: "a b c",
 					comments: "abc      def",
-					"white space": "abc\n\tdef"
+					whitespace: "abc\n\tdef",
 				})
 			);
 		} catch (e) {
@@ -55,14 +55,14 @@ it("should allow to reexport a css module", done => {
 });
 
 it("should allow to import a css module", done => {
-	import("../exports/imported").then(({ default: x }) => {
+	import("../pseudo-export/imported").then(({ default: x }) => {
 		try {
 			expect(x).toEqual(
 				nsObj({
 					a: "a",
 					abc: "a b c",
 					comments: "abc      def",
-					"white space": "abc\n\tdef",
+					whitespace: "abc\n\tdef",
 					default: "default"
 				})
 			);

--- a/tests/webpack-test/configCases/css/exports-in-node/test.filter.js
+++ b/tests/webpack-test/configCases/css/exports-in-node/test.filter.js
@@ -1,2 +1,0 @@
-// css-lexer cannot parse invalidate css comments
-module.exports = () => true

--- a/tests/webpack-test/configCases/css/exports-in-node/test.filter.js
+++ b/tests/webpack-test/configCases/css/exports-in-node/test.filter.js
@@ -1,2 +1,2 @@
 // css-lexer cannot parse invalidate css comments
-module.exports = () => false
+module.exports = () => true

--- a/tests/webpack-test/configCases/css/exports-only-generator-options/index.js
+++ b/tests/webpack-test/configCases/css/exports-only-generator-options/index.js
@@ -1,26 +1,26 @@
 it("should not have .css file", (done) => {
 	__non_webpack_require__("./pseudo-export_style_module_css.bundle0.js");
-	__non_webpack_require__("./pseudo-export_style_module_css_exportsOnly.bundle0.js");
+	// __non_webpack_require__("./pseudo-export_style_module_css_exportsOnly.bundle0.js");
 	Promise.all([
 		import("../pseudo-export/style.module.css"),
 		import("../pseudo-export/style.module.css?module"),
-		import("../pseudo-export/style.module.css?exportsOnly"),
+		// import("../pseudo-export/style.module.css?exportsOnly"),
 	]).then(([style1, style2, style3]) => {
 		const ns = nsObj({
 			a: "a",
 			abc: "a b c",
-			comments: "abc/****/   /* hello world *//****/   def",
+			comments: "abc      def",
 			whitespace: "abc\n\tdef",
 			default: "default"
 		});
 		expect(style1).toEqual(ns);
 		expect(style2).toEqual(ns);
-		expect(style3).toEqual(ns);
+		// expect(style3).toEqual(ns);
 	}).then(() => {
 		const fs = __non_webpack_require__("fs");
 		const path = __non_webpack_require__("path");
-		expect(fs.existsSync(path.resolve(__dirname, "pseudo-export_style_module_css.bundle0.css"))).toBe(false);
-		expect(fs.existsSync(path.resolve(__dirname, "pseudo-export_style_module_css_exportsOnly.bundle0.css"))).toBe(false);
+		// expect(fs.existsSync(path.resolve(__dirname, "pseudo-export_style_module_css.bundle0.css"))).toBe(false);
+		// expect(fs.existsSync(path.resolve(__dirname, "pseudo-export_style_module_css_exportsOnly.bundle0.css"))).toBe(false);
 		done()
 	}).catch(e => done(e))
 });

--- a/tests/webpack-test/configCases/css/exports-only-generator-options/test.config.js
+++ b/tests/webpack-test/configCases/css/exports-only-generator-options/test.config.js
@@ -3,7 +3,7 @@ module.exports = {
 		return [
 			"pseudo-export_style_module_css.bundle0.js",
 			"pseudo-export_style_module_css_module.bundle0.js",
-			"pseudo-export_style_module_css_exportsOnly.bundle0.js",
+			// "pseudo-export_style_module_css_exportsOnly.bundle0.js",
 			"bundle0.js"
 		];
 	}

--- a/tests/webpack-test/configCases/css/exports-only-generator-options/test.filter.js
+++ b/tests/webpack-test/configCases/css/exports-only-generator-options/test.filter.js
@@ -1,2 +1,6 @@
-// unreachable: unknow module type: css/global
-module.exports = () => false;
+const { FilteredStatus } = require("../../../lib/util/filterUtil");
+
+module.exports = () => [
+  FilteredStatus.PARTIAL_PASS,
+  "TODO: not support css/global"
+];

--- a/tests/webpack-test/configCases/css/exports-only-generator-options/webpack.config.js
+++ b/tests/webpack-test/configCases/css/exports-only-generator-options/webpack.config.js
@@ -17,13 +17,13 @@ module.exports = [
 					resourceQuery: /\?module/,
 					type: "css/module"
 				},
-				{
-					resourceQuery: /\?exportsOnly/,
-					generator: {
-						exportsOnly: true
-					},
-					type: "css/global"
-				}
+				// {
+				// 	resourceQuery: /\?exportsOnly/,
+				// 	generator: {
+				// 		exportsOnly: true
+				// 	},
+				// 	type: "css/global"
+				// }
 			]
 		},
 		experiments: {

--- a/tests/webpack-test/configCases/css/import-at-middle/test.filter.js
+++ b/tests/webpack-test/configCases/css/import-at-middle/test.filter.js
@@ -1,2 +1,1 @@
-// missing "Any '@import' rules must precede all other rules" warnings
-module.exports = () => false;
+module.exports = () => "FIXME: missing `Any '@import' rules must precede all other rules` warnings";

--- a/tests/webpack-test/configCases/css/import/test.filter.js
+++ b/tests/webpack-test/configCases/css/import/test.filter.js
@@ -1,2 +1,1 @@
-// Many "Module not found: Can't resolve" errors
-module.exports = () => false;
+module.exports = () => "FIXME: Many `Module not found: Can't resolve` errors";

--- a/tests/webpack-test/configCases/css/named-exports-parser-options/index.js
+++ b/tests/webpack-test/configCases/css/named-exports-parser-options/index.js
@@ -3,9 +3,9 @@ import style2 from "./style.module.css?default"
 import * as style3 from "./style.module.css?named"
 
 it("should able to import with different namedExports", () => {
-	expect(style1).toEqual(nsObj({ class: '-_style_module_css-class' }));
-	expect(style2).toEqual(nsObj({ class: '-_style_module_css_default-class' }));
-	expect(style3).toEqual(nsObj({ class: '-_style_module_css_named-class' }));
+	expect(style1).toEqual(nsObj({ class: '_style_module_css-class' }));
+	expect(style2).toEqual(nsObj({ class: '_style_module_css_default-class' }));
+	expect(style3).toEqual(nsObj({ class: '_style_module_css_named-class' }));
 });
 
 it("should able to import with different namedExports (async)", (done) => {
@@ -14,12 +14,12 @@ it("should able to import with different namedExports (async)", (done) => {
 		import("./style.module.css?default"),
 		import("./style.module.css?named"),
 	]).then(([style1, style2, style3]) => {
-		expect(style1).toEqual(nsObj({ class: '-_style_module_css-class' }));
+		expect(style1).toEqual(nsObj({ class: '_style_module_css-class' }));
 		expect(style2).toEqual(nsObj({
-			class: "-_style_module_css_default-class",
-			default: nsObj({ class: '-_style_module_css_default-class' })
+			class: "_style_module_css_default-class",
+			default: nsObj({ class: '_style_module_css_default-class' })
 		}));
-		expect(style3).toEqual(nsObj({ class: '-_style_module_css_named-class' }));
+		expect(style3).toEqual(nsObj({ class: '_style_module_css_named-class' }));
 		done()
 	}, done)
 });

--- a/tests/webpack-test/configCases/css/no-extra-runtime-in-js/test.filter.js
+++ b/tests/webpack-test/configCases/css/no-extra-runtime-in-js/test.filter.js
@@ -1,2 +1,1 @@
-// __webpack_require__.m missing properties
-module.exports = () => false;
+module.exports = () => "FIXME: more png modules than webpack";

--- a/tests/webpack-test/hotCases/css/css-modules/index.js
+++ b/tests/webpack-test/hotCases/css/css-modules/index.js
@@ -1,21 +1,21 @@
 import * as styles from "./style.module.css";
 
 it("should work", async function (done) {
-	expect(styles).toMatchObject({ class: "-_style_module_css-class" });
+	expect(styles).toMatchObject({ class: "_style_module_css-class" });
 
 	const styles2 = await import("./style2.module.css");
 
 	expect(styles2).toMatchObject({
-		foo: "-_style2_module_css-foo"
+		foo: "_style2_module_css-foo"
 	});
 
 	module.hot.accept(["./style.module.css", "./style2.module.css"], () => {
 		expect(styles).toMatchObject({
-			"class-other": "-_style_module_css-class-other"
+			"class-other": "_style_module_css-class-other"
 		});
 		import("./style2.module.css").then(styles2 => {
 			expect(styles2).toMatchObject({
-				"bar": "-_style2_module_css-bar"
+				"bar": "_style2_module_css-bar"
 			});
 
 			done();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- when `uniqueName` is not set, the localIdentName should be `[id]-[local]`, not `[uniqueName]-[id]-[local]` to prevent generating a unused `-` behind the names. Align with webpack https://github.com/webpack/webpack/blob/main/lib/config/defaults.js#L740-L741
- enable more webpack tests

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
