### PR TITLE
fix: Use correct tag for canary release

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -104,6 +104,6 @@ jobs:
         run: |
           ./x version snapshot
           pnpm run build:js:canary
-          ./x publish snapshot --tag canary
+          ./x publish snapshot --tag latest
         env:
           NPM_TOKEN: ${{ secrets.RSPACK_CANARY_RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

I have noticed that in the documentation its suggested to use `latest` tag for the rspack-canary packages. But latest released version for the package actually has a `canary` tag. The version by `latest` tag seems to be outdated and not updated anymore.

Because of the alleged inconsistency of documentation and versions tags, I suggest changing the tag in the canary release workflow from `canary` to `latest`.

Alternative would be to update the documentation.

Links:
https://rspack.rs/guide/start/quick-start#install-canary-version

<img width="917" alt="Screenshot 2025-05-31 at 11 35 50" src="https://github.com/user-attachments/assets/8366d399-fe02-4e43-9408-225a5382396e" />

https://www.npmjs.com/package/@rspack-canary/core?activeTab=versions

<img width="816" alt="Screenshot 2025-05-31 at 11 37 40" src="https://github.com/user-attachments/assets/1790239c-2af9-42fa-9232-d8a0c8f4b746" />


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
