### PR TITLE
fix: CopyRspackPlugin's transformer function should handle Buffer input

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1650,7 +1650,7 @@ export interface RawCopyPattern {
    * @default false
    */
   copyPermissions?: boolean
-  transform?: { transformer: (input: string, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>  } | ((input: string, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>)
+  transform?: { transformer: (input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>  } | ((input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>)
 }
 
 export interface RawCopyRspackPluginOptions {

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
@@ -12,7 +12,7 @@ use rspack_plugin_copy::{
   TransformerFn,
 };
 
-type RawTransformer = ThreadsafeFunction<FnArgs<(String, String)>, Promise<Either<String, Buffer>>>;
+type RawTransformer = ThreadsafeFunction<FnArgs<(Buffer, String)>, Promise<Either<String, Buffer>>>;
 
 type RawToFn = ThreadsafeFunction<RawToOptions, String>;
 
@@ -48,7 +48,7 @@ pub struct RawCopyPattern {
   pub copy_permissions: Option<bool>,
   #[debug(skip)]
   #[napi(
-    ts_type = "{ transformer: (input: string, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>  } | ((input: string, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>)"
+    ts_type = "{ transformer: (input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>  } | ((input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>)"
   )]
   pub transform: Option<RawTransformer>,
 }
@@ -150,7 +150,7 @@ impl From<RawCopyPattern> for CopyPattern {
         Box::new(move |input, absolute_filename| {
           let f = transformer.clone();
           Box::pin(async move {
-            f.call_with_promise((input, absolute_filename.to_owned()).into())
+            f.call_with_promise((input.into(), absolute_filename.to_owned()).into())
               .await
               .map(|input| match input {
                 Either::A(s) => RawSource::from(s),

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -72,7 +72,7 @@ impl Display for ToType {
 }
 
 pub type TransformerFn =
-  Box<dyn for<'a> Fn(String, &'a str) -> BoxFuture<'a, Result<RawSource>> + Sync + Send>;
+  Box<dyn for<'a> Fn(Vec<u8>, &'a str) -> BoxFuture<'a, Result<RawSource>> + Sync + Send>;
 
 pub struct ToFnCtx<'a> {
   pub context: &'a Utf8Path,
@@ -270,9 +270,9 @@ impl CopyRspackPlugin {
     // TODO inputFileSystem
 
     #[cfg(not(target_family = "wasm"))]
-    let data = tokio::fs::read_to_string(absolute_filename.clone()).await;
+    let data = tokio::fs::read(absolute_filename.clone()).await;
     #[cfg(target_family = "wasm")]
-    let data = std::fs::read_to_string(absolute_filename.clone());
+    let data = std::fs::read(absolute_filename.clone());
 
     let source_vec = match data {
       Ok(data) => {
@@ -788,7 +788,7 @@ fn set_info(target: &mut AssetInfo, info: Info) {
 
 async fn handle_transform(
   transformer: &TransformerFn,
-  source_vec: String,
+  source_vec: Vec<u8>,
   absolute_filename: Utf8PathBuf,
   source: &mut RawSource,
   diagnostics: Arc<Mutex<Vec<Diagnostic>>>,

--- a/packages/rspack-test-tools/tests/configCases/plugins/copy-plugin-transform/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/copy-plugin-transform/rspack.config.js
@@ -1,5 +1,6 @@
 const { CopyRspackPlugin } = require("@rspack/core");
 const path = require("path");
+const assert = require("assert");
 
 module.exports = {
 	entry: "./index.js",
@@ -11,6 +12,7 @@ module.exports = {
 					from: path.join(__dirname, "src", "test-sync-fn.txt"),
 					copyPermissions: true,
 					transform: (content, absoluteFilename) => {
+						assert(content instanceof Buffer);
 						return `file: ${absoluteFilename} transformed: ${content} changed`;
 					}
 				},
@@ -18,6 +20,7 @@ module.exports = {
 					from: path.join(__dirname, "src", "test-async-fn.txt"),
 					copyPermissions: true,
 					transform: async (content, absoluteFilename) => {
+						assert(content instanceof Buffer);
 						return `file: ${absoluteFilename} transformed: ${content} changed`;
 					}
 				},
@@ -26,6 +29,7 @@ module.exports = {
 					copyPermissions: true,
 					transform: {
 						transformer: (content, absoluteFilename) => {
+							assert(content instanceof Buffer);
 							return `file: ${absoluteFilename} transformed: ${content} changed`;
 						}
 					}
@@ -35,6 +39,7 @@ module.exports = {
 					copyPermissions: true,
 					transform: {
 						transformer: async (content, absoluteFilename) => {
+							assert(content instanceof Buffer);
 							return `file: ${absoluteFilename} transformed: ${content} changed`;
 						}
 					}

--- a/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
@@ -408,12 +408,12 @@ export default {
 type transform =
   | {
       transformer: (
-        input: string,
+        input: Buffer,
         absoluteFilename: string,
       ) => string | Buffer | Promise<string> | Promise<Buffer>;
     }
   | ((
-      input: string,
+      input: Buffer,
       absoluteFilename: string,
     ) => string | Buffer | Promise<string> | Promise<Buffer>);
 ```

--- a/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
@@ -412,12 +412,12 @@ export default {
 type transform =
   | {
       transformer: (
-        input: string,
+        input: Buffer,
         absoluteFilename: string,
       ) => string | Buffer | Promise<string> | Promise<Buffer>;
     }
   | ((
-      input: string,
+      input: Buffer,
       absoluteFilename: string,
     ) => string | Buffer | Promise<string> | Promise<Buffer>);
 ```


### PR DESCRIPTION
## Summary

https://webpack.js.org/plugins/copy-webpack-plugin/#transform is actually out of date.
From https://github.com/webpack-contrib/copy-webpack-plugin/blob/0cae504f3044eef77a62b338cdf0c092675748fe/types/index.d.ts#L123 we can see that `input` parameter should be `Buffer`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
