### PR TITLE
docs: clarify `target` default value and browserslist usage

### DIFF
--- a/website/docs/en/config/target.mdx
+++ b/website/docs/en/config/target.mdx
@@ -7,6 +7,7 @@ import WebpackLicense from '@components/WebpackLicense';
 Used to configure the target environment of Rspack output and the ECMAScript version of Rspack runtime code.
 
 - **Type:** `string | string[]`
+- **Default:** `browserslist` if the current project has a browserslist config, otherwise `web`.
 
 ## string
 
@@ -63,7 +64,7 @@ For this case, you can define multiple Rspack configurations for bundling based 
 
 ## browserslist
 
-If a project has a browserslist config, then Rspack will use it for:
+If the current project has a browserslist config, then Rspack will use it for:
 
 - Determinate ES-features that may be used to generate a runtime-code.
 - Infer an environment (e.g: `last 2 node versions` the same as `target: "node"` with some [`output.environment`](/config/output#outputenvironment) settings).
@@ -74,7 +75,7 @@ If a project has a browserslist config, then Rspack will use it for:
 
 Supported browserslist values:
 
-- `browserslist` - use automatically resolved browserslist config and environment (from the nearest `package.json` or `BROWSERSLIST` environment variable, see [browserslist documentation](https://github.com/browserslist/browserslist#queries) for details)
+- `browserslist` - use automatically resolved browserslist config and environment (from the nearest `.browserslistrc` file, `package.json`'s `browserslist` field, or `BROWSERSLIST` environment variable, see [browserslist documentation](https://github.com/browserslist/browserslist#queries) for details)
 - `browserslist:modern` - use `modern` environment from automatically resolved browserslist config
 - `browserslist:last 2 versions` - use an explicit browserslist query (config will be ignored)
 - `browserslist:/path/to/config` - explicitly specify browserslist config

--- a/website/docs/en/config/target.mdx
+++ b/website/docs/en/config/target.mdx
@@ -66,8 +66,8 @@ For this case, you can define multiple Rspack configurations for bundling based 
 
 If the current project has a browserslist config, then Rspack will use it for:
 
-- Determinate ES-features that may be used to generate a runtime-code.
-- Infer an environment (e.g: `last 2 node versions` the same as `target: "node"` with some [`output.environment`](/config/output#outputenvironment) settings).
+- Determinate ES-features that may be used to generate the **Rspack runtime code** (this will not affect the transpilation result of user code).
+- Infer a target environment (e.g: `last 2 node versions` the same as `target: "node"` with some [`output.environment`](/config/output#outputenvironment) settings).
 
 :::tip What is Browserslist
 [Browserslist](https://browsersl.ist/) can specify which browsers your web application can run in, it provides a configuration for specifying browsers range. Browserslist has become a standard in the industry, it is used by libraries such as Autoprefixer, Babel, ESLint, PostCSS, SWC and webpack.

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -7,6 +7,7 @@ import WebpackLicense from '@components/WebpackLicense';
 目标环境与兼容性：该选项用于配置 Rspack 输出产物的目标环境和 Rspack runtime 代码的 ECMAScript 版本。
 
 - **类型：** `string | string[]`
+- **默认值：** 如果当前项目中存在 `browserslist` 配置，则为 `browserslist`，否则为 `web`。
 
 ## string
 
@@ -63,7 +64,7 @@ export default {
 
 ## browserslist
 
-如果一个项目有 browserslist 配置，那么 Rspack 将会使用它：
+如果当前项目存在 browserslist 配置，那么 Rspack 将会使用它：
 
 - 确定可用于运行时代码的 ES 特性。
 - 推断环境（例如：`last 2 node versions` 等价于 `target: node`，并会进行一些 [`output.environment`](/config/output#outputenvironment) 设置).
@@ -74,7 +75,7 @@ export default {
 
 支持的 browserslist 值：
 
-- `browserslist` - 使用自动解析的 browserslist 配置和环境（从最近的 `package.json` 或 `BROWSERSLIST` 环境变量中获取，具体请查阅 [browserslist 文档](https://github.com/browserslist/browserslist#queries)）
+- `browserslist` - 使用自动解析的 browserslist 配置和环境（从最近的 `.browserslistrc` 文件， `package.json` 的 `browserslist` 字段，或 `BROWSERSLIST` 环境变量中获取，具体请查阅 [browserslist 文档](https://github.com/browserslist/browserslist#queries)）
 - `browserslist:modern` - 使用自动解析的 browserslist 配置中的 `modern` 环境
 - `browserslist:last 2 versions` - 使用显式 browserslist 查询（配置将被忽略）
 - `browserslist:/path/to/config` - 明确指定 browserslist 配置路径

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -66,7 +66,7 @@ export default {
 
 如果当前项目存在 browserslist 配置，那么 Rspack 将会使用它：
 
-- 确定可用于 **Rspack 的运行时代码** 的 ES 特性（这不会影响用户代码的转移结果）。
+- 确定可用于 **Rspack 的运行时代码** 的 ES 特性（这不会影响用户代码的转译结果）。
 - 推断目标环境（例如：`last 2 node versions` 等价于 `target: node`，并会进行一些 [`output.environment`](/config/output#outputenvironment) 设置).
 
 :::tip 什么是 Browserslist

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -66,8 +66,8 @@ export default {
 
 如果当前项目存在 browserslist 配置，那么 Rspack 将会使用它：
 
-- 确定可用于运行时代码的 ES 特性。
-- 推断环境（例如：`last 2 node versions` 等价于 `target: node`，并会进行一些 [`output.environment`](/config/output#outputenvironment) 设置).
+- 确定可用于 **Rspack 的运行时代码** 的 ES 特性（这不会影响用户代码的转移结果）。
+- 推断目标环境（例如：`last 2 node versions` 等价于 `target: node`，并会进行一些 [`output.environment`](/config/output#outputenvironment) 设置).
 
 :::tip 什么是 Browserslist
 [Browserslist](https://browsersl.ist/) 可以指定 web 应用能够在哪些浏览器中正常运行，它提供了统一的配置格式，并且已经成为了前端社区中的标准。Browserslist 被 Autoprefixer, Babel, ESLint, PostCSS，SWC 和 webpack 等库所使用。

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -21,6 +21,7 @@ builtinspresetenv
 builtinswc
 bundleless
 Bundleless
+browserslistrc
 bvanjoi
 chakra
 chapple


### PR DESCRIPTION
## Summary

This pull request updates documentation for Rspack's `target` configuration, clarifying the default behavior and supported values for `browserslist`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
