### PR TITLE
feat: warn if using [contenthash] in filenames in development mode

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -544,6 +544,17 @@ const applyOutputDefaults = (
 		futureDefaults: boolean;
 	}
 ) => {
+	// Warn if [contenthash] is used in output.filename in development mode
+	if (
+		development &&
+		typeof output.filename === "string" &&
+		output.filename.includes("[contenthash]")
+	) {
+		console.warn(
+			"[Rspack] Warning: Using [contenthash] in output.filename in development mode will bloat memory. It is recommended to use [name] or [hash] instead."
+		);
+	}
+
 	const getLibraryName = (library: Library): string => {
 		const libraryName =
 			typeof library === "object" &&


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Using [contenthash] in filenames in development mode would bloat memory. Added a warning to the console if `[contenthash]` is added to the filename in development mode.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fixes https://github.com/web-infra-dev/rspack/issues/9513

Gave a shot at implementing the feature. Please let me know if the warning should be added somewhere else in the codebase or if this needs an accompanying documentation update as well. I'd imagine the warning should go somewhere in the output docs as well: https://rspack.rs/config/output

**Update:** I noticed that the warning for this is already documented but it's too far down the page in another section and I just happened to stumble across it as I was reading the docs.

<img width="765" alt="Screenshot 2025-05-31 at 02 26 02" src="https://github.com/user-attachments/assets/32de6122-1e2f-422f-bdac-ca652834a93f" />

IMO it'd be easier to come across this warning if it came earlier in the output.filename docs, right where the usage of contenthash is first suggested:

<img width="765" alt="Screenshot 2025-05-31 at 02 28 02" src="https://github.com/user-attachments/assets/e1214f9b-6bce-406c-9a6c-8e763ed3a275" />

Let me know, I'll move the warning up in the page if it makes sense.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
