### PR TITLE
fix(core): remove Node 10 compatibility code

### DIFF
--- a/packages/rspack/src/util/bindingVersionCheck.ts
+++ b/packages/rspack/src/util/bindingVersionCheck.ts
@@ -75,15 +75,12 @@ let result: Error | undefined | null;
  * `@rspack/core`, `@rspack/binding`, `@rspack/binding-<platform>-<arch>-<abi>`
  */
 export const checkVersion = () => {
-	console.time("checkVersion");
 	if (result !== undefined) {
-		console.timeEnd("checkVersion");
 		return result;
 	}
 
 	const platformArchAbi = getAddonPlatformArchAbi();
 	if (platformArchAbi instanceof Error) {
-		console.timeEnd("checkVersion");
 		return (result = platformArchAbi);
 	}
 
@@ -120,12 +117,10 @@ export const checkVersion = () => {
 		}
 	} catch (error: any) {
 		if (error instanceof Error) {
-			console.timeEnd("checkVersion");
 			return (result = new Error(
 				`${error.toString()}. Maybe you forget to install the correct addon package ${`@rspack/binding-${platformArchAbi}`} or forget to build binding locally?`
 			));
 		}
-		console.timeEnd("checkVersion");
 		return (result = new Error(error));
 	}
 
@@ -134,12 +129,10 @@ export const checkVersion = () => {
 	);
 
 	if (!isMatch) {
-		console.timeEnd("checkVersion");
 		return (result = new Error(
 			`Unmatched version @rspack/core@${CORE_VERSION}, @rspack/binding@${BINDING_VERSION}, @rspack/binding-${platformArchAbi}@${ADDON_VERSION}.\nRspack requires these versions to be the same or you may have installed the wrong version. Otherwise, Rspack may not work properly.`
 		));
 	}
 
-	console.timeEnd("checkVersion");
 	return (result = null);
 };


### PR DESCRIPTION
## Summary

Rspack requires Node.js >= 16 and we can remove Node 10 compatibility code.

Ref: https://nodejs.org/api/process.html#processreportgetreporterr

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
