### PR TITLE
chore(infra): add `onlyBuiltDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,13 @@
     "patchedDependencies": {
       "graceful-fs": "patches/graceful-fs.patch",
       "rollup-plugin-dts": "patches/rollup-plugin-dts.patch"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@biomejs/biome",
+      "@swc/core",
+      "core-js",
+      "es5-ext",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Transitive preinstall/postinstall scripts keep showing up in supply-chain attacks. Running them automatically is no longer safe.

ref: https://github.com/orgs/pnpm/discussions/8945

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
