### PR TITLE
refactor(zod/v4): replace `z.function` with `z.custom`

### DIFF
--- a/packages/rspack-test-tools/tests/Validation.test.js
+++ b/packages/rspack-test-tools/tests/Validation.test.js
@@ -147,6 +147,29 @@ describe("Validation", () => {
 		`);
 			}
 		);
+
+		createTestCase(
+			"function type",
+			{
+				ignoreWarnings: [new Map()],
+				output: {
+					devtoolModuleFilenameTemplate: new Set()
+				}
+			},
+			message => {
+				throw new Error("should not have error");
+			},
+			"loose",
+			log => {
+				expect(log).toMatchInlineSnapshot(`
+			Array [
+			  Invalid configuration object. Rspack has been initialized using a configuration object that does not match the API schema.
+			- Expected string, received set at "output.devtoolModuleFilenameTemplate", or Expected function, received set at "output.devtoolModuleFilenameTemplate"
+			- Input not instance of RegExp at "ignoreWarnings[0]", or Expected function, received map at "ignoreWarnings[0]",
+			]
+		`);
+			}
+		);
 	});
 
 	describe("strict", () => {
@@ -189,6 +212,29 @@ describe("Validation", () => {
 				throw new Error("should not have log");
 			}
 		);
+
+		createTestCase(
+			"function type",
+			{
+				ignoreWarnings: [new Map()],
+				output: {
+					devtoolModuleFilenameTemplate: new Set(),
+					filename: []
+				}
+			},
+			message => {
+				expect(message).toMatchInlineSnapshot(`
+			Invalid configuration object. Rspack has been initialized using a configuration object that does not match the API schema.
+			- Expected string, received array at "output.filename", or Expected function, received array at "output.filename"
+			- Expected string, received set at "output.devtoolModuleFilenameTemplate", or Expected function, received set at "output.devtoolModuleFilenameTemplate"
+			- Input not instance of RegExp at "ignoreWarnings[0]", or Expected function, received map at "ignoreWarnings[0]"
+		`);
+			},
+			"strict",
+			log => {
+				throw new Error("should not have log");
+			}
+		);
 	});
 
 	describe("default (strict)", () => {
@@ -223,6 +269,28 @@ describe("Validation", () => {
 			- The provided value "./" must be an absolute path. at "context"
 			- Unrecognized key(s) in object: '_additionalProperty' at "optimization"
 			- Unrecognized key(s) in object: '_additionalProperty'
+		`);
+			},
+			log => {
+				throw new Error("should not have log");
+			}
+		);
+
+		createTestCase(
+			"function type",
+			{
+				ignoreWarnings: [new Map()],
+				output: {
+					devtoolModuleFilenameTemplate: new Set(),
+					filename: []
+				}
+			},
+			message => {
+				expect(message).toMatchInlineSnapshot(`
+			Invalid configuration object. Rspack has been initialized using a configuration object that does not match the API schema.
+			- Expected string, received array at "output.filename", or Expected function, received array at "output.filename"
+			- Expected string, received set at "output.devtoolModuleFilenameTemplate", or Expected function, received set at "output.devtoolModuleFilenameTemplate"
+			- Input not instance of RegExp at "ignoreWarnings[0]", or Expected function, received map at "ignoreWarnings[0]"
 		`);
 			},
 			log => {

--- a/packages/rspack/src/builtin-plugin/IgnorePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/IgnorePlugin.ts
@@ -4,6 +4,7 @@ import {
 } from "@rspack/binding";
 import { z } from "zod";
 
+import { anyFunction } from "../config/utils";
 import { validate } from "../util/validate";
 import { create } from "./base";
 
@@ -26,7 +27,7 @@ const IgnorePluginOptions = z.union([
 		resourceRegExp: z.instanceof(RegExp)
 	}),
 	z.object({
-		checkResource: z.function(z.tuple([z.string(), z.string()]), z.boolean())
+		checkResource: anyFunction
 	})
 ]) satisfies z.ZodType<IgnorePluginOptions>;
 

--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { Compilation } from "../../Compilation";
+import { anyFunction } from "../../config/utils";
 import { validate } from "../../util/validate";
 
 const compilationOptionsMap: WeakMap<Compilation, HtmlRspackPluginOptions> =
@@ -9,23 +10,15 @@ export type TemplateRenderFunction = (
 	params: Record<string, any>
 ) => string | Promise<string>;
 
-const templateRenderFunction = z
-	.function()
-	.args(z.record(z.string(), z.any()))
-	.returns(
-		z.string().or(z.promise(z.string()))
-	) satisfies z.ZodType<TemplateRenderFunction>;
+const templateRenderFunction =
+	anyFunction satisfies z.ZodType<TemplateRenderFunction>;
 
 export type TemplateParamFunction = (
 	params: Record<string, any>
 ) => Record<string, any> | Promise<Record<string, any>>;
 
-const templateParamFunction = z
-	.function()
-	.args(z.record(z.string(), z.any()))
-	.returns(
-		z.record(z.string(), z.any()).or(z.promise(z.record(z.string(), z.any())))
-	) satisfies z.ZodType<TemplateParamFunction>;
+const templateParamFunction =
+	anyFunction satisfies z.ZodType<TemplateParamFunction>;
 
 export type HtmlRspackPluginOptions = {
 	/** The title to use for the generated HTML document. */
@@ -120,13 +113,8 @@ export type HtmlRspackPluginOptions = {
 	[key: string]: any;
 };
 
-const templateFilenameFunction = z
-	.function()
-	.args(z.string())
-	.returns(z.string());
-
 const pluginOptionsSchema = z.object({
-	filename: z.string().or(templateFilenameFunction).optional(),
+	filename: z.string().or(anyFunction).optional(),
 	template: z
 		.string()
 		.refine(

--- a/packages/rspack/src/config/utils.ts
+++ b/packages/rspack/src/config/utils.ts
@@ -18,6 +18,7 @@ import {
 	ZodUnion,
 	type ZodUnionOptions,
 	addIssueToContext,
+	getParsedType,
 	z
 } from "zod";
 import type { RspackOptions } from "./types";
@@ -222,3 +223,10 @@ export class ZodRspackCrossChecker<T> extends ZodType<T> {
 		return root.data;
 	}
 }
+
+export const anyFunction = z.custom<(...args: unknown[]) => any>(
+	data => typeof data === "function",
+	// Make the similar error message as zod v3
+	// https://github.com/colinhacks/zod/blob/64bfb7001cf6f2575bf38b5e6130bc73b4b0e371/packages/zod/src/v3/types.ts#L3821-L3828
+	input => ({ message: `Expected function, received ${getParsedType(input)}` })
+);

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1,24 +1,14 @@
 import nodePath from "node:path";
-import type { AssetInfo, RawFuncUseCtx } from "@rspack/binding";
 import { type SyncParseReturnType, ZodIssueCode, z } from "zod";
-import { Chunk } from "../Chunk";
-import { ChunkGraph } from "../ChunkGraph";
-import type { Compilation, PathData } from "../Compilation";
-import { Module } from "../Module";
-import ModuleGraph from "../ModuleGraph";
 import { ZodSwcLoaderOptions } from "../builtin-loader/swc/types";
 import { validate } from "../util/validate";
-import type { ResolveCallback } from "./adapterRuleUse";
 import type * as t from "./types";
-import { ZodRspackCrossChecker } from "./utils";
+import { ZodRspackCrossChecker, anyFunction } from "./utils";
 
 const filenameTemplate = z.string() satisfies z.ZodType<t.FilenameTemplate>;
 
 const filename = filenameTemplate.or(
-	z
-		.function()
-		.args(z.custom<PathData>(), z.custom<AssetInfo>().optional())
-		.returns(z.string())
+	anyFunction
 ) satisfies z.ZodType<t.Filename>;
 
 //#region Name
@@ -193,11 +183,7 @@ const entryStatic = entryObject.or(
 	entryUnnamed
 ) satisfies z.ZodType<t.EntryStatic>;
 
-const entryDynamic = z
-	.function()
-	.returns(
-		entryStatic.or(z.promise(entryStatic))
-	) satisfies z.ZodType<t.EntryDynamic>;
+const entryDynamic = anyFunction satisfies z.ZodType<t.EntryDynamic>;
 
 const entry = entryStatic.or(entryDynamic) satisfies z.ZodType<t.Entry>;
 //#endregion
@@ -245,11 +231,7 @@ const enabledLibraryTypes = z.array(
 const clean = z.union([
 	z.boolean(),
 	z.strictObject({
-		keep: z
-			.instanceof(RegExp)
-			.or(z.string())
-			.or(z.function().args(z.string()).returns(z.boolean()))
-			.optional()
+		keep: z.instanceof(RegExp).or(z.string()).or(anyFunction).optional()
 	})
 ]) satisfies z.ZodType<t.Clean>;
 
@@ -305,7 +287,7 @@ const devtoolNamespace = z.string() satisfies z.ZodType<t.DevtoolNamespace>;
 
 const devtoolModuleFilenameTemplate = z.union([
 	z.string(),
-	z.function(z.tuple([z.any()]), z.any())
+	anyFunction
 ]) satisfies z.ZodType<t.DevtoolModuleFilenameTemplate>;
 
 const devtoolFallbackModuleFilenameTemplate =
@@ -441,7 +423,7 @@ const resolveOptions: z.ZodType<t.ResolveOptions> = baseResolveOptions.extend({
 const baseRuleSetCondition = z
 	.instanceof(RegExp)
 	.or(z.string())
-	.or(z.function().args(z.string()).returns(z.boolean()));
+	.or(anyFunction);
 
 const ruleSetCondition: z.ZodType<t.RuleSetCondition> = baseRuleSetCondition
 	.or(z.lazy(() => ruleSetConditions))
@@ -521,9 +503,7 @@ const ruleSetUseItem = ruleSetLoader.or(
 
 const ruleSetUse = ruleSetUseItem
 	.or(ruleSetUseItem.array())
-	.or(
-		z.function().args(z.custom<RawFuncUseCtx>()).returns(ruleSetUseItem.array())
-	) satisfies z.ZodType<t.RuleSetUse>;
+	.or(anyFunction) satisfies z.ZodType<t.RuleSetUse>;
 
 const baseRuleSetRule = z.strictObject({
 	test: ruleSetCondition.optional(),
@@ -705,16 +685,8 @@ const assetGeneratorDataUrlOptions = z.strictObject({
 	mimetype: z.string().optional()
 }) satisfies z.ZodType<t.AssetGeneratorDataUrlOptions>;
 
-const assetGeneratorDataUrlFunction = z
-	.function()
-	.args(
-		z.instanceof(Buffer),
-		z.strictObject({
-			filename: z.string(),
-			module: z.custom<Module>()
-		})
-	)
-	.returns(z.string()) satisfies z.ZodType<t.AssetGeneratorDataUrlFunction>;
+const assetGeneratorDataUrlFunction =
+	anyFunction satisfies z.ZodType<t.AssetGeneratorDataUrlFunction>;
 
 const assetGeneratorDataUrl = assetGeneratorDataUrlOptions.or(
 	assetGeneratorDataUrlFunction
@@ -787,10 +759,7 @@ const generatorOptionsByModuleTypeKnown = z.strictObject({
 
 const generatorOptionsByModuleType = generatorOptionsByModuleTypeKnown;
 
-const noParseOptionSingle = z
-	.string()
-	.or(z.instanceof(RegExp))
-	.or(z.function().args(z.string()).returns(z.boolean()));
+const noParseOptionSingle = z.string().or(z.instanceof(RegExp)).or(anyFunction);
 const noParseOption = noParseOptionSingle.or(
 	z.array(noParseOptionSingle)
 ) satisfies z.ZodType<t.NoParseOption>;
@@ -968,64 +937,11 @@ const externalItemObjectUnknown = z.record(
 	externalItemValue
 ) satisfies z.ZodType<t.ExternalItemObjectUnknown>;
 
-const externalItemFunctionData = z.strictObject({
-	context: z.string().optional(),
-	dependencyType: z.string().optional(),
-	request: z.string().optional(),
-	contextInfo: z
-		.strictObject({
-			issuer: z.string(),
-			issuerLayer: z.string().or(z.null()).optional()
-		})
-		.optional(),
-	getResolve: z
-		.function()
-		.returns(
-			z
-				.function()
-				.args(z.string(), z.string())
-				.returns(z.promise(z.string()))
-				.or(
-					z
-						.function()
-						.args(z.string(), z.string(), z.custom<ResolveCallback>())
-						.returns(z.void())
-				)
-		)
-		.optional()
-}) satisfies z.ZodType<t.ExternalItemFunctionData>;
-
 const externalItem = z
 	.string()
 	.or(z.instanceof(RegExp))
 	.or(externalItemObjectUnknown)
-	.or(
-		z
-			.function()
-			.args(
-				externalItemFunctionData as z.ZodType<t.ExternalItemFunctionData>,
-				z
-					.function()
-					.args(
-						z.instanceof(Error).optional(),
-						externalItemValue.optional(),
-						externalsType.optional()
-					)
-					.returns(z.void())
-			)
-	)
-	.or(
-		z
-			.function()
-			.args(externalItemFunctionData as z.ZodType<t.ExternalItemFunctionData>)
-			.returns(z.promise(externalItemValue))
-	)
-	.or(
-		z
-			.function()
-			.args(externalItemFunctionData as z.ZodType<t.ExternalItemFunctionData>)
-			.returns(externalItemValue)
-	) satisfies z.ZodType<t.ExternalItem>;
+	.or(anyFunction) satisfies z.ZodType<t.ExternalItem>;
 
 const externals = externalItem
 	.array()
@@ -1048,9 +964,7 @@ const externalsPresets = z.strictObject({
 const filterItemTypes = z
 	.instanceof(RegExp)
 	.or(z.string())
-	.or(
-		z.function().args(z.string()).returns(z.boolean())
-	) satisfies z.ZodType<t.FilterItemTypes>;
+	.or(anyFunction) satisfies z.ZodType<t.FilterItemTypes>;
 
 const filterTypes = filterItemTypes
 	.array()
@@ -1194,27 +1108,17 @@ const statsOptions = z.strictObject({
 	assetsSpace: z.number().optional(),
 	orphanModules: z.boolean().optional(),
 	excludeModules: z
-		.array(
-			z
-				.string()
-				.or(z.instanceof(RegExp))
-				.or(z.function(z.tuple([z.string(), z.any(), z.any()]), z.boolean()))
-		)
+		.array(z.string().or(z.instanceof(RegExp)).or(anyFunction))
 		.or(z.string())
 		.or(z.instanceof(RegExp))
-		.or(z.function(z.tuple([z.string(), z.any(), z.any()]), z.boolean()))
+		.or(anyFunction)
 		.or(z.boolean())
 		.optional(),
 	excludeAssets: z
-		.array(
-			z
-				.string()
-				.or(z.instanceof(RegExp))
-				.or(z.function(z.tuple([z.string(), z.any()]), z.boolean()))
-		)
+		.array(z.string().or(z.instanceof(RegExp)).or(anyFunction))
 		.or(z.string())
 		.or(z.instanceof(RegExp))
-		.or(z.function(z.tuple([z.string(), z.any()]), z.boolean()))
+		.or(anyFunction)
 		.optional(),
 	modulesSort: z.string().optional(),
 	chunkModulesSort: z.string().optional(),
@@ -1268,24 +1172,12 @@ const optimizationRuntimeChunk = z
 	.or(z.boolean())
 	.or(
 		z.strictObject({
-			name: z
-				.string()
-				.or(
-					z
-						.function()
-						.args(z.strictObject({ name: z.string() }))
-						.returns(z.string())
-				)
-				.optional()
+			name: z.string().or(anyFunction).optional()
 		})
 	) satisfies z.ZodType<t.OptimizationRuntimeChunk>;
 
-const optimizationSplitChunksNameFunction = z
-	.function()
-	.args(z.instanceof(Module), z.array(z.instanceof(Chunk)), z.string())
-	.returns(
-		z.string().optional()
-	) satisfies z.ZodType<t.OptimizationSplitChunksNameFunction>;
+const optimizationSplitChunksNameFunction =
+	anyFunction satisfies z.ZodType<t.OptimizationSplitChunksNameFunction>;
 
 const optimizationSplitChunksName = z
 	.string()
@@ -1294,12 +1186,7 @@ const optimizationSplitChunksName = z
 const optimizationSplitChunksChunks = z
 	.enum(["initial", "async", "all"])
 	.or(z.instanceof(RegExp))
-	.or(
-		z
-			.function()
-			.args(z.instanceof(Chunk, { message: "Input not instance of Chunk" }))
-			.returns(z.boolean())
-	);
+	.or(anyFunction);
 const optimizationSplitChunksSizes = z
 	.number()
 	.or(z.record(z.string(), z.number()));
@@ -1321,32 +1208,13 @@ const sharedOptimizationSplitChunksCacheGroup = {
 	automaticNameDelimiter: z.string().optional()
 };
 const optimizationSplitChunksCacheGroup = z.strictObject({
-	test: z
-		.string()
-		.or(z.instanceof(RegExp))
-		.or(
-			z
-				.function()
-				.args(
-					z.instanceof(Module) /** FIXME: lack of CacheGroupContext */,
-					z.object({
-						moduleGraph: z.instanceof(ModuleGraph),
-						chunkGraph: z.instanceof(ChunkGraph)
-					})
-				)
-				.returns(z.boolean())
-		)
-		.optional(),
+	test: z.string().or(z.instanceof(RegExp)).or(anyFunction).optional(),
 	priority: z.number().optional(),
 	enforce: z.boolean().optional(),
 	reuseExistingChunk: z.boolean().optional(),
 	type: z.string().or(z.instanceof(RegExp)).optional(),
 	idHint: z.string().optional(),
-	layer: z
-		.string()
-		.or(z.instanceof(RegExp))
-		.or(z.function(z.tuple([z.string().optional()]), z.boolean()))
-		.optional(),
+	layer: z.string().or(z.instanceof(RegExp)).or(anyFunction).optional(),
 	...sharedOptimizationSplitChunksCacheGroup
 }) satisfies z.ZodType<t.OptimizationSplitChunksCacheGroup>;
 
@@ -1443,10 +1311,7 @@ const experimentCacheOptions = z
 const lazyCompilationOptions = z.object({
 	imports: z.boolean().optional(),
 	entries: z.boolean().optional(),
-	test: z
-		.instanceof(RegExp)
-		.or(z.function().args(z.custom<Module>()).returns(z.boolean()))
-		.optional(),
+	test: z.instanceof(RegExp).or(anyFunction).optional(),
 	client: z.string().optional(),
 	serverUrl: z.string().optional(),
 	prefix: z.string().optional()
@@ -1478,19 +1343,7 @@ const buildHttpOptions = z.object({
 	upgrade: z.boolean().optional(),
 	// proxy: z.string().optional(),
 	// frozen: z.boolean().optional(),
-	httpClient: z
-		.function()
-		.args(z.string(), z.record(z.string(), z.string()))
-		.returns(
-			z.promise(
-				z.object({
-					status: z.number(),
-					headers: z.record(z.string(), z.string()),
-					body: z.instanceof(Buffer)
-				})
-			)
-		)
-		.optional()
+	httpClient: anyFunction.optional()
 }) satisfies z.ZodType<t.HttpUriOptions>;
 
 const experiments = z.strictObject({
@@ -1542,12 +1395,7 @@ const devServer = z.custom<t.DevServer>();
 //#region IgnoreWarnings
 const ignoreWarnings = z
 	.instanceof(RegExp)
-	.or(
-		z
-			.function()
-			.args(z.instanceof(Error), z.custom<Compilation>())
-			.returns(z.boolean())
-	)
+	.or(anyFunction)
 	.array() satisfies z.ZodType<t.IgnoreWarnings>;
 //#endregion
 
@@ -1568,7 +1416,7 @@ const bail = z.boolean() satisfies z.ZodType<t.Bail>;
 //#region Performance
 const performance = z
 	.strictObject({
-		assetFilter: z.function().args(z.string()).returns(z.boolean()).optional(),
+		assetFilter: anyFunction.optional(),
 		hints: z.enum(["error", "warning"]).or(z.literal(false)).optional(),
 		maxAssetSize: z.number().optional(),
 		maxEntrypointSize: z.number().optional()


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The result of `z.function()` in Zod v4 is no longer a schema: https://zod.dev/v4/changelog#zfunction. We need to migrate when upgrading to v4.

Since we are not exporting the Zod-generated types now, I think it would be fine to replace all the `z.function` with `z.custom<(...args: unknown[]) => any>`.

```ts
export const anyFunction = z.custom<(...args: unknown[]) => any>(
	data => typeof data === "function",
	input => ({ message: `Expected function, received ${getParsedType(input)}` })
);
```

<details><summary>Alternatives</summary>
<p>

I've tried the workaround at https://github.com/colinhacks/zod/issues/4143#issuecomment-2845134912 (which is recommended in the migration guide). It works with type but it will make validation pass for all inputs.

I've also tried to use generics in `anyFunction`, which could keep all the types of Zod schema:

```ts
export function anyFunction<T>() {
	return z.custom<T>(
		data => typeof data === "function",
		input => ({ message: `Expected function, received ${getParsedType(input)}` })
	);
}
```

However, this approach would involve additional function calls (and some additional objects/functions are created), potentially reducing performance, and could also slow down TypeScript's type-checking process.

I decided to opt for a universal `anyFunction` instead.

</p>
</details> 

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

issue: #10467 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).

I add the tests in [ec1c292](https://github.com/web-infra-dev/rspack/pull/10602/commits/ec1c292b715fdfd431b2e6a183bcd33b98b24a1c) and replace the `z.function` in [1200be4](https://github.com/web-infra-dev/rspack/pull/10602/commits/1200be4d6f5a61a909c1d5eb896c4209a43cc772) without modifying the tests.

- [ ] Documentation updated (or **not required**).
