### PR TITLE
fix: Narrow the Dev Server Middleware type

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -32,7 +32,7 @@ import type { ExternalObject } from '@rspack/binding';
 import { fs } from 'fs';
 import { default as fs_2 } from 'graceful-fs';
 import { HookMap } from '@rspack/lite-tapable';
-import { IncomingMessage as IncomingMessage_2 } from 'http';
+import { IncomingMessage } from 'http';
 import { inspect } from 'node:util';
 import type { JsAddingRuntimeModule } from '@rspack/binding';
 import type { JsAfterEmitData } from '@rspack/binding';
@@ -85,7 +85,7 @@ import { Server } from 'net';
 import { Server as Server_2 } from 'tls';
 import { Server as Server_3 } from 'http';
 import { ServerOptions as ServerOptions_2 } from 'https';
-import { ServerResponse as ServerResponse_2 } from 'http';
+import { ServerResponse } from 'http';
 import { SourceMapDevToolPluginOptions } from '@rspack/binding';
 import sources = require('../compiled/webpack-sources');
 import { StatSyncFn } from 'fs';
@@ -1808,7 +1808,7 @@ export { Dependency }
 type DependencyLocation = any;
 
 // @public (undocumented)
-type DevMiddlewareContext<RequestInternal extends IncomingMessage = IncomingMessage, ResponseInternal extends ServerResponse = ServerResponse> = {
+type DevMiddlewareContext<RequestInternal extends IncomingMessage_2 = IncomingMessage_2, ResponseInternal extends ServerResponse_2 = ServerResponse_2> = {
     state: boolean;
     stats: Stats | MultiStats | undefined;
     callbacks: Callback_2[];
@@ -1820,7 +1820,7 @@ type DevMiddlewareContext<RequestInternal extends IncomingMessage = IncomingMess
 };
 
 // @public (undocumented)
-type DevMiddlewareOptions<RequestInternal extends IncomingMessage = IncomingMessage, ResponseInternal extends ServerResponse = ServerResponse> = {
+type DevMiddlewareOptions<RequestInternal extends IncomingMessage_2 = IncomingMessage_2, ResponseInternal extends ServerResponse_2 = ServerResponse_2> = {
     mimeTypes?: {
         [key: string]: string;
     } | undefined;
@@ -1848,6 +1848,9 @@ export interface DevServer extends DevServerOptions {
 }
 
 // @public (undocumented)
+export type DevServerMiddleware<RequestInternal extends Request_2 = Request_2, ResponseInternal extends Response_2 = Response_2> = MiddlewareObject<RequestInternal, ResponseInternal> | MiddlewareHandler<RequestInternal, ResponseInternal>;
+
+// @public (undocumented)
 type DevServerOptions<A extends BasicApplication = BasicApplication, S extends BasicServer = Server_3<IncomingMessage, ServerResponse>> = {
     ipc?: string | boolean | undefined;
     host?: string | undefined;
@@ -1870,7 +1873,7 @@ type DevServerOptions<A extends BasicApplication = BasicApplication, S extends B
     client?: boolean | ClientConfiguration | undefined;
     headers?: Headers_2 | ((req: Request_2, res: Response_2, context: DevMiddlewareContext<Request_2, Response_2> | undefined) => Headers_2) | undefined;
     onListening?: ((devServer: Server_4) => void) | undefined;
-    setupMiddlewares?: ((middlewares: Middleware[], devServer: Server_4) => Middleware[]) | undefined;
+    setupMiddlewares?: ((middlewares: DevServerMiddleware[], devServer: Server_4) => DevServerMiddleware[]) | undefined;
 };
 
 // @public
@@ -3249,7 +3252,7 @@ interface ImportNamespaceSpecifier extends Node_4, HasSpan {
 type ImportSpecifier = NamedImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier;
 
 // @public (undocumented)
-type IncomingMessage = IncomingMessage_2;
+type IncomingMessage_2 = IncomingMessage;
 
 // @public
 export type Incremental = {
@@ -4133,7 +4136,7 @@ interface LabeledStatement extends Node_4, HasSpan {
 export type Layer = string | null;
 
 // @public (undocumented)
-const lazyCompilationMiddleware: (compiler: Compiler, userOptions?: LazyCompilationOptions | boolean) => Middleware;
+const lazyCompilationMiddleware: (compiler: Compiler, userOptions?: LazyCompilationOptions | boolean) => DevServerMiddleware;
 
 // @public
 export type LazyCompilationOptions = {
@@ -4626,16 +4629,13 @@ interface MethodProperty extends PropBase, Fn {
 }
 
 // @public (undocumented)
-type Middleware = MiddlewareObject | MiddlewareHandler;
+type MiddlewareHandler<RequestInternal extends Request_2 = Request_2, ResponseInternal extends Response_2 = Response_2> = (req: RequestInternal, res: ResponseInternal, next: NextFunction) => void | Promise<void>;
 
 // @public (undocumented)
-type MiddlewareHandler = any;
-
-// @public (undocumented)
-type MiddlewareObject = {
+type MiddlewareObject<RequestInternal extends Request_2 = Request_2, ResponseInternal extends Response_2 = Response_2> = {
     name?: string;
     path?: string;
-    middleware: MiddlewareHandler;
+    middleware: MiddlewareHandler<RequestInternal, ResponseInternal>;
 };
 
 // @public (undocumented)
@@ -4648,7 +4648,7 @@ type MkdirSync = (path: PathLike, options: MakeDirectoryOptions) => undefined | 
 export type Mode = "development" | "production" | "none";
 
 // @public (undocumented)
-type ModifyResponseData<RequestInternal extends IncomingMessage = IncomingMessage, ResponseInternal extends ServerResponse = ServerResponse> = (req: RequestInternal, res: ResponseInternal, data: Buffer | ReadStream, byteLength: number) => ResponseData;
+type ModifyResponseData<RequestInternal extends IncomingMessage_2 = IncomingMessage_2, ResponseInternal extends ServerResponse_2 = ServerResponse_2> = (req: RequestInternal, res: ResponseInternal, data: Buffer | ReadStream, byteLength: number) => ResponseData;
 
 export { Module }
 
@@ -6016,7 +6016,7 @@ const RemoveDuplicateModulesPlugin: {
 };
 
 // @public (undocumented)
-type Request_2 = IncomingMessage;
+type Request_2 = IncomingMessage_2;
 
 // @public
 export type Resolve = ResolveOptions;
@@ -6121,7 +6121,7 @@ export type ResourceDataWithData = ResourceData & {
 };
 
 // @public (undocumented)
-type Response_2 = ServerResponse;
+type Response_2 = ServerResponse_2;
 
 // @public (undocumented)
 type ResponseData = {
@@ -6587,6 +6587,7 @@ declare namespace rspackExports {
         Watch,
         WatchOptions,
         DevServer,
+        DevServerMiddleware,
         IgnoreWarnings,
         Profile,
         Amd,
@@ -7034,7 +7035,7 @@ type ServerOptions = ServerOptions_2 & {
 };
 
 // @public (undocumented)
-type ServerResponse = ServerResponse_2;
+type ServerResponse_2 = ServerResponse;
 
 // @public (undocumented)
 type ServerType<A extends BasicApplication = BasicApplication, S extends BasicServer = Server_3<IncomingMessage, ServerResponse>> = "http" | "https" | "spdy" | "http2" | string | ((arg0: ServerOptions, arg1: A) => S);

--- a/packages/rspack/src/config/devServer.ts
+++ b/packages/rspack/src/config/devServer.ts
@@ -12,9 +12,9 @@ type Logger = ReturnType<Compiler["getInfrastructureLogger"]>;
 type MultiWatching = MultiCompiler["watch"];
 type BasicServer = import("net").Server | import("tls").Server;
 
-type ReadStream = typeof import("fs").ReadStream;
-type IncomingMessage = typeof import("http").IncomingMessage;
-type ServerResponse = typeof import("http").ServerResponse;
+type ReadStream = import("fs").ReadStream;
+type IncomingMessage = import("http").IncomingMessage;
+type ServerResponse = import("http").ServerResponse;
 type ServerOptions = import("https").ServerOptions & {
 	spdy?: {
 		plain?: boolean | undefined;
@@ -143,7 +143,10 @@ type Static = {
 
 type ServerType<
 	A extends BasicApplication = BasicApplication,
-	S extends BasicServer = import("http").Server<IncomingMessage, ServerResponse>
+	S extends BasicServer = import("http").Server<
+		typeof import("http").IncomingMessage,
+		typeof import("http").ServerResponse
+	>
 > =
 	| "http"
 	| "https"
@@ -154,7 +157,10 @@ type ServerType<
 
 type ServerConfiguration<
 	A extends BasicApplication = BasicApplication,
-	S extends BasicServer = import("http").Server<IncomingMessage, ServerResponse>
+	S extends BasicServer = import("http").Server<
+		typeof import("http").IncomingMessage,
+		typeof import("http").ServerResponse
+	>
 > = {
 	type?: ServerType<A, S> | undefined;
 	options?: ServerOptions | undefined;
@@ -204,7 +210,7 @@ type Server = any;
 
 type MiddlewareHandler<
 	RequestInternal extends Request = Request,
-	ResponseInternal extends Response = Response,
+	ResponseInternal extends Response = Response
 > = (
 	req: RequestInternal,
 	res: ResponseInternal,
@@ -213,7 +219,7 @@ type MiddlewareHandler<
 
 type MiddlewareObject<
 	RequestInternal extends Request = Request,
-	ResponseInternal extends Response = Response,
+	ResponseInternal extends Response = Response
 > = {
 	name?: string;
 	path?: string;
@@ -221,8 +227,10 @@ type MiddlewareObject<
 };
 export type Middleware<
 	RequestInternal extends Request = Request,
-	ResponseInternal extends Response = Response,
-> = MiddlewareObject<RequestInternal, ResponseInternal> | MiddlewareHandler<RequestInternal, ResponseInternal>;
+	ResponseInternal extends Response = Response
+> =
+	| MiddlewareObject<RequestInternal, ResponseInternal>
+	| MiddlewareHandler<RequestInternal, ResponseInternal>;
 
 type OpenApp = {
 	name?: string | undefined;
@@ -259,7 +267,10 @@ type ClientConfiguration = {
 
 export type DevServerOptions<
 	A extends BasicApplication = BasicApplication,
-	S extends BasicServer = import("http").Server<IncomingMessage, ServerResponse>
+	S extends BasicServer = import("http").Server<
+		typeof import("http").IncomingMessage,
+		typeof import("http").ServerResponse
+	>
 > = {
 	ipc?: string | boolean | undefined;
 	host?: string | undefined;

--- a/packages/rspack/src/config/devServer.ts
+++ b/packages/rspack/src/config/devServer.ts
@@ -202,13 +202,28 @@ type DevMiddlewareContext<
 };
 type Server = any;
 
-type MiddlewareHandler = any;
-type MiddlewareObject = {
+type MiddlewareHandler<
+	RequestInternal extends Request = Request,
+	ResponseInternal extends Response = Response,
+> = (
+	req: RequestInternal,
+	res: ResponseInternal,
+	next: NextFunction
+) => void | Promise<void>;
+
+type MiddlewareObject<
+	RequestInternal extends Request = Request,
+	ResponseInternal extends Response = Response,
+> = {
 	name?: string;
 	path?: string;
-	middleware: MiddlewareHandler;
+	middleware: MiddlewareHandler<RequestInternal, ResponseInternal>;
 };
-export type Middleware = MiddlewareObject | MiddlewareHandler;
+export type Middleware<
+	RequestInternal extends Request = Request,
+	ResponseInternal extends Response = Response,
+> = MiddlewareObject<RequestInternal, ResponseInternal> | MiddlewareHandler<RequestInternal, ResponseInternal>;
+
 type OpenApp = {
 	name?: string | undefined;
 	arguments?: string[] | undefined;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2749,6 +2749,8 @@ export type WatchOptions = {
  * Options for devServer, it based on `webpack-dev-server@5`
  * */
 export interface DevServer extends DevServerOptions {}
+
+export type { Middleware as DevServerMiddleware } from "./devServer";
 //#endregion
 
 //#region IgnoreWarnings


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

It will be convenient to have the Dev Server Middleware types exported from the rspack. All our middleware is written in separate modules and annotated with JSDoc types.
By exporting the type, we can ge rid of webpack-dev-server mentions in the annotation and use `import('@rspack/core').DevServerMiddleware` to type the middleware we have.

I have also made an effort to narrow the Middleware type so it is aligned with the one in the webpack-dev-middleware.

(see https://github.com/webpack/webpack-dev-middleware/blob/master/types/index.d.ts#L370)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
