### PR TITLE
fix: missing module header info of css modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,7 +4660,6 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.7.1",
  "once_cell",
- "rayon",
  "regex",
  "rspack_cacheable",
  "rspack_collections",
@@ -5048,7 +5047,6 @@ dependencies = [
  "rspack_hook",
  "rspack_plugin_css",
  "rspack_plugin_javascript",
- "rspack_util",
  "rustc-hash 2.1.0",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4527,6 +4527,7 @@ dependencies = [
  "rspack_plugin_limit_chunk_count",
  "rspack_plugin_merge_duplicate_chunks",
  "rspack_plugin_mf",
+ "rspack_plugin_module_info_header",
  "rspack_plugin_no_emit_on_errors",
  "rspack_plugin_progress",
  "rspack_plugin_real_content_hash",
@@ -4655,6 +4656,7 @@ dependencies = [
  "async-trait",
  "cow-utils",
  "css-module-lexer",
+ "dashmap 6.1.0",
  "heck 0.5.0",
  "indexmap 2.7.1",
  "once_cell",
@@ -4664,6 +4666,7 @@ dependencies = [
  "rspack_collections",
  "rspack_core",
  "rspack_error",
+ "rspack_futures",
  "rspack_hash",
  "rspack_hook",
  "rspack_plugin_runtime",
@@ -5028,6 +5031,25 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "rspack_plugin_module_info_header"
+version = "0.2.0"
+dependencies = [
+ "async-trait",
+ "regex",
+ "rspack_cacheable",
+ "rspack_collections",
+ "rspack_core",
+ "rspack_error",
+ "rspack_hash",
+ "rspack_hook",
+ "rspack_plugin_css",
+ "rspack_plugin_javascript",
+ "rspack_util",
+ "rustc-hash 2.1.0",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ rspack_plugin_merge                    = { version = "0.2.0", path = "crates/rsp
 rspack_plugin_merge_duplicate_chunks   = { version = "0.2.0", path = "crates/rspack_plugin_merge_duplicate_chunks" }
 rspack_plugin_mf                       = { version = "0.2.0", path = "crates/rspack_plugin_mf" }
 rspack_plugin_mini_css_extract         = { version = "0.2.0", path = "crates/rspack_plugin_mini_css_extract" }
+rspack_plugin_module_info_header       = { version = "0.2.0", path = "crates/rspack_plugin_module_info_header" }
 rspack_plugin_no_emit_on_errors        = { version = "0.2.0", path = "crates/rspack_plugin_no_emit_on_errors" }
 rspack_plugin_progress                 = { version = "0.2.0", path = "crates/rspack_plugin_progress" }
 rspack_plugin_real_content_hash        = { version = "0.2.0", path = "crates/rspack_plugin_real_content_hash" }

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -82,6 +82,7 @@ rspack_plugin_lightning_css_minimizer  = { workspace = true }
 rspack_plugin_limit_chunk_count        = { workspace = true }
 rspack_plugin_merge_duplicate_chunks   = { workspace = true }
 rspack_plugin_mf                       = { workspace = true }
+rspack_plugin_module_info_header       = { workspace = true }
 rspack_plugin_no_emit_on_errors        = { workspace = true }
 rspack_plugin_progress                 = { workspace = true }
 rspack_plugin_real_content_hash        = { workspace = true }

--- a/crates/node_binding/src/raw_options/raw_builtins/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/mod.rs
@@ -60,7 +60,7 @@ use rspack_plugin_ignore::IgnorePlugin;
 use rspack_plugin_javascript::{
   api_plugin::APIPlugin, define_plugin::DefinePlugin, provide_plugin::ProvidePlugin,
   FlagDependencyExportsPlugin, FlagDependencyUsagePlugin, InferAsyncModulesPlugin, JsPlugin,
-  MangleExportsPlugin, ModuleConcatenationPlugin, ModuleInfoHeaderPlugin, SideEffectsFlagPlugin,
+  MangleExportsPlugin, ModuleConcatenationPlugin, SideEffectsFlagPlugin,
 };
 use rspack_plugin_json::JsonPlugin;
 use rspack_plugin_library::enable_library_plugin;
@@ -71,6 +71,7 @@ use rspack_plugin_mf::{
   ConsumeSharedPlugin, ContainerPlugin, ContainerReferencePlugin, ModuleFederationRuntimePlugin,
   ProvideSharedPlugin, ShareRuntimePlugin,
 };
+use rspack_plugin_module_info_header::ModuleInfoHeaderPlugin;
 use rspack_plugin_no_emit_on_errors::NoEmitOnErrorsPlugin;
 use rspack_plugin_progress::ProgressPlugin;
 use rspack_plugin_real_content_hash::RealContentHashPlugin;

--- a/crates/rspack_plugin_css/Cargo.toml
+++ b/crates/rspack_plugin_css/Cargo.toml
@@ -9,6 +9,7 @@ version     = "0.2.0"
 async-trait           = { workspace = true }
 cow-utils             = { workspace = true }
 css-module-lexer      = { workspace = true }
+dashmap               = { workspace = true }
 heck                  = { workspace = true }
 indexmap              = { workspace = true }
 once_cell             = { workspace = true }
@@ -18,6 +19,7 @@ rspack_cacheable      = { workspace = true }
 rspack_collections    = { workspace = true }
 rspack_core           = { workspace = true }
 rspack_error          = { workspace = true }
+rspack_futures        = { workspace = true }
 rspack_hash           = { workspace = true }
 rspack_hook           = { workspace = true }
 rspack_plugin_runtime = { workspace = true }

--- a/crates/rspack_plugin_css/Cargo.toml
+++ b/crates/rspack_plugin_css/Cargo.toml
@@ -13,7 +13,6 @@ dashmap               = { workspace = true }
 heck                  = { workspace = true }
 indexmap              = { workspace = true }
 once_cell             = { workspace = true }
-rayon                 = { workspace = true }
 regex                 = { workspace = true }
 rspack_cacheable      = { workspace = true }
 rspack_collections    = { workspace = true }

--- a/crates/rspack_plugin_css/src/plugin/drive.rs
+++ b/crates/rspack_plugin_css/src/plugin/drive.rs
@@ -1,0 +1,14 @@
+use rspack_core::{rspack_sources::BoxSource, ChunkUkey, Compilation, Module};
+use rspack_hook::define_hook;
+
+define_hook!(CssModulesRenderModulePackage: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &dyn Module, source: &mut CssModulesRenderSource),tracing=false);
+
+#[derive(Debug, Default)]
+pub struct CssModulesPluginHooks {
+  pub render_module_package: CssModulesRenderModulePackageHook,
+}
+
+#[derive(Debug)]
+pub struct CssModulesRenderSource {
+  pub source: BoxSource,
+}

--- a/crates/rspack_plugin_css/src/plugin/mod.rs
+++ b/crates/rspack_plugin_css/src/plugin/mod.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::comparison_chain)]
+mod drive;
 mod impl_plugin_for_css_plugin;
 use std::cmp::{self, Reverse};
 
+pub use drive::*;
 use rspack_collections::{DatabaseItem, IdentifierSet};
 use rspack_core::{Chunk, ChunkUkey, Compilation, Module, ModuleIdentifier};
 use rspack_hook::plugin;

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -15,7 +15,6 @@ pub mod impl_plugin_for_js_plugin;
 pub mod infer_async_modules_plugin;
 mod mangle_exports_plugin;
 pub mod module_concatenation_plugin;
-mod module_info_header_plugin;
 mod side_effects_flag_plugin;
 
 pub use drive::*;
@@ -24,7 +23,6 @@ pub use flag_dependency_usage_plugin::*;
 use indoc::indoc;
 pub use mangle_exports_plugin::*;
 pub use module_concatenation_plugin::*;
-pub use module_info_header_plugin::*;
 use rspack_collections::{Identifier, IdentifierDashMap, IdentifierLinkedMap, IdentifierMap};
 use rspack_core::{
   basic_function,

--- a/crates/rspack_plugin_module_info_header/Cargo.toml
+++ b/crates/rspack_plugin_module_info_header/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+description = "rspack module info header plugin"
+edition     = "2021"
+license     = "MIT"
+name        = "rspack_plugin_module_info_header"
+repository  = "https://github.com/web-infra-dev/rspack"
+version     = "0.2.0"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait              = { workspace = true }
+regex                    = { workspace = true }
+rspack_cacheable         = { workspace = true }
+rspack_collections       = { workspace = true }
+rspack_core              = { workspace = true }
+rspack_error             = { workspace = true }
+rspack_hash              = { workspace = true }
+rspack_hook              = { workspace = true }
+rspack_plugin_css        = { workspace = true }
+rspack_plugin_javascript = { workspace = true }
+rspack_util              = { workspace = true }
+rustc-hash               = { workspace = true }
+tracing                  = { workspace = true }
+
+[package.metadata.cargo-shear]
+ignored = ["tracing", "rspack_hash"]

--- a/crates/rspack_plugin_module_info_header/Cargo.toml
+++ b/crates/rspack_plugin_module_info_header/Cargo.toml
@@ -18,7 +18,6 @@ rspack_hash              = { workspace = true }
 rspack_hook              = { workspace = true }
 rspack_plugin_css        = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
-rspack_util              = { workspace = true }
 rustc-hash               = { workspace = true }
 tracing                  = { workspace = true }
 

--- a/crates/rspack_plugin_module_info_header/LICENSE
+++ b/crates/rspack_plugin_module_info_header/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2022-present Bytedance, Inc. and its affiliates.
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/rspack-test-tools/tests/configCases/build-http/css/__snapshot__/bundle0.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/build-http/css/__snapshot__/bundle0.css.txt
@@ -1,48 +1,40 @@
 Array [
-  "/* #region \"https://raw.githubusercontent.com/web-infra-dev/rspack/55d5d81/packages/rspack-test-tools/tests/configCases/css/at-import/c.css\" */
-/*
-- type: css/auto
-*/
+  "
+/*!***************************************************************************************************************************************!*\\
+  !*** https://raw.githubusercontent.com/web-infra-dev/rspack/55d5d81/packages/rspack-test-tools/tests/configCases/css/at-import/c.css ***!
+  \\***************************************************************************************************************************************/
 .c {
 	color: pink;
 }
 
-/* #endregion \"https://raw.githubusercontent.com/web-infra-dev/rspack/55d5d81/packages/rspack-test-tools/tests/configCases/css/at-import/c.css\" */
 
-/* #region \"./style.css\" */
-/*
-- type: css/auto
-*/
+/*!*******************!*\\
+  !*** ./style.css ***!
+  \\*******************/
 
 
 div {
 	background: url(0dbf5c303a9fe7ec.jpg)
 }
-
-/* #endregion \"./style.css\" */
 
 ",
-  "/* #region \"https://raw.githubusercontent.com/web-infra-dev/rspack/55d5d81/packages/rspack-test-tools/tests/configCases/css/at-import/c.css\" */
-/*
-- type: css/auto
-*/
+  "
+/*!***************************************************************************************************************************************!*\\
+  !*** https://raw.githubusercontent.com/web-infra-dev/rspack/55d5d81/packages/rspack-test-tools/tests/configCases/css/at-import/c.css ***!
+  \\***************************************************************************************************************************************/
 .c {
 	color: pink;
 }
 
-/* #endregion \"https://raw.githubusercontent.com/web-infra-dev/rspack/55d5d81/packages/rspack-test-tools/tests/configCases/css/at-import/c.css\" */
 
-/* #region \"./style.css\" */
-/*
-- type: css/auto
-*/
+/*!*******************!*\\
+  !*** ./style.css ***!
+  \\*******************/
 
 
 div {
 	background: url(0dbf5c303a9fe7ec.jpg)
 }
-
-/* #endregion \"./style.css\" */
 
 ",
 ]

--- a/packages/rspack-test-tools/tests/configCases/css/export-selector/__snapshot__/imported_js.bundle0.css.txt
+++ b/packages/rspack-test-tools/tests/configCases/css/export-selector/__snapshot__/imported_js.bundle0.css.txt
@@ -1,13 +1,11 @@
-/* #region "./style.module.css?imported" */
-/*
-- type: css/auto
-*/
+
+/*!***********************************!*\
+  !*** ./style.module.css?imported ***!
+  \***********************************/
 
 
 .local {}
 
 
 
-
-/* #endregion "./style.module.css?imported" */
 

--- a/tests/webpack-test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -7,10 +7,10 @@ Object {
 `;
 
 exports[`ConfigTestCases css css-modules-no-space exported tests should allow to create css modules 2`] = `
-"/* #region \\"./style.module.css\\" */
-/*
-- type: css/auto
-*/
+"
+/*!**************************!*\\\\
+  !*** ./style.module.css ***!
+  \\\\**************************/
 ._style_module_css-no-space {
 	.class {
 		color: red;
@@ -36,8 +36,6 @@ exports[`ConfigTestCases css css-modules-no-space exported tests should allow to
 		color: red;
 	}
 }
-
-/* #endregion \\"./style.module.css\\" */
 
 "
 `;
@@ -154,10 +152,10 @@ Object {
 
 exports[`ConfigTestCases css escape-unescape exported tests should work with URLs in CSS: css 1`] = `
 Array [
-  "/* #region \\"./style.modules.css\\" */
-/*
-- type: css/auto
-*/
+  "
+/*!***************************!*\\\\
+  !*** ./style.modules.css ***!
+  \\\\***************************/
 ._style_modules_css-class {
 	color: red;
 }
@@ -292,8 +290,6 @@ details {
 }
 
 @keyframes _style_modules_css-f\\\\@oo { from { color: red; } to { color: blue; } }
-
-/* #endregion \\"./style.modules.css\\" */
 
 ",
 ]
@@ -301,10 +297,10 @@ details {
 
 exports[`ConfigTestCases css escape-unescape exported tests should work with URLs in CSS: css 2`] = `
 Array [
-  "/* #region \\"./style.modules.css\\" */
-/*
-- type: css/auto
-*/
+  "
+/*!***************************!*\\\\
+  !*** ./style.modules.css ***!
+  \\\\***************************/
 ._style_modules_css-class {
 	color: red;
 }
@@ -439,8 +435,6 @@ details {
 }
 
 @keyframes _style_modules_css-f\\\\@oo { from { color: red; } to { color: blue; } }
-
-/* #endregion \\"./style.modules.css\\" */
 
 ",
 ]
@@ -636,10 +630,10 @@ Object {
 
 exports[`ConfigTestCases css no-extra-runtime-in-js exported tests should compile 1`] = `
 Array [
-  "/* #region \\"./style.css\\" */
-/*
-- type: css/auto
-*/
+  "
+/*!*******************!*\\\\
+  !*** ./style.css ***!
+  \\\\*******************/
 .class {
 	color: red;
 	background:
@@ -669,18 +663,16 @@ Array [
 	background: url(1237b02e54ad8fd3.png);
 }
 
-/* #endregion \\"./style.css\\" */
-
 ",
 ]
 `;
 
 exports[`ConfigTestCases css pure-css exported tests should compile 1`] = `
 Array [
-  "/* #region \\"../css-modules/style.module.css\\" */
-/*
-- type: css
-*/
+  "
+/*!***************************************!*\\\\
+  !*** ../css-modules/style.module.css ***!
+  \\\\***************************************/
 .class {
 	color: red;
 }
@@ -753,12 +745,10 @@ Array [
 	--global-color: red;
 }
 
-/* #endregion \\"../css-modules/style.module.css\\" */
 
-/* #region \\"./style.css\\" */
-/*
-- type: css
-*/
+/*!*******************!*\\\\
+  !*** ./style.css ***!
+  \\\\*******************/
 
 
 .class {
@@ -798,8 +788,6 @@ Array [
 .class {
 	animation: test 1s, test;
 }
-
-/* #endregion \\"./style.css\\" */
 
 ",
 ]

--- a/tests/webpack-test/configCases/chunk-index/recalc-index/test.filter.js
+++ b/tests/webpack-test/configCases/chunk-index/recalc-index/test.filter.js
@@ -1,2 +1,2 @@
 // module.readableIdentifier (from compilation.chunkGraph.getChunkModulesIterable()) is not a function
-module.exports = () => false;
+module.exports = () => "TODO: CssModule of experiments.css";

--- a/tests/webpack-test/configCases/container/reference-hoisting/test.filter.js
+++ b/tests/webpack-test/configCases/container/reference-hoisting/test.filter.js
@@ -1,2 +1,1 @@
-// no such file main.js
-module.exports = () => false
+module.exports = () => "FIXME: Module build failed, reading from data:text/javascript as uri"

--- a/tests/webpack-test/configCases/container/track-initial-chunks/test.filter.js
+++ b/tests/webpack-test/configCases/container/track-initial-chunks/test.filter.js
@@ -1,2 +1,1 @@
-// no such file, main.js
-module.exports = () => false
+module.exports = () => "FIXME: Module build failed, reading from data:text/javascript as uri"

--- a/tests/webpack-test/configCases/contenthash/css-generator-options/test.config.js
+++ b/tests/webpack-test/configCases/contenthash/css-generator-options/test.config.js
@@ -15,6 +15,6 @@ module.exports = {
 	},
 	afterExecute: () => {
 		expect(allBundles.size).toBe(7);
-		expect(allCss.size).toBe(7);
+		expect(allCss.size).toBe(5);
 	}
 };

--- a/tests/webpack-test/configCases/contenthash/css-generator-options/test.filter.js
+++ b/tests/webpack-test/configCases/contenthash/css-generator-options/test.filter.js
@@ -1,2 +1,6 @@
-// RuleSetRule generator generator entry can be a function
-module.exports = () => false;
+const { FilteredStatus } = require("../../../lib/util/filterUtil");
+
+module.exports = () => [
+  FilteredStatus.PARTIAL_PASS,
+  "TODO: support function as generator.exportsConvention of css/module"
+];

--- a/tests/webpack-test/configCases/contenthash/css-generator-options/webpack.config.js
+++ b/tests/webpack-test/configCases/contenthash/css-generator-options/webpack.config.js
@@ -77,7 +77,7 @@ module.exports = [
 					test: /\.css$/,
 					type: "css/module",
 					generator: {
-						exportsConvention: name => name.toUpperCase()
+						// exportsConvention: name => name.toUpperCase()
 					}
 				}
 			]

--- a/tests/webpack-test/configCases/contenthash/module-ids-size/test.filter.js
+++ b/tests/webpack-test/configCases/contenthash/module-ids-size/test.filter.js
@@ -1,2 +1,1 @@
-// moduleIds: size is not implemented
-module.exports = () => false;
+module.exports = () => "NOPLAN: support moduleIds: size";

--- a/tests/webpack-test/configCases/css/pathinfo/test.config.js
+++ b/tests/webpack-test/configCases/css/pathinfo/test.config.js
@@ -14,13 +14,15 @@ module.exports = {
 			"utf-8"
 		);
 
+		// CHANGE: readable identifier does not starts with `css: `
+		// because rspack use NormalModule to render css
 		if (
-			!source.includes(`/*!********************************!*\\
-  !*** css ./style-imported.css ***!
-  \\********************************/`) &&
-			!source.includes(`/*!***********************!*\\
-  !*** css ./style.css ***!
-  \\***********************/`)
+			!source.includes(`/*!****************************!*\\
+  !*** ./style-imported.css ***!
+  \\****************************/`) &&
+			!source.includes(`/*!*******************!*\\
+  !*** ./style.css ***!
+  \\*******************/`)
 		) {
 			throw new Error("The `pathinfo` option doesn't work.");
 		}

--- a/tests/webpack-test/configCases/css/pathinfo/test.filter.js
+++ b/tests/webpack-test/configCases/css/pathinfo/test.filter.js
@@ -1,2 +1,0 @@
-// The `pathinfo` option doesn't work
-module.exports = () => false;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix the missing of module header info in css modules and remove the old debug region infos. 

And also refactor the render methods of CssPlugin to async functions. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
