### PR TITLE
fix: `number_hash` should use `u64` to avoid addition overflow

### DIFF
--- a/crates/rspack_util/src/number_hash.rs
+++ b/crates/rspack_util/src/number_hash.rs
@@ -10,29 +10,29 @@ const SAFE_PART: usize = SAFE_LIMIT - 1;
 const COUNT: usize = 4;
 
 pub fn get_number_hash(str: &str, range: usize) -> usize {
-  let mut arr = [0usize; COUNT];
-  let primes = [3usize, 7usize, 17usize, 19usize];
+  let mut arr = [0u64; COUNT];
+  let primes = [3u64, 7u64, 17u64, 19u64];
 
   for i in 0..str.len() {
-    let c = str.as_bytes()[i] as usize;
-    arr[0] = (arr[0] + c * primes[0] + arr[3]) & SAFE_PART;
-    arr[1] = (arr[1] + c * primes[1] + arr[0]) & SAFE_PART;
-    arr[2] = (arr[2] + c * primes[2] + arr[1]) & SAFE_PART;
-    arr[3] = (arr[3] + c * primes[3] + arr[2]) & SAFE_PART;
+    let c = str.as_bytes()[i] as u64;
+    arr[0] = (arr[0] + c * primes[0] + arr[3]) & SAFE_PART as u64;
+    arr[1] = (arr[1] + c * primes[1] + arr[0]) & SAFE_PART as u64;
+    arr[2] = (arr[2] + c * primes[2] + arr[1]) & SAFE_PART as u64;
+    arr[3] = (arr[3] + c * primes[3] + arr[2]) & SAFE_PART as u64;
 
-    arr[0] ^= arr[arr[0] % COUNT] >> 1;
-    arr[1] ^= arr[arr[1] % COUNT] >> 1;
-    arr[2] ^= arr[arr[2] % COUNT] >> 1;
-    arr[3] ^= arr[arr[3] % COUNT] >> 1;
+    arr[0] ^= arr[(arr[0] % COUNT as u64) as usize] >> 1;
+    arr[1] ^= arr[(arr[1] % COUNT as u64) as usize] >> 1;
+    arr[2] ^= arr[(arr[2] % COUNT as u64) as usize] >> 1;
+    arr[3] ^= arr[(arr[3] % COUNT as u64) as usize] >> 1;
   }
 
   if range <= SAFE_PART {
-    (arr[0] + arr[1] + arr[2] + arr[3]) % range
+    ((arr[0] + arr[1] + arr[2] + arr[3]) % range as u64) as usize
   } else {
     let range_ext = range / SAFE_LIMIT;
-    let sum1 = (arr[0] + arr[2]) & SAFE_PART;
-    let sum2 = (arr[0] + arr[2]) % range_ext;
-    (sum2 * SAFE_LIMIT + sum1) % range
+    let sum1 = (arr[0] + arr[2]) & SAFE_PART as u64;
+    let sum2 = (arr[0] + arr[2]) % range_ext as u64;
+    ((sum2 * SAFE_LIMIT as u64 + sum1) % range as u64) as usize
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

related: https://github.com/web-infra-dev/rspack/issues/10614

This is a temporary fix. @quininer will port the new `fnv` algorithm.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
