### PR TITLE
fix(rstest): should stringify resource path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5208,6 +5208,7 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_plugin_javascript",
+ "rspack_util",
  "swc_core",
  "tracing",
 ]

--- a/crates/rspack_plugin_rstest/Cargo.toml
+++ b/crates/rspack_plugin_rstest/Cargo.toml
@@ -15,6 +15,7 @@ rspack_core              = { workspace = true }
 rspack_error             = { workspace = true }
 rspack_hook              = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
+rspack_util              = { workspace = true }
 swc_core                 = { workspace = true }
 tracing                  = { workspace = true }
 

--- a/crates/rspack_plugin_rstest/src/module_path_name_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/module_path_name_dependency.rs
@@ -2,8 +2,9 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, AsModuleDependency, DependencyCodeGeneration, DependencyTemplate,
   DependencyTemplateType, DependencyType, InitFragmentExt, InitFragmentKey, InitFragmentStage,
-  Module, NormalInitFragment, TemplateContext, TemplateReplaceSource,
+  NormalInitFragment, TemplateContext, TemplateReplaceSource,
 };
+use rspack_util::json_stringify;
 
 #[cacheable]
 #[derive(Debug, Clone, PartialEq)]
@@ -60,7 +61,6 @@ impl DependencyTemplate for ModulePathNameDependencyTemplate {
     let m = module.as_normal_module();
     if let Some(m) = m {
       let resource_path = &m.resource_resolved_data().resource_path;
-      let context = &m.get_context();
 
       let dep = dep
         .as_any()
@@ -70,7 +70,10 @@ impl DependencyTemplate for ModulePathNameDependencyTemplate {
       if dep.r#type == NameType::FileName {
         if let Some(resource_path) = resource_path {
           let init = NormalInitFragment::new(
-            format!("const __filename = '{resource_path}';\n"),
+            format!(
+              "const __filename = {};\n",
+              json_stringify(&resource_path.as_std_path())
+            ),
             InitFragmentStage::StageConstants,
             0,
             InitFragmentKey::Const(format!("retest __filename {}", m.id())),
@@ -80,16 +83,23 @@ impl DependencyTemplate for ModulePathNameDependencyTemplate {
           init_fragments.push(init.boxed());
         }
       } else if dep.r#type == NameType::DirName {
-        if let Some(context) = context {
-          let init = NormalInitFragment::new(
-            format!("const __dirname = '{context}';\n"),
-            InitFragmentStage::StageConstants,
-            0,
-            InitFragmentKey::Const(format!("retest __dirname {}", m.id())),
-            None,
-          );
+        if let Some(resource_path) = resource_path {
+          if let Some(parent_path) = resource_path.parent() {
+            // If the parent path is None, we use an empty string
+            // to avoid issues with the path being undefined.
+            let init = NormalInitFragment::new(
+              format!(
+                "const __dirname = {};\n",
+                json_stringify(parent_path.as_std_path())
+              ),
+              InitFragmentStage::StageConstants,
+              0,
+              InitFragmentKey::Const(format!("retest __dirname {}", m.id())),
+              None,
+            );
 
-          init_fragments.push(init.boxed());
+            init_fragments.push(init.boxed());
+          }
         }
       }
     }

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -4,6 +4,7 @@ use rspack_plugin_javascript::{
   visitors::JavascriptParser,
   JavascriptParserPlugin,
 };
+use rspack_util::json_stringify;
 use swc_core::{
   common::Spanned,
   ecma::ast::{CallExpr, Ident, MemberExpr, UnaryExpr},
@@ -77,7 +78,7 @@ impl RstestParserPlugin {
   fn process_import_meta(&self, parser: &mut JavascriptParser, r#type: ModulePathType) -> String {
     if r#type == ModulePathType::FileName {
       if let Some(resource_path) = &parser.resource_data.resource_path {
-        format!("'{}'", resource_path.clone().into_string())
+        json_stringify(&resource_path.clone().into_string())
       } else {
         "''".to_string()
       }
@@ -89,7 +90,7 @@ impl RstestParserPlugin {
         .and_then(|p| p.parent())
         .map(|p| p.to_string())
         .unwrap_or_default();
-      format!("'{resource_path}'")
+      json_stringify(&resource_path)
     }
   }
 }

--- a/packages/rspack-test-tools/tests/configCases/rstest/module-path-names/index.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/module-path-names/index.js
@@ -1,16 +1,16 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 const sourceDir = path.resolve(__dirname, "../../../../configCases/rstest/module-path-names/src");
 
 it("Insert module path names with concatenateModules", () => {
 	const content = fs.readFileSync(path.resolve(__dirname, "modulePathName.js"), "utf-8");
 	// __dirname and __filename renamed after concatenation
-	expect(content).toContain(`const foo_filename = '${path.resolve(sourceDir, "./foo.js")}'`);
-	expect(content).toMatch(`const foo_dirname = '${path.resolve(sourceDir, ".")}'`);
+	expect(content).toContain(`const foo_filename = ${JSON.stringify(path.resolve(sourceDir, "./foo.js"))}`);
+	expect(content).toContain(`const foo_dirname = ${JSON.stringify(path.resolve(sourceDir, "."))}`);
 
-	expect(content).toMatch(`const metaFile1 = '${path.resolve(sourceDir, "./foo.js")}'`)
-	expect(content).toMatch(`const metaDir1 = '${path.resolve(sourceDir, ".")}'`)
+	expect(content).toContain(`const metaFile1 = ${JSON.stringify(path.resolve(sourceDir, "./foo.js"))}`)
+	expect(content).toContain(`const metaDir1 = ${JSON.stringify(path.resolve(sourceDir, "."))}`)
 
 	expect(content).toContain(`const typeofMetaDir = 'string'`);
 	expect(content).toContain(`const typeofMetaFile = 'string'`);
@@ -18,13 +18,13 @@ it("Insert module path names with concatenateModules", () => {
 
 it("Insert module path names without concatenateModules", () => {
 	const content = fs.readFileSync(path.resolve(__dirname, "modulePathNameWithoutConcatenate.js"), "utf-8");
-	expect(content).toContain(`const __filename = '${path.resolve(sourceDir, "./foo.js")}'`);
-	expect(content).toMatch(`const __dirname = '${path.resolve(sourceDir, ".")}'`);
+	expect(content).toContain(`const __filename = ${JSON.stringify(path.resolve(sourceDir, "./foo.js"))}`);
+	expect(content).toContain(`const __dirname = ${JSON.stringify(path.resolve(sourceDir, "."))}`);
 	expect(content.match(/const __dirname = /g).length).toBe(2);
 	expect(content.match(/const __filename = /g).length).toBe(2);
 
-	expect(content).toMatch(`const metaFile1 = '${path.resolve(sourceDir, "./foo.js")}'`)
-	expect(content).toMatch(`const metaDir1 = '${path.resolve(sourceDir, ".")}'`)
+	expect(content).toContain(`const metaFile1 = ${JSON.stringify(path.resolve(sourceDir, "./foo.js"))}`)
+	expect(content).toContain(`const metaDir1 = ${JSON.stringify(path.resolve(sourceDir, "."))}`)
 
 	expect(content).toContain(`const typeofMetaDir = 'string'`);
 	expect(content).toContain(`const typeofMetaFile = 'string'`);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should use stringify to get correct path on win32.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
