### PR TITLE
feat: serialized build info custom fields from js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4455,6 +4455,7 @@ dependencies = [
  "napi",
  "oneshot",
  "rspack_error",
+ "serde_json",
  "tokio",
 ]
 

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -19,7 +19,7 @@ export const BUILD_INFO_FILE_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL: unique symbol;
-export const SYNC_CUSTOM_FIELDS_SYMBOL: unique symbol;
+export const COMMIT_CUSTOM_FIELDS_SYMBOL: unique symbol;
 
 interface KnownBuildInfo {
 	[BUILD_INFO_ASSETS_SYMBOL]: Assets,
@@ -27,7 +27,7 @@ interface KnownBuildInfo {
 	[BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL]: string[],
-	[SYNC_CUSTOM_FIELDS_SYMBOL](): void;
+	[COMMIT_CUSTOM_FIELDS_SYMBOL](): void;
 }
 
 export type BuildInfo = KnownBuildInfo & Record<string, any>;

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -14,6 +14,24 @@ export const MODULE_IDENTIFIER_SYMBOL: unique symbol;
 
 export const COMPILATION_HOOKS_MAP_SYMBOL: unique symbol;
 
+export const BUILD_INFO_ASSETS_SYMBOL: unique symbol;
+export const BUILD_INFO_FILE_DEPENDENCIES_SYMBOL: unique symbol;
+export const BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL: unique symbol;
+export const BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL: unique symbol;
+export const BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL: unique symbol;
+export const SYNC_CUSTOM_FIELDS_SYMBOL: unique symbol;
+
+interface KnownBuildInfo {
+	[BUILD_INFO_ASSETS_SYMBOL]: Assets,
+	[BUILD_INFO_FILE_DEPENDENCIES_SYMBOL]: string[],
+	[BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL]: string[],
+	[BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL]: string[],
+	[BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL]: string[],
+	[SYNC_CUSTOM_FIELDS_SYMBOL](): void;
+}
+
+export type BuildInfo = KnownBuildInfo & Record<string, any>;
+
 export interface Module {
 	[MODULE_IDENTIFIER_SYMBOL]: string;
 	readonly type: string;
@@ -24,8 +42,8 @@ export interface Module {
 	get useSourceMap(): boolean;
 	get useSimpleSourceMap(): boolean;
 	get _readableIdentifier(): string;
-	buildInfo: KnownBuildInfo & Record<string, any>;
-	buildMeta: KnownBuildInfo & Record<string, any>;
+	buildInfo: BuildInfo;
+	buildMeta: Record<string, any>;
 }
 
 interface NormalModuleConstructor {

--- a/crates/node_binding/scripts/banner.d.ts
+++ b/crates/node_binding/scripts/banner.d.ts
@@ -19,7 +19,7 @@ export const BUILD_INFO_FILE_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL: unique symbol;
-export const SYNC_CUSTOM_FIELDS_SYMBOL: unique symbol;
+export const COMMIT_CUSTOM_FIELDS_SYMBOL: unique symbol;
 
 interface KnownBuildInfo {
 	[BUILD_INFO_ASSETS_SYMBOL]: Assets,
@@ -27,7 +27,7 @@ interface KnownBuildInfo {
 	[BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL]: string[],
-	[SYNC_CUSTOM_FIELDS_SYMBOL](): void;
+	[COMMIT_CUSTOM_FIELDS_SYMBOL](): void;
 }
 
 export type BuildInfo = KnownBuildInfo & Record<string, any>;

--- a/crates/node_binding/scripts/banner.d.ts
+++ b/crates/node_binding/scripts/banner.d.ts
@@ -14,6 +14,22 @@ export const MODULE_IDENTIFIER_SYMBOL: unique symbol;
 
 export const COMPILATION_HOOKS_MAP_SYMBOL: unique symbol;
 
+export const BUILD_INFO_ASSETS_SYMBOL: unique symbol;
+export const BUILD_INFO_FILE_DEPENDENCIES_SYMBOL: unique symbol;
+export const BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL: unique symbol;
+export const BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL: unique symbol;
+export const BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL: unique symbol;
+export const SYNC_CUSTOM_FIELDS_SYMBOL: unique symbol;
+
+interface KnownBuildInfo {
+	[BUILD_INFO_ASSETS_SYMBOL]: Assets,
+	[BUILD_INFO_FILE_DEPENDENCIES_SYMBOL]: string[],
+	[BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL]: string[],
+	[BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL]: string[],
+	[BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL]: string[],
+	[SYNC_CUSTOM_FIELDS_SYMBOL](): void;
+}
+
 export type BuildInfo = KnownBuildInfo & Record<string, any>;
 
 export interface Module {

--- a/crates/node_binding/scripts/banner.d.ts
+++ b/crates/node_binding/scripts/banner.d.ts
@@ -14,6 +14,8 @@ export const MODULE_IDENTIFIER_SYMBOL: unique symbol;
 
 export const COMPILATION_HOOKS_MAP_SYMBOL: unique symbol;
 
+export type BuildInfo = KnownBuildInfo & Record<string, any>;
+
 export interface Module {
 	[MODULE_IDENTIFIER_SYMBOL]: string;
 	readonly type: string;
@@ -24,8 +26,8 @@ export interface Module {
 	get useSourceMap(): boolean;
 	get useSimpleSourceMap(): boolean;
 	get _readableIdentifier(): string;
-	buildInfo: KnownBuildInfo & Record<string, any>;
-	buildMeta: KnownBuildInfo & Record<string, any>;
+	buildInfo: BuildInfo;
+	buildMeta: Record<string, any>;
 }
 
 interface NormalModuleConstructor {

--- a/crates/node_binding/src/asset.rs
+++ b/crates/node_binding/src/asset.rs
@@ -77,7 +77,7 @@ impl FromNapiValue for AssetInfo {
       if let Some(name) = names.get::<String>(index)? {
         if !known_field_names.contains(&name) {
           let value = object.get_named_property::<Unknown>(&name)?;
-          if let Some(json_value) = unknown_to_json_value(env, value)? {
+          if let Some(json_value) = unknown_to_json_value(value)? {
             extras.insert(name, json_value);
           }
         }

--- a/crates/node_binding/src/asset.rs
+++ b/crates/node_binding/src/asset.rs
@@ -7,7 +7,7 @@ use napi::{
 };
 use napi_derive::napi;
 use rspack_core::Reflector;
-use rspack_napi::string::JsStringExt;
+use rspack_napi::unknown_to_json_value;
 use rspack_napi_macros::field_names;
 use rustc_hash::FxHashSet;
 
@@ -65,85 +65,19 @@ pub struct AssetInfo {
   extras: serde_json::Map<String, serde_json::Value>,
 }
 
-unsafe fn napi_value_to_json(
-  env: sys::napi_env,
-  value: Unknown,
-) -> napi::Result<Option<serde_json::Value>> {
-  if value.is_array()? {
-    let js_array = Array::from_unknown(value)?;
-    let mut array = Vec::with_capacity(js_array.len() as usize);
-
-    for index in 0..js_array.len() {
-      if let Some(item) = js_array.get::<Unknown>(index)? {
-        if let Some(json_val) = napi_value_to_json(env, item)? {
-          array.push(json_val);
-        } else {
-          array.push(serde_json::Value::Null);
-        }
-      } else {
-        array.push(serde_json::Value::Null);
-      }
-    }
-
-    return Ok(Some(serde_json::Value::Array(array)));
-  }
-
-  match value.get_type()? {
-    napi::ValueType::Null => Ok(Some(serde_json::Value::Null)),
-    napi::ValueType::Boolean => {
-      let b = value.coerce_to_bool()?;
-      Ok(Some(serde_json::Value::Bool(b)))
-    }
-    napi::ValueType::Number => {
-      let number = value.coerce_to_number()?.get_double()?;
-      let f64_val = serde_json::Number::from_f64(number);
-      match f64_val {
-        Some(n) => Ok(Some(serde_json::Value::Number(n))),
-        None => Ok(None),
-      }
-    }
-    napi::ValueType::String => {
-      let s = value.coerce_to_string()?.into_string();
-      Ok(Some(serde_json::Value::String(s)))
-    }
-    napi::ValueType::Object => {
-      let js_obj = value.coerce_to_object()?;
-      let mut map = serde_json::Map::new();
-
-      let names = Array::from_napi_value(env, js_obj.get_property_names()?.raw())?;
-      for index in 0..names.len() {
-        if let Some(name) = names.get::<String>(index)? {
-          let prop_val = js_obj.get_named_property::<Unknown>(&name)?;
-          if let Some(json_val) = napi_value_to_json(env, prop_val)? {
-            map.insert(name, json_val);
-          }
-        }
-      }
-
-      Ok(Some(serde_json::Value::Object(map)))
-    }
-    napi::ValueType::Undefined
-    | napi::ValueType::Symbol
-    | napi::ValueType::Function
-    | napi::ValueType::External
-    | napi::ValueType::BigInt
-    | napi::ValueType::Unknown => Ok(None),
-  }
-}
-
 impl FromNapiValue for AssetInfo {
   unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
     let known = KnownAssetInfo::from_napi_value(env, napi_val)?;
     let known_field_names = FxHashSet::from_iter(KnownAssetInfo::field_names());
 
     let mut extras = serde_json::Map::new();
-    let js_obj = Object::from_napi_value(env, napi_val)?;
-    let names = Array::from_napi_value(env, js_obj.get_property_names()?.raw())?;
+    let object = Object::from_napi_value(env, napi_val)?;
+    let names = Array::from_napi_value(env, object.get_property_names()?.raw())?;
     for index in 0..names.len() {
       if let Some(name) = names.get::<String>(index)? {
         if !known_field_names.contains(&name) {
-          let value = js_obj.get_named_property::<Unknown>(&name)?;
-          if let Some(json_value) = napi_value_to_json(env, value)? {
+          let value = object.get_named_property::<Unknown>(&name)?;
+          if let Some(json_value) = unknown_to_json_value(env, value)? {
             extras.insert(name, json_value);
           }
         }

--- a/crates/node_binding/src/build_info.rs
+++ b/crates/node_binding/src/build_info.rs
@@ -117,62 +117,6 @@ impl KnownBuildInfo {
   }
 }
 
-#[napi]
-impl KnownBuildInfo {
-  #[napi(getter, js_name = "_assets", ts_return_type = "Assets")]
-  pub fn assets(&mut self) -> napi::Result<Reflector> {
-    self.with_ref(|module| Ok(module.build_info().assets.reflector()))
-  }
-
-  #[napi(getter, js_name = "_fileDependencies")]
-  pub fn file_dependencies<'a>(&mut self, env: &'a Env) -> napi::Result<Vec<JsString<'a>>> {
-    self.with_ref(|module| {
-      module
-        .build_info()
-        .file_dependencies
-        .iter()
-        .map(|dependency| env.create_string(dependency.to_string_lossy().as_ref()))
-        .collect::<napi::Result<Vec<JsString>>>()
-    })
-  }
-
-  #[napi(getter, js_name = "_contextDependencies")]
-  pub fn context_dependencies<'a>(&mut self, env: &'a Env) -> napi::Result<Vec<JsString<'a>>> {
-    self.with_ref(|module| {
-      module
-        .build_info()
-        .context_dependencies
-        .iter()
-        .map(|dependency| env.create_string(dependency.to_string_lossy().as_ref()))
-        .collect::<napi::Result<Vec<JsString>>>()
-    })
-  }
-
-  #[napi(getter, js_name = "_missingDependencies")]
-  pub fn missing_dependencies<'a>(&mut self, env: &'a Env) -> napi::Result<Vec<JsString<'a>>> {
-    self.with_ref(|module| {
-      module
-        .build_info()
-        .missing_dependencies
-        .iter()
-        .map(|dependency| env.create_string(dependency.to_string_lossy().as_ref()))
-        .collect::<napi::Result<Vec<JsString>>>()
-    })
-  }
-
-  #[napi(getter, js_name = "_buildDependencies")]
-  pub fn build_dependencies<'a>(&mut self, env: &'a Env) -> napi::Result<Vec<JsString<'a>>> {
-    self.with_ref(|module| {
-      module
-        .build_info()
-        .build_dependencies
-        .iter()
-        .map(|dependency| env.create_string(dependency.to_string_lossy().as_ref()))
-        .collect::<napi::Result<Vec<JsString>>>()
-    })
-  }
-}
-
 // KnownBuildInfo & Record<string, any>
 pub struct BuildInfo {
   module_reference: WeakReference<Module>,

--- a/crates/node_binding/src/build_info.rs
+++ b/crates/node_binding/src/build_info.rs
@@ -6,7 +6,7 @@ use napi::{
   },
   Env, JsString, JsValue, Property, PropertyAttributes, Unknown,
 };
-use rspack_core::{Reflector, WeakBindingCell};
+use rspack_core::WeakBindingCell;
 use rspack_napi::unknown_to_json_value;
 use rustc_hash::{FxHashMap, FxHashSet};
 

--- a/crates/node_binding/src/build_info.rs
+++ b/crates/node_binding/src/build_info.rs
@@ -18,7 +18,7 @@ define_symbols! {
   BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL => "BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL",
   BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL => "BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL",
   BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL => "BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL",
-  SYNC_CUSTOM_FIELDS_SYMBOL => "SYNC_CUSTOM_FIELDS_SYMBOL",
+  COMMIT_CUSTOM_FIELDS_SYMBOL => "COMMIT_CUSTOM_FIELDS_SYMBOL",
 }
 
 // Record<string, Source>
@@ -280,8 +280,8 @@ impl ToNapiValue for BuildInfo {
 
     let mut properties = create_known_private_properties(&env_wrapper)?;
 
-    let sync_custom_fields_fn: napi::bindgen_prelude::Function<'_, (), ()> = env_wrapper
-      .create_function_from_closure("syncCustomFields", |ctx| {
+    let commit_custom_fields_fn: napi::bindgen_prelude::Function<'_, (), ()> = env_wrapper
+      .create_function_from_closure("commitCustomFieldsToRust", |ctx| {
         let object = ctx.this::<Object>()?;
         let env = ctx.env;
         let this: &mut KnownBuildInfo = FromNapiMutRef::from_napi_mut_ref(env.raw(), object.raw())?;
@@ -319,13 +319,13 @@ impl ToNapiValue for BuildInfo {
       }
       Ok(())
     })?;
-    SYNC_CUSTOM_FIELDS_SYMBOL.with(|once_cell| {
+    COMMIT_CUSTOM_FIELDS_SYMBOL.with(|once_cell| {
       #[allow(clippy::unwrap_used)]
       let symbol = once_cell.get().unwrap();
       properties.push(
         Property::new()
           .with_name(&env_wrapper, symbol)?
-          .with_value(&sync_custom_fields_fn)
+          .with_value(&commit_custom_fields_fn)
           .with_property_attributes(PropertyAttributes::Configurable),
       );
       Ok::<(), napi::Error>(())

--- a/crates/node_binding/src/build_info.rs
+++ b/crates/node_binding/src/build_info.rs
@@ -210,6 +210,7 @@ fn create_known_private_properties(env: &Env) -> napi::Result<Vec<Property>> {
   let mut properties = vec![];
 
   BUILD_INFO_ASSETS_SYMBOL.with(|once_cell| {
+    #[allow(clippy::unwrap_used)]
     let symbol = once_cell.get().unwrap();
     properties.push(
       Property::new()
@@ -224,6 +225,7 @@ fn create_known_private_properties(env: &Env) -> napi::Result<Vec<Property>> {
   })?;
 
   BUILD_INFO_FILE_DEPENDENCIES_SYMBOL.with(|once_cell| {
+    #[allow(clippy::unwrap_used)]
     let symbol = once_cell.get().unwrap();
     properties.push(
       Property::new()
@@ -247,6 +249,7 @@ fn create_known_private_properties(env: &Env) -> napi::Result<Vec<Property>> {
   })?;
 
   BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL.with(|once_cell| {
+    #[allow(clippy::unwrap_used)]
     let symbol = once_cell.get().unwrap();
     properties.push(
       Property::new()
@@ -270,6 +273,7 @@ fn create_known_private_properties(env: &Env) -> napi::Result<Vec<Property>> {
   })?;
 
   BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL.with(|once_cell| {
+    #[allow(clippy::unwrap_used)]
     let symbol = once_cell.get().unwrap();
     properties.push(
       Property::new()
@@ -293,6 +297,7 @@ fn create_known_private_properties(env: &Env) -> napi::Result<Vec<Property>> {
   })?;
 
   BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL.with(|once_cell| {
+    #[allow(clippy::unwrap_used)]
     let symbol = once_cell.get().unwrap();
     properties.push(
       Property::new()
@@ -344,7 +349,7 @@ impl ToNapiValue for BuildInfo {
             if let Some(name) = names.get::<String>(index)? {
               if !KNOWN_BUILD_INFO_FIELD_NAMES.contains(name.as_str()) {
                 let value = object.get_named_property::<Unknown>(&name)?;
-                if let Some(json_value) = unknown_to_json_value(env.raw(), value)? {
+                if let Some(json_value) = unknown_to_json_value(value)? {
                   extras.insert(name, json_value);
                 }
               }
@@ -371,6 +376,7 @@ impl ToNapiValue for BuildInfo {
       Ok(())
     })?;
     SYNC_CUSTOM_FIELDS_SYMBOL.with(|once_cell| {
+      #[allow(clippy::unwrap_used)]
       let symbol = once_cell.get().unwrap();
       properties.push(
         Property::new()

--- a/crates/node_binding/src/define_symbols.rs
+++ b/crates/node_binding/src/define_symbols.rs
@@ -1,0 +1,27 @@
+#[macro_export]
+macro_rules! define_symbols {
+  (
+    $(
+      $(#[$meta:meta])*
+      $cell:ident => $name:expr
+    ),* $(,)?
+  ) => {
+    thread_local! {
+      $(
+        $(#[$meta])*
+        pub(crate) static $cell: ::once_cell::unsync::OnceCell<::rspack_napi::OneShotRef> = Default::default();
+      )*
+    }
+
+    pub(super) fn export_symbols(mut exports: ::napi::bindgen_prelude::Object, env: ::napi::Env) -> ::napi::Result<()> {
+      $(
+        let symbol = ::rspack_napi::OneShotRef::new(env.raw(), env.create_symbol(Some($name))?)?;
+        exports.set_named_property($name, &symbol)?;
+        $cell.with(|once_cell| {
+          once_cell.get_or_init(move || symbol);
+        });
+      )*
+      Ok(())
+    }
+  };
+}

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -497,6 +497,7 @@ fn node_init(mut _exports: Object, env: Env) -> Result<()> {
 pub fn rspack_module_exports(exports: Object, env: Env) -> Result<()> {
   node_init(exports, env)?;
   module::init(exports, env)?;
+  build_info::init(exports, env)?;
   Ok(())
 }
 

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -33,6 +33,7 @@ mod codegen_result;
 mod compilation;
 mod compiler;
 mod context_module_factory;
+mod define_symbols;
 mod dependencies;
 mod dependency;
 mod diagnostic;
@@ -496,8 +497,8 @@ fn node_init(mut _exports: Object, env: Env) -> Result<()> {
 #[napi(module_exports)]
 pub fn rspack_module_exports(exports: Object, env: Env) -> Result<()> {
   node_init(exports, env)?;
-  module::init(exports, env)?;
-  build_info::init(exports, env)?;
+  module::export_symbols(exports, env)?;
+  build_info::export_symbols(exports, env)?;
   Ok(())
 }
 

--- a/crates/node_binding/src/module.rs
+++ b/crates/node_binding/src/module.rs
@@ -18,9 +18,9 @@ use rspack_util::source_map::SourceMapKind;
 
 use super::JsCompatSourceOwned;
 use crate::{
-  AssetInfo, AsyncDependenciesBlockWrapper, ConcatenatedModule, ContextModule, DependencyWrapper,
-  ExternalModule, JsChunkWrapper, JsCodegenerationResults, JsCompatSource, JsCompiler,
-  KnownBuildInfo, NormalModule, ToJsCompatSource, COMPILER_REFERENCES,
+  AssetInfo, AsyncDependenciesBlockWrapper, BuildInfo, ConcatenatedModule, ContextModule,
+  DependencyWrapper, ExternalModule, JsChunkWrapper, JsCodegenerationResults, JsCompatSource,
+  JsCompiler, NormalModule, ToJsCompatSource, COMPILER_REFERENCES,
 };
 
 #[napi(object)]
@@ -149,7 +149,7 @@ impl Module {
       if let Some(r) = &reference.build_info_ref {
         return r.as_object(env);
       }
-      let mut build_info = KnownBuildInfo::new(reference.downgrade()).get_jsobject(env)?;
+      let mut build_info = BuildInfo::new(reference.downgrade()).get_jsobject(env)?;
       MODULE_BUILD_INFO_SYMBOL.with(|once_cell| {
         let sym = unsafe {
           #[allow(clippy::unwrap_used)]
@@ -172,7 +172,7 @@ impl Module {
       let raw_env = env.raw();
       let mut reference: Reference<Module> =
         unsafe { Reference::from_napi_value(raw_env, this.raw())? };
-      let new_build_info = KnownBuildInfo::new(reference.downgrade());
+      let new_build_info = BuildInfo::new(reference.downgrade());
       let mut new_instrance = new_build_info.get_jsobject(env)?;
 
       let names = input_object.get_all_property_names(

--- a/crates/node_binding/src/module.rs
+++ b/crates/node_binding/src/module.rs
@@ -247,6 +247,7 @@ impl Module {
 
     MODULE_IDENTIFIER_SYMBOL.with(|once_cell| {
       let identifier = env.create_string(module.identifier().as_str())?;
+      #[allow(clippy::unwrap_used)]
       let symbol = once_cell.get().unwrap();
       properties.push(
         Property::new()

--- a/crates/node_binding/src/modules/macros.rs
+++ b/crates/node_binding/src/modules/macros.rs
@@ -141,7 +141,7 @@ macro_rules! impl_module_methods {
           if let Some(r) = &reference.build_info_ref {
             return r.as_object(env);
           }
-          let mut build_info = $crate::KnownBuildInfo::new(reference.downgrade()).get_jsobject(env)?;
+          let mut build_info = $crate::BuildInfo::new(reference.downgrade()).get_jsobject(env)?;
           $crate::MODULE_BUILD_INFO_SYMBOL.with(|once_cell| {
             let sym = unsafe {
               #[allow(clippy::unwrap_used)]
@@ -166,7 +166,7 @@ macro_rules! impl_module_methods {
           let raw_env = env.raw();
           let mut reference: napi::bindgen_prelude::Reference<Module> =
             unsafe { napi::bindgen_prelude::Reference::from_napi_value(raw_env, this.raw())? };
-          let new_build_info = $crate::KnownBuildInfo::new(reference.downgrade());
+          let new_build_info = $crate::BuildInfo::new(reference.downgrade());
           let mut new_instrance = new_build_info.get_jsobject(env)?;
 
           let names = input_object.get_all_property_names(

--- a/crates/rspack_napi/Cargo.toml
+++ b/crates/rspack_napi/Cargo.toml
@@ -11,4 +11,5 @@ version           = "0.2.0"
 napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi7"] }
 oneshot      = "0.1.8"
 rspack_error = { workspace = true }
+serde_json   = { workspace = true }
 tokio        = { workspace = true, features = ["sync"] }

--- a/crates/rspack_napi/src/utils.rs
+++ b/crates/rspack_napi/src/utils.rs
@@ -1,5 +1,6 @@
 use napi::{
   bindgen_prelude::{Array, FromNapiValue, JsObjectValue, Object, Unknown},
+  sys::napi_env,
   Env, JsValue,
 };
 
@@ -43,4 +44,70 @@ pub fn object_clone<'a>(env: &Env, object: &'a Object<'a>) -> napi::Result<Objec
   }
 
   Ok(new_object)
+}
+
+pub fn unknown_to_json_value(
+  env: napi_env,
+  value: Unknown,
+) -> napi::Result<Option<serde_json::Value>> {
+  if value.is_array()? {
+    let js_array = Array::from_unknown(value)?;
+    let mut array = Vec::with_capacity(js_array.len() as usize);
+
+    for index in 0..js_array.len() {
+      if let Some(item) = js_array.get::<Unknown>(index)? {
+        if let Some(json_val) = unknown_to_json_value(env, item)? {
+          array.push(json_val);
+        } else {
+          array.push(serde_json::Value::Null);
+        }
+      } else {
+        array.push(serde_json::Value::Null);
+      }
+    }
+
+    return Ok(Some(serde_json::Value::Array(array)));
+  }
+
+  match value.get_type()? {
+    napi::ValueType::Null => Ok(Some(serde_json::Value::Null)),
+    napi::ValueType::Boolean => {
+      let b = value.coerce_to_bool()?;
+      Ok(Some(serde_json::Value::Bool(b)))
+    }
+    napi::ValueType::Number => {
+      let number = value.coerce_to_number()?.get_double()?;
+      let f64_val = serde_json::Number::from_f64(number);
+      match f64_val {
+        Some(n) => Ok(Some(serde_json::Value::Number(n))),
+        None => Ok(None),
+      }
+    }
+    napi::ValueType::String => {
+      let s = value.coerce_to_string()?.into_utf8()?.into_owned()?;
+      Ok(Some(serde_json::Value::String(s)))
+    }
+    napi::ValueType::Object => {
+      let object = value.coerce_to_object()?;
+      let mut map = serde_json::Map::new();
+
+      let names = Array::from_unknown(object.get_property_names()?.to_unknown())?;
+      for index in 0..names.len() {
+        if let Some(name) = names.get::<String>(index)? {
+          let prop_val = object.get_named_property::<Unknown>(&name)?;
+          if let Some(json_val) = unknown_to_json_value(env, prop_val)? {
+            map.insert(name, json_val);
+          }
+        }
+      }
+
+      Ok(Some(serde_json::Value::Object(map)))
+    }
+    napi::ValueType::Undefined
+    | napi::ValueType::Symbol
+    | napi::ValueType::Function
+    | napi::ValueType::External
+    | napi::ValueType::BigInt
+    | napi::ValueType::Unknown => Ok(None),
+  }
 }

--- a/crates/rspack_napi/src/utils.rs
+++ b/crates/rspack_napi/src/utils.rs
@@ -1,6 +1,5 @@
 use napi::{
   bindgen_prelude::{Array, FromNapiValue, JsObjectValue, Object, Unknown},
-  sys::napi_env,
   Env, JsValue,
 };
 
@@ -46,17 +45,14 @@ pub fn object_clone<'a>(env: &Env, object: &'a Object<'a>) -> napi::Result<Objec
   Ok(new_object)
 }
 
-pub fn unknown_to_json_value(
-  env: napi_env,
-  value: Unknown,
-) -> napi::Result<Option<serde_json::Value>> {
+pub fn unknown_to_json_value(value: Unknown) -> napi::Result<Option<serde_json::Value>> {
   if value.is_array()? {
     let js_array = Array::from_unknown(value)?;
     let mut array = Vec::with_capacity(js_array.len() as usize);
 
     for index in 0..js_array.len() {
       if let Some(item) = js_array.get::<Unknown>(index)? {
-        if let Some(json_val) = unknown_to_json_value(env, item)? {
+        if let Some(json_val) = unknown_to_json_value(item)? {
           array.push(json_val);
         } else {
           array.push(serde_json::Value::Null);
@@ -95,7 +91,7 @@ pub fn unknown_to_json_value(
       for index in 0..names.len() {
         if let Some(name) = names.get::<String>(index)? {
           let prop_val = object.get_named_property::<Unknown>(&name)?;
-          if let Some(json_val) = unknown_to_json_value(env, prop_val)? {
+          if let Some(json_val) = unknown_to_json_value(prop_val)? {
             map.insert(name, json_val);
           }
         }

--- a/packages/rspack-test-tools/tests/compilerCases/persist-build-info.js
+++ b/packages/rspack-test-tools/tests/compilerCases/persist-build-info.js
@@ -1,0 +1,58 @@
+const customFieldValues = [];
+
+class MyPlugin {
+    apply(compiler) {
+        compiler.hooks.compilation.tap("Plugin", compilation => {
+            compilation.hooks.finishModules.tap("Plugin", modules => {
+                for (const module of modules) {
+                    customFieldValues.push(module.buildInfo.foo);
+                }
+            });
+        });
+    }
+}
+
+/** @type {import('../..').TCompilerCaseConfig} */
+module.exports = {
+    description: "should persist build info custom fields",
+    options(context) {
+        return {
+            context: context.getSource(),
+            entry: "./d",
+            plugins: [new MyPlugin()],
+            cache: true,
+            experiments: {
+                cache: {
+                    type: "persistent"
+                }
+            },
+            module: {
+                rules: [
+                    {
+                        test: /\.js$/,
+                        use: [
+                            {
+                                loader: context.getSource("build-info-loader.js"),
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+    },
+    async build(_, compiler) {
+        await new Promise(resolve => {
+            compiler.run(() => {
+                compiler.run(() => {
+                    resolve();
+                });
+            });
+        });
+    },
+    async check() {
+        expect(customFieldValues.length).toBeGreaterThan(0);
+        customFieldValues.forEach(foo => {
+            expect(foo).toBeTruthy();
+        });
+    }
+};

--- a/packages/rspack-test-tools/tests/fixtures/build-info-loader.js
+++ b/packages/rspack-test-tools/tests/fixtures/build-info-loader.js
@@ -1,0 +1,4 @@
+module.exports = function (content) {
+    this._module.buildInfo.foo = true;
+    return content
+}

--- a/packages/rspack/src/BuildInfo.ts
+++ b/packages/rspack/src/BuildInfo.ts
@@ -1,0 +1,110 @@
+import util from "node:util";
+import * as binding from "@rspack/binding";
+import type { Source } from "webpack-sources";
+
+const $assets: unique symbol = Symbol("assets");
+
+declare module "@rspack/binding" {
+	interface Assets {
+		[$assets]: Record<string, Source>;
+	}
+
+	interface KnownBuildInfo {
+		assets: Record<string, Source>;
+		fileDependencies: Set<string>;
+		contextDependencies: Set<string>;
+		missingDependencies: Set<string>;
+		buildDependencies: Set<string>;
+	}
+}
+
+Object.defineProperty(binding.KnownBuildInfo.prototype, util.inspect.custom, {
+	enumerable: true,
+	configurable: true,
+	value(this: binding.KnownBuildInfo): any {
+		return {
+			...this,
+			assets: this.assets,
+			fileDependencies: this.fileDependencies,
+			contextDependencies: this.contextDependencies,
+			missingDependencies: this.missingDependencies,
+			buildDependencies: this.buildDependencies
+		};
+	}
+});
+
+Object.defineProperty(binding.KnownBuildInfo.prototype, "assets", {
+	enumerable: true,
+	configurable: true,
+	get(this: binding.KnownBuildInfo): Record<string, Source> {
+		if (this[binding.BUILD_INFO_ASSETS_SYMBOL][$assets]) {
+			return this[binding.BUILD_INFO_ASSETS_SYMBOL][$assets];
+		}
+		const assets = new Proxy(Object.create(null), {
+			ownKeys: () => {
+				return this[binding.BUILD_INFO_ASSETS_SYMBOL].keys();
+			},
+			getOwnPropertyDescriptor() {
+				return {
+					enumerable: true,
+					configurable: true
+				};
+			}
+		}) as Record<string, Source>;
+		Object.defineProperty(this[binding.BUILD_INFO_ASSETS_SYMBOL], $assets, {
+			enumerable: false,
+			configurable: true,
+			value: assets
+		});
+		return assets;
+	}
+});
+
+Object.defineProperty(binding.KnownBuildInfo.prototype, "fileDependencies", {
+	enumerable: true,
+	configurable: true,
+	get(this: binding.KnownBuildInfo): Set<string> {
+		return new Set(this[binding.BUILD_INFO_FILE_DEPENDENCIES_SYMBOL]);
+	}
+});
+
+Object.defineProperty(binding.KnownBuildInfo.prototype, "contextDependencies", {
+	enumerable: true,
+	configurable: true,
+	get(this: binding.KnownBuildInfo): Set<string> {
+		return new Set(this[binding.BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL]);
+	}
+});
+
+Object.defineProperty(binding.KnownBuildInfo.prototype, "missingDependencies", {
+	enumerable: true,
+	configurable: true,
+	get(this: binding.KnownBuildInfo): Set<string> {
+		return new Set(this[binding.BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL]);
+	}
+});
+
+Object.defineProperty(binding.KnownBuildInfo.prototype, "buildDependencies", {
+	enumerable: true,
+	configurable: true,
+	get(this: binding.KnownBuildInfo): Set<string> {
+		return new Set(this[binding.BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL]);
+	}
+});
+
+export type { BuildInfo } from "@rspack/binding";
+
+const knownBuildInfoFields: Set<string> = new Set([
+	"assets",
+	"fileDependencies",
+	"contextDependencies",
+	"missingDependencies",
+	"buildDependencies"
+]);
+
+export const syncCustomFields = (buildInfo: binding.BuildInfo) => {
+	// Sync custom buildInfo fields to the Rust side for later persistent caching by Rust.
+	if (Object.keys(buildInfo).some(key => !knownBuildInfoFields.has(key))) {
+		buildInfo[binding.SYNC_CUSTOM_FIELDS_SYMBOL]();
+	}
+};

--- a/packages/rspack/src/BuildInfo.ts
+++ b/packages/rspack/src/BuildInfo.ts
@@ -102,9 +102,9 @@ const knownBuildInfoFields: Set<string> = new Set([
 	"buildDependencies"
 ]);
 
-export const syncCustomFields = (buildInfo: binding.BuildInfo) => {
+export const commitCustomFieldsToRust = (buildInfo: binding.BuildInfo) => {
 	// Sync custom buildInfo fields to the Rust side for later persistent caching by Rust.
 	if (Object.keys(buildInfo).some(key => !knownBuildInfoFields.has(key))) {
-		buildInfo[binding.SYNC_CUSTOM_FIELDS_SYMBOL]();
+		buildInfo[binding.COMMIT_CUSTOM_FIELDS_SYMBOL]();
 	}
 };

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -2,6 +2,8 @@ import * as binding from "@rspack/binding";
 import type { Source } from "webpack-sources";
 import type { ResourceData } from "./Resolver";
 import { JsSource } from "./util/source";
+// patch buildInfo
+import "./BuildInfo";
 
 export type ResourceDataWithData = ResourceData & {
 	data?: Record<string, any>;
@@ -175,81 +177,6 @@ export class ContextModuleFactoryAfterResolveData {
 export type ContextModuleFactoryAfterResolveResult =
 	| false
 	| ContextModuleFactoryAfterResolveData;
-
-const $assets: unique symbol = Symbol("assets");
-
-declare module "@rspack/binding" {
-	interface Assets {
-		[$assets]: Record<string, Source>;
-	}
-
-	interface KnownBuildInfo {
-		assets: Record<string, Source>;
-		fileDependencies: Set<string>;
-		contextDependencies: Set<string>;
-		missingDependencies: Set<string>;
-		buildDependencies: Set<string>;
-	}
-}
-
-Object.defineProperty(binding.KnownBuildInfo.prototype, "assets", {
-	enumerable: true,
-	configurable: true,
-	get(this: binding.KnownBuildInfo): Record<string, Source> {
-		if (this._assets[$assets]) {
-			return this._assets[$assets];
-		}
-		const assets = new Proxy(Object.create(null), {
-			ownKeys: () => {
-				return this._assets.keys();
-			},
-			getOwnPropertyDescriptor() {
-				return {
-					enumerable: true,
-					configurable: true
-				};
-			}
-		}) as Record<string, Source>;
-		Object.defineProperty(this._assets, $assets, {
-			enumerable: false,
-			configurable: true,
-			value: assets
-		});
-		return assets;
-	}
-});
-
-Object.defineProperty(binding.KnownBuildInfo.prototype, "fileDependencies", {
-	enumerable: true,
-	configurable: true,
-	get(this: binding.KnownBuildInfo): Set<string> {
-		return new Set(this._fileDependencies);
-	}
-});
-
-Object.defineProperty(binding.KnownBuildInfo.prototype, "contextDependencies", {
-	enumerable: true,
-	configurable: true,
-	get(this: binding.KnownBuildInfo): Set<string> {
-		return new Set(this._contextDependencies);
-	}
-});
-
-Object.defineProperty(binding.KnownBuildInfo.prototype, "missingDependencies", {
-	enumerable: true,
-	configurable: true,
-	get(this: binding.KnownBuildInfo): Set<string> {
-		return new Set(this._missingDependencies);
-	}
-});
-
-Object.defineProperty(binding.KnownBuildInfo.prototype, "buildDependencies", {
-	enumerable: true,
-	configurable: true,
-	get(this: binding.KnownBuildInfo): Set<string> {
-		return new Set(this._buildDependencies);
-	}
-});
 
 Object.defineProperty(binding.Module.prototype, "identifier", {
 	enumerable: true,

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -61,6 +61,7 @@ import {
 	loadLoader,
 	runSyncOrAsync
 } from "./utils";
+import { syncCustomFields } from "../BuildInfo";
 
 function createLoaderObject(
 	loader: JsLoaderItem,
@@ -1103,8 +1104,7 @@ export async function runLoaders(
 	});
 
 	if (compiler.options.experiments.cache && compiler.options?.cache) {
-		// Serialize buildInfo to the Rust side for later persistent caching by Rust.
-		context._module.buildInfo.serialize();
+		syncCustomFields(context._module.buildInfo);
 	}
 
 	return context;

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -25,7 +25,7 @@ import {
 	SourceMapSource
 } from "webpack-sources";
 
-import { syncCustomFields } from "../BuildInfo";
+import { commitCustomFieldsToRust } from "../BuildInfo";
 import type { Compilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import { NormalModule } from "../NormalModule";
@@ -1104,7 +1104,7 @@ export async function runLoaders(
 	});
 
 	if (compiler.options.experiments.cache && compiler.options?.cache) {
-		syncCustomFields(context._module.buildInfo);
+		commitCustomFieldsToRust(context._module.buildInfo);
 	}
 
 	return context;

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -1101,6 +1101,7 @@ export async function runLoaders(
 			id2: resource
 		}
 	});
+	context._module.buildInfo.serializeCustomFields();
 	return context;
 }
 

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -1101,7 +1101,12 @@ export async function runLoaders(
 			id2: resource
 		}
 	});
-	context._module.buildInfo.serializeCustomFields();
+
+	if (compiler.options.experiments.cache && compiler.options?.cache) {
+		// Serialize buildInfo to the Rust side for later persistent caching by Rust.
+		context._module.buildInfo.serialize();
+	}
+
 	return context;
 }
 

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -25,6 +25,7 @@ import {
 	SourceMapSource
 } from "webpack-sources";
 
+import { syncCustomFields } from "../BuildInfo";
 import type { Compilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import { NormalModule } from "../NormalModule";
@@ -61,7 +62,6 @@ import {
 	loadLoader,
 	runSyncOrAsync
 } from "./utils";
-import { syncCustomFields } from "../BuildInfo";
 
 function createLoaderObject(
 	loader: JsLoaderItem,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This PR synchronizes user-defined fields on the JavaScript buildInfo object to Rust, enabling persistent caching of these custom fields on the Rust side.

Additionally, minor refactors are included leveraging napi-rs' new support for symbol-named properties in define_properties. Private properties are now consolidated using Symbols to prevent accidental exposure to users.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
