### PR TITLE
feat(rspack): implement addEntry, succeedEntry & failedEntry hooks

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -254,6 +254,10 @@ export class Compilation {
 		seal: liteTapable.SyncHook<[], void>;
 		afterSeal: liteTapable.AsyncSeriesHook<[], void>;
 		needAdditionalPass: liteTapable.SyncBailHook<[], boolean>;
+
+		addEntry: liteTapable.SyncHook<[binding.Module]>;
+		succeedEntry: liteTapable.SyncHook<[binding.Module]>;
+		failedEntry: liteTapable.SyncHook<[string]>;
 	}>;
 	name?: string;
 	startTime?: number;
@@ -387,7 +391,11 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			runtimeModule: new liteTapable.SyncHook(["module", "chunk"]),
 			seal: new liteTapable.SyncHook([]),
 			afterSeal: new liteTapable.AsyncSeriesHook([]),
-			needAdditionalPass: new liteTapable.SyncBailHook([])
+			needAdditionalPass: new liteTapable.SyncBailHook([]),
+
+			addEntry: new liteTapable.SyncHook(["module"]),
+			succeedEntry: new liteTapable.SyncHook(["module"]),
+			failedEntry: new liteTapable.SyncHook(["error"])
 		};
 		this.compiler = compiler;
 		this.resolverFactory = compiler.resolverFactory;
@@ -403,10 +411,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this.moduleGraph = ModuleGraph.__from_binding(inner.moduleGraph);
 
 		this.#addIncludeDispatcher = new AddEntryItemDispatcher(
-			inner.addInclude.bind(inner)
+			inner.addInclude.bind(inner),
+			this.hooks
 		);
 		this.#addEntryDispatcher = new AddEntryItemDispatcher(
-			inner.addEntry.bind(inner)
+			inner.addEntry.bind(inner),
+			this.hooks
 		);
 		this[binding.COMPILATION_HOOKS_MAP_SYMBOL] = new WeakMap();
 	}
@@ -1091,6 +1101,7 @@ class AddEntryItemDispatcher {
 		binding.JsEntryOptions | undefined
 	][] = [];
 	#cbs: ((err?: null | WebpackError, module?: Module) => void)[] = [];
+	#hooks: typeof Compilation.prototype.hooks;
 
 	#execute = () => {
 		if (this.#running) {
@@ -1101,6 +1112,7 @@ class AddEntryItemDispatcher {
 		this.#args = [];
 		const cbs = this.#cbs;
 		this.#cbs = [];
+
 		this.#inner(args, (wholeErr, results) => {
 			if (this.#args.length !== 0) {
 				queueMicrotask(this.#execute.bind(this));
@@ -1115,8 +1127,15 @@ class AddEntryItemDispatcher {
 			}
 			for (let i = 0; i < results.length; i++) {
 				const [errMsg, module] = results[i];
+				this.#hooks.addEntry.call(module);
 				const cb = cbs[i];
-				cb(errMsg ? new WebpackError(errMsg) : null, module);
+				if (errMsg != null) {
+					this.#hooks.failedEntry.call(errMsg);
+					cb(new WebpackError(errMsg), module);
+					continue;
+				}
+				this.#hooks.succeedEntry.call(module);
+				cb(null, module);
 			}
 		});
 	};
@@ -1124,9 +1143,11 @@ class AddEntryItemDispatcher {
 	constructor(
 		binding:
 			| binding.JsCompilation["addInclude"]
-			| binding.JsCompilation["addEntry"]
+			| binding.JsCompilation["addEntry"],
+		hooks: typeof Compilation.prototype.hooks
 	) {
 		this.#inner = binding;
+		this.#hooks = hooks;
 		this.#running = false;
 	}
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Adds the missing `compiler.hooks.addEntry`, `compiler.hooks.succeedEntry`, and `compiler.hooks.failedEntry` to rspack.

- Why: Several webpack-ecosystem plugins—most notably ProgressPlugin—depend on these hooks to report build progress and entry-point status. Their absence broke progress output and blocked plugin compatibility.
- Problem solved: Restores correct progress reporting and lets existing webpack plugins work in rspack without modification, advancing API parity.

close #3523 
close #3524 
close #3525 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
