### PR TITLE
fix(create-rspack): ignore rspack profile and remove npmignore file

### DIFF
--- a/packages/create-rspack/template-common/gitignore
+++ b/packages/create-rspack/template-common/gitignore
@@ -7,6 +7,9 @@
 node_modules
 dist/
 
+# Profile
+.rspack-profile-*/
+
 # IDE
 .vscode/*
 !.vscode/extensions.json

--- a/packages/create-rspack/template-react-js/.npmignore
+++ b/packages/create-rspack/template-react-js/.npmignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/packages/create-rspack/template-react-ts/.npmignore
+++ b/packages/create-rspack/template-react-ts/.npmignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/packages/create-rspack/template-vanilla-js/.npmignore
+++ b/packages/create-rspack/template-vanilla-js/.npmignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/packages/create-rspack/template-vanilla-ts/.npmignore
+++ b/packages/create-rspack/template-vanilla-ts/.npmignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/packages/create-rspack/template-vue-js/.npmignore
+++ b/packages/create-rspack/template-vue-js/.npmignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/packages/create-rspack/template-vue-ts/.npmignore
+++ b/packages/create-rspack/template-vue-ts/.npmignore
@@ -1,1 +1,0 @@
-node_modules/


### PR DESCRIPTION
## Summary

- Updates the `.gitignore` file to add patterns to ignore Rspack profile directories (`.rspack-profile-*`).
- Remove the useless `.npmignore` files.

## Related Links

- https://rsbuild.rs/guide/debug/build-profiling#rspack-profiling

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
