### PR TITLE
fix: swc compiler api using wasm plugin without tokio runtime panic.

### DIFF
--- a/crates/node_binding/src/swc.rs
+++ b/crates/node_binding/src/swc.rs
@@ -1,4 +1,3 @@
-use napi::{bindgen_prelude::AsyncTask, Task};
 use rspack_javascript_compiler::{
   minify::JsMinifyOptions, transform::SwcOptions, JavaScriptCompiler,
   TransformOutput as CompilerTransformOutput,
@@ -22,80 +21,42 @@ impl From<CompilerTransformOutput> for TransformOutput {
   }
 }
 
-pub struct AsyncTransform {
-  source: String,
-  options: String,
+#[napi]
+pub async fn transform(source: String, options: String) -> napi::Result<TransformOutput> {
+  let options: SwcOptions = serde_json::from_str(&options)?;
+  let compiler = JavaScriptCompiler::new();
+  compiler
+    .transform(
+      source,
+      Some(swc_core::common::FileName::Anon),
+      options,
+      None,
+      |_| noop_pass(),
+    )
+    .map(|output| TransformOutput::from(output))
+    .map_err(|e| napi::Error::new(napi::Status::GenericFailure, format!("{}", e)))
 }
 
-impl Task for AsyncTransform {
-  type Output = CompilerTransformOutput;
-  type JsValue = TransformOutput;
+#[napi]
+pub async fn minify(source: String, options: String) -> napi::Result<TransformOutput> {
+  let options: JsMinifyOptions = serde_json::from_str(&options)?;
+  let compiler = JavaScriptCompiler::new();
+  compiler
+    .minify(
+      swc_core::common::FileName::Anon,
+      source,
+      options,
+      None::<&dyn Fn(&swc_core::common::comments::SingleThreadedComments)>,
+    )
+    .map(|output| TransformOutput::from(output))
+    .map_err(|e| {
+      let v = e.into_inner();
+      let err = v
+        .into_iter()
+        .map(|e| format!("{:?}", e))
+        .collect::<Vec<_>>()
+        .join("\n");
 
-  fn compute(&mut self) -> napi::Result<Self::Output> {
-    let compiler = JavaScriptCompiler::new();
-    let options: SwcOptions = serde_json::from_str(&self.options)?;
-    let source = std::mem::take(&mut self.source);
-    compiler
-      .transform(
-        source,
-        Some(swc_core::common::FileName::Anon),
-        options,
-        None,
-        |_| noop_pass(),
-      )
-      .map_err(|e| napi::Error::new(napi::Status::GenericFailure, format!("{}", e)))
-  }
-
-  fn resolve(&mut self, _env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
-    let output = TransformOutput::from(output);
-    Ok(output)
-  }
-}
-
-pub struct AsyncMinifier {
-  source: String,
-  options: String,
-}
-
-impl Task for AsyncMinifier {
-  type Output = CompilerTransformOutput;
-  type JsValue = TransformOutput;
-
-  fn compute(&mut self) -> napi::Result<Self::Output> {
-    let options: JsMinifyOptions = serde_json::from_str(&self.options)?;
-    let compiler = JavaScriptCompiler::new();
-    let source = std::mem::take(&mut self.source);
-    compiler
-      .minify(
-        swc_core::common::FileName::Anon,
-        source,
-        options,
-        None::<&dyn Fn(&swc_core::common::comments::SingleThreadedComments)>,
-      )
-      .map_err(|e| {
-        let v = e.into_inner();
-        let err = v
-          .into_iter()
-          .map(|e| format!("{:?}", e))
-          .collect::<Vec<_>>()
-          .join("\n");
-
-        napi::Error::new(napi::Status::GenericFailure, err)
-      })
-  }
-
-  fn resolve(&mut self, _env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
-    let output = TransformOutput::from(output);
-    Ok(output)
-  }
-}
-
-#[napi(ts_return_type = "Promise<TransformOutput>")]
-pub fn transform(source: String, options: String) -> AsyncTask<AsyncTransform> {
-  AsyncTask::new(AsyncTransform { source, options })
-}
-
-#[napi(ts_return_type = "Promise<TransformOutput>")]
-pub fn minify(source: String, options: String) -> AsyncTask<AsyncMinifier> {
-  AsyncTask::new(AsyncMinifier { source, options })
+      napi::Error::new(napi::Status::GenericFailure, err)
+    })
 }

--- a/crates/node_binding/src/swc.rs
+++ b/crates/node_binding/src/swc.rs
@@ -33,7 +33,7 @@ pub async fn transform(source: String, options: String) -> napi::Result<Transfor
       None,
       |_| noop_pass(),
     )
-    .map(|output| TransformOutput::from(output))
+    .map(TransformOutput::from)
     .map_err(|e| napi::Error::new(napi::Status::GenericFailure, format!("{}", e)))
 }
 
@@ -48,7 +48,7 @@ pub async fn minify(source: String, options: String) -> napi::Result<TransformOu
       options,
       None::<&dyn Fn(&swc_core::common::comments::SingleThreadedComments)>,
     )
-    .map(|output| TransformOutput::from(output))
+    .map(TransformOutput::from)
     .map_err(|e| {
       let v = e.into_inner();
       let err = v

--- a/packages/rspack-test-tools/tests/compilerCases/swc-api.js
+++ b/packages/rspack-test-tools/tests/compilerCases/swc-api.js
@@ -1,0 +1,25 @@
+/** @type {import('../..').TCompilerCaseConfig} */
+module.exports = {
+	description: "should load @swc/plugin-remove-console successfully and transform code using rspack inner swc api",
+	async check(_, compiler, __) {
+		let swc = compiler.rspack.experiments.swc;
+
+		let source = 'function main() { console.log("Hello Rspack") }; main();';
+		let result = await swc.transform(source, {
+			filename: "index.js",
+			minify: true,
+			jsc: {
+				parser: {
+					syntax: "ecmascript",
+					dynamicImport: true
+				},
+				target: "es5",
+				experimental: {
+					plugins: [[require.resolve("@swc/plugin-remove-console"), {}]],
+				}
+			}
+		});
+
+		expect(result.code).toMatchInlineSnapshot(`function main(){;};main();`);
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
swc wasm runtime need runnning in tokio runtime, otherwise it will panic: `Message:  there is no reactor running, must be called from the context of a Tokio 1.x runtime`
`napi-rs` will add tokio runtime auto in async fn.
So we using async fn directly, using the tokio runtime provided by `napi-rs`

fix: https://github.com/web-infra-dev/rspack/issues/10305

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
