### PR TITLE
refactor: remove module graph param of export info setters

### DIFF
--- a/crates/rspack_core/src/exports/export_info_setter.rs
+++ b/crates/rspack_core/src/exports/export_info_setter.rs
@@ -1,0 +1,225 @@
+use std::collections::hash_map::Entry;
+
+use rspack_util::atom::Atom;
+
+use super::{
+  ExportInfoData, ExportInfoTargetValue, ExportProvided, ExportsInfo, UsageFilterFnTy, UsageState,
+};
+use crate::{DependencyId, Nullable, RuntimeSpec};
+
+pub struct ExportInfoSetter;
+
+impl ExportInfoSetter {
+  pub fn reset_provide_info(info: &mut ExportInfoData) {
+    info.provided = None;
+    info.can_mangle_provide = None;
+    info.exports_info_owned = false;
+    info.exports_info = None;
+    info.target_is_set = false;
+    info.target.clear();
+    info.terminal_binding = false;
+  }
+
+  pub fn set_provided(info: &mut ExportInfoData, value: Option<ExportProvided>) {
+    info.provided = value;
+  }
+
+  pub fn set_can_mangle_provide(info: &mut ExportInfoData, value: Option<bool>) {
+    info.can_mangle_provide = value;
+  }
+
+  pub fn set_can_mangle_use(info: &mut ExportInfoData, value: Option<bool>) {
+    info.can_mangle_use = value;
+  }
+
+  pub fn set_terminal_binding(info: &mut ExportInfoData, value: bool) {
+    info.terminal_binding = value;
+  }
+
+  pub fn set_exports_info(info: &mut ExportInfoData, value: Option<ExportsInfo>) {
+    info.exports_info = value;
+  }
+
+  pub fn set_used_name(info: &mut ExportInfoData, name: Atom) {
+    info.used_name = Some(name);
+  }
+
+  pub fn unset_target(info: &mut ExportInfoData, key: &DependencyId) -> bool {
+    if !info.target_is_set {
+      false
+    } else {
+      info.target.remove(&Some(*key)).is_some()
+    }
+  }
+
+  pub fn set_target(
+    info: &mut ExportInfoData,
+    key: Option<DependencyId>,
+    dependency: Option<DependencyId>,
+    export_name: Option<&Nullable<Vec<Atom>>>,
+    priority: Option<u8>,
+  ) -> bool {
+    let export_name = match export_name {
+      Some(Nullable::Null) => None,
+      Some(Nullable::Value(vec)) => Some(vec),
+      None => None,
+    };
+    let normalized_priority = priority.unwrap_or(0);
+    if !info.target_is_set {
+      info.target.insert(
+        key,
+        ExportInfoTargetValue {
+          dependency,
+          export: export_name.cloned(),
+          priority: normalized_priority,
+        },
+      );
+      info.target_is_set = true;
+      return true;
+    }
+    let Some(old_target) = info.target.get_mut(&key) else {
+      if dependency.is_none() {
+        return false;
+      }
+
+      info.target.insert(
+        key,
+        ExportInfoTargetValue {
+          dependency,
+          export: export_name.cloned(),
+          priority: normalized_priority,
+        },
+      );
+      return true;
+    };
+    if old_target.dependency != dependency
+      || old_target.priority != normalized_priority
+      || old_target.export.as_ref() != export_name
+    {
+      old_target.export = export_name.cloned();
+      old_target.priority = normalized_priority;
+      old_target.dependency = dependency;
+      return true;
+    }
+
+    false
+  }
+
+  pub fn set_used(
+    info: &mut ExportInfoData,
+    new_value: UsageState,
+    runtime: Option<&RuntimeSpec>,
+  ) -> bool {
+    if let Some(runtime) = runtime {
+      let used_in_runtime = info.used_in_runtime.get_or_insert_default();
+      let mut changed = false;
+      for &k in runtime.iter() {
+        match used_in_runtime.entry(k) {
+          Entry::Occupied(mut occ) => match (&new_value, occ.get()) {
+            (new, _) if new == &UsageState::Unused => {
+              occ.remove();
+              changed = true;
+            }
+            (new, old) if new != old => {
+              occ.insert(new_value);
+              changed = true;
+            }
+            (_new, _old) => {}
+          },
+          Entry::Vacant(vac) => {
+            if new_value != UsageState::Unused {
+              vac.insert(new_value);
+              changed = true;
+            }
+          }
+        }
+      }
+      if used_in_runtime.is_empty() {
+        info.used_in_runtime = None;
+        changed = true;
+      }
+      return changed;
+    } else if info.global_used != Some(new_value) {
+      info.global_used = Some(new_value);
+      return true;
+    }
+    false
+  }
+
+  pub fn set_used_conditionally(
+    info: &mut ExportInfoData,
+    condition: UsageFilterFnTy<UsageState>,
+    new_value: UsageState,
+    runtime: Option<&RuntimeSpec>,
+  ) -> bool {
+    if let Some(runtime) = runtime {
+      let used_in_runtime = info.used_in_runtime.get_or_insert_default();
+      let mut changed = false;
+
+      for &k in runtime.iter() {
+        match used_in_runtime.entry(k) {
+          Entry::Occupied(mut occ) => match (&new_value, occ.get()) {
+            (new, old) if condition(old) && new == &UsageState::Unused => {
+              occ.remove();
+              changed = true;
+            }
+            (new, old) if condition(old) && new != old => {
+              occ.insert(new_value);
+              changed = true;
+            }
+            _ => {}
+          },
+          Entry::Vacant(vac) => {
+            if new_value != UsageState::Unused && condition(&UsageState::Unused) {
+              vac.insert(new_value);
+              changed = true;
+            }
+          }
+        }
+      }
+      if used_in_runtime.is_empty() {
+        info.used_in_runtime = None;
+        changed = true;
+      }
+      return changed;
+    } else if let Some(global_used) = info.global_used {
+      if global_used != new_value && condition(&global_used) {
+        info.global_used = Some(new_value);
+        return true;
+      }
+    } else {
+      info.global_used = Some(new_value);
+      return true;
+    }
+    false
+  }
+
+  pub fn set_used_in_unknown_way(info: &mut ExportInfoData, runtime: Option<&RuntimeSpec>) -> bool {
+    let mut changed = false;
+
+    if ExportInfoSetter::set_used_conditionally(
+      info,
+      Box::new(|value| value < &UsageState::Unknown),
+      UsageState::Unknown,
+      runtime,
+    ) {
+      changed = true;
+    }
+    if info.can_mangle_use != Some(false) {
+      info.can_mangle_use = Some(false);
+      changed = true;
+    }
+    changed
+  }
+
+  pub fn set_used_without_info(info: &mut ExportInfoData, runtime: Option<&RuntimeSpec>) -> bool {
+    let mut changed = false;
+    let flag = ExportInfoSetter::set_used(info, UsageState::NoInfo, runtime);
+    changed |= flag;
+    if !matches!(info.can_mangle_use, Some(false)) {
+      info.can_mangle_use = Some(false);
+      changed = true;
+    }
+    changed
+  }
+}

--- a/crates/rspack_core/src/exports/mod.rs
+++ b/crates/rspack_core/src/exports/mod.rs
@@ -1,7 +1,9 @@
 mod export_info;
+mod export_info_setter;
 mod exports_info;
 mod utils;
 
 pub use export_info::*;
+pub use export_info_setter::*;
 pub use exports_info::*;
 pub use utils::*;

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -3,8 +3,8 @@ use std::sync::LazyLock;
 use regex::Regex;
 use rspack_core::{
   incremental::IncrementalPasses, ApplyContext, BuildMetaExportsType, Compilation,
-  CompilationOptimizeCodeGeneration, CompilerOptions, ExportProvided, ExportsInfo, ModuleGraph,
-  Plugin, PluginContext, UsageState,
+  CompilationOptimizeCodeGeneration, CompilerOptions, ExportInfoSetter, ExportProvided,
+  ExportsInfo, ModuleGraph, Plugin, PluginContext, UsageState,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -136,7 +136,7 @@ fn mangle_exports_info(
           && !matches!(export_info.provided(mg), Some(ExportProvided::Provided)));
 
       if can_not_mangle {
-        export_info.set_used_name(mg, name.clone());
+        ExportInfoSetter::set_used_name(export_info.as_data_mut(mg), name.clone());
         used_names.insert(name.to_string());
       } else {
         mangleable_exports.push(export_info);
@@ -186,7 +186,7 @@ fn mangle_exports_info(
       0,
     );
     for (export_info, name) in export_info_used_name {
-      export_info.set_used_name(mg, name.into());
+      ExportInfoSetter::set_used_name(export_info.as_data_mut(mg), name.into());
     }
   } else {
     let mut used_exports = Vec::new();
@@ -214,7 +214,7 @@ fn mangle_exports_info(
           }
           i += 1;
         }
-        export_info.set_used_name(mg, name.into());
+        ExportInfoSetter::set_used_name(export_info.as_data_mut(mg), name.into());
       }
     }
   }

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -8,9 +8,9 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier, ApplyContext, BoxModule, Chunk, ChunkUkey, CodeGenerationDataTopLevelDeclarations,
   Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules,
-  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportProvided, Filename,
-  LibraryExport, LibraryName, LibraryNonUmdObject, LibraryOptions, ModuleIdentifier, PathData,
-  Plugin, PluginContext, RuntimeGlobals, SourceType, UsageState,
+  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportInfoSetter,
+  ExportProvided, Filename, LibraryExport, LibraryName, LibraryNonUmdObject, LibraryOptions,
+  ModuleIdentifier, PathData, Plugin, PluginContext, RuntimeGlobals, SourceType, UsageState,
 };
 use rspack_error::{error, error_bail, Result, ToStringResultToRspackResultExt};
 use rspack_hash::RspackHash;
@@ -474,8 +474,9 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
     let mut module_graph = compilation.get_module_graph_mut();
     if let Some(export) = export {
       let export_info = module_graph.get_export_info(module_identifier, &(export.as_str()).into());
-      export_info.set_used(&mut module_graph, UsageState::Used, Some(&runtime));
-      export_info.set_can_mangle_use(&mut module_graph, Some(false));
+      let info = export_info.as_data_mut(&mut module_graph);
+      ExportInfoSetter::set_used(info, UsageState::Used, Some(&runtime));
+      ExportInfoSetter::set_can_mangle_use(info, Some(false));
     } else {
       let exports_info = module_graph.get_exports_info(&module_identifier);
       exports_info.set_used_in_unknown_way(&mut module_graph, Some(&runtime));

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -5,8 +5,8 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   ApplyContext, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationFinishModules, CompilationParams, CompilerCompilation, CompilerOptions, EntryData,
-  LibraryExport, LibraryOptions, LibraryType, ModuleIdentifier, Plugin, PluginContext,
-  RuntimeGlobals, UsageState,
+  ExportInfoSetter, LibraryExport, LibraryOptions, LibraryType, ModuleIdentifier, Plugin,
+  PluginContext, RuntimeGlobals, UsageState,
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
@@ -152,8 +152,9 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
     let mut module_graph = compilation.get_module_graph_mut();
     if let Some(export) = export {
       let export_info = module_graph.get_export_info(module_identifier, &(export.as_str()).into());
-      export_info.set_used(&mut module_graph, UsageState::Used, Some(&runtime));
-      export_info.set_can_mangle_use(&mut module_graph, Some(false));
+      let info = export_info.as_data_mut(&mut module_graph);
+      ExportInfoSetter::set_used(info, UsageState::Used, Some(&runtime));
+      ExportInfoSetter::set_can_mangle_use(info, Some(false));
     } else {
       let exports_info = module_graph.get_exports_info(&module_identifier);
       if self.ns_object_used {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Just remove module graph param of export info setters to not send the whole module graph everywhere

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
