### PR TITLE
docs: add info option and JSDoc for copy plugin

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1628,20 +1628,93 @@ export interface RawContextReplacementPluginOptions {
 }
 
 export interface RawCopyGlobOptions {
+  /**
+   * Whether the match is case sensitive
+   * @default true
+   */
   caseSensitiveMatch?: boolean
+  /**
+   * Whether to match files starting with `.`
+   * @default true
+   */
   dot?: boolean
+  /**
+   * An array of strings in glob format, which can be used to ignore specific paths
+   * @default undefined
+   */
   ignore?: Array<string>
 }
 
 export interface RawCopyPattern {
+  /**
+   * The source path of the copy operation, which can be an absolute path, a relative
+   * path, or a glob pattern. It can refer to a file or a directory. If a relative path
+   * is passed, it is relative to the `context` option.
+   * @default undefined
+   */
   from: string
+  /**
+   * The destination path of the copy operation, which can be an absolute path, a
+   * relative path, or a template string. If not specified, it is equal to Rspack's
+   * `output.path`.
+   * @default Rspack's `output.path`
+   */
   to?: string | ((pathData: { context: string; absoluteFilename?: string }) => string | Promise<string>)
+  /**
+   * `context` is a path to be prepended to `from` and removed from the start of the
+   * result paths. `context` can be an absolute path or a relative path. If it is a
+   * relative path, then it will be converted to an absolute path based on Rspack's
+   * `context`.
+   * `context` should be explicitly set only when `from` contains a glob. Otherwise,
+   * `context` is automatically set based on whether `from` is a file or a directory:
+   * - If `from` is a file, then `context` is its directory. The result path will be
+   * the filename alone.
+   * - If `from` is a directory, then `context` equals `from`. The result paths will
+   * be the paths of the directory's contents (including nested contents), relative
+   * to the directory.
+   * @default Rspack's `context`
+   */
   context?: string
+  /**
+   * Specify the type of [to](#to), which can be a directory, a file, or a template
+   * name in Rspack. If not specified, it will be automatically inferred.
+   * The automatic inference rules are as follows:
+   * - `dir`: If `to` has no extension, or ends on `/`.
+   * - `file`: If `to` is not a directory and is not a template.
+   * - `template`: If `to` contains a template pattern.
+   * @default undefined
+   */
   toType?: string
+  /**
+   * Whether to ignore the error if there are missing files or directories.
+   * @default false
+   */
   noErrorOnMissing: boolean
+  /**
+   * Whether to force the copy operation to overwrite the destination file if it
+   * already exists.
+   * @default false
+   */
   force: boolean
+  /**
+   * The priority of the copy operation. The higher the priority, the earlier the copy
+   * operation will be executed. When `force` is set to `true`, if a matching file is
+   * found, the one with higher priority will overwrite the one with lower priority.
+   * @default 0
+   */
   priority: number
+  /**
+   * Set the glob options for the copy operation.
+   * @default undefined
+   */
   globOptions: RawCopyGlobOptions
+  /**
+   * Allows to add some assets info to the copied files, which may affect some behaviors
+   * in the build process. For example, by default, the copied JS and CSS files will be
+   * minified by Rspack's minimizer, if you want to skip minification for copied files,
+   * you can set `info.minimized` to `true`.
+   * @default undefined
+   */
   info?: RawInfo
   /**
    * Determines whether to copy file permissions from the source to the destination.
@@ -1650,10 +1723,15 @@ export interface RawCopyPattern {
    * @default false
    */
   copyPermissions?: boolean
+  /**
+   * Allows to modify the file contents.
+   * @default undefined
+   */
   transform?: { transformer: (input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>  } | ((input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>)
 }
 
 export interface RawCopyRspackPluginOptions {
+  /** An array of objects that describe the copy operations to be performed. */
   patterns: Array<RawCopyPattern>
 }
 
@@ -1934,6 +2012,10 @@ export interface RawIncremental {
 
 export interface RawInfo {
   immutable?: boolean
+  /**
+   * Whether to skip minification for the copied files.
+   * @default false
+   */
   minimized?: boolean
   chunkHash?: Array<string>
   contentHash?: Array<string>

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_copy.rs
@@ -28,24 +28,69 @@ pub struct RawToOptions {
 #[derive(Debug, Clone)]
 #[napi(object, object_to_js = false)]
 pub struct RawCopyPattern {
+  /// The source path of the copy operation, which can be an absolute path, a relative
+  /// path, or a glob pattern. It can refer to a file or a directory. If a relative path
+  /// is passed, it is relative to the `context` option.
+  /// @default undefined
   pub from: String,
+  /// The destination path of the copy operation, which can be an absolute path, a
+  /// relative path, or a template string. If not specified, it is equal to Rspack's
+  /// `output.path`.
+  /// @default Rspack's `output.path`
   #[debug(skip)]
   #[napi(
     ts_type = "string | ((pathData: { context: string; absoluteFilename?: string }) => string | Promise<string>)"
   )]
   pub to: Option<RawTo>,
+  /// `context` is a path to be prepended to `from` and removed from the start of the
+  /// result paths. `context` can be an absolute path or a relative path. If it is a
+  /// relative path, then it will be converted to an absolute path based on Rspack's
+  /// `context`.
+  /// `context` should be explicitly set only when `from` contains a glob. Otherwise,
+  /// `context` is automatically set based on whether `from` is a file or a directory:
+  /// - If `from` is a file, then `context` is its directory. The result path will be
+  /// the filename alone.
+  /// - If `from` is a directory, then `context` equals `from`. The result paths will
+  /// be the paths of the directory's contents (including nested contents), relative
+  /// to the directory.
+  /// @default Rspack's `context`
   pub context: Option<String>,
+  /// Specify the type of [to](#to), which can be a directory, a file, or a template
+  /// name in Rspack. If not specified, it will be automatically inferred.
+  /// The automatic inference rules are as follows:
+  /// - `dir`: If `to` has no extension, or ends on `/`.
+  /// - `file`: If `to` is not a directory and is not a template.
+  /// - `template`: If `to` contains a template pattern.
+  /// @default undefined
   pub to_type: Option<String>,
+  /// Whether to ignore the error if there are missing files or directories.
+  /// @default false
   pub no_error_on_missing: bool,
+  /// Whether to force the copy operation to overwrite the destination file if it
+  /// already exists.
+  /// @default false
   pub force: bool,
+  /// The priority of the copy operation. The higher the priority, the earlier the copy
+  /// operation will be executed. When `force` is set to `true`, if a matching file is
+  /// found, the one with higher priority will overwrite the one with lower priority.
+  /// @default 0
   pub priority: i32,
+  /// Set the glob options for the copy operation.
+  /// @default undefined
   pub glob_options: RawCopyGlobOptions,
+  /// Allows to add some assets info to the copied files, which may affect some behaviors
+  /// in the build process. For example, by default, the copied JS and CSS files will be
+  /// minified by Rspack's minimizer, if you want to skip minification for copied files,
+  /// you can set `info.minimized` to `true`.
+  /// @default undefined
   pub info: Option<RawInfo>,
   /// Determines whether to copy file permissions from the source to the destination.
   /// When set to true, the plugin will preserve executable permissions and other file modes.
   /// This is particularly useful when copying scripts or executable files.
   /// @default false
   pub copy_permissions: Option<bool>,
+  /// Allows to modify the file contents.
+  /// @default undefined
   #[debug(skip)]
   #[napi(
     ts_type = "{ transformer: (input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>  } | ((input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>)"
@@ -57,6 +102,8 @@ pub struct RawCopyPattern {
 #[napi(object)]
 pub struct RawInfo {
   pub immutable: Option<bool>,
+  /// Whether to skip minification for the copied files.
+  /// @default false
   pub minimized: Option<bool>,
   pub chunk_hash: Option<Vec<String>>,
   pub content_hash: Option<Vec<String>>,
@@ -75,14 +122,21 @@ pub struct RawRelated {
 #[derive(Debug, Clone)]
 #[napi(object)]
 pub struct RawCopyGlobOptions {
+  /// Whether the match is case sensitive
+  /// @default true
   pub case_sensitive_match: Option<bool>,
+  /// Whether to match files starting with `.`
+  /// @default true
   pub dot: Option<bool>,
+  /// An array of strings in glob format, which can be used to ignore specific paths
+  /// @default undefined
   pub ignore: Option<Vec<String>>,
 }
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
 pub struct RawCopyRspackPluginOptions {
+  /// An array of objects that describe the copy operations to be performed.
   pub patterns: Vec<RawCopyPattern>,
 }
 

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -27,7 +27,7 @@ import { EntryDependency } from '@rspack/binding';
 import { RawEvalDevToolModulePluginOptions as EvalDevToolModulePluginOptions } from '@rspack/binding';
 import { EventEmitter } from 'events';
 import { ExternalModule } from '@rspack/binding';
-import { ExternalObject } from '@rspack/binding';
+import type { ExternalObject } from '@rspack/binding';
 import { fs } from 'fs';
 import { default as fs_2 } from 'graceful-fs';
 import { HookMap } from '@rspack/lite-tapable';
@@ -44,7 +44,7 @@ import type { JsBuildMeta } from '@rspack/binding';
 import { JsChunk } from '@rspack/binding';
 import type { JsChunkGraph } from '@rspack/binding';
 import type { JsChunkGroup } from '@rspack/binding';
-import { JsCompilation } from '@rspack/binding';
+import type { JsCompilation } from '@rspack/binding';
 import type { JsExportsInfo } from '@rspack/binding';
 import { JsHtmlPluginTag } from '@rspack/binding';
 import { JsLoaderItem } from '@rspack/binding';
@@ -54,7 +54,7 @@ import { JsRsdoctorChunkGraph } from '@rspack/binding';
 import { JsRsdoctorModuleGraph } from '@rspack/binding';
 import { JsRsdoctorModuleIdsPatch } from '@rspack/binding';
 import { JsRsdoctorModuleSourcesPatch } from '@rspack/binding';
-import { JsRuntimeModule } from '@rspack/binding';
+import type { JsRuntimeModule } from '@rspack/binding';
 import type { JsStats } from '@rspack/binding';
 import type { JsStatsCompilation } from '@rspack/binding';
 import type { JsStatsError } from '@rspack/binding';
@@ -1623,9 +1623,7 @@ export const CopyRspackPlugin: {
 
 // @public (undocumented)
 export type CopyRspackPluginOptions = {
-    patterns: (string | ({
-        from: string;
-    } & Partial<RawCopyPattern>))[];
+    patterns: (string | (Pick<RawCopyPattern, "from"> & Partial<Omit<RawCopyPattern, "from">>))[];
 };
 
 // @public (undocumented)

--- a/packages/rspack/src/builtin-plugin/CopyRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/CopyRspackPlugin.ts
@@ -7,11 +7,10 @@ import {
 import { create } from "./base";
 
 export type CopyRspackPluginOptions = {
+	/** An array of objects that describe the copy operations to be performed. */
 	patterns: (
 		| string
-		| ({
-				from: string;
-		  } & Partial<RawCopyPattern>)
+		| (Pick<RawCopyPattern, "from"> & Partial<Omit<RawCopyPattern, "from">>)
 	)[];
 };
 

--- a/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
@@ -115,7 +115,9 @@ export default {
 - **Type:** `string`
 - **Default:** `undefined`
 
-The source path of the copy operation, which can be an absolute path, a relative path, or a glob pattern. It can refer to a file or a directory. If a relative path is passed, it is relative to the [context](#context) option.
+The source path of the copy operation, which can be an absolute path, a relative path, or a glob pattern.
+
+It can refer to a file or a directory. If a relative path is passed, it is relative to the [context](#context) option.
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
@@ -366,20 +368,20 @@ export default {
 ```ts
 type GlobOptions = {
   // Whether the match is case sensitive
-  // Default to true
+  // @default true
   caseSensitiveMatch?: boolean;
   // Whether to match files starting with `.`
-  // Default to true
+  // @default true
   dot?: boolean;
-  // Ignore specific paths
   // An array of strings in glob format, which can be used to ignore specific paths
+  // @default undefined
   ignore?: string[];
 };
 ```
 
 - **Default:** `undefined`
 
-Glob options.
+Set the glob options for the copy operation.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -465,3 +467,45 @@ export default {
 ```
 
 This is particularly useful when copying executable files, scripts, or any files where permissions are important. When set to `true`, the plugin will attempt to set the same permissions on the destination file as the source file has.
+
+### info
+
+- **Type:**
+
+```ts
+type Info = {
+  immutable?: boolean;
+  // Whether to skip minification for the copied files.
+  // @default false
+  minimized?: boolean;
+  chunkHash?: string[];
+  contentHash?: string[];
+  development?: boolean;
+  hotModuleReplacement?: boolean;
+  related?: {
+    sourceMap?: string;
+  };
+  version?: string;
+};
+```
+
+- **Default:** `undefined`
+
+Allows to add some assets info to the copied files, which may affect some behaviors in the build process.
+
+For example, by default, the copied JS and CSS files will be minified by Rspack's [minimizer](/config/optimization#optimizationminimizer), if you want to skip minification for copied files, you can set `info.minimized` to `true`.
+
+```js title="rspack.config.mjs"
+export default {
+  plugins: [
+    new rspack.CopyRspackPlugin({
+      patterns: [
+        {
+          from: 'src/file.js',
+          info: { minimized: true },
+        },
+      ],
+    }),
+  ],
+};
+```

--- a/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
@@ -115,7 +115,9 @@ export default {
 - **类型：** `string`
 - **默认值：** `undefined`
 
-拷贝的源路径，可以是绝对路径、相对路径、glob pattern，可以是文件或目录。若传入相对路径，则是相对于 [context](#context) 选项。
+拷贝的源路径，可以是绝对路径、相对路径、glob pattern，可以是文件或目录。
+
+若传入相对路径，则是相对于 [context](#context) 选项。
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
@@ -370,20 +372,20 @@ export default {
 ```ts
 type GlobOptions = {
   // 是否大小写敏感
-  // 默认 true
+  // @default true
   caseSensitiveMatch?: boolean;
   // 是否匹配以 `.` 开头的文件
-  // 默认 true
+  // @default true
   dot?: boolean;
-  // 忽略特定路径
-  // glob 形式的字符串数组，可以使用该配置忽略部分特定路径
+  // 忽略特定路径，可以是一个 glob 形式的字符串数组
+  // @default undefined
   ignore?: string[];
 };
 ```
 
 - **默认值：** `undefined`
 
-glob 匹配的选项。
+设置拷贝时 glob 匹配的选项。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -469,3 +471,45 @@ export default {
 ```
 
 这对于复制可执行文件、脚本或任何权限重要的文件特别有用。当设置为 `true` 时，插件将尝试在目标文件上设置与源文件相同的权限。
+
+### info
+
+- **类型：**
+
+```ts
+type Info = {
+  immutable?: boolean;
+  // 是否为拷贝的文件跳过压缩
+  // @default false
+  minimized?: boolean;
+  chunkHash?: string[];
+  contentHash?: string[];
+  development?: boolean;
+  hotModuleReplacement?: boolean;
+  related?: {
+    sourceMap?: string;
+  };
+  version?: string;
+};
+```
+
+- **默认值：** `undefined`
+
+允许你为拷贝的文件添加一些 assets info，这些信息可能会影响构建流程中的某些行为。
+
+例如，默认情况下，被拷贝的 JS、CSS 文件会经过 Rspack 的 [minimizer](/config/optimization#optimizationminimizer) 进行压缩，如果你希望被拷贝的文件跳过压缩，可以设置 `info.minimized` 为 `true`。
+
+```js title="rspack.config.mjs"
+export default {
+  plugins: [
+    new rspack.CopyRspackPlugin({
+      patterns: [
+        {
+          from: 'src/file.js',
+          info: { minimized: true },
+        },
+      ],
+    }),
+  ],
+};
+```


### PR DESCRIPTION
## Summary

- Add documentation for the `info` option of CopyRspackPlugin to demonstrate how to skip the code minification.
- Add JSDoc for all options of CopyRspackPlugin to improve DX.

Ref: https://github.com/webpack-contrib/copy-webpack-plugin/blob/0cae504f3044eef77a62b338cdf0c092675748fe/README.md#info

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
