### PR TITLE
fix: align tsconfig paths matching with tsconfig-paths-webpack-plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5375,9 +5375,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6175326c187f3b310a3694ca5681bba8e024c46e35cdfb6f796629a64c599143"
+checksum = "9e3bb6b0edc681de93831f8f3e531b9338afbea4ef6f49534ac025d11d1bca2d"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ quote              = { version = "1.0.38" }
 rayon              = { version = "1.10.0" }
 regex              = { version = "1.11.1" }
 ropey              = { version = "1.6.1" }
-rspack_resolver    = { features = ["package_json_raw_json_api"], version = "0.5.6" }
+rspack_resolver    = { features = ["package_json_raw_json_api"], version = "0.6.0" }
 rspack_sources     = { version = "0.4.8" }
 rustc-hash         = { version = "2.1.0" }
 scopeguard         = "1.2.0"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
upgrade rspack resolver to 0.6.0 to align the paths matching with [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin)

detail plz refer to https://github.com/web-infra-dev/rspack-resolver/releases/tag/v0.6.0

close https://github.com/web-infra-dev/rspack/issues/10487

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
