### PR TITLE
feat(core): add tracing for javascript plugin

### DIFF
--- a/packages/rspack-test-tools/tests/errorCases/error-test-push.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-test-push.js
@@ -18,9 +18,9 @@ module.exports = {
 		Object {
 		  "errors": Array [
 		    Object {
-		      "message": "  × Error: test push\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  × Error: test push\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: test push\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/error-test-push.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: test push\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/error-test-push.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		    Object {
 		      "loc": "1:0-33",

--- a/packages/rspack-test-tools/tests/errorCases/error-test-set.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-test-set.js
@@ -18,14 +18,14 @@ module.exports = {
 		Object {
 		  "errors": Array [
 		    Object {
-		      "message": "  × Error: error 1\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  × Error: error 1\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: error 1\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/error-test-set.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: error 1\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/error-test-set.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		    Object {
-		      "message": "  × Error: error 2\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  × Error: error 2\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: error 2\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/error-test-set.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: error 2\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/error-test-set.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		  ],
 		  "warnings": Array [],

--- a/packages/rspack-test-tools/tests/errorCases/error-test-shift.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-test-shift.js
@@ -22,9 +22,9 @@ module.exports = {
 		Object {
 		  "errors": Array [
 		    Object {
-		      "message": "  × Error: test unshift\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  × Error: test unshift\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: test unshift\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/error-test-shift.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: test unshift\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/error-test-shift.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		  ],
 		  "warnings": Array [],

--- a/packages/rspack-test-tools/tests/errorCases/error-test-splice-1.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-test-splice-1.js
@@ -18,9 +18,9 @@ module.exports = {
 		Object {
 		  "errors": Array [
 		    Object {
-		      "message": "  × Error: test splice\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  × Error: test splice\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: test splice\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/error-test-splice-1.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: test splice\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/error-test-splice-1.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		  ],
 		  "warnings": Array [],

--- a/packages/rspack-test-tools/tests/errorCases/error-test-splice-2.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-test-splice-2.js
@@ -18,9 +18,9 @@ module.exports = {
 		Object {
 		  "errors": Array [
 		    Object {
-		      "message": "  × Error: test splice\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  × Error: test splice\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: test splice\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/error-test-splice-2.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: test splice\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/error-test-splice-2.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		    Object {
 		      "loc": "1:0-33",

--- a/packages/rspack-test-tools/tests/errorCases/warning-test-push.js
+++ b/packages/rspack-test-tools/tests/errorCases/warning-test-push.js
@@ -19,9 +19,9 @@ module.exports = {
 		  "errors": Array [],
 		  "warnings": Array [
 		    Object {
-		      "message": "  ⚠ Error: test push\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  ⚠ Error: test push\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: test push\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/warning-test-push.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: test push\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/warning-test-push.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		    Object {
 		      "message": "  ⚠ Module parse warning:\\n  ╰─▶   ⚠ Unsupported feature: require.main.require() is not supported by Rspack.\\n         ╭────\\n       1 │ require.main.require('./file');\\n         · ──────────────────────────────\\n         ╰────\\n      \\n",

--- a/packages/rspack-test-tools/tests/errorCases/warning-test-set.js
+++ b/packages/rspack-test-tools/tests/errorCases/warning-test-set.js
@@ -22,14 +22,14 @@ module.exports = {
 		  "errors": Array [],
 		  "warnings": Array [
 		    Object {
-		      "message": "  ⚠ Error: warning 1\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  ⚠ Error: warning 1\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: warning 1\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/warning-test-set.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: warning 1\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/warning-test-set.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		    Object {
-		      "message": "  ⚠ Error: warning 2\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  ⚠ Error: warning 2\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: warning 2\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/warning-test-set.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: warning 2\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/warning-test-set.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		  ],
 		}

--- a/packages/rspack-test-tools/tests/errorCases/warning-test-shift.js
+++ b/packages/rspack-test-tools/tests/errorCases/warning-test-shift.js
@@ -23,9 +23,9 @@ module.exports = {
 		  "errors": Array [],
 		  "warnings": Array [
 		    Object {
-		      "message": "  ⚠ Error: test unshift\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  ⚠ Error: test unshift\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: test unshift\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/warning-test-shift.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: test unshift\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/warning-test-shift.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		  ],
 		}

--- a/packages/rspack-test-tools/tests/errorCases/warning-test-splice-1.js
+++ b/packages/rspack-test-tools/tests/errorCases/warning-test-splice-1.js
@@ -19,9 +19,9 @@ module.exports = {
 		  "errors": Array [],
 		  "warnings": Array [
 		    Object {
-		      "message": "  ⚠ Error: test splice\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  ⚠ Error: test splice\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: test splice\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/warning-test-splice-1.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: test splice\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/warning-test-splice-1.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		  ],
 		}

--- a/packages/rspack-test-tools/tests/errorCases/warning-test-splice-2.js
+++ b/packages/rspack-test-tools/tests/errorCases/warning-test-splice-2.js
@@ -19,9 +19,9 @@ module.exports = {
 		  "errors": Array [],
 		  "warnings": Array [
 		    Object {
-		      "message": "  ⚠ Error: test splice\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
+		      "message": "  ⚠ Error: test splice\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n  │     at xxx\\n",
 		      "moduleTrace": Array [],
-		      "stack": "Error: test splice\\n    at Object.fn (<TEST_TOOLS_ROOT>/tests/errorCases/warning-test-splice-2.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
+		      "stack": "Error: test splice\\n    at <TEST_TOOLS_ROOT>/tests/errorCases/warning-test-splice-2.js<LINE_COL>\\n    at Object.fn (<RSPACK_ROOT>/dist/index.js<LINE_COL>)\\n    at next (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsyncStageRange (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at AsyncSeriesHook.callAsync (<ROOT>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)\\n    at <RSPACK_ROOT>/dist/index.js<LINE_COL>",
 		    },
 		    Object {
 		      "message": "  ⚠ Module parse warning:\\n  ╰─▶   ⚠ Unsupported feature: require.main.require() is not supported by Rspack.\\n         ╭────\\n       1 │ require.main.require('./file');\\n         · ──────────────────────────────\\n         ╰────\\n      \\n",

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -62,6 +62,7 @@ import {
 	createJavaScriptModulesHooksRegisters,
 	createNormalModuleFactoryHooksRegisters
 } from "./taps";
+import { TraceHookPlugin } from "./trace/traceHookPlugin";
 import type {
 	InputFileSystem,
 	IntermediateFileSystem,
@@ -248,6 +249,7 @@ class Compiler {
 		);
 		new JsLoaderRspackPlugin(this).apply(this);
 		new ExecuteModulePlugin().apply(this);
+		new TraceHookPlugin().apply(this);
 
 		// this.hooks.shutdown.tap("rspack:cleanup", () => {
 		// 	// Delayed rspack cleanup to the next tick.

--- a/packages/rspack/src/trace/index.ts
+++ b/packages/rspack/src/trace/index.ts
@@ -29,7 +29,8 @@ export class JavaScriptTracer {
 	static output: string;
 	// inspector session for CPU Profiler
 	static session: import("node:inspector").Session;
-
+	// plugin counter for different channel in trace viewer, choose 100 to avoid conflict with known tracks
+	static counter = 100;
 	static async initJavaScriptTrace(layer: string, output: string) {
 		const { Session } = await import("node:inspector");
 		this.session = new Session();

--- a/packages/rspack/src/trace/index.ts
+++ b/packages/rspack/src/trace/index.ts
@@ -6,9 +6,9 @@ export interface ChromeEvent {
 	ph?: string;
 	cat?: string; // cat is used to show different track in perfetto with id
 	ts?: number;
-	pid?: number;
-	tid?: number;
-	id?: number; // updated to allow string id
+	pid?: number | string;
+	tid?: number | string;
+	id?: number | string; // updated to allow string id
 	args?: {
 		[key: string]: any;
 	};

--- a/packages/rspack/src/trace/traceHookPlugin.ts
+++ b/packages/rspack/src/trace/traceHookPlugin.ts
@@ -1,0 +1,196 @@
+import {} from "@rspack/lite-tapable";
+import { JavaScriptTracer } from ".";
+// adjust from webpack's ProfilingPlugin https://github.com/webpack/webpack/blob/dec18718be5dfba28f067fb3827dd620a1f33667/lib/debug/ProfilingPlugin.js#L1
+import type { Compiler } from "../exports";
+const PLUGIN_NAME = "TraceHookPlugin";
+type FullTap = Tap & {
+	type: "sync" | "async" | "promise";
+	fn: Function;
+};
+type Tap = TapOptions & {
+	name: string;
+};
+type TapOptions = {
+	before?: string;
+	stage?: number;
+};
+// This plugin is used to trace the execution of various hooks in the build process.
+const makeInterceptorFor =
+	(compilerName: string, tracer: typeof JavaScriptTracer) =>
+	(hookName: string) => ({
+		register: (tapInfo: FullTap) => {
+			const { name, type, fn: internalFn } = tapInfo;
+			const newFn =
+				// Don't tap our own hooks to ensure stream can close cleanly
+				name === PLUGIN_NAME
+					? internalFn
+					: makeNewTraceTapFn(compilerName, hookName, tracer, {
+							name,
+							type,
+							fn: internalFn
+						});
+			return { ...tapInfo, fn: newFn };
+		}
+	});
+const interceptAllHooksFor = (
+	instance: any,
+	tracer: typeof JavaScriptTracer,
+	logLabel: string
+) => {
+	if (Reflect.has(instance, "hooks")) {
+		for (const hookName of Object.keys(instance.hooks)) {
+			const hook = instance.hooks[hookName];
+			if (hook && !hook._fakeHook) {
+				hook.intercept(makeInterceptorFor(logLabel, tracer)(hookName));
+			}
+		}
+	}
+};
+const makeNewTraceTapFn = (
+	compilerName: string,
+	hookName: string,
+	tracer: typeof JavaScriptTracer,
+	{ name: pluginName, type, fn }: { name: string; type: string; fn: Function }
+) => {
+	const name = `${compilerName}:${pluginName}:${hookName}`;
+	switch (type) {
+		case "promise":
+			return (...args: any[]) => {
+				const id = tracer.counter++;
+				tracer.startAsync({
+					name,
+					id,
+					args: {
+						compilerName,
+						hookName,
+						pluginName
+					}
+				});
+				const promise =
+					/** @type {Promise<(...args: EXPECTED_ANY[]) => EXPECTED_ANY>} */
+					fn(...args);
+				return promise.then((r: any) => {
+					tracer.endAsync({
+						name,
+						id,
+						args: {
+							compilerName,
+							hookName,
+							pluginName
+						}
+					});
+					return r;
+				});
+			};
+		case "async":
+			return (...args: any[]) => {
+				const id = tracer.counter++;
+				tracer.startAsync({
+					name,
+					id,
+					args: {
+						compilerName,
+						hookName,
+						pluginName
+					}
+				});
+				const callback = args.pop();
+				fn(
+					...args,
+					/**
+					 * @param {...EXPECTED_ANY[]} r result
+					 */
+					(...r: any[]) => {
+						tracer.endAsync({
+							name,
+							id,
+							args: {
+								compilerName,
+								hookName,
+								pluginName
+							}
+						});
+						callback(...r);
+					}
+				);
+			};
+		case "sync":
+			return (...args: any[]) => {
+				const id = tracer.counter++;
+				// Do not instrument ourself due to the CPU
+				// profile needing to be the last event in the trace.
+				if (name === PLUGIN_NAME) {
+					return fn(...args);
+				}
+
+				tracer.startAsync({
+					name,
+					id,
+					args: {
+						compilerName,
+						hookName,
+						pluginName
+					}
+				});
+				let r: any;
+				try {
+					r = fn(...args);
+				} catch (err) {
+					tracer.endAsync({
+						name,
+						id,
+						args: {
+							compilerName,
+							hookName,
+							pluginName
+						}
+					});
+					throw err;
+				}
+				tracer.endAsync({
+					name,
+					args: {
+						compilerName,
+						hookName,
+						pluginName
+					}
+				});
+				return r;
+			};
+		default:
+			return fn;
+	}
+};
+let compilerId = 0;
+export class TraceHookPlugin {
+	name = PLUGIN_NAME;
+	apply(compiler: Compiler) {
+		// FIXME: we need a compiler.id for track child compiler
+		const compilerName = compiler.name || (compilerId++).toString();
+		// Compiler Hooks
+		for (const hookName of Object.keys(compiler.hooks)) {
+			const hook = compiler.hooks[hookName as keyof Compiler["hooks"]];
+			if (hook) {
+				hook.intercept(
+					makeInterceptorFor(compilerName, JavaScriptTracer)(hookName)
+				);
+			}
+		}
+		compiler.hooks.compilation.tap(
+			PLUGIN_NAME,
+			(compilation, { normalModuleFactory, contextModuleFactory }) => {
+				interceptAllHooksFor(compilation, JavaScriptTracer, "Compilation");
+				interceptAllHooksFor(
+					normalModuleFactory,
+					JavaScriptTracer,
+					"Normal Module Factory"
+				);
+				interceptAllHooksFor(
+					contextModuleFactory,
+					JavaScriptTracer,
+					"Context Module Factory"
+				);
+			}
+		);
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
needs more tracing to debug javascript plugin performance problem like https://github.com/web-infra-dev/rspack/issues/10372#issuecomment-2883992566 (and sometime the profile is not enough)
* after
![image](https://github.com/user-attachments/assets/6b649b2e-9ad4-4cc1-93eb-3ba2eb578bee)

Unfortunately the trace event is very limited to generated good perfetto UI and I can't group same hook in same track due to https://github.com/google/perfetto/issues/1548#issuecomment-2886020935,
so we may need to use perfetto native protocol in the future

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
