### PR TITLE
fix: Webpack config test cases falsely pass when compilation error occur

### DIFF
--- a/tests/webpack-test/ConfigTestCases.template.js
+++ b/tests/webpack-test/ConfigTestCases.template.js
@@ -731,7 +731,7 @@ const describeCases = config => {
 									}
 									// give a free pass to compilation that generated an error
 									if (
-										!stats.hasErrors() &&
+										stats.hasErrors() &&
 										filesCount !== optionsArr.length
 									) {
 										return done(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

I noticed this issue when investigating why #10546 was not caught.

reference:

https://github.com/webpack/webpack/blob/19ca74127f7668aaf60d59f4af8fcaee7924541a/test/ConfigTestCases.template.js#L712

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
