### PR TITLE
fix: should disconnect children correctly when remove available modules

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/available_modules.rs
+++ b/crates/rspack_core/src/build_chunk_graph/available_modules.rs
@@ -220,6 +220,11 @@ pub fn remove_available_modules(
       continue;
     }
 
+    let outgoings = chunk.outgoings_mut();
+    for remove_id in &removed {
+      outgoings.swap_remove(remove_id);
+    }
+
     let chunk = &chunks[chunk_index].1.chunk_desc;
     let outgoings = chunk.outgoings();
 
@@ -229,7 +234,7 @@ pub fn remove_available_modules(
       // if all incomings from current chunk are removed, we can remove this child
       if child_chunk.incomings().iter().all(|incoming| {
         // if all incomings are not from current chunk, we disconnect them
-        !removed.contains(incoming) && !outgoings.contains(incoming)
+        !outgoings.contains(incoming)
       }) {
         disconnect_children.insert(*child);
       }

--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -97,6 +97,15 @@ impl ChunkDesc {
     }
   }
 
+  pub(crate) fn outgoings_mut(
+    &mut self,
+  ) -> &mut IndexSet<AsyncDependenciesBlockIdentifier, BuildHasherDefault<IdentifierHasher>> {
+    match self {
+      ChunkDesc::Entry(entry) => &mut entry.outgoing_blocks,
+      ChunkDesc::Chunk(chunk) => &mut chunk.outgoing_blocks,
+    }
+  }
+
   pub(crate) fn incomings(&self) -> &HashSet<AsyncDependenciesBlockIdentifier> {
     match self {
       ChunkDesc::Entry(entry) => &entry.incoming_blocks,

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/foo.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/foo.js
@@ -1,0 +1,1 @@
+export const value = 1

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/index.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/index.js
@@ -1,0 +1,12 @@
+import './routes.js'
+
+it('should load routes', async () => {
+	const {value} = await import(/*webpackChunkName: "routes"*/ './module.js')
+
+	expect(await value).toBe(1)
+
+	// foo should contain no children at all
+	const chunkId = __STATS__.namedChunkGroups.routes.chunks[0];
+	const chunk = __STATS__.chunks.find(c => c.id === chunkId);
+	expect(chunk.children.length).toBe(0);
+})

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/module.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/module.js
@@ -1,0 +1,1 @@
+export * from './routes'

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/routes.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/routes.js
@@ -1,0 +1,1 @@
+export const value = import(/*webpackChunkName: "foo"*/ './foo.js').then(({ value }) => value)

--- a/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/webpack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/chunk-graph/disconnect-unneeded-chunks/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	output: {
+		chunkFilename: "[name].js"
+	},
+	stats: {
+		chunkGroups: true
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

When a chunk has some modules removed, should disconnect its AsyncDependencies as well.

For example giving the following chunk graph, you can see the test case for detail

![image](https://github.com/user-attachments/assets/fd5f2326-a3f3-42d3-a890-85915fdbd427)

The `routes.js` exists in both `main` and `routes` chunk, the chunk graph looks just like above

When removing available modules, the `routes.js` should be removed from `routes` chunk, and then `routes` chunk should not contain `routes.js`, the `routes` chunk should not have a child of chunk `foo`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
