### PR TITLE
chore: Enable no-embed-metadata

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -65,3 +65,7 @@ rustflags = ["-C", "target-feature=+crt-static"]
 rustflags = ["-C", "target-feature=+crt-static"]
 [target.aarch64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+# This must be the last line to allow ci script to append flags
+[unstable]
+no-embed-metadata = true

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -58,7 +58,6 @@ jobs:
       - name: Trim paths
         run: |
           echo $'\n' >> .cargo/config.toml
-          echo '[unstable]' >> .cargo/config.toml
           echo 'trim-paths = true' >> .cargo/config.toml
 
       # Fix: Resolve disk space error "ENOSPC: no space left on device" on GitHub Actions runners


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

see https://kobzol.github.io/rust/rustc/2025/06/02/reduce-cargo-target-dir-size-with-z-no-embed-metadata.html

This reduced 700M in a fresh profiling build.

before:
```
4.3G ┌─┴ target
```

after:
```
3.6G ┌─┴ target
``` 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
