### PR TITLE
fix: render namespace template in devtool plugins

### DIFF
--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
   ApplyContext, BoxModule, ChunkInitFragments, ChunkUkey, Compilation,
   CompilationAdditionalModuleRuntimeRequirements, CompilationParams, CompilerCompilation,
-  CompilerOptions, ModuleIdentifier, Plugin, PluginContext, RuntimeGlobals,
+  CompilerOptions, Filename, ModuleIdentifier, PathData, Plugin, PluginContext, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
@@ -89,7 +89,7 @@ async fn eval_devtool_plugin_compilation(
 async fn eval_devtool_plugin_render_module_content(
   &self,
   compilation: &Compilation,
-  _chunk_ukey: &ChunkUkey,
+  chunk_ukey: &ChunkUkey,
   module: &BoxModule,
   render_source: &mut RenderSource,
   _init_fragments: &mut ChunkInitFragments,
@@ -102,6 +102,22 @@ async fn eval_devtool_plugin_render_module_content(
     return Ok(());
   }
 
+  let chunk = compilation.chunk_by_ukey.get(chunk_ukey);
+  let path_data = PathData::default()
+    .chunk_id_optional(
+      chunk.and_then(|c| c.id(&compilation.chunk_ids_artifact).map(|id| id.as_str())),
+    )
+    .chunk_name_optional(chunk.and_then(|c| c.name()))
+    .chunk_hash_optional(chunk.and_then(|c| {
+      c.rendered_hash(
+        &compilation.chunk_hashes_artifact,
+        compilation.options.output.hash_digest_length,
+      )
+    }));
+
+  let filename = Filename::from(self.namespace.as_str());
+  let namespace = compilation.get_path(&filename, path_data).await?;
+
   let output_options = &compilation.options.output;
   let str = match &self.module_filename_template {
     ModuleFilenameTemplate::String(s) => ModuleFilenameHelpers::create_filename_of_string_template(
@@ -109,7 +125,7 @@ async fn eval_devtool_plugin_render_module_content(
       compilation,
       s,
       output_options,
-      &self.namespace,
+      &namespace,
     ),
     ModuleFilenameTemplate::Fn(f) => {
       ModuleFilenameHelpers::create_filename_of_fn_template(
@@ -117,7 +133,7 @@ async fn eval_devtool_plugin_render_module_content(
         compilation,
         f,
         output_options,
-        &self.namespace,
+        &namespace,
       )
       .await?
     }

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, MapOptions, RawStringSource, Source, SourceExt},
   ApplyContext, BoxModule, ChunkGraph, ChunkInitFragments, ChunkUkey, Compilation,
   CompilationAdditionalModuleRuntimeRequirements, CompilationParams, CompilerCompilation,
-  CompilerOptions, ModuleIdentifier, Plugin, PluginContext, RuntimeGlobals,
+  CompilerOptions, Filename, ModuleIdentifier, PathData, Plugin, PluginContext, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -123,6 +123,21 @@ async fn eval_source_map_devtool_plugin_render_module_content(
             ModuleOrSource::Source(source.to_string())
           }
         });
+        let path_data = PathData::default()
+          .chunk_id_optional(
+            chunk
+              .id(&compilation.chunk_ids_artifact)
+              .map(|id| id.as_str()),
+          )
+          .chunk_name_optional(chunk.name())
+          .chunk_hash_optional(chunk.rendered_hash(
+            &compilation.chunk_hashes_artifact,
+            compilation.options.output.hash_digest_length,
+          ));
+
+        let filename = Filename::from(self.namespace.as_str());
+        let namespace = compilation.get_path(&filename, path_data).await?;
+
         let module_filenames = match &self.module_filename_template {
           ModuleFilenameTemplate::String(s) => modules
             .map(|module_or_source| {
@@ -131,7 +146,7 @@ async fn eval_source_map_devtool_plugin_render_module_content(
                 compilation,
                 s,
                 output_options,
-                &self.namespace,
+                &namespace,
               )
             })
             .collect::<Vec<_>>(),
@@ -143,7 +158,7 @@ async fn eval_source_map_devtool_plugin_render_module_content(
                 compilation,
                 f,
                 output_options,
-                &self.namespace,
+                &namespace,
               )
             });
             join_all(features)

--- a/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/test.filter.js
+++ b/tests/webpack-test/configCases/source-map/devtool-namespace-with-source-map/test.filter.js
@@ -1,2 +1,0 @@
-// missing substitution on output.library
-module.exports = () => false


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

should render `devNamespace` as a filename template in devtool plugins

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
