### PR TITLE
refactor: rename TaskType::Sync to Main & TaskType::Async to background

### DIFF
--- a/crates/rspack_core/src/compiler/make/repair/add.rs
+++ b/crates/rspack_core/src/compiler/make/repair/add.rs
@@ -19,7 +19,7 @@ pub struct AddTask {
 #[async_trait::async_trait]
 impl Task<MakeTaskContext> for AddTask {
   fn get_task_type(&self) -> TaskType {
-    TaskType::Sync
+    TaskType::Main
   }
   async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let module_identifier = self.module.identifier();

--- a/crates/rspack_core/src/compiler/make/repair/build.rs
+++ b/crates/rspack_core/src/compiler/make/repair/build.rs
@@ -24,7 +24,7 @@ pub struct BuildTask {
 #[async_trait::async_trait]
 impl Task<MakeTaskContext> for BuildTask {
   fn get_task_type(&self) -> TaskType {
-    TaskType::Async
+    TaskType::Background
   }
   async fn background_run(self: Box<Self>) -> TaskResult<MakeTaskContext> {
     let Self {
@@ -86,7 +86,7 @@ struct BuildResultTask {
 #[async_trait::async_trait]
 impl Task<MakeTaskContext> for BuildResultTask {
   fn get_task_type(&self) -> TaskType {
-    TaskType::Sync
+    TaskType::Main
   }
   async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let BuildResultTask {

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -32,7 +32,7 @@ pub struct FactorizeTask {
 #[async_trait::async_trait]
 impl Task<MakeTaskContext> for FactorizeTask {
   fn get_task_type(&self) -> TaskType {
-    TaskType::Async
+    TaskType::Background
   }
   async fn background_run(self: Box<Self>) -> TaskResult<MakeTaskContext> {
     if let Some(current_profile) = &self.current_profile {
@@ -157,7 +157,7 @@ pub struct FactorizeResultTask {
 #[async_trait::async_trait]
 impl Task<MakeTaskContext> for FactorizeResultTask {
   fn get_task_type(&self) -> TaskType {
-    TaskType::Sync
+    TaskType::Main
   }
   async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let FactorizeResultTask {

--- a/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
@@ -16,7 +16,7 @@ pub struct ProcessDependenciesTask {
 #[async_trait::async_trait]
 impl Task<MakeTaskContext> for ProcessDependenciesTask {
   fn get_task_type(&self) -> TaskType {
-    TaskType::Sync
+    TaskType::Main
   }
 
   async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {

--- a/crates/rspack_core/src/compiler/module_executor/ctrl.rs
+++ b/crates/rspack_core/src/compiler/module_executor/ctrl.rs
@@ -21,7 +21,7 @@ pub struct CtrlTask {
 #[async_trait::async_trait]
 impl Task<ExecutorTaskContext> for CtrlTask {
   fn get_task_type(&self) -> TaskType {
-    TaskType::Async
+    TaskType::Background
   }
 
   async fn background_run(mut self: Box<Self>) -> TaskResult<ExecutorTaskContext> {

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -23,7 +23,7 @@ pub struct EntryTask {
 #[async_trait::async_trait]
 impl Task<ExecutorTaskContext> for EntryTask {
   fn get_task_type(&self) -> TaskType {
-    TaskType::Sync
+    TaskType::Main
   }
 
   async fn main_run(

--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -77,7 +77,7 @@ impl ExecuteTask {
 #[async_trait::async_trait]
 impl Task<ExecutorTaskContext> for ExecuteTask {
   fn get_task_type(&self) -> TaskType {
-    TaskType::Sync
+    TaskType::Main
   }
 
   async fn main_run(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR will rename TaskType::Sync to TaskType::Main & TaskType::Async to TaskType::background.
``` rust
struct TaskA {}
impl Task<MakeTaskContext> for TaskA {
  fn get_task_type(&self) -> TaskType {
    // run main_run
    TaskType::Main
  }
  async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) { ... }
}

struct TaskB {}
impl Task<MakeTaskContext> for TaskB {
  fn get_task_type(&self) -> TaskType {
    // run background
    TaskType::Background
  }
  async fn background_run(self: Box<Self>) { ... }
}
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
