### PR TITLE
chore: bump swc version to 26.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.24",
+ "semver",
  "serde",
  "serde_json",
  "thiserror 2.0.9",
@@ -1740,9 +1740,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1851,7 +1851,7 @@ checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version 0.4.1",
+ "rustc_version",
  "spin",
  "stable_deref_trait",
 ]
@@ -1893,7 +1893,7 @@ dependencies = [
  "new_debug_unreachable",
  "once_cell",
  "phf",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "triomphe",
 ]
 
@@ -2794,7 +2794,7 @@ dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
  "quote",
- "semver 1.0.24",
+ "semver",
  "syn 2.0.95",
 ]
 
@@ -3115,7 +3115,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "static-self",
@@ -3414,8 +3414,8 @@ dependencies = [
  "dashmap 5.5.3",
  "from_variant",
  "once_cell",
- "rustc-hash 2.1.0",
- "semver 1.0.24",
+ "rustc-hash 2.1.1",
+ "semver",
  "serde",
  "st-map",
  "tracing",
@@ -3553,7 +3553,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.9",
@@ -3572,7 +3572,7 @@ dependencies = [
  "getrandom 0.3.2",
  "rand 0.9.1",
  "ring",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4035,7 +4035,7 @@ dependencies = [
  "rspack_plugin_wasm",
  "rspack_plugin_worker",
  "rspack_regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "tokio",
 ]
@@ -4121,7 +4121,7 @@ dependencies = [
  "rspack_cacheable",
  "rspack_resolver",
  "rspack_sources",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "swc_core",
  "ustr-fxhash",
@@ -4189,7 +4189,7 @@ dependencies = [
  "rspack_sources",
  "rspack_storage",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "scopeguard",
  "serde",
  "serde_json",
@@ -4270,7 +4270,7 @@ dependencies = [
  "async-trait",
  "rspack_error",
  "rspack_macros",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -4286,7 +4286,7 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -4303,7 +4303,7 @@ dependencies = [
  "rspack_error",
  "rspack_sources",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "stacker",
@@ -4377,7 +4377,7 @@ dependencies = [
  "rspack_paths",
  "rspack_sources",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "tokio",
  "tracing",
@@ -4397,7 +4397,7 @@ dependencies = [
  "rspack_javascript_compiler",
  "rspack_loader_runner",
  "rspack_swc_plugin_import",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "stacker",
@@ -4553,7 +4553,7 @@ dependencies = [
  "rspack_regex",
  "rspack_tracing",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "swc_core",
@@ -4617,7 +4617,7 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -4630,7 +4630,7 @@ dependencies = [
  "rspack_hook",
  "rspack_paths",
  "rspack_regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -4649,7 +4649,7 @@ dependencies = [
  "rspack_hash",
  "rspack_hook",
  "rspack_paths",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "sugar_path",
  "tokio",
  "tracing",
@@ -4676,7 +4676,7 @@ dependencies = [
  "rspack_hook",
  "rspack_plugin_runtime",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "tokio",
  "tracing",
@@ -4718,7 +4718,7 @@ dependencies = [
  "rspack_hook",
  "rspack_plugin_javascript",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "simd-json",
  "sugar_path",
  "tracing",
@@ -4738,7 +4738,7 @@ dependencies = [
  "rspack_paths",
  "rspack_plugin_externals",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "tracing",
@@ -4765,7 +4765,7 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hook",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -4810,7 +4810,7 @@ dependencies = [
  "rspack_plugin_javascript",
  "rspack_plugin_runtime",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "tokio",
@@ -4833,7 +4833,7 @@ dependencies = [
  "rspack_plugin_css",
  "rspack_plugin_javascript",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "tokio",
  "tracing",
@@ -4913,10 +4913,11 @@ dependencies = [
  "rspack_paths",
  "rspack_regex",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "sugar_path",
  "swc_core",
+ "swc_ecma_lexer",
  "swc_node_comments",
  "tracing",
  "url",
@@ -4950,7 +4951,7 @@ dependencies = [
  "rspack_plugin_javascript",
  "rspack_regex",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tokio",
  "tracing",
 ]
@@ -4969,7 +4970,7 @@ dependencies = [
  "rspack_hash",
  "rspack_hook",
  "rspack_plugin_javascript",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "swc_core",
  "tracing",
@@ -5011,7 +5012,7 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hook",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -5032,7 +5033,7 @@ dependencies = [
  "rspack_loader_runner",
  "rspack_plugin_runtime",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "tokio",
@@ -5053,7 +5054,7 @@ dependencies = [
  "rspack_hook",
  "rspack_plugin_css",
  "rspack_plugin_javascript",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -5097,7 +5098,7 @@ dependencies = [
  "rspack_hash",
  "rspack_hook",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -5108,7 +5109,7 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hook",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -5138,7 +5139,7 @@ dependencies = [
  "rspack_hook",
  "rspack_paths",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tokio",
  "tracing",
 ]
@@ -5176,7 +5177,7 @@ dependencies = [
  "rspack_hook",
  "rspack_plugin_javascript",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "tokio",
  "tracing",
@@ -5248,7 +5249,7 @@ dependencies = [
  "rspack_hook",
  "rspack_regex",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -5278,7 +5279,7 @@ dependencies = [
  "rspack_plugin_real_content_hash",
  "rspack_plugin_runtime",
  "rspack_util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "sha2",
  "tokio",
@@ -5317,7 +5318,7 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hook",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -5389,7 +5390,7 @@ dependencies = [
  "indexmap 2.7.1",
  "json-strip-comments",
  "pnp",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5407,7 +5408,7 @@ dependencies = [
  "dyn-clone",
  "itertools 0.13.0",
  "memchr",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "simd-json",
@@ -5426,7 +5427,7 @@ dependencies = [
  "rspack_error",
  "rspack_fs",
  "rspack_paths",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "tokio",
  "tracing",
 ]
@@ -5438,7 +5439,7 @@ dependencies = [
  "cow-utils",
  "handlebars",
  "heck 0.5.0",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "swc_core",
 ]
@@ -5476,7 +5477,7 @@ dependencies = [
  "rspack_cacheable",
  "rspack_paths",
  "rspack_regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sugar_path",
@@ -5499,18 +5500,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -5518,7 +5510,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.24",
+ "semver",
 ]
 
 [[package]]
@@ -5723,27 +5715,12 @@ checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -6038,17 +6015,16 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "9.1.2"
+version = "9.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c4ea7042fd1a155ad95335b5d505ab00d5124ea0332a06c8390d200bb1a76a"
+checksum = "bdee719193ae5c919a3ee43f64c2c0dd87f9b9a451d67918a2a5ec2e3c70561c"
 dependencies = [
- "base64-simd 0.7.0",
+ "base64-simd 0.8.0",
  "bitvec",
  "data-encoding",
  "debugid",
  "if_chain",
- "rustc-hash 1.1.0",
- "rustc_version 0.2.3",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "unicode-id-start",
@@ -6197,9 +6173,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "swc"
-version = "22.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c62891c5429818ccfd614cc1e6023ca005a8a893ef47a18c4620d5f1bf4e8e"
+checksum = "707e7a089761c5f4661765cc38b689d795d67bb0810782cdece3997cd03a6e94"
 dependencies = [
  "anyhow",
  "base64",
@@ -6214,12 +6190,11 @@ dependencies = [
  "parking_lot",
  "pathdiff",
  "regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sourcemap",
  "swc_atoms",
- "swc_cached",
  "swc_common",
  "swc_compiler_base",
  "swc_config",
@@ -6260,7 +6235,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.14.5",
  "ptr_meta 0.3.0",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "triomphe",
 ]
 
@@ -6275,29 +6250,15 @@ dependencies = [
  "once_cell",
  "rancor",
  "rkyv 0.8.8",
- "rustc-hash 2.1.0",
- "serde",
-]
-
-[[package]]
-name = "swc_cached"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7133338c3bef796430deced151b0eaa5430710a90e38da19e8e3045e8e36eeb"
-dependencies = [
- "anyhow",
- "dashmap 5.5.3",
- "once_cell",
- "regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
 [[package]]
 name = "swc_common"
-version = "9.1.0"
+version = "11.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d8a9a267de961d9ff62ef1edabb05a8e71543b5fdcc0fa43e7a247ea66c88"
+checksum = "d4a057a154061e6af54d037b5366f0776033e57ee07bf710dfb88d2677d08eea"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -6312,7 +6273,7 @@ dependencies = [
  "parking_lot",
  "rancor",
  "rkyv 0.8.8",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "siphasher",
  "sourcemap",
@@ -6327,15 +6288,15 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "19.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac447d455ed338b84dcd914e790525a12a2a2f91173359e5ac7d62b4915af39"
+checksum = "3aef98ee955eac3339cb3a8152c64746196bd14919b41afdf2cc410c06e6cfee"
 dependencies = [
  "anyhow",
  "base64",
  "once_cell",
  "pathdiff",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sourcemap",
@@ -6353,16 +6314,20 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb63364aebd1a8490a80fa8933825c6916d4df55d5472312d5adb62c9fb4e4ba"
+checksum = "a01bfcbbdea182bdda93713aeecd997749ae324686bf7944f54d128e56be4ea9"
 dependencies = [
  "anyhow",
+ "dashmap 5.5.3",
+ "globset",
  "indexmap 2.7.1",
+ "once_cell",
+ "regex",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sourcemap",
- "swc_cached",
  "swc_config_macro",
 ]
 
@@ -6380,9 +6345,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "23.2.0"
+version = "26.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd11a6fb068925bcb493d68ec6f1f35fb28c0bd9052071d22e49d4d60fae8916"
+checksum = "395a4d94afc37599de55c25be87fb3c6e53e1e8204f3de98e77e017b76f8733e"
 dependencies = [
  "par-core",
  "swc",
@@ -6409,9 +6374,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0613d84468a6bb6d45d13c5a3368b37bd21f3067a089f69adac630dcb462a018"
+checksum = "d2313360a518a37c4b9ee50030d189222927a3af902903cc70c50f6929e402dc"
 dependencies = [
  "bitflags 2.9.1",
  "bytecheck 0.8.0",
@@ -6421,7 +6386,7 @@ dependencies = [
  "phf",
  "rancor",
  "rkyv 0.8.8",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "scoped-tls",
  "serde",
  "string_enum",
@@ -6433,9 +6398,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "11.0.0"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01b3de365a86b8f982cc162f257c82f84bda31d61084174a3be37e8ab15c0f4"
+checksum = "005b9e6e4cdd15c4c437d6662e4fc6dc93f60bd1c5159a1afcf6cd9eea6fb24f"
 dependencies = [
  "ascii",
  "compact_str",
@@ -6443,7 +6408,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
+ "ryu-js",
  "serde",
  "sourcemap",
  "swc_allocator",
@@ -6468,11 +6434,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "13.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff1612d4d90df938533b5308634be1228c6bf14d7141c9f7787c99b5b26f4cc"
+checksum = "842e35f35bb7732f35b885c906e93183817d76e167234ab45948bf7cfc856804"
 dependencies = [
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -6486,9 +6452,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611db1605bff05603aacaf5e14f58cf2339991cceef03817bb8ed19010d10506"
+checksum = "ed5d027ec8260c28031723a13d30f12793f0f1cdb1f64133c4da32891e5058e8"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6499,14 +6465,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "13.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2cf0263f34234cfcebde0545e4ed017e1b2b5667792c6902319d75df03110"
+checksum = "073fd6f4f2fe6e5929056fab53d1ce188818b81b7008904bc7f932efa3348717"
 dependencies = [
  "arrayvec",
  "indexmap 2.7.1",
  "is-macro",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_derive",
  "smallvec",
@@ -6526,9 +6492,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c8cce4b0b0acfa156c235eca429d1bbffe3297cb48cd61578908ddcc5a8899"
+checksum = "6f53fcada063eba1c278e829a8b9ec024408c5bad526171b0cb96c77bf9c533b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6543,9 +6509,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da9ff1172f67c8792b73d97a9c578e7de44b3af7a60991ce87145cf7f5372c8"
+checksum = "5d9a8e0589b8933b4e2de95a787b33e6ef91371c5a85f9d73c5870ac546fc6b7"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6561,9 +6527,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544ef337a40dfa7f3fe7b4c7e65bba99057258f3ecee79fa9052eac59f502b97"
+checksum = "eb69df2828e6d00ca815d66fd1e609e64683abf705dcc46b195fbc7353cabe89"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6580,9 +6546,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e116fb7a5a50251947160862c52596bdd2d8c417a1f9b8eb061d83bdfc699272"
+checksum = "a71abfad6a3a6093098f46e68e026d132ca15906fed912b0912f561a1cbd67f5"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6596,9 +6562,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "14.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e858e1fc3d5a4299a81ca25028f8a01feca8f1876db6d2e19bbe5a8bac39c8a"
+checksum = "73b226871c16b8f4e3914c1dff2e8c93626fbc6a6bfeb3fb598f941d04890e20"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6614,9 +6580,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba25f8d0c7f915525abe4f2efde17c7f04ecd7a1500acc82a36133bef7b9f60"
+checksum = "2f79df9e55b7c3fd29e4116fc6ef1e0155c86fe64fa6a91d357469501d574ef2"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6630,11 +6596,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "14.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c412ba2452b20fdcb791448c6606ba43fa84f80e23b0b2fef0cc9ee02794d12c"
+checksum = "6a7749e111ac8251708d6067dc20d0a9399dd7d8e3cd75a18d309830575064d1"
 dependencies = [
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -6650,9 +6616,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059c8b419ce4a2e432ec1520dde77db3b8f45df552bf0b6bd974d8516986c9eb"
+checksum = "ecfb2f4d16cd2459bdae7a12a0c3258bb53d63d97c0bbff50dade9c3f324c634"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6665,9 +6631,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9adc21155b19e21ee6c304015f9ef1a8af41ee3123b849af02c708f33dea69"
+checksum = "1db3a2e81be5e12bf58f53a9217791e695bb79e43e6e9e0b63be602c048f0451"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -6679,9 +6645,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lexer"
-version = "12.0.0"
+version = "14.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d11c8e71901401b9aae2ece4946eeb7674b14b8301a53768afbbeeb0e48b599"
+checksum = "b29306eb443a376e2389c31859c4ef3592bd1a6c9473408678717129f7e62b66"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
@@ -6690,7 +6656,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "phf",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "smartstring",
@@ -6704,16 +6670,16 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "13.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10710ebbe155fd07b5be28a6af80c6f46c6385feeb3f6b3033d1d5d93b885312"
+checksum = "daf720184ed1f84a61a34df1c9d73be0931a8184a7ed6af67ad8f5f1bbec3881"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
  "par-core",
  "parking_lot",
  "regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
  "swc_common",
@@ -6725,9 +6691,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb574d660c05f3483c984107452b386e45b95531bdb1253794077edc986f413"
+checksum = "209c6a8a5ca19c9b24daf598debb4f2fa57bf21a3bd76046d9791b7f2a0b0c93"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -6737,20 +6703,19 @@ dependencies = [
  "parking_lot",
  "path-clean 0.1.0",
  "pathdiff",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_cached",
  "swc_common",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "17.0.0"
+version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca0ad5b72d8b440e701d47f544a728543414f6f165c6c61a899a76d3c7fdf9d"
+checksum = "5c43654113e9a75edf05fbe2c66b5232e149f563c97bef58ff1a896daa288092"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
@@ -6764,7 +6729,7 @@ dependencies = [
  "phf",
  "radix_fmt",
  "regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "serde_json",
@@ -6786,9 +6751,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "12.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250786944fbc05f6484eda9213df129ccfe17226ae9ad51b62fce2f72135dbee"
+checksum = "8b59cd2d4c1989c38eae5cd5888f3a3120ecbe2e53b939e586d340b12de7c1e2"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
@@ -6797,7 +6762,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "phf",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "smartstring",
@@ -6812,17 +6777,17 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "17.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551d1b1d3f27e9525b001fba9afd06294a5eaf8a8a9aff85da458a51e790ca1c"
+checksum = "e8f94ea6dfa4daf55a08e210cbc213b5758b6bc92a929a3af75f478c8b0253cf"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
  "indexmap 2.7.1",
  "once_cell",
  "preset_env_base",
- "rustc-hash 2.1.0",
- "semver 1.0.24",
+ "rustc-hash 2.1.1",
+ "semver",
  "serde",
  "serde_json",
  "st-map",
@@ -6837,14 +6802,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "12.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3221879cd18131a3946f8f29d181fe239b58b6595ccefa7263a9395ad4b5e575"
+checksum = "3f755b824a30c6b70dba267077f4e2471d2a6e440623dc8e399ff27f59759a5a"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -6855,9 +6820,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "16.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2813bad599d24b1aeba4c90891703a046d86b681b003863673f2b418dff185"
+checksum = "82f91c0e075315f1e745f65888e135ff05e3d16b6c6393c70dc9fb2c944b40fe"
 dependencies = [
  "par-core",
  "swc_atoms",
@@ -6876,9 +6841,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "13.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6856da3da598f4da001b7e4ce225ee8970bc9d5cbaafcaf580190cf0a6031ec5"
+checksum = "bb01eeec1de9e2cfd089e3afcf3db60df10c812f97a42d953d094eba32e9d26f"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.9.1",
@@ -6887,7 +6852,7 @@ dependencies = [
  "par-core",
  "phf",
  "rayon",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "swc_atoms",
@@ -6901,9 +6866,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f84248f82bad599d250bbcd52cb4db6ff6409f48267fd6f001302a2e9716f80"
+checksum = "1c30a47eb83be77705a16103918db015a409a45e158a490697d8419a6f92151a"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6915,9 +6880,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "14.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012cd84fcc6c6fab718a177a3ffc360332d6bad29dbe19699be2ccbaba91e712"
+checksum = "4ab71af00c78903335fc2ac0ad4308e6729b6be60e47393a36357fb20ffbb612"
 dependencies = [
  "arrayvec",
  "indexmap 2.7.1",
@@ -6964,9 +6929,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "14.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4653a46bffad40875469a0b75f0b9c8f1e019ca7014a45e876c3a10aadd58721"
+checksum = "bc169d2f3e52ab9619aff70b97b6f9db7b96feec8112454df3dd7d134f34078a"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6976,11 +6941,11 @@ dependencies = [
  "path-clean 1.0.1",
  "pathdiff",
  "regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_cached",
  "swc_common",
+ "swc_config",
  "swc_ecma_ast",
  "swc_ecma_loader",
  "swc_ecma_parser",
@@ -6992,9 +6957,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "13.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5874d0c808f0e658882edf00fef3d206f01a22781c48ca9b1795cf025cc9650"
+checksum = "1e184bf675c5c9111e1b155e49fc267bc2971b732ac22d80887cc46973a782b7"
 dependencies = [
  "dashmap 5.5.3",
  "indexmap 2.7.1",
@@ -7002,7 +6967,7 @@ dependencies = [
  "par-core",
  "petgraph 0.7.1",
  "rayon",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde_json",
  "swc_atoms",
  "swc_common",
@@ -7017,12 +6982,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193237e318421ef621c2b3958b4db174770c5280ef999f1878f2df93a2837ca6"
+checksum = "f21a20e2231143fe4aacecf2f1957c80bca8096ebe52f27e6e5624a49a2a385d"
 dependencies = [
  "either",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "swc_atoms",
@@ -7037,15 +7002,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "14.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17564ef28b1183a5d79f890066f11aba4563f390708cb03a6738cbc24799210"
+checksum = "a3f141582d19aa9679ecfc811bc72cb8ef24290bc1e53ba208445ff5d5745f2b"
 dependencies = [
  "base64",
  "dashmap 5.5.3",
  "indexmap 2.7.1",
  "once_cell",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "sha1",
  "string_enum",
@@ -7063,12 +7028,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "14.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a647a99548ead69e5e87cf2b7caa7921e8a81e252e13e3180c3101a1d911fa6b"
+checksum = "5af18b9b3f38cf775b9dcf46f0fdbde542d6559e5759799263ef0f76563fcd9b"
 dependencies = [
  "once_cell",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "swc_atoms",
@@ -7082,13 +7047,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "14.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7858f1eccac3c8a85b97ba3820020583efa28bc766d253f0a93d7bbc54c985"
+checksum = "f4061a34574b9431c94c21519948ad4421d7b28479a1a78bb94b878c67d9fac9"
 dependencies = [
  "bitflags 2.9.1",
  "indexmap 2.7.1",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -7100,9 +7065,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "13.0.0"
+version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6ecf7485a130df25c4ba4e27cfde0cc7bf45f453f40cf0c52eb69b3a4235d0"
+checksum = "199e2f048c1998d550ebe5296e0876a3e5b2f963d75a925c2208466071edb9d8"
 dependencies = [
  "indexmap 2.7.1",
  "num_cpus",
@@ -7110,7 +7075,7 @@ dependencies = [
  "par-core",
  "par-iter",
  "rayon",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "ryu-js",
  "swc_atoms",
  "swc_common",
@@ -7122,9 +7087,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249dc9eede1a4ad59a038f9cfd61ce67845bd2c1392ade3586d714e7181f3c1a"
+checksum = "8227d1d2d76a9ccfd190ec06bb4a4720bf3edb9f954c69816b2bca5f5aa43887"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -7148,9 +7113,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "11.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5be5f151485ec9372c23bbb132c4a829c879632db8b790439779b873970be"
+checksum = "572075b92eef780f9a13b99abcb4fbf8e6272abeed27b361632b5e3a2e8de70d"
 dependencies = [
  "anyhow",
  "miette",
@@ -7164,9 +7129,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html"
-version = "17.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8bc27ad32be9f7544004b24244af0953109f8cd36b948b00b936094903cb0b9"
+checksum = "7246397da37cfe250a88e6dc03bca27bac52388c1943844a3fbfcb7deba506ce"
 dependencies = [
  "swc_html_ast",
  "swc_html_codegen",
@@ -7176,9 +7141,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_ast"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8a2b70702c289d86218a6b08d3d3832d4c1a0372a2c32ec7a4ab58872e6d8e"
+checksum = "5cf011d422c327fe895a11748459c6b7f87a1fe2be3b8ddf88ff1b8a387bcfa0"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -7188,13 +7153,13 @@ dependencies = [
 
 [[package]]
 name = "swc_html_codegen"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9d3601b31a2a9b6ffc5bb97561a172b28adb62b0ae11e8c2165edd16bc1ad5"
+checksum = "ebb539cb7801958fa9830e191ea287c44763fb28f2ffd1c03f680682dbfca005"
 dependencies = [
  "auto_impl",
  "bitflags 2.9.1",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
  "swc_html_ast",
@@ -7216,17 +7181,17 @@ dependencies = [
 
 [[package]]
 name = "swc_html_minifier"
-version = "17.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185b629f67bfe9d3952a248152462ae3b98d7e6295b687e3724712eb4db1cc4f"
+checksum = "c09e7b1f35254c3d9fb0dc4ff10a8e5078f8d49c52be41724f144fb5a2189e1c"
 dependencies = [
  "once_cell",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_cached",
  "swc_common",
+ "swc_config",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_minifier",
@@ -7242,11 +7207,11 @@ dependencies = [
 
 [[package]]
 name = "swc_html_parser"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343b47e824ac6eea458c14b191f97ce353cf3f66c2a1cb77e630e81404460e9f"
+checksum = "8d61db194416b3bb8c3b6d83594a7879744c3c0e39cfea4857a9828ad928733a"
 dependencies = [
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
  "swc_html_ast",
@@ -7255,12 +7220,12 @@ dependencies = [
 
 [[package]]
 name = "swc_html_utils"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb0be1e55563de2d6de3a01f08826490076334adbc2c837aec1fb5fc93085c6"
+checksum = "e7e20f7a34bd591c5ccd3dadc03fd604de4d553375c54b5bd1908561e6d7306f"
 dependencies = [
  "once_cell",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "swc_atoms",
@@ -7269,9 +7234,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_visit"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eb81e6a4c19617ec82077c97123aae9e5d29b5dc5d7b09f38f92b921f33740"
+checksum = "d69629a92e1f71bf078506e1cc2298678d69bdc6e89e582fbaf8139d7be65310"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7293,27 +7258,27 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9ded5a3355c56eb1148491c70bd4f85f7fcb706d40c0a86a67260cbcb560c3"
+checksum = "c75011be56778fa9d67fce20853b9a00f46484bfaef230e8098c08ad9caf8dc7"
 dependencies = [
  "dashmap 5.5.3",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
 ]
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbd6dddc6f98f7ded495b918c80bc59c78d9b297ed98081e22def0f27a117f9"
+checksum = "ab1281343dca1fe02aa027e2dfdf77067e62506e77b651e3e9c1a4e3fa8bccf6"
 dependencies = [
  "better_scoped_tls",
  "bytecheck 0.8.0",
  "rancor",
  "rkyv 0.8.8",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "swc_common",
  "swc_ecma_ast",
  "swc_trace_macro",
@@ -7322,16 +7287,16 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "11.1.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397ed07e0a652da33372327862d8fb977176b21f903a9f90ed0885ca847844b5"
+checksum = "4802311e7168c171b047c28335603e8969e62ba4d75c0c607b53e77fbcb1a9aa"
 dependencies = [
  "anyhow",
  "enumset",
  "futures",
  "once_cell",
  "parking_lot",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "swc_atoms",
@@ -7371,13 +7336,13 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "3.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d73c21cecc518e0107f890012a747fa679cb0faf04f32fc8f5bd618040eb8fe"
+checksum = "3be97f7341c59045d8ecbd5579acad8063e545d10304db086846b9dcf985c56e"
 dependencies = [
  "better_scoped_tls",
  "once_cell",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "swc_common",
@@ -7385,13 +7350,13 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "12.0.0"
+version = "14.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c01b8c9b645f4b3b39664477166876bdc239c9b5f785389e117dee822dbcec5"
+checksum = "18cd2a925ff8cf74f64a2efe3aaf9b63bfc5458b62620878a9444b2b18cf5fc4"
 dependencies = [
  "bitflags 2.9.1",
  "petgraph 0.7.1",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -8045,7 +8010,7 @@ dependencies = [
  "byteorder",
  "lazy_static",
  "parking_lot",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -8550,7 +8515,7 @@ dependencies = [
  "hex",
  "indexmap 2.7.1",
  "schemars",
- "semver 1.0.24",
+ "semver",
  "serde",
  "serde_json",
  "serde_yml",
@@ -8573,7 +8538,7 @@ dependencies = [
  "indexmap 2.7.1",
  "saffron",
  "schemars",
- "semver 1.0.24",
+ "semver",
  "serde",
  "serde_json",
  "serde_yml",
@@ -8634,7 +8599,7 @@ dependencies = [
  "ciborium",
  "flate2",
  "insta",
- "semver 1.0.24",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -8661,7 +8626,7 @@ dependencies = [
  "flate2",
  "ignore",
  "insta",
- "semver 1.0.24",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -8759,7 +8724,7 @@ dependencies = [
  "reqwest",
  "rkyv 0.8.8",
  "rusty_pool",
- "semver 1.0.24",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -8825,7 +8790,7 @@ dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.2",
  "indexmap 2.7.1",
- "semver 1.0.24",
+ "semver",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,14 +98,15 @@ rkyv      = { version = "=0.8.8" }
 
 # Must be pinned with the same swc versions
 pnp                 = { version = "0.9.0" }
-swc                 = { version = "=22.0.0" }
-swc_config          = { version = "=2.0.0" }
-swc_core            = { version = "=23.2.0", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "=17.0.0", default-features = false }
-swc_error_reporters = { version = "=11.0.0" }
-swc_html            = { version = "=17.0.0" }
-swc_html_minifier   = { version = "=17.0.0", default-features = false }
-swc_node_comments   = { version = "=9.0.0" }
+swc                 = { version = "=25.0.0" }
+swc_config          = { version = "=3.0.0" }
+swc_core            = { version = "=26.3.4", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_lexer      = { version = "=14.0.4" }
+swc_ecma_minifier   = { version = "=20.0.3", default-features = false }
+swc_error_reporters = { version = "=13.0.0" }
+swc_html            = { version = "=20.0.0" }
+swc_html_minifier   = { version = "=20.0.0", default-features = false }
+swc_node_comments   = { version = "=11.0.0" }
 
 rspack_dojang = { version = "0.1.11" }
 

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1342,6 +1342,14 @@ CompilerOptions {
         parser: Some(
             ParserOptionsMap(
                 {
+                    "json": Json(
+                        JsonParserOptions {
+                            exports_depth: Some(
+                                4294967295,
+                            ),
+                            parse: ParseOption::None,
+                        },
+                    ),
                     "asset": Asset(
                         AssetParserOptions {
                             data_url_condition: Some(
@@ -1409,14 +1417,6 @@ CompilerOptions {
                             import_dynamic: Some(
                                 true,
                             ),
-                        },
-                    ),
-                    "json": Json(
-                        JsonParserOptions {
-                            exports_depth: Some(
-                                4294967295,
-                            ),
-                            parse: ParseOption::None,
                         },
                     ),
                 },

--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -166,7 +166,7 @@ impl JavaScriptCompiler {
 
     let map = if source_map_config.enable {
       let combined_source_map =
-        source_map.build_source_map_with_config(&src_map_buf, input_source_map, source_map_config);
+        source_map.build_source_map(&src_map_buf, input_source_map.cloned(), source_map_config);
 
       let mappings = encode_mappings(combined_source_map.tokens().map(|token| Mapping {
         generated_line: token.get_dst_line() + 1,

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -19,7 +19,7 @@ use jsonc_parser::parse_to_serde_value;
 use rspack_error::{miette::MietteDiagnostic, AnyhowResultToRspackResultExt, Error};
 use rspack_util::{itoa, source_map::SourceMapKind, swc::minify_file_comments};
 use serde_json::error::Category;
-use swc_config::{merge::Merge, IsModule};
+use swc_config::{is_module::IsModule, merge::Merge};
 pub use swc_core::base::config::Options as SwcOptions;
 use swc_core::{
   base::{
@@ -404,6 +404,7 @@ impl<'a> JavaScriptTransformer<'a> {
           self.options.output_path.as_deref(),
           self.options.source_root.clone(),
           self.options.source_file_name.clone(),
+          self.config.source_map_ignore_list.clone(),
           handler,
           Some(self.config.clone()),
           Some(&self.comments),

--- a/crates/rspack_javascript_compiler/src/error.rs
+++ b/crates/rspack_javascript_compiler/src/error.rs
@@ -22,12 +22,6 @@ pub struct ErrorSpan {
   pub end: u32,
 }
 
-impl ErrorSpan {
-  pub fn new(start: u32, end: u32) -> Self {
-    Self { start, end }
-  }
-}
-
 impl From<Span> for ErrorSpan {
   fn from(span: Span) -> Self {
     Self {

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -14,7 +14,7 @@ use rspack_core::{Mode, RunnerContext};
 use rspack_error::{miette, Diagnostic, Result};
 use rspack_javascript_compiler::{JavaScriptCompiler, TransformOutput};
 use rspack_loader_runner::{Identifiable, Identifier, Loader, LoaderContext};
-use swc_config::{config_types::MergingOption, merge::Merge};
+use swc_config::{merge::Merge, types::MergingOption};
 use swc_core::{
   base::config::{InputSourceMap, TransformConfig},
   common::FileName,

--- a/crates/rspack_loader_swc/src/options.rs
+++ b/crates/rspack_loader_swc/src/options.rs
@@ -4,7 +4,7 @@ use rspack_cacheable::{
 };
 use rspack_swc_plugin_import::{ImportOptions, RawImportOptions};
 use serde::Deserialize;
-use swc_config::config_types::BoolConfig;
+use swc_config::{file_pattern::FilePattern, types::BoolConfig};
 use swc_core::base::config::{
   Config, ErrorConfig, FileMatcher, InputSourceMap, IsModule, JscConfig, ModuleConfig, Options,
   SourceMapsConfig,
@@ -75,6 +75,9 @@ pub struct SwcLoaderJsOptions {
   pub schema: Option<String>,
 
   #[serde(default)]
+  pub source_map_ignore_list: Option<FilePattern>,
+
+  #[serde(default)]
   pub rspack_experiments: Option<RawRspackExperiments>,
 }
 
@@ -118,6 +121,7 @@ impl TryFrom<&str> for SwcCompilerOptionsWithAdditional {
       is_module,
       schema,
       rspack_experiments,
+      source_map_ignore_list,
     } = option;
     let mut source_maps: Option<SourceMapsConfig> = source_maps;
     if source_maps.is_none() && source_map.is_some() {
@@ -145,6 +149,7 @@ impl TryFrom<&str> for SwcCompilerOptionsWithAdditional {
           error,
           is_module,
           schema,
+          source_map_ignore_list,
         },
         ..Default::default()
       },

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -49,6 +49,7 @@ swc_core = { workspace = true, features = [
   "base",
   "ecma_quote",
 ] }
+swc_ecma_lexer = { workspace = true }
 swc_node_comments = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -175,7 +175,21 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     );
     let comments = SwcComments::default();
     let target = ast::EsVersion::EsNext;
-    let lexer = Lexer::new(
+    let parser_lexer = Lexer::new(
+      Syntax::Es(EsSyntax {
+        allow_return_outside_function: matches!(
+          module_type,
+          ModuleType::JsDynamic | ModuleType::JsAuto
+        ),
+        import_attributes: true,
+        ..Default::default()
+      }),
+      target,
+      SourceFileInput::from(&*fm),
+      Some(&comments),
+    );
+
+    let lexer = swc_ecma_lexer::Lexer::new(
       Syntax::Es(EsSyntax {
         allow_return_outside_function: matches!(
           module_type,
@@ -193,7 +207,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
 
     let mut ast = match javascript_compiler.parse_with_lexer(
       &fm,
-      lexer.clone(),
+      parser_lexer,
       module_type_to_is_module(module_type),
       Some(comments.clone()),
     ) {

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/hygiene.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/hygiene.rs
@@ -13,6 +13,6 @@ pub fn hygiene(keep_class_names: bool, top_level_mark: Mark) -> impl 'static + P
     top_level_mark,
     ignore_eval: false,
     // FIXME: support user passing preserved_symbols in the future
-    preserved_symbols: Default::default(),
+    // preserved_symbols: Default::default(),
   })
 }

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -26,7 +26,7 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_javascript_compiler::JavaScriptCompiler;
 use rspack_plugin_javascript::{ExtractedCommentsInfo, JavascriptModulesChunkHash, JsPlugin};
 use rspack_util::asset_condition::AssetConditions;
-use swc_config::config_types::BoolOrDataConfig;
+use swc_config::types::BoolOrDataConfig;
 use swc_core::{
   base::config::JsMinifyFormatOptions,
   common::comments::{CommentKind, SingleThreadedComments},

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -1,4 +1,4 @@
-use swc_config::config_types::BoolOr;
+use swc_config::types::BoolOr;
 use swc_core::{
   atoms::Atom,
   base::config::JsMinifyCommentOption,

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
@@ -49,7 +49,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: 80313a5c41e5c924,
+      hash: a34894c488dc33e3,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -179,7 +179,7 @@ Object {
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: f7b5bbac5b0af67c,
+  hash: 80c3d0658c233f6b,
   modules: Array [
     Object {
       assets: Array [],
@@ -330,7 +330,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: de26a35b45f420b8,
+      hash: cfe10b32fa6df1ab,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -718,7 +718,7 @@ Object {
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: 7067b9acea310afd,
+  hash: de56093745c27934,
   modules: Array [
     Object {
       assets: Array [],
@@ -1521,7 +1521,7 @@ Object {
       files: Array [
         main.js,
       ],
-      hash: 80313a5c41e5c924,
+      hash: a34894c488dc33e3,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -1661,7 +1661,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: 634049ea1ad0eaed,
+      hash: 6bc9713a458ae827,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -2030,7 +2030,7 @@ exports.c = require("./c?c=3");,
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: e327a90264c6733b,
+  hash: 6f5733011a2cd224,
   modules: Array [
     Object {
       assets: Array [],

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -58,7 +58,7 @@ runtime modules xx KiB
     [no exports]
     [used exports unknown]
   
-Rspack compiled successfully (18cc1e9efd1c355c)
+Rspack compiled successfully (cb468c46ad9d7f18)
 `;
 
 exports[`statsOutput statsOutput/builtin-swc-loader-parse-error should print correct stats for 1`] = `
@@ -206,20 +206,20 @@ runtime modules 647 bytes 3 modules
 exports[`statsOutput statsOutput/minify-error should print correct stats for 1`] = `
 ERROR in main.js
   × Chunk minification failed:
-  ╰─▶   × JavaScript parse error: Expected a semicolon
-         ╭─[1:8]
+  ╰─▶   × JavaScript parse error: 'const' declarations must be initialized
+         ╭─[1:6]
        1 │ const a {}
-         ·         ─
+         ·       ─
        2 │ (() => { // webpackBootstrap
        3 │ console.log(0);
          ╰────
 
 ERROR in main.js
   × Chunk minification failed:
-  ╰─▶   × JavaScript parse error: 'const' declarations must be initialized
-         ╭─[1:6]
+  ╰─▶   × JavaScript parse error: Expected a semicolon
+         ╭─[1:8]
        1 │ const a {}
-         ·       ─
+         ·         ─
        2 │ (() => { // webpackBootstrap
        3 │ console.log(0);
          ╰────

--- a/packages/rspack-test-tools/tests/builtinCases/samples/cycle-dynamic-entry/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/cycle-dynamic-entry/__snapshots__/output.snap.txt
@@ -1,12 +1,12 @@
-```js title=dynamic-1_js-_5ebd0.js
+```js title=dynamic-1_js-_af6f0.js
 "use strict";
-(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["dynamic-1_js-_5ebd0"], {
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["dynamic-1_js-_af6f0"], {
 "./dynamic-1.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 /* ESM import */var _shared__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./shared.js");
 /* ESM import */var _shared__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_shared__WEBPACK_IMPORTED_MODULE_0__);
 
-__webpack_require__.e(/* import() */ "dynamic-2_js-_72240").then(__webpack_require__.bind(__webpack_require__, "./dynamic-2.js"));
+__webpack_require__.e(/* import() */ "dynamic-2_js-_89260").then(__webpack_require__.bind(__webpack_require__, "./dynamic-2.js"));
 console.log("dynamic-1");
 
 
@@ -15,15 +15,15 @@ console.log("dynamic-1");
 }]);
 ```
 
-```js title=dynamic-1_js-_5ebd1.js
-(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["dynamic-1_js-_5ebd1"], {
+```js title=dynamic-1_js-_af6f1.js
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["dynamic-1_js-_af6f1"], {
 "./dynamic-1.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* ESM import */var _shared__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./shared.js");
 /* ESM import */var _shared__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_shared__WEBPACK_IMPORTED_MODULE_0__);
 
-__webpack_require__.e(/* import() */ "dynamic-2_js-_72240").then(__webpack_require__.bind(__webpack_require__, "./dynamic-2.js"));
+__webpack_require__.e(/* import() */ "dynamic-2_js-_89260").then(__webpack_require__.bind(__webpack_require__, "./dynamic-2.js"));
 console.log("dynamic-1");
 
 
@@ -37,15 +37,15 @@ console.log("shared");
 }]);
 ```
 
-```js title=dynamic-2_js-_72240.js
+```js title=dynamic-2_js-_89260.js
 "use strict";
-(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["dynamic-2_js-_72240"], {
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["dynamic-2_js-_89260"], {
 "./dynamic-2.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 /* ESM import */var _shared__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./shared.js");
 /* ESM import */var _shared__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_shared__WEBPACK_IMPORTED_MODULE_0__);
 
-__webpack_require__.e(/* import() */ "dynamic-1_js-_5ebd0").then(__webpack_require__.bind(__webpack_require__, "./dynamic-1.js"));
+__webpack_require__.e(/* import() */ "dynamic-1_js-_af6f0").then(__webpack_require__.bind(__webpack_require__, "./dynamic-1.js"));
 console.log("dynamic-2");
 
 
@@ -54,15 +54,15 @@ console.log("dynamic-2");
 }]);
 ```
 
-```js title=dynamic-2_js-_72241.js
-(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["dynamic-2_js-_72241"], {
+```js title=dynamic-2_js-_89261.js
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["dynamic-2_js-_89261"], {
 "./dynamic-2.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* ESM import */var _shared__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./shared.js");
 /* ESM import */var _shared__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_shared__WEBPACK_IMPORTED_MODULE_0__);
 
-__webpack_require__.e(/* import() */ "dynamic-1_js-_5ebd0").then(__webpack_require__.bind(__webpack_require__, "./dynamic-1.js"));
+__webpack_require__.e(/* import() */ "dynamic-1_js-_af6f0").then(__webpack_require__.bind(__webpack_require__, "./dynamic-1.js"));
 console.log("dynamic-2");
 
 
@@ -79,8 +79,8 @@ console.log("shared");
 ```js title=main.js
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["main"], {
 "./index.js": (function (__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.e(/* import() */ "dynamic-1_js-_5ebd1").then(__webpack_require__.bind(__webpack_require__, "./dynamic-1.js"));
-__webpack_require__.e(/* import() */ "dynamic-2_js-_72241").then(__webpack_require__.bind(__webpack_require__, "./dynamic-2.js"));
+__webpack_require__.e(/* import() */ "dynamic-1_js-_af6f1").then(__webpack_require__.bind(__webpack_require__, "./dynamic-1.js"));
+__webpack_require__.e(/* import() */ "dynamic-2_js-_89261").then(__webpack_require__.bind(__webpack_require__, "./dynamic-2.js"));
 console.log("index");
 
 

--- a/packages/rspack-test-tools/tests/builtinCases/samples/intersection/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/intersection/__snapshots__/output.snap.txt
@@ -1,5 +1,5 @@
-```js title=a_js-_c18a0.js
-(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["a_js-_c18a0"], {
+```js title=a_js-_62a90.js
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["a_js-_62a90"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
@@ -25,8 +25,8 @@ console.log("i-1");
 }]);
 ```
 
-```js title=a_js-_c18a1.js
-(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["a_js-_c18a1"], {
+```js title=a_js-_62a91.js
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["a_js-_62a91"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
@@ -67,7 +67,7 @@ console.log("i-1");
 /* ESM import */var _i_1__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_i_1__WEBPACK_IMPORTED_MODULE_1__);
 
 
-__webpack_require__.e(/* import() */ "a_js-_c18a1").then(__webpack_require__.bind(__webpack_require__, "./a.js"));
+__webpack_require__.e(/* import() */ "a_js-_62a91").then(__webpack_require__.bind(__webpack_require__, "./a.js"));
 console.log("index");
 
 
@@ -101,7 +101,7 @@ console.log("i-2");
 /* ESM import */var _i_2__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_i_2__WEBPACK_IMPORTED_MODULE_1__);
 
 
-__webpack_require__.e(/* import() */ "a_js-_c18a0").then(__webpack_require__.bind(__webpack_require__, "./a.js"));
+__webpack_require__.e(/* import() */ "a_js-_62a90").then(__webpack_require__.bind(__webpack_require__, "./a.js"));
 console.log("index");
 
 

--- a/packages/rspack-test-tools/tests/builtinCases/samples/parent-have-partial-module/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/parent-have-partial-module/__snapshots__/output.snap.txt
@@ -28,7 +28,7 @@ __webpack_require__.r(__webpack_exports__);
 /* ESM import */var _exist__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./exist.js");
 /* ESM import */var _exist__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_exist__WEBPACK_IMPORTED_MODULE_0__);
 
-__webpack_require__.e(/* import() */ "shared_js-_5ce21").then(__webpack_require__.bind(__webpack_require__, "./shared.js"));
+__webpack_require__.e(/* import() */ "shared_js-_38af1").then(__webpack_require__.bind(__webpack_require__, "./shared.js"));
 
 
 }),
@@ -39,7 +39,7 @@ __webpack_require__.e(/* import() */ "shared_js-_5ce21").then(__webpack_require_
 ```js title=parent-2_js.js
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["parent-2_js"], {
 "./parent-2.js": (function (__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.e(/* import() */ "shared_js-_5ce20").then(__webpack_require__.bind(__webpack_require__, "./shared.js"));
+__webpack_require__.e(/* import() */ "shared_js-_38af0").then(__webpack_require__.bind(__webpack_require__, "./shared.js"));
 
 
 }),
@@ -47,8 +47,8 @@ __webpack_require__.e(/* import() */ "shared_js-_5ce20").then(__webpack_require_
 }]);
 ```
 
-```js title=shared_js-_5ce20.js
-(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["shared_js-_5ce20"], {
+```js title=shared_js-_38af0.js
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["shared_js-_38af0"], {
 "./exist.js": (function () {
 console.log("exist");
 
@@ -69,9 +69,9 @@ console.log("shared");
 }]);
 ```
 
-```js title=shared_js-_5ce21.js
+```js title=shared_js-_38af1.js
 "use strict";
-(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["shared_js-_5ce21"], {
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["shared_js-_38af1"], {
 "./shared.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 /* ESM import */var _exist__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./exist.js");

--- a/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
+++ b/packages/rspack-test-tools/tests/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
@@ -2,7 +2,7 @@ node_modules_cell_index_js-XXX0.bundle0.js
 
 ::
 
-exports.ids = ["node_modules_cell_index_js-_861a0"];
+exports.ids = ["node_modules_cell_index_js-_86ae0"];
 exports.modules = {
 "./node_modules/cell/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
 const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
@@ -20,7 +20,7 @@ node_modules_cell_index_js-XXX1.bundle0.js
 
 ::
 
-exports.ids = ["node_modules_cell_index_js-_861a1"];
+exports.ids = ["node_modules_cell_index_js-_86ae1"];
 exports.modules = {
 "./node_modules/cell/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
 const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
@@ -38,7 +38,7 @@ node_modules_row_index_js-XXX0.bundle0.js
 
 ::
 
-exports.ids = ["node_modules_row_index_js-_b2e20"];
+exports.ids = ["node_modules_row_index_js-_b8840"];
 exports.modules = {
 "./node_modules/row/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
 const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")
@@ -57,7 +57,7 @@ node_modules_row_index_js-XXX1.bundle0.js
 
 ::
 
-exports.ids = ["node_modules_row_index_js-_b2e21"];
+exports.ids = ["node_modules_row_index_js-_b8841"];
 exports.modules = {
 "./node_modules/row/index.js": (function (module, __unused_webpack_exports, __webpack_require__) {
 const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")

--- a/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-5120-strict-block/errors.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-5120-strict-block/errors.js
@@ -1,3 +1,4 @@
 module.exports = [
-	[/JavaScript parse error: The keyword 'let' is reserved in strict mode/]
+	[/JavaScript parse error: `let` cannot be used as an identifier in strict mode/],
+	[/JavaScript parse error: `let` cannot be used as an identifier in strict mode/]
 ];

--- a/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-5120-strict-block/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-5120-strict-block/index.js
@@ -3,6 +3,6 @@ const path = require("path");
 
 it("should throw error", () => {
 	expect(fs.readFileSync(path.join(__dirname, "fail.js"), "utf-8")).toContain(
-		"JavaScript parse error: The keyword 'let' is reserved in strict mode"
+		"JavaScript parse error: `let` cannot be used as an identifier in strict mode"
 	);
 });

--- a/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-5120-strict/errors.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-5120-strict/errors.js
@@ -1,3 +1,4 @@
 module.exports = [
-	[/JavaScript parse error: The keyword 'let' is reserved in strict mode/]
+	[/JavaScript parse error: `let` cannot be used as an identifier in strict mode/],
+	[/JavaScript parse error: `let` cannot be used as an identifier in strict mode/]
 ];

--- a/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-5120-strict/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/rspack-issue-5120-strict/index.js
@@ -3,6 +3,6 @@ const path = require("path");
 
 it("should throw error", () => {
 	expect(fs.readFileSync(path.join(__dirname, "fail.js"), "utf-8")).toContain(
-		"JavaScript parse error: The keyword 'let' is reserved in strict mode"
+		"JavaScript parse error: `let` cannot be used as an identifier in strict mode"
 	);
 });

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/mismatched-module-type/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/mismatched-module-type/stats.err
@@ -1,11 +1,11 @@
 ERROR in ./app.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[4:32]
+  ╰─▶   × JavaScript parse error: Unterminated regexp literal
+         ╭─[4:31]
        2 │     createElement() {}
        3 │ };
        4 │ export const App = () => <div></div>;
-         ·                                 ─────
+         ·                                ──────
          ╰────
       
   help: 
@@ -27,6 +27,19 @@ ERROR in ./app.js
 ERROR in ./app.js
   × Module parse failed:
   ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[4:32]
+       2 │     createElement() {}
+       3 │ };
+       4 │ export const App = () => <div></div>;
+         ·                                 ─────
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+
+ERROR in ./app.js
+  × Module parse failed:
+  ╰─▶   × JavaScript parse error: Expression expected
          ╭─[4:30]
        2 │     createElement() {}
        3 │ };
@@ -37,7 +50,7 @@ ERROR in ./app.js
   help: 
         You may need an appropriate loader to handle this file type.
 
-ERROR in ./app.js
+ERROR in ./app.jsx
   × Module parse failed:
   ╰─▶   × JavaScript parse error: Unterminated regexp literal
          ╭─[4:31]
@@ -45,19 +58,6 @@ ERROR in ./app.js
        3 │ };
        4 │ export const App = () => <div></div>;
          ·                                ──────
-         ╰────
-      
-  help: 
-        You may need an appropriate loader to handle this file type.
-
-ERROR in ./app.jsx
-  × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[4:32]
-       2 │     createElement() {}
-       3 │ };
-       4 │ export const App = () => <div></div>;
-         ·                                 ─────
          ╰────
       
   help: 
@@ -79,11 +79,11 @@ ERROR in ./app.jsx
 ERROR in ./app.jsx
   × Module parse failed:
   ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[4:30]
+         ╭─[4:32]
        2 │     createElement() {}
        3 │ };
        4 │ export const App = () => <div></div>;
-         ·                               ─
+         ·                                 ─────
          ╰────
       
   help: 
@@ -91,12 +91,12 @@ ERROR in ./app.jsx
 
 ERROR in ./app.jsx
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Unterminated regexp literal
-         ╭─[4:31]
+  ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[4:30]
        2 │     createElement() {}
        3 │ };
        4 │ export const App = () => <div></div>;
-         ·                                ──────
+         ·                               ─
          ╰────
       
   help: 

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/lack-equal/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/lack-equal/stats.err
@@ -1,18 +1,5 @@
 ERROR in ./index.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[5:0]
-       3 │     d = 10
-       4 │     g = CONST
-       5 │ }
-         · ─
-         ╰────
-      
-  help: 
-        You may need an appropriate loader to handle this file type.
-
-ERROR in ./index.js
-  × Module parse failed:
   ╰─▶   × JavaScript parse error: 'const' declarations must be initialized
          ╭─[2:6]
        1 │ const CONST = 9000 % 2;
@@ -20,6 +7,19 @@ ERROR in ./index.js
          ·       ─
        3 │     d = 10
        4 │     g = CONST
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+
+ERROR in ./index.js
+  × Module parse failed:
+  ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[5:0]
+       3 │     d = 10
+       4 │     g = CONST
+       5 │ }
+         · ─
          ╰────
       
   help: 

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/module-parse-error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/module-parse-error/stats.err
@@ -11,10 +11,10 @@ ERROR in ./non-recoverable.js
 
 ERROR in ./recoverable.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: 'const' declarations must be initialized
+  ╰─▶   × JavaScript parse error: Expected a semicolon
          ╭────
        1 │ const foo {};
-         ·       ───
+         ·           ─
          ╰────
       
   help: 
@@ -22,10 +22,10 @@ ERROR in ./recoverable.js
 
 ERROR in ./recoverable.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expected a semicolon
+  ╰─▶   × JavaScript parse error: 'const' declarations must be initialized
          ╭────
        1 │ const foo {};
-         ·           ─
+         ·       ───
          ╰────
       
   help: 

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/multiple_file_syntax_error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/multiple_file_syntax_error/stats.err
@@ -14,13 +14,12 @@ ERROR in ./a.js
 
 ERROR in ./a.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expected a semicolon
-         ╭─[2:9]
-       1 │ const CONST = 9000 % 2;
-       2 │ const  D {
-         ·          ─
-       3 │     // Comma is required, but parser can recover because of the newline.
+  ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[6:0]
        4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ─
          ╰────
       
   help: 
@@ -28,12 +27,13 @@ ERROR in ./a.js
 
 ERROR in ./a.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[6:0]
+  ╰─▶   × JavaScript parse error: Expected a semicolon
+         ╭─[2:9]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ─
+       3 │     // Comma is required, but parser can recover because of the newline.
        4 │     d = 10
-       5 │     g = CONST
-       6 │ }
-         · ─
          ╰────
       
   help: 
@@ -55,13 +55,12 @@ ERROR in ./b.js
 
 ERROR in ./b.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expected a semicolon
-         ╭─[2:9]
-       1 │ const CONST = 9000 % 2;
-       2 │ const  D {
-         ·          ─
-       3 │     // Comma is required, but parser can recover because of the newline.
+  ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[6:0]
        4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ─
          ╰────
       
   help: 
@@ -69,12 +68,13 @@ ERROR in ./b.js
 
 ERROR in ./b.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[6:0]
+  ╰─▶   × JavaScript parse error: Expected a semicolon
+         ╭─[2:9]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ─
+       3 │     // Comma is required, but parser can recover because of the newline.
        4 │     d = 10
-       5 │     g = CONST
-       6 │ }
-         · ─
          ╰────
       
   help: 
@@ -96,13 +96,12 @@ ERROR in ./c.js
 
 ERROR in ./c.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expected a semicolon
-         ╭─[2:9]
-       1 │ const CONST = 9000 % 2;
-       2 │ const  D {
-         ·          ─
-       3 │     // Comma is required, but parser can recover because of the newline.
+  ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[6:0]
        4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ─
          ╰────
       
   help: 
@@ -110,12 +109,13 @@ ERROR in ./c.js
 
 ERROR in ./c.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[6:0]
+  ╰─▶   × JavaScript parse error: Expected a semicolon
+         ╭─[2:9]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ─
+       3 │     // Comma is required, but parser can recover because of the newline.
        4 │     d = 10
-       5 │     g = CONST
-       6 │ }
-         · ─
          ╰────
       
   help: 
@@ -137,13 +137,12 @@ ERROR in ./d.js
 
 ERROR in ./d.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expected a semicolon
-         ╭─[2:9]
-       1 │ const CONST = 9000 % 2;
-       2 │ const  D {
-         ·          ─
-       3 │     // Comma is required, but parser can recover because of the newline.
+  ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[6:0]
        4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ─
          ╰────
       
   help: 
@@ -151,12 +150,13 @@ ERROR in ./d.js
 
 ERROR in ./d.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[6:0]
+  ╰─▶   × JavaScript parse error: Expected a semicolon
+         ╭─[2:9]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ─
+       3 │     // Comma is required, but parser can recover because of the newline.
        4 │     d = 10
-       5 │     g = CONST
-       6 │ }
-         · ─
          ╰────
       
   help: 
@@ -178,13 +178,12 @@ ERROR in ./e.js
 
 ERROR in ./e.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expected a semicolon
-         ╭─[2:9]
-       1 │ const CONST = 9000 % 2;
-       2 │ const  D {
-         ·          ─
-       3 │     // Comma is required, but parser can recover because of the newline.
+  ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[6:0]
        4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ─
          ╰────
       
   help: 
@@ -192,12 +191,13 @@ ERROR in ./e.js
 
 ERROR in ./e.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[6:0]
+  ╰─▶   × JavaScript parse error: Expected a semicolon
+         ╭─[2:9]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ─
+       3 │     // Comma is required, but parser can recover because of the newline.
        4 │     d = 10
-       5 │     g = CONST
-       6 │ }
-         · ─
          ╰────
       
   help: 
@@ -219,13 +219,12 @@ ERROR in ./f.js
 
 ERROR in ./f.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expected a semicolon
-         ╭─[2:9]
-       1 │ const CONST = 9000 % 2;
-       2 │ const  D {
-         ·          ─
-       3 │     // Comma is required, but parser can recover because of the newline.
+  ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[6:0]
        4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ─
          ╰────
       
   help: 
@@ -233,12 +232,13 @@ ERROR in ./f.js
 
 ERROR in ./f.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[6:0]
+  ╰─▶   × JavaScript parse error: Expected a semicolon
+         ╭─[2:9]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ─
+       3 │     // Comma is required, but parser can recover because of the newline.
        4 │     d = 10
-       5 │     g = CONST
-       6 │ }
-         · ─
          ╰────
       
   help: 
@@ -260,13 +260,12 @@ ERROR in ./g.js
 
 ERROR in ./g.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expected a semicolon
-         ╭─[2:9]
-       1 │ const CONST = 9000 % 2;
-       2 │ const  D {
-         ·          ─
-       3 │     // Comma is required, but parser can recover because of the newline.
+  ╰─▶   × JavaScript parse error: Expression expected
+         ╭─[6:0]
        4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ─
          ╰────
       
   help: 
@@ -274,12 +273,13 @@ ERROR in ./g.js
 
 ERROR in ./g.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Expression expected
-         ╭─[6:0]
+  ╰─▶   × JavaScript parse error: Expected a semicolon
+         ╭─[2:9]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ─
+       3 │     // Comma is required, but parser can recover because of the newline.
        4 │     d = 10
-       5 │     g = CONST
-       6 │ }
-         · ─
          ╰────
       
   help: 

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/reserved_name_error/raw-error.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/reserved_name_error/raw-error.err
@@ -4,4 +4,9 @@ Array [
     moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/module-parse-failed/reserved_name_error/index.js,
     moduleName: ./index.js,
   },
+  Object {
+    code: ModuleParseError,
+    moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/module-parse-failed/reserved_name_error/index.js,
+    moduleName: ./index.js,
+  },
 ]

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/reserved_name_error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/reserved_name_error/stats.err
@@ -1,6 +1,18 @@
 ERROR in ./index.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: The keyword 'let' is reserved in strict mode
+  ╰─▶   × JavaScript parse error: `let` cannot be used as an identifier in strict mode
+         ╭─[2:10]
+       1 │ "use strict";
+       2 │ var let = let;
+         ·           ───
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+
+ERROR in ./index.js
+  × Module parse failed:
+  ╰─▶   × JavaScript parse error: `let` cannot be used as an identifier in strict mode
          ╭─[2:4]
        1 │ "use strict";
        2 │ var let = let;

--- a/packages/rspack-test-tools/tests/hookCases/compilation#processAssets/update-asset/hooks.snap.txt
+++ b/packages/rspack-test-tools/tests/hookCases/compilation#processAssets/update-asset/hooks.snap.txt
@@ -5,7 +5,7 @@
 ```javascript
 Array [
   Object {
-    "main.20af8dc95eedc570.js": (() => { // webpackBootstrap
+    "main.aa6afac1fee0ff8f.js": (() => { // webpackBootstrap
 var __webpack_modules__ = ({
 600: (function (module) {
 module.exports = "This is hook"

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/chunk-loading/module-chunk-loading/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/chunk-loading/module-chunk-loading/rspack.config.js
@@ -7,12 +7,33 @@ module.exports = {
 		filename: "[name].js",
 		chunkLoading: "import",
 		chunkFormat: "module",
-		enabledChunkLoadingTypes: ["import"]
+		enabledChunkLoadingTypes: ["import"],
+		environment: {
+			arrowFunction: false,
+			bigIntLiteral: false,
+			const: false,
+			destructuring: false,
+			dynamicImport: false,
+			dynamicImportInWorker: false,
+			forOf: false,
+			globalThis: false,
+			module: false,
+			optionalChaining: false,
+			templateLiteral: false
+		}
 	},
 	optimization: {
 		runtimeChunk: {
 			name: "bundle"
-		}
+		},
+		minimize: false,
+		chunkIds: "named",
+		moduleIds: "named",
+		mangleExports: false,
+		concatenateModules: true
 	},
-	target: "node"
+
+	devtool: false,
+	target: "node",
+	mode: "development"
 };

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/chunk-loading/module-chunk-loading/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/chunk-loading/module-chunk-loading/rspack.config.js
@@ -7,33 +7,12 @@ module.exports = {
 		filename: "[name].js",
 		chunkLoading: "import",
 		chunkFormat: "module",
-		enabledChunkLoadingTypes: ["import"],
-		environment: {
-			arrowFunction: false,
-			bigIntLiteral: false,
-			const: false,
-			destructuring: false,
-			dynamicImport: false,
-			dynamicImportInWorker: false,
-			forOf: false,
-			globalThis: false,
-			module: false,
-			optionalChaining: false,
-			templateLiteral: false
-		}
+		enabledChunkLoadingTypes: ["import"]
 	},
 	optimization: {
 		runtimeChunk: {
 			name: "bundle"
-		},
-		minimize: false,
-		chunkIds: "named",
-		moduleIds: "named",
-		mangleExports: false,
-		concatenateModules: true
+		}
 	},
-
-	devtool: false,
-	target: "node",
-	mode: "development"
+	target: "node"
 };

--- a/packages/rspack-test-tools/tests/statsAPICases/basic.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/basic.js
@@ -37,7 +37,7 @@ module.exports = {
 		  entry ./fixtures/a
 		  cjs self exports reference self [585] ./fixtures/a.js
 		  
-		Rspack compiled successfully (f7b5bbac5b0af67c)
+		Rspack compiled successfully (80c3d0658c233f6b)
 	`);
 	}
 };

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -422,12 +422,12 @@ Rspack x.x.x compiled successfully in X.23"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-plugin-issue-4980 1`] = `
-"asset app.824f7ad4e050d52c-xxx.js xx bytes [emitted] [immutable] (name: app)
+"asset app.65cf6affbf0cd0c0-xxx.js xx bytes [emitted] [immutable] (name: app)
 orphan modules xx bytes [orphan] 3 modules
 ./entry-xxx.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X.23
 
-asset app.05ce3dc57a31149c-xxx.js xx bytes [emitted] [immutable] (name: app)
+asset app.61e784f58e359016-xxx.js xx bytes [emitted] [immutable] (name: app)
 orphan modules xx bytes [orphan] 3 modules
 ./entry-xxx.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X.23"
@@ -696,8 +696,8 @@ Rspack x.x.x compiled successfully in X.23"
 `;
 
 exports[`StatsTestCases should print correct stats for immutable 1`] = `
-"asset 39070086cb7cbb92.js xx KiB [emitted] [immutable] (name: main)
-asset cc8bb03cea0d9f6f.js xx bytes [emitted] [immutable]"
+"asset d4e3657fcff58763.js xx KiB [emitted] [immutable] (name: main)
+asset 861a015ed5554248.js xx bytes [emitted] [immutable]"
 `;
 
 exports[`StatsTestCases should print correct stats for import-context-filter 1`] = `


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
- Bump swc versiont to 26.3.4
- `rspack_plugin_javascript` parsing tokens using `swc_ecma_lexer`

we use `swc_ecma_lexer` to collections tokens instead of using `swc_ecma_lexer::parser`, due to `swc_ecma_lexer::parser` is more slower. More detail see [benchmarking-using-swc_ecma_lexer::lexer](https://github.com/web-infra-dev/rspack/pull/10566#issuecomment-2938148213) vs [benchmarking-using-swc_ecma_lexer::parser](https://github.com/web-infra-dev/rspack/pull/10568#issuecomment-2938706798)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
