### PR TITLE
fix: module_executor circular check only for internal modules

### DIFF
--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -95,7 +95,7 @@ impl Task<ExecutorTaskContext> for EntryTask {
       let mg = origin_context.artifact.get_module_graph();
       // the module in module executor need to check.
       if mg
-        .module_by_identifier(&meta.origin_module_identifier)
+        .module_graph_module_by_identifier(&meta.origin_module_identifier)
         .is_some()
       {
         execute_task.finish_with_error(

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -92,14 +92,21 @@ impl Task<ExecutorTaskContext> for EntryTask {
     executed_entry_deps.insert(dep_id);
 
     if tracker.is_running(&dep_id) {
-      execute_task.finish_with_error(
-        diagnostic!(
-          "The added task is running, maybe have a circular build dependency. MetaInfo: {:?}",
-          meta
-        )
-        .into(),
-      );
-      return Ok(vec![]);
+      let mg = origin_context.artifact.get_module_graph();
+      // the module in module executor need to check.
+      if mg
+        .module_by_identifier(&meta.origin_module_identifier)
+        .is_some()
+      {
+        execute_task.finish_with_error(
+          diagnostic!(
+            "The added task is running, maybe have a circular build dependency. MetaInfo: {:?}",
+            meta
+          )
+          .into(),
+        );
+        return Ok(vec![]);
+      }
     }
 
     res.extend(tracker.on_entry(is_new, dep_id, Box::new(execute_task)));

--- a/crates/rspack_core/src/compiler/module_executor/module_tracker.rs
+++ b/crates/rspack_core/src/compiler/module_executor/module_tracker.rs
@@ -19,12 +19,12 @@ pub struct ModuleTracker {
   /// If the submodules count is usize::MAX means the module is building.
   unfinished_module: IdentifierMap<usize>,
 
-  /// Entry dependency id to target box task.
+  /// Entry dependency id to target box tasks.
   ///
   /// when entry dependency submodules are built,
-  /// 1. if reused_unfinished_module is empty, return box task directly.
-  /// 2. if reused_unfinished_module is not empty, add box task to pending_callbacks.
-  entry_finish_task: HashMap<DependencyId, BoxTask>,
+  /// 1. if reused_unfinished_module is empty, return box tasks directly.
+  /// 2. if reused_unfinished_module is not empty, add box tasks to pending_callbacks.
+  entry_finish_tasks: HashMap<DependencyId, Vec<BoxTask>>,
 
   /// Reused and unfinished modules.
   ///
@@ -65,7 +65,7 @@ impl ModuleTracker {
     mid: ModuleIdentifier,
   ) -> Vec<BoxTask> {
     let mut queue = VecDeque::from(vec![mid]);
-    let mut tasks = vec![];
+    let mut ready_tasks = vec![];
     let module_graph = context.artifact.get_module_graph();
     while let Some(module_identifier) = queue.pop_front() {
       tracing::debug!("finish build module {:?}", module_identifier);
@@ -88,8 +88,8 @@ impl ModuleTracker {
             let connection = module_graph
               .connection_by_dependency_id(dep_id)
               .expect("should have connection");
-            if let Some(task) = self.entry_finish_task.remove(&connection.dependency_id) {
-              tasks.push(task);
+            if let Some(tasks) = self.entry_finish_tasks.remove(&connection.dependency_id) {
+              ready_tasks.extend(tasks);
             }
           }
         }
@@ -104,7 +104,7 @@ impl ModuleTracker {
       };
     }
 
-    self.calc_runnable_tasks(tasks)
+    self.calc_runnable_tasks(ready_tasks)
   }
 
   /// Set a dependency as finished. Returns runnable box tasks.
@@ -121,8 +121,8 @@ impl ModuleTracker {
   ) -> Vec<BoxTask> {
     let Some(origin_mid) = origin_mid else {
       // entry
-      if let Some(task) = self.entry_finish_task.remove(&dep_id) {
-        return self.calc_runnable_tasks(vec![task]);
+      if let Some(tasks) = self.entry_finish_tasks.remove(&dep_id) {
+        return self.calc_runnable_tasks(tasks);
       }
       return vec![];
     };
@@ -185,24 +185,26 @@ impl ModuleTracker {
 
   /// Handle entry task.
   pub fn on_entry(&mut self, is_new: bool, dep_id: DependencyId, task: BoxTask) -> Vec<BoxTask> {
-    let Entry::Vacant(entry) = self.entry_finish_task.entry(dep_id) else {
-      // Entry task already exist means have circular build dependency.
-      // You should call self.is_running to check this before run on_entry.
-      panic!("The added task is running, maybe have a circular build dependency.",)
-    };
-
-    if is_new {
-      // insert it and wait for it to factorize.
-      entry.insert(task);
-      vec![]
-    } else {
-      // The target module is complete and the task can be run.
-      self.calc_runnable_tasks(vec![task])
+    match self.entry_finish_tasks.entry(dep_id) {
+      Entry::Occupied(mut entry) => {
+        entry.get_mut().push(task);
+        vec![]
+      }
+      Entry::Vacant(entry) => {
+        if is_new {
+          // insert it and wait for it to factorize.
+          entry.insert(vec![task]);
+          vec![]
+        } else {
+          // The target module is complete and the task can be run.
+          self.calc_runnable_tasks(vec![task])
+        }
+      }
     }
   }
 
   /// Check if a dep_id is running
   pub fn is_running(&self, dep_id: &DependencyId) -> bool {
-    self.entry_finish_task.contains_key(dep_id)
+    self.entry_finish_tasks.contains_key(dep_id)
   }
 }

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/cycle-dependency/loader.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/cycle-dependency/loader.js
@@ -1,6 +1,4 @@
-const fs = require("fs");
-
-module.exports = async function (code) {
+module.exports = async function () {
 	const exports = await this.importModule(this.resourcePath, {});
 	return `export default ${exports.add_one(1)}`;
 };

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/multi-import-module/index.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/multi-import-module/index.js
@@ -1,0 +1,5 @@
+import value from "./loader.js!./value";
+
+it("should multi import module works", () => {
+	expect(value).toBe(2);
+});

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/multi-import-module/loader.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/multi-import-module/loader.js
@@ -1,0 +1,9 @@
+module.exports = async function () {
+	const [exports_1, exports_2] = await Promise.all([
+		this.importModule(this.resourcePath, {}),
+		this.importModule(this.resourcePath, {})
+	]);
+
+	const value = exports_1.default + exports_2.default;
+	return `export default ${value}`;
+};

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/multi-import-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/multi-import-module/rspack.config.js
@@ -1,0 +1,7 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		publicPath: "/public/"
+	},
+	entry: "./index.js"
+};

--- a/packages/rspack-test-tools/tests/configCases/loader-import-module/multi-import-module/value.js
+++ b/packages/rspack-test-tools/tests/configCases/loader-import-module/multi-import-module/value.js
@@ -1,0 +1,1 @@
+export default 1;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

LoaderContext.importModule called from the main module graph will not cause a cycle error, so only the inner modules need to be checked.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
