### PR TITLE
refactor: remove module graph of export_info getters

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -920,17 +920,15 @@ impl Module for ConcatenatedModule {
     let mut exports_final_names: Vec<(String, String)> = vec![];
 
     for export_info in exports_info.ordered_exports(&module_graph) {
-      let name = ExportInfoGetter::name(export_info.as_data(&module_graph))
-        .cloned()
-        .unwrap_or("".into());
+      let info = export_info.as_data(&module_graph);
+      let name = ExportInfoGetter::name(info).cloned().unwrap_or("".into());
       if matches!(
-        ExportInfoGetter::provided(export_info.as_data(&module_graph)),
+        ExportInfoGetter::provided(info),
         Some(ExportProvided::NotProvided)
       ) {
         continue;
       }
-      let used_name =
-        ExportInfoGetter::get_used_name(export_info.as_data(&module_graph), None, runtime);
+      let used_name = ExportInfoGetter::get_used_name(info, None, runtime);
 
       let Some(used_name) = used_name else {
         unused_exports.insert(name);
@@ -953,7 +951,7 @@ impl Module for ConcatenatedModule {
         exports_final_names.push((used_name.to_string(), final_name.clone()));
         format!(
           "/* {} */ {}",
-          if ExportInfoGetter::is_reexport(export_info.as_data(&module_graph)) {
+          if ExportInfoGetter::is_reexport(info) {
             "reexport"
           } else {
             "binding"

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -48,11 +48,11 @@ use crate::{
   CodeGenerationDataTopLevelDeclarations, CodeGenerationExportsFinalNames,
   CodeGenerationPublicPathAutoReplace, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
   ConcatenationScope, ConnectionState, Context, DependenciesBlock, DependencyId, DependencyType,
-  ErrorSpan, ExportProvided, ExportsArgument, ExportsType, FactoryMeta, IdentCollector,
-  LibIdentOptions, MaybeDynamicTargetExportInfoHashKey, Module, ModuleArgument, ModuleGraph,
-  ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleType, Resolve, RuntimeCondition,
-  RuntimeGlobals, RuntimeSpec, SourceType, SpanExt, Template, UsageState, DEFAULT_EXPORT,
-  NAMESPACE_OBJECT_EXPORT,
+  ErrorSpan, ExportInfoGetter, ExportProvided, ExportsArgument, ExportsType, FactoryMeta,
+  IdentCollector, LibIdentOptions, MaybeDynamicTargetExportInfoHashKey, Module, ModuleArgument,
+  ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleType, Resolve,
+  RuntimeCondition, RuntimeGlobals, RuntimeSpec, SourceType, SpanExt, Template, UsageState,
+  DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
 };
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
@@ -920,17 +920,17 @@ impl Module for ConcatenatedModule {
     let mut exports_final_names: Vec<(String, String)> = vec![];
 
     for export_info in exports_info.ordered_exports(&module_graph) {
-      let name = export_info
-        .name(&module_graph)
+      let name = ExportInfoGetter::name(export_info.as_data(&module_graph))
         .cloned()
         .unwrap_or("".into());
       if matches!(
-        export_info.provided(&module_graph),
+        ExportInfoGetter::provided(export_info.as_data(&module_graph)),
         Some(ExportProvided::NotProvided)
       ) {
         continue;
       }
-      let used_name = export_info.get_used_name(&module_graph, None, runtime);
+      let used_name =
+        ExportInfoGetter::get_used_name(export_info.as_data(&module_graph), None, runtime);
 
       let Some(used_name) = used_name else {
         unused_exports.insert(name);
@@ -953,7 +953,7 @@ impl Module for ConcatenatedModule {
         exports_final_names.push((used_name.to_string(), final_name.clone()));
         format!(
           "/* {} */ {}",
-          if export_info.is_reexport(&module_graph) {
+          if ExportInfoGetter::is_reexport(export_info.as_data(&module_graph)) {
             "reexport"
           } else {
             "binding"
@@ -966,14 +966,16 @@ impl Module for ConcatenatedModule {
     let mut result = ConcatSource::default();
     let mut should_add_esm_flag = false;
 
+    let used = ExportInfoGetter::get_used(
+      compilation
+        .get_module_graph()
+        .get_exports_info(&self.id())
+        .other_exports_info(&module_graph)
+        .as_data(&module_graph),
+      runtime,
+    );
     // Add ESM compatibility flag (must be first because of possible circular dependencies)
-    if compilation
-      .get_module_graph()
-      .get_exports_info(&self.id())
-      .other_exports_info(&module_graph)
-      .get_used(&module_graph, runtime)
-      != UsageState::Unused
-    {
+    if matches!(used, UsageState::Used) {
       should_add_esm_flag = true
     }
 
@@ -1071,18 +1073,19 @@ impl Module for ConcatenatedModule {
         let exports_info = module_graph.get_exports_info(module_info_id);
         for export_info in exports_info.ordered_exports(&module_graph) {
           if matches!(
-            export_info.provided(&module_graph),
+            ExportInfoGetter::provided(export_info.as_data(&module_graph)),
             Some(ExportProvided::NotProvided)
           ) {
             continue;
           }
 
-          if let Some(used_name) = export_info.get_used_name(&module_graph, None, runtime) {
+          if let Some(used_name) =
+            ExportInfoGetter::get_used_name(export_info.as_data(&module_graph), None, runtime)
+          {
             let final_name = Self::get_final_name(
               &compilation.get_module_graph(),
               module_info_id,
-              vec![export_info
-                .name(&module_graph)
+              vec![ExportInfoGetter::name(export_info.as_data(&module_graph))
                 .cloned()
                 .unwrap_or("".into())],
               &mut module_to_info_map,

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -973,7 +973,7 @@ impl Module for ConcatenatedModule {
       runtime,
     );
     // Add ESM compatibility flag (must be first because of possible circular dependencies)
-    if matches!(used, UsageState::Used) {
+    if used != UsageState::Unused {
       should_add_esm_flag = true
     }
 

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -702,6 +702,7 @@ pub fn process_export_info(
       &ExportInfoGetter::exports_info(export_info_data).expect("should have exports info"),
     ) {
       for export_info in exports_info.id.ordered_exports(module_graph) {
+        let export_info_data = export_info.as_data(module_graph);
         process_export_info(
           module_graph,
           runtime,

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -6,16 +6,16 @@ use std::{
   sync::{atomic::Ordering::Relaxed, Arc},
 };
 
-use itertools::Itertools;
 use rspack_collections::{impl_item_ukey, Ukey, UkeySet};
 use rspack_util::{atom::Atom, ext::DynHash};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use serde::Serialize;
 
 use super::{
-  ExportInfoTargetValue, ExportProvided, ExportsInfo, ExportsInfoData, FindTargetRetEnum,
-  FindTargetRetValue, ResolvedExportInfoTarget, ResolvedExportInfoTargetWithCircular,
-  TerminalBinding, UnResolvedExportInfoTarget, UsageState, NEXT_EXPORT_INFO_UKEY,
+  ExportInfoGetter, ExportInfoTargetValue, ExportProvided, ExportsInfo, ExportsInfoData,
+  FindTargetRetEnum, FindTargetRetValue, ResolvedExportInfoTarget,
+  ResolvedExportInfoTargetWithCircular, TerminalBinding, UnResolvedExportInfoTarget, UsageState,
+  NEXT_EXPORT_INFO_UKEY,
 };
 use crate::{Compilation, DependencyId, ModuleGraph, ModuleIdentifier, RuntimeSpec};
 
@@ -29,199 +29,12 @@ impl ExportInfo {
     Self(NEXT_EXPORT_INFO_UKEY.fetch_add(1, Relaxed).into())
   }
 
-  pub fn name<'a>(&self, mg: &'a ModuleGraph) -> Option<&'a Atom> {
-    self.as_data(mg).name.as_ref()
-  }
-
-  pub fn provided<'a>(&self, mg: &'a ModuleGraph) -> Option<&'a ExportProvided> {
-    self.as_data(mg).provided.as_ref()
-  }
-
-  pub fn can_mangle_provide(&self, mg: &ModuleGraph) -> Option<bool> {
-    self.as_data(mg).can_mangle_provide
-  }
-
-  pub fn can_mangle_use(&self, mg: &ModuleGraph) -> Option<bool> {
-    self.as_data(mg).can_mangle_use
-  }
-
-  pub fn terminal_binding(&self, mg: &ModuleGraph) -> bool {
-    self.as_data(mg).terminal_binding
-  }
-
-  pub fn exports_info_owned(&self, mg: &ModuleGraph) -> bool {
-    self.as_data(mg).exports_info_owned
-  }
-
-  pub fn exports_info(&self, mg: &ModuleGraph) -> Option<ExportsInfo> {
-    self.as_data(mg).exports_info
-  }
-
   pub fn as_data<'a>(&self, mg: &'a ModuleGraph) -> &'a ExportInfoData {
     mg.get_export_info_by_id(self)
   }
 
   pub fn as_data_mut<'a>(&self, mg: &'a mut ModuleGraph) -> &'a mut ExportInfoData {
     mg.get_export_info_mut_by_id(self)
-  }
-
-  pub fn get_provided_info(&self, mg: &ModuleGraph) -> &'static str {
-    let export_info = self.as_data(mg);
-    match export_info.provided {
-      Some(ExportProvided::NotProvided) => "not provided",
-      Some(ExportProvided::Unknown) => "maybe provided (runtime-defined)",
-      Some(ExportProvided::Provided) => "provided",
-      None => "no provided info",
-    }
-  }
-
-  pub fn get_rename_info(&self, mg: &ModuleGraph) -> Cow<str> {
-    let export_info_data = self.as_data(mg);
-
-    match (&export_info_data.used_name, &export_info_data.name) {
-      (Some(used), Some(name)) if used != name => return format!("renamed to {used}").into(),
-      (Some(used), None) => return format!("renamed to {used}").into(),
-      _ => {}
-    }
-
-    match (self.can_mangle_provide(mg), self.can_mangle_use(mg)) {
-      (None, None) => "missing provision and use info prevents renaming",
-      (None, Some(false)) => "usage prevents renaming (no provision info)",
-      (None, Some(true)) => "missing provision info prevents renaming",
-
-      (Some(true), None) => "missing usage info prevents renaming",
-      (Some(true), Some(false)) => "usage prevents renaming",
-      (Some(true), Some(true)) => "could be renamed",
-
-      (Some(false), None) => "provision prevents renaming (no use info)",
-      (Some(false), Some(false)) => "usage and provision prevents renaming",
-      (Some(false), Some(true)) => "provision prevents renaming",
-    }
-    .into()
-  }
-
-  pub fn get_used_info(&self, mg: &ModuleGraph) -> Cow<str> {
-    let export_info = self.as_data(mg);
-    if let Some(global_used) = export_info.global_used {
-      return match global_used {
-        UsageState::Unused => "unused".into(),
-        UsageState::NoInfo => "no usage info".into(),
-        UsageState::Unknown => "maybe used (runtime-defined)".into(),
-        UsageState::Used => "used".into(),
-        UsageState::OnlyPropertiesUsed => "only properties used".into(),
-      };
-    } else if let Some(used_in_runtime) = &export_info.used_in_runtime {
-      let mut map = HashMap::default();
-
-      for (runtime, used) in used_in_runtime.iter() {
-        let list = map.entry(*used).or_insert(vec![]);
-        list.push(runtime);
-      }
-
-      let specific_info: Vec<String> = map
-        .iter()
-        .map(|(used, runtimes)| match used {
-          UsageState::NoInfo => format!("no usage info in {}", runtimes.iter().join(", ")),
-          UsageState::Unknown => format!(
-            "maybe used in {} (runtime-defined)",
-            runtimes.iter().join(", ")
-          ),
-          UsageState::Used => format!("used in {}", runtimes.iter().join(", ")),
-          UsageState::OnlyPropertiesUsed => {
-            format!("only properties used in {}", runtimes.iter().join(", "))
-          }
-          UsageState::Unused => {
-            // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/ExportsInfo.js#L1470-L1481
-            unreachable!()
-          }
-        })
-        .collect();
-
-      if !specific_info.is_empty() {
-        return specific_info.join("; ").into();
-      }
-    }
-
-    if export_info.has_use_in_runtime_info {
-      "unused".into()
-    } else {
-      "no usage info".into()
-    }
-  }
-
-  pub fn get_used(&self, mg: &ModuleGraph, runtime: Option<&RuntimeSpec>) -> UsageState {
-    let info = self.as_data(mg);
-    if !info.has_use_in_runtime_info {
-      return UsageState::NoInfo;
-    }
-    if let Some(global_used) = info.global_used {
-      return global_used;
-    }
-    if let Some(used_in_runtime) = info.used_in_runtime.as_ref() {
-      let mut max = UsageState::Unused;
-      if let Some(runtime) = runtime {
-        for item in runtime.iter() {
-          let Some(usage) = used_in_runtime.get(item) else {
-            continue;
-          };
-          match usage {
-            UsageState::Used => return UsageState::Used,
-            _ => {
-              max = std::cmp::max(max, *usage);
-            }
-          }
-        }
-      } else {
-        for usage in used_in_runtime.values() {
-          match usage {
-            UsageState::Used => return UsageState::Used,
-            _ => {
-              max = std::cmp::max(max, *usage);
-            }
-          }
-        }
-      }
-      max
-    } else {
-      UsageState::Unused
-    }
-  }
-
-  /// Webpack returns `false | string`, we use `Option<Atom>` to avoid declare a redundant enum
-  /// type
-  pub fn get_used_name(
-    &self,
-    mg: &ModuleGraph,
-    fallback_name: Option<&Atom>,
-    runtime: Option<&RuntimeSpec>,
-  ) -> Option<Atom> {
-    let info = self.as_data(mg);
-    if info.has_use_in_runtime_info {
-      if let Some(usage) = info.global_used {
-        if matches!(usage, UsageState::Unused) {
-          return None;
-        }
-      } else if let Some(used_in_runtime) = info.used_in_runtime.as_ref() {
-        if let Some(runtime) = runtime {
-          if runtime
-            .iter()
-            .all(|item| !used_in_runtime.contains_key(item))
-          {
-            return None;
-          }
-        }
-      } else {
-        return None;
-      }
-    }
-    if let Some(used_name) = info.used_name.as_ref() {
-      return Some(used_name.clone());
-    }
-    if let Some(name) = info.name.as_ref() {
-      Some(name.clone())
-    } else {
-      fallback_name.cloned()
-    }
   }
 
   pub fn create_nested_exports_info(&self, mg: &mut ModuleGraph) -> ExportsInfo {
@@ -272,11 +85,6 @@ impl ExportInfo {
     {
       exports_info.set_has_use_info(mg);
     }
-  }
-
-  pub fn is_reexport(&self, mg: &ModuleGraph) -> bool {
-    let info = self.as_data(mg);
-    !info.terminal_binding && info.target_is_set && !info.target.is_empty()
   }
 
   pub fn get_terminal_binding(&self, mg: &ModuleGraph) -> Option<TerminalBinding> {
@@ -335,10 +143,6 @@ impl ExportInfo {
     self.as_data(mg).get_max_target()
   }
 
-  pub fn has_used_name(&self, mg: &ModuleGraph) -> bool {
-    self.as_data(mg).used_name.is_some()
-  }
-
   pub fn find_target(
     &self,
     mg: &ModuleGraph,
@@ -383,7 +187,8 @@ impl ExportInfo {
     data.used_name.is_some()
       || data.provided.is_some()
       || data.terminal_binding
-      || (self.get_used(mg, runtime) != base_info.get_used(mg, runtime))
+      || (ExportInfoGetter::get_used(self.as_data(mg), runtime)
+        != ExportInfoGetter::get_used(base_info.as_data(mg), runtime))
   }
 
   pub fn update_hash_with_visited(
@@ -400,7 +205,7 @@ impl ExportInfo {
     } else {
       data.name.dyn_hash(hasher);
     }
-    self.get_used(mg, runtime).dyn_hash(hasher);
+    ExportInfoGetter::get_used(data, runtime).dyn_hash(hasher);
     data.provided.dyn_hash(hasher);
     data.terminal_binding.dyn_hash(hasher);
     if let Some(exports_info) = data.exports_info
@@ -688,7 +493,9 @@ impl MaybeDynamicTargetExportInfo {
 
   pub fn provided<'a>(&'a self, mg: &'a ModuleGraph) -> Option<&'a ExportProvided> {
     match self {
-      MaybeDynamicTargetExportInfo::Static(export_info) => export_info.provided(mg),
+      MaybeDynamicTargetExportInfo::Static(export_info) => {
+        ExportInfoGetter::provided(export_info.as_data(mg))
+      }
       MaybeDynamicTargetExportInfo::Dynamic { data, .. } => data.provided.as_ref(),
     }
   }
@@ -890,7 +697,7 @@ pub fn process_export_info(
   already_visited: &mut UkeySet<ExportInfo>,
 ) {
   if let Some(export_info) = export_info {
-    let used = export_info.get_used(module_graph, runtime);
+    let used = ExportInfoGetter::get_used(export_info.as_data(module_graph), runtime);
     if used == UsageState::Unused {
       return;
     }
@@ -906,8 +713,7 @@ pub fn process_export_info(
       return;
     }
     if let Some(exports_info) = module_graph.try_get_exports_info_by_id(
-      &export_info
-        .exports_info(module_graph)
+      &ExportInfoGetter::exports_info(export_info.as_data(module_graph))
         .expect("should have exports info"),
     ) {
       for export_info in exports_info.id.ordered_exports(module_graph) {
@@ -916,15 +722,14 @@ pub fn process_export_info(
           runtime,
           referenced_export,
           if default_points_to_self
-            && export_info
-              .name(module_graph)
+            && ExportInfoGetter::name(export_info.as_data(module_graph))
               .map(|name| name == "default")
               .unwrap_or_default()
           {
             prefix.clone()
           } else {
             let mut value = prefix.clone();
-            if let Some(name) = export_info.name(module_graph) {
+            if let Some(name) = ExportInfoGetter::name(export_info.as_data(module_graph)) {
               value.push(name.clone());
             }
             value

--- a/crates/rspack_core/src/exports/export_info_getter.rs
+++ b/crates/rspack_core/src/exports/export_info_getter.rs
@@ -1,0 +1,225 @@
+use std::borrow::Cow;
+
+use itertools::Itertools;
+use rspack_util::atom::Atom;
+use rustc_hash::FxHashMap as HashMap;
+
+use super::{ExportInfoData, ExportProvided, ExportsInfo, UsageState};
+use crate::RuntimeSpec;
+
+pub struct ExportInfoGetter;
+
+impl ExportInfoGetter {
+  pub fn name(info: &ExportInfoData) -> Option<&Atom> {
+    info.name.as_ref()
+  }
+
+  pub fn provided(info: &ExportInfoData) -> Option<&ExportProvided> {
+    info.provided.as_ref()
+  }
+
+  pub fn can_mangle_provide(info: &ExportInfoData) -> Option<bool> {
+    info.can_mangle_provide
+  }
+
+  pub fn can_mangle_use(info: &ExportInfoData) -> Option<bool> {
+    info.can_mangle_use
+  }
+
+  pub fn terminal_binding(info: &ExportInfoData) -> bool {
+    info.terminal_binding
+  }
+
+  pub fn exports_info_owned(info: &ExportInfoData) -> bool {
+    info.exports_info_owned
+  }
+
+  pub fn exports_info(info: &ExportInfoData) -> Option<ExportsInfo> {
+    info.exports_info
+  }
+
+  /// Webpack returns `false | string`, we use `Option<Atom>` to avoid declare a redundant enum
+  /// type
+  pub fn get_used_name(
+    info: &ExportInfoData,
+    fallback_name: Option<&Atom>,
+    runtime: Option<&RuntimeSpec>,
+  ) -> Option<Atom> {
+    if info.has_use_in_runtime_info {
+      if let Some(usage) = info.global_used {
+        if matches!(usage, UsageState::Unused) {
+          return None;
+        }
+      } else if let Some(used_in_runtime) = info.used_in_runtime.as_ref() {
+        if let Some(runtime) = runtime {
+          if runtime
+            .iter()
+            .all(|item| !used_in_runtime.contains_key(item))
+          {
+            return None;
+          }
+        }
+      } else {
+        return None;
+      }
+    }
+    if let Some(used_name) = info.used_name.as_ref() {
+      return Some(used_name.clone());
+    }
+    if let Some(name) = info.name.as_ref() {
+      Some(name.clone())
+    } else {
+      fallback_name.cloned()
+    }
+  }
+
+  pub fn get_used(info: &ExportInfoData, runtime: Option<&RuntimeSpec>) -> UsageState {
+    if !info.has_use_in_runtime_info {
+      return UsageState::NoInfo;
+    }
+    if let Some(global_used) = info.global_used {
+      return global_used;
+    }
+    if let Some(used_in_runtime) = info.used_in_runtime.as_ref() {
+      let mut max = UsageState::Unused;
+      if let Some(runtime) = runtime {
+        for item in runtime.iter() {
+          let Some(usage) = used_in_runtime.get(item) else {
+            continue;
+          };
+          match usage {
+            UsageState::Used => return UsageState::Used,
+            _ => {
+              max = std::cmp::max(max, *usage);
+            }
+          }
+        }
+      } else {
+        for usage in used_in_runtime.values() {
+          match usage {
+            UsageState::Used => return UsageState::Used,
+            _ => {
+              max = std::cmp::max(max, *usage);
+            }
+          }
+        }
+      }
+      max
+    } else {
+      UsageState::Unused
+    }
+  }
+
+  pub fn get_provided_info(info: &ExportInfoData) -> &'static str {
+    match info.provided {
+      Some(ExportProvided::NotProvided) => "not provided",
+      Some(ExportProvided::Unknown) => "maybe provided (runtime-defined)",
+      Some(ExportProvided::Provided) => "provided",
+      None => "no provided info",
+    }
+  }
+
+  pub fn get_rename_info(info: &ExportInfoData) -> Cow<str> {
+    match (&info.used_name, &info.name) {
+      (Some(used), Some(name)) if used != name => return format!("renamed to {used}").into(),
+      (Some(used), None) => return format!("renamed to {used}").into(),
+      _ => {}
+    }
+
+    match (Self::can_mangle_provide(info), Self::can_mangle_use(info)) {
+      (None, None) => "missing provision and use info prevents renaming",
+      (None, Some(false)) => "usage prevents renaming (no provision info)",
+      (None, Some(true)) => "missing provision info prevents renaming",
+
+      (Some(true), None) => "missing usage info prevents renaming",
+      (Some(true), Some(false)) => "usage prevents renaming",
+      (Some(true), Some(true)) => "could be renamed",
+
+      (Some(false), None) => "provision prevents renaming (no use info)",
+      (Some(false), Some(false)) => "usage and provision prevents renaming",
+      (Some(false), Some(true)) => "provision prevents renaming",
+    }
+    .into()
+  }
+
+  pub fn get_used_info(info: &ExportInfoData) -> Cow<str> {
+    if let Some(global_used) = info.global_used {
+      return match global_used {
+        UsageState::Unused => "unused".into(),
+        UsageState::NoInfo => "no usage info".into(),
+        UsageState::Unknown => "maybe used (runtime-defined)".into(),
+        UsageState::Used => "used".into(),
+        UsageState::OnlyPropertiesUsed => "only properties used".into(),
+      };
+    } else if let Some(used_in_runtime) = &info.used_in_runtime {
+      let mut map = HashMap::default();
+
+      for (runtime, used) in used_in_runtime.iter() {
+        let list = map.entry(*used).or_insert(vec![]);
+        list.push(runtime);
+      }
+
+      let specific_info: Vec<String> = map
+        .iter()
+        .map(|(used, runtimes)| match used {
+          UsageState::NoInfo => format!("no usage info in {}", runtimes.iter().join(", ")),
+          UsageState::Unknown => format!(
+            "maybe used in {} (runtime-defined)",
+            runtimes.iter().join(", ")
+          ),
+          UsageState::Used => format!("used in {}", runtimes.iter().join(", ")),
+          UsageState::OnlyPropertiesUsed => {
+            format!("only properties used in {}", runtimes.iter().join(", "))
+          }
+          UsageState::Unused => {
+            // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/ExportsInfo.js#L1470-L1481
+            unreachable!()
+          }
+        })
+        .collect();
+
+      if !specific_info.is_empty() {
+        return specific_info.join("; ").into();
+      }
+    }
+
+    if info.has_use_in_runtime_info {
+      "unused".into()
+    } else {
+      "no usage info".into()
+    }
+  }
+
+  pub fn is_reexport(info: &ExportInfoData) -> bool {
+    !info.terminal_binding && info.target_is_set && !info.target.is_empty()
+  }
+
+  pub fn has_info(
+    info: &ExportInfoData,
+    base_info: &ExportInfoData,
+    runtime: Option<&RuntimeSpec>,
+  ) -> bool {
+    info.used_name.is_some()
+      || info.provided.is_some()
+      || info.terminal_binding
+      || (Self::get_used(info, runtime) != Self::get_used(base_info, runtime))
+  }
+
+  pub fn can_mangle(info: &ExportInfoData) -> Option<bool> {
+    match info.can_mangle_provide {
+      Some(true) => info.can_mangle_use,
+      Some(false) => Some(false),
+      None => {
+        if info.can_mangle_use == Some(false) {
+          Some(false)
+        } else {
+          None
+        }
+      }
+    }
+  }
+
+  pub fn has_used_name(info: &ExportInfoData) -> bool {
+    info.used_name.is_some()
+  }
+}

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -63,12 +63,13 @@ impl ExportsInfo {
   pub fn is_export_provided(&self, mg: &ModuleGraph, names: &[Atom]) -> Option<ExportProvided> {
     let name = names.first()?;
     let info = self.get_read_only_export_info(mg, name);
-    if let Some(exports_info) = ExportInfoGetter::exports_info(info.as_data(mg))
+    let info_data = info.as_data(mg);
+    if let Some(exports_info) = ExportInfoGetter::exports_info(info_data)
       && names.len() > 1
     {
       return exports_info.is_export_provided(mg, &names[1..]);
     }
-    let provided = ExportInfoGetter::provided(info.as_data(mg))?;
+    let provided = ExportInfoGetter::provided(info_data)?;
 
     match provided {
       ExportProvided::Provided => {
@@ -101,7 +102,7 @@ impl ExportsInfo {
   // ExportProvideInfo is created by FlagDependencyExportsPlugin, and should not mutate after create
   // ExportUsedInfo is created by FlagDependencyUsagePlugin or Plugin::finish_modules, and should not mutate after create
   pub fn reset_provide_info(&self, mg: &mut ModuleGraph) {
-    let exports: Vec<_> = self.exports(mg).collect();
+    let exports = self.exports(mg).collect::<Vec<_>>();
     for export_info in exports {
       ExportInfoSetter::reset_provide_info(export_info.as_data_mut(mg));
     }
@@ -172,30 +173,30 @@ impl ExportsInfo {
     let other_exports_info = exports_info.other_exports_info;
     let exports_id_list = exports_info.exports.values().copied().collect::<Vec<_>>();
     for export_info in exports_id_list {
-      if !can_mangle && ExportInfoGetter::can_mangle_provide(export_info.as_data(mg)) != Some(false)
-      {
-        ExportInfoSetter::set_can_mangle_provide(export_info.as_data_mut(mg), Some(false));
+      let export_info_data = export_info.as_data_mut(mg);
+      if !can_mangle && ExportInfoGetter::can_mangle_provide(export_info_data) != Some(false) {
+        ExportInfoSetter::set_can_mangle_provide(export_info_data, Some(false));
         changed = true;
       }
       if let Some(exclude_exports) = &exclude_exports {
-        if let Some(export_name) = ExportInfoGetter::name(export_info.as_data(mg))
+        if let Some(export_name) = ExportInfoGetter::name(export_info_data)
           && exclude_exports.contains(export_name)
         {
           continue;
         }
       }
       if !matches!(
-        ExportInfoGetter::provided(export_info.as_data(mg)),
+        ExportInfoGetter::provided(export_info_data),
         Some(ExportProvided::Provided | ExportProvided::Unknown)
       ) {
-        ExportInfoSetter::set_provided(export_info.as_data_mut(mg), Some(ExportProvided::Unknown));
+        ExportInfoSetter::set_provided(export_info_data, Some(ExportProvided::Unknown));
         changed = true;
       }
       if let Some(target_key) = target_key {
-        let name = ExportInfoGetter::name(export_info.as_data(mg))
-          .map(|name| Nullable::Value(vec![name.clone()]));
+        let name =
+          ExportInfoGetter::name(export_info_data).map(|name| Nullable::Value(vec![name.clone()]));
         ExportInfoSetter::set_target(
-          export_info.as_data_mut(mg),
+          export_info_data,
           Some(target_key),
           target_module,
           name.as_ref(),
@@ -217,20 +218,18 @@ impl ExportsInfo {
         changed = true;
       }
     } else {
+      let other_exports_info_data = other_exports_info.as_data_mut(mg);
       if !matches!(
-        ExportInfoGetter::provided(other_exports_info.as_data(mg)),
+        ExportInfoGetter::provided(other_exports_info_data),
         Some(ExportProvided::Provided | ExportProvided::Unknown)
       ) {
-        ExportInfoSetter::set_provided(
-          other_exports_info.as_data_mut(mg),
-          Some(ExportProvided::Unknown),
-        );
+        ExportInfoSetter::set_provided(other_exports_info_data, Some(ExportProvided::Unknown));
         changed = true;
       }
 
       if let Some(target_key) = target_key {
         ExportInfoSetter::set_target(
-          other_exports_info.as_data_mut(mg),
+          other_exports_info_data,
           Some(target_key),
           target_module,
           None,
@@ -238,10 +237,9 @@ impl ExportsInfo {
         );
       }
 
-      if !can_mangle
-        && ExportInfoGetter::can_mangle_provide(other_exports_info.as_data(mg)) != Some(false)
+      if !can_mangle && ExportInfoGetter::can_mangle_provide(other_exports_info_data) != Some(false)
       {
-        ExportInfoSetter::set_can_mangle_provide(other_exports_info.as_data_mut(mg), Some(false));
+        ExportInfoSetter::set_can_mangle_provide(other_exports_info_data, Some(false));
         changed = true;
       }
     }
@@ -488,8 +486,8 @@ impl ExportsInfo {
       return Some(UsedName::Normal(names.to_vec()));
     }
     let export_info = self.get_read_only_export_info(mg, &names[0]);
-    let used_name =
-      ExportInfoGetter::get_used_name(export_info.as_data(mg), Some(&names[0]), runtime)?;
+    let export_info_data = export_info.as_data(mg);
+    let used_name = ExportInfoGetter::get_used_name(export_info_data, Some(&names[0]), runtime)?;
     let mut arr = if used_name == names[0] && names.len() == 1 {
       names.to_vec()
     } else {
@@ -498,9 +496,8 @@ impl ExportsInfo {
     if names.len() == 1 {
       return Some(UsedName::Normal(arr));
     }
-    if let Some(exports_info) = ExportInfoGetter::exports_info(export_info.as_data(mg))
-      && ExportInfoGetter::get_used(export_info.as_data(mg), runtime)
-        == UsageState::OnlyPropertiesUsed
+    if let Some(exports_info) = ExportInfoGetter::exports_info(export_info_data)
+      && ExportInfoGetter::get_used(export_info_data, runtime) == UsageState::OnlyPropertiesUsed
     {
       let nested = exports_info.get_used_name(mg, runtime, &names[1..]);
       let nested = nested?;
@@ -515,8 +512,9 @@ impl ExportsInfo {
 
   pub fn get_provided_exports(&self, mg: &ModuleGraph) -> ProvidedExports {
     let info = self.as_exports_info(mg);
+    let other_exports_info_data = info.other_exports_info.as_data(mg);
     if info.redirect_to.is_none() {
-      match ExportInfoGetter::provided(info.other_exports_info.as_data(mg)) {
+      match ExportInfoGetter::provided(other_exports_info_data) {
         Some(ExportProvided::Unknown) => {
           return ProvidedExports::ProvidedAll;
         }
@@ -569,12 +567,13 @@ impl ExportsInfo {
 
     let mut res = vec![];
     for export_info_id in info.exports.values() {
-      let used = ExportInfoGetter::get_used(export_info_id.as_data(mg), runtime);
+      let export_info_id_data = export_info_id.as_data(mg);
+      let used = ExportInfoGetter::get_used(export_info_id_data, runtime);
       match used {
         UsageState::NoInfo => return UsedExports::Unknown,
         UsageState::Unknown => return UsedExports::UsedNamespace(true),
         UsageState::OnlyPropertiesUsed | UsageState::Used => {
-          if let Some(name) = export_info_id.as_data(mg).name.clone() {
+          if let Some(name) = export_info_id_data.name.clone() {
             res.push(name);
           }
         }
@@ -612,12 +611,13 @@ impl ExportsInfo {
     let info = self.as_exports_info(mg);
     let mut list = vec![];
     for export_info in info.exports.values() {
-      let used = ExportInfoGetter::get_used(export_info.as_data(mg), runtime);
+      let export_info_data = export_info.as_data(mg);
+      let used = ExportInfoGetter::get_used(export_info_data, runtime);
       if matches!(used, UsageState::Unused) {
         continue;
       }
       if matches!(
-        ExportInfoGetter::provided(export_info.as_data(mg)),
+        ExportInfoGetter::provided(export_info_data),
         Some(ExportProvided::NotProvided)
       ) {
         continue;
@@ -634,10 +634,11 @@ impl ExportsInfo {
     }
 
     let other_export_info = info.other_exports_info;
+    let other_export_info_data = other_export_info.as_data(mg);
     if !matches!(
-      ExportInfoGetter::provided(other_export_info.as_data(mg)),
+      ExportInfoGetter::provided(other_export_info_data),
       Some(ExportProvided::NotProvided)
-    ) && ExportInfoGetter::get_used(other_export_info.as_data(mg), runtime) != UsageState::Unused
+    ) && ExportInfoGetter::get_used(other_export_info_data, runtime) != UsageState::Unused
     {
       list.push(info.other_exports_info);
     }
@@ -652,21 +653,24 @@ impl ExportsInfo {
       }
     } else {
       let other_exports_info = info.other_exports_info;
-      if ExportInfoGetter::get_used(other_exports_info.as_data(mg), Some(a))
-        != ExportInfoGetter::get_used(other_exports_info.as_data(mg), Some(b))
+      let other_exports_info_data = other_exports_info.as_data(mg);
+      if ExportInfoGetter::get_used(other_exports_info_data, Some(a))
+        != ExportInfoGetter::get_used(other_exports_info_data, Some(b))
       {
         return false;
       }
     }
     let side_effects_only_info = info.side_effects_only_info;
-    if ExportInfoGetter::get_used(side_effects_only_info.as_data(mg), Some(a))
-      != ExportInfoGetter::get_used(side_effects_only_info.as_data(mg), Some(b))
+    let side_effects_only_info_data = side_effects_only_info.as_data(mg);
+    if ExportInfoGetter::get_used(side_effects_only_info_data, Some(a))
+      != ExportInfoGetter::get_used(side_effects_only_info_data, Some(b))
     {
       return false;
     }
     for export_info in self.owned_exports(mg) {
-      if ExportInfoGetter::get_used(export_info.as_data(mg), Some(a))
-        != ExportInfoGetter::get_used(export_info.as_data(mg), Some(b))
+      let export_info_data = export_info.as_data(mg);
+      if ExportInfoGetter::get_used(export_info_data, Some(a))
+        != ExportInfoGetter::get_used(export_info_data, Some(b))
       {
         return false;
       }

--- a/crates/rspack_core/src/exports/mod.rs
+++ b/crates/rspack_core/src/exports/mod.rs
@@ -1,9 +1,11 @@
 mod export_info;
+mod export_info_getter;
 mod export_info_setter;
 mod exports_info;
 mod utils;
 
 pub use export_info::*;
+pub use export_info_getter::*;
 pub use export_info_setter::*;
 pub use exports_info::*;
 pub use utils::*;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -31,9 +31,9 @@ use crate::{
   AsyncDependenciesBlock, BindingCell, BoxDependency, BoxDependencyTemplate, BoxModuleDependency,
   ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, CompilationAsset, CompilationId,
   CompilerId, CompilerOptions, ConcatenationScope, ConnectionState, Context, ContextModule,
-  DependenciesBlock, DependencyId, ExportProvided, ExternalModule, ModuleGraph, ModuleLayer,
-  ModuleType, NormalModule, RawModule, Resolve, ResolverFactory, RuntimeSpec, SelfModule,
-  SharedPluginDriver, SourceType,
+  DependenciesBlock, DependencyId, ExportInfoGetter, ExportProvided, ExternalModule, ModuleGraph,
+  ModuleLayer, ModuleType, NormalModule, RawModule, Resolve, ResolverFactory, RuntimeSpec,
+  SelfModule, SharedPluginDriver, SourceType,
 };
 
 pub struct BuildContext {
@@ -437,7 +437,10 @@ fn get_exports_type_impl(
         if let Some(export_info) =
           mg.get_read_only_export_info(&identifier, Atom::from("__esModule"))
         {
-          if matches!(export_info.provided(mg), Some(ExportProvided::NotProvided)) {
+          if matches!(
+            ExportInfoGetter::provided(export_info.as_data(mg)),
+            Some(ExportProvided::NotProvided)
+          ) {
             handle_default(default_object)
           } else {
             let Some(target) = export_info.get_target(mg) else {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -697,10 +697,7 @@ fn get_used_exports<'a>(
       let export_info = mg.get_read_only_export_info(&identifier, name.as_str().into());
 
       if let Some(export_info) = export_info {
-        matches!(
-          ExportInfoGetter::get_used(export_info.as_data(mg), runtime),
-          UsageState::Unused
-        )
+        ExportInfoGetter::get_used(export_info.as_data(mg), runtime) != UsageState::Unused
       } else {
         true
       }

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -16,9 +16,10 @@ use rspack_core::{
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
   BoxDependencyTemplate, BoxModuleDependency, BuildMetaDefaultObject, BuildMetaExportsType,
   ChunkGraph, Compilation, ConstDependency, CssExportsConvention, Dependency, DependencyId,
-  DependencyRange, DependencyType, GenerateContext, LocalIdentName, Module, ModuleGraph,
-  ModuleIdentifier, ModuleInitFragments, ModuleType, NormalModule, ParseContext, ParseResult,
-  ParserAndGenerator, RuntimeGlobals, RuntimeSpec, SourceType, TemplateContext, UsageState,
+  DependencyRange, DependencyType, ExportInfoGetter, GenerateContext, LocalIdentName, Module,
+  ModuleGraph, ModuleIdentifier, ModuleInitFragments, ModuleType, NormalModule, ParseContext,
+  ParseResult, ParserAndGenerator, RuntimeGlobals, RuntimeSpec, SourceType, TemplateContext,
+  UsageState,
 };
 use rspack_error::{
   miette::Diagnostic, IntoTWithDiagnosticArray, Result, RspackSeverity, TWithDiagnosticArray,
@@ -590,11 +591,12 @@ impl ParserAndGenerator for CssParserAndGenerator {
         } else {
           let mg = generate_context.compilation.get_module_graph();
           let (ns_obj, left, right) = if self.es_module
-            && mg
-              .get_exports_info(&module.identifier())
-              .other_exports_info(&mg)
-              .get_used(&mg, generate_context.runtime)
-              != UsageState::Unused
+            && ExportInfoGetter::get_used(
+              mg.get_exports_info(&module.identifier())
+                .other_exports_info(&mg)
+                .as_data(&mg),
+              generate_context.runtime,
+            ) != UsageState::Unused
           {
             (RuntimeGlobals::MAKE_NAMESPACE_OBJECT.name(), "(", ")")
           } else {
@@ -695,7 +697,10 @@ fn get_used_exports<'a>(
       let export_info = mg.get_read_only_export_info(&identifier, name.as_str().into());
 
       if let Some(export_info) = export_info {
-        export_info.get_used(mg, runtime) != UsageState::Unused
+        matches!(
+          ExportInfoGetter::get_used(export_info.as_data(mg), runtime),
+          UsageState::Unused
+        )
       } else {
         true
       }
@@ -723,7 +728,10 @@ fn get_unused_local_ident(
         let export_info = mg.get_read_only_export_info(&identifier, name.as_str().into());
 
         if let Some(export_info) = export_info {
-          matches!(export_info.get_used(mg, runtime), UsageState::Unused)
+          matches!(
+            ExportInfoGetter::get_used(export_info.as_data(mg), runtime),
+            UsageState::Unused
+          )
         } else {
           false
         }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -147,17 +147,19 @@ impl CommonJsExportRequireDependency {
         unreachable!();
       };
       for imported_export_info in imported_exports_info.ordered_exports(mg) {
-        let name = ExportInfoGetter::name(imported_export_info.as_data(mg));
+        let imported_export_info_data = imported_export_info.as_data(mg);
+        let name = ExportInfoGetter::name(imported_export_info_data);
         if let Some(name) = name {
           if matches!(
-            ExportInfoGetter::provided(imported_export_info.as_data(mg)),
+            ExportInfoGetter::provided(imported_export_info_data),
             Some(ExportProvided::NotProvided)
           ) {
             continue;
           }
           if let Some(exports_info) = exports_info {
             let export_info = exports_info.get_read_only_export_info(mg, name);
-            let used = ExportInfoGetter::get_used(export_info.as_data(mg), runtime);
+            let export_info_data = export_info.as_data(mg);
+            let used = ExportInfoGetter::get_used(export_info_data, runtime);
             if matches!(used, UsageState::Unused) {
               continue;
             }
@@ -295,7 +297,8 @@ impl Dependency for CommonJsExportRequireDependency {
 
     for name in &self.names {
       let export_info = exports_info.get_read_only_export_info(mg, name);
-      let used = ExportInfoGetter::get_used(export_info.as_data(mg), runtime);
+      let export_info_data = export_info.as_data(mg);
+      let used = ExportInfoGetter::get_used(export_info_data, runtime);
       if matches!(used, UsageState::Unused) {
         return vec![ExtendedReferencedExport::Array(vec![])];
       }
@@ -303,7 +306,7 @@ impl Dependency for CommonJsExportRequireDependency {
         return get_full_result();
       }
 
-      match ExportInfoGetter::exports_info(export_info.as_data(mg)) {
+      match ExportInfoGetter::exports_info(export_info_data) {
         Some(v) => exports_info = v,
         None => return get_full_result(),
       };
@@ -318,10 +321,11 @@ impl Dependency for CommonJsExportRequireDependency {
 
     let mut referenced_exports = vec![];
     for export_info in exports_info.ordered_exports(mg) {
+      let export_info_data = export_info.as_data(mg);
       let prefix = ids
         .iter()
         .chain(
-          if let Some(name) = ExportInfoGetter::name(export_info.as_data(mg)) {
+          if let Some(name) = ExportInfoGetter::name(export_info_data) {
             vec![name]
           } else {
             vec![]

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -6,10 +6,10 @@ use rspack_cacheable::{
 use rspack_core::{
   module_raw, process_export_info, property_access, AsContextDependency, Dependency,
   DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportNameOrSpec, ExportProvided, ExportSpec,
-  ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport, FactorizeInfo,
-  ModuleDependency, ModuleGraph, ModuleIdentifier, Nullable, ReferencedExport, RuntimeGlobals,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
+  DependencyTemplateType, DependencyType, ExportInfoGetter, ExportNameOrSpec, ExportProvided,
+  ExportSpec, ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
+  FactorizeInfo, ModuleDependency, ModuleGraph, ModuleIdentifier, Nullable, ReferencedExport,
+  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
 };
 use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
@@ -88,14 +88,16 @@ impl CommonJsExportRequireDependency {
     }
 
     let no_extra_exports = imported_exports_info.is_some_and(|imported_exports_info| {
-      imported_exports_info
-        .other_exports_info(mg)
-        .provided(mg)
-        .is_some_and(|provided| matches!(provided, ExportProvided::NotProvided))
+      let provided =
+        ExportInfoGetter::provided(imported_exports_info.other_exports_info(mg).as_data(mg));
+      matches!(provided, Some(ExportProvided::NotProvided))
     });
 
     let no_extra_imports = exports_info.is_some_and(|exports_info| {
-      exports_info.other_exports_info(mg).get_used(mg, runtime) == UsageState::Unused
+      matches!(
+        ExportInfoGetter::get_used(exports_info.other_exports_info(mg).as_data(mg), runtime),
+        UsageState::Unused
+      )
     });
 
     if !no_extra_exports && !no_extra_imports {
@@ -116,8 +118,11 @@ impl CommonJsExportRequireDependency {
         unreachable!();
       };
       for export_info in exports_info.ordered_exports(mg) {
-        let name = export_info.name(mg);
-        if matches!(export_info.get_used(mg, runtime), UsageState::Unused) {
+        let name = ExportInfoGetter::name(export_info.as_data(mg));
+        if matches!(
+          ExportInfoGetter::get_used(export_info.as_data(mg), runtime),
+          UsageState::Unused
+        ) {
           continue;
         }
         if let Some(name) = name {
@@ -126,7 +131,7 @@ impl CommonJsExportRequireDependency {
           } else if let Some(imported_exports_info) = imported_exports_info {
             let imported_export_info = imported_exports_info.get_read_only_export_info(mg, name);
             if matches!(
-              imported_export_info.provided(mg),
+              ExportInfoGetter::provided(imported_export_info.as_data(mg)),
               Some(ExportProvided::NotProvided)
             ) {
               continue;
@@ -142,17 +147,18 @@ impl CommonJsExportRequireDependency {
         unreachable!();
       };
       for imported_export_info in imported_exports_info.ordered_exports(mg) {
-        let name = imported_export_info.name(mg);
+        let name = ExportInfoGetter::name(imported_export_info.as_data(mg));
         if let Some(name) = name {
           if matches!(
-            imported_export_info.provided(mg),
+            ExportInfoGetter::provided(imported_export_info.as_data(mg)),
             Some(ExportProvided::NotProvided)
           ) {
             continue;
           }
           if let Some(exports_info) = exports_info {
             let export_info = exports_info.get_read_only_export_info(mg, name);
-            if matches!(export_info.get_used(mg, runtime), UsageState::Unused) {
+            let used = ExportInfoGetter::get_used(export_info.as_data(mg), runtime);
+            if matches!(used, UsageState::Unused) {
               continue;
             }
             exports.insert(name.to_owned());
@@ -289,7 +295,7 @@ impl Dependency for CommonJsExportRequireDependency {
 
     for name in &self.names {
       let export_info = exports_info.get_read_only_export_info(mg, name);
-      let used = export_info.get_used(mg, runtime);
+      let used = ExportInfoGetter::get_used(export_info.as_data(mg), runtime);
       if matches!(used, UsageState::Unused) {
         return vec![ExtendedReferencedExport::Array(vec![])];
       }
@@ -297,14 +303,14 @@ impl Dependency for CommonJsExportRequireDependency {
         return get_full_result();
       }
 
-      match export_info.exports_info(mg) {
+      match ExportInfoGetter::exports_info(export_info.as_data(mg)) {
         Some(v) => exports_info = v,
         None => return get_full_result(),
       };
     }
 
     if !matches!(
-      exports_info.other_exports_info(mg).get_used(mg, runtime),
+      ExportInfoGetter::get_used(exports_info.other_exports_info(mg).as_data(mg), runtime),
       UsageState::Unused
     ) {
       return get_full_result();
@@ -314,11 +320,13 @@ impl Dependency for CommonJsExportRequireDependency {
     for export_info in exports_info.ordered_exports(mg) {
       let prefix = ids
         .iter()
-        .chain(if let Some(name) = export_info.name(mg) {
-          vec![name]
-        } else {
-          vec![]
-        })
+        .chain(
+          if let Some(name) = ExportInfoGetter::name(export_info.as_data(mg)) {
+            vec![name]
+          } else {
+            vec![]
+          },
+        )
         .map(|i| i.to_owned())
         .collect_vec();
       process_export_info(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, InitFragmentKey,
-  InitFragmentStage, ModuleGraph, NormalInitFragment, RuntimeGlobals, TemplateContext,
-  TemplateReplaceSource, UsageState,
+  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportInfoGetter,
+  InitFragmentKey, InitFragmentStage, ModuleGraph, NormalInitFragment, RuntimeGlobals,
+  TemplateContext, TemplateReplaceSource, UsageState,
 };
 use swc_core::atoms::Atom;
 
@@ -53,12 +53,13 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
     let exports_info = module_graph.get_exports_info(&module.identifier());
-    if !matches!(
+    let used = ExportInfoGetter::get_used(
       exports_info
-        .get_read_only_export_info(&module_graph, &Atom::from("__esModule"),)
-        .get_used(&module_graph, *runtime),
-      UsageState::Unused
-    ) {
+        .get_read_only_export_info(&module_graph, &Atom::from("__esModule"))
+        .as_data(&module_graph),
+      *runtime,
+    );
+    if !matches!(used, UsageState::Unused) {
       runtime_requirements.insert(RuntimeGlobals::MAKE_NAMESPACE_OBJECT);
       runtime_requirements.insert(RuntimeGlobals::EXPORTS);
       init_fragments.push(Box::new(NormalInitFragment::new(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -349,12 +349,13 @@ impl ESMExportImportedSpecifierDependency {
 
     if no_extra_imports {
       for export_info in exports_info.ordered_exports(module_graph) {
-        let export_name = ExportInfoGetter::name(export_info.as_data(module_graph))
+        let export_info_data = export_info.as_data(module_graph);
+        let export_name = ExportInfoGetter::name(export_info_data)
           .cloned()
           .unwrap_or_default();
         if ignored_exports.contains(&export_name)
           || matches!(
-            ExportInfoGetter::get_used(export_info.as_data(module_graph), runtime),
+            ExportInfoGetter::get_used(export_info_data, runtime),
             UsageState::Unused
           )
         {
@@ -363,8 +364,9 @@ impl ESMExportImportedSpecifierDependency {
 
         let imported_export_info =
           imported_exports_info.get_read_only_export_info(module_graph, &export_name);
+        let imported_export_info_data = imported_export_info.as_data(module_graph);
         if matches!(
-          ExportInfoGetter::provided(imported_export_info.as_data(module_graph)),
+          ExportInfoGetter::provided(imported_export_info_data),
           Some(ExportProvided::NotProvided)
         ) {
           continue;
@@ -381,7 +383,7 @@ impl ESMExportImportedSpecifierDependency {
 
         exports.insert(export_name.clone());
         if matches!(
-          ExportInfoGetter::provided(imported_export_info.as_data(module_graph)),
+          ExportInfoGetter::provided(imported_export_info_data),
           Some(ExportProvided::Provided)
         ) {
           continue;
@@ -390,13 +392,13 @@ impl ESMExportImportedSpecifierDependency {
       }
     } else if no_extra_exports {
       for imported_export_info in imported_exports_info.ordered_exports(module_graph) {
-        let imported_export_info_name =
-          ExportInfoGetter::name(imported_export_info.as_data(module_graph))
-            .cloned()
-            .unwrap_or_default();
+        let imported_export_info_data = imported_export_info.as_data(module_graph);
+        let imported_export_info_name = ExportInfoGetter::name(imported_export_info_data)
+          .cloned()
+          .unwrap_or_default();
         if ignored_exports.contains(&imported_export_info_name)
           || matches!(
-            ExportInfoGetter::provided(imported_export_info.as_data(module_graph)),
+            ExportInfoGetter::provided(imported_export_info_data),
             Some(ExportProvided::NotProvided)
           )
         {
@@ -404,8 +406,9 @@ impl ESMExportImportedSpecifierDependency {
         }
         let export_info =
           exports_info.get_read_only_export_info(module_graph, &imported_export_info_name);
+        let export_info_data = export_info.as_data(module_graph);
         if matches!(
-          ExportInfoGetter::get_used(export_info.as_data(module_graph), runtime),
+          ExportInfoGetter::get_used(export_info_data, runtime),
           UsageState::Unused
         ) {
           continue;
@@ -422,7 +425,7 @@ impl ESMExportImportedSpecifierDependency {
 
         exports.insert(imported_export_info_name.clone());
         if matches!(
-          ExportInfoGetter::provided(imported_export_info.as_data(module_graph)),
+          ExportInfoGetter::provided(imported_export_info_data),
           Some(ExportProvided::Provided)
         ) {
           continue;
@@ -918,13 +921,14 @@ impl ESMExportImportedSpecifierDependency {
       let mut conflicts: IndexMap<&str, Vec<&Atom>, BuildHasherDefault<FxHasher>> =
         IndexMap::default();
       for export_info in exports_info.ordered_exports(module_graph) {
+        let export_info_data = export_info.as_data(module_graph);
         if !matches!(
-          ExportInfoGetter::provided(export_info.as_data(module_graph)),
+          ExportInfoGetter::provided(export_info_data),
           Some(ExportProvided::Provided)
         ) {
           continue;
         }
-        let Some(name) = ExportInfoGetter::name(export_info.as_data(module_graph)) else {
+        let Some(name) = ExportInfoGetter::name(export_info_data) else {
           continue;
         };
         if name == "default" {
@@ -1459,11 +1463,12 @@ fn determine_export_assignments<'a>(
     if let Some(module_identifier) = module_graph.module_identifier_by_dependency_id(dependency) {
       let exports_info = module_graph.get_exports_info(module_identifier);
       for export_info in exports_info.ordered_exports(module_graph) {
+        let export_info_data = export_info.as_data(module_graph);
         // SAFETY: This is safe because a real export can't export empty string
         let export_info_name =
-          ExportInfoGetter::name(export_info.as_data(module_graph)).expect("export name is empty");
+          ExportInfoGetter::name(export_info_data).expect("export name is empty");
         if matches!(
-          ExportInfoGetter::provided(export_info.as_data(module_graph)),
+          ExportInfoGetter::provided(export_info_data),
           Some(ExportProvided::Provided)
         ) && export_info_name != "default"
           && !names.contains(export_info_name)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -10,10 +10,10 @@ use rspack_core::{
   BuildMetaDefaultObject, ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ErrorSpan, ExportProvided, ExportsType, ExtendedReferencedExport, FactorizeInfo,
-  ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleDependency,
-  ModuleGraph, ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap, TemplateContext,
-  TemplateReplaceSource,
+  ErrorSpan, ExportInfoGetter, ExportProvided, ExportsType, ExtendedReferencedExport,
+  FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  ModuleDependency, ModuleGraph, ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap,
+  TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -297,7 +297,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
         pos += 1;
         let export_info = exports_info.get_read_only_export_info(module_graph, id);
         if matches!(
-          export_info.provided(module_graph),
+          ExportInfoGetter::provided(export_info.as_data(module_graph)),
           Some(ExportProvided::NotProvided)
         ) {
           let provided_exports = exports_info.get_provided_exports(module_graph);

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -4,8 +4,8 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportProvided,
-  TemplateContext, TemplateReplaceSource, UsageState, UsedExports,
+  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportInfoGetter,
+  ExportProvided, TemplateContext, TemplateReplaceSource, UsageState, UsedExports,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -78,11 +78,13 @@ impl ExportInfoDependency {
         let can_mangle = if let Some(export_info) =
           exports_info.get_read_only_export_info_recursive(&module_graph, export_name)
         {
-          export_info.can_mangle(&module_graph)
+          ExportInfoGetter::can_mangle(export_info.as_data(&module_graph))
         } else {
-          exports_info
-            .other_exports_info(&module_graph)
-            .can_mangle(&module_graph)
+          ExportInfoGetter::can_mangle(
+            exports_info
+              .other_exports_info(&module_graph)
+              .as_data(&module_graph),
+          )
         };
         can_mangle.map(|v| v.to_string())
       }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -5,9 +5,9 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   incremental::{self, IncrementalPasses},
   ApplyContext, BuildMetaExportsType, Compilation, CompilationFinishModules, CompilerOptions,
-  DependenciesBlock, DependencyId, ExportInfoSetter, ExportNameOrSpec, ExportProvided, ExportsInfo,
-  ExportsOfExportsSpec, ExportsSpec, Logger, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
-  Plugin, PluginContext,
+  DependenciesBlock, DependencyId, ExportInfoGetter, ExportInfoSetter, ExportNameOrSpec,
+  ExportProvided, ExportsInfo, ExportsOfExportsSpec, ExportsSpec, Logger, ModuleGraph,
+  ModuleGraphConnection, ModuleIdentifier, Plugin, PluginContext,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -52,7 +52,7 @@ impl<'a> FlagDependencyExportsState<'a> {
       if is_module_without_exports {
         let other_exports_info = exports_info.other_exports_info(self.mg);
         if !matches!(
-          other_exports_info.provided(self.mg),
+          ExportInfoGetter::provided(other_exports_info.as_data(self.mg)),
           Some(ExportProvided::Unknown)
         ) {
           exports_info.set_has_provide_info(self.mg);
@@ -249,7 +249,7 @@ impl<'a> FlagDependencyExportsState<'a> {
           ),
         };
       let export_info = exports_info.get_export_info(self.mg, &name);
-      if let Some(provided) = export_info.provided(self.mg)
+      if let Some(provided) = ExportInfoGetter::provided(export_info.as_data(self.mg))
         && matches!(
           provided,
           ExportProvided::NotProvided | ExportProvided::Unknown
@@ -262,12 +262,14 @@ impl<'a> FlagDependencyExportsState<'a> {
         self.changed = true;
       }
 
-      if Some(false) != export_info.can_mangle_provide(self.mg) && can_mangle == Some(false) {
+      if Some(false) != ExportInfoGetter::can_mangle_provide(export_info.as_data(self.mg))
+        && can_mangle == Some(false)
+      {
         ExportInfoSetter::set_can_mangle_provide(export_info.as_data_mut(self.mg), Some(false));
         self.changed = true;
       }
 
-      if terminal_binding && !export_info.terminal_binding(self.mg) {
+      if terminal_binding && !ExportInfoGetter::terminal_binding(export_info.as_data(self.mg)) {
         ExportInfoSetter::set_terminal_binding(export_info.as_data_mut(self.mg), true);
         self.changed = true;
       }
@@ -323,15 +325,15 @@ impl<'a> FlagDependencyExportsState<'a> {
         }
       }
 
-      if export_info.exports_info_owned(self.mg) {
-        let changed = export_info
-          .exports_info(self.mg)
+      if ExportInfoGetter::exports_info_owned(export_info.as_data(self.mg)) {
+        let changed = ExportInfoGetter::exports_info(export_info.as_data(self.mg))
           .expect("should have exports_info when exports_info_owned is true")
           .set_redirect_name_to(self.mg, target_exports_info);
         if changed {
           self.changed = true;
         }
-      } else if export_info.exports_info(self.mg) != target_exports_info {
+      } else if ExportInfoGetter::exports_info(export_info.as_data(self.mg)) != target_exports_info
+      {
         ExportInfoSetter::set_exports_info(export_info.as_data_mut(self.mg), target_exports_info);
         self.changed = true;
       }

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -17,10 +17,9 @@ use crate::utils::mangle_exports::{
 };
 
 fn can_mangle(exports_info: ExportsInfo, mg: &ModuleGraph) -> bool {
-  if matches!(
-    ExportInfoGetter::get_used(exports_info.other_exports_info(mg).as_data(mg), None),
-    UsageState::Unused
-  ) {
+  if ExportInfoGetter::get_used(exports_info.other_exports_info(mg).as_data(mg), None)
+    != UsageState::Unused
+  {
     return false;
   }
   let mut has_something_to_mangle = false;

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -278,10 +278,9 @@ fn create_object_for_exports_info(
   runtime: Option<&RuntimeSpec>,
   mg: &ModuleGraph,
 ) -> JsonValue {
-  if matches!(
-    ExportInfoGetter::get_used(exports_info.other_exports_info(mg).as_data(mg), runtime),
-    UsageState::Unused
-  ) {
+  if ExportInfoGetter::get_used(exports_info.other_exports_info(mg).as_data(mg), runtime)
+    != UsageState::Unused
+  {
     return data;
   }
 

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -15,9 +15,9 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   diagnostics::ModuleParseError,
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
-  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, CompilerOptions, ExportsInfo,
-  GenerateContext, Module, ModuleGraph, ParseOption, ParserAndGenerator, Plugin, RuntimeGlobals,
-  RuntimeSpec, SourceType, UsageState, NAMESPACE_OBJECT_EXPORT,
+  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, CompilerOptions, ExportInfoGetter,
+  ExportsInfo, GenerateContext, Module, ModuleGraph, ParseOption, ParserAndGenerator, Plugin,
+  RuntimeGlobals, RuntimeSpec, SourceType, UsageState, NAMESPACE_OBJECT_EXPORT,
 };
 use rspack_error::{
   miette::diagnostic, DiagnosticExt, DiagnosticKind, IntoTWithDiagnosticArray, Result,
@@ -184,10 +184,15 @@ impl ParserAndGenerator for JsonParserAndGenerator {
 
         let final_json = match json_data {
           json::JsonValue::Object(_) | json::JsonValue::Array(_)
-            if exports_info
-              .other_exports_info(&module_graph)
-              .get_used(&module_graph, *runtime)
-              == UsageState::Unused =>
+            if matches!(
+              ExportInfoGetter::get_used(
+                exports_info
+                  .other_exports_info(&module_graph)
+                  .as_data(&module_graph),
+                *runtime
+              ),
+              UsageState::Unused
+            ) =>
           {
             create_object_for_exports_info(json_data.clone(), exports_info, *runtime, &module_graph)
           }
@@ -273,7 +278,10 @@ fn create_object_for_exports_info(
   runtime: Option<&RuntimeSpec>,
   mg: &ModuleGraph,
 ) -> JsonValue {
-  if exports_info.other_exports_info(mg).get_used(mg, runtime) != UsageState::Unused {
+  if matches!(
+    ExportInfoGetter::get_used(exports_info.other_exports_info(mg).as_data(mg), runtime),
+    UsageState::Unused
+  ) {
     return data;
   }
 
@@ -287,12 +295,12 @@ fn create_object_for_exports_info(
       let mut used_pair = vec![];
       for (key, value) in obj.iter_mut() {
         let export_info = exports_info.get_read_only_export_info(mg, &key.into());
-        let used = export_info.get_used(mg, runtime);
+        let used = ExportInfoGetter::get_used(export_info.as_data(mg), runtime);
         if used == UsageState::Unused {
           continue;
         }
         let new_value = if used == UsageState::OnlyPropertiesUsed
-          && let Some(exports_info) = export_info.exports_info(mg)
+          && let Some(exports_info) = ExportInfoGetter::exports_info(export_info.as_data(mg))
         {
           // avoid clone
           let temp = std::mem::replace(value, JsonValue::Null);
@@ -300,9 +308,9 @@ fn create_object_for_exports_info(
         } else {
           std::mem::replace(value, JsonValue::Null)
         };
-        let used_name = export_info
-          .get_used_name(mg, Some(&(key.into())), runtime)
-          .expect("should have used name");
+        let used_name =
+          ExportInfoGetter::get_used_name(export_info.as_data(mg), Some(&(key.into())), runtime)
+            .expect("should have used name");
         used_pair.push((used_name, new_value));
       }
       let mut new_obj = Object::new();
@@ -319,13 +327,13 @@ fn create_object_for_exports_info(
         .enumerate()
         .map(|(i, item)| {
           let export_info = exports_info.get_read_only_export_info(mg, &itoa!(i).into());
-          let used = export_info.get_used(mg, runtime);
+          let used = ExportInfoGetter::get_used(export_info.as_data(mg), runtime);
           if used == UsageState::Unused {
             return None;
           }
           max_used_index = max_used_index.max(i);
           if used == UsageState::OnlyPropertiesUsed
-            && let Some(exports_info) = export_info.exports_info(mg)
+            && let Some(exports_info) = ExportInfoGetter::exports_info(export_info.as_data(mg))
           {
             Some(create_object_for_exports_info(
               item,
@@ -338,9 +346,12 @@ fn create_object_for_exports_info(
           }
         })
         .collect::<Vec<_>>();
-      let arr_length_used = exports_info
-        .get_read_only_export_info(mg, &"length".into())
-        .get_used(mg, runtime);
+      let arr_length_used = ExportInfoGetter::get_used(
+        exports_info
+          .get_read_only_export_info(mg, &"length".into())
+          .as_data(mg),
+        runtime,
+      );
       let array_length_when_used = match arr_length_used {
         UsageState::Unused => None,
         _ => Some(original_len),

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -8,9 +8,10 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier, ApplyContext, BoxModule, Chunk, ChunkUkey, CodeGenerationDataTopLevelDeclarations,
   Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules,
-  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportInfoSetter,
-  ExportProvided, Filename, LibraryExport, LibraryName, LibraryNonUmdObject, LibraryOptions,
-  ModuleIdentifier, PathData, Plugin, PluginContext, RuntimeGlobals, SourceType, UsageState,
+  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportInfoGetter,
+  ExportInfoSetter, ExportProvided, Filename, LibraryExport, LibraryName, LibraryNonUmdObject,
+  LibraryOptions, ModuleIdentifier, PathData, Plugin, PluginContext, RuntimeGlobals, SourceType,
+  UsageState,
 };
 use rspack_error::{error, error_bail, Result, ToStringResultToRspackResultExt};
 use rspack_hash::RspackHash;
@@ -268,13 +269,12 @@ async fn render_startup(
     let mut provided = vec![];
     for export_info in exports_info.ordered_exports(&module_graph) {
       if matches!(
-        export_info.provided(&module_graph),
+        ExportInfoGetter::provided(export_info.as_data(&module_graph)),
         Some(ExportProvided::NotProvided)
       ) {
         continue;
       }
-      let export_info_name = export_info
-        .name(&module_graph)
+      let export_info_name = ExportInfoGetter::name(export_info.as_data(&module_graph))
         .expect("should have name")
         .to_string();
       provided.push(export_info_name.clone());

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -6,8 +6,8 @@ use rspack_core::{
   to_identifier, ApplyContext, BoxDependency, ChunkUkey, CodeGenerationExportsFinalNames,
   Compilation, CompilationOptimizeChunkModules, CompilationParams, CompilerCompilation,
   CompilerFinishMake, CompilerOptions, ConcatenatedModule, ConcatenatedModuleExportsDefinitions,
-  DependenciesBlock, Dependency, DependencyId, LibraryOptions, ModuleGraph, ModuleIdentifier,
-  Plugin, PluginContext, RuntimeSpec,
+  DependenciesBlock, Dependency, DependencyId, ExportInfoGetter, LibraryOptions, ModuleGraph,
+  ModuleIdentifier, Plugin, PluginContext, RuntimeSpec,
 };
 use rspack_error::{error_bail, Result};
 use rspack_hash::RspackHash;
@@ -173,10 +173,14 @@ async fn render_startup(
   {
     let exports_info = module_graph.get_exports_info(module_id);
     for export_info in exports_info.ordered_exports(&module_graph) {
-      let info_name = export_info.name(&module_graph).expect("should have name");
-      let used_name = export_info
-        .get_used_name(&module_graph, Some(info_name), Some(chunk.runtime()))
-        .expect("name can't be empty");
+      let info_name =
+        ExportInfoGetter::name(export_info.as_data(&module_graph)).expect("should have name");
+      let used_name = ExportInfoGetter::get_used_name(
+        export_info.as_data(&module_graph),
+        Some(info_name),
+        Some(chunk.runtime()),
+      )
+      .expect("name can't be empty");
 
       let final_name = exports_final_names.get(used_name.as_str());
 

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -4,8 +4,8 @@ use rspack_core::{
   property_access,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier, ApplyContext, ChunkUkey, Compilation, CompilationParams, CompilerCompilation,
-  CompilerOptions, ExportProvided, ExportsType, LibraryOptions, ModuleGraph, ModuleIdentifier,
-  Plugin, PluginContext,
+  CompilerOptions, ExportInfoGetter, ExportProvided, ExportsType, LibraryOptions, ModuleGraph,
+  ModuleIdentifier, Plugin, PluginContext,
 };
 use rspack_error::{error_bail, Result};
 use rspack_hash::RspackHash;
@@ -82,17 +82,21 @@ async fn render_startup(
   let exports_type = boxed_module.get_exports_type(&module_graph, boxed_module.build_info().strict);
   for export_info in exports_info.ordered_exports(&module_graph) {
     if matches!(
-      export_info.provided(&module_graph),
+      ExportInfoGetter::provided(export_info.as_data(&module_graph)),
       Some(ExportProvided::NotProvided)
     ) {
       continue;
     };
 
     let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
-    let info_name = export_info.name(&module_graph).expect("should have name");
-    let used_name = export_info
-      .get_used_name(&module_graph, Some(info_name), Some(chunk.runtime()))
-      .expect("name can't be empty");
+    let info_name =
+      ExportInfoGetter::name(export_info.as_data(&module_graph)).expect("should have name");
+    let used_name = ExportInfoGetter::get_used_name(
+      export_info.as_data(&module_graph),
+      Some(info_name),
+      Some(chunk.runtime()),
+    )
+    .expect("name can't be empty");
     let var_name = format!("__webpack_exports__{}", to_identifier(info_name));
 
     if info_name == "default"

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -81,22 +81,19 @@ async fn render_startup(
     .expect("should have build meta");
   let exports_type = boxed_module.get_exports_type(&module_graph, boxed_module.build_info().strict);
   for export_info in exports_info.ordered_exports(&module_graph) {
+    let export_info_data = export_info.as_data(&module_graph);
     if matches!(
-      ExportInfoGetter::provided(export_info.as_data(&module_graph)),
+      ExportInfoGetter::provided(export_info_data),
       Some(ExportProvided::NotProvided)
     ) {
       continue;
     };
 
     let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
-    let info_name =
-      ExportInfoGetter::name(export_info.as_data(&module_graph)).expect("should have name");
-    let used_name = ExportInfoGetter::get_used_name(
-      export_info.as_data(&module_graph),
-      Some(info_name),
-      Some(chunk.runtime()),
-    )
-    .expect("name can't be empty");
+    let info_name = ExportInfoGetter::name(export_info_data).expect("should have name");
+    let used_name =
+      ExportInfoGetter::get_used_name(export_info_data, Some(info_name), Some(chunk.runtime()))
+        .expect("name can't be empty");
     let var_name = format!("__webpack_exports__{}", to_identifier(info_name));
 
     if info_name == "default"

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -95,7 +95,7 @@ fn print_exports_info_to_source<F>(
 
     source.add(RawStringSource::from(to_comment_with_nl(&export_str)));
 
-    if let Some(exports_info) = &ExportInfoGetter::exports_info(export_info.as_data(module_graph)) {
+    if let Some(exports_info) = &ExportInfoGetter::exports_info(info) {
       print_exports_info_to_source(
         source,
         &format!("{ident}  "),
@@ -115,16 +115,16 @@ fn print_exports_info_to_source<F>(
 
   if show_other_exports {
     let other_exports_info = exports_info_id.other_exports_info(module_graph);
+    let other_exports_info_data = other_exports_info.as_data(module_graph);
 
     let target = other_exports_info.get_target(module_graph);
 
     if target.is_some()
       || !matches!(
-        ExportInfoGetter::provided(other_exports_info.as_data(module_graph)),
+        ExportInfoGetter::provided(other_exports_info_data),
         Some(ExportProvided::NotProvided)
       )
-      || ExportInfoGetter::get_used(other_exports_info.as_data(module_graph), None)
-        != UsageState::Unused
+      || ExportInfoGetter::get_used(other_exports_info_data, None) != UsageState::Unused
     {
       let title = if !printed_exports.is_empty() || already_printed_exports > 0 {
         "other exports"
@@ -132,9 +132,8 @@ fn print_exports_info_to_source<F>(
         "exports"
       };
 
-      let provide_info =
-        ExportInfoGetter::get_provided_info(other_exports_info.as_data(module_graph));
-      let used_info = ExportInfoGetter::get_used_info(other_exports_info.as_data(module_graph));
+      let provide_info = ExportInfoGetter::get_provided_info(other_exports_info_data);
+      let used_info = ExportInfoGetter::get_used_info(other_exports_info_data);
       let target_desc = match target {
         Some(resolve_target) => {
           format!(" -> {}", request_shortener(&resolve_target.module))

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -8,8 +8,8 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_comment_with_nl, ApplyContext, BoxModule, BuildMetaExportsType, ChunkGraph,
   ChunkInitFragments, ChunkUkey, Compilation, CompilationParams, CompilerCompilation,
-  CompilerOptions, ExportInfo, ExportProvided, ExportsInfo, Module, ModuleGraph, ModuleIdentifier,
-  Plugin, PluginContext, UsageState,
+  CompilerOptions, ExportInfo, ExportInfoGetter, ExportProvided, ExportsInfo, Module, ModuleGraph,
+  ModuleIdentifier, Plugin, PluginContext, UsageState,
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
@@ -66,13 +66,14 @@ fn print_exports_info_to_source<F>(
 
   // print the exports
   for export_info in &printed_exports {
-    let export_name: String = export_info
-      .name(module_graph)
+    let info = export_info.as_data(module_graph);
+
+    let export_name: String = ExportInfoGetter::name(info)
       .map(|n| n.to_string())
       .unwrap_or("null".into());
-    let provide_info = export_info.get_provided_info(module_graph);
-    let usage_info = export_info.get_used_info(module_graph);
-    let rename_info = export_info.get_rename_info(module_graph);
+    let provide_info = ExportInfoGetter::get_provided_info(info);
+    let usage_info = ExportInfoGetter::get_used_info(info);
+    let rename_info = ExportInfoGetter::get_rename_info(info);
 
     let target_desc = match export_info.get_target(module_graph) {
       Some(resolve_target) => {
@@ -94,7 +95,7 @@ fn print_exports_info_to_source<F>(
 
     source.add(RawStringSource::from(to_comment_with_nl(&export_str)));
 
-    if let Some(exports_info) = &export_info.exports_info(module_graph) {
+    if let Some(exports_info) = &ExportInfoGetter::exports_info(export_info.as_data(module_graph)) {
       print_exports_info_to_source(
         source,
         &format!("{ident}  "),
@@ -119,10 +120,11 @@ fn print_exports_info_to_source<F>(
 
     if target.is_some()
       || !matches!(
-        other_exports_info.provided(module_graph),
+        ExportInfoGetter::provided(other_exports_info.as_data(module_graph)),
         Some(ExportProvided::NotProvided)
       )
-      || other_exports_info.get_used(module_graph, None) != UsageState::Unused
+      || ExportInfoGetter::get_used(other_exports_info.as_data(module_graph), None)
+        != UsageState::Unused
     {
       let title = if !printed_exports.is_empty() || already_printed_exports > 0 {
         "other exports"
@@ -130,8 +132,9 @@ fn print_exports_info_to_source<F>(
         "exports"
       };
 
-      let provide_info = other_exports_info.get_provided_info(module_graph);
-      let used_info = other_exports_info.get_used_info(module_graph);
+      let provide_info =
+        ExportInfoGetter::get_provided_info(other_exports_info.as_data(module_graph));
+      let used_info = ExportInfoGetter::get_used_info(other_exports_info.as_data(module_graph));
       let target_desc = match target {
         Some(resolve_target) => {
           format!(" -> {}", request_shortener(&resolve_target.module))


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Remove module graph param of getters of export info to make sure the module graph is not sent everywhere

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
