### PR TITLE
feat(core): expose `StatsErrorCode`

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -6296,6 +6296,7 @@ declare namespace rspackExports {
         StatsCompilation,
         StatsError,
         StatsModule,
+        StatsErrorCode,
         Stats,
         RuntimeModule,
         EntryDependency,
@@ -7343,7 +7344,7 @@ export type StatsCompilation = KnownStatsCompilation & Record<string, any>;
 export type StatsError = KnownStatsError & Record<string, any>;
 
 // @public (undocumented)
-enum StatsErrorCode {
+export enum StatsErrorCode {
     ChunkMinificationError = "ChunkMinificationError",
     ChunkMinificationWarning = "ChunkMinificationWarning",
     ModuleBuildError = "ModuleBuildError",

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -38,6 +38,7 @@ export type {
 	StatsError,
 	StatsModule
 } from "./Stats";
+export { StatsErrorCode } from "./stats/statsFactoryUtils";
 export { Stats } from "./Stats";
 export { RuntimeModule } from "./RuntimeModule";
 export {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Export `StatsErrorCode` to support users filtering stats errors based on its code.
Check the original PR for the supported code: https://github.com/web-infra-dev/rspack/pull/10057


```js
import { rspack, StatsErrorCode } from '@rspack/core';

rspack(<your-config-here>, (err, stats) => {
  if (err) {
    // handle error
    return;
  }

  // filter minification error
  const hasMinificationError = stats.toJson({ errors: true }).errors
    ?.some(e => e.code === StatsErrorCode.ChunkMinificationError);

  if (hasMinificationError) {
    // handle minification error
    return;
  }
});
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
