### PR TITLE
fix: assets imported by css should not generate js modules

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -411,7 +411,7 @@ impl ChunkGraph {
         {
           module_source_types.contains(&source_type)
         } else {
-          module.source_types(&module_graph).contains(&source_type)
+          module.source_types(module_graph).contains(&source_type)
         }
       })
       .collect::<Vec<_>>();
@@ -429,7 +429,7 @@ impl ChunkGraph {
       .modules
       .iter()
       .filter_map(|uri| module_graph.module_by_identifier(uri))
-      .filter(move |module| module.source_types(&module_graph).contains(&source_type))
+      .filter(move |module| module.source_types(module_graph).contains(&source_type))
       .map(|m| m.as_ref())
   }
 

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -102,8 +102,9 @@ impl ChunkGraphChunk {
 
 fn get_modules_size(modules: &[&BoxModule], compilation: &Compilation) -> f64 {
   let mut size = 0f64;
+  let module_graph = compilation.get_module_graph();
   for module in modules {
-    for source_type in module.source_types() {
+    for source_type in module.source_types(&module_graph) {
       size += module.size(Some(source_type), Some(compilation));
     }
   }
@@ -410,7 +411,7 @@ impl ChunkGraph {
         {
           module_source_types.contains(&source_type)
         } else {
-          module.source_types().contains(&source_type)
+          module.source_types(&module_graph).contains(&source_type)
         }
       })
       .collect::<Vec<_>>();
@@ -428,7 +429,7 @@ impl ChunkGraph {
       .modules
       .iter()
       .filter_map(|uri| module_graph.module_by_identifier(uri))
-      .filter(move |module| module.source_types().contains(&source_type))
+      .filter(move |module| module.source_types(&module_graph).contains(&source_type))
       .map(|m| m.as_ref())
   }
 
@@ -440,7 +441,7 @@ impl ChunkGraph {
       .fold(0.0, |acc, m| {
         acc
           + m
-            .source_types()
+            .source_types(module_graph)
             .iter()
             .fold(0.0, |acc, t| acc + m.size(Some(t), Some(compilation)))
       })
@@ -457,7 +458,7 @@ impl ChunkGraph {
     for identifier in &cgc.modules {
       let module = module_graph.module_by_identifier(identifier);
       if let Some(module) = module {
-        for source_type in module.source_types() {
+        for source_type in module.source_types(module_graph) {
           let size = module.size(Some(source_type), Some(compilation));
           sizes
             .entry(*source_type)
@@ -967,6 +968,7 @@ impl ChunkGraph {
     &self,
     chunk: &ChunkUkey,
     module: &BoxModule,
+    module_graph: &ModuleGraph,
   ) -> FxHashSet<SourceType> {
     self
       .chunk_graph_chunk_by_chunk_ukey
@@ -978,7 +980,7 @@ impl ChunkGraph {
 
         None
       })
-      .unwrap_or(module.source_types().iter().copied().collect())
+      .unwrap_or(module.source_types(module_graph).iter().copied().collect())
   }
 
   pub fn get_chunk_id<'a>(

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -339,8 +339,9 @@ impl ChunkGraph {
     let mut hasher = FxHasher::default();
     let mg = compilation.get_module_graph();
     let module_identifier = module.identifier();
+    let module_graph = compilation.get_module_graph();
     Self::get_module_id(&compilation.module_ids_artifact, module_identifier).dyn_hash(&mut hasher);
-    module.source_types().dyn_hash(&mut hasher);
+    module.source_types(&module_graph).dyn_hash(&mut hasher);
     ModuleGraph::is_async(compilation, &module_identifier).dyn_hash(&mut hasher);
     mg.get_exports_info(&module_identifier)
       .update_hash(&mg, &mut hasher, compilation, runtime);

--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -289,7 +289,7 @@ mod t {
       todo!()
     }
 
-    fn source_types(&self) -> &[SourceType] {
+    fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
       todo!()
     }
 

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -523,7 +523,7 @@ impl Module for ConcatenatedModule {
     &mut self.root_module_ctxt.build_meta
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
   }
 

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -31,8 +31,8 @@ use crate::{
   CodeGenerationResult, Compilation, ConcatenationScope, ContextElementDependency,
   DependenciesBlock, Dependency, DependencyCategory, DependencyId, DependencyLocation,
   DynamicImportMode, ExportsType, FactoryMeta, FakeNamespaceObjectMode, GroupOptions,
-  ImportAttributes, LibIdentOptions, Module, ModuleId, ModuleIdsArtifact, ModuleLayer, ModuleType,
-  RealDependencyLocation, Resolve, RuntimeGlobals, RuntimeSpec, SourceType,
+  ImportAttributes, LibIdentOptions, Module, ModuleGraph, ModuleId, ModuleIdsArtifact, ModuleLayer,
+  ModuleType, RealDependencyLocation, Resolve, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
 static WEBPACK_CHUNK_NAME_INDEX_PLACEHOLDER: &str = "[index]";
@@ -857,7 +857,7 @@ impl Module for ContextModule {
     &ModuleType::JsAuto
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
   }
 

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -23,7 +23,7 @@ use crate::{
 
 static EXTERNAL_MODULE_JS_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
 static EXTERNAL_MODULE_CSS_SOURCE_TYPES: &[SourceType] = &[SourceType::CssImport];
-
+static EXTERNAL_MODULE_CSS_URL_SOURCE_TYPES: &[SourceType] = &[SourceType::CssUrl];
 #[cacheable]
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
@@ -209,6 +209,7 @@ pub type MetaExternalType = Option<ExternalTypeEnum>;
 pub struct DependencyMeta {
   pub external_type: MetaExternalType,
   pub attributes: Option<ImportAttributes>,
+  pub source_type: Option<SourceType>,
 }
 
 impl ExternalModule {
@@ -559,8 +560,15 @@ impl Module for ExternalModule {
     &ModuleType::JsDynamic
   }
 
-  fn source_types(&self) -> &[SourceType] {
-    if self.external_type == "css-import" {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
+    if self.external_type == "asset"
+      && self
+        .dependency_meta
+        .source_type
+        .is_some_and(|t| t == SourceType::CssUrl)
+    {
+      EXTERNAL_MODULE_CSS_URL_SOURCE_TYPES
+    } else if self.external_type == "css-import" {
       EXTERNAL_MODULE_CSS_SOURCE_TYPES
     } else {
       EXTERNAL_MODULE_JS_SOURCE_TYPES

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -115,6 +115,7 @@ pub mod debug_info;
 pub enum SourceType {
   JavaScript,
   Css,
+  CssUrl,
   Wasm,
   Asset,
   Expose,
@@ -133,6 +134,7 @@ impl std::fmt::Display for SourceType {
     match self {
       SourceType::JavaScript => write!(f, "javascript"),
       SourceType::Css => write!(f, "css"),
+      SourceType::CssUrl => write!(f, "css-url"),
       SourceType::Wasm => write!(f, "wasm"),
       SourceType::Asset => write!(f, "asset"),
       SourceType::Expose => write!(f, "expose"),
@@ -161,6 +163,19 @@ impl From<&str> for SourceType {
       "unknown" => Self::Unknown,
       "css-import" => Self::CssImport,
       other => SourceType::Custom(other.into()),
+    }
+  }
+}
+
+impl From<&ModuleType> for SourceType {
+  fn from(value: &ModuleType) -> Self {
+    match value {
+      ModuleType::JsAuto | ModuleType::JsEsm | ModuleType::JsDynamic => Self::JavaScript,
+      ModuleType::Css | ModuleType::CssModule | ModuleType::CssAuto => Self::Css,
+      ModuleType::WasmSync | ModuleType::WasmAsync => Self::Wasm,
+      ModuleType::Asset | ModuleType::AssetInline | ModuleType::AssetResource => Self::Asset,
+      ModuleType::ConsumeShared => Self::ConsumeShared,
+      _ => Self::Unknown,
     }
   }
 }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -231,7 +231,7 @@ pub trait Module:
   fn module_type(&self) -> &ModuleType;
 
   /// Defines what kind of code generation results this module can generate.
-  fn source_types(&self) -> &[SourceType];
+  fn source_types(&self, module_graph: &ModuleGraph) -> &[SourceType];
 
   /// The source of the module. This could be optional, modules like the `NormalModule` can have the corresponding source.
   /// However, modules that is created from "nowhere" (e.g. `ExternalModule` and `MissingModule`) does not have its source.
@@ -678,7 +678,7 @@ mod test {
           unreachable!()
         }
 
-        fn source_types(&self) -> &[SourceType] {
+        fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
           unreachable!()
         }
 

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -627,8 +627,8 @@ mod test {
   use super::Module;
   use crate::{
     AsyncDependenciesBlockIdentifier, BuildContext, BuildResult, CodeGenerationResult, Compilation,
-    ConcatenationScope, Context, DependenciesBlock, DependencyId, ModuleExt, ModuleType,
-    RuntimeSpec, SourceType,
+    ConcatenationScope, Context, DependenciesBlock, DependencyId, ModuleExt, ModuleGraph,
+    ModuleType, RuntimeSpec, SourceType,
   };
 
   #[cacheable]

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -87,7 +87,7 @@ pub struct GenerateContext<'a> {
 #[async_trait::async_trait]
 pub trait ParserAndGenerator: Send + Sync + Debug + AsAny {
   /// The source types that the generator can generate (the source types you can make requests for)
-  fn source_types(&self) -> &[SourceType];
+  fn source_types(&self, module: &dyn Module, module_graph: &ModuleGraph) -> &[SourceType];
   /// Parse the source and return the dependencies and the ast or source
   async fn parse<'a>(
     &mut self,

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -14,7 +14,7 @@ use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 use crate::{
   dependencies_block::AsyncDependenciesBlockIdentifier, impl_module_meta_info, module_update_hash,
   BuildInfo, BuildMeta, CodeGenerationResult, Compilation, ConcatenationScope, Context,
-  DependenciesBlock, DependencyId, FactoryMeta, Module, ModuleIdentifier, ModuleType,
+  DependenciesBlock, DependencyId, FactoryMeta, Module, ModuleGraph, ModuleIdentifier, ModuleType,
   RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
@@ -101,7 +101,7 @@ impl Module for RawModule {
     &ModuleType::JsAuto
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     RAW_MODULE_SOURCE_TYPES
   }
 

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -12,7 +12,8 @@ use rspack_util::source_map::SourceMapKind;
 use crate::{
   impl_module_meta_info, AsyncDependenciesBlockIdentifier, BuildInfo, BuildMeta, ChunkUkey,
   CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
+  FactoryMeta, LibIdentOptions, Module, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec,
+  SourceType,
 };
 
 #[impl_source_map_config]
@@ -88,7 +89,7 @@ impl Module for SelfModule {
     &ModuleType::Fallback
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
   }
 

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -749,7 +749,7 @@ impl Stats<'_> {
       .contains(&identifier);
 
     let sizes = module
-      .source_types(&module_graph)
+      .source_types(module_graph)
       .iter()
       .map(|t| StatsSourceTypeSize {
         source_type: *t,

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -749,7 +749,7 @@ impl Stats<'_> {
       .contains(&identifier);
 
     let sizes = module
-      .source_types()
+      .source_types(&module_graph)
       .iter()
       .map(|t| StatsSourceTypeSize {
         source_type: *t,

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -131,7 +131,7 @@ pub fn impl_runtime_module(
         &::rspack_core::ModuleType::Runtime
       }
 
-      fn source_types(&self) -> &[::rspack_core::SourceType] {
+      fn source_types(&self, module_graph: &::rspack_core::ModuleGraph) -> &[::rspack_core::SourceType] {
         &[::rspack_core::SourceType::JavaScript]
       }
 

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(let_chains)]
 
-use std::{borrow::Cow, hash::Hasher, path::PathBuf};
+use std::{borrow::Cow, collections::HashSet, hash::Hasher, path::PathBuf};
 
 use asset_exports_dependency::AssetExportsDependency;
 use async_trait::async_trait;
@@ -31,10 +31,19 @@ pub const AUTO_PUBLIC_PATH_PLACEHOLDER: &str = "__RSPACK_PLUGIN_ASSET_AUTO_PUBLI
 #[derive(Debug, Default)]
 pub struct AssetPlugin;
 
-static ASSET_MODULE_SOURCE_TYPE_LIST: &[SourceType; 2] =
-  &[SourceType::Asset, SourceType::JavaScript];
+static JS_AND_CSS_URL_TYPES: &[SourceType; 2] = &[SourceType::JavaScript, SourceType::CssUrl];
+static JS_TYPES: &[SourceType; 1] = &[SourceType::JavaScript];
+static CSS_URL_TYPES: &[SourceType; 1] = &[SourceType::CssUrl];
+static NO_TYPES: &[SourceType; 0] = &[];
 
-static ASSET_SOURCE_MODULE_SOURCE_TYPE_LIST: &[SourceType; 1] = &[SourceType::JavaScript];
+static ASSET_AND_JS_AND_CSS_URL_TYPES: &[SourceType; 3] = &[
+  SourceType::Asset,
+  SourceType::JavaScript,
+  SourceType::CssUrl,
+];
+static ASSET_AND_JS_TYPES: &[SourceType; 2] = &[SourceType::Asset, SourceType::JavaScript];
+static ASSET_AND_CSS_URL_TYPES: &[SourceType; 2] = &[SourceType::Asset, SourceType::CssUrl];
+static ASSET_TYPES: &[SourceType; 1] = &[SourceType::Asset];
 
 const DEFAULT_ENCODING: &str = "base64";
 
@@ -337,17 +346,60 @@ const DEFAULT_MAX_SIZE: f64 = 8096.0;
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl ParserAndGenerator for AssetParserAndGenerator {
-  fn source_types(&self) -> &[SourceType] {
-    if let Some(config) = self.parsed_asset_config.as_ref() {
-      if config.is_source() || config.is_inline() || !self.emit {
-        ASSET_SOURCE_MODULE_SOURCE_TYPE_LIST
+  fn source_types(&self, module: &dyn Module, module_graph: &ModuleGraph) -> &[SourceType] {
+    let mut source_types = HashSet::new();
+    let module_id = module.identifier();
+    for connection in module_graph.get_incoming_connections(&module_id) {
+      if let Some(module) = connection
+        .original_module_identifier
+        .and_then(|id| module_graph.module_by_identifier(&id))
+      {
+        let module_type = module.module_type();
+        source_types.insert(SourceType::from(module_type));
+      }
+    }
+
+    if source_types.is_empty() {
+      if self
+        .parsed_asset_config
+        .as_ref()
+        .is_some_and(|x| x.is_source() || x.is_inline())
+        || !self.emit
+      {
+        return JS_TYPES;
       } else {
-        ASSET_MODULE_SOURCE_TYPE_LIST
+        return ASSET_AND_JS_TYPES;
+      }
+    }
+
+    let has_js = source_types.contains(&SourceType::JavaScript);
+    let has_css = source_types.contains(&SourceType::Css);
+
+    if self
+      .parsed_asset_config
+      .as_ref()
+      .is_some_and(|x| x.is_source() || x.is_inline())
+      || !self.emit
+    {
+      if has_js && has_css {
+        JS_AND_CSS_URL_TYPES
+      } else if has_js {
+        JS_TYPES
+      } else if has_css {
+        CSS_URL_TYPES
+      } else {
+        NO_TYPES
       }
     } else {
-      // If module is failed to build, then the `parsed_asset_config` is not set.
-      // Align with webpacks's asset module: https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/asset/AssetGenerator.js#L386
-      ASSET_MODULE_SOURCE_TYPE_LIST
+      if has_js && has_css {
+        ASSET_AND_JS_AND_CSS_URL_TYPES
+      } else if has_js {
+        ASSET_AND_JS_TYPES
+      } else if has_css {
+        ASSET_AND_CSS_URL_TYPES
+      } else {
+        ASSET_TYPES
+      }
     }
   }
 
@@ -355,7 +407,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     let original_source_size = module.source().map_or(0, |source| source.size()) as f64;
     match source_type.unwrap_or(&SourceType::Asset) {
       SourceType::Asset => original_source_size,
-      SourceType::JavaScript => {
+      SourceType::JavaScript | SourceType::CssUrl => {
         if module.source().is_none() {
           return 0.0;
         }
@@ -465,7 +517,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     let import_mode = self.get_import_mode(module_generator_options)?;
 
     let result = match generate_context.requested_source_type {
-      SourceType::JavaScript => {
+      SourceType::JavaScript | SourceType::CssUrl => {
         let exported_content = if parsed_asset_config.is_inline() {
           let resource_data: &ResourceData = normal_module.resource_resolved_data();
           let data_url = module_generator_options.and_then(|x| x.asset_data_url());
@@ -575,6 +627,10 @@ impl ParserAndGenerator for AssetParserAndGenerator {
         } else {
           unreachable!()
         };
+
+        if generate_context.requested_source_type == SourceType::CssUrl {
+          return Ok(RawStringSource::from("").boxed());
+        }
 
         if import_mode.is_preserve() && parsed_asset_config.is_resource() {
           let is_module = compilation.options.output.module;

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -381,7 +381,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
       .is_some_and(|x| x.is_source() || x.is_inline())
       || !self.emit
     {
-      if has_js && has_css {
+      return if has_js && has_css {
         JS_AND_CSS_URL_TYPES
       } else if has_js {
         JS_TYPES
@@ -389,17 +389,17 @@ impl ParserAndGenerator for AssetParserAndGenerator {
         CSS_URL_TYPES
       } else {
         NO_TYPES
-      }
+      };
+    }
+
+    if has_js && has_css {
+      ASSET_AND_JS_AND_CSS_URL_TYPES
+    } else if has_js {
+      ASSET_AND_JS_TYPES
+    } else if has_css {
+      ASSET_AND_CSS_URL_TYPES
     } else {
-      if has_js && has_css {
-        ASSET_AND_JS_AND_CSS_URL_TYPES
-      } else if has_js {
-        ASSET_AND_JS_TYPES
-      } else if has_css {
-        ASSET_AND_CSS_URL_TYPES
-      } else {
-        ASSET_TYPES
-      }
+      ASSET_TYPES
     }
   }
 

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -90,7 +90,7 @@ pub struct CssParserAndGenerator {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl ParserAndGenerator for CssParserAndGenerator {
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module: &dyn Module, _module_graph: &ModuleGraph) -> &[SourceType] {
     if self.exports_only {
       CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST
     } else {

--- a/crates/rspack_plugin_css_chunking/src/lib.rs
+++ b/crates/rspack_plugin_css_chunking/src/lib.rs
@@ -96,7 +96,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
       .get_chunk_modules(chunk_ukey, &module_graph)
       .into_iter()
       .filter(|module| {
-        module.source_types().iter().any(|t| match t {
+        module.source_types(&module_graph).iter().any(|t| match t {
           SourceType::Css => true,
           SourceType::CssImport => true,
           SourceType::Custom(str) => str == "css/mini-extract",

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -8,8 +8,8 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource},
   AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta, BuildResult,
   CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock, Dependency,
-  DependencyId, EntryDependency, FactoryMeta, Module, ModuleType, RuntimeGlobals, RuntimeSpec,
-  SourceType,
+  DependencyId, EntryDependency, FactoryMeta, Module, ModuleGraph, ModuleType, RuntimeGlobals,
+  RuntimeSpec, SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -65,7 +65,7 @@ impl Module for DllModule {
     &ModuleType::JsDynamic
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
   }
 

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -9,8 +9,8 @@ use rspack_core::{
   throw_missing_module_error_block, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext,
   BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Compilation, ConcatenationScope,
   Context, DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleDependency,
-  ModuleId, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency,
-  StaticExportsSpec,
+  ModuleGraph, ModuleId, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  StaticExportsDependency, StaticExportsSpec,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -67,7 +67,7 @@ impl Module for DelegatedModule {
     &ModuleType::JsDynamic
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
   }
 

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -5,10 +5,11 @@ use std::{
 
 use regex::Regex;
 use rspack_core::{
-  ApplyContext, BoxModule, CompilerOptions, ContextInfo, DependencyMeta, ExternalItem,
-  ExternalItemFnCtx, ExternalItemValue, ExternalModule, ExternalRequest, ExternalRequestValue,
-  ExternalType, ExternalTypeEnum, ModuleDependency, ModuleExt, ModuleFactoryCreateData,
-  NormalModuleFactoryFactorize, Plugin, PluginContext, ResolveOptionsWithDependencyType,
+  ApplyContext, BoxModule, CompilerOptions, ContextInfo, DependencyMeta, DependencyType,
+  ExternalItem, ExternalItemFnCtx, ExternalItemValue, ExternalModule, ExternalRequest,
+  ExternalRequestValue, ExternalType, ExternalTypeEnum, ModuleDependency, ModuleExt,
+  ModuleFactoryCreateData, NormalModuleFactoryFactorize, Plugin, PluginContext,
+  ResolveOptionsWithDependencyType, SourceType,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -104,7 +105,7 @@ impl ExternalsPlugin {
       None
     }
 
-    let dependency_meta: DependencyMeta = DependencyMeta {
+    let mut dependency_meta: DependencyMeta = DependencyMeta {
       attributes: dependency.get_attributes().cloned(),
       external_type: {
         if dependency
@@ -123,7 +124,14 @@ impl ExternalsPlugin {
           None
         }
       },
+      source_type: None,
     };
+
+    if r#type.as_ref().is_some_and(|t| t == "asset")
+      && matches!(dependency.dependency_type(), DependencyType::CssUrl)
+    {
+      dependency_meta.source_type = Some(SourceType::CssUrl);
+    }
 
     Some(ExternalModule::new(
       external_module_config,

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta, BuildResult,
   CodeGenerationResult, Compilation, CompilerOptions, ConcatenationScope, DependenciesBlock,
   DependencyId, FactoryMeta, Module, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult,
-  RuntimeSpec, SourceType,
+  ModuleGraph, RuntimeSpec, SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -151,7 +151,7 @@ impl Module for CssModule {
     &MODULE_TYPE
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &*SOURCE_TYPE
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -110,7 +110,7 @@ static SOURCE_TYPES: &[SourceType; 1] = &[SourceType::JavaScript];
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl ParserAndGenerator for JavaScriptParserAndGenerator {
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module: &dyn Module, _module_graph: &ModuleGraph) -> &[SourceType] {
     SOURCE_TYPES
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -554,7 +554,7 @@ impl ModuleConcatenationPlugin {
     let box_module = module_graph
       .module_by_identifier(&root_module_id)
       .expect("should have module");
-    let root_module_source_types = box_module.source_types();
+    let root_module_source_types = box_module.source_types(&module_graph);
     let is_root_module_asset_module = root_module_source_types.contains(&SourceType::Asset);
 
     let root_module_ctxt = RootModuleContext {
@@ -654,7 +654,8 @@ impl ModuleConcatenationPlugin {
           .module_by_identifier(m)
           .expect("should exist module");
 
-        let source_types = chunk_graph.get_chunk_module_source_types(&chunk_ukey, module);
+        let source_types =
+          chunk_graph.get_chunk_module_source_types(&chunk_ukey, module, &module_graph);
 
         if source_types.len() == 1 {
           chunk_graph.disconnect_chunk_and_module(&chunk_ukey, *m);
@@ -681,7 +682,8 @@ impl ModuleConcatenationPlugin {
           .module_by_identifier(&root_module_id)
           .expect("should exist module");
 
-        let source_types = chunk_graph.get_chunk_module_source_types(&chunk_ukey, module);
+        let source_types =
+          chunk_graph.get_chunk_module_source_types(&chunk_ukey, module, &module_graph);
         let new_source_types = source_types
           .iter()
           .filter(|source_type| !matches!(source_type, SourceType::JavaScript))

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -40,7 +40,7 @@ struct JsonParserAndGenerator {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl ParserAndGenerator for JsonParserAndGenerator {
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module: &dyn Module, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
   }
 

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -8,8 +8,8 @@ use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo,
   BuildMeta, BuildResult, ChunkGraph, CodeGenerationData, CodeGenerationResult, Compilation,
   ConcatenationScope, Context, DependenciesBlock, DependencyId, DependencyRange, FactoryMeta,
-  LibIdentOptions, Module, ModuleFactoryCreateData, ModuleIdentifier, ModuleLayer, ModuleType,
-  RuntimeGlobals, RuntimeSpec, SourceType, TemplateContext,
+  LibIdentOptions, Module, ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, ModuleLayer,
+  ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, TemplateContext,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -109,7 +109,7 @@ impl_empty_diagnosable_trait!(LazyCompilationProxyModule);
 impl Module for LazyCompilationProxyModule {
   impl_module_meta_info!();
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &SOURCE_TYPE
   }
 

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -11,8 +11,8 @@ use rspack_core::{
   BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult,
   ChunkGroupOptions, CodeGenerationResult, Compilation, ConcatenationScope, Context,
   DependenciesBlock, Dependency, DependencyId, FactoryMeta, GroupOptions, LibIdentOptions, Module,
-  ModuleDependency, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
-  StaticExportsDependency, StaticExportsSpec,
+  ModuleDependency, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec,
+  SourceType, StaticExportsDependency, StaticExportsSpec,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -116,7 +116,7 @@ impl Module for ContainerEntryModule {
     &ModuleType::JsDynamic
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript, SourceType::Expose]
   }
 

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -8,8 +8,8 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, ConcatenationScope, Context,
-  DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleIdentifier,
-  ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleGraph,
+  ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -102,7 +102,7 @@ impl Module for FallbackModule {
     &ModuleType::Fallback
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
   }
 

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -8,8 +8,8 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   ChunkGraph, CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock,
-  DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeSpec,
-  SourceType,
+  DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleGraph, ModuleIdentifier, ModuleType,
+  RuntimeSpec, SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -120,7 +120,7 @@ impl Module for RemoteModule {
     &ModuleType::Remote
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::Remote, SourceType::ShareInit]
   }
 

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -8,8 +8,8 @@ use rspack_core::{
   rspack_sources::BoxSource, sync_module_factory, AsyncDependenciesBlock,
   AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec,
-  SourceType,
+  FactoryMeta, LibIdentOptions, Module, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
+  RuntimeSpec, SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -127,7 +127,7 @@ impl Module for ConsumeSharedModule {
     &ModuleType::ConsumeShared
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::ConsumeShared]
   }
 

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -8,8 +8,8 @@ use rspack_core::{
   rspack_sources::BoxSource, sync_module_factory, AsyncDependenciesBlock,
   AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec,
-  SourceType,
+  FactoryMeta, LibIdentOptions, Module, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
+  RuntimeSpec, SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -128,7 +128,7 @@ impl Module for ProvideSharedModule {
     &ModuleType::ProvideShared
   }
 
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::ShareInit]
   }
 

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -51,10 +51,11 @@ impl ModuleGroup {
 
   pub fn add_module(&mut self, module: &dyn Module, compilation: &Compilation) {
     let old_len = self.modules.len();
+    let module_graph = compilation.get_module_graph();
     self.modules.insert(module.identifier());
 
     if self.modules.len() != old_len {
-      module.source_types().iter().for_each(|ty| {
+      module.source_types(&module_graph).iter().for_each(|ty| {
         let size = self.sizes.entry(*ty).or_default();
         *size += module.size(Some(ty), Some(compilation));
       });
@@ -65,8 +66,9 @@ impl ModuleGroup {
     let old_len = self.modules.len();
     self.modules.remove(&module.identifier());
 
+    let module_graph = compilation.get_module_graph();
     if self.modules.len() != old_len {
-      module.source_types().iter().for_each(|ty| {
+      module.source_types(&module_graph).iter().for_each(|ty| {
         let size = self.sizes.entry(*ty).or_default();
         *size -= module.size(Some(ty), Some(compilation));
         *size = size.max(0.0)

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -108,9 +108,10 @@ fn sum_size(size: &mut SplitChunkSizes, items: &[GroupItem]) {
 }
 
 fn get_size(module: &dyn Module, compilation: &Compilation) -> SplitChunkSizes {
+  let module_graph = compilation.get_module_graph();
   SplitChunkSizes(
     module
-      .source_types()
+      .source_types(&module_graph)
       .iter()
       .map(|ty| (*ty, module.size(Some(ty), Some(compilation))))
       .collect(),

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -75,7 +75,7 @@ impl SplitChunksPlugin {
           .expect("Should have a module");
         let having_violating_source_type = violating_source_types
           .iter()
-          .any(|ty: &SourceType| module.source_types().contains(ty));
+          .any(|ty: &SourceType| module.source_types(&module_graph).contains(ty));
         if having_violating_source_type {
           Some(module)
         } else {

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -34,7 +34,7 @@ pub(crate) static WASM_SOURCE_TYPE: &[SourceType; 2] = &[SourceType::Wasm, Sourc
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl ParserAndGenerator for AsyncWasmParserAndGenerator {
-  fn source_types(&self) -> &[SourceType] {
+  fn source_types(&self, _module: &dyn Module, _module_graph: &ModuleGraph) -> &[SourceType] {
     WASM_SOURCE_TYPE
   }
 

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -58,7 +58,7 @@ runtime modules xx KiB
     [no exports]
     [used exports unknown]
   
-Rspack compiled successfully (27eddb11e03f28d2)
+Rspack compiled successfully (18cc1e9efd1c355c)
 `;
 
 exports[`statsOutput statsOutput/builtin-swc-loader-parse-error should print correct stats for 1`] = `

--- a/tests/webpack-test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -634,6 +634,47 @@ Object {
 }
 `;
 
+exports[`ConfigTestCases css no-extra-runtime-in-js exported tests should compile 1`] = `
+Array [
+  "/* #region \\"./style.css\\" */
+/*
+- type: css/auto
+*/
+.class {
+	color: red;
+	background:
+		url(img.png),
+		url(img.png),
+		url(9aaba41ffa2da101.png);
+		url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=),
+		url(resource.png),
+		url('./source.text'),
+		url(fae013ca3772b2c5.htm),
+		url(https://example.com/img.png);
+}
+
+.class-2 {
+	background: url(shared.png);
+}
+
+.class-3 {
+	background: url(shared-external.png);
+}
+
+.class-4 {
+	background: url(4e418f0d69cf49fa.gif);
+}
+
+.class-5 {
+	background: url(1237b02e54ad8fd3.png);
+}
+
+/* #endregion \\"./style.css\\" */
+
+",
+]
+`;
+
 exports[`ConfigTestCases css pure-css exported tests should compile 1`] = `
 Array [
   "/* #region \\"../css-modules/style.module.css\\" */

--- a/tests/webpack-test/configCases/css/no-extra-runtime-in-js/test.filter.js
+++ b/tests/webpack-test/configCases/css/no-extra-runtime-in-js/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "FIXME: more png modules than webpack";


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

If an asset is imported by uri in css files, it should not generate a JavaScript module through code generation. This makes sense in the scenario when importing an image with asset/inline, which transforms that image to base64 and replaces the asset URI with it. If the JavaScript module of the image is generated, the long base64 string will be generated again, which significantly increases the size of the final assets.


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
