### PR TITLE
perf: use js api to access module.resourceResolveData

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -407,8 +407,8 @@ export declare class RawExternalItemFnCtx {
 }
 
 export declare class ReadonlyResourceData {
-  get descriptionFileData(): any | null
-  get descriptionFilePath(): string | null
+  get descriptionFileData(): any
+  get descriptionFilePath(): string
 }
 
 export declare class Sources {

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -40,7 +40,7 @@ export interface NormalModule extends Module {
 	readonly request: string;
 	readonly userRequest: string;
 	readonly rawRequest: string;
-	readonly resourceResolveData: JsResourceData | undefined;
+	readonly resourceResolveData: Readonly<JsResourceData> | undefined;
 	readonly loaders: JsLoaderItem[];
 	get matchResource(): string | undefined;
 	set matchResource(val: string | undefined);
@@ -404,6 +404,11 @@ export declare class ModuleGraphConnection {
 export declare class RawExternalItemFnCtx {
   data(): RawExternalItemFnCtxData
   getResolver(): JsResolver
+}
+
+export declare class ReadonlyResourceData {
+  get descriptionFileData(): any | null
+  get descriptionFilePath(): string | null
 }
 
 export declare class Sources {

--- a/crates/node_binding/scripts/banner.d.ts
+++ b/crates/node_binding/scripts/banner.d.ts
@@ -40,7 +40,7 @@ export interface NormalModule extends Module {
 	readonly request: string;
 	readonly userRequest: string;
 	readonly rawRequest: string;
-	readonly resourceResolveData: JsResourceData | undefined;
+	readonly resourceResolveData: Readonly<JsResourceData> | undefined;
 	readonly loaders: JsLoaderItem[];
 	get matchResource(): string | undefined;
 	set matchResource(val: string | undefined);

--- a/crates/node_binding/src/module.rs
+++ b/crates/node_binding/src/module.rs
@@ -55,10 +55,7 @@ pub struct Module {
 impl Module {
   pub(crate) fn custom_into_instance(self, env: &Env) -> napi::Result<ClassInstance<Self>> {
     let mut instance = self.into_instance(env)?;
-    // The returned Object's lifetime should be tied to the input Env's lifetime, not the ClassInstance itself.
-    // Fix in: https://github.com/napi-rs/napi-rs/pull/2655
-    let mut object =
-      unsafe { std::mem::transmute::<Object, Object<'static>>(instance.as_object(env)) };
+    let mut object = instance.as_object(env);
     let (_, module) = (*instance).as_ref()?;
 
     #[js_function]

--- a/crates/node_binding/src/modules/macros.rs
+++ b/crates/node_binding/src/modules/macros.rs
@@ -10,10 +10,7 @@ macro_rules! impl_module_methods {
         use napi::bindgen_prelude::{JavaScriptClassExt, JsObjectValue, JsValue};
 
         let mut instance = self.into_instance(env)?;
-        // The returned Object's lifetime should be tied to the input Env's lifetime, not the ClassInstance itself.
-        // Fix in: https://github.com/napi-rs/napi-rs/pull/2655
-        let mut object =
-        unsafe { std::mem::transmute::<napi::bindgen_prelude::Object, napi::bindgen_prelude::Object<'static>>(instance.as_object(env)) };
+        let mut object = instance.as_object(env);
         let (_, module) = instance.module.as_ref()?;
 
         #[js_function]

--- a/crates/node_binding/src/modules/normal_module.rs
+++ b/crates/node_binding/src/modules/normal_module.rs
@@ -4,7 +4,7 @@ use napi::{
 };
 use rspack_core::{parse_resource, ResourceData, ResourceParsedData};
 
-use crate::{impl_module_methods, plugins::JsLoaderItem, JsResourceData, Module};
+use crate::{impl_module_methods, plugins::JsLoaderItem, Module, ReadonlyResourceDataWrapper};
 
 #[napi]
 #[repr(C)]
@@ -31,7 +31,7 @@ impl NormalModule {
     let resource_resolve_data = Object::from_raw(env.raw(), unsafe {
       ToNapiValue::to_napi_value(
         env.raw(),
-        JsResourceData::from(resource_resolved_data.clone()),
+        ReadonlyResourceDataWrapper::from(resource_resolved_data.clone()),
       )?
     });
     let loaders = Object::from_raw(env.raw(), unsafe {

--- a/crates/node_binding/src/resource_data.rs
+++ b/crates/node_binding/src/resource_data.rs
@@ -1,5 +1,77 @@
+use std::sync::Arc;
+
+use napi::{
+  bindgen_prelude::{JavaScriptClassExt, JsObjectValue, ToNapiValue},
+  Env, JsValue, Property,
+};
 use napi_derive::napi;
-use rspack_core::ResourceData;
+
+// Converting the descriptionFileData property to a JSObject may become a performance bottleneck.
+// Additionally, descriptionFileData and descriptionFilePath are rarely used, so they are exposed via getter methods and only converted to JSObject when accessed.
+#[napi]
+pub struct ReadonlyResourceData {
+  i: Arc<rspack_core::ResourceData>,
+}
+
+#[napi]
+impl ReadonlyResourceData {
+  #[napi(getter)]
+  pub fn description_file_data(&self) -> Option<&serde_json::Value> {
+    self.i.resource_description.as_ref().map(|data| data.json())
+  }
+
+  #[napi(getter)]
+  pub fn description_file_path(&self) -> Option<String> {
+    self
+      .i
+      .resource_description
+      .as_ref()
+      .map(|data| data.path().to_string_lossy().to_string())
+  }
+}
+
+pub struct ReadonlyResourceDataWrapper {
+  i: Arc<rspack_core::ResourceData>,
+}
+
+impl ToNapiValue for ReadonlyResourceDataWrapper {
+  unsafe fn to_napi_value(
+    env: napi::sys::napi_env,
+    val: Self,
+  ) -> napi::Result<napi::sys::napi_value> {
+    let env_wrapper = Env::from_raw(env);
+
+    let resource_data = val.i;
+    let mut properties = vec![];
+    let resource = env_wrapper.create_string(&resource_data.resource)?;
+    properties.push(Property::new("resource")?.with_value(&resource));
+    if let Some(path) = &resource_data.resource_path {
+      let path_str = env_wrapper.create_string(path.as_str())?;
+      properties.push(Property::new("path")?.with_value(&path_str));
+    }
+    if let Some(query) = &resource_data.resource_query {
+      let query_str = env_wrapper.create_string(query)?;
+      properties.push(Property::new("query")?.with_value(&query_str));
+    }
+    if let Some(fragment) = &resource_data.resource_fragment {
+      let fragment_str = env_wrapper.create_string(fragment)?;
+      properties.push(Property::new("fragment")?.with_value(&fragment_str));
+    }
+
+    let template = ReadonlyResourceData { i: resource_data };
+    let instance = template.into_instance(&env_wrapper)?;
+    let mut object = instance.as_object(&env_wrapper);
+    object.define_properties(&properties)?;
+
+    Ok(object.raw())
+  }
+}
+
+impl From<Arc<rspack_core::ResourceData>> for ReadonlyResourceDataWrapper {
+  fn from(value: Arc<rspack_core::ResourceData>) -> Self {
+    ReadonlyResourceDataWrapper { i: value }
+  }
+}
 
 #[napi(object)]
 pub struct JsResourceData {
@@ -15,8 +87,8 @@ pub struct JsResourceData {
   pub description_file_path: Option<String>,
 }
 
-impl From<ResourceData> for JsResourceData {
-  fn from(value: ResourceData) -> Self {
+impl From<rspack_core::ResourceData> for JsResourceData {
+  fn from(value: rspack_core::ResourceData) -> Self {
     let (description_file_path, description_file_data) = value
       .resource_description
       .map(|data| data.into_parts())
@@ -32,8 +104,8 @@ impl From<ResourceData> for JsResourceData {
   }
 }
 
-impl From<&ResourceData> for JsResourceData {
-  fn from(value: &ResourceData) -> Self {
+impl From<&rspack_core::ResourceData> for JsResourceData {
+  fn from(value: &rspack_core::ResourceData) -> Self {
     Self {
       resource: value.resource.to_owned(),
       path: value.resource_path.as_ref().map(|p| p.as_str().to_string()),

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -231,7 +231,7 @@ impl NormalModule {
     &mut self.match_resource
   }
 
-  pub fn resource_resolved_data(&self) -> &ResourceData {
+  pub fn resource_resolved_data(&self) -> &Arc<ResourceData> {
     &self.resource_data
   }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Cloning descriptionFileData and converting the descriptionFileData property to a JSObject may become a performance bottleneck.

![image](https://github.com/user-attachments/assets/6e5b4a2c-8cb6-49e6-8f3e-6e2276d0a94d)

New ReadonlyResourceData wrap `Arc<rspack_core::ResourceData>` to avoid clone descriptionFileData.

Additionally, descriptionFileData and descriptionFilePath are rarely used, so they are exposed via getter methods and only converted to JSObject when accessed.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
