### PR TITLE
refactor: avoid read rust side json in js side

### DIFF
--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -6,20 +6,20 @@ use std::{
   marker::PhantomData,
   path::Path,
   sync::{
-    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
     mpsc,
     mpsc::Sender,
+    Arc, Mutex,
   },
   thread::JoinHandle,
 };
 
-use serde_json::{Value as JsonValue, json};
-use tracing_core::{Event, Subscriber, field::Field, span};
+use serde_json::{json, Value as JsonValue};
+use tracing_core::{field::Field, span, Event, Subscriber};
 use tracing_subscriber::{
-  Layer,
   layer::Context,
   registry::{LookupSpan, SpanRef},
+  Layer,
 };
 
 thread_local! {
@@ -433,8 +433,8 @@ where
         serde_json::to_writer(&mut write, &entry).unwrap();
         has_started = true;
       }
-
-      write.write_all(b"\n]").unwrap();
+      // we need to merge tracing with js side, so don't end it early
+      // write.write_all(b"\n]").unwrap();
       write.flush().unwrap();
     });
 

--- a/crates/rspack_tracing_chrome/src/lib.rs
+++ b/crates/rspack_tracing_chrome/src/lib.rs
@@ -6,20 +6,20 @@ use std::{
   marker::PhantomData,
   path::Path,
   sync::{
+    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
     mpsc,
     mpsc::Sender,
-    Arc, Mutex,
   },
   thread::JoinHandle,
 };
 
-use serde_json::{json, Value as JsonValue};
-use tracing_core::{field::Field, span, Event, Subscriber};
+use serde_json::{Value as JsonValue, json};
+use tracing_core::{Event, Subscriber, field::Field, span};
 use tracing_subscriber::{
+  Layer,
   layer::Context,
   registry::{LookupSpan, SpanRef},
-  Layer,
 };
 
 thread_local! {

--- a/packages/rspack/src/trace/index.ts
+++ b/packages/rspack/src/trace/index.ts
@@ -92,20 +92,17 @@ export class JavaScriptTracer {
 					}
 				});
 			}
-			const originTrace = fs.readFileSync(this.output, "utf-8");
 			// this is hack, [] is empty and [{}] is not empty
-			const originTraceIsEmpty = !originTrace.includes("{");
-			const eventMsg =
-				(this.events.length > 0 && !originTraceIsEmpty ? "," : "") +
-				this.events
-					.map(x => {
-						return JSON.stringify(x);
-					})
-					.join(",\n");
+			const eventMsg = this.events
+				.map(x => {
+					return JSON.stringify(x);
+				})
+				.join(",\n");
+			// even lots of tracing tools supports json without ending ], we end it for better compat with other tools
+			const wholeMessage = `${eventMsg ? "," : ""}${eventMsg}\n]`;
 
 			// a naive implementation to merge rust & Node.js trace, we can't use JSON.parse because sometime the trace file is too big to parse
-			const newTrace = originTrace.replace(/]$/, `${eventMsg}\n]`);
-			fs.writeFileSync(this.output, newTrace, {
+			fs.appendFileSync(this.output, wholeMessage, {
 				flush: true
 			});
 		});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
sometimes the rust side json file is too big too read in js side, so avoid reading it in js side
```js
Error: Cannot create a string longer than 0x1fffffe8 characters
    at Object.readFileSync (node:fs:448:20)
    at JavaScriptTracer.dumpJavaScriptTrace
```
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
