### PR TITLE
feat: rsdoctor native plugin add bailout_reason property

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1048,6 +1048,7 @@ export interface JsRsdoctorModule {
   belongModules: Array<number>
   chunks: Array<number>
   issuerPath: Array<number>
+  bailoutReason?: string
 }
 
 export interface JsRsdoctorModuleGraph {

--- a/crates/node_binding/src/rsdoctor.rs
+++ b/crates/node_binding/src/rsdoctor.rs
@@ -27,6 +27,7 @@ pub struct JsRsdoctorModule {
   pub belong_modules: Vec<i32>,
   pub chunks: Vec<i32>,
   pub issuer_path: Vec<i32>,
+  pub bailout_reason: Option<String>,
 }
 
 impl From<RsdoctorModule> for JsRsdoctorModule {
@@ -49,6 +50,7 @@ impl From<RsdoctorModule> for JsRsdoctorModule {
         .into_iter()
         .filter_map(|i| i.ukey)
         .collect::<Vec<_>>(),
+      bailout_reason: value.bailout_reason,
     }
   }
 }

--- a/crates/rspack_plugin_rsdoctor/src/data.rs
+++ b/crates/rspack_plugin_rsdoctor/src/data.rs
@@ -47,6 +47,7 @@ pub struct RsdoctorModule {
   pub modules: HashSet<ModuleUkey>,
   pub belong_modules: HashSet<ModuleUkey>,
   pub issuer_path: Option<Vec<RsdoctorStatsModuleIssuer>>,
+  pub bailout_reason: Option<String>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -72,6 +72,7 @@ pub fn collect_modules(
           belong_modules: HashSet::default(),
           chunks,
           issuer_path: None,
+          bailout_reason: None,
         },
       )
     })

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -319,6 +319,11 @@ async fn optimize_chunk_modules(&self, compilation: &mut Compilation) -> Result<
     if let Some(rsd_module) = rsd_modules.get_mut(&module_id) {
       rsd_module.issuer_path = Some(issuer_path);
     }
+    if let Some(rsd_module) = rsd_modules.get_mut(&module_id) {
+      let (_, module) = module;
+      let bailout_reason = module_graph.get_optimization_bailout(&module.identifier());
+      rsd_module.bailout_reason = Some(bailout_reason.join(", "));
+    }
   }
 
   // 6. collect chunk modules

--- a/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rsdoctor/moduleGraph/rspack.config.js
@@ -38,6 +38,8 @@ module.exports = {
 							expect(issuerPathList).toContain(value);
 						});
 
+						expect(normalModules[0].bailoutReason).toBeTruthy();
+
 						const entryModule = modules.find(
 							module => module.isEntry && module.kind === "concatenated"
 						);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
This pull request introduces a new `bailout_reason` field to the `RsdoctorModule` and `JsRsdoctorModule` structures, along with the necessary logic to populate and transfer this field during module processing. The changes enhance the ability to track optimization bailout reasons in the `Rsdoctor` plugin.

### Addition of `bailout_reason` field:

* [`crates/node_binding/src/rsdoctor.rs`](diffhunk://#diff-78b74f07f1c5a3728ce3495127830a73e965afe532de2330b19d670406c8bb48R30): Added an optional `bailout_reason` field to the `JsRsdoctorModule` struct and updated the `From<RsdoctorModule>` implementation to transfer the `bailout_reason` value. [[1]](diffhunk://#diff-78b74f07f1c5a3728ce3495127830a73e965afe532de2330b19d670406c8bb48R30) [[2]](diffhunk://#diff-78b74f07f1c5a3728ce3495127830a73e965afe532de2330b19d670406c8bb48R53)
* [`crates/rspack_plugin_rsdoctor/src/data.rs`](diffhunk://#diff-51cc9ed8678c895a2662b2f0b5825406f853793266f2d06e0eed96706e1249adR50): Added an optional `bailout_reason` field to the `RsdoctorModule` struct to store optimization bailout reasons.

### Logic for populating `bailout_reason`:

* [`crates/rspack_plugin_rsdoctor/src/module_graph.rs`](diffhunk://#diff-47aab1b39b6b234ddb905c290c3faab092114f84cc49c8c400cb5caa9da3730cR75): Initialized the `bailout_reason` field to `None` in the `collect_modules` function.
* [`crates/rspack_plugin_rsdoctor/src/plugin.rs`](diffhunk://#diff-bbbaef80d0e831527745f700440d57ac04632271530457983a6cd401196c9637R322-R326): Updated the `optimize_chunk_modules` method to fetch and populate the `bailout_reason` field using the `module_graph.get_optimization_bailout` method.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
