### PR TITLE
fix: Add $schema field for the swc config validation

### DIFF
--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -458,6 +458,7 @@ const ZodSwcModuleConfig = z.union([
 ]) satisfies z.ZodType<ModuleConfig>;
 
 export const ZodSwcConfig = z.strictObject({
+	$schema: z.string().optional(),
 	test: z.string().or(z.string().array()).optional(),
 	exclude: z.string().or(z.string().array()).optional(),
 	env: ZodSwcEnvConfig.optional(),


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

According to swc documentation, we are able to narrow the json type for the configuration object.

https://swc.rs/docs/configuration/swcrc

```json
{
  "$schema": "https://swc.rs/schema.json",
}
```

In fact, rspack now throws a validation error

```
- Invalid options of 'builtin:swc-loader': Invalid configuration object. Rspack has been initialized using a configuration object that does not match the API schema.
- Unrecognized key(s) in object: '$schema' at "module.rules[0].oneOf[6]"
```

I suggest fixing the validation schema

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
