### PR TITLE
feat: improve external render

### DIFF
--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -78,6 +78,24 @@ impl ConcatenationScope {
     }
   }
 
+  pub fn register_import(
+    &mut self,
+    import_source: String,
+    attributes: Option<String>,
+    import_symbol: Option<Atom>,
+  ) {
+    let raw_import_map = self.current_module.import_map.get_or_insert_default();
+    let entry = raw_import_map
+      .entry((import_source, attributes))
+      .or_default();
+
+    let Some(import_symbol) = import_symbol else {
+      return;
+    };
+
+    entry.insert(import_symbol);
+  }
+
   pub fn register_namespace_export(&mut self, symbol: &str) {
     self.current_module.namespace_export_symbol = Some(symbol.into());
   }

--- a/packages/rspack-test-tools/tests/configCases/externals/reexport-star/__snapshot__/case2.txt
+++ b/packages/rspack-test-tools/tests/configCases/externals/reexport-star/__snapshot__/case2.txt
@@ -1,5 +1,5 @@
-import * as __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__ from "external1-alias";
 export * from "external1-alias";
+import * as __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__ from "external1-alias";
 
 ;// CONCATENATED MODULE: external "external1-alias"
 

--- a/packages/rspack-test-tools/tests/configCases/externals/reexport-star/__snapshot__/case3.txt
+++ b/packages/rspack-test-tools/tests/configCases/externals/reexport-star/__snapshot__/case3.txt
@@ -1,4 +1,4 @@
-import * as __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__ from "external1-alias";
+import "external1-alias";
 
 ;// CONCATENATED MODULE: external "external1-alias"
 

--- a/packages/rspack-test-tools/tests/configCases/externals/reexport-star/__snapshot__/case5.txt
+++ b/packages/rspack-test-tools/tests/configCases/externals/reexport-star/__snapshot__/case5.txt
@@ -1,4 +1,4 @@
-import * as __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__ from "external1-alias";
+import { foo } from "external1-alias";
 export * from "external1-alias";
 
 ;// CONCATENATED MODULE: external "external1-alias"
@@ -6,7 +6,7 @@ export * from "external1-alias";
 ;// CONCATENATED MODULE: ./case5.js
 
 
-const bar = __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__.foo + 1
+const bar = foo + 1
 
 
 

--- a/packages/rspack-test-tools/tests/configCases/externals/reexport-star/__snapshot__/case6.txt
+++ b/packages/rspack-test-tools/tests/configCases/externals/reexport-star/__snapshot__/case6.txt
@@ -1,4 +1,4 @@
-import * as __WEBPACK_EXTERNAL_MODULE_external1_alias_bc4b12e4__ from "external1-alias";
+import "external1-alias";
 export * from "external1-alias";
 
 ;// CONCATENATED MODULE: external "external1-alias"

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/index.js
@@ -7,8 +7,8 @@ it("modern-module-dynamic-import-runtime", () => {
 
 	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_lit_alias_9f8ad874__ from "lit-alias"');
 	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_svelte_alias_b2b3c54d__ from "svelte-alias"');
-	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_react_alias_fd8b3826__ from "react-alias"');
-	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_angular_alias_7d25287d__ from "angular-alias"');
+	expect(initialChunk).toContain('import { react } from "react-alias"');
+	expect(initialChunk).toContain('import { angular } from "angular-alias";');
 	expect(initialChunk).toContain('const reactNs = await import("react-alias")');
 	expect(initialChunk).toContain('const vueNs = await import("vue-alias")');
 	expect(initialChunk).toContain('const jqueryNs = await import("jquery-alias", { with: {"type":"url"} })');

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
@@ -31,8 +31,10 @@ module.exports = {
 					const bundle = Object.values(assets)[0]._value;
 					expect(bundle)
 						.toContain(`var __webpack_exports__cjsInterop = (foo_default());
-var __webpack_exports__defaultImport = __WEBPACK_EXTERNAL_MODULE_external_module_43054e33__["default"];
-var __webpack_exports__namedImport = __WEBPACK_EXTERNAL_MODULE_external_module_43054e33__.namedImport;`);
+export { external_external_module_default as defaultImport, namedImport, __webpack_exports__cjsInterop as cjsInterop };`);
+					expect(bundle).toContain(
+						'import external_external_module_default, { namedImport } from "external-module";'
+					);
 				});
 			};
 			this.hooks.compilation.tap("testcase", handler);

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/index.js
@@ -1,0 +1,2 @@
+
+it('should compile', () => {})

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/lib.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/lib.js
@@ -1,0 +1,6 @@
+import { HomeLayout as aaa } from 'externals0';
+
+(function Layout(props) {
+  const { HomeLayout = aaa } = props;
+  call({ HomeLayout });
+})()

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/rspack.config.js
@@ -1,0 +1,89 @@
+module.exports = {
+	mode: "none",
+	entry: { main: "./index.js", test: "./test.js" },
+	output: {
+		module: true,
+		library: {
+			type: "modern-module"
+		},
+		filename: "[name].js",
+		chunkFormat: "module"
+	},
+	experiments: {
+		outputModule: true
+	},
+	resolve: {
+		extensions: [".js"]
+	},
+	externalsType: "module",
+	externals: [
+		"externals0",
+		"externals1",
+		"externals2",
+		"externals3",
+		"externals4"
+	],
+	optimization: {
+		concatenateModules: true,
+		usedExports: true
+	},
+	plugins: [
+		function () {
+			const handler = compilation => {
+				compilation.hooks.processAssets.tap("testcase", assets => {
+					const source = assets["test.js"].source();
+					expect(source).toMatchInlineSnapshot(`
+				import { HomeLayout as external_externals0_HomeLayout, a } from "externals0";
+				import { a as external_externals1_a } from "externals1";
+				import external_externals2_default from "externals2";
+				import "externals4";
+				import * as __WEBPACK_EXTERNAL_MODULE_externals3__ from "externals3";
+
+				;// CONCATENATED MODULE: external "externals0"
+
+				;// CONCATENATED MODULE: external "externals1"
+
+				;// CONCATENATED MODULE: external "externals2"
+
+				;// CONCATENATED MODULE: external "externals3"
+
+				;// CONCATENATED MODULE: external "externals4"
+
+				;// CONCATENATED MODULE: ./lib.js
+
+
+				(function Layout(props) {
+				  const { HomeLayout = external_externals0_HomeLayout } = props;
+				  call({ HomeLayout });
+				})()
+
+				;// CONCATENATED MODULE: ./test.js
+				// re export
+
+
+				// named import
+				;
+
+				// default import
+
+
+				// namespace import
+
+
+				// side effect only import
+
+
+
+
+				external_externals1_a;
+				external_externals2_default;
+				__WEBPACK_EXTERNAL_MODULE_externals3__;
+
+				export { a };
+			`);
+				});
+			};
+			this.hooks.compilation.tap("testcase", handler);
+		}
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/test.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/test.js
@@ -1,0 +1,20 @@
+// re export
+export { a } from 'externals0'
+
+// named import
+import { a as a_2 } from 'externals1'
+
+// default import
+import defaultValue from 'externals2'
+
+// namespace import
+import * as namespace from 'externals3'
+
+// side effect only import
+import 'externals4'
+
+import './lib'
+
+a_2;
+defaultValue;
+namespace;

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-module/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-module/index.js
@@ -7,6 +7,6 @@ it("should minify outputModule", async () => {
 		"utf-8"
 	);
 	expect(
-		out.startsWith('import*as s from"https://test.rspack.rs/test.js"')
+		out.startsWith('import s from"https://test.rspack.rs/test.js"')
 	).toBe(true);
 });

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-parser/index.js
@@ -3,5 +3,5 @@ const path = require("path");
 
 it("[minify-parser]: import attributes should be preserved", () => {
 	const content = fs.readFileSync(path.resolve(__dirname, "importAttributes.js"), "utf-8");
-	expect(content).toContain('import*as o from"./a.json"with{type:"json"}');
+	expect(content).toContain('import o from"./a.json"with{type:"json"}');
 });

--- a/tests/webpack-test/configCases/externals/module-import/index.js
+++ b/tests/webpack-test/configCases/externals/module-import/index.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 it("module-import should correctly get fallback type", function() {
 	const content = fs.readFileSync(path.resolve(__dirname, "a.js"), "utf-8");
-	expect(content).toContain(`import * as __WEBPACK_EXTERNAL_MODULE_external0__ from "external0"`); // module
+	expect(content).toContain(`import external_external0_default from \"external0\";`); // module
 	expect(content).toContain(`import * as __WEBPACK_EXTERNAL_MODULE_external1__ from "external1"`); // module
 	expect(content).toContain(`module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("external2")`); // node-commonjs
 	expect(content).toContain(`import * as __WEBPACK_EXTERNAL_MODULE_external3__ from "external3"`); // module


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Improve the rendering of ExternalModule.

Before:

```js
import * as __WEBPACK_EXTERNALS_foo__ from 'foo'

__WEBPACK_EXTERNALS_foo__.value
```

This PR:

```js
import { value } from 'foo'

value
```

## Design detail

Add a new concatenation hook named `concatenation_info`, this hook is used to let module prepare some data in the correct **topological** order, for example, moduleA, moduleB can use this hook to add their globally used names.

ExternalModule has global names because they will insert some import statements through `InitFragment`.

```
// a.js
import { a } from 'foo';
// b.js
import { a } from 'bar';
```

Tap this hook, and insert the `a` to the globally used names, so we can deconflict the conflict symbol name.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
