### PR TITLE
feat: should rename default import based on source

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -795,7 +795,11 @@ impl Module for ConcatenatedModule {
                 }
 
                 let new_name = if all_used_names.contains(atom) {
-                  let new_name = find_new_name(atom, &all_used_names, None, &readable_identifier);
+                  let new_name = if atom == "default" {
+                    find_new_name("", &all_used_names, None, &source.replace("\"", ""))
+                  } else {
+                    find_new_name(atom, &all_used_names, None, &readable_identifier)
+                  };
                   all_used_names.insert(new_name.clone());
                   // if the imported symbol is exported, we rename the export as well
                   if let Some(raw_export_map) = info.raw_export_map.as_mut()

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
@@ -31,9 +31,9 @@ module.exports = {
 					const bundle = Object.values(assets)[0]._value;
 					expect(bundle)
 						.toContain(`var __webpack_exports__cjsInterop = (foo_default());
-export { external_external_module_default as defaultImport, namedImport, __webpack_exports__cjsInterop as cjsInterop };`);
+export { external_module as defaultImport, namedImport, __webpack_exports__cjsInterop as cjsInterop };`);
 					expect(bundle).toContain(
-						'import external_external_module_default, { namedImport } from "external-module";'
+						'import external_module, { namedImport } from "external-module";'
 					);
 				});
 			};

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-named-import-externals/rspack.config.js
@@ -35,7 +35,7 @@ module.exports = {
 					expect(source).toMatchInlineSnapshot(`
 				import { HomeLayout as external_externals0_HomeLayout, a } from "externals0";
 				import { a as external_externals1_a } from "externals1";
-				import external_externals2_default from "externals2";
+				import externals2 from "externals2";
 				import "externals4";
 				import * as __WEBPACK_EXTERNAL_MODULE_externals3__ from "externals3";
 
@@ -76,7 +76,7 @@ module.exports = {
 
 
 				external_externals1_a;
-				external_externals2_default;
+				externals2;
 				__WEBPACK_EXTERNAL_MODULE_externals3__;
 
 				export { a };

--- a/tests/webpack-test/configCases/externals/module-import/index.js
+++ b/tests/webpack-test/configCases/externals/module-import/index.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 it("module-import should correctly get fallback type", function() {
 	const content = fs.readFileSync(path.resolve(__dirname, "a.js"), "utf-8");
-	expect(content).toContain(`import external_external0_default from \"external0\";`); // module
+	expect(content).toContain(`import external0 from \"external0\";`); // module
 	expect(content).toContain(`import * as __WEBPACK_EXTERNAL_MODULE_external1__ from "external1"`); // module
 	expect(content).toContain(`module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("external2")`); // node-commonjs
 	expect(content).toContain(`import * as __WEBPACK_EXTERNAL_MODULE_external3__ from "external3"`); // module


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Before

```js
import external_external_module from 'external-module'
```

This pr

```js
import external_module from 'external-module'
```

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
