### PR TITLE
fix(zod/v4): drop `z.record()` with single argument

### DIFF
--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -139,7 +139,7 @@ const pluginOptionsSchema = z.object({
 		.optional(),
 	templateContent: z.string().or(templateRenderFunction).optional(),
 	templateParameters: z
-		.record(z.string())
+		.record(z.string(), z.string())
 		.or(z.boolean())
 		.or(templateParamFunction)
 		.optional(),
@@ -164,7 +164,9 @@ const pluginOptionsSchema = z.object({
 	minify: z.boolean().optional(),
 	title: z.string().optional(),
 	favicon: z.string().optional(),
-	meta: z.record(z.string().or(z.record(z.string()))).optional(),
+	meta: z
+		.record(z.string(), z.string().or(z.record(z.string(), z.string())))
+		.optional(),
 	hash: z.boolean().optional()
 }) satisfies z.ZodType<HtmlRspackPluginOptions>;
 

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -185,6 +185,7 @@ const entryDescription = z.strictObject({
 const entryUnnamed = entryItem satisfies z.ZodType<t.EntryUnnamed>;
 
 const entryObject = z.record(
+	z.string(),
 	entryItem.or(entryDescription)
 ) satisfies z.ZodType<t.EntryObject>;
 
@@ -388,6 +389,7 @@ const output = z.strictObject({
 //#region Resolve
 const resolveAlias = z
 	.record(
+		z.string(),
 		z
 			.literal(false)
 			.or(z.string())
@@ -420,7 +422,9 @@ const baseResolveOptions = z.strictObject({
 	tsConfig: resolveTsConfig.optional(),
 	fullySpecified: z.boolean().optional(),
 	exportsFields: z.array(z.string()).optional(),
-	extensionAlias: z.record(z.string().or(z.array(z.string()))).optional(),
+	extensionAlias: z
+		.record(z.string(), z.string().or(z.array(z.string())))
+		.optional(),
 	aliasFields: z.array(z.string()).optional(),
 	restrictions: z.array(z.string()).optional(),
 	roots: z.array(z.string()).optional(),
@@ -428,7 +432,7 @@ const baseResolveOptions = z.strictObject({
 }) satisfies z.ZodType<t.ResolveOptions>;
 
 const resolveOptions: z.ZodType<t.ResolveOptions> = baseResolveOptions.extend({
-	byDependency: z.lazy(() => z.record(resolveOptions)).optional()
+	byDependency: z.lazy(() => z.record(z.string(), resolveOptions)).optional()
 });
 
 //#endregion
@@ -458,7 +462,9 @@ const ruleSetLoader = z.string() satisfies z.ZodType<t.RuleSetLoader>;
 
 const ruleSetLoaderOptions = z
 	.string()
-	.or(z.record(z.any())) satisfies z.ZodType<t.RuleSetLoaderOptions>;
+	.or(
+		z.record(z.string(), z.any())
+	) satisfies z.ZodType<t.RuleSetLoaderOptions>;
 
 const ruleSetLoaderWithOptions =
 	new ZodRspackCrossChecker<t.RuleSetLoaderWithOptions>({
@@ -531,15 +537,15 @@ const baseRuleSetRule = z.strictObject({
 	resourceQuery: ruleSetCondition.optional(),
 	scheme: ruleSetCondition.optional(),
 	mimetype: ruleSetCondition.optional(),
-	descriptionData: z.record(ruleSetCondition).optional(),
-	with: z.record(ruleSetCondition).optional(),
+	descriptionData: z.record(z.string(), ruleSetCondition).optional(),
+	with: z.record(z.string(), ruleSetCondition).optional(),
 	type: z.string().optional(),
 	layer: z.string().optional(),
 	loader: ruleSetLoader.optional(),
 	options: ruleSetLoaderOptions.optional(),
 	use: ruleSetUse.optional(),
-	parser: z.record(z.any()).optional(),
-	generator: z.record(z.any()).optional(),
+	parser: z.record(z.string(), z.any()).optional(),
+	generator: z.record(z.string(), z.any()).optional(),
 	resolve: resolveOptions.optional(),
 	sideEffects: z.boolean().optional(),
 	enforce: z.literal("pre").or(z.literal("post")).optional()
@@ -947,7 +953,7 @@ const externalObjectValue = new ZodRspackCrossChecker<
 			}
 		}
 	],
-	default: z.record(z.string().or(z.string().array()))
+	default: z.record(z.string(), z.string().or(z.string().array()))
 });
 
 // #region Externals
@@ -958,6 +964,7 @@ const externalItemValue = z
 	.or(externalObjectValue) satisfies z.ZodType<t.ExternalItemValue>;
 
 const externalItemObjectUnknown = z.record(
+	z.string(),
 	externalItemValue
 ) satisfies z.ZodType<t.ExternalItemObjectUnknown>;
 
@@ -1293,7 +1300,9 @@ const optimizationSplitChunksChunks = z
 			.args(z.instanceof(Chunk, { message: "Input not instance of Chunk" }))
 			.returns(z.boolean())
 	);
-const optimizationSplitChunksSizes = z.number().or(z.record(z.number()));
+const optimizationSplitChunksSizes = z
+	.number()
+	.or(z.record(z.string(), z.number()));
 const optimizationSplitChunksDefaultSizeTypes = z.array(z.string());
 const sharedOptimizationSplitChunksCacheGroup = {
 	chunks: optimizationSplitChunksChunks.optional(),
@@ -1471,12 +1480,12 @@ const buildHttpOptions = z.object({
 	// frozen: z.boolean().optional(),
 	httpClient: z
 		.function()
-		.args(z.string(), z.record(z.string()))
+		.args(z.string(), z.record(z.string(), z.string()))
 		.returns(
 			z.promise(
 				z.object({
 					status: z.number(),
-					headers: z.record(z.string()),
+					headers: z.record(z.string(), z.string()),
 					body: z.instanceof(Buffer)
 				})
 			)
@@ -1547,7 +1556,9 @@ const profile = z.boolean() satisfies z.ZodType<t.Profile>;
 //#endregion
 
 //#region Amd
-const amd = z.literal(false).or(z.record(z.any())) satisfies z.ZodType<t.Amd>;
+const amd = z
+	.literal(false)
+	.or(z.record(z.string(), z.any())) satisfies z.ZodType<t.Amd>;
 //#endregion
 
 //#region Bail

--- a/packages/rspack/src/lib/DllReferencePlugin.ts
+++ b/packages/rspack/src/lib/DllReferencePlugin.ts
@@ -144,6 +144,7 @@ const dllReferencePluginOptionsContentItem = z.object({
 });
 
 const dllReferencePluginOptionsContent = z.record(
+	z.string(),
 	dllReferencePluginOptionsContentItem
 ) satisfies z.ZodType<DllReferencePluginOptionsContent>;
 


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Replace `z.record(<type>)` with `z.record(z.string(), <type>)`. Preparing for upgrading to Zod v4.

> [!NOTE]
> The default key type of zod v3 is `z.string()`. See: https://github.com/colinhacks/zod/blob/592de8de6e9c1f1d41aaa68e2c8ba57adced6507/packages/zod/src/v3/types.ts#L3567 

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

issue: #10467 

Zod v4: https://zod.dev/v4/changelog#zrecord

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
