### PR TITLE
fix: should render name by chunk id when chunk name is empty

### DIFF
--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -310,6 +310,8 @@ fn render_template(
   // chunk-level
   if let Some(name) = options.chunk_name {
     t = t.map(|t| t.replace_all(NAME_PLACEHOLDER, name));
+  } else if let Some(id) = options.chunk_id {
+    t = t.map(|t| t.replace_all(NAME_PLACEHOLDER, id));
   }
   if let Some(hash) = options.chunk_hash {
     t = t.map(|t| {

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -330,7 +330,11 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
 
         let filename = compilation
           .get_path(
-            &Filename::from(
+            &Filename::from(if let Some(template) = fake_filename.template() {
+              #[allow(clippy::unwrap_used)]
+              serde_json::to_string(template).unwrap()
+            } else {
+              #[allow(clippy::unwrap_used)]
               serde_json::to_string(
                 fake_filename
                   .render(
@@ -346,8 +350,8 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
                   .await?
                   .as_str(),
               )
-              .expect("invalid json to_string"),
-            ),
+              .unwrap()
+            }),
             PathData::default()
               .chunk_id_optional(chunk_id.as_deref())
               .chunk_hash_optional(chunk_hash.as_deref())

--- a/packages/rspack-test-tools/tests/configCases/hooks/get-path-custom-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/get-path-custom-chunk/rspack.config.js
@@ -18,6 +18,19 @@ class Plugin {
 					contentHashType: "javascript"
 				})
 			).toBe("chunkid-chunkname-chunkhash-contenthash");
+
+			expect(
+				compilation.getPath("[name]-[chunkhash]-[contenthash]", {
+					chunk: {
+						id: "chunkid",
+						hash: "chunkhash",
+						contentHash: {
+							javascript: "contenthash"
+						}
+					},
+					contentHashType: "javascript"
+				})
+			).toBe("chunkid-chunkhash-contenthash");
 		});
 		compiler.hooks.done.tap(pluginName, stats => {
 			let json = stats.toJson();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fix should render name by chunk id when chunk name is empty.

The logic in wepback: https://github.com/webpack/webpack/blob/main/lib/TemplatedPathPlugin.js#L262 

Close: #10475

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
