### PR TITLE
fix: use `Mutex<Arc<tokio::sync::OnceCell<JsLoaderRunner>>>` to avoid loader runner deadlock

### DIFF
--- a/crates/node_binding/src/plugins/js_loader/mod.rs
+++ b/crates/node_binding/src/plugins/js_loader/mod.rs
@@ -2,7 +2,12 @@ mod context;
 mod resolver;
 mod scheduler;
 
-use std::{ffi::c_void, fmt::Debug, ptr};
+use std::{
+  ffi::c_void,
+  fmt::Debug,
+  ptr,
+  sync::{Arc, Mutex},
+};
 
 pub use context::{JsLoaderContext, JsLoaderItem};
 use napi::{
@@ -10,7 +15,6 @@ use napi::{
   sys::{napi_call_threadsafe_function, napi_threadsafe_function},
   threadsafe_function::ThreadsafeFunction,
 };
-use once_cell::sync::OnceCell;
 use rspack_core::{
   ApplyContext, Compilation, CompilationParams, CompilerEmit, CompilerId, CompilerOptions,
   CompilerThisCompilation, Plugin, PluginContext,
@@ -18,7 +22,7 @@ use rspack_core::{
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashSet;
-use tokio::sync::RwLock;
+use tokio::sync::{OnceCell, RwLock};
 
 use crate::{RspackResultToNapiResultExt, COMPILER_REFERENCES};
 
@@ -144,9 +148,9 @@ impl JsLoaderRunnerGetter {
 
 #[plugin]
 pub(crate) struct JsLoaderRspackPlugin {
-  compiler_id: OnceCell<CompilerId>,
+  compiler_id: once_cell::sync::OnceCell<CompilerId>,
   pub(crate) runner_getter: JsLoaderRunnerGetter,
-  pub(crate) runner: RwLock<Option<JsLoaderRunner>>,
+  pub(crate) runner: Mutex<Arc<tokio::sync::OnceCell<JsLoaderRunner>>>,
   pub(crate) loaders_without_pitch: RwLock<FxHashSet<String>>,
 }
 
@@ -155,7 +159,7 @@ impl JsLoaderRspackPlugin {
     Self::new_inner(
       Default::default(),
       runner_getter,
-      RwLock::new(None),
+      Mutex::default(),
       RwLock::new(FxHashSet::default()),
     )
   }
@@ -180,8 +184,7 @@ async fn this_compilation(
 
 #[plugin_hook(CompilerEmit for JsLoaderRspackPlugin)]
 async fn done(&self, _compilation: &mut Compilation) -> Result<()> {
-  let mut write_guard = self.runner.write().await;
-  *write_guard = None;
+  *self.runner.lock().expect("should get lock") = Arc::new(OnceCell::new());
   Ok(())
 }
 


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
