### PR TITLE
perf: lazy load watchpack and some Node built-in modules

### DIFF
--- a/packages/rspack/src/ExecuteModulePlugin.ts
+++ b/packages/rspack/src/ExecuteModulePlugin.ts
@@ -1,5 +1,3 @@
-import vm from "node:vm";
-
 import { RuntimeGlobals } from ".";
 import type { Compiler } from "./Compiler";
 
@@ -13,6 +11,7 @@ export default class ExecuteModulePlugin {
 			compilation.hooks.executeModule.tap(
 				"executeModule",
 				(options, context) => {
+					const vm = require("node:vm");
 					const moduleObject = options.moduleObject;
 					const source = options.codeGenerationResult.get("javascript");
 					if (source === undefined) return;

--- a/packages/rspack/src/builtin-plugin/HttpUriPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HttpUriPlugin.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { createBrotliDecompress, createGunzip, createInflate } from "node:zlib";
 import {
 	type BuiltinPlugin,
 	BuiltinPluginName,
@@ -45,10 +44,17 @@ export type HttpUriPluginOptions = {
 
 const getHttp = memoize(() => require("node:http"));
 const getHttps = memoize(() => require("node:https"));
+
 function fetch(url: string, options: { headers: Record<string, string> }) {
 	const parsedURL = new URL(url);
 	const send: typeof import("node:http") =
 		parsedURL.protocol === "https:" ? getHttps() : getHttp();
+	const {
+		createBrotliDecompress,
+		createGunzip,
+		createInflate
+	} = require("node:zlib");
+
 	return new Promise<{ res: IncomingMessage; body: Buffer }>(
 		(resolve, reject) => {
 			send


### PR DESCRIPTION
## Summary

- Lazy load some modules (`watchpack`, `node:vm`, `node:zlib`) to make startup faster.
- Removed an extra `new Watchpack()` to improve initial startup speed, always create watchpack instance in `the NodeWatchFileSystem.watch` method.

## Lazy load

- before:

```bash
hyperfine --warmup 10 --runs 100  'node ./dist/index.js'
Benchmark 1: node ./dist/index.js
  Time (mean ± σ):      61.4 ms ±   5.6 ms    [User: 43.2 ms, System: 16.9 ms]
  Range (min … max):    58.5 ms … 115.7 ms    100 runs
```

- after:

```bash
hyperfine --warmup 10 --runs 100  'node ./dist/index.js'
Benchmark 1: node ./dist/index.js
  Time (mean ± σ):      59.9 ms ±   0.8 ms    [User: 41.3 ms, System: 16.7 ms]
  Range (min … max):    57.8 ms …  63.2 ms    100 runs
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
