### PR TITLE
feat: support passing error code to `callbackify` callbacks

### DIFF
--- a/crates/node_binding/src/resolver.rs
+++ b/crates/node_binding/src/resolver.rs
@@ -80,7 +80,10 @@ impl JsResolver {
             Either::<JsResourceData, bool>::A(ResourceData::from(resource).into()),
           ),
           Ok(rspack_core::ResolveResult::Ignored) => Ok(Either::B(false)),
-          Err(err) => Err(napi::Error::from_reason(format!("{err:?}"))),
+          Err(err) => Err(napi::Error::new(
+            ErrorCode::Napi(napi::Status::GenericFailure),
+            format!("{err:?}"),
+          )),
         }
       },
       || {},

--- a/crates/node_binding/src/utils.rs
+++ b/crates/node_binding/src/utils.rs
@@ -12,12 +12,13 @@ pub fn callbackify<R, F>(
 ) -> Result<(), ErrorCode>
 where
   R: 'static + ToNapiValue,
-  F: 'static + Send + Future<Output = Result<R>>,
+  F: 'static + Send + Future<Output = Result<R, ErrorCode>>,
 {
   let mut call_js_back = Some(Box::new(call_js_back));
 
   let tsfn = f
     .build_threadsafe_function::<R>()
+    .error_status::<ErrorCode>()
     .callee_handled::<true>()
     .max_queue_size::<1>()
     .weak::<false>()


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Support passing `ErrorCode` to `callbackify` callbacks.

Affected **internal** methods:

1. compilation.rebuildModule
2. compilation.addModule
3. compilation.addEntry
4. compilation.addInclude
5. compiler.build
6. compiler.rebuild

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
