### PR TITLE
fix(minify): parser allow import attributes syntax

### DIFF
--- a/crates/rspack_javascript_compiler/src/compiler/minify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/minify.rs
@@ -129,6 +129,7 @@ impl JavaScriptCompiler {
               jsx: true,
               decorators: true,
               decorators_before_export: true,
+              import_attributes: true,
               ..Default::default()
             }),
             opts

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/importAttributes.mjs
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/importAttributes.mjs
@@ -1,0 +1,4 @@
+import pkg from "./a.json" with { type: "json" };
+
+console.log(pkg);
+

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/index.js
@@ -1,0 +1,7 @@
+const fs = require("fs");
+const path = require("path");
+
+it("[minify-parser]: import attributes should be preserved", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "importAttributes.js"), "utf-8");
+	expect(content).toContain('import*as o from"./a.json"with{type:"json"}');
+});

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/rspack.config.js
@@ -1,0 +1,34 @@
+const { rspack } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = [
+	{
+		entry: {
+			importAttributes: "./importAttributes.mjs"
+		},
+		output: {
+			filename: "[name].js",
+			module: true
+		},
+		externalsType: "module",
+		externals: ["./a.json"],
+		experiments: {
+			outputModule: true
+		},
+		optimization: {
+			minimize: true,
+			minimizer: [new rspack.SwcJsMinimizerRspackPlugin()]
+		}
+	},
+	{
+		entry: {
+			main: "./index.js"
+		},
+		output: {
+			filename: "[name].js"
+		},
+		externalsPresets: {
+			node: true
+		}
+	}
+];

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: function (i) {
+		return ["main.js"];
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix https://github.com/web-infra-dev/rslib/issues/999.

Allow parsing import attributes syntax, as it might be handled directly by minimizer which is commonly used in library building.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
