### PR TITLE
chore: let prettier ignore pnpm lock file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,9 @@ package.json
 dist/
 packages/rspack/src/config/schema.check.js
 
+# Ignore lock files
+pnpm-lock.yaml
+
 # Ignore example fixtures
 
 # Ignore test related


### PR DESCRIPTION
## Summary

Add `pnpm-lock.yaml` to .prettierignore to let prettier ignore pnpm lock file.

Related: https://github.com/web-infra-dev/rspack/pull/10400

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
