### PR TITLE
fix: missing import scripts runtime when target is webworker

### DIFF
--- a/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
@@ -44,7 +44,7 @@ async fn runtime_requirements_in_tree(
         runtime_requirements_mut.insert(RuntimeGlobals::PUBLIC_PATH);
         runtime_requirements_mut.insert(RuntimeGlobals::GET_UPDATE_MANIFEST_FILENAME);
       }
-      RuntimeGlobals::BASE_URI if is_enabled_for_chunk => {
+      RuntimeGlobals::BASE_URI | RuntimeGlobals::ON_CHUNKS_LOADED if is_enabled_for_chunk => {
         has_chunk_loading = true;
       }
       _ => {}

--- a/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
@@ -108,6 +108,7 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
     let with_hmr = runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS);
     let with_hmr_manifest = runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
     let with_loading = runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+    let with_callback = runtime_requirements.contains(RuntimeGlobals::CHUNK_CALLBACK);
 
     let condition_map =
       compilation
@@ -138,7 +139,7 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
       ));
     }
 
-    if with_loading {
+    if with_loading || with_callback {
       let chunk_loading_global_expr = format!(
         "{}[\"{}\"]",
         &compilation.options.output.global_object, &compilation.options.output.chunk_loading_global
@@ -180,6 +181,7 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
         Some(serde_json::json!({
           "_body": body,
           "_chunk_loading_global_expr": chunk_loading_global_expr,
+          "_with_loading": with_loading,
         })),
       )?;
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading.ejs
@@ -10,9 +10,11 @@ var installChunk = <%- basicFunction("data") %> {
     while (chunkIds.length) installedChunks[chunkIds.pop()] = 1;
     parentChunkLoadingFunction(data);
 };
+<% if (_with_loading) { %>
 <%- ENSURE_CHUNK_HANDLERS %>.i = <%- basicFunction("chunkId, promises") %> {
     <%- _body %>
 };
+<% } %>
 var chunkLoadingGlobal = <%- _chunk_loading_global_expr %> = <%- _chunk_loading_global_expr %> || [];
 var parentChunkLoadingFunction = chunkLoadingGlobal.push.bind(chunkLoadingGlobal);
 chunkLoadingGlobal.push = installChunk;

--- a/tests/webpack-test/configCases/runtime/target-webworker/test.filter.js
+++ b/tests/webpack-test/configCases/runtime/target-webworker/test.filter.js
@@ -1,2 +1,0 @@
-// No tests exported by test case
-module.exports = () => false


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix missing import scripts runtime when target is webworker

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
