### PR TITLE
fix: set compilation errors result is wrong

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -256,6 +256,7 @@ export declare class JsCompilation {
   pushNativeDiagnostic(diagnostic: ExternalObject<'Diagnostic'>): void
   pushNativeDiagnostics(diagnostics: ExternalObject<'Diagnostic[]'>): void
   get errors(): Diagnostics
+  get warnings(): Diagnostics
   getErrors(): Array<JsRspackError>
   getWarnings(): Array<JsRspackError>
   getStats(): JsStats

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -253,7 +253,6 @@ export declare class JsCompilation {
   get hash(): string | null
   dependencies(): JsDependencies
   pushDiagnostic(diagnostic: JsRspackDiagnostic): void
-  spliceDiagnostic(start: number, end: number, replaceWith: Array<JsRspackDiagnostic>): void
   pushNativeDiagnostic(diagnostic: ExternalObject<'Diagnostic'>): void
   pushNativeDiagnostics(diagnostics: ExternalObject<'Diagnostic[]'>): void
   get errors(): Diagnostics

--- a/crates/node_binding/rspack.wasi-browser.js
+++ b/crates/node_binding/rspack.wasi-browser.js
@@ -1,8 +1,8 @@
 import {
-  instantiateNapiModuleSync as __emnapiInstantiateNapiModuleSync,
-  getDefaultContext as __emnapiGetDefaultContext,
-  WASI as __WASI,
   createOnMessage as __wasmCreateOnMessageForFsProxy,
+  getDefaultContext as __emnapiGetDefaultContext,
+  instantiateNapiModuleSync as __emnapiInstantiateNapiModuleSync,
+  WASI as __WASI,
 } from '@napi-rs/wasm-runtime'
 import { memfs } from '@napi-rs/wasm-runtime/fs'
 import __wasmUrl from './rspack.wasm32-wasi.wasm?url'
@@ -60,6 +60,7 @@ const {
     }
   },
 })
+export default __napiModule.exports
 export const Assets = __napiModule.exports.Assets
 export const AsyncDependenciesBlock = __napiModule.exports.AsyncDependenciesBlock
 export const BuildInfo = __napiModule.exports.BuildInfo

--- a/crates/node_binding/rspack.wasi.cjs
+++ b/crates/node_binding/rspack.wasi.cjs
@@ -9,9 +9,9 @@ const { WASI: __nodeWASI } = require('node:wasi')
 const { Worker } = require('node:worker_threads')
 
 const {
-  instantiateNapiModuleSync: __emnapiInstantiateNapiModuleSync,
-  getDefaultContext: __emnapiGetDefaultContext,
   createOnMessage: __wasmCreateOnMessageForFsProxy,
+  getDefaultContext: __emnapiGetDefaultContext,
+  instantiateNapiModuleSync: __emnapiInstantiateNapiModuleSync,
 } = require('@napi-rs/wasm-runtime')
 
 const __rootDir = __nodePath.parse(process.cwd()).root
@@ -84,7 +84,7 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
     }
   },
 })
-
+module.exports = __napiModule.exports
 module.exports.Assets = __napiModule.exports.Assets
 module.exports.AsyncDependenciesBlock = __napiModule.exports.AsyncDependenciesBlock
 module.exports.BuildInfo = __napiModule.exports.BuildInfo

--- a/crates/node_binding/src/compilation/mod.rs
+++ b/crates/node_binding/src/compilation/mod.rs
@@ -424,10 +424,18 @@ impl JsCompilation {
     Ok(())
   }
 
-  #[napi(getter, ts_return_type = "Diagnostics")]
+  #[napi(getter)]
   pub fn errors(&self, reference: Reference<JsCompilation>) -> Result<Diagnostics> {
     Ok(Diagnostics::new(
       RspackSeverity::Error,
+      reference.downgrade(),
+    ))
+  }
+
+  #[napi(getter)]
+  pub fn warnings(&self, reference: Reference<JsCompilation>) -> Result<Diagnostics> {
+    Ok(Diagnostics::new(
+      RspackSeverity::Warn,
       reference.downgrade(),
     ))
   }

--- a/crates/node_binding/src/compilation/mod.rs
+++ b/crates/node_binding/src/compilation/mod.rs
@@ -403,20 +403,6 @@ impl JsCompilation {
     Ok(())
   }
 
-  #[napi]
-  pub fn splice_diagnostic(
-    &mut self,
-    start: u32,
-    end: u32,
-    replace_with: Vec<crate::JsRspackDiagnostic>,
-  ) -> Result<()> {
-    let compilation = self.as_mut()?;
-
-    let diagnostics = replace_with.into_iter().map(Into::into).collect();
-    compilation.splice_diagnostic(start as usize, end as usize, diagnostics);
-    Ok(())
-  }
-
   #[napi(ts_args_type = r#"diagnostic: ExternalObject<'Diagnostic'>"#)]
   pub fn push_native_diagnostic(&mut self, diagnostic: &External<Diagnostic>) -> Result<()> {
     let compilation = self.as_mut()?;

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -809,15 +809,6 @@ impl Compilation {
     self.diagnostics.push(diagnostic);
   }
 
-  pub fn splice_diagnostic(
-    &mut self,
-    s: usize,
-    e: usize,
-    replace_with: Vec<Diagnostic>,
-  ) -> Vec<Diagnostic> {
-    self.diagnostics.splice(s..e, replace_with).collect()
-  }
-
   pub fn extend_diagnostics(&mut self, diagnostics: impl IntoIterator<Item = Diagnostic>) {
     self.diagnostics.extend(diagnostics);
   }

--- a/packages/rspack-test-tools/tests/configCases/compilation/errors/loader.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/errors/loader.js
@@ -1,0 +1,8 @@
+module.exports = function (content) {
+    this.emitWarning(new Error("emitted warning1"));
+    this.emitError(new Error("emitted error1"));
+    this.emitWarning(new Error("emitted warning2"));
+    this.emitError(new Error("emitted error2"));
+
+    return content;
+}

--- a/packages/rspack-test-tools/tests/configCases/compilation/errors/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/errors/rspack.config.js
@@ -7,12 +7,18 @@ class Plugin {
 	apply(compiler) {
 		compiler.hooks.make.tap(PLUGIN_NAME, compilation => {
 			compilation.hooks.processAssets.tap(PLUGIN_NAME, () => {
+				expect(compilation.errors.length).toBe(2);
 				expect(compilation.errors[0].message).toMatch(/emitted error1/);
 				expect(compilation.errors[1].message).toMatch(/emitted error2/);
+
+				expect(compilation.warnings.length).toBe(2);
 				expect(compilation.warnings[0].message).toMatch(/emitted warning1/);
 				expect(compilation.warnings[1].message).toMatch(/emitted warning2/);
+
 				compilation.errors = [];
 				expect(compilation.errors.length).toBe(0);
+
+				expect(compilation.warnings.length).toBe(2);
 				expect(compilation.warnings[0].message).toMatch(/emitted warning1/);
 				expect(compilation.warnings[1].message).toMatch(/emitted warning2/);
 

--- a/packages/rspack-test-tools/tests/configCases/compilation/errors/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/compilation/errors/rspack.config.js
@@ -1,0 +1,42 @@
+const PLUGIN_NAME = "plugin";
+
+class Plugin {
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.make.tap(PLUGIN_NAME, compilation => {
+			compilation.hooks.processAssets.tap(PLUGIN_NAME, () => {
+				expect(compilation.errors[0].message).toMatch(/emitted error1/);
+				expect(compilation.errors[1].message).toMatch(/emitted error2/);
+				expect(compilation.warnings[0].message).toMatch(/emitted warning1/);
+				expect(compilation.warnings[1].message).toMatch(/emitted warning2/);
+				compilation.errors = [];
+				expect(compilation.errors.length).toBe(0);
+				expect(compilation.warnings[0].message).toMatch(/emitted warning1/);
+				expect(compilation.warnings[1].message).toMatch(/emitted warning2/);
+
+				compilation.warnings = [];
+				expect(compilation.warnings.length).toBe(0);
+			});
+		});
+	}
+}
+
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+	entry: "./index.js",
+	plugins: [new Plugin()],
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				use: [
+					{
+						loader: require.resolve("./loader")
+					}
+				]
+			}
+		]
+	}
+};

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -8,15 +8,14 @@
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
 import * as binding from "@rspack/binding";
-import {
-	type AssetInfo,
-	type Dependency,
-	type ExternalObject,
-	type JsCompatSourceOwned,
-	type JsCompilation,
-	type JsPathData,
-	JsRspackSeverity,
-	type JsRuntimeModule
+import type {
+	AssetInfo,
+	Dependency,
+	ExternalObject,
+	JsCompatSourceOwned,
+	JsCompilation,
+	JsPathData,
+	JsRuntimeModule
 } from "@rspack/binding";
 export type { AssetInfo } from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
@@ -33,7 +32,7 @@ import ModuleGraph from "./ModuleGraph";
 import type { NormalModuleCompilationHooks } from "./NormalModule";
 import type { NormalModuleFactory } from "./NormalModuleFactory";
 import type { ResolverFactory } from "./ResolverFactory";
-import { JsRspackDiagnostic, type RspackError } from "./RspackError";
+import { type RspackError } from "./RspackError";
 import { RuntimeModule } from "./RuntimeModule";
 import {
 	Stats,
@@ -202,6 +201,7 @@ export class Compilation {
 	#inner: JsCompilation;
 	#shutdown: boolean;
 	#errors?: RspackError[];
+	#warnings?: RspackError[];
 	#chunks?: ReadonlySet<Chunk>;
 
 	hooks: Readonly<{
@@ -717,110 +717,24 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	}
 
 	set errors(errors: RspackError[]) {
-		const inner = this.#inner;
-		const length = inner.getErrors().length;
-		inner.spliceDiagnostic(
-			0,
-			length,
-			errors.map(error => {
-				return JsRspackDiagnostic.__to_binding(error, JsRspackSeverity.Error);
-			})
-		);
+		if (!this.#errors) {
+			this.#errors = createDiagnosticArray(this.#inner.errors);
+		}
+		this.#errors.splice(0, this.#errors.length, ...errors);
 	}
 
 	get warnings(): RspackError[] {
-		const inner = this.#inner;
-		type WarnType = Error | RspackError;
-		const warnings = inner.getWarnings();
-		const proxyMethod = [
-			{
-				method: "push",
-				handler(
-					target: typeof Array.prototype.push,
-					thisArg: Array<WarnType>,
-					warns: WarnType[]
-				) {
-					for (const warn of warns) {
-						inner.pushDiagnostic(
-							JsRspackDiagnostic.__to_binding(warn, JsRspackSeverity.Warn)
-						);
-					}
-					return Reflect.apply(target, thisArg, warns);
-				}
-			},
-			{
-				method: "pop",
-				handler(target: typeof Array.prototype.pop, thisArg: Array<WarnType>) {
-					inner.spliceDiagnostic(warnings.length - 1, warnings.length, []);
-					return Reflect.apply(target, thisArg, []);
-				}
-			},
-			{
-				method: "shift",
-				handler(
-					target: typeof Array.prototype.shift,
-					thisArg: Array<WarnType>
-				) {
-					inner.spliceDiagnostic(0, 1, []);
-					return Reflect.apply(target, thisArg, []);
-				}
-			},
-			{
-				method: "unshift",
-				handler(
-					target: typeof Array.prototype.unshift,
-					thisArg: Array<WarnType>,
-					warns: WarnType[]
-				) {
-					inner.spliceDiagnostic(
-						0,
-						0,
-						warns.map(warn =>
-							JsRspackDiagnostic.__to_binding(warn, JsRspackSeverity.Warn)
-						)
-					);
-					return Reflect.apply(target, thisArg, warns);
-				}
-			},
-			{
-				method: "splice",
-				handler(
-					target: typeof Array.prototype.splice,
-					thisArg: Array<WarnType>,
-					[startIdx, delCount, ...warns]: [number, number, ...WarnType[]]
-				) {
-					const warnList = warns.map(warn =>
-						JsRspackDiagnostic.__to_binding(warn, JsRspackSeverity.Warn)
-					);
-					inner.spliceDiagnostic(startIdx, startIdx + delCount, warnList);
-					return Reflect.apply(target, thisArg, [
-						startIdx,
-						delCount,
-						...warnList
-					]);
-				}
-			}
-		];
-
-		for (const item of proxyMethod) {
-			const proxiedMethod = new Proxy(warnings[item.method as any], {
-				apply: item.handler as any
-			});
-			warnings[item.method as any] = proxiedMethod;
+		if (!this.#warnings) {
+			this.#warnings = createDiagnosticArray(this.#inner.errors);
 		}
-		return warnings;
+		return this.#warnings;
 	}
 
 	set warnings(warnings: RspackError[]) {
-		const inner = this.#inner;
-		const length = inner.getWarnings().length;
-		inner.spliceDiagnostic(
-			0,
-			length,
-			warnings.map(warning => {
-				return JsRspackDiagnostic.__to_binding(warning, JsRspackSeverity.Warn);
-			})
-		);
+		if (!this.#errors) {
+			this.#errors = createDiagnosticArray(this.#inner.errors);
+		}
+		this.#errors.splice(0, this.#errors.length, ...warnings);
 	}
 
 	getPath(filename: string, data: PathData = {}) {

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -32,7 +32,7 @@ import ModuleGraph from "./ModuleGraph";
 import type { NormalModuleCompilationHooks } from "./NormalModule";
 import type { NormalModuleFactory } from "./NormalModuleFactory";
 import type { ResolverFactory } from "./ResolverFactory";
-import { type RspackError } from "./RspackError";
+import type { RspackError } from "./RspackError";
 import { RuntimeModule } from "./RuntimeModule";
 import {
 	Stats,
@@ -725,16 +725,16 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 
 	get warnings(): RspackError[] {
 		if (!this.#warnings) {
-			this.#warnings = createDiagnosticArray(this.#inner.errors);
+			this.#warnings = createDiagnosticArray(this.#inner.warnings);
 		}
 		return this.#warnings;
 	}
 
 	set warnings(warnings: RspackError[]) {
-		if (!this.#errors) {
-			this.#errors = createDiagnosticArray(this.#inner.errors);
+		if (!this.#warnings) {
+			this.#warnings = createDiagnosticArray(this.#inner.warnings);
 		}
-		this.#errors.splice(0, this.#errors.length, ...warnings);
+		this.#warnings.splice(0, this.#warnings.length, ...warnings);
 	}
 
 	getPath(filename: string, data: PathData = {}) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fix incorrect diagnostic removal when setting `compilation.errors = []`

Current Issue:
- When `compilation.errors = []` is set, the `spliceDiagnostic()` function removes all diagnostics without checking their level
Since warnings and errors are stored in the same array (differentiated only by level), this can cause incorrect diagnostic indexing (e.g., removing first item which might be a warning when we meant to remove errors)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
