### PR TITLE
docs: introducing Compilation and Compiler objects

### DIFF
--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -20,7 +20,9 @@ import { ApiMeta } from '@components/ApiMeta';
 
 # Compilation
 
-This page will list the methods and properties available on the compilation object.
+The Compilation object is one of the core objects used in the Rspack build process. Whenever Rspack performs a build (including rebuilds in watch mode), a new Compilation instance is created, which contains all the information about the current build.
+
+This page lists the available methods and properties of the Compilation object. You can also refer to [Compilation Hooks](/api/plugin-api/compilation-hooks) to learn about the hooks provided by the Compilation object.
 
 :::warning Notice
 In Rspack, the real compilation object runs on the Rust side, and the JavaScript compilation object is only a **proxy object** used to communicate with the Rust compilation object.

--- a/website/docs/en/api/javascript-api/compiler.mdx
+++ b/website/docs/en/api/javascript-api/compiler.mdx
@@ -12,7 +12,7 @@ import { Badge } from '@theme';
 
 # Compiler
 
-The Compiler is a core object in Rspack. A Compiler instance is created whenever you call Rspack's [JavaScript API](/api/javascript-api/index) or [CLI](/api/cli/index).
+The Compiler is a core object in Rspack. A Compiler instance is created whenever you call Rspack's [JavaScript API](/api/javascript-api/index) or [CLI](/api/cli).
 
 It provides methods like [run](#run) and [watch](#watch) to start builds, while exposing various [Compiler hooks](/api/plugin-api/compiler-hooks) that allow Rspack plugins to intervene at different stages of the build process.
 

--- a/website/docs/en/api/javascript-api/compiler.mdx
+++ b/website/docs/en/api/javascript-api/compiler.mdx
@@ -12,6 +12,10 @@ import { Badge } from '@theme';
 
 # Compiler
 
+The Compiler is a core object in Rspack. A Compiler instance is created whenever you call Rspack's [JavaScript API](/api/javascript-api/index) or [CLI](/api/cli/index).
+
+It provides methods like [run](#run) and [watch](#watch) to start builds, while exposing various [Compiler hooks](/api/plugin-api/compiler-hooks) that allow Rspack plugins to intervene at different stages of the build process.
+
 ## Compiler methods
 
 ### run

--- a/website/docs/en/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compilation-hooks.mdx
@@ -13,6 +13,14 @@ import { ApiMeta } from '@components/ApiMeta';
 
 # Compilation hooks
 
+Compilation hooks are the primary extension method for Rspack plugins. These hooks enable developers to intervene at various stages of the build process.
+
+This document lists the available Compilation hooks in Rspack, detailing their triggering timing, parameters, and usage examples.
+
+:::tip
+See the [Compilation](/api/javascript-api/compilation) for more information about the Compilation object.
+:::
+
 :::info
 The main compilation logic of Rspack runs on the Rust side. For factors such as stability, performance, and architecture, after the Rust side compilation objects are transferred to the JavaScript side when using hooks, the modifications on these objects will not be synchronized to the Rust side. Therefore, most of hooks are "read-only".
 :::

--- a/website/docs/en/api/plugin-api/compiler-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compiler-hooks.mdx
@@ -8,6 +8,14 @@ import { NoSSR } from 'rspress/runtime';
 
 # Compiler hooks
 
+Compiler hooks allow Rspack plugins to intervene at specific stages of the build process. These hooks represent various lifecycle stages from initialization to asset output.
+
+This document lists the available compiler hooks in Rspack, their trigger timing, parameters, and usage examples.
+
+:::tip
+See [Compiler](/api/javascript-api/compiler) for more information about the Compiler object.
+:::
+
 ## Overview
 
 <NoSSR>

--- a/website/docs/en/api/plugin-api/index.mdx
+++ b/website/docs/en/api/plugin-api/index.mdx
@@ -1,5 +1,15 @@
 # Overview
 
+## Plugin hooks
+
+Rspack plugin hooks are similar to the webpack plugin, mainly including the following categories:
+
+- [Compiler hooks](/api/plugin-api/compiler-hooks): Intervene at various stages of the entire build process
+- [Compilation hooks](/api/plugin-api/compilation-hooks): Intervene at various stages of a single build
+- [RuntimePlugin hooks](/api/plugin-api/runtime-plugin-hooks): Intervene in the generation of runtime code
+- [NormalModuleFactory hooks](/api/plugin-api/normal-module-factory-hooks): Intervene at various stages of the module creation process
+- [Stats hooks](/api/plugin-api/stats-hooks): Intervene in the generation of stats
+
 ## Compatibility status
 
 Rspack is committed to being compatible with the plugins within the webpack ecosystem. We ensure that Rspack is as compatible as possible with the webpack plugin API, allowing more existing webpack plugins to be directly used in Rspack.

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -20,7 +20,9 @@ import { ApiMeta } from '@components/ApiMeta';
 
 # Compilation
 
-此页面将列举 Compilation 对象上可用的方法和属性。
+Compilation 对象是 Rspack 构建过程中的核心对象之一，每当 Rspack 执行构建时（包括监听模式下的重新构建），都会创建一个新的 Compilation 实例，它包含了当前构建的所有信息。
+
+当前页面列举了 Compilation 对象上可用的方法和属性。你也可以参考 [Compilation 钩子](/api/plugin-api/compilation-hooks) 了解 Compilation 对象提供的钩子。
 
 :::warning 注意
 在 Rspack 中，真实的 Compilation 运行在 Rust 侧，JavaScript Compilation 仅作为用于与 Rust Compilation 通信的**代理对象**。

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -12,6 +12,10 @@ import { Badge } from '@theme';
 
 # Compiler
 
+Compiler 是 Rspack 内部的核心对象，当你调用 Rspack 的 [JavaScript API](/api/javascript-api/index) 或 [CLI](/api/cli/index) 时，都会创建一个 Compiler 实例。
+
+它提供了 [run](#run) 和 [watch](#watch) 等方法来启动构建，同时暴露了丰富的 [Compiler 钩子](/api/plugin-api/compiler-hooks)，使 Rspack 插件能够干预构建的各个阶段。
+
 ## Compiler 对象方法
 
 ### run

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -12,7 +12,7 @@ import { Badge } from '@theme';
 
 # Compiler
 
-Compiler 是 Rspack 内部的核心对象，当你调用 Rspack 的 [JavaScript API](/api/javascript-api/index) 或 [CLI](/api/cli/index) 时，都会创建一个 Compiler 实例。
+Compiler 是 Rspack 内部的核心对象，当你调用 Rspack 的 [JavaScript API](/api/javascript-api/index) 或 [CLI](/api/cli) 时，都会创建一个 Compiler 实例。
 
 它提供了 [run](#run) 和 [watch](#watch) 等方法来启动构建，同时暴露了丰富的 [Compiler 钩子](/api/plugin-api/compiler-hooks)，使 Rspack 插件能够干预构建的各个阶段。
 

--- a/website/docs/zh/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compilation-hooks.mdx
@@ -13,8 +13,16 @@ import { ApiMeta } from '@components/ApiMeta';
 
 # Compilation 钩子
 
+Compilation 钩子是 Rspack 插件的主要扩展方式，为开发者提供了介入构建流程各阶段的能力。
+
+本文档列举了 Rspack 中可用的 Compilation 钩子、它们的触发时机、参数以及使用示例。
+
+:::tip
+查看 [Compilation](/api/javascript-api/compilation) 了解更多关于 Compilation 对象的信息。
+:::
+
 :::info
-Rspack 主要编译逻辑运行在 Rust 侧。出于稳定性、性能、架构等因素，在使用钩子时 Rust 侧编译对象传输到 JavaScript 侧后，对 JavaScript 侧的修改不会被同步到 Rust 侧。因此绝大部分钩子为“只读”。
+Rspack 的主要编译逻辑运行在 Rust 侧。出于稳定性、性能、架构等因素，在使用钩子时，Rust 侧编译对象传输到 JavaScript 侧后，对 JavaScript 侧的修改不会被同步到 Rust 侧。因此绝大部分钩子为“只读”。
 :::
 
 ## Overview

--- a/website/docs/zh/api/plugin-api/compiler-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compiler-hooks.mdx
@@ -8,6 +8,14 @@ import { NoSSR } from 'rspress/runtime';
 
 # Compiler 钩子
 
+Compiler hooks 允许 Rspack 插件在特定阶段介入构建流程。它们代表了从初始化到资源输出的各个生命周期阶段。
+
+本文档列举了 Rspack 中可用的 Compiler 钩子、它们的触发时机、参数以及使用示例。
+
+:::tip
+查看 [Compiler](/api/javascript-api/compiler) 了解更多关于 Compiler 对象的信息。
+:::
+
 ## Overview
 
 <NoSSR>

--- a/website/docs/zh/api/plugin-api/index.mdx
+++ b/website/docs/zh/api/plugin-api/index.mdx
@@ -1,5 +1,15 @@
 # 总览
 
+## 插件钩子
+
+Rspack 插件的钩子与 webpack 插件类似，主要包括以下几类：
+
+- [Compiler 钩子](/api/plugin-api/compiler-hooks)：介入整个构建流程中的各个阶段
+- [Compilation 钩子](/api/plugin-api/compilation-hooks)：介入单次构建中的各个阶段
+- [RuntimePlugin 钩子](/api/plugin-api/runtime-plugin-hooks)：介入运行时代码的生成
+- [NormalModuleFactory 钩子](/api/plugin-api/normal-module-factory-hooks)：介入模块创建过程中的各个阶段
+- [Stats 钩子](/api/plugin-api/stats-hooks)：介入 stats 的生成
+
 ## 兼容情况
 
 Rspack 致力于兼容 webpack 生态中的插件。我们确保 Rspack 尽可能地去兼容 webpack 的插件 API，使更多现有的 webpack 插件能够在 Rspack 中直接使用。


### PR DESCRIPTION
## Summary

This PR adds more detailed introductions of core objects like `Compiler`, `Compilation` and their hooks, which can help plugin developers better distinguish the core concepts in Rspack.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
