### PR TITLE
refactor: prefetch exports info data of getters part 2

### DIFF
--- a/crates/node_binding/src/exports_info.rs
+++ b/crates/node_binding/src/exports_info.rs
@@ -107,7 +107,7 @@ impl JsExportsInfo {
     let exports_info = ExportsInfoGetter::prefetch(
       &self.exports_info,
       &module_graph,
-      PrefetchExportsInfoMode::NamedNestedExports(&names),
+      PrefetchExportsInfoMode::NamedNestedExports(names.iter().collect::<Vec<_>>()),
     );
     let used = ExportsInfoGetter::get_used(&exports_info, &names, runtime.as_ref());
     Ok(used as u32)

--- a/crates/node_binding/src/exports_info.rs
+++ b/crates/node_binding/src/exports_info.rs
@@ -107,7 +107,7 @@ impl JsExportsInfo {
     let exports_info = ExportsInfoGetter::prefetch(
       &self.exports_info,
       &module_graph,
-      PrefetchExportsInfoMode::NamedNestedExports(names.iter().collect::<Vec<_>>()),
+      PrefetchExportsInfoMode::NamedNestedExports(&names),
     );
     let used = ExportsInfoGetter::get_used(&exports_info, &names, runtime.as_ref());
     Ok(used as u32)

--- a/crates/node_binding/src/exports_info.rs
+++ b/crates/node_binding/src/exports_info.rs
@@ -3,6 +3,7 @@ use std::ptr::NonNull;
 use napi::Either;
 use napi_derive::napi;
 use rspack_core::{Compilation, ExportsInfo, ExportsInfoGetter, ModuleGraph, RuntimeSpec};
+use rspack_util::atom::Atom;
 
 use crate::JsRuntimeSpec;
 
@@ -43,7 +44,8 @@ impl JsExportsInfo {
       Either::A(str) => std::iter::once(str).map(Into::into).collect(),
       Either::B(vec) => vec.into_iter().map(Into::into).collect(),
     });
-    Ok(self.exports_info.is_used(&module_graph, runtime.as_ref()))
+    let exports_info = ExportsInfoGetter::prefetch(&self.exports_info, &module_graph, None);
+    Ok(ExportsInfoGetter::is_used(&exports_info, runtime.as_ref()))
   }
 
   #[napi(ts_args_type = "runtime: string | string[] | undefined")]
@@ -88,16 +90,12 @@ impl JsExportsInfo {
       Either::A(str) => std::iter::once(str).map(Into::into).collect(),
       Either::B(vec) => vec.into_iter().map(Into::into).collect(),
     });
-    let used = match js_name {
-      Either::A(s) => self
-        .exports_info
-        .get_used(&module_graph, &[s.into()], runtime.as_ref()),
-      Either::B(v) => self.exports_info.get_used(
-        &module_graph,
-        v.into_iter().map(Into::into).collect::<Vec<_>>().as_slice(),
-        runtime.as_ref(),
-      ),
+    let names = match js_name {
+      Either::A(s) => vec![Atom::from(s)],
+      Either::B(v) => v.into_iter().map(Into::into).collect::<Vec<_>>(),
     };
+    let exports_info = ExportsInfoGetter::prefetch(&self.exports_info, &module_graph, Some(&names));
+    let used = ExportsInfoGetter::get_used(&exports_info, &names, runtime.as_ref());
     Ok(used as u32)
   }
 }

--- a/crates/node_binding/src/exports_info.rs
+++ b/crates/node_binding/src/exports_info.rs
@@ -2,7 +2,9 @@ use std::ptr::NonNull;
 
 use napi::Either;
 use napi_derive::napi;
-use rspack_core::{Compilation, ExportsInfo, ExportsInfoGetter, ModuleGraph, RuntimeSpec};
+use rspack_core::{
+  Compilation, ExportsInfo, ExportsInfoGetter, ModuleGraph, PrefetchExportsInfoMode, RuntimeSpec,
+};
 use rspack_util::atom::Atom;
 
 use crate::JsRuntimeSpec;
@@ -44,7 +46,11 @@ impl JsExportsInfo {
       Either::A(str) => std::iter::once(str).map(Into::into).collect(),
       Either::B(vec) => vec.into_iter().map(Into::into).collect(),
     });
-    let exports_info = ExportsInfoGetter::prefetch(&self.exports_info, &module_graph, None);
+    let exports_info = ExportsInfoGetter::prefetch(
+      &self.exports_info,
+      &module_graph,
+      PrefetchExportsInfoMode::AllExports,
+    );
     Ok(ExportsInfoGetter::is_used(&exports_info, runtime.as_ref()))
   }
 
@@ -55,7 +61,11 @@ impl JsExportsInfo {
       Either::A(str) => std::iter::once(str).map(Into::into).collect(),
       Either::B(vec) => vec.into_iter().map(Into::into).collect(),
     });
-    let exports_info = ExportsInfoGetter::prefetch(&self.exports_info, &module_graph, None);
+    let exports_info = ExportsInfoGetter::prefetch(
+      &self.exports_info,
+      &module_graph,
+      PrefetchExportsInfoMode::AllExports,
+    );
     Ok(ExportsInfoGetter::is_module_used(
       &exports_info,
       runtime.as_ref(),
@@ -94,7 +104,11 @@ impl JsExportsInfo {
       Either::A(s) => vec![Atom::from(s)],
       Either::B(v) => v.into_iter().map(Into::into).collect::<Vec<_>>(),
     };
-    let exports_info = ExportsInfoGetter::prefetch(&self.exports_info, &module_graph, Some(&names));
+    let exports_info = ExportsInfoGetter::prefetch(
+      &self.exports_info,
+      &module_graph,
+      PrefetchExportsInfoMode::NamedNestedExports(&names),
+    );
     let used = ExportsInfoGetter::get_used(&exports_info, &names, runtime.as_ref());
     Ok(used as u32)
   }

--- a/crates/node_binding/src/module_graph.rs
+++ b/crates/node_binding/src/module_graph.rs
@@ -89,8 +89,8 @@ impl JsModuleGraph {
         runtime.extend(vec.iter().map(String::as_str).map(ustr::Ustr::from));
       }
     };
-    let used_exports =
-      module_graph.get_used_exports(&js_module.identifier, Some(&RuntimeSpec::new(runtime)));
+    let exports_info = module_graph.get_prefetched_exports_info(&js_module.identifier, None);
+    let used_exports = exports_info.get_used_exports(Some(&RuntimeSpec::new(runtime)));
     Ok(match used_exports {
       rspack_core::UsedExports::Unknown => None,
       rspack_core::UsedExports::UsedNamespace(b) => Some(Either::A(b)),

--- a/crates/node_binding/src/module_graph.rs
+++ b/crates/node_binding/src/module_graph.rs
@@ -2,7 +2,7 @@ use std::ptr::NonNull;
 
 use napi::{Either, Env, JsString};
 use napi_derive::napi;
-use rspack_core::{Compilation, ModuleGraph, RuntimeSpec};
+use rspack_core::{Compilation, ModuleGraph, PrefetchExportsInfoMode, RuntimeSpec};
 
 use crate::{
   DependencyObject, JsExportsInfo, ModuleGraphConnectionWrapper, ModuleObject, ModuleObjectRef,
@@ -89,7 +89,8 @@ impl JsModuleGraph {
         runtime.extend(vec.iter().map(String::as_str).map(ustr::Ustr::from));
       }
     };
-    let exports_info = module_graph.get_prefetched_exports_info(&js_module.identifier, None);
+    let exports_info = module_graph
+      .get_prefetched_exports_info(&js_module.identifier, PrefetchExportsInfoMode::AllExports);
     let used_exports = exports_info.get_used_exports(Some(&RuntimeSpec::new(runtime)));
     Ok(match used_exports {
       rspack_core::UsedExports::Unknown => None,

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2218,7 +2218,7 @@ impl ConcatenatedModule {
       ModuleInfo::Concatenated(info) => {
         let export_id = export_name.first().cloned();
         if matches!(
-          export_info.provided(mg),
+          export_info.provided(),
           Some(crate::ExportProvided::NotProvided)
         ) {
           needed_namespace_objects.insert(info.module);

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -49,10 +49,11 @@ use crate::{
   CodeGenerationPublicPathAutoReplace, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
   ConcatenationScope, ConditionalInitFragment, ConnectionState, Context, DependenciesBlock,
   DependencyId, DependencyType, ErrorSpan, ExportInfoGetter, ExportProvided, ExportsArgument,
-  ExportsType, FactoryMeta, IdentCollector, InitFragment, InitFragmentStage, LibIdentOptions,
-  MaybeDynamicTargetExportInfoHashKey, Module, ModuleArgument, ModuleGraph, ModuleGraphConnection,
-  ModuleIdentifier, ModuleLayer, ModuleType, Resolve, RuntimeCondition, RuntimeGlobals,
-  RuntimeSpec, SourceType, SpanExt, Template, UsageState, DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
+  ExportsInfoGetter, ExportsType, FactoryMeta, IdentCollector, InitFragment, InitFragmentStage,
+  LibIdentOptions, MaybeDynamicTargetExportInfoHashKey, Module, ModuleArgument, ModuleGraph,
+  ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleType, PrefetchExportsInfoMode,
+  Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SourceType, SpanExt, Template,
+  UsageState, DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
 };
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
@@ -2196,10 +2197,13 @@ impl ConcatenatedModule {
       }
     }
 
-    let exports_info = mg.get_exports_info(&info.id());
+    let exports_info = mg.get_prefetched_exports_info(
+      &info.id(),
+      PrefetchExportsInfoMode::NamedNestedExports(&export_name),
+    );
     // webpack use `get_exports_info` here, https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L377-L377
     // But in our arch, there is no way to modify module graph during code_generation phase, so we use `get_export_info_without_mut_module_graph` instead.`
-    let export_info = exports_info.get_export_info_without_mut_module_graph(mg, &export_name[0]);
+    let export_info = exports_info.get_export_info_without_mut_module_graph(&export_name[0]);
     let export_info_hash_key = export_info.as_hash_key();
 
     if already_visited.contains(&export_info_hash_key) {
@@ -2237,7 +2241,9 @@ impl ConcatenatedModule {
         if let Some(ref export_id) = export_id
           && let Some(direct_export) = info.export_map.as_ref().and_then(|map| map.get(export_id))
         {
-          if let Some(used_name) = exports_info.get_used_name(mg, runtime, &export_name) {
+          if let Some(used_name) =
+            ExportsInfoGetter::get_used_name(&exports_info, runtime, &export_name)
+          {
             // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L402-L404
             let used_name = used_name.to_used_name_vec();
 
@@ -2315,9 +2321,9 @@ impl ConcatenatedModule {
 
         if info.namespace_export_symbol.is_some() {
           // That's how webpack write https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L463-L471
-          let used_name = exports_info
-            .get_used_name(mg, runtime, &export_name)
+          let used_name = ExportsInfoGetter::get_used_name(&exports_info, runtime, &export_name)
             .expect("should have export name");
+
           let used_name = used_name.to_used_name_vec();
           return Binding::Raw(RawBinding {
             info_id: info.module,
@@ -2340,7 +2346,9 @@ impl ConcatenatedModule {
         );
       }
       ModuleInfo::External(info) => {
-        if let Some(used_name) = exports_info.get_used_name(mg, runtime, &export_name) {
+        if let Some(used_name) =
+          ExportsInfoGetter::get_used_name(&exports_info, runtime, &export_name)
+        {
           let used_name = used_name.to_used_name_vec();
           let comment = if used_name == export_name {
             String::new()

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -6,10 +6,10 @@ use swc_core::ecma::atoms::Atom;
 use crate::{
   compile_boolean_matcher_from_lists, contextify, property_access, to_comment, to_normal_comment,
   AsyncDependenciesBlockIdentifier, ChunkGraph, Compilation, CompilerOptions, DependenciesBlock,
-  DependencyId, Environment, ExportsArgument, ExportsType, FakeNamespaceObjectMode,
-  InitFragmentExt, InitFragmentKey, InitFragmentStage, Module, ModuleGraph, ModuleId,
-  ModuleIdentifier, NormalInitFragment, PathInfo, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
-  TemplateContext,
+  DependencyId, Environment, ExportsArgument, ExportsInfoGetter, ExportsType,
+  FakeNamespaceObjectMode, InitFragmentExt, InitFragmentKey, InitFragmentStage, Module,
+  ModuleGraph, ModuleId, ModuleIdentifier, NormalInitFragment, PathInfo, PrefetchExportsInfoMode,
+  RuntimeCondition, RuntimeGlobals, RuntimeSpec, TemplateContext,
 };
 
 pub fn runtime_condition_expression(
@@ -208,12 +208,14 @@ pub fn export_from_import(
     .as_deref()
     .unwrap_or(export_name);
   if !export_name.is_empty() {
-    let exports_info = compilation
-      .get_module_graph()
-      .get_exports_info(&module_identifier);
-    let Some(used_name) =
-      exports_info.get_used_name(&compilation.get_module_graph(), *runtime, export_name)
-    else {
+    let Some(used_name) = ExportsInfoGetter::get_used_name(
+      &compilation.get_module_graph().get_prefetched_exports_info(
+        &module_identifier,
+        PrefetchExportsInfoMode::NamedExports(export_name),
+      ),
+      *runtime,
+      export_name,
+    ) else {
       return format!(
         "{} undefined",
         to_normal_comment(&property_access(export_name, 0))

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -211,7 +211,7 @@ pub fn export_from_import(
     let Some(used_name) = ExportsInfoGetter::get_used_name(
       &compilation.get_module_graph().get_prefetched_exports_info(
         &module_identifier,
-        PrefetchExportsInfoMode::NamedExports(export_name),
+        PrefetchExportsInfoMode::NamedNestedExports(export_name.iter().collect::<Vec<_>>()),
       ),
       *runtime,
       export_name,

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -211,7 +211,7 @@ pub fn export_from_import(
     let Some(used_name) = ExportsInfoGetter::get_used_name(
       &compilation.get_module_graph().get_prefetched_exports_info(
         &module_identifier,
-        PrefetchExportsInfoMode::NamedNestedExports(export_name.iter().collect::<Vec<_>>()),
+        PrefetchExportsInfoMode::NamedNestedExports(export_name),
       ),
       *runtime,
       export_name,

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -98,7 +98,7 @@ impl ExportInfo {
     ExportsInfoGetter::prefetch(
       &exports_info,
       mg,
-      PrefetchExportsInfoMode::NamedNestedExports(export.iter().collect::<Vec<_>>()),
+      PrefetchExportsInfoMode::NamedNestedExports(&export),
     )
     .get_read_only_export_info_recursive(&export)
     .map(|data| TerminalBinding::ExportInfo(data.id))
@@ -244,7 +244,7 @@ impl ExportInfoData {
       let name = &target.export.as_ref().expect("should have export")[0];
       let exports_info = mg.get_prefetched_exports_info(
         &target.module,
-        PrefetchExportsInfoMode::NamedExports(vec![name]),
+        PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(name)),
       );
       let export_info = exports_info.get_export_info_without_mut_module_graph(name);
       let export_info_hash_key = export_info.as_hash_key();
@@ -569,7 +569,7 @@ fn resolve_target(
 
       let exports_info = mg.get_prefetched_exports_info(
         &target.module,
-        PrefetchExportsInfoMode::NamedExports(vec![name]),
+        PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(name)),
       );
       let export_info = exports_info.get_export_info_without_mut_module_graph(name);
       let export_info_hash_key = export_info.as_hash_key();

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -244,7 +244,7 @@ impl ExportInfoData {
       let name = &target.export.as_ref().expect("should have export")[0];
       let exports_info = mg.get_prefetched_exports_info(
         &target.module,
-        PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(name)),
+        PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([name])),
       );
       let export_info = exports_info.get_export_info_without_mut_module_graph(name);
       let export_info_hash_key = export_info.as_hash_key();
@@ -569,7 +569,7 @@ fn resolve_target(
 
       let exports_info = mg.get_prefetched_exports_info(
         &target.module,
-        PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(name)),
+        PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([name])),
       );
       let export_info = exports_info.get_export_info_without_mut_module_graph(name);
       let export_info_hash_key = export_info.as_hash_key();

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 
 use super::{
   ExportInfoGetter, ExportInfoTargetValue, ExportProvided, ExportsInfo, ExportsInfoData,
-  FindTargetRetEnum, FindTargetRetValue, ResolvedExportInfoTarget,
+  ExportsInfoGetter, FindTargetRetEnum, FindTargetRetValue, ResolvedExportInfoTarget,
   ResolvedExportInfoTargetWithCircular, TerminalBinding, UnResolvedExportInfoTarget, UsageState,
   NEXT_EXPORT_INFO_UKEY,
 };
@@ -88,13 +88,14 @@ impl ExportInfo {
       return Some(TerminalBinding::ExportInfo(*self));
     }
     let target = info.get_target(mg)?;
+
     let exports_info = mg.get_exports_info(&target.module);
     let Some(export) = target.export else {
       return Some(TerminalBinding::ExportsInfo(exports_info));
     };
-    exports_info
-      .get_read_only_export_info_recursive(mg, &export)
-      .map(TerminalBinding::ExportInfo)
+    ExportsInfoGetter::prefetch(&exports_info, mg, Some(&export))
+      .get_read_only_export_info_recursive(&export)
+      .map(|data| TerminalBinding::ExportInfo(data.id))
   }
 
   pub fn update_hash_with_visited(
@@ -234,9 +235,8 @@ impl ExportInfoData {
       if valid_target_module_filter(&target.module) {
         return FindTargetRetEnum::Value(target);
       }
-      let exports_info = mg.get_exports_info(&target.module);
+      let exports_info = mg.get_prefetched_exports_info(&target.module, None);
       let export_info = exports_info.get_export_info_without_mut_module_graph(
-        mg,
         &target.export.as_ref().expect("should have export")[0],
       );
       let export_info_hash_key = export_info.as_hash_key();
@@ -372,11 +372,11 @@ impl ExportInfoData {
 // and the Static variant represents the most situation which FlagDependencyExportsPlugin can
 // analyze the exports statically.
 #[derive(Debug)]
-pub enum MaybeDynamicTargetExportInfo {
-  Static(ExportInfo),
+pub enum MaybeDynamicTargetExportInfo<'a> {
+  Static(&'a ExportInfoData),
   Dynamic {
     export_name: Atom,
-    other_export_info: ExportInfo,
+    other_export_info: &'a ExportInfoData,
     data: ExportInfoData,
   },
 }
@@ -390,11 +390,11 @@ pub enum MaybeDynamicTargetExportInfoHashKey {
   },
 }
 
-impl MaybeDynamicTargetExportInfo {
+impl<'a> MaybeDynamicTargetExportInfo<'a> {
   pub fn as_hash_key(&self) -> MaybeDynamicTargetExportInfoHashKey {
     match self {
       MaybeDynamicTargetExportInfo::Static(export_info) => {
-        MaybeDynamicTargetExportInfoHashKey::ExportInfo(*export_info)
+        MaybeDynamicTargetExportInfoHashKey::ExportInfo(export_info.id())
       }
       MaybeDynamicTargetExportInfo::Dynamic {
         export_name,
@@ -402,16 +402,14 @@ impl MaybeDynamicTargetExportInfo {
         ..
       } => MaybeDynamicTargetExportInfoHashKey::TemporaryData {
         export_name: export_name.clone(),
-        other_export_info: *other_export_info,
+        other_export_info: other_export_info.id(),
       },
     }
   }
 
-  pub fn provided<'a>(&'a self, mg: &'a ModuleGraph) -> Option<&'a ExportProvided> {
+  pub fn provided(&'a self) -> Option<&'a ExportProvided> {
     match self {
-      MaybeDynamicTargetExportInfo::Static(export_info) => {
-        ExportInfoGetter::provided(export_info.as_data(mg))
-      }
+      MaybeDynamicTargetExportInfo::Static(export_info) => ExportInfoGetter::provided(export_info),
       MaybeDynamicTargetExportInfo::Dynamic { data, .. } => data.provided.as_ref(),
     }
   }
@@ -432,8 +430,7 @@ impl MaybeDynamicTargetExportInfo {
   ) -> FindTargetRetEnum {
     match self {
       MaybeDynamicTargetExportInfo::Static(export_info) => {
-        let data = export_info.as_data(mg);
-        data.find_target_impl(mg, valid_target_module_filter, visited)
+        export_info.find_target_impl(mg, valid_target_module_filter, visited)
       }
       MaybeDynamicTargetExportInfo::Dynamic { data, .. } => {
         data.find_target_impl(mg, valid_target_module_filter, visited)
@@ -461,8 +458,7 @@ impl MaybeDynamicTargetExportInfo {
   ) -> Option<ResolvedExportInfoTargetWithCircular> {
     match self {
       MaybeDynamicTargetExportInfo::Static(export_info) => {
-        let export_info_data = export_info.as_data(mg);
-        export_info_data.get_target_proxy(mg, resolve_filter, already_visited)
+        export_info.get_target_proxy(mg, resolve_filter, already_visited)
       }
       MaybeDynamicTargetExportInfo::Dynamic { data, .. } => {
         if !data.target_is_set || data.target.is_empty() {
@@ -478,14 +474,10 @@ impl MaybeDynamicTargetExportInfo {
     }
   }
 
-  fn get_max_target<'a>(
-    &'a self,
-    mg: &'a ModuleGraph,
-  ) -> Cow<'a, HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
+  fn get_max_target(&self) -> Cow<HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
     match self {
       MaybeDynamicTargetExportInfo::Static(export_info) => {
-        let data = export_info.as_data(mg);
-        ExportInfoGetter::get_max_target(data)
+        ExportInfoGetter::get_max_target(export_info)
       }
       MaybeDynamicTargetExportInfo::Dynamic { data, .. } => ExportInfoGetter::get_max_target(data),
     }
@@ -497,11 +489,11 @@ impl MaybeDynamicTargetExportInfo {
     resolve_filter: ResolveFilterFnTy,
   ) -> Option<ResolvedExportInfoTarget> {
     let data = match self {
-      MaybeDynamicTargetExportInfo::Static(export_info) => export_info.as_data(mg),
+      MaybeDynamicTargetExportInfo::Static(export_info) => *export_info,
       MaybeDynamicTargetExportInfo::Dynamic { data, .. } => data,
     };
     let target = data.get_target_with_filter(mg, resolve_filter)?;
-    let max_target = self.get_max_target(mg);
+    let max_target = self.get_max_target();
     let original_target = max_target
       .values()
       .next()
@@ -567,8 +559,8 @@ fn resolve_target(
         return Some(ResolvedExportInfoTargetWithCircular::Target(target));
       };
 
-      let exports_info = mg.get_exports_info(&target.module);
-      let export_info = exports_info.get_export_info_without_mut_module_graph(mg, name);
+      let exports_info = mg.get_prefetched_exports_info(&target.module, None);
+      let export_info = exports_info.get_export_info_without_mut_module_graph(name);
       let export_info_hash_key = export_info.as_hash_key();
       if already_visited.contains(&export_info_hash_key) {
         return Some(ResolvedExportInfoTargetWithCircular::Circular);

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -98,7 +98,7 @@ impl ExportInfo {
     ExportsInfoGetter::prefetch(
       &exports_info,
       mg,
-      PrefetchExportsInfoMode::NamedNestedExports(&export),
+      PrefetchExportsInfoMode::NamedNestedExports(export.iter().collect::<Vec<_>>()),
     )
     .get_read_only_export_info_recursive(&export)
     .map(|data| TerminalBinding::ExportInfo(data.id))
@@ -244,7 +244,7 @@ impl ExportInfoData {
       let name = &target.export.as_ref().expect("should have export")[0];
       let exports_info = mg.get_prefetched_exports_info(
         &target.module,
-        PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(name)),
+        PrefetchExportsInfoMode::NamedExports(vec![name]),
       );
       let export_info = exports_info.get_export_info_without_mut_module_graph(name);
       let export_info_hash_key = export_info.as_hash_key();
@@ -569,7 +569,7 @@ fn resolve_target(
 
       let exports_info = mg.get_prefetched_exports_info(
         &target.module,
-        PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(name)),
+        PrefetchExportsInfoMode::NamedExports(vec![name]),
       );
       let export_info = exports_info.get_export_info_without_mut_module_graph(name);
       let export_info_hash_key = export_info.as_hash_key();

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -313,17 +313,17 @@ impl ExportsInfo {
   // An alternative version of `get_export_info`, and don't need `&mut ModuleGraph`.
   // You can use this when you can't or don't want to use `&mut ModuleGraph`.
   // Currently this function is used to finding a reexport's target.
-  pub fn get_export_info_without_mut_module_graph(
+  pub fn get_export_info_without_mut_module_graph<'a>(
     &self,
-    mg: &ModuleGraph,
+    mg: &'a ModuleGraph,
     name: &Atom,
-  ) -> MaybeDynamicTargetExportInfo {
+  ) -> MaybeDynamicTargetExportInfo<'a> {
     let exports_info = self.as_exports_info(mg);
     let redirect_id = exports_info.redirect_to;
     let other_exports_info_id = exports_info.other_exports_info;
     let export_info_id = exports_info.exports.get(name);
     if let Some(export_info_id) = export_info_id {
-      return MaybeDynamicTargetExportInfo::Static(*export_info_id);
+      return MaybeDynamicTargetExportInfo::Static(export_info_id.as_data(mg));
     }
     if let Some(redirect_id) = redirect_id {
       return redirect_id.get_export_info_without_mut_module_graph(mg, name);
@@ -333,7 +333,7 @@ impl ExportsInfo {
     let data = ExportInfoData::new(Some(name.clone()), Some(other_export_info));
     MaybeDynamicTargetExportInfo::Dynamic {
       export_name: name.clone(),
-      other_export_info: other_exports_info_id,
+      other_export_info,
       data,
     }
   }

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -71,44 +71,6 @@ impl ExportsInfo {
     mg.get_exports_info_mut_by_id(self)
   }
 
-  pub fn is_export_provided(&self, mg: &ModuleGraph, names: &[Atom]) -> Option<ExportProvided> {
-    let name = names.first()?;
-    let info = self.get_read_only_export_info(mg, name);
-    let info_data = info.as_data(mg);
-    if let Some(exports_info) = ExportInfoGetter::exports_info(info_data)
-      && names.len() > 1
-    {
-      return exports_info.is_export_provided(mg, &names[1..]);
-    }
-    let provided = ExportInfoGetter::provided(info_data)?;
-
-    match provided {
-      ExportProvided::Provided => {
-        if names.len() == 1 {
-          Some(ExportProvided::Provided)
-        } else {
-          None
-        }
-      }
-      _ => Some(*provided),
-    }
-  }
-
-  pub fn is_module_used(&self, mg: &ModuleGraph, runtime: Option<&RuntimeSpec>) -> bool {
-    if self.is_used(mg, runtime) {
-      return true;
-    }
-
-    let exports_info = self.as_exports_info(mg);
-    if !matches!(
-      ExportInfoGetter::get_used(exports_info.side_effects_only_info.as_data(mg), runtime),
-      UsageState::Unused
-    ) {
-      return true;
-    }
-    false
-  }
-
   // TODO: remove this, we should refactor ExportInfo into ExportName and ExportProvideInfo and ExportUsedInfo
   // ExportProvideInfo is created by FlagDependencyExportsPlugin, and should not mutate after create
   // ExportUsedInfo is created by FlagDependencyUsagePlugin or Plugin::finish_modules, and should not mutate after create
@@ -257,22 +219,6 @@ impl ExportsInfo {
     changed
   }
 
-  pub fn get_read_only_export_info_recursive(
-    &self,
-    mg: &ModuleGraph,
-    names: &[Atom],
-  ) -> Option<ExportInfo> {
-    if names.is_empty() {
-      return None;
-    }
-    let export_info = self.get_read_only_export_info(mg, &names[0]);
-    if names.len() == 1 {
-      return Some(export_info);
-    }
-    let exports_info = ExportInfoGetter::exports_info(export_info.as_data(mg))?;
-    exports_info.get_read_only_export_info_recursive(mg, &names[1..])
-  }
-
   pub fn get_read_only_export_info(&self, mg: &ModuleGraph, name: &Atom) -> ExportInfo {
     let exports_info = self.as_exports_info(mg);
     let redirect_to = exports_info.redirect_to;
@@ -335,24 +281,6 @@ impl ExportsInfo {
       other_export_info,
       data,
     }
-  }
-
-  pub fn get_nested_exports_info(
-    &self,
-    mg: &ModuleGraph,
-    name: Option<&[Atom]>,
-  ) -> Option<ExportsInfo> {
-    if let Some(name) = name
-      && !name.is_empty()
-    {
-      let info = self.get_read_only_export_info(mg, &name[0]);
-      if let Some(exports_info) = ExportInfoGetter::exports_info(info.as_data(mg)) {
-        return exports_info.get_nested_exports_info(mg, Some(&name[1..]));
-      } else {
-        return None;
-      }
-    }
-    Some(*self)
   }
 
   pub fn set_has_use_info(&self, mg: &mut ModuleGraph) {

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -12,11 +12,11 @@ use crate::{MaybeDynamicTargetExportInfo, ModuleGraph, RuntimeSpec, UsedExports}
 
 #[derive(Debug, Clone)]
 pub enum PrefetchExportsInfoMode<'a> {
-  Default,                              // prefetch without exports
-  NamedExports(Vec<&'a Atom>),          // prefetch with named exports but no nested exports
-  AllExports,                           // prefetch with all exports but no nested exports
-  NamedNestedExports(Vec<&'a Atom>),    // prefetch with named exports and its nested chain
-  NamedNestedAllExports(Vec<&'a Atom>), // prefetch with named nested exports and all exports on its chain
+  Default,                           // prefetch without exports
+  NamedExports(&'a [Atom]),          // prefetch with named exports but no nested exports
+  AllExports,                        // prefetch with all exports but no nested exports
+  NamedNestedExports(&'a [Atom]),    // prefetch with named exports and its nested chain
+  NamedNestedAllExports(&'a [Atom]), // prefetch with named nested exports and all exports on its chain
 }
 
 /**
@@ -377,8 +377,8 @@ impl ExportsInfoGetter {
       let exports_info = id.as_data(mg);
       let exports = match mode {
         PrefetchExportsInfoMode::Default => IndexMap::new(),
-        PrefetchExportsInfoMode::NamedExports(ref names) => {
-          let names = names.iter().copied().collect::<HashSet<_>>();
+        PrefetchExportsInfoMode::NamedExports(names) => {
+          let names = names.iter().collect::<HashSet<_>>();
           let mut exports = IndexMap::new();
           for (key, value) in exports_info.exports.iter() {
             if !names.contains(key) {
@@ -407,17 +407,17 @@ impl ExportsInfoGetter {
           }
           exports
         }
-        PrefetchExportsInfoMode::NamedNestedExports(ref names) => {
+        PrefetchExportsInfoMode::NamedNestedExports(names) => {
           let mut exports = IndexMap::new();
           if let Some(name) = names.first() {
-            if let Some(export_info) = exports_info.exports.get(*name) {
+            if let Some(export_info) = exports_info.exports.get(name) {
               let export_info = export_info.as_data(mg);
-              let nested_mode = PrefetchExportsInfoMode::NamedNestedExports(names[1..].to_vec());
+              let nested_mode = PrefetchExportsInfoMode::NamedNestedExports(&names[1..]);
               if let Some(nested_exports_info) = export_info.exports_info {
                 prefetch_exports(&nested_exports_info, mg, res, nested_mode);
               }
               exports.insert(
-                *name,
+                name,
                 PrefetchedExportInfoData {
                   inner: export_info,
                   // exports_info: export_info_data.exports_info,
@@ -427,15 +427,14 @@ impl ExportsInfoGetter {
           }
           exports
         }
-        PrefetchExportsInfoMode::NamedNestedAllExports(ref names) => {
+        PrefetchExportsInfoMode::NamedNestedAllExports(names) => {
           let mut exports = IndexMap::new();
           for (key, value) in exports_info.exports.iter() {
             let export_info = value.as_data(mg);
 
-            if names.first().is_some_and(|name| *name == key) {
+            if names.first().is_some_and(|name| name == key) {
               if let Some(nested_exports_info) = export_info.exports_info {
-                let nested_mode =
-                  PrefetchExportsInfoMode::NamedNestedAllExports(names[1..].to_vec());
+                let nested_mode = PrefetchExportsInfoMode::NamedNestedAllExports(&names[1..]);
                 prefetch_exports(&nested_exports_info, mg, res, nested_mode);
               }
             }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -76,6 +76,9 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   pub fn other_exports_info(&self) -> &ExportInfoData {
+    if let Some(redirect) = self.get_redirect_to_in_exports_info(&self.entry) {
+      return self.get_other_in_exports_info(redirect);
+    }
     self.get_other_in_exports_info(&self.entry)
   }
 

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -3,8 +3,11 @@ use std::{collections::BTreeMap, sync::Arc};
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashMap as HashMap;
 
-use super::{ExportInfoData, ExportInfoGetter, ExportProvided, ExportsInfo, UsageState};
-use crate::{ModuleGraph, RuntimeSpec};
+use super::{
+  ExportInfoData, ExportInfoGetter, ExportProvided, ExportsInfo, ProvidedExports, UsageState,
+  UsedName,
+};
+use crate::{MaybeDynamicTargetExportInfo, ModuleGraph, RuntimeSpec, UsedExports};
 
 /**
  * Used to store data pre-fetched from Module Graph
@@ -26,6 +29,15 @@ pub struct PrefetchedExportsInfoWrapper<'a> {
 
 impl<'a> PrefetchedExportsInfoWrapper<'a> {
   /**
+   * Generate a new PrefetchedExportsInfoWrapper with a new entry
+   */
+  pub fn redirect(&self, entry: ExportsInfo) -> Self {
+    Self {
+      exports: self.exports.clone(),
+      entry,
+    }
+  }
+  /**
    * Get the data of the current exports info
    */
   pub fn data(&self) -> &PrefetchedExportsInfoData<'a> {
@@ -33,16 +45,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
       .exports
       .get(&self.entry)
       .expect("should have nested exports info")
-  }
-
-  /**
-   * Generate a new PrefetchedExportsInfoWrapper with a new entry
-   */
-  pub fn redirect(&self, entry: ExportsInfo) -> PrefetchedExportsInfoWrapper<'_> {
-    PrefetchedExportsInfoWrapper {
-      exports: self.exports.clone(),
-      entry,
-    }
   }
 
   pub fn other_exports_info(&self) -> &ExportInfoData {
@@ -91,7 +93,12 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
         return None;
       }
     }
-    Some(self.data())
+    Some(
+      self
+        .exports
+        .get(exports_info)
+        .expect("should have nested exports info"),
+    )
   }
 
   fn get_read_only_export_info_recursive_impl(
@@ -129,22 +136,210 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     }
     data.other_exports_info.inner
   }
+
+  pub fn get_relevant_exports(&self, runtime: Option<&RuntimeSpec>) -> Vec<&ExportInfoData> {
+    self.get_relevant_exports_impl(&self.entry, runtime)
+  }
+
+  fn get_relevant_exports_impl(
+    &self,
+    exports_info: &ExportsInfo,
+    runtime: Option<&RuntimeSpec>,
+  ) -> Vec<&ExportInfoData> {
+    let data = self
+      .exports
+      .get(exports_info)
+      .expect("should have nested exports info");
+
+    let mut list = vec![];
+    for export_info in data.exports.values() {
+      let used = ExportInfoGetter::get_used(export_info.inner, runtime);
+      if matches!(used, UsageState::Unused) {
+        continue;
+      }
+      if matches!(
+        ExportInfoGetter::provided(export_info.inner),
+        Some(ExportProvided::NotProvided)
+      ) {
+        continue;
+      }
+      list.push(export_info.inner);
+    }
+    if let Some(redirect) = &data.redirect_to {
+      for export_info in self.get_relevant_exports_impl(redirect, runtime) {
+        let name = ExportInfoGetter::name(export_info);
+        if !data.exports.contains_key(name.unwrap_or(&"".into())) {
+          list.push(export_info);
+        }
+      }
+    }
+
+    let other_export_info = data.other_exports_info.inner;
+    if !matches!(
+      ExportInfoGetter::provided(other_export_info),
+      Some(ExportProvided::NotProvided)
+    ) && ExportInfoGetter::get_used(other_export_info, runtime) != UsageState::Unused
+    {
+      list.push(other_export_info);
+    }
+    list
+  }
+
+  pub fn get_used_exports(&self, runtime: Option<&RuntimeSpec>) -> UsedExports {
+    self.get_used_exports_impl(&self.entry, runtime)
+  }
+
+  fn get_used_exports_impl(
+    &self,
+    exports_info: &ExportsInfo,
+    runtime: Option<&RuntimeSpec>,
+  ) -> UsedExports {
+    let data = self
+      .exports
+      .get(exports_info)
+      .expect("should have nested exports info");
+    if data.redirect_to.is_none() {
+      match ExportInfoGetter::get_used(data.other_exports_info.inner, runtime) {
+        UsageState::NoInfo => return UsedExports::Unknown,
+        UsageState::Unknown | UsageState::OnlyPropertiesUsed | UsageState::Used => {
+          return UsedExports::UsedNamespace(true);
+        }
+        _ => (),
+      }
+    }
+
+    let mut res = vec![];
+    for export_info in data.exports.values() {
+      let used = ExportInfoGetter::get_used(export_info.inner, runtime);
+      match used {
+        UsageState::NoInfo => return UsedExports::Unknown,
+        UsageState::Unknown => return UsedExports::UsedNamespace(true),
+        UsageState::OnlyPropertiesUsed | UsageState::Used => {
+          if let Some(name) = export_info.inner.name.clone() {
+            res.push(name);
+          }
+        }
+        _ => (),
+      }
+    }
+
+    if let Some(redirect) = &data.redirect_to {
+      let inner = self.get_used_exports_impl(redirect, runtime);
+      match inner {
+        UsedExports::UsedNames(v) => res.extend(v),
+        UsedExports::Unknown | UsedExports::UsedNamespace(true) => return inner,
+        _ => (),
+      }
+    }
+
+    if res.is_empty() {
+      let used = ExportInfoGetter::get_used(data.side_effects_only_info.inner, runtime);
+      match used {
+        UsageState::NoInfo => return UsedExports::Unknown,
+        UsageState::Unused => return UsedExports::UsedNamespace(false),
+        _ => (),
+      }
+    }
+
+    UsedExports::UsedNames(res)
+  }
+
+  pub fn get_provided_exports(&self) -> ProvidedExports {
+    self.get_provided_exports_impl(&self.entry)
+  }
+
+  fn get_provided_exports_impl(&self, exports_info: &ExportsInfo) -> ProvidedExports {
+    let data = self
+      .exports
+      .get(exports_info)
+      .expect("should have nested exports info");
+    if data.redirect_to.is_none() {
+      match ExportInfoGetter::provided(data.other_exports_info.inner) {
+        Some(ExportProvided::Unknown) => {
+          return ProvidedExports::ProvidedAll;
+        }
+        Some(ExportProvided::Provided) => {
+          return ProvidedExports::ProvidedAll;
+        }
+        None => {
+          return ProvidedExports::Unknown;
+        }
+        _ => {}
+      }
+    }
+    let mut ret = vec![];
+    for export_info in data.exports.values() {
+      match export_info.inner.provided {
+        Some(ExportProvided::Provided | ExportProvided::Unknown) | None => {
+          ret.push(export_info.inner.name.clone().unwrap_or("".into()));
+        }
+        _ => {}
+      }
+    }
+    if let Some(exports_info) = data.redirect_to {
+      let provided_exports = self.get_provided_exports_impl(&exports_info);
+      let inner = match provided_exports {
+        ProvidedExports::Unknown => return ProvidedExports::Unknown,
+        ProvidedExports::ProvidedAll => return ProvidedExports::ProvidedAll,
+        ProvidedExports::ProvidedNames(arr) => arr,
+      };
+      for item in inner {
+        if !ret.contains(&item) {
+          ret.push(item);
+        }
+      }
+    }
+    ProvidedExports::ProvidedNames(ret)
+  }
+
+  // An alternative version of `get_export_info`, and don't need `&mut ModuleGraph`.
+  // You can use this when you can't or don't want to use `&mut ModuleGraph`.
+  // Currently this function is used to finding a reexport's target.
+  pub fn get_export_info_without_mut_module_graph(
+    &self,
+    name: &Atom,
+  ) -> MaybeDynamicTargetExportInfo {
+    self.get_export_info_without_mut_module_graph_impl(&self.entry, name)
+  }
+
+  fn get_export_info_without_mut_module_graph_impl(
+    &self,
+    exports_info: &ExportsInfo,
+    name: &Atom,
+  ) -> MaybeDynamicTargetExportInfo {
+    let data = self
+      .exports
+      .get(exports_info)
+      .expect("should have nested exports info");
+    if let Some(export_info) = data.exports.get(name) {
+      return MaybeDynamicTargetExportInfo::Static(export_info.inner);
+    }
+    if let Some(redirect) = &data.redirect_to {
+      return self.get_export_info_without_mut_module_graph_impl(redirect, name);
+    }
+
+    MaybeDynamicTargetExportInfo::Dynamic {
+      export_name: name.clone(),
+      other_export_info: data.other_exports_info.inner,
+      data: ExportInfoData::new(Some(name.clone()), Some(data.other_exports_info.inner)),
+    }
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct PrefetchedExportsInfoData<'a> {
-  pub(crate) exports: BTreeMap<&'a Atom, PrefetchedExportInfoData<'a>>,
-  pub(crate) other_exports_info: PrefetchedExportInfoData<'a>,
+  pub exports: BTreeMap<&'a Atom, PrefetchedExportInfoData<'a>>,
+  pub other_exports_info: PrefetchedExportInfoData<'a>,
 
-  pub(crate) side_effects_only_info: PrefetchedExportInfoData<'a>,
-  pub(crate) redirect_to: Option<ExportsInfo>,
-  // pub(crate) id: ExportsInfo,
+  pub side_effects_only_info: PrefetchedExportInfoData<'a>,
+  pub redirect_to: Option<ExportsInfo>,
+  pub id: ExportsInfo,
 }
 
 #[derive(Debug, Clone)]
 pub struct PrefetchedExportInfoData<'a> {
-  pub(crate) inner: &'a ExportInfoData,
-  // pub(crate) exports_info: Option<ExportsInfo>,
+  pub inner: &'a ExportInfoData,
+  // pub exports_info: Option<ExportsInfo>,
 }
 pub struct ExportsInfoGetter;
 
@@ -223,7 +418,7 @@ impl ExportsInfoGetter {
             // exports_info: side_effects_only_info_data.exports_info,
           },
           redirect_to: exports_info.redirect_to,
-          // id: *id,
+          id: *id,
         },
       );
     }
@@ -295,5 +490,142 @@ impl ExportsInfoGetter {
       }
       _ => Some(*provided),
     }
+  }
+
+  pub fn get_provided_exports(info: &PrefetchedExportsInfoWrapper) -> ProvidedExports {
+    if info.data().redirect_to.is_none() {
+      match ExportInfoGetter::provided(info.other_exports_info()) {
+        Some(ExportProvided::Unknown) => {
+          return ProvidedExports::ProvidedAll;
+        }
+        Some(ExportProvided::Provided) => {
+          return ProvidedExports::ProvidedAll;
+        }
+        None => {
+          return ProvidedExports::Unknown;
+        }
+        _ => {}
+      }
+    }
+    let mut ret = vec![];
+    for (_, export_info) in info.exports() {
+      match export_info.provided {
+        Some(ExportProvided::Provided | ExportProvided::Unknown) | None => {
+          ret.push(export_info.name.clone().unwrap_or("".into()));
+        }
+        _ => {}
+      }
+    }
+    if let Some(redirect) = &info.data().redirect_to {
+      let redirected = info.redirect(*redirect);
+      let provided_exports = Self::get_provided_exports(&redirected);
+      let inner = match provided_exports {
+        ProvidedExports::Unknown => return ProvidedExports::Unknown,
+        ProvidedExports::ProvidedAll => return ProvidedExports::ProvidedAll,
+        ProvidedExports::ProvidedNames(arr) => arr,
+      };
+      for item in inner {
+        if !ret.contains(&item) {
+          ret.push(item);
+        }
+      }
+    }
+    ProvidedExports::ProvidedNames(ret)
+  }
+
+  pub fn get_used(
+    info: &PrefetchedExportsInfoWrapper,
+    names: &[Atom],
+    runtime: Option<&RuntimeSpec>,
+  ) -> UsageState {
+    if names.len() == 1 {
+      let value = &names[0];
+      let info = info.get_read_only_export_info(value);
+      let used = ExportInfoGetter::get_used(info, runtime);
+      return used;
+    }
+    if names.is_empty() {
+      return ExportInfoGetter::get_used(info.other_exports_info(), runtime);
+    }
+    let info_data = info.get_read_only_export_info(&names[0]);
+    if let Some(exports_info) = &info_data.exports_info
+      && names.len() > 1
+    {
+      let redirected = info.redirect(*exports_info);
+      return Self::get_used(&redirected, &names[1..], runtime);
+    }
+    ExportInfoGetter::get_used(info_data, runtime)
+  }
+
+  /// `Option<UsedName>` correspond to webpack `string | string[] | false`
+  pub fn get_used_name(
+    info: &PrefetchedExportsInfoWrapper,
+    runtime: Option<&RuntimeSpec>,
+    names: &[Atom],
+  ) -> Option<UsedName> {
+    if names.len() == 1 {
+      let name = &names[0];
+      let info = info.get_read_only_export_info(name);
+      let used_name = ExportInfoGetter::get_used_name(info, Some(name), runtime);
+      return used_name.map(|n| UsedName::Normal(vec![n]));
+    }
+    if names.is_empty() {
+      if !Self::is_used(info, runtime) {
+        return None;
+      }
+      return Some(UsedName::Normal(names.to_vec()));
+    }
+    let export_info = info.get_read_only_export_info(&names[0]);
+    let used_name = ExportInfoGetter::get_used_name(export_info, Some(&names[0]), runtime)?;
+    let mut arr = if used_name == names[0] && names.len() == 1 {
+      names.to_vec()
+    } else {
+      vec![used_name]
+    };
+    if names.len() == 1 {
+      return Some(UsedName::Normal(arr));
+    }
+    if let Some(exports_info) = &export_info.exports_info
+      && ExportInfoGetter::get_used(export_info, runtime) == UsageState::OnlyPropertiesUsed
+    {
+      let nested_exports_info = info.redirect(*exports_info);
+      let nested = Self::get_used_name(&nested_exports_info, runtime, &names[1..])?;
+      arr.extend(match nested {
+        UsedName::Normal(names) => names,
+      });
+      return Some(UsedName::Normal(arr));
+    }
+    arr.extend(names.iter().skip(1).cloned());
+    Some(UsedName::Normal(arr))
+  }
+
+  pub fn is_equally_used(
+    info: &PrefetchedExportsInfoWrapper,
+    a: &RuntimeSpec,
+    b: &RuntimeSpec,
+  ) -> bool {
+    if let Some(redirect) = &info.data().redirect_to {
+      let redirected = info.redirect(*redirect);
+      if Self::is_equally_used(&redirected, a, b) {
+        return false;
+      }
+    } else if ExportInfoGetter::get_used(info.other_exports_info(), Some(a))
+      != ExportInfoGetter::get_used(info.other_exports_info(), Some(b))
+    {
+      return false;
+    }
+    if ExportInfoGetter::get_used(info.side_effects_only_info(), Some(a))
+      != ExportInfoGetter::get_used(info.side_effects_only_info(), Some(b))
+    {
+      return false;
+    }
+    for (_, export_info) in info.exports() {
+      if ExportInfoGetter::get_used(export_info, Some(a))
+        != ExportInfoGetter::get_used(export_info, Some(b))
+      {
+        return false;
+      }
+    }
+    true
   }
 }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -1,5 +1,6 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::sync::Arc;
 
+use indexmap::IndexMap;
 use rspack_util::atom::Atom;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -337,7 +338,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
 
 #[derive(Debug, Clone)]
 pub struct PrefetchedExportsInfoData<'a> {
-  pub exports: BTreeMap<&'a Atom, PrefetchedExportInfoData<'a>>,
+  pub exports: IndexMap<&'a Atom, PrefetchedExportInfoData<'a>>,
   pub other_exports_info: PrefetchedExportInfoData<'a>,
 
   pub side_effects_only_info: PrefetchedExportInfoData<'a>,
@@ -375,10 +376,10 @@ impl ExportsInfoGetter {
 
       let exports_info = id.as_data(mg);
       let exports = match mode {
-        PrefetchExportsInfoMode::Default => BTreeMap::new(),
+        PrefetchExportsInfoMode::Default => IndexMap::new(),
         PrefetchExportsInfoMode::NamedExports(names) => {
           let names = names.iter().collect::<HashSet<_>>();
-          let mut exports = BTreeMap::new();
+          let mut exports = IndexMap::new();
           for (key, value) in exports_info.exports.iter() {
             if !names.contains(key) {
               continue;
@@ -394,7 +395,7 @@ impl ExportsInfoGetter {
           exports
         }
         PrefetchExportsInfoMode::AllExports => {
-          let mut exports = BTreeMap::new();
+          let mut exports = IndexMap::new();
           for (key, value) in exports_info.exports.iter() {
             exports.insert(
               key,
@@ -407,7 +408,7 @@ impl ExportsInfoGetter {
           exports
         }
         PrefetchExportsInfoMode::NamedNestedExports(names) => {
-          let mut exports = BTreeMap::new();
+          let mut exports = IndexMap::new();
           if let Some(name) = names.first() {
             if let Some(export_info) = exports_info.exports.get(name) {
               let export_info = export_info.as_data(mg);
@@ -427,7 +428,7 @@ impl ExportsInfoGetter {
           exports
         }
         PrefetchExportsInfoMode::NamedNestedAllExports(names) => {
-          let mut exports = BTreeMap::new();
+          let mut exports = IndexMap::new();
           for (key, value) in exports_info.exports.iter() {
             let export_info = value.as_data(mg);
 

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -145,10 +145,10 @@ impl DependencyConditionFn for UsedByExportsDependencyCondition {
     let module_identifier = mg
       .get_parent_module(&self.dependency_id)
       .expect("should have parent module");
-    let names = self.used_by_exports.iter().collect::<Vec<_>>();
+    let names = self.used_by_exports.iter().cloned().collect::<Vec<_>>();
     let exports_info = mg.get_prefetched_exports_info(
       module_identifier,
-      PrefetchExportsInfoMode::NamedExports(names),
+      PrefetchExportsInfoMode::NamedExports(&names),
     );
     for export_name in self.used_by_exports.iter() {
       if ExportsInfoGetter::get_used(&exports_info, std::slice::from_ref(export_name), runtime)

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -148,7 +148,7 @@ impl DependencyConditionFn for UsedByExportsDependencyCondition {
     let names = self.used_by_exports.iter().cloned().collect::<Vec<_>>();
     let exports_info = mg.get_prefetched_exports_info(
       module_identifier,
-      PrefetchExportsInfoMode::NamedExports(&names),
+      PrefetchExportsInfoMode::NamedExports(names.iter().collect()),
     );
     for export_name in self.used_by_exports.iter() {
       if ExportsInfoGetter::get_used(&exports_info, std::slice::from_ref(export_name), runtime)

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -429,8 +429,8 @@ impl ExternalModule {
           };
 
           if let Some(concatenation_scope) = concatenation_scope {
-            let exports_info = module_graph.get_exports_info(&self.identifier());
-            let used_exports = exports_info.get_used_exports(&module_graph, runtime);
+            let exports_info = module_graph.get_prefetched_exports_info(&self.identifier(), None);
+            let used_exports = exports_info.get_used_exports(runtime);
             let meta = &self.dependency_meta.attributes;
             let attributes = meta.as_ref().map(|meta| {
               format!(

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -17,8 +17,8 @@ use crate::{
   ChunkUkey, CodeGenerationDataUrl, CodeGenerationResult, Compilation, ConcatenationScope, Context,
   DependenciesBlock, DependencyId, ExternalType, FactoryMeta, ImportAttributes, InitFragmentExt,
   InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleGraph, ModuleType,
-  NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency,
-  StaticExportsSpec, UsedExports, NAMESPACE_OBJECT_EXPORT,
+  NormalInitFragment, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, SourceType,
+  StaticExportsDependency, StaticExportsSpec, UsedExports, NAMESPACE_OBJECT_EXPORT,
 };
 
 static EXTERNAL_MODULE_JS_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -429,7 +429,8 @@ impl ExternalModule {
           };
 
           if let Some(concatenation_scope) = concatenation_scope {
-            let exports_info = module_graph.get_prefetched_exports_info(&self.identifier(), None);
+            let exports_info = module_graph
+              .get_prefetched_exports_info(&self.identifier(), PrefetchExportsInfoMode::AllExports);
             let used_exports = exports_info.get_used_exports(runtime);
             let meta = &self.dependency_meta.attributes;
             let attributes = meta.as_ref().map(|meta| {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -442,7 +442,7 @@ fn get_exports_type_impl(
         let name = Atom::from("__esModule");
         let exports_info = mg.get_prefetched_exports_info_optional(
           &identifier,
-          PrefetchExportsInfoMode::NamedExports(vec![&name]),
+          PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&name)),
         );
         if let Some(export_info) = exports_info
           .as_ref()

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -442,7 +442,7 @@ fn get_exports_type_impl(
         let name = Atom::from("__esModule");
         let exports_info = mg.get_prefetched_exports_info_optional(
           &identifier,
-          PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&name)),
+          PrefetchExportsInfoMode::NamedExports(vec![&name]),
         );
         if let Some(export_info) = exports_info
           .as_ref()

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -442,7 +442,7 @@ fn get_exports_type_impl(
         let name = Atom::from("__esModule");
         let exports_info = mg.get_prefetched_exports_info_optional(
           &identifier,
-          PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&name)),
+          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([&name])),
         );
         if let Some(export_info) = exports_info
           .as_ref()

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -32,8 +32,8 @@ use crate::{
   ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, CompilationAsset, CompilationId,
   CompilerId, CompilerOptions, ConcatenationScope, ConnectionState, Context, ContextModule,
   DependenciesBlock, DependencyId, ExportInfoGetter, ExportProvided, ExternalModule, ModuleGraph,
-  ModuleLayer, ModuleType, NormalModule, RawModule, Resolve, ResolverFactory, RuntimeSpec,
-  SelfModule, SharedPluginDriver, SourceType,
+  ModuleLayer, ModuleType, NormalModule, PrefetchExportsInfoMode, RawModule, Resolve,
+  ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver, SourceType,
 };
 
 pub struct BuildContext {
@@ -439,17 +439,22 @@ fn get_exports_type_impl(
           }
         }
 
-        if let Some(export_info) =
-          mg.get_read_only_export_info(&identifier, Atom::from("__esModule"))
+        let name = Atom::from("__esModule");
+        let exports_info = mg.get_prefetched_exports_info_optional(
+          &identifier,
+          PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&name)),
+        );
+        if let Some(export_info) = exports_info
+          .as_ref()
+          .map(|info| info.get_read_only_export_info(&name))
         {
-          let export_info_data = export_info.as_data(mg);
           if matches!(
-            ExportInfoGetter::provided(export_info_data),
+            ExportInfoGetter::provided(export_info),
             Some(ExportProvided::NotProvided)
           ) {
             handle_default(default_object)
           } else {
-            let Some(target) = export_info_data.get_target(mg) else {
+            let Some(target) = export_info.get_target(mg) else {
               return ExportsType::Dynamic;
             };
             if target

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -9,7 +9,7 @@ use swc_core::ecma::atoms::Atom;
 use crate::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, Compilation, DependenciesBlock,
   Dependency, ExportProvided, ExportsInfoGetter, PrefetchExportsInfoMode,
-  PrefetchedExportsInfoWrapper, ProvidedExports, RuntimeSpec, UsedExports,
+  PrefetchedExportsInfoWrapper, RuntimeSpec,
 };
 mod module;
 pub use module::*;
@@ -1092,24 +1092,6 @@ impl<'a> ModuleGraph<'a> {
       panic!("should have active partial");
     };
     active_partial.export_info_map.insert(id, info);
-  }
-
-  pub fn get_provided_exports(&self, module_id: ModuleIdentifier) -> ProvidedExports {
-    let mgm = self
-      .module_graph_module_by_identifier(&module_id)
-      .expect("should have module graph module");
-    mgm.exports.get_provided_exports(self)
-  }
-
-  pub fn get_used_exports(
-    &self,
-    id: &ModuleIdentifier,
-    runtime: Option<&RuntimeSpec>,
-  ) -> UsedExports {
-    let mgm = self
-      .module_graph_module_by_identifier(id)
-      .expect("should have module graph module");
-    mgm.exports.get_used_exports(self, runtime)
   }
 
   pub fn get_optimization_bailout_mut(&mut self, id: &ModuleIdentifier) -> &mut Vec<String> {

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1159,7 +1159,7 @@ impl<'a> ModuleGraph<'a> {
       let exports_info = ExportsInfoGetter::prefetch(
         &mgm.exports,
         self,
-        PrefetchExportsInfoMode::NamedNestedExports(names.iter().collect::<Vec<_>>()),
+        PrefetchExportsInfoMode::NamedNestedExports(names),
       );
       ExportsInfoGetter::is_export_provided(&exports_info, names)
     })

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1159,7 +1159,7 @@ impl<'a> ModuleGraph<'a> {
       let exports_info = ExportsInfoGetter::prefetch(
         &mgm.exports,
         self,
-        PrefetchExportsInfoMode::NamedNestedExports(names),
+        PrefetchExportsInfoMode::NamedNestedExports(names.iter().collect::<Vec<_>>()),
       );
       ExportsInfoGetter::is_export_provided(&exports_info, names)
     })

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -1038,11 +1038,10 @@ impl Stats<'_> {
           .used_exports
           .is_enable()
       {
-        match self
-          .compilation
-          .get_module_graph()
-          .get_used_exports(&module.identifier(), None)
-        {
+        let module_graph = self.compilation.get_module_graph();
+        let exports_info = module_graph.get_prefetched_exports_info(&module.identifier(), None);
+        let used_exports = exports_info.get_used_exports(None);
+        match used_exports {
           UsedExports::Unknown => Some(StatsUsedExports::Null),
           UsedExports::UsedNames(v) => Some(StatsUsedExports::Vec(v)),
           UsedExports::UsedNamespace(b) => Some(StatsUsedExports::Bool(b)),
@@ -1055,11 +1054,10 @@ impl Stats<'_> {
     if options.provided_exports {
       stats.provided_exports =
         if !executed && self.compilation.options.optimization.provided_exports {
-          match self
-            .compilation
-            .get_module_graph()
-            .get_provided_exports(module.identifier())
-          {
+          let module_graph = self.compilation.get_module_graph();
+          let exports_info = module_graph.get_prefetched_exports_info(&module.identifier(), None);
+          let provided_exports = exports_info.get_provided_exports();
+          match provided_exports {
             ProvidedExports::ProvidedNames(v) => Some(v),
             _ => None,
           }

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -20,8 +20,8 @@ pub use r#struct::*;
 
 use crate::{
   BoxModule, BoxRuntimeModule, Chunk, ChunkGraph, ChunkGroupOrderKey, ChunkGroupUkey, ChunkUkey,
-  Compilation, ExecutedRuntimeModule, LogType, ModuleGraph, ModuleIdentifier, ProvidedExports,
-  SourceType, UsedExports,
+  Compilation, ExecutedRuntimeModule, LogType, ModuleGraph, ModuleIdentifier,
+  PrefetchExportsInfoMode, ProvidedExports, SourceType, UsedExports,
 };
 
 #[derive(Debug, Clone)]
@@ -1039,7 +1039,8 @@ impl Stats<'_> {
           .is_enable()
       {
         let module_graph = self.compilation.get_module_graph();
-        let exports_info = module_graph.get_prefetched_exports_info(&module.identifier(), None);
+        let exports_info = module_graph
+          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::AllExports);
         let used_exports = exports_info.get_used_exports(None);
         match used_exports {
           UsedExports::Unknown => Some(StatsUsedExports::Null),
@@ -1055,7 +1056,8 @@ impl Stats<'_> {
       stats.provided_exports =
         if !executed && self.compilation.options.optimization.provided_exports {
           let module_graph = self.compilation.get_module_graph();
-          let exports_info = module_graph.get_prefetched_exports_info(&module.identifier(), None);
+          let exports_info = module_graph
+            .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::AllExports);
           let provided_exports = exports_info.get_provided_exports();
           match provided_exports {
             ProvidedExports::ProvidedNames(v) => Some(v),

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -700,7 +700,7 @@ fn get_used_exports<'a>(
 
   let exports_info = mg.get_prefetched_exports_info_optional(
     &identifier,
-    PrefetchExportsInfoMode::NamedExports(exports_names.iter().collect::<Vec<_>>()),
+    PrefetchExportsInfoMode::NamedExports(&exports_names),
   );
 
   exports
@@ -738,7 +738,7 @@ fn get_unused_local_ident(
     .collect::<Vec<_>>();
   let exports_info = mg.get_prefetched_exports_info_optional(
     &identifier,
-    PrefetchExportsInfoMode::NamedExports(exports_names.iter().collect::<Vec<_>>()),
+    PrefetchExportsInfoMode::NamedExports(&exports_names),
   );
 
   CodeGenerationDataUnusedLocalIdent {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -700,7 +700,7 @@ fn get_used_exports<'a>(
 
   let exports_info = mg.get_prefetched_exports_info_optional(
     &identifier,
-    PrefetchExportsInfoMode::NamedExports(&exports_names),
+    PrefetchExportsInfoMode::NamedExports(exports_names.iter().collect::<Vec<_>>()),
   );
 
   exports
@@ -738,7 +738,7 @@ fn get_unused_local_ident(
     .collect::<Vec<_>>();
   let exports_info = mg.get_prefetched_exports_info_optional(
     &identifier,
-    PrefetchExportsInfoMode::NamedExports(&exports_names),
+    PrefetchExportsInfoMode::NamedExports(exports_names.iter().collect::<Vec<_>>()),
   );
 
   CodeGenerationDataUnusedLocalIdent {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -700,7 +700,7 @@ fn get_used_exports<'a>(
 
   let exports_info = mg.get_prefetched_exports_info_optional(
     &identifier,
-    PrefetchExportsInfoMode::NamedExports(&exports_names),
+    PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter(exports_names.iter())),
   );
 
   exports
@@ -738,7 +738,7 @@ fn get_unused_local_ident(
     .collect::<Vec<_>>();
   let exports_info = mg.get_prefetched_exports_info_optional(
     &identifier,
-    PrefetchExportsInfoMode::NamedExports(&exports_names),
+    PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter(exports_names.iter())),
   );
 
   CodeGenerationDataUnusedLocalIdent {

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -1,7 +1,8 @@
 use rspack_collections::DatabaseItem;
 use rspack_core::{
   ApplyContext, ChunkGraph, Compilation, CompilerEmit, CompilerOptions, Context, EntryDependency,
-  Filename, LibIdentOptions, PathData, Plugin, PluginContext, ProvidedExports, SourceType,
+  ExportsInfoGetter, Filename, LibIdentOptions, PathData, Plugin, PluginContext, ProvidedExports,
+  SourceType,
 };
 use rspack_error::{Error, Result, ToStringResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
@@ -140,9 +141,9 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
       let ident = module.lib_ident(LibIdentOptions { context });
 
       if let Some(ident) = ident {
-        let exports_info = module_graph.get_exports_info(&module.identifier());
+        let exports_info = module_graph.get_prefetched_exports_info(&module.identifier(), None);
 
-        let provided_exports = match exports_info.get_provided_exports(&module_graph) {
+        let provided_exports = match ExportsInfoGetter::get_provided_exports(&exports_info) {
           ProvidedExports::ProvidedNames(vec) => Some(DllManifestContentItemExports::Vec(vec)),
           ProvidedExports::ProvidedAll => Some(DllManifestContentItemExports::True),
           _ => None,

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -1,8 +1,8 @@
 use rspack_collections::DatabaseItem;
 use rspack_core::{
   ApplyContext, ChunkGraph, Compilation, CompilerEmit, CompilerOptions, Context, EntryDependency,
-  ExportsInfoGetter, Filename, LibIdentOptions, PathData, Plugin, PluginContext, ProvidedExports,
-  SourceType,
+  ExportsInfoGetter, Filename, LibIdentOptions, PathData, Plugin, PluginContext,
+  PrefetchExportsInfoMode, ProvidedExports, SourceType,
 };
 use rspack_error::{Error, Result, ToStringResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
@@ -141,7 +141,8 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
       let ident = module.lib_ident(LibIdentOptions { context });
 
       if let Some(ident) = ident {
-        let exports_info = module_graph.get_prefetched_exports_info(&module.identifier(), None);
+        let exports_info = module_graph
+          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::AllExports);
 
         let provided_exports = match ExportsInfoGetter::get_provided_exports(&exports_info) {
           ProvidedExports::ProvidedNames(vec) => Some(DllManifestContentItemExports::Vec(vec)),

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -81,7 +81,8 @@ impl CommonJsExportRequireDependency {
         .get_nested_exports_info(Some(ids))
         .map(|data| data.id);
 
-      imported_exports_info = nested.map(|id| nested_exports_info.redirect(id));
+      imported_exports_info =
+        nested.map(|id| ExportsInfoGetter::prefetch(&id, mg, PrefetchExportsInfoMode::AllExports));
     }
 
     let mut exports_info = Some(
@@ -99,7 +100,8 @@ impl CommonJsExportRequireDependency {
       let nested = nested_exports_info
         .get_nested_exports_info(Some(&self.names))
         .map(|data| data.id);
-      exports_info = nested.map(|id| nested_exports_info.redirect(id));
+      exports_info =
+        nested.map(|id| ExportsInfoGetter::prefetch(&id, mg, PrefetchExportsInfoMode::AllExports));
     };
 
     let no_extra_exports = imported_exports_info.as_ref().is_some_and(|data| {
@@ -319,7 +321,7 @@ impl Dependency for CommonJsExportRequireDependency {
       }
 
       match ExportInfoGetter::exports_info(export_info) {
-        Some(v) => exports_info = exports_info.redirect(v),
+        Some(v) => exports_info = exports_info.redirect(v, false),
         None => return get_full_result(),
       };
     }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -5,9 +5,10 @@ use rspack_cacheable::{
 use rspack_core::{
   property_access, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportNameOrSpec, ExportSpec, ExportsOfExportsSpec,
-  ExportsSpec, InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleGraph,
-  NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsedName,
+  DependencyTemplateType, DependencyType, ExportNameOrSpec, ExportSpec, ExportsInfoGetter,
+  ExportsOfExportsSpec, ExportsSpec, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  ModuleGraph, NormalInitFragment, PrefetchExportsInfoMode, RuntimeGlobals, TemplateContext,
+  TemplateReplaceSource, UsedName,
 };
 use swc_core::atoms::Atom;
 
@@ -162,9 +163,18 @@ impl DependencyTemplate for CommonJsExportsDependencyTemplate {
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
 
-    let used = module_graph
-      .get_exports_info(&module.identifier())
-      .get_used_name(&module_graph, *runtime, &dep.names);
+    let used = ExportsInfoGetter::get_used_name(
+      &module_graph.get_prefetched_exports_info(
+        &module.identifier(),
+        if dep.names.is_empty() {
+          PrefetchExportsInfoMode::AllExports
+        } else {
+          PrefetchExportsInfoMode::NamedNestedExports(&dep.names)
+        },
+      ),
+      *runtime,
+      &dep.names,
+    );
 
     let exports_argument = module.get_exports_argument();
     let module_argument = module.get_module_argument();

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -5,9 +5,9 @@ use rspack_cacheable::{
 use rspack_core::{
   module_id, property_access, to_normal_comment, AsContextDependency, Dependency,
   DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange,
-  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsType,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, RuntimeGlobals,
-  RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoGetter, ExportsType,
+  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, PrefetchExportsInfoMode,
+  RuntimeGlobals, RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
 };
 use swc_core::atoms::Atom;
 
@@ -175,9 +175,18 @@ impl DependencyTemplate for CommonJsFullRequireDependencyTemplate {
     );
 
     if let Some(imported_module) = module_graph.module_graph_module_by_dependency_id(&dep.id) {
-      let used = module_graph
-        .get_exports_info(&imported_module.module_identifier)
-        .get_used_name(&module_graph, *runtime, &dep.names);
+      let used = ExportsInfoGetter::get_used_name(
+        &module_graph.get_prefetched_exports_info(
+          &imported_module.module_identifier,
+          if dep.names.is_empty() {
+            PrefetchExportsInfoMode::AllExports
+          } else {
+            PrefetchExportsInfoMode::NamedNestedExports(&dep.names)
+          },
+        ),
+        *runtime,
+        &dep.names,
+      );
 
       if let Some(used) = used {
         let comment = to_normal_comment(&property_access(dep.names.clone(), 0));

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -4,6 +4,7 @@ use rspack_core::{
   InitFragmentKey, InitFragmentStage, ModuleGraph, NormalInitFragment, PrefetchExportsInfoMode,
   RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsageState,
 };
+use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
 
 // Mark module `__esModule`.
@@ -55,7 +56,7 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
     let name = Atom::from("__esModule");
     let exports_info = module_graph.get_prefetched_exports_info(
       &module.identifier(),
-      PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&name)),
+      PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&name])),
     );
     let used = ExportInfoGetter::get_used(exports_info.get_read_only_export_info(&name), *runtime);
     if !matches!(used, UsageState::Unused) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -9,6 +9,7 @@ use rspack_core::{
   ModuleGraph, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, SharedSourceMap,
   TemplateContext, TemplateReplaceSource, UsedName, DEFAULT_EXPORT,
 };
+use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
 
 use crate::parser_plugin::JS_DEFAULT_KEYWORD;
@@ -165,7 +166,7 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
       ExportsInfoGetter::get_used_name(
         &compilation.get_module_graph().get_prefetched_exports_info(
           module_identifier,
-          PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&name)),
+          PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&name])),
         ),
         *runtime,
         std::slice::from_ref(&name),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -5,9 +5,9 @@ use rspack_core::{
   property_access, rspack_sources::ReplacementEnforce, AsContextDependency, AsModuleDependency,
   Compilation, Dependency, DependencyCodeGeneration, DependencyId, DependencyLocation,
   DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ESMExportInitFragment, ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
-  RuntimeGlobals, RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
-  DEFAULT_EXPORT,
+  ESMExportInitFragment, ExportNameOrSpec, ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec,
+  ModuleGraph, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, SharedSourceMap,
+  TemplateContext, TemplateReplaceSource, UsedName, DEFAULT_EXPORT,
 };
 use swc_core::atoms::Atom;
 
@@ -161,10 +161,15 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
       runtime: &Option<&RuntimeSpec>,
       module_identifier: &Identifier,
     ) -> Option<UsedName> {
-      let module_graph = compilation.get_module_graph();
-      module_graph
-        .get_exports_info(module_identifier)
-        .get_used_name(&module_graph, *runtime, &[name.into()])
+      let name = Atom::from(name);
+      ExportsInfoGetter::get_used_name(
+        &compilation.get_module_graph().get_prefetched_exports_info(
+          module_identifier,
+          PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&name)),
+        ),
+        *runtime,
+        std::slice::from_ref(&name),
+      )
     }
 
     if let Some(declaration) = &dep.declaration {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -13,12 +13,11 @@ use rspack_core::{
   DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
   ESMExportInitFragment, ExportInfo, ExportInfoGetter, ExportNameOrSpec, ExportPresenceMode,
-  ExportProvided, ExportSpec, ExportsInfo, ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec,
-  ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt,
-  InitFragmentKey, InitFragmentStage, JavascriptParserOptions, ModuleDependency, ModuleGraph,
-  ModuleIdentifier, NormalInitFragment, PrefetchExportsInfoMode, RuntimeCondition, RuntimeGlobals,
-  RuntimeSpec, SharedSourceMap, Template, TemplateContext, TemplateReplaceSource, UsageState,
-  UsedName,
+  ExportProvided, ExportSpec, ExportsInfo, ExportsOfExportsSpec, ExportsSpec, ExportsType,
+  ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleIdentifier,
+  NormalInitFragment, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SharedSourceMap, Template,
+  TemplateContext, TemplateReplaceSource, UsageState, UsedName,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -145,12 +144,7 @@ impl ESMExportImportedSpecifierDependency {
     let is_name_unused = if let Some(ref name) = name {
       exports_info.get_used(module_graph, std::slice::from_ref(name), runtime) == UsageState::Unused
     } else {
-      let exports_info_data = ExportsInfoGetter::prefetch(
-        &exports_info,
-        module_graph,
-        PrefetchExportsInfoMode::AllExports,
-      );
-      !ExportsInfoGetter::is_used(&exports_info_data, runtime)
+      !exports_info.is_used(module_graph, runtime)
     };
     if is_name_unused {
       let mut mode = ExportMode::new(ExportModeType::Unused);

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -16,8 +16,9 @@ use rspack_core::{
   ExportProvided, ExportSpec, ExportsInfo, ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec,
   ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt,
   InitFragmentKey, InitFragmentStage, JavascriptParserOptions, ModuleDependency, ModuleGraph,
-  ModuleIdentifier, NormalInitFragment, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
-  SharedSourceMap, Template, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
+  ModuleIdentifier, NormalInitFragment, PrefetchExportsInfoMode, RuntimeCondition, RuntimeGlobals,
+  RuntimeSpec, SharedSourceMap, Template, TemplateContext, TemplateReplaceSource, UsageState,
+  UsedName,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -144,7 +145,11 @@ impl ESMExportImportedSpecifierDependency {
     let is_name_unused = if let Some(ref name) = name {
       exports_info.get_used(module_graph, std::slice::from_ref(name), runtime) == UsageState::Unused
     } else {
-      let exports_info_data = ExportsInfoGetter::prefetch(&exports_info, module_graph, None);
+      let exports_info_data = ExportsInfoGetter::prefetch(
+        &exports_info,
+        module_graph,
+        PrefetchExportsInfoMode::AllExports,
+      );
       !ExportsInfoGetter::is_used(&exports_info_data, runtime)
     };
     if is_name_unused {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -10,6 +10,7 @@ use rspack_core::{
   ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, ModuleGraph, PrefetchExportsInfoMode,
   SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
 };
+use rustc_hash::FxHashSet;
 use swc_core::ecma::atoms::Atom;
 
 // Create _webpack_require__.d(__webpack_exports__, {}) for each export.
@@ -142,7 +143,7 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
     let used_name = {
       let exports_info = module_graph.get_prefetched_exports_info(
         &module.identifier(),
-        PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&dep.name)),
+        PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&dep.name])),
       );
       let used_name =
         ExportsInfoGetter::get_used_name(&exports_info, *runtime, std::slice::from_ref(&dep.name));

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -7,8 +7,8 @@ use rspack_core::{
   AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyTemplateType, DependencyType, ESMExportInitFragment, ExportNameOrSpec,
-  ExportsOfExportsSpec, ExportsSpec, ModuleGraph, SharedSourceMap, TemplateContext,
-  TemplateReplaceSource, UsedName,
+  ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, ModuleGraph, PrefetchExportsInfoMode,
+  SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -140,9 +140,12 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
       .expect("should have module graph module");
 
     let used_name = {
-      let exports_info = module_graph.get_exports_info(&module.identifier());
+      let exports_info = module_graph.get_prefetched_exports_info(
+        &module.identifier(),
+        PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&dep.name)),
+      );
       let used_name =
-        exports_info.get_used_name(&module_graph, *runtime, std::slice::from_ref(&dep.name));
+        ExportsInfoGetter::get_used_name(&exports_info, *runtime, std::slice::from_ref(&dep.name));
       used_name.map(|item| match item {
         UsedName::Normal(vec) => {
           // only have one value for export specifier dependency

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -10,10 +10,10 @@ use rspack_core::{
   BuildMetaDefaultObject, ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ErrorSpan, ExportInfoGetter, ExportProvided, ExportsType, ExtendedReferencedExport,
-  FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage,
-  ModuleDependency, ModuleGraph, ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap,
-  TemplateContext, TemplateReplaceSource,
+  ErrorSpan, ExportInfoGetter, ExportProvided, ExportsInfoGetter, ExportsType,
+  ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, ModuleDependency, ModuleGraph, PrefetchExportsInfoMode, ProvidedExports,
+  RuntimeCondition, RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -282,25 +282,32 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       return None;
     }
     let imported_module_identifier = imported_module.identifier();
+    let exports_info = module_graph.get_prefetched_exports_info(
+      &imported_module_identifier,
+      PrefetchExportsInfoMode::NamedNestedExports(ids),
+    );
     if (!matches!(exports_type, ExportsType::DefaultWithNamed) || ids[0] != "default")
       && matches!(
-        module_graph.is_export_provided(&imported_module_identifier, ids),
+        ExportsInfoGetter::is_export_provided(&exports_info, ids),
         Some(ExportProvided::NotProvided)
       )
     {
       let mut pos = 0;
-      let mut maybe_exports_info = Some(module_graph.get_exports_info(&imported_module_identifier));
+      let mut maybe_exports_info = Some(module_graph.get_prefetched_exports_info(
+        &imported_module_identifier,
+        PrefetchExportsInfoMode::NamedNestedAllExports(ids),
+      ));
       while pos < ids.len()
-        && let Some(exports_info) = maybe_exports_info
+        && let Some(exports_info) = &maybe_exports_info
       {
         let id = &ids[pos];
         pos += 1;
-        let export_info = exports_info.get_read_only_export_info(module_graph, id);
+        let export_info = exports_info.get_read_only_export_info(id);
         if matches!(
-          ExportInfoGetter::provided(export_info.as_data(module_graph)),
+          ExportInfoGetter::provided(export_info),
           Some(ExportProvided::NotProvided)
         ) {
-          let provided_exports = exports_info.get_provided_exports(module_graph);
+          let provided_exports = ExportsInfoGetter::get_provided_exports(exports_info);
           let more_info = if let ProvidedExports::ProvidedNames(exports) = &provided_exports {
             if exports.is_empty() {
               " (module has no exports)".to_string()
@@ -330,7 +337,11 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
           );
           return Some(create_error(msg));
         }
-        maybe_exports_info = ExportInfoGetter::exports_info(export_info.as_data(module_graph));
+        let Some(nested_exports_info) = ExportInfoGetter::exports_info(export_info) else {
+          maybe_exports_info = None;
+          continue;
+        };
+        maybe_exports_info = Some(exports_info.redirect(nested_exports_info));
       }
       let msg = format!(
         "export {} {} was not found in '{}'",

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -341,7 +341,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
           maybe_exports_info = None;
           continue;
         };
-        maybe_exports_info = Some(exports_info.redirect(nested_exports_info));
+        maybe_exports_info = Some(exports_info.redirect(nested_exports_info, true));
       }
       let msg = format!(
         "export {} {} was not found in '{}'",

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -8,8 +8,8 @@ use rspack_core::{
   DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange,
   DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoGetter,
   ExtendedReferencedExport, FactorizeInfo, InitFragmentKey, InitFragmentStage, ModuleDependency,
-  ModuleGraph, NormalInitFragment, RuntimeSpec, SharedSourceMap, TemplateContext,
-  TemplateReplaceSource, UsedName,
+  ModuleGraph, NormalInitFragment, PrefetchExportsInfoMode, RuntimeSpec, SharedSourceMap,
+  TemplateContext, TemplateReplaceSource, UsedName,
 };
 use rspack_util::ext::DynHash;
 use swc_core::atoms::Atom;
@@ -174,7 +174,10 @@ impl DependencyTemplate for ProvideDependencyTemplate {
       return;
     };
     let used_name = ExportsInfoGetter::get_used_name(
-      &module_graph.get_prefetched_exports_info(con.module_identifier(), Some(&dep.ids)),
+      &module_graph.get_prefetched_exports_info(
+        con.module_identifier(),
+        PrefetchExportsInfoMode::NamedNestedExports(&dep.ids),
+      ),
       *runtime,
       &dep.ids,
     );

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -176,7 +176,11 @@ impl DependencyTemplate for ProvideDependencyTemplate {
     let used_name = ExportsInfoGetter::get_used_name(
       &module_graph.get_prefetched_exports_info(
         con.module_identifier(),
-        PrefetchExportsInfoMode::NamedNestedExports(&dep.ids),
+        if dep.ids.is_empty() {
+          PrefetchExportsInfoMode::AllExports
+        } else {
+          PrefetchExportsInfoMode::NamedNestedExports(&dep.ids)
+        },
       ),
       *runtime,
       &dep.ids,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -176,7 +176,7 @@ impl DependencyTemplate for ProvideDependencyTemplate {
     let used_name = ExportsInfoGetter::get_used_name(
       &module_graph.get_prefetched_exports_info(
         con.module_identifier(),
-        PrefetchExportsInfoMode::NamedNestedExports(dep.ids.iter().collect::<Vec<_>>()),
+        PrefetchExportsInfoMode::NamedNestedExports(&dep.ids),
       ),
       *runtime,
       &dep.ids,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -176,7 +176,7 @@ impl DependencyTemplate for ProvideDependencyTemplate {
     let used_name = ExportsInfoGetter::get_used_name(
       &module_graph.get_prefetched_exports_info(
         con.module_identifier(),
-        PrefetchExportsInfoMode::NamedNestedExports(&dep.ids),
+        PrefetchExportsInfoMode::NamedNestedExports(dep.ids.iter().collect::<Vec<_>>()),
       ),
       *runtime,
       &dep.ids,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -6,10 +6,10 @@ use rspack_cacheable::{
 use rspack_core::{
   create_exports_object_referenced, module_raw, AsContextDependency, Compilation, Dependency,
   DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange,
-  DependencyTemplate, DependencyTemplateType, DependencyType, ExtendedReferencedExport,
-  FactorizeInfo, InitFragmentKey, InitFragmentStage, ModuleDependency, ModuleGraph,
-  NormalInitFragment, RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource,
-  UsedName,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoGetter,
+  ExtendedReferencedExport, FactorizeInfo, InitFragmentKey, InitFragmentStage, ModuleDependency,
+  ModuleGraph, NormalInitFragment, RuntimeSpec, SharedSourceMap, TemplateContext,
+  TemplateReplaceSource, UsedName,
 };
 use rspack_util::ext::DynHash;
 use swc_core::atoms::Atom;
@@ -173,8 +173,11 @@ impl DependencyTemplate for ProvideDependencyTemplate {
       // not find connection, maybe because it's not resolved in make phase, and `bail` is false
       return;
     };
-    let exports_info = module_graph.get_exports_info(con.module_identifier());
-    let used_name = exports_info.get_used_name(&module_graph, *runtime, &dep.ids.clone());
+    let used_name = ExportsInfoGetter::get_used_name(
+      &module_graph.get_prefetched_exports_info(con.module_identifier(), Some(&dep.ids)),
+      *runtime,
+      &dep.ids,
+    );
     init_fragments.push(Box::new(NormalInitFragment::new(
       format!(
         "/* provided dependency */ var {} = {}{};\n",

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -5,8 +5,8 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportInfoGetter,
-  ExportProvided, ExportsInfoGetter, TemplateContext, TemplateReplaceSource, UsageState,
-  UsedExports,
+  ExportProvided, ExportsInfoGetter, PrefetchExportsInfoMode, TemplateContext,
+  TemplateReplaceSource, UsageState, UsedExports,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -73,8 +73,6 @@ impl ExportInfoDependency {
     }
 
     let exports_info = module_graph.get_exports_info(&module_identifier);
-    let exports_info_data =
-      ExportsInfoGetter::prefetch(&exports_info, &module_graph, Some(export_name));
 
     match prop.to_string().as_str() {
       "canMangle" => {
@@ -109,6 +107,11 @@ impl ExportInfoDependency {
         )
       }
       "provideInfo" => {
+        let exports_info_data = ExportsInfoGetter::prefetch(
+          &exports_info,
+          &module_graph,
+          PrefetchExportsInfoMode::NamedNestedExports(export_name),
+        );
         ExportsInfoGetter::is_export_provided(&exports_info_data, export_name).map(|provided| {
           (match provided {
             ExportProvided::Provided => "true",

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -110,7 +110,7 @@ impl ExportInfoDependency {
         let exports_info_data = ExportsInfoGetter::prefetch(
           &exports_info,
           &module_graph,
-          PrefetchExportsInfoMode::NamedNestedExports(export_name),
+          PrefetchExportsInfoMode::NamedNestedExports(export_name.iter().collect::<Vec<_>>()),
         );
         ExportsInfoGetter::is_export_provided(&exports_info_data, export_name).map(|provided| {
           (match provided {

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -74,7 +74,7 @@ impl ExportInfoDependency {
 
     let exports_info = module_graph.get_prefetched_exports_info(
       &module_identifier,
-      PrefetchExportsInfoMode::NamedNestedExports(&export_name),
+      PrefetchExportsInfoMode::NamedNestedExports(export_name),
     );
 
     match prop.to_string().as_str() {
@@ -89,11 +89,11 @@ impl ExportInfoDependency {
         can_mangle.map(|v| v.to_string())
       }
       "used" => {
-        let used = ExportsInfoGetter::get_used(&exports_info, &export_name, *runtime);
+        let used = ExportsInfoGetter::get_used(&exports_info, export_name, *runtime);
         Some((!matches!(used, UsageState::Unused)).to_string())
       }
       "useInfo" => {
-        let used_state = ExportsInfoGetter::get_used(&exports_info, &export_name, *runtime);
+        let used_state = ExportsInfoGetter::get_used(&exports_info, export_name, *runtime);
         Some(
           (match used_state {
             UsageState::Used => "true",

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -110,7 +110,7 @@ impl ExportInfoDependency {
         let exports_info_data = ExportsInfoGetter::prefetch(
           &exports_info,
           &module_graph,
-          PrefetchExportsInfoMode::NamedNestedExports(export_name.iter().collect::<Vec<_>>()),
+          PrefetchExportsInfoMode::NamedNestedExports(export_name),
         );
         ExportsInfoGetter::is_export_provided(&exports_info_data, export_name).map(|provided| {
           (match provided {

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -53,9 +53,9 @@ impl ExportInfoDependency {
     let module_identifier = module.identifier();
 
     if export_name.is_empty() && prop == "usedExports" {
-      let used_exports = module_graph
-        .get_exports_info(&module_identifier)
-        .get_used_exports(&module_graph, *runtime);
+      let exports_info = module_graph
+        .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::AllExports);
+      let used_exports = exports_info.get_used_exports(*runtime);
       return Some(match used_exports {
         UsedExports::Unknown => "null".to_owned(),
         UsedExports::UsedNamespace(value) => value.to_string(),
@@ -72,29 +72,28 @@ impl ExportInfoDependency {
       });
     }
 
-    let exports_info = module_graph.get_exports_info(&module_identifier);
+    let exports_info = module_graph.get_prefetched_exports_info(
+      &module_identifier,
+      PrefetchExportsInfoMode::NamedNestedExports(&export_name),
+    );
 
     match prop.to_string().as_str() {
       "canMangle" => {
         let can_mangle = if let Some(export_info) =
-          exports_info.get_read_only_export_info_recursive(&module_graph, export_name)
+          exports_info.get_read_only_export_info_recursive(export_name)
         {
-          ExportInfoGetter::can_mangle(export_info.as_data(&module_graph))
+          ExportInfoGetter::can_mangle(export_info)
         } else {
-          ExportInfoGetter::can_mangle(
-            exports_info
-              .other_exports_info(&module_graph)
-              .as_data(&module_graph),
-          )
+          ExportInfoGetter::can_mangle(exports_info.other_exports_info())
         };
         can_mangle.map(|v| v.to_string())
       }
       "used" => {
-        let used = exports_info.get_used(&module_graph, &export_name.clone(), *runtime);
+        let used = ExportsInfoGetter::get_used(&exports_info, &export_name, *runtime);
         Some((!matches!(used, UsageState::Unused)).to_string())
       }
       "useInfo" => {
-        let used_state = exports_info.get_used(&module_graph, &export_name.clone(), *runtime);
+        let used_state = ExportsInfoGetter::get_used(&exports_info, &export_name, *runtime);
         Some(
           (match used_state {
             UsageState::Used => "true",
@@ -107,12 +106,7 @@ impl ExportInfoDependency {
         )
       }
       "provideInfo" => {
-        let exports_info_data = ExportsInfoGetter::prefetch(
-          &exports_info,
-          &module_graph,
-          PrefetchExportsInfoMode::NamedNestedExports(export_name),
-        );
-        ExportsInfoGetter::is_export_provided(&exports_info_data, export_name).map(|provided| {
+        ExportsInfoGetter::is_export_provided(&exports_info, export_name).map(|provided| {
           (match provided {
             ExportProvided::Provided => "true",
             ExportProvided::NotProvided => "false",

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -3,8 +3,9 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   filter_runtime, runtime_condition_expression, AsContextDependency, AsModuleDependency,
   Compilation, ConnectionState, Dependency, DependencyCodeGeneration, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyTemplateType, ModuleGraph, ModuleIdentifier,
-  RuntimeCondition, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedByExports,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, ExportsInfoGetter, ModuleGraph,
+  ModuleIdentifier, PrefetchExportsInfoMode, RuntimeCondition, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource, UsageState, UsedByExports,
 };
 use rspack_util::ext::DynHash;
 
@@ -39,10 +40,14 @@ impl PureExpressionDependency {
       Some(UsedByExports::Bool(false)) => RuntimeCondition::Boolean(false),
       Some(UsedByExports::Set(ref set)) => {
         let module_graph = compilation.get_module_graph();
-        let exports_info = module_graph.get_exports_info(&self.module_identifier);
+        let names = set.iter().cloned().collect::<Vec<_>>();
+        let exports_info = module_graph.get_prefetched_exports_info(
+          &self.module_identifier,
+          PrefetchExportsInfoMode::NamedExports(&names),
+        );
         filter_runtime(runtime, |cur_runtime| {
           set.iter().any(|id| {
-            exports_info.get_used(&module_graph, std::slice::from_ref(id), cur_runtime)
+            ExportsInfoGetter::get_used(&exports_info, std::slice::from_ref(id), cur_runtime)
               != UsageState::Unused
           })
         })

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -8,6 +8,7 @@ use rspack_core::{
   TemplateReplaceSource, UsageState, UsedByExports,
 };
 use rspack_util::ext::DynHash;
+use rustc_hash::FxHashSet;
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -40,10 +41,10 @@ impl PureExpressionDependency {
       Some(UsedByExports::Bool(false)) => RuntimeCondition::Boolean(false),
       Some(UsedByExports::Set(ref set)) => {
         let module_graph = compilation.get_module_graph();
-        let names = set.iter().cloned().collect::<Vec<_>>();
+        let names = set.iter().collect::<FxHashSet<_>>();
         let exports_info = module_graph.get_prefetched_exports_info(
           &self.module_identifier,
-          PrefetchExportsInfoMode::NamedExports(&names),
+          PrefetchExportsInfoMode::NamedExports(names),
         );
         filter_runtime(runtime, |cur_runtime| {
           set.iter().any(|id| {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -315,7 +315,7 @@ impl<'a> FlagDependencyExportsState<'a> {
         let target_module_exports_info = self.mg.get_prefetched_exports_info(
           &target.module,
           if let Some(names) = &target.export {
-            PrefetchExportsInfoMode::NamedNestedExports(names.iter().collect::<Vec<_>>())
+            PrefetchExportsInfoMode::NamedNestedExports(names)
           } else {
             PrefetchExportsInfoMode::Default
           },

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -16,7 +16,7 @@ use rspack_core::{
   ApplyContext, Compilation, CompilationOptimizeChunkModules, CompilerOptions, ExportInfoGetter,
   ExportProvided, ExportsInfoGetter, ExtendedReferencedExport, LibIdentOptions, Logger, Module,
   ModuleExt, ModuleGraph, ModuleGraphModule, ModuleIdentifier, Plugin, PluginContext,
-  ProvidedExports, RuntimeCondition, RuntimeSpec, SourceType,
+  PrefetchExportsInfoMode, ProvidedExports, RuntimeCondition, RuntimeSpec, SourceType,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -972,7 +972,11 @@ impl ModuleConcatenationPlugin {
       let module_graph = compilation.get_module_graph();
       let exports_info = module_graph.get_exports_info(current_root);
       let filtered_runtime = filter_runtime(Some(&chunk_runtime), |r| {
-        let exports_info_data = ExportsInfoGetter::prefetch(&exports_info, &module_graph, None);
+        let exports_info_data = ExportsInfoGetter::prefetch(
+          &exports_info,
+          &module_graph,
+          PrefetchExportsInfoMode::AllExports,
+        );
         ExportsInfoGetter::is_module_used(&exports_info_data, r)
       });
       let active_runtime = match filtered_runtime {

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -14,6 +14,7 @@ use rspack_core::{
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{AssertUtf8, Utf8Path};
+use rustc_hash::FxHashSet;
 use sugar_path::SugarPath;
 use swc_core::{
   common::{comments, comments::Comments, Span, Spanned, SyntaxContext, GLOBALS},
@@ -854,7 +855,7 @@ fn can_optimize_connection(
   {
     let exports_info = module_graph.get_prefetched_exports_info(
       &original_module,
-      PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(name)),
+      PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([name])),
     );
     let export_info = exports_info.get_export_info_without_mut_module_graph(name);
 
@@ -900,7 +901,7 @@ fn can_optimize_connection(
   {
     let exports_info = module_graph.get_prefetched_exports_info(
       connection.module_identifier(),
-      PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&ids[0])),
+      PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&ids[0]])),
     );
     let export_info = exports_info.get_export_info_without_mut_module_graph(&ids[0]);
 

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -854,7 +854,7 @@ fn can_optimize_connection(
   {
     let exports_info = module_graph.get_prefetched_exports_info(
       &original_module,
-      PrefetchExportsInfoMode::NamedExports(vec![name]),
+      PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(name)),
     );
     let export_info = exports_info.get_export_info_without_mut_module_graph(name);
 
@@ -900,7 +900,7 @@ fn can_optimize_connection(
   {
     let exports_info = module_graph.get_prefetched_exports_info(
       connection.module_identifier(),
-      PrefetchExportsInfoMode::NamedExports(vec![&ids[0]]),
+      PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&ids[0])),
     );
     let export_info = exports_info.get_export_info_without_mut_module_graph(&ids[0]);
 

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -876,7 +876,7 @@ fn can_optimize_connection(
       .unwrap_or_else(|| ids.get(1..).unwrap_or_default().to_vec());
     let need_move_target = match export_info {
       MaybeDynamicTargetExportInfo::Static(export_info) => Some(SideEffectsDoOptimizeMoveTarget {
-        export_info,
+        export_info: export_info.id(),
         target_export: target.export,
       }),
       MaybeDynamicTargetExportInfo::Dynamic { .. } => None,

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -7,8 +7,9 @@ use rspack_core::{
   BoxModule, Compilation, CompilationOptimizeDependencies, ConnectionState, DependencyExtraMeta,
   DependencyId, FactoryMeta, Logger, MaybeDynamicTargetExportInfo, ModuleFactoryCreateData,
   ModuleGraph, ModuleGraphConnection, ModuleIdentifier, NormalModuleCreateData,
-  NormalModuleFactoryModule, Plugin, ResolvedExportInfoTarget, SideEffectsBailoutItemWithSpan,
-  SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget, SideEffectsOptimizeArtifact,
+  NormalModuleFactoryModule, Plugin, PrefetchExportsInfoMode, ResolvedExportInfoTarget,
+  SideEffectsBailoutItemWithSpan, SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget,
+  SideEffectsOptimizeArtifact,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -851,8 +852,11 @@ fn can_optimize_connection(
   if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>()
     && let Some(name) = &dep.name
   {
-    let exports_info = module_graph.get_exports_info(&original_module);
-    let export_info = exports_info.get_export_info_without_mut_module_graph(module_graph, name);
+    let exports_info = module_graph.get_prefetched_exports_info(
+      &original_module,
+      PrefetchExportsInfoMode::NamedExports(vec![name]),
+    );
+    let export_info = exports_info.get_export_info_without_mut_module_graph(name);
 
     let target = export_info.can_move_target(
       module_graph,
@@ -894,8 +898,11 @@ fn can_optimize_connection(
     && let ids = dep.get_ids(module_graph)
     && !ids.is_empty()
   {
-    let exports_info = module_graph.get_exports_info(connection.module_identifier());
-    let export_info = exports_info.get_export_info_without_mut_module_graph(module_graph, &ids[0]);
+    let exports_info = module_graph.get_prefetched_exports_info(
+      connection.module_identifier(),
+      PrefetchExportsInfoMode::NamedExports(vec![&ids[0]]),
+    );
+    let export_info = exports_info.get_export_info_without_mut_module_graph(&ids[0]);
 
     let target = export_info.get_target_with_filter(
       module_graph,

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -17,8 +17,8 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
   BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, CompilerOptions, ExportInfoGetter,
   ExportsInfo, ExportsInfoGetter, GenerateContext, Module, ModuleGraph, ParseOption,
-  ParserAndGenerator, Plugin, RuntimeGlobals, RuntimeSpec, SourceType, UsageState,
-  NAMESPACE_OBJECT_EXPORT,
+  ParserAndGenerator, Plugin, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, SourceType,
+  UsageState, NAMESPACE_OBJECT_EXPORT,
 };
 use rspack_error::{
   miette::diagnostic, DiagnosticExt, DiagnosticKind, IntoTWithDiagnosticArray, Result,
@@ -279,7 +279,8 @@ fn create_object_for_exports_info(
   runtime: Option<&RuntimeSpec>,
   mg: &ModuleGraph,
 ) -> JsonValue {
-  let exports_info_data = ExportsInfoGetter::prefetch(&exports_info, mg, None);
+  let exports_info_data =
+    ExportsInfoGetter::prefetch(&exports_info, mg, PrefetchExportsInfoMode::AllExports);
 
   if ExportInfoGetter::get_used(exports_info_data.other_exports_info(), runtime)
     != UsageState::Unused

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -16,8 +16,9 @@ use rspack_core::{
   diagnostics::ModuleParseError,
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
   BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, CompilerOptions, ExportInfoGetter,
-  ExportsInfo, GenerateContext, Module, ModuleGraph, ParseOption, ParserAndGenerator, Plugin,
-  RuntimeGlobals, RuntimeSpec, SourceType, UsageState, NAMESPACE_OBJECT_EXPORT,
+  ExportsInfo, ExportsInfoGetter, GenerateContext, Module, ModuleGraph, ParseOption,
+  ParserAndGenerator, Plugin, RuntimeGlobals, RuntimeSpec, SourceType, UsageState,
+  NAMESPACE_OBJECT_EXPORT,
 };
 use rspack_error::{
   miette::diagnostic, DiagnosticExt, DiagnosticKind, IntoTWithDiagnosticArray, Result,
@@ -278,7 +279,9 @@ fn create_object_for_exports_info(
   runtime: Option<&RuntimeSpec>,
   mg: &ModuleGraph,
 ) -> JsonValue {
-  if ExportInfoGetter::get_used(exports_info.other_exports_info(mg).as_data(mg), runtime)
+  let exports_info_data = ExportsInfoGetter::prefetch(&exports_info, mg, None);
+
+  if ExportInfoGetter::get_used(exports_info_data.other_exports_info(), runtime)
     != UsageState::Unused
   {
     return data;
@@ -293,13 +296,13 @@ fn create_object_for_exports_info(
     JsonValue::Object(mut obj) => {
       let mut used_pair = vec![];
       for (key, value) in obj.iter_mut() {
-        let export_info = exports_info.get_read_only_export_info(mg, &key.into());
-        let used = ExportInfoGetter::get_used(export_info.as_data(mg), runtime);
+        let export_info = exports_info_data.get_read_only_export_info(&key.into());
+        let used = ExportInfoGetter::get_used(export_info, runtime);
         if used == UsageState::Unused {
           continue;
         }
         let new_value = if used == UsageState::OnlyPropertiesUsed
-          && let Some(exports_info) = ExportInfoGetter::exports_info(export_info.as_data(mg))
+          && let Some(exports_info) = ExportInfoGetter::exports_info(export_info)
         {
           // avoid clone
           let temp = std::mem::replace(value, JsonValue::Null);
@@ -307,9 +310,8 @@ fn create_object_for_exports_info(
         } else {
           std::mem::replace(value, JsonValue::Null)
         };
-        let used_name =
-          ExportInfoGetter::get_used_name(export_info.as_data(mg), Some(&(key.into())), runtime)
-            .expect("should have used name");
+        let used_name = ExportInfoGetter::get_used_name(export_info, Some(&(key.into())), runtime)
+          .expect("should have used name");
         used_pair.push((used_name, new_value));
       }
       let mut new_obj = Object::new();
@@ -325,14 +327,14 @@ fn create_object_for_exports_info(
         .into_iter()
         .enumerate()
         .map(|(i, item)| {
-          let export_info = exports_info.get_read_only_export_info(mg, &itoa!(i).into());
-          let used = ExportInfoGetter::get_used(export_info.as_data(mg), runtime);
+          let export_info = exports_info_data.get_read_only_export_info(&itoa!(i).into());
+          let used = ExportInfoGetter::get_used(export_info, runtime);
           if used == UsageState::Unused {
             return None;
           }
           max_used_index = max_used_index.max(i);
           if used == UsageState::OnlyPropertiesUsed
-            && let Some(exports_info) = ExportInfoGetter::exports_info(export_info.as_data(mg))
+            && let Some(exports_info) = ExportInfoGetter::exports_info(export_info)
           {
             Some(create_object_for_exports_info(
               item,
@@ -346,9 +348,7 @@ fn create_object_for_exports_info(
         })
         .collect::<Vec<_>>();
       let arr_length_used = ExportInfoGetter::get_used(
-        exports_info
-          .get_read_only_export_info(mg, &"length".into())
-          .as_data(mg),
+        exports_info_data.get_read_only_export_info(&"length".into()),
         runtime,
       );
       let array_length_when_used = match arr_length_used {

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -18,7 +18,7 @@ use rspack_core::{
   UsedName,
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
-use rspack_util::itoa;
+use rspack_util::{fx_hash::FxHashSet, itoa};
 use swc_core::atoms::Atom;
 use wasmparser::{Import, Parser, Payload};
 
@@ -205,7 +205,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
               let Some(UsedName::Normal(used_name)) = ExportsInfoGetter::get_used_name(
                 &module_graph.get_prefetched_exports_info(
                   &mgm.module_identifier,
-                  PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&name)),
+                  PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&name])),
                 ),
                 *runtime,
                 &[dep.name().into()],

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -14,7 +14,8 @@ use rspack_core::{
   DependencyType::WasmImport,
   ExportsInfoGetter, Filename, GenerateContext, Module, ModuleDependency, ModuleGraph, ModuleId,
   ModuleIdentifier, NormalModule, ParseContext, ParseResult, ParserAndGenerator, PathData,
-  RuntimeGlobals, SourceType, StaticExportsDependency, StaticExportsSpec, UsedName,
+  PrefetchExportsInfoMode, RuntimeGlobals, SourceType, StaticExportsDependency, StaticExportsSpec,
+  UsedName,
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_util::itoa;
@@ -201,7 +202,10 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
 
               let dep_name = serde_json::to_string(dep.name()).expect("should be ok.");
               let Some(UsedName::Normal(used_name)) = ExportsInfoGetter::get_used_name(
-                &module_graph.get_prefetched_exports_info(&mgm.module_identifier, None),
+                &module_graph.get_prefetched_exports_info(
+                  &mgm.module_identifier,
+                  PrefetchExportsInfoMode::NamedExports(&[dep.name().into()]),
+                ),
                 *runtime,
                 &[dep.name().into()],
               ) else {

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -205,7 +205,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
               let Some(UsedName::Normal(used_name)) = ExportsInfoGetter::get_used_name(
                 &module_graph.get_prefetched_exports_info(
                   &mgm.module_identifier,
-                  PrefetchExportsInfoMode::NamedExports(vec![&name]),
+                  PrefetchExportsInfoMode::NamedExports(std::slice::from_ref(&name)),
                 ),
                 *runtime,
                 &[dep.name().into()],

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -201,10 +201,11 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
                 .expect("should be wasm import dependency");
 
               let dep_name = serde_json::to_string(dep.name()).expect("should be ok.");
+              let name = Atom::from(dep.name());
               let Some(UsedName::Normal(used_name)) = ExportsInfoGetter::get_used_name(
                 &module_graph.get_prefetched_exports_info(
                   &mgm.module_identifier,
-                  PrefetchExportsInfoMode::NamedExports(&[dep.name().into()]),
+                  PrefetchExportsInfoMode::NamedExports(vec![&name]),
                 ),
                 *runtime,
                 &[dep.name().into()],

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -12,9 +12,9 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
   AssetInfo, BoxDependency, BuildMetaExportsType, ChunkGraph, Compilation,
   DependencyType::WasmImport,
-  Filename, GenerateContext, Module, ModuleDependency, ModuleGraph, ModuleId, ModuleIdentifier,
-  NormalModule, ParseContext, ParseResult, ParserAndGenerator, PathData, RuntimeGlobals,
-  SourceType, StaticExportsDependency, StaticExportsSpec, UsedName,
+  ExportsInfoGetter, Filename, GenerateContext, Module, ModuleDependency, ModuleGraph, ModuleId,
+  ModuleIdentifier, NormalModule, ParseContext, ParseResult, ParserAndGenerator, PathData,
+  RuntimeGlobals, SourceType, StaticExportsDependency, StaticExportsSpec, UsedName,
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_util::itoa;
@@ -200,10 +200,11 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
                 .expect("should be wasm import dependency");
 
               let dep_name = serde_json::to_string(dep.name()).expect("should be ok.");
-              let Some(UsedName::Normal(used_name)) = module_graph
-                .get_exports_info(&mgm.module_identifier)
-                .get_used_name(module_graph, *runtime, &[dep.name().into()])
-              else {
+              let Some(UsedName::Normal(used_name)) = ExportsInfoGetter::get_used_name(
+                &module_graph.get_prefetched_exports_info(&mgm.module_identifier, None),
+                *runtime,
+                &[dep.name().into()],
+              ) else {
                 return;
               };
               let request = dep.request();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Introduce the `PrefetchExportsInfoMode` to limit the data scope of ExportsInfo, thereby reducing the performance consumption caused by unnecessary data prefetching. Since there is an infinite hierarchical nesting relationship between ExportsInfo and ExportInfo, but when consuming, local data is usually consumed based on Names. Therefore, the following modes are provided:
- Default: prefetch without any named ExportInfo, only prefetch redirect_to, other, side effects
- `NamedExports(names)`: prefetch with named ExportInfos but no nested ExportsInfo
- `AllExports`: prefetch all named ExportInfos but no nested Exports
- `NamedNestedExports(nestedNames)`: prefetch with a named ExportInfo and its nested ExportsInfo chain
- `NamedNestedAllExports(nestedNames)`: prefetch with all named nested ExportsInfo and all ExportInfos on the chain

And the PrefetchedExportsInfoWrapper will get data according to the mode, if any data which is not prefetched is used, it will panic. Therefore, before reading ExportsInfo data, it is necessary to clarify the scope of data usage.

In terms of performance, since it is still need to prefetch more data than the consumption requirements, it may cause some performance degradation. However, as all operations of reading ExportsInfo and ExportInfo no longer need to query through the ID on the module graph, there will also be some performance improvements. And according to the benchmark, there is no significant performance degradation.

At the same time, this PR has made substantial changes to the way of retrieving data of ExportsInfo, and has removed some old methods of obtaining data based on the module graph. 

> The `getMode` related methods is not removed due to performance issues. Adding it will be considered later after the `getMode` cache is completed.


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
