### PR TITLE
Update builtin-swc-loader.mdx

### DIFF
--- a/website/docs/zh/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-swc-loader.mdx
@@ -60,7 +60,6 @@ export default {
                   pragmaFrag: 'React.Fragment',
                   throwIfNamespace: true,
                   development: false,
-                  useBuiltins: false,
                 },
               },
             },


### PR DESCRIPTION
"useBuiltIns" is Deprecated since 0.167.4. Since useBuiltIns is removed in swc, we should remove it from the config. Otherwise, "npm start" will result in an error message as follows: Unrecognized key(s) in object: 'useBuiltIns' at "module.rules[0].options.jsc.transform.react"

ref: https://rustdoc.swc.rs/swc_ecma_transforms_react/struct.Options.html#structfield.development

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
