### PR TITLE
docs: fix rsbuild command typo in tracing doc

### DIFF
--- a/website/docs/en/contribute/development/tracing.md
+++ b/website/docs/en/contribute/development/tracing.md
@@ -13,9 +13,8 @@ Tracing can be enabled in two ways:
 RSPACK_PROFILE=OVERVIEW rspack build # recommend
 RSPACK_PROFILE=ALL rspack build # not recommend, may generate too large trace.json for large projects
 
-
 # Rsbuild
-RSPACK_PROFILE=OVERVIEW rspack build
+RSPACK_PROFILE=OVERVIEW rsbuild build
 RSPACK_PROFILE=ALL rsbuild build
 ```
 

--- a/website/docs/zh/contribute/development/tracing.md
+++ b/website/docs/zh/contribute/development/tracing.md
@@ -16,7 +16,6 @@ RSPACK_PROFILE=ALL rspack build # 不推荐，大项目的 trace.json 体积可�
 # Rsbuild
 RSPACK_PROFILE=OVERVIEW rsbuild build
 RSPACK_PROFILE=ALL rsbuild build
-
 ```
 
 - 如果直接使用 `@rspack/core`：可通过 `rspack.experiments.globalTrace.register` 和 `rspack.experiments.globalTrace.cleanup` 开启。你可以查看我们如何在 [`@rspack/cli` 中实现 `RSPACK_PROFILE`](https://github.com/web-infra-dev/rspack/blob/9be47217b5179186b0825ca79990ab2808aa1a0f/packages/rspack-cli/src/utils/profile.ts#L219-L224)获取更多信息。


### PR DESCRIPTION
## Summary

This PR updates the documentation for enabling tracing to correct the command usage for `rsbuild`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
