### PR TITLE
fix: missing destucturing properties while getting referenced exports

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -2,17 +2,14 @@ use rspack_core::{ConstDependency, Dependency, DependencyType, ImportAttributes}
 use swc_core::{
   atoms::Atom,
   common::{Span, Spanned},
-  ecma::ast::{
-    AssignExpr, AssignOp, AssignTarget, AssignTargetPat, Callee, Expr, Ident, ImportDecl,
-    MemberExpr, OptChainBase,
-  },
+  ecma::ast::{Callee, Expr, Ident, ImportDecl, MemberExpr, OptChainBase},
 };
 
 use super::{InnerGraphPlugin, JavascriptParserPlugin};
 use crate::{
   dependency::{ESMImportSideEffectDependency, ESMImportSpecifierDependency},
   utils::object_properties::get_attributes,
-  visitors::{collect_destructuring_assignment_properties, JavascriptParser, TagInfoData},
+  visitors::{JavascriptParser, TagInfoData},
 };
 
 fn get_non_optional_part<'a>(members: &'a [Atom], members_optionals: &[bool]) -> &'a [Atom] {
@@ -134,6 +131,9 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       .definitions_db
       .expect_get_tag_info(parser.current_tag_info?);
     let settings = ESMSpecifierData::downcast(tag_info.data.clone()?);
+    let referenced_properties_in_destructuring = parser
+      .destructuring_assignment_properties_for(&ident.span())
+      .map(|x| x.into_iter().map(Atom::from).collect());
     let dep = ESMImportSpecifierDependency::new(
       settings.source,
       settings.name,
@@ -145,7 +145,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       parser.in_tagged_template_tag,
       true,
       ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
-      parser.properties_in_destructuring.remove(&ident.sym),
+      referenced_properties_in_destructuring,
       settings.attributes,
       Some(parser.source_map.clone()),
     );
@@ -201,6 +201,9 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
     let mut ids = settings.ids;
     ids.extend(non_optional_members.iter().cloned());
     let direct_import = members.is_empty();
+    let referenced_properties_in_destructuring = parser
+      .destructuring_assignment_properties_for(&call_expr.span())
+      .map(|x| x.into_iter().map(Atom::from).collect());
     let dep = ESMImportSpecifierDependency::new(
       settings.source,
       settings.name,
@@ -212,7 +215,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       true,
       direct_import,
       ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
-      None,
+      referenced_properties_in_destructuring,
       settings.attributes,
       Some(parser.source_map.clone()),
     );
@@ -265,6 +268,9 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
     };
     let mut ids = settings.ids;
     ids.extend(non_optional_members.iter().cloned());
+    let referenced_properties_in_destructuring = parser
+      .destructuring_assignment_properties_for(&member_expr.span())
+      .map(|x| x.into_iter().map(Atom::from).collect());
     let dep = ESMImportSpecifierDependency::new(
       settings.source,
       settings.name,
@@ -276,7 +282,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       false,
       false, // x.xx()
       ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
-      None,
+      referenced_properties_in_destructuring,
       settings.attributes,
       Some(parser.source_map.clone()),
     );
@@ -297,33 +303,5 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
     );
 
     Some(true)
-  }
-
-  // collect referenced properties in destructuring
-  // import * as a from 'a';
-  // const { value } = a;
-  fn assign(
-    &self,
-    parser: &mut JavascriptParser,
-    assign_expr: &AssignExpr,
-    _for_name: Option<&str>,
-  ) -> Option<bool> {
-    if let AssignTarget::Pat(AssignTargetPat::Object(object_pat)) = &assign_expr.left
-      && assign_expr.op == AssignOp::Assign
-      && let box Expr::Ident(ident) = &assign_expr.right
-      && let Some(settings) = parser.get_tag_data(&ident.sym, ESM_SPECIFIER_TAG)
-      && let settings = ESMSpecifierData::downcast(settings)
-      // import namespace
-      && settings.ids.is_empty()
-    {
-      if let Some(value) = collect_destructuring_assignment_properties(object_pat) {
-        parser
-          .properties_in_destructuring
-          .entry(ident.sym.clone())
-          .and_modify(|v| v.extend(value.clone()))
-          .or_insert(value);
-      }
-    }
-    None
   }
 }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_lit_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_lit_expr.rs
@@ -1,7 +1,7 @@
 use rspack_core::SpanExt;
 use swc_core::{
   common::Spanned,
-  ecma::ast::{Lit, PropName, Str},
+  ecma::ast::{Expr, Lit, PropName, Str},
 };
 
 use super::BasicEvaluatedExpression;
@@ -64,6 +64,11 @@ pub fn eval_prop_name(prop_name: &PropName) -> Option<BasicEvaluatedExpression> 
     PropName::BigInt(bigint) => Some(eval_bigint(bigint)),
     // TODO:
     PropName::Ident(_) => None,
-    PropName::Computed(_) => None,
+    PropName::Computed(computed) => match &*computed.expr {
+      Expr::Lit(Lit::Str(str)) => Some(eval_str(str)),
+      Expr::Lit(Lit::Num(num)) => Some(eval_number(num)),
+      // TODO: more computed expr
+      _ => None,
+    },
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -236,8 +236,6 @@ pub struct JavascriptParser<'parser> {
   // TODO: delete `enter_call`
   pub(crate) enter_call: u32,
   pub(crate) member_expr_in_optional_chain: bool,
-  // TODO: delete `properties_in_destructuring`
-  pub(crate) properties_in_destructuring: FxHashMap<Atom, FxHashSet<Atom>>,
   pub(crate) destructuring_assignment_properties: Option<FxHashMap<Span, FxHashSet<String>>>,
   pub(crate) semicolons: &'parser mut FxHashSet<BytePos>,
   pub(crate) statement_path: Vec<StatementPath>,
@@ -391,7 +389,6 @@ impl<'parser> JavascriptParser<'parser> {
       worker_index: 0,
       module_identifier,
       member_expr_in_optional_chain: false,
-      properties_in_destructuring: Default::default(),
       destructuring_assignment_properties: None,
       semicolons,
       statement_path: Default::default(),

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -4,39 +4,12 @@ use rspack_error::{
   DiagnosticKind, TraceableError,
 };
 use rspack_regex::RspackRegex;
-use rustc_hash::FxHashSet as HashSet;
 use swc_core::{
   common::{SourceFile, Spanned},
   ecma::{ast::*, atoms::Atom},
 };
 
 use super::{AllowedMemberTypes, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo};
-
-pub fn collect_destructuring_assignment_properties(
-  object_pat: &ObjectPat,
-) -> Option<HashSet<Atom>> {
-  let mut properties = HashSet::default();
-
-  for property in &object_pat.props {
-    match property {
-      ObjectPatProp::Assign(assign) => {
-        properties.insert(assign.key.sym.clone());
-      }
-      ObjectPatProp::KeyValue(key_value) => {
-        if let PropName::Ident(ident) = &key_value.key {
-          properties.insert(ident.sym.clone());
-        }
-      }
-      ObjectPatProp::Rest(_) => {}
-    }
-  }
-
-  if properties.is_empty() {
-    None
-  } else {
-    Some(properties)
-  }
-}
 
 #[allow(dead_code)]
 pub(crate) mod expr_like {

--- a/packages/rspack-test-tools/tests/treeShakingCases/cyclic-reference-export-all/__snapshots__/treeshaking.snap.txt
+++ b/packages/rspack-test-tools/tests/treeShakingCases/cyclic-reference-export-all/__snapshots__/treeshaking.snap.txt
@@ -19,10 +19,8 @@ const Index = () => {
 
 }),
 "./src/containers/containers.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  PlatformProvider: () => (/* reexport safe */ _platform_container__WEBPACK_IMPORTED_MODULE_0__.PlatformProvider),
-  usePlatform: () => (/* reexport safe */ _platform_container__WEBPACK_IMPORTED_MODULE_0__.usePlatform)
+  PlatformProvider: () => (/* reexport safe */ _platform_container__WEBPACK_IMPORTED_MODULE_0__.PlatformProvider)
 });
 /* ESM import */var _platform_container__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./src/containers/platform-container/index.js");
 
@@ -33,8 +31,7 @@ __webpack_require__.d(__webpack_exports__, {
 }),
 "./src/containers/platform-container/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  PlatformProvider: () => (PlatformProvider),
-  usePlatform: () => (usePlatform)
+  PlatformProvider: () => (PlatformProvider)
 });
 const usePlatform = 3;
 const PlatformProvider = 1000;

--- a/tests/webpack-test/cases/errors/case-sensitive/test.filter.js
+++ b/tests/webpack-test/cases/errors/case-sensitive/test.filter.js
@@ -4,4 +4,4 @@
 // 	return fs.existsSync(path.join(__dirname, "TEST.FILTER.JS"));
 // };
 // TODO: Works on Linux but fail on Windows
-module.exports = () => false;
+module.exports = () => "TODO: support CaseSensitiveModulesWarning";

--- a/tests/webpack-test/cases/errors/import-module-cycle-multiple/test.filter.js
+++ b/tests/webpack-test/cases/errors/import-module-cycle-multiple/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => false;
+module.exports = () => "FIXME: dead loop of importModule";

--- a/tests/webpack-test/cases/errors/import-module-cycle/test.filter.js
+++ b/tests/webpack-test/cases/errors/import-module-cycle/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => false;
+module.exports = () => "FIXME: dead loop of importModule";

--- a/tests/webpack-test/cases/parsing/harmony-destructuring-assignment/test.filter.js
+++ b/tests/webpack-test/cases/parsing/harmony-destructuring-assignment/test.filter.js
@@ -1,6 +1,5 @@
-// module.exports = function (config) {
-// 	// This test can't run in development mode
-// 	return config.mode !== "development";
-// };
+module.exports = function (config) {
+  // This test can't run in development mode
+  return config.mode !== "development";
+};
 
-module.exports = () => false;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

pass `tests/webpack-test/cases/parsing/harmony-destructuring-assignment`, fix destucturing properties while getting referenced exports, and then impove the effect of tree shaking.

Also remove old ` parser.properties_in_destructuring` which can be full replaced by `parser.destructuring_assignment_properties_for()` which is aligned with webpack

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
