### PR TITLE
feat(swc_compiler_api): add diagnostics field to TransformOutput

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -2627,4 +2627,5 @@ export declare function transform(source: string, options: string): Promise<Tran
 export interface TransformOutput {
   code: string
   map?: string
+  diagnostics: Array<string>
 }

--- a/crates/node_binding/src/swc.rs
+++ b/crates/node_binding/src/swc.rs
@@ -9,6 +9,7 @@ use swc_core::ecma::ast::noop_pass;
 pub struct TransformOutput {
   pub code: String,
   pub map: Option<String>,
+  pub diagnostics: Vec<String>,
 }
 
 impl From<CompilerTransformOutput> for TransformOutput {
@@ -18,6 +19,7 @@ impl From<CompilerTransformOutput> for TransformOutput {
       map: value
         .map
         .map(|v| serde_json::to_string(&v).expect("failed to serialize transformOutput.map")),
+      diagnostics: value.diagnostics,
     }
   }
 }

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -1033,18 +1033,18 @@ export class Compilation {
     // (undocumented)
     getAsset(name: string): Readonly<Asset> | void;
     // (undocumented)
-    getAssetPath(filename: Filename, data?: PathData): string;
+    getAssetPath(filename: string, data?: PathData): string;
     // (undocumented)
-    getAssetPathWithInfo(filename: Filename, data?: PathData): binding.PathWithInfo;
+    getAssetPathWithInfo(filename: string, data?: PathData): binding.PathWithInfo;
     getAssets(): ReadonlyArray<Asset>;
     // (undocumented)
     getCache(name: string): CacheFacade_2;
     // (undocumented)
     getLogger(name: string | (() => string)): Logger_3;
     // (undocumented)
-    getPath(filename: Filename, data?: PathData): string;
+    getPath(filename: string, data?: PathData): string;
     // (undocumented)
-    getPathWithInfo(filename: Filename, data?: PathData): binding.PathWithInfo;
+    getPathWithInfo(filename: string, data?: PathData): binding.PathWithInfo;
     // (undocumented)
     getStats(): Stats;
     // (undocumented)
@@ -1653,6 +1653,24 @@ export type CssAutoParserOptions = {
 
 // @public
 export type CssChunkFilename = Filename;
+
+// @public (undocumented)
+const CssChunkingPlugin: {
+    new (options: CssChunkingPluginOptions): {
+        name: binding.BuiltinPluginName;
+        _args: [options: CssChunkingPluginOptions];
+        affectedHooks: "done" | "make" | "compile" | "emit" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        raw(compiler: Compiler_2): binding.BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
+    };
+};
+
+// @public (undocumented)
+interface CssChunkingPluginOptions {
+    nextjs?: boolean;
+    // (undocumented)
+    strict?: boolean;
+}
 
 // @public (undocumented)
 export interface CssExtractRspackLoaderOptions {
@@ -2447,6 +2465,8 @@ export const experiments: Experiments_2;
 
 // @public (undocumented)
 interface Experiments_2 {
+    // (undocumented)
+    CssChunkingPlugin: typeof CssChunkingPlugin;
     // (undocumented)
     globalTrace: {
         register: (filter: string, layer: "chrome" | "logger", output: string) => Promise<void>;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

**Enhance**: add diagnostics field to TransformOutput for external plugin can emit warning in rust side.

Relative PR: https://github.com/web-infra-dev/rspack/pull/10312

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
