### PR TITLE
feat(rstest_plugin): handle import.meta.dirname and import.meta.filename

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -231,7 +231,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) worker_index: u32,
   pub(crate) build_meta: &'parser mut BuildMeta,
   pub build_info: &'parser mut BuildInfo,
-  pub(crate) resource_data: &'parser ResourceData,
+  pub resource_data: &'parser ResourceData,
   pub(crate) plugin_drive: Rc<JavaScriptParserPluginDrive>,
   pub(crate) definitions_db: ScopeInfoDB,
   pub(crate) compiler_options: &'parser CompilerOptions,

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -1,12 +1,45 @@
-use rspack_plugin_javascript::JavascriptParserPlugin;
+use rspack_core::{ConstDependency, SpanExt};
+use rspack_plugin_javascript::{
+  utils, utils::eval, visitors::JavascriptParser, JavascriptParserPlugin,
+};
+use swc_core::common::Spanned;
 
 use crate::module_path_name_dependency::{ModulePathNameDependency, NameType};
 
 const DIR_NAME: &str = "__dirname";
 const FILE_NAME: &str = "__filename";
+const IMPORT_META_DIRNAME: &str = "import.meta.dirname";
+const IMPORT_META_FILENAME: &str = "import.meta.filename";
+
+#[derive(PartialEq)]
+enum ModulePathType {
+  DirName,
+  FileName,
+}
 
 #[derive(Debug, Default)]
 pub struct RstestParserPlugin;
+
+impl RstestParserPlugin {
+  fn import_meta(&self, parser: &mut JavascriptParser, r#type: ModulePathType) -> String {
+    if r#type == ModulePathType::FileName {
+      if let Some(resource_path) = &parser.resource_data.resource_path {
+        format!("'{}'", resource_path.clone().into_string())
+      } else {
+        "''".to_string()
+      }
+    } else {
+      let resource_path = parser
+        .resource_data
+        .resource_path
+        .as_deref()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_string())
+        .unwrap_or_default();
+      format!("'{}'", resource_path)
+    }
+  }
+}
 
 impl JavascriptParserPlugin for RstestParserPlugin {
   fn identifier(
@@ -34,6 +67,94 @@ impl JavascriptParserPlugin for RstestParserPlugin {
         Some(true)
       }
       _ => None,
+    }
+  }
+
+  fn evaluate_typeof<'a>(
+    &self,
+    _parser: &mut JavascriptParser,
+    expr: &'a swc_core::ecma::ast::UnaryExpr,
+    for_name: &str,
+  ) -> Option<utils::eval::BasicEvaluatedExpression<'a>> {
+    let mut evaluated = None;
+    if for_name == IMPORT_META_DIRNAME || for_name == IMPORT_META_FILENAME {
+      evaluated = Some("string".to_string());
+    }
+    evaluated.map(|e| eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi()))
+  }
+
+  fn evaluate_identifier(
+    &self,
+    parser: &mut JavascriptParser,
+    ident: &str,
+    start: u32,
+    end: u32,
+  ) -> Option<eval::BasicEvaluatedExpression<'static>> {
+    if ident == IMPORT_META_DIRNAME {
+      Some(eval::evaluate_to_string(
+        self.import_meta(parser, ModulePathType::DirName),
+        start,
+        end,
+      ))
+    } else if ident == IMPORT_META_FILENAME {
+      Some(eval::evaluate_to_string(
+        self.import_meta(parser, ModulePathType::FileName),
+        start,
+        end,
+      ))
+    } else {
+      None
+    }
+  }
+
+  fn r#typeof(
+    &self,
+    parser: &mut JavascriptParser,
+    unary_expr: &swc_core::ecma::ast::UnaryExpr,
+    for_name: &str,
+  ) -> Option<bool> {
+    if for_name == IMPORT_META_DIRNAME || for_name == IMPORT_META_FILENAME {
+      parser
+        .presentational_dependencies
+        .push(Box::new(ConstDependency::new(
+          unary_expr.span().into(),
+          "'string'".into(),
+          None,
+        )));
+      Some(true)
+    } else {
+      None
+    }
+  }
+
+  fn member(
+    &self,
+    parser: &mut JavascriptParser,
+    member_expr: &swc_core::ecma::ast::MemberExpr,
+    for_name: &str,
+  ) -> Option<bool> {
+    if for_name == IMPORT_META_DIRNAME {
+      let result = self.import_meta(parser, ModulePathType::DirName);
+      parser
+        .presentational_dependencies
+        .push(Box::new(ConstDependency::new(
+          member_expr.span().into(),
+          result.into(),
+          None,
+        )));
+      Some(true)
+    } else if for_name == IMPORT_META_FILENAME {
+      let result = self.import_meta(parser, ModulePathType::FileName);
+      parser
+        .presentational_dependencies
+        .push(Box::new(ConstDependency::new(
+          member_expr.span().into(),
+          result.into(),
+          None,
+        )));
+      Some(true)
+    } else {
+      None
     }
   }
 }

--- a/packages/rspack-test-tools/tests/configCases/plugins/rstest/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/rstest/index.js
@@ -4,8 +4,15 @@ const path = require('path');
 it("Insert module path names with concatenateModules", () => {
 	const sourceDir = path.resolve(__dirname, "../../../../");
 	const content = fs.readFileSync(path.resolve(__dirname, "modulePathName.js"), "utf-8");
+	// __dirname and __filename renamed after concatenation
 	expect(content).toContain(`const foo_filename = '${path.resolve(sourceDir, "./configCases/plugins/rstest/src/foo.js")}'`);
-	expect(content).toMatch(`const bar_dirname = '${path.resolve(sourceDir, "./configCases/plugins/rstest/src")}'`);
+	expect(content).toMatch(`const foo_dirname = '${path.resolve(sourceDir, "./configCases/plugins/rstest/src")}'`);
+
+	expect(content).toMatch(`const metaFile1 = '${path.resolve(sourceDir, "./configCases/plugins/rstest/src/foo.js")}'`)
+	expect(content).toMatch(`const metaDir1 = '${path.resolve(sourceDir, "./configCases/plugins/rstest/src")}'`)
+
+	expect(content).toContain(`const typeofMetaDir = 'string'`);
+	expect(content).toContain(`const typeofMetaFile = 'string'`);
 });
 
 it("Insert module path names without concatenateModules", () => {
@@ -13,7 +20,12 @@ it("Insert module path names without concatenateModules", () => {
 	const content = fs.readFileSync(path.resolve(__dirname, "modulePathNameWithoutConcatenate.js"), "utf-8");
 	expect(content).toContain(`const __filename = '${path.resolve(sourceDir, "./configCases/plugins/rstest/src/foo.js")}'`);
 	expect(content).toMatch(`const __dirname = '${path.resolve(sourceDir, "./configCases/plugins/rstest/src")}'`);
-
 	expect(content.match(/const __dirname = /g).length).toBe(2);
 	expect(content.match(/const __filename = /g).length).toBe(2);
+
+	expect(content).toMatch(`const metaFile1 = '${path.resolve(sourceDir, "./configCases/plugins/rstest/src/foo.js")}'`)
+	expect(content).toMatch(`const metaDir1 = '${path.resolve(sourceDir, "./configCases/plugins/rstest/src")}'`)
+
+	expect(content).toContain(`const typeofMetaDir = 'string'`);
+	expect(content).toContain(`const typeofMetaFile = 'string'`);
 });

--- a/packages/rspack-test-tools/tests/configCases/plugins/rstest/src/bar.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/rstest/src/bar.js
@@ -1,1 +1,2 @@
-export const barValue = 'bar: ' + __dirname
+export const file = __filename
+export const dir = __dirname

--- a/packages/rspack-test-tools/tests/configCases/plugins/rstest/src/baz.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/rstest/src/baz.js
@@ -1,2 +1,0 @@
-export const bazValue1 = 'baz: ' + __filename
-export const bazValue2 = 'baz: ' + __dirname

--- a/packages/rspack-test-tools/tests/configCases/plugins/rstest/src/foo.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/rstest/src/foo.js
@@ -1,3 +1,18 @@
-export const fooValue1 = 'foo: ' + __filename
-export const fooValue2 = 'foo: ' + __filename
-export const fooValue3 = 'foo: ' + __filename
+export const file1 = __filename
+export const file2 = __filename
+export const metaFile1 = import.meta.filename
+export const typeofMetaFile = typeof import.meta.filename
+
+export const dir1 =  __dirname
+export const dir2 =  __dirname
+export const metaDir1 = import.meta.dirname
+export const typeofMetaDir = typeof import.meta.dirname
+
+if (import.meta.filename.indexOf("foo.js") === -1) {
+  require("fail")
+};
+
+if (import.meta.dirname.indexOf("src") === -1) {
+  require("fail")
+};
+

--- a/packages/rspack-test-tools/tests/configCases/plugins/rstest/src/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/rstest/src/index.js
@@ -1,12 +1,15 @@
-import { fooValue1, fooValue2, fooValue3 } from './foo'
-import { barValue } from './bar'
-import { bazValue1, bazValue2 } from './baz'
+import { file1, file2, metaFile1, dir1, dir2, metaDir1, typeofMetaFile, typeofMetaDir } from './foo'
+import { file, dir } from './bar'
 
 console.log(
-	fooValue1,
-	fooValue2,
-	fooValue3,
-	barValue,
-	bazValue1,
-	bazValue2
+	file1,
+	file2,
+	metaFile1,
+	dir1,
+	dir2,
+	metaDir1,
+	typeofMetaFile,
+	typeofMetaDir,
+	file,
+	dir
 )


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Handle `import.meta.dirname` and `import.meta.filename` just like `__dirname` and `__filename` in Rstest plugin.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
