### PR TITLE
refactor: prefetch exports info data of getters part 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5072,6 +5072,7 @@ dependencies = [
 name = "rspack_plugin_merge_duplicate_chunks"
 version = "0.2.0"
 dependencies = [
+ "rayon",
  "rspack_collections",
  "rspack_core",
  "rspack_error",

--- a/crates/node_binding/src/exports_info.rs
+++ b/crates/node_binding/src/exports_info.rs
@@ -46,12 +46,13 @@ impl JsExportsInfo {
       Either::A(str) => std::iter::once(str).map(Into::into).collect(),
       Either::B(vec) => vec.into_iter().map(Into::into).collect(),
     });
-    let exports_info = ExportsInfoGetter::prefetch(
+    let exports_info = ExportsInfoGetter::prefetch_used_info_without_name(
       &self.exports_info,
       &module_graph,
-      PrefetchExportsInfoMode::AllExports,
+      runtime.as_ref(),
+      false,
     );
-    Ok(ExportsInfoGetter::is_used(&exports_info, runtime.as_ref()))
+    Ok(exports_info.is_used())
   }
 
   #[napi(ts_args_type = "runtime: string | string[] | undefined")]
@@ -61,15 +62,13 @@ impl JsExportsInfo {
       Either::A(str) => std::iter::once(str).map(Into::into).collect(),
       Either::B(vec) => vec.into_iter().map(Into::into).collect(),
     });
-    let exports_info = ExportsInfoGetter::prefetch(
+    let exports_info = ExportsInfoGetter::prefetch_used_info_without_name(
       &self.exports_info,
       &module_graph,
-      PrefetchExportsInfoMode::AllExports,
-    );
-    Ok(ExportsInfoGetter::is_module_used(
-      &exports_info,
       runtime.as_ref(),
-    ))
+      false,
+    );
+    Ok(exports_info.is_module_used())
   }
 
   #[napi(ts_args_type = "runtime: string | string[] | undefined")]

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2317,14 +2317,14 @@ impl ConcatenatedModule {
           Arc::new(|module: &ModuleIdentifier| module_to_info_map.contains_key(module)),
         );
         match reexport {
-          crate::FindTargetRetEnum::Undefined => {}
-          crate::FindTargetRetEnum::False => {
+          crate::FindTargetResult::NoTarget => {}
+          crate::FindTargetResult::NoValidTarget => {
             panic!(
               "Target module of reexport is not part of the concatenation (export '{:?}')",
               &export_id
             );
           }
-          crate::FindTargetRetEnum::Value(reexport) => {
+          crate::FindTargetResult::ValidTarget(reexport) => {
             if let Some(ref_info) = module_to_info_map.get(&reexport.module) {
               // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L457
               let build_meta = mg

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1009,13 +1009,8 @@ impl Module for ConcatenatedModule {
     let mut exports_final_names: Vec<(String, String)> = vec![];
 
     for (_, export_info) in exports_info.exports() {
-      let name = ExportInfoGetter::name(export_info)
-        .cloned()
-        .unwrap_or("".into());
-      if matches!(
-        ExportInfoGetter::provided(export_info),
-        Some(ExportProvided::NotProvided)
-      ) {
+      let name = export_info.name().cloned().unwrap_or("".into());
+      if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
         continue;
       }
       let used_name = ExportInfoGetter::get_used_name(export_info, None, runtime);
@@ -1213,10 +1208,7 @@ impl Module for ConcatenatedModule {
         let exports_info = module_graph
           .get_prefetched_exports_info(module_info_id, PrefetchExportsInfoMode::AllExports);
         for (_, export_info) in exports_info.exports() {
-          if matches!(
-            ExportInfoGetter::provided(export_info),
-            Some(ExportProvided::NotProvided)
-          ) {
+          if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
             continue;
           }
 
@@ -1226,9 +1218,7 @@ impl Module for ConcatenatedModule {
             let final_name = Self::get_final_name(
               &compilation.get_module_graph(),
               module_info_id,
-              vec![ExportInfoGetter::name(export_info)
-                .cloned()
-                .unwrap_or("".into())],
+              vec![export_info.name().cloned().unwrap_or("".into())],
               &mut module_to_info_map,
               runtime,
               &mut needed_namespace_objects,

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -7,9 +7,10 @@ use crate::{
   compile_boolean_matcher_from_lists, contextify, property_access, to_comment, to_normal_comment,
   AsyncDependenciesBlockIdentifier, ChunkGraph, Compilation, CompilerOptions, DependenciesBlock,
   DependencyId, Environment, ExportsArgument, ExportsInfoGetter, ExportsType,
-  FakeNamespaceObjectMode, InitFragmentExt, InitFragmentKey, InitFragmentStage, Module,
-  ModuleGraph, ModuleId, ModuleIdentifier, NormalInitFragment, PathInfo, PrefetchExportsInfoMode,
-  RuntimeCondition, RuntimeGlobals, RuntimeSpec, TemplateContext, UsedName,
+  FakeNamespaceObjectMode, GetUsedNameParam, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  Module, ModuleGraph, ModuleId, ModuleIdentifier, NormalInitFragment, PathInfo,
+  PrefetchExportsInfoMode, RuntimeCondition, RuntimeGlobals, RuntimeSpec, TemplateContext,
+  UsedName,
 };
 
 pub fn runtime_condition_expression(
@@ -209,10 +210,10 @@ pub fn export_from_import(
     .unwrap_or(export_name);
   if !export_name.is_empty() {
     let used_name = match ExportsInfoGetter::get_used_name(
-      &compilation.get_module_graph().get_prefetched_exports_info(
+      GetUsedNameParam::WithNames(&compilation.get_module_graph().get_prefetched_exports_info(
         &module_identifier,
         PrefetchExportsInfoMode::NamedNestedExports(export_name),
-      ),
+      )),
       *runtime,
       export_name,
     ) {

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -1,23 +1,23 @@
 use std::{
   borrow::Cow,
-  collections::VecDeque,
   hash::Hash,
-  rc::Rc,
   sync::{atomic::Ordering::Relaxed, Arc},
 };
 
-use rspack_collections::{impl_item_ukey, Ukey, UkeySet};
+use rspack_collections::{impl_item_ukey, Ukey};
 use rspack_util::atom::Atom;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 use serde::Serialize;
 
 use super::{
-  ExportInfoGetter, ExportInfoTargetValue, ExportProvided, ExportsInfo, ExportsInfoData,
-  ExportsInfoGetter, FindTargetRetEnum, FindTargetRetValue, Inlinable, ResolvedExportInfoTarget,
-  ResolvedExportInfoTargetWithCircular, TerminalBinding, UnResolvedExportInfoTarget, UsageState,
+  ExportInfoGetter, ExportInfoTargetValue, ExportProvided, ExportsInfo, Inlinable,
+  ResolvedExportInfoTarget, ResolvedExportInfoTargetWithCircular, UsageState,
   NEXT_EXPORT_INFO_UKEY,
 };
-use crate::{DependencyId, ModuleGraph, ModuleIdentifier, PrefetchExportsInfoMode, RuntimeSpec};
+use crate::{
+  find_target_from_export_info, get_target_from_maybe_export_info, get_target_with_filter,
+  DependencyId, FindTargetResult, ModuleGraph, ModuleIdentifier, ResolveFilterFnTy,
+};
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
 pub struct ExportInfo(Ukey);
@@ -35,90 +35,6 @@ impl ExportInfo {
 
   pub fn as_data_mut<'a>(&self, mg: &'a mut ModuleGraph) -> &'a mut ExportInfoData {
     mg.get_export_info_mut_by_id(self)
-  }
-
-  pub fn create_nested_exports_info(&self, mg: &mut ModuleGraph) -> ExportsInfo {
-    let export_info_mut = self.as_data_mut(mg);
-
-    if export_info_mut.exports_info_owned {
-      return export_info_mut
-        .exports_info
-        .expect("should have exports_info when exports_info is true");
-    }
-
-    export_info_mut.exports_info_owned = true;
-    let other_exports_info = ExportInfoData::new(None, None);
-    let side_effects_only_info = ExportInfoData::new(Some("*side effects only*".into()), None);
-    let new_exports_info = ExportsInfoData::new(other_exports_info.id, side_effects_only_info.id);
-    let new_exports_info_id = new_exports_info.id;
-
-    let old_exports_info = export_info_mut.exports_info;
-    export_info_mut.exports_info_owned = true;
-    export_info_mut.exports_info = Some(new_exports_info_id);
-
-    mg.set_exports_info(new_exports_info_id, new_exports_info);
-    mg.set_export_info(other_exports_info.id, other_exports_info);
-    mg.set_export_info(side_effects_only_info.id, side_effects_only_info);
-
-    new_exports_info_id.set_has_provide_info(mg);
-    if let Some(exports_info) = old_exports_info {
-      exports_info.set_redirect_name_to(mg, Some(new_exports_info_id));
-    }
-    new_exports_info_id
-  }
-
-  pub fn set_has_use_info(&self, mg: &mut ModuleGraph) {
-    let export_info = mg.get_export_info_mut_by_id(self);
-    if !export_info.has_use_in_runtime_info {
-      export_info.has_use_in_runtime_info = true;
-    }
-    if export_info.can_mangle_use.is_none() {
-      export_info.can_mangle_use = Some(true);
-    }
-    if export_info.exports_info_owned
-      && let Some(exports_info) = export_info.exports_info
-    {
-      exports_info.set_has_use_info(mg);
-    }
-  }
-
-  pub fn get_terminal_binding(&self, mg: &ModuleGraph) -> Option<TerminalBinding> {
-    let info = self.as_data(mg);
-    if info.terminal_binding {
-      return Some(TerminalBinding::ExportInfo(*self));
-    }
-    let target = info.get_target(mg)?;
-
-    let exports_info = mg.get_exports_info(&target.module);
-    let Some(export) = target.export else {
-      return Some(TerminalBinding::ExportsInfo(exports_info));
-    };
-    ExportsInfoGetter::prefetch(
-      &exports_info,
-      mg,
-      PrefetchExportsInfoMode::NamedNestedExports(&export),
-    )
-    .get_read_only_export_info_recursive(&export)
-    .map(|data| TerminalBinding::ExportInfo(data.id))
-  }
-
-  pub fn do_move_target(
-    &self,
-    mg: &mut ModuleGraph,
-    dependency: DependencyId,
-    target_export: Option<Vec<Atom>>,
-  ) {
-    let export_info_mut = self.as_data_mut(mg);
-    export_info_mut.target.clear();
-    export_info_mut.target.insert(
-      None,
-      ExportInfoTargetValue {
-        dependency: Some(dependency),
-        export: target_export,
-        priority: 0,
-      },
-    );
-    export_info_mut.target_is_set = true;
   }
 }
 
@@ -146,6 +62,67 @@ pub struct ExportInfoData {
 }
 
 impl ExportInfoData {
+  pub fn new(name: Option<Atom>, init_from: Option<&ExportInfoData>) -> Self {
+    let used_name = init_from.and_then(|init_from| init_from.used_name.clone());
+    let global_used = init_from.and_then(|init_from| init_from.global_used);
+    let used_in_runtime = init_from.and_then(|init_from| init_from.used_in_runtime.clone());
+    let has_use_in_runtime_info =
+      init_from.is_some_and(|init_from| init_from.has_use_in_runtime_info);
+
+    let provided = init_from.and_then(|init_from| init_from.provided);
+    let terminal_binding = init_from.is_some_and(|init_from| init_from.terminal_binding);
+    let can_mangle_provide = init_from.and_then(|init_from| init_from.can_mangle_provide);
+    let can_mangle_use = init_from.and_then(|init_from| init_from.can_mangle_use);
+
+    let target = init_from
+      .and_then(|item| {
+        if item.target_is_set {
+          Some(
+            item
+              .target
+              .clone()
+              .into_iter()
+              .map(|(k, v)| {
+                (
+                  k,
+                  ExportInfoTargetValue {
+                    dependency: v.dependency,
+                    export: match v.export {
+                      Some(vec) => Some(vec),
+                      None => Some(vec![name
+                        .clone()
+                        .expect("name should not be empty if target is set")]),
+                    },
+                    priority: v.priority,
+                  },
+                )
+              })
+              .collect::<HashMap<Option<DependencyId>, ExportInfoTargetValue>>(),
+          )
+        } else {
+          None
+        }
+      })
+      .unwrap_or_default();
+    Self {
+      name,
+      used_name,
+      used_in_runtime,
+      target,
+      provided,
+      can_mangle_provide,
+      terminal_binding,
+      target_is_set: init_from.map(|init| init.target_is_set).unwrap_or_default(),
+      id: ExportInfo::new(),
+      exports_info: None,
+      exports_info_owned: false,
+      has_use_in_runtime_info,
+      can_mangle_use,
+      global_used,
+      inlinable: Inlinable::NoByProvide,
+    }
+  }
+
   pub fn name(&self) -> Option<&Atom> {
     self.name.as_ref()
   }
@@ -258,219 +235,8 @@ impl ExportInfoData {
     self.used_in_runtime = value;
   }
 
-  pub fn new(name: Option<Atom>, init_from: Option<&ExportInfoData>) -> Self {
-    let used_name = init_from.and_then(|init_from| init_from.used_name.clone());
-    let global_used = init_from.and_then(|init_from| init_from.global_used);
-    let used_in_runtime = init_from.and_then(|init_from| init_from.used_in_runtime.clone());
-    let has_use_in_runtime_info =
-      init_from.is_some_and(|init_from| init_from.has_use_in_runtime_info);
-
-    let provided = init_from.and_then(|init_from| init_from.provided);
-    let terminal_binding = init_from.is_some_and(|init_from| init_from.terminal_binding);
-    let can_mangle_provide = init_from.and_then(|init_from| init_from.can_mangle_provide);
-    let can_mangle_use = init_from.and_then(|init_from| init_from.can_mangle_use);
-
-    let target = init_from
-      .and_then(|item| {
-        if item.target_is_set {
-          Some(
-            item
-              .target
-              .clone()
-              .into_iter()
-              .map(|(k, v)| {
-                (
-                  k,
-                  ExportInfoTargetValue {
-                    dependency: v.dependency,
-                    export: match v.export {
-                      Some(vec) => Some(vec),
-                      None => Some(vec![name
-                        .clone()
-                        .expect("name should not be empty if target is set")]),
-                    },
-                    priority: v.priority,
-                  },
-                )
-              })
-              .collect::<HashMap<Option<DependencyId>, ExportInfoTargetValue>>(),
-          )
-        } else {
-          None
-        }
-      })
-      .unwrap_or_default();
-    Self {
-      name,
-      used_name,
-      used_in_runtime,
-      target,
-      provided,
-      can_mangle_provide,
-      terminal_binding,
-      target_is_set: init_from.map(|init| init.target_is_set).unwrap_or_default(),
-      id: ExportInfo::new(),
-      exports_info: None,
-      exports_info_owned: false,
-      has_use_in_runtime_info,
-      can_mangle_use,
-      global_used,
-      inlinable: Inlinable::NoByProvide,
-    }
-  }
-
-  pub fn find_target_impl(
-    &self,
-    mg: &ModuleGraph,
-    valid_target_module_filter: Arc<impl Fn(&ModuleIdentifier) -> bool>,
-    visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
-  ) -> FindTargetRetEnum {
-    if !self.target_is_set || self.target.is_empty() {
-      return FindTargetRetEnum::Undefined;
-    }
-    let max_target = ExportInfoGetter::get_max_target(self);
-    let raw_target = max_target.values().next();
-    let Some(raw_target) = raw_target else {
-      return FindTargetRetEnum::Undefined;
-    };
-    let mut target = FindTargetRetValue {
-      module: *raw_target
-        .dependency
-        .and_then(|dep_id| mg.connection_by_dependency_id(&dep_id))
-        .expect("should have connection")
-        .module_identifier(),
-      export: raw_target.export.clone(),
-    };
-    loop {
-      if valid_target_module_filter(&target.module) {
-        return FindTargetRetEnum::Value(target);
-      }
-      let name = &target.export.as_ref().expect("should have export")[0];
-      let exports_info = mg.get_prefetched_exports_info(
-        &target.module,
-        PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([name])),
-      );
-      let export_info = exports_info.get_export_info_without_mut_module_graph(name);
-      let export_info_hash_key = export_info.as_hash_key();
-      if visited.contains(&export_info_hash_key) {
-        return FindTargetRetEnum::Undefined;
-      }
-      visited.insert(export_info_hash_key);
-      let new_target =
-        export_info.find_target_impl(mg, valid_target_module_filter.clone(), visited);
-      let new_target = match new_target {
-        FindTargetRetEnum::Undefined => return FindTargetRetEnum::False,
-        FindTargetRetEnum::False => return FindTargetRetEnum::False,
-        FindTargetRetEnum::Value(target) => target,
-      };
-      if target.export.as_ref().map(|item| item.len()) == Some(1) {
-        target = new_target;
-      } else {
-        target = FindTargetRetValue {
-          module: new_target.module,
-          export: if let Some(export) = new_target.export {
-            Some(
-              [
-                export,
-                target
-                  .export
-                  .as_ref()
-                  .and_then(|export| export.get(1..).map(|slice| slice.to_vec()))
-                  .unwrap_or_default(),
-              ]
-              .concat(),
-            )
-          } else {
-            target
-              .export
-              .and_then(|export| export.get(1..).map(|slice| slice.to_vec()))
-          },
-        }
-      }
-    }
-  }
-
-  pub fn get_target(&self, mg: &ModuleGraph) -> Option<ResolvedExportInfoTarget> {
-    self.get_target_with_filter(mg, Rc::new(|_| true))
-  }
-
-  pub fn get_target_with_filter(
-    &self,
-    mg: &ModuleGraph,
-    resolve_filter: ResolveFilterFnTy,
-  ) -> Option<ResolvedExportInfoTarget> {
-    match self.get_target_impl(mg, resolve_filter, &mut Default::default()) {
-      Some(ResolvedExportInfoTargetWithCircular::Circular) => None,
-      Some(ResolvedExportInfoTargetWithCircular::Target(target)) => Some(target),
-      None => None,
-    }
-  }
-
-  pub fn get_target_proxy(
-    &self,
-    mg: &ModuleGraph,
-    resolve_filter: ResolveFilterFnTy,
-    already_visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
-  ) -> Option<ResolvedExportInfoTargetWithCircular> {
-    if !self.target_is_set || self.target.is_empty() {
-      return None;
-    }
-    let hash_key = MaybeDynamicTargetExportInfoHashKey::ExportInfo(self.id);
-    if already_visited.contains(&hash_key) {
-      return Some(ResolvedExportInfoTargetWithCircular::Circular);
-    }
-    already_visited.insert(hash_key);
-    self.get_target_impl(mg, resolve_filter, already_visited)
-  }
-
-  pub fn get_target_impl(
-    &self,
-    mg: &ModuleGraph,
-    resolve_filter: ResolveFilterFnTy,
-    already_visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
-  ) -> Option<ResolvedExportInfoTargetWithCircular> {
-    let max_target = ExportInfoGetter::get_max_target(self);
-    let mut values = max_target
-      .values()
-      .map(|item| UnResolvedExportInfoTarget {
-        dependency: item.dependency,
-        export: item.export.clone(),
-      })
-      .collect::<VecDeque<_>>();
-    let target = resolve_target(
-      values.pop_front(),
-      already_visited,
-      resolve_filter.clone(),
-      mg,
-    );
-
-    match target {
-      Some(ResolvedExportInfoTargetWithCircular::Circular) => {
-        Some(ResolvedExportInfoTargetWithCircular::Circular)
-      }
-      None => None,
-      Some(ResolvedExportInfoTargetWithCircular::Target(target)) => {
-        for val in values {
-          let resolved_target =
-            resolve_target(Some(val), already_visited, resolve_filter.clone(), mg);
-          match resolved_target {
-            Some(ResolvedExportInfoTargetWithCircular::Circular) => {
-              return Some(ResolvedExportInfoTargetWithCircular::Circular);
-            }
-            Some(ResolvedExportInfoTargetWithCircular::Target(tt)) => {
-              if target.module != tt.module {
-                return None;
-              }
-              if target.export != tt.export {
-                return None;
-              }
-            }
-            None => return None,
-          }
-        }
-        Some(ResolvedExportInfoTargetWithCircular::Target(target))
-      }
-    }
+  pub fn set_has_use_in_runtime_info(&mut self, value: bool) {
+    self.has_use_in_runtime_info = value;
   }
 }
 
@@ -503,6 +269,13 @@ pub enum MaybeDynamicTargetExportInfoHashKey {
 }
 
 impl<'a> MaybeDynamicTargetExportInfo<'a> {
+  pub fn to_data(&self) -> &ExportInfoData {
+    match self {
+      MaybeDynamicTargetExportInfo::Static(export_info) => export_info,
+      MaybeDynamicTargetExportInfo::Dynamic { data, .. } => data,
+    }
+  }
+
   pub fn as_hash_key(&self) -> MaybeDynamicTargetExportInfoHashKey {
     match self {
       MaybeDynamicTargetExportInfo::Static(export_info) => {
@@ -520,78 +293,35 @@ impl<'a> MaybeDynamicTargetExportInfo<'a> {
   }
 
   pub fn provided(&'a self) -> Option<ExportProvided> {
-    match self {
-      MaybeDynamicTargetExportInfo::Static(export_info) => export_info.provided(),
-      MaybeDynamicTargetExportInfo::Dynamic { data, .. } => data.provided(),
-    }
+    self.to_data().provided()
+  }
+
+  fn get_max_target(&self) -> Cow<HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
+    ExportInfoGetter::get_max_target(self.to_data())
   }
 
   pub fn find_target(
     &self,
     mg: &ModuleGraph,
     valid_target_module_filter: Arc<impl Fn(&ModuleIdentifier) -> bool>,
-  ) -> FindTargetRetEnum {
-    self.find_target_impl(mg, valid_target_module_filter, &mut Default::default())
+  ) -> FindTargetResult {
+    find_target_from_export_info(
+      self.to_data(),
+      mg,
+      valid_target_module_filter,
+      &mut Default::default(),
+    )
   }
 
-  fn find_target_impl(
-    &self,
-    mg: &ModuleGraph,
-    valid_target_module_filter: Arc<impl Fn(&ModuleIdentifier) -> bool>,
-    visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
-  ) -> FindTargetRetEnum {
-    match self {
-      MaybeDynamicTargetExportInfo::Static(export_info) => {
-        export_info.find_target_impl(mg, valid_target_module_filter, visited)
-      }
-      MaybeDynamicTargetExportInfo::Dynamic { data, .. } => {
-        data.find_target_impl(mg, valid_target_module_filter, visited)
-      }
-    }
-  }
-
-  pub fn get_target_with_filter(
+  pub fn get_target(
     &self,
     mg: &ModuleGraph,
     resolve_filter: ResolveFilterFnTy,
   ) -> Option<ResolvedExportInfoTarget> {
-    match self.get_target_impl(mg, resolve_filter, &mut Default::default()) {
+    match get_target_from_maybe_export_info(self, mg, resolve_filter, &mut Default::default()) {
       Some(ResolvedExportInfoTargetWithCircular::Circular) => None,
       Some(ResolvedExportInfoTargetWithCircular::Target(target)) => Some(target),
       None => None,
-    }
-  }
-
-  fn get_target_impl(
-    &self,
-    mg: &ModuleGraph,
-    resolve_filter: ResolveFilterFnTy,
-    already_visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
-  ) -> Option<ResolvedExportInfoTargetWithCircular> {
-    match self {
-      MaybeDynamicTargetExportInfo::Static(export_info) => {
-        export_info.get_target_proxy(mg, resolve_filter, already_visited)
-      }
-      MaybeDynamicTargetExportInfo::Dynamic { data, .. } => {
-        if !data.target_is_set || data.target.is_empty() {
-          return None;
-        }
-        let hash_key = self.as_hash_key();
-        if already_visited.contains(&hash_key) {
-          return Some(ResolvedExportInfoTargetWithCircular::Circular);
-        }
-        already_visited.insert(hash_key);
-        data.get_target_impl(mg, resolve_filter, already_visited)
-      }
-    }
-  }
-
-  fn get_max_target(&self) -> Cow<HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
-    match self {
-      MaybeDynamicTargetExportInfo::Static(export_info) => {
-        ExportInfoGetter::get_max_target(export_info)
-      }
-      MaybeDynamicTargetExportInfo::Dynamic { data, .. } => ExportInfoGetter::get_max_target(data),
     }
   }
 
@@ -600,11 +330,8 @@ impl<'a> MaybeDynamicTargetExportInfo<'a> {
     mg: &ModuleGraph,
     resolve_filter: ResolveFilterFnTy,
   ) -> Option<ResolvedExportInfoTarget> {
-    let data = match self {
-      MaybeDynamicTargetExportInfo::Static(export_info) => *export_info,
-      MaybeDynamicTargetExportInfo::Dynamic { data, .. } => data,
-    };
-    let target = data.get_target_with_filter(mg, resolve_filter)?;
+    let data = self.to_data();
+    let target = get_target_with_filter(data, mg, resolve_filter)?;
     let max_target = self.get_max_target();
     let original_target = max_target
       .values()
@@ -616,145 +343,5 @@ impl<'a> MaybeDynamicTargetExportInfo<'a> {
       return None;
     }
     Some(target)
-  }
-}
-
-pub type ResolveFilterFnTy<'a> = Rc<dyn Fn(&ResolvedExportInfoTarget) -> bool + 'a>;
-
-fn resolve_target(
-  input_target: Option<UnResolvedExportInfoTarget>,
-  already_visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
-  resolve_filter: ResolveFilterFnTy,
-  mg: &ModuleGraph,
-) -> Option<ResolvedExportInfoTargetWithCircular> {
-  if let Some(input_target) = input_target {
-    let mut target = ResolvedExportInfoTarget {
-      module: *input_target
-        .dependency
-        .and_then(|dep_id| mg.connection_by_dependency_id(&dep_id))
-        .expect("should have connection")
-        .module_identifier(),
-      export: input_target.export,
-      dependency: input_target.dependency.expect("should have dependency"),
-    };
-    if target.export.is_none() {
-      return Some(ResolvedExportInfoTargetWithCircular::Target(target));
-    }
-    if !resolve_filter(&target) {
-      return Some(ResolvedExportInfoTargetWithCircular::Target(target));
-    }
-    loop {
-      let name = if let Some(export) = target.export.as_ref().and_then(|exports| exports.first()) {
-        export
-      } else {
-        return Some(ResolvedExportInfoTargetWithCircular::Target(target));
-      };
-
-      let exports_info = mg.get_prefetched_exports_info(
-        &target.module,
-        PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([name])),
-      );
-      let export_info = exports_info.get_export_info_without_mut_module_graph(name);
-      let export_info_hash_key = export_info.as_hash_key();
-      if already_visited.contains(&export_info_hash_key) {
-        return Some(ResolvedExportInfoTargetWithCircular::Circular);
-      }
-      let new_target = export_info.get_target_impl(mg, resolve_filter.clone(), already_visited);
-
-      match new_target {
-        Some(ResolvedExportInfoTargetWithCircular::Circular) => {
-          return Some(ResolvedExportInfoTargetWithCircular::Circular);
-        }
-        None => return Some(ResolvedExportInfoTargetWithCircular::Target(target)),
-        Some(ResolvedExportInfoTargetWithCircular::Target(t)) => {
-          // SAFETY: if the target.exports is None, program will not reach here
-          let target_exports = target.export.as_ref().expect("should have exports");
-          if target_exports.len() == 1 {
-            target = t;
-            if target.export.is_none() {
-              return Some(ResolvedExportInfoTargetWithCircular::Target(target));
-            }
-          } else {
-            target.module = t.module;
-            target.dependency = t.dependency;
-            target.export = if let Some(mut exports) = t.export {
-              exports.extend_from_slice(&target_exports[1..]);
-              Some(exports)
-            } else {
-              Some(target_exports[1..].to_vec())
-            }
-          }
-        }
-      }
-      if !resolve_filter(&target) {
-        return Some(ResolvedExportInfoTargetWithCircular::Target(target));
-      }
-      already_visited.insert(export_info_hash_key);
-    }
-  } else {
-    None
-  }
-}
-
-pub fn process_export_info<'a>(
-  module_graph: &'a ModuleGraph,
-  runtime: Option<&'a RuntimeSpec>,
-  referenced_export: &mut Vec<Vec<&'a Atom>>,
-  prefix: Vec<&'a Atom>,
-  export_info: Option<&'a ExportInfoData>,
-  default_points_to_self: bool,
-  already_visited: &mut UkeySet<ExportInfo>,
-) {
-  if let Some(export_info) = export_info {
-    let used = ExportInfoGetter::get_used(export_info, runtime);
-    if used == UsageState::Unused {
-      return;
-    }
-    if already_visited.contains(&export_info.id()) {
-      referenced_export.push(prefix);
-      return;
-    }
-    already_visited.insert(export_info.id());
-    // FIXME: more branch
-    if used != UsageState::OnlyPropertiesUsed {
-      already_visited.remove(&export_info.id());
-      referenced_export.push(prefix);
-      return;
-    }
-    if let Some(exports_info) = module_graph.try_get_exports_info_by_id(
-      &export_info
-        .exports_info()
-        .expect("should have exports info"),
-    ) {
-      for export_info in exports_info.exports.values() {
-        let export_info = export_info.as_data(module_graph);
-
-        process_export_info(
-          module_graph,
-          runtime,
-          referenced_export,
-          if default_points_to_self
-            && export_info
-              .name()
-              .map(|name| name == "default")
-              .unwrap_or_default()
-          {
-            prefix.clone()
-          } else {
-            let mut value = prefix.clone();
-            if let Some(name) = export_info.name() {
-              value.push(name);
-            }
-            value
-          },
-          Some(export_info),
-          false,
-          already_visited,
-        );
-      }
-    }
-    already_visited.remove(&export_info.id());
-  } else {
-    referenced_export.push(prefix);
   }
 }

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -593,57 +593,56 @@ pub fn process_export_info<'a>(
   runtime: Option<&'a RuntimeSpec>,
   referenced_export: &mut Vec<Vec<&'a Atom>>,
   prefix: Vec<&'a Atom>,
-  export_info: Option<ExportInfo>,
+  export_info: Option<&'a ExportInfoData>,
   default_points_to_self: bool,
   already_visited: &mut UkeySet<ExportInfo>,
 ) {
   if let Some(export_info) = export_info {
-    let export_info_data = export_info.as_data(module_graph);
-    let used = ExportInfoGetter::get_used(export_info_data, runtime);
+    let used = ExportInfoGetter::get_used(export_info, runtime);
     if used == UsageState::Unused {
       return;
     }
-    if already_visited.contains(&export_info) {
+    if already_visited.contains(&export_info.id()) {
       referenced_export.push(prefix);
       return;
     }
-    already_visited.insert(export_info);
+    already_visited.insert(export_info.id());
     // FIXME: more branch
     if used != UsageState::OnlyPropertiesUsed {
-      already_visited.remove(&export_info);
+      already_visited.remove(&export_info.id());
       referenced_export.push(prefix);
       return;
     }
     if let Some(exports_info) = module_graph.try_get_exports_info_by_id(
-      &ExportInfoGetter::exports_info(export_info_data).expect("should have exports info"),
+      &ExportInfoGetter::exports_info(export_info).expect("should have exports info"),
     ) {
       for export_info in exports_info.exports.values() {
-        let export_info_data = export_info.as_data(module_graph);
+        let export_info = export_info.as_data(module_graph);
 
         process_export_info(
           module_graph,
           runtime,
           referenced_export,
           if default_points_to_self
-            && ExportInfoGetter::name(export_info_data)
+            && ExportInfoGetter::name(export_info)
               .map(|name| name == "default")
               .unwrap_or_default()
           {
             prefix.clone()
           } else {
             let mut value = prefix.clone();
-            if let Some(name) = ExportInfoGetter::name(export_info_data) {
+            if let Some(name) = ExportInfoGetter::name(export_info) {
               value.push(name);
             }
             value
           },
-          Some(*export_info),
+          Some(export_info),
           false,
           already_visited,
         );
       }
     }
-    already_visited.remove(&export_info);
+    already_visited.remove(&export_info.id());
   } else {
     referenced_export.push(prefix);
   }

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -125,27 +125,139 @@ impl ExportInfo {
 #[derive(Debug, Clone)]
 pub struct ExportInfoData {
   // the name could be `null` you could refer https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad4153d/lib/ExportsInfo.js#L78
-  pub(crate) name: Option<Atom>,
+  name: Option<Atom>,
   /// this is mangled name, https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/ExportsInfo.js#L1181-L1188
-  pub(crate) used_name: Option<Atom>,
-  pub(crate) target: HashMap<Option<DependencyId>, ExportInfoTargetValue>,
+  used_name: Option<Atom>,
+  target: HashMap<Option<DependencyId>, ExportInfoTargetValue>,
   /// This is rspack only variable, it is used to flag if the target has been initialized
-  pub(crate) target_is_set: bool,
-  pub(crate) provided: Option<ExportProvided>,
-  pub(crate) can_mangle_provide: Option<bool>,
-  pub(crate) can_mangle_use: Option<bool>,
+  target_is_set: bool,
+  provided: Option<ExportProvided>,
+  can_mangle_provide: Option<bool>,
+  can_mangle_use: Option<bool>,
   // only specific export info can be inlined, so other_export_info.inlinable is always NoByProvide
-  pub(crate) inlinable: Inlinable,
-  pub(crate) terminal_binding: bool,
-  pub(crate) id: ExportInfo,
-  pub(crate) exports_info: Option<ExportsInfo>,
-  pub(crate) exports_info_owned: bool,
-  pub(crate) has_use_in_runtime_info: bool,
-  pub(crate) global_used: Option<UsageState>,
-  pub(crate) used_in_runtime: Option<ustr::UstrMap<UsageState>>,
+  inlinable: Inlinable,
+  terminal_binding: bool,
+  id: ExportInfo,
+  exports_info: Option<ExportsInfo>,
+  exports_info_owned: bool,
+  has_use_in_runtime_info: bool,
+  global_used: Option<UsageState>,
+  used_in_runtime: Option<ustr::UstrMap<UsageState>>,
 }
 
 impl ExportInfoData {
+  pub fn name(&self) -> Option<&Atom> {
+    self.name.as_ref()
+  }
+
+  pub fn used_name(&self) -> Option<&Atom> {
+    self.used_name.as_ref()
+  }
+
+  pub fn target(&self) -> &HashMap<Option<DependencyId>, ExportInfoTargetValue> {
+    &self.target
+  }
+
+  pub fn target_is_set(&self) -> bool {
+    self.target_is_set
+  }
+
+  pub fn target_mut(&mut self) -> &mut HashMap<Option<DependencyId>, ExportInfoTargetValue> {
+    &mut self.target
+  }
+
+  pub fn provided(&self) -> Option<ExportProvided> {
+    self.provided
+  }
+
+  pub fn can_mangle_provide(&self) -> Option<bool> {
+    self.can_mangle_provide
+  }
+
+  pub fn can_mangle_use(&self) -> Option<bool> {
+    self.can_mangle_use
+  }
+
+  pub fn inlinable(&self) -> &Inlinable {
+    &self.inlinable
+  }
+
+  pub fn terminal_binding(&self) -> bool {
+    self.terminal_binding
+  }
+
+  pub fn id(&self) -> ExportInfo {
+    self.id
+  }
+
+  pub fn exports_info(&self) -> Option<ExportsInfo> {
+    self.exports_info
+  }
+
+  pub fn exports_info_owned(&self) -> bool {
+    self.exports_info_owned
+  }
+
+  pub fn has_use_in_runtime_info(&self) -> bool {
+    self.has_use_in_runtime_info
+  }
+
+  pub fn global_used(&self) -> Option<UsageState> {
+    self.global_used
+  }
+
+  pub fn used_in_runtime(&self) -> Option<&ustr::UstrMap<UsageState>> {
+    self.used_in_runtime.as_ref()
+  }
+
+  pub fn used_in_runtime_mut(&mut self) -> &mut ustr::UstrMap<UsageState> {
+    self.used_in_runtime.get_or_insert_default()
+  }
+
+  pub fn set_provided(&mut self, value: Option<ExportProvided>) {
+    self.provided = value;
+  }
+
+  pub fn set_can_mangle_provide(&mut self, value: Option<bool>) {
+    self.can_mangle_provide = value;
+  }
+
+  pub fn set_can_mangle_use(&mut self, value: Option<bool>) {
+    self.can_mangle_use = value;
+  }
+
+  pub fn set_terminal_binding(&mut self, value: bool) {
+    self.terminal_binding = value;
+  }
+
+  pub fn set_exports_info(&mut self, value: Option<ExportsInfo>) {
+    self.exports_info = value;
+  }
+
+  pub fn set_exports_info_owned(&mut self, value: bool) {
+    self.exports_info_owned = value;
+  }
+
+  pub fn set_inlinable(&mut self, inlinable: Inlinable) {
+    self.inlinable = inlinable;
+  }
+
+  pub fn set_used_name(&mut self, name: Atom) {
+    self.used_name = Some(name);
+  }
+
+  pub fn set_target_is_set(&mut self, value: bool) {
+    self.target_is_set = value;
+  }
+
+  pub fn set_global_used(&mut self, value: Option<UsageState>) {
+    self.global_used = value;
+  }
+
+  pub fn set_used_in_runtime(&mut self, value: Option<ustr::UstrMap<UsageState>>) {
+    self.used_in_runtime = value;
+  }
+
   pub fn new(name: Option<Atom>, init_from: Option<&ExportInfoData>) -> Self {
     let used_name = init_from.and_then(|init_from| init_from.used_name.clone());
     let global_used = init_from.and_then(|init_from| init_from.global_used);
@@ -205,10 +317,6 @@ impl ExportInfoData {
       global_used,
       inlinable: Inlinable::NoByProvide,
     }
-  }
-
-  pub fn id(&self) -> ExportInfo {
-    self.id
   }
 
   pub fn find_target_impl(
@@ -411,10 +519,10 @@ impl<'a> MaybeDynamicTargetExportInfo<'a> {
     }
   }
 
-  pub fn provided(&'a self) -> Option<&'a ExportProvided> {
+  pub fn provided(&'a self) -> Option<ExportProvided> {
     match self {
-      MaybeDynamicTargetExportInfo::Static(export_info) => ExportInfoGetter::provided(export_info),
-      MaybeDynamicTargetExportInfo::Dynamic { data, .. } => data.provided.as_ref(),
+      MaybeDynamicTargetExportInfo::Static(export_info) => export_info.provided(),
+      MaybeDynamicTargetExportInfo::Dynamic { data, .. } => data.provided(),
     }
   }
 
@@ -614,7 +722,9 @@ pub fn process_export_info<'a>(
       return;
     }
     if let Some(exports_info) = module_graph.try_get_exports_info_by_id(
-      &ExportInfoGetter::exports_info(export_info).expect("should have exports info"),
+      &export_info
+        .exports_info()
+        .expect("should have exports info"),
     ) {
       for export_info in exports_info.exports.values() {
         let export_info = export_info.as_data(module_graph);
@@ -624,14 +734,15 @@ pub fn process_export_info<'a>(
           runtime,
           referenced_export,
           if default_points_to_self
-            && ExportInfoGetter::name(export_info)
+            && export_info
+              .name()
               .map(|name| name == "default")
               .unwrap_or_default()
           {
             prefix.clone()
           } else {
             let mut value = prefix.clone();
-            if let Some(name) = ExportInfoGetter::name(export_info) {
+            if let Some(name) = export_info.name() {
               value.push(name);
             }
             value

--- a/crates/rspack_core/src/exports/export_info_getter.rs
+++ b/crates/rspack_core/src/exports/export_info_getter.rs
@@ -204,7 +204,7 @@ impl ExportInfoGetter {
     info: &ExportInfoData,
   ) -> Cow<HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
     if info.target().len() <= 1 {
-      return Cow::Borrowed(&info.target());
+      return Cow::Borrowed(info.target());
     }
     let mut max_priority = u8::MIN;
     let mut min_priority = u8::MAX;
@@ -213,7 +213,7 @@ impl ExportInfoGetter {
       min_priority = min_priority.min(value.priority);
     }
     if max_priority == min_priority {
-      return Cow::Borrowed(&info.target());
+      return Cow::Borrowed(info.target());
     }
     let mut map = HashMap::default();
     for (k, v) in info.target().iter() {

--- a/crates/rspack_core/src/exports/export_info_getter.rs
+++ b/crates/rspack_core/src/exports/export_info_getter.rs
@@ -5,46 +5,13 @@ use rspack_util::atom::Atom;
 use rustc_hash::FxHashMap as HashMap;
 
 use super::{
-  ExportInfoData, ExportInfoTargetValue, ExportProvided, ExportsInfo, Inlinable, UsageState,
-  UsedNameItem,
+  ExportInfoData, ExportInfoTargetValue, ExportProvided, Inlinable, UsageState, UsedNameItem,
 };
 use crate::{DependencyId, RuntimeSpec};
 
 pub struct ExportInfoGetter;
 
 impl ExportInfoGetter {
-  pub fn name(info: &ExportInfoData) -> Option<&Atom> {
-    info.name.as_ref()
-  }
-
-  pub fn provided(info: &ExportInfoData) -> Option<&ExportProvided> {
-    info.provided.as_ref()
-  }
-
-  pub fn can_mangle_provide(info: &ExportInfoData) -> Option<bool> {
-    info.can_mangle_provide
-  }
-
-  pub fn can_mangle_use(info: &ExportInfoData) -> Option<bool> {
-    info.can_mangle_use
-  }
-
-  pub fn terminal_binding(info: &ExportInfoData) -> bool {
-    info.terminal_binding
-  }
-
-  pub fn exports_info_owned(info: &ExportInfoData) -> bool {
-    info.exports_info_owned
-  }
-
-  pub fn exports_info(info: &ExportInfoData) -> Option<ExportsInfo> {
-    info.exports_info
-  }
-
-  pub fn inlinable(info: &ExportInfoData) -> &Inlinable {
-    &info.inlinable
-  }
-
   /// Webpack returns `false | string`, we use `Option<Atom>` to avoid declare a redundant enum
   /// type
   pub fn get_used_name(
@@ -52,15 +19,15 @@ impl ExportInfoGetter {
     fallback_name: Option<&Atom>,
     runtime: Option<&RuntimeSpec>,
   ) -> Option<UsedNameItem> {
-    if let Inlinable::Inlined(inlined) = &info.inlinable {
+    if let Inlinable::Inlined(inlined) = &info.inlinable() {
       return Some(UsedNameItem::Inlined(*inlined));
     }
-    if info.has_use_in_runtime_info {
-      if let Some(usage) = info.global_used {
+    if info.has_use_in_runtime_info() {
+      if let Some(usage) = info.global_used() {
         if matches!(usage, UsageState::Unused) {
           return None;
         }
-      } else if let Some(used_in_runtime) = info.used_in_runtime.as_ref() {
+      } else if let Some(used_in_runtime) = info.used_in_runtime() {
         if let Some(runtime) = runtime {
           if runtime
             .iter()
@@ -73,10 +40,10 @@ impl ExportInfoGetter {
         return None;
       }
     }
-    if let Some(used_name) = info.used_name.as_ref() {
+    if let Some(used_name) = info.used_name() {
       return Some(UsedNameItem::Str(used_name.clone()));
     }
-    if let Some(name) = info.name.as_ref() {
+    if let Some(name) = info.name() {
       Some(UsedNameItem::Str(name.clone()))
     } else {
       fallback_name.map(|n| UsedNameItem::Str(n.clone()))
@@ -84,13 +51,13 @@ impl ExportInfoGetter {
   }
 
   pub fn get_used(info: &ExportInfoData, runtime: Option<&RuntimeSpec>) -> UsageState {
-    if !info.has_use_in_runtime_info {
+    if !info.has_use_in_runtime_info() {
       return UsageState::NoInfo;
     }
-    if let Some(global_used) = info.global_used {
+    if let Some(global_used) = info.global_used() {
       return global_used;
     }
-    if let Some(used_in_runtime) = info.used_in_runtime.as_ref() {
+    if let Some(used_in_runtime) = info.used_in_runtime() {
       let mut max = UsageState::Unused;
       if let Some(runtime) = runtime {
         for item in runtime.iter() {
@@ -121,7 +88,7 @@ impl ExportInfoGetter {
   }
 
   pub fn get_provided_info(info: &ExportInfoData) -> &'static str {
-    match info.provided {
+    match info.provided() {
       Some(ExportProvided::NotProvided) => "not provided",
       Some(ExportProvided::Unknown) => "maybe provided (runtime-defined)",
       Some(ExportProvided::Provided) => "provided",
@@ -130,13 +97,13 @@ impl ExportInfoGetter {
   }
 
   pub fn get_rename_info(info: &ExportInfoData) -> Cow<str> {
-    match (&info.used_name, &info.name) {
+    match (info.used_name(), info.name()) {
       (Some(used), Some(name)) if used != name => return format!("renamed to {used}").into(),
       (Some(used), None) => return format!("renamed to {used}").into(),
       _ => {}
     }
 
-    match (Self::can_mangle_provide(info), Self::can_mangle_use(info)) {
+    match (info.can_mangle_provide(), info.can_mangle_use()) {
       (None, None) => "missing provision and use info prevents renaming",
       (None, Some(false)) => "usage prevents renaming (no provision info)",
       (None, Some(true)) => "missing provision info prevents renaming",
@@ -153,7 +120,7 @@ impl ExportInfoGetter {
   }
 
   pub fn get_used_info(info: &ExportInfoData) -> Cow<str> {
-    if let Some(global_used) = info.global_used {
+    if let Some(global_used) = info.global_used() {
       return match global_used {
         UsageState::Unused => "unused".into(),
         UsageState::NoInfo => "no usage info".into(),
@@ -161,7 +128,7 @@ impl ExportInfoGetter {
         UsageState::Used => "used".into(),
         UsageState::OnlyPropertiesUsed => "only properties used".into(),
       };
-    } else if let Some(used_in_runtime) = &info.used_in_runtime {
+    } else if let Some(used_in_runtime) = info.used_in_runtime() {
       let mut map = HashMap::default();
 
       for (runtime, used) in used_in_runtime.iter() {
@@ -193,7 +160,7 @@ impl ExportInfoGetter {
       }
     }
 
-    if info.has_use_in_runtime_info {
+    if info.has_use_in_runtime_info() {
       "unused".into()
     } else {
       "no usage info".into()
@@ -201,7 +168,7 @@ impl ExportInfoGetter {
   }
 
   pub fn is_reexport(info: &ExportInfoData) -> bool {
-    !info.terminal_binding && info.target_is_set && !info.target.is_empty()
+    !info.terminal_binding() && info.target_is_set() && !info.target().is_empty()
   }
 
   pub fn has_info(
@@ -209,18 +176,18 @@ impl ExportInfoGetter {
     base_info: &ExportInfoData,
     runtime: Option<&RuntimeSpec>,
   ) -> bool {
-    info.used_name.is_some()
-      || info.provided.is_some()
-      || info.terminal_binding
+    info.used_name().is_some()
+      || info.provided().is_some()
+      || info.terminal_binding()
       || (Self::get_used(info, runtime) != Self::get_used(base_info, runtime))
   }
 
   pub fn can_mangle(info: &ExportInfoData) -> Option<bool> {
-    match info.can_mangle_provide {
-      Some(true) => info.can_mangle_use,
+    match info.can_mangle_provide() {
+      Some(true) => info.can_mangle_use(),
       Some(false) => Some(false),
       None => {
-        if info.can_mangle_use == Some(false) {
+        if info.can_mangle_use() == Some(false) {
           Some(false)
         } else {
           None
@@ -230,26 +197,26 @@ impl ExportInfoGetter {
   }
 
   pub fn has_used_name(info: &ExportInfoData) -> bool {
-    info.used_name.is_some()
+    info.used_name().is_some()
   }
 
   pub fn get_max_target(
     info: &ExportInfoData,
   ) -> Cow<HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
-    if info.target.len() <= 1 {
-      return Cow::Borrowed(&info.target);
+    if info.target().len() <= 1 {
+      return Cow::Borrowed(&info.target());
     }
     let mut max_priority = u8::MIN;
     let mut min_priority = u8::MAX;
-    for value in info.target.values() {
+    for value in info.target().values() {
       max_priority = max_priority.max(value.priority);
       min_priority = min_priority.min(value.priority);
     }
     if max_priority == min_priority {
-      return Cow::Borrowed(&info.target);
+      return Cow::Borrowed(&info.target());
     }
     let mut map = HashMap::default();
-    for (k, v) in info.target.iter() {
+    for (k, v) in info.target().iter() {
       if max_priority == v.priority {
         map.insert(*k, v.clone());
       }

--- a/crates/rspack_core/src/exports/export_info_setter.rs
+++ b/crates/rspack_core/src/exports/export_info_setter.rs
@@ -82,6 +82,23 @@ impl ExportInfoSetter {
     false
   }
 
+  pub fn do_move_target(
+    export_info: &mut ExportInfoData,
+    dependency: DependencyId,
+    target_export: Option<Vec<Atom>>,
+  ) {
+    export_info.target_mut().clear();
+    export_info.target_mut().insert(
+      None,
+      ExportInfoTargetValue {
+        dependency: Some(dependency),
+        export: target_export,
+        priority: 0,
+      },
+    );
+    export_info.set_target_is_set(true);
+  }
+
   pub fn set_used(
     info: &mut ExportInfoData,
     new_value: UsageState,

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -232,13 +232,13 @@ impl ExportsInfo {
     // this clone aiming to avoid use the mutable ref and immutable ref at the same time.
     let export_id_list = exports_info.exports.values().copied().collect::<Vec<_>>();
     for export_info in export_id_list {
-      export_info.set_has_use_info(mg);
+      ExportInfoSetter::set_has_use_info(&export_info, mg);
     }
-    side_effects_only_info_id.set_has_use_info(mg);
+    ExportInfoSetter::set_has_use_info(&side_effects_only_info_id, mg);
     if let Some(redirect) = redirect_to_id {
       redirect.set_has_use_info(mg);
     } else {
-      other_exports_info_id.set_has_use_info(mg);
+      ExportInfoSetter::set_has_use_info(&other_exports_info_id, mg);
       let other_exports_info = mg.get_export_info_mut_by_id(&other_exports_info_id);
       if other_exports_info.can_mangle_use().is_none() {
         other_exports_info.set_can_mangle_use(Some(true));
@@ -471,10 +471,4 @@ impl ExportsInfoData {
   pub fn id(&self) -> ExportsInfo {
     self.id
   }
-}
-
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
-pub enum TerminalBinding {
-  ExportInfo(ExportInfo),
-  ExportsInfo(ExportsInfo),
 }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -498,7 +498,7 @@ impl ExportsInfoGetter {
         PrefetchExportsInfoMode::Default => IndexMap::new(),
         PrefetchExportsInfoMode::NamedExports(ref names) => {
           let mut exports = IndexMap::new();
-          for (key, value) in exports_info.exports.iter() {
+          for (key, value) in exports_info.exports_with_names() {
             if !names.contains(key) {
               continue;
             }
@@ -514,7 +514,7 @@ impl ExportsInfoGetter {
         }
         PrefetchExportsInfoMode::AllExports => {
           let mut exports = IndexMap::new();
-          for (key, value) in exports_info.exports.iter() {
+          for (key, value) in exports_info.exports_with_names() {
             exports.insert(
               key,
               PrefetchedExportInfoData {
@@ -528,7 +528,7 @@ impl ExportsInfoGetter {
         PrefetchExportsInfoMode::NamedNestedExports(names) => {
           let mut exports = IndexMap::new();
           if let Some(name) = names.first() {
-            if let Some(export_info) = exports_info.exports.get(name) {
+            if let Some(export_info) = exports_info.named_exports(name) {
               let export_info = export_info.as_data(mg);
               if let Some(nested_exports_info) = export_info.exports_info() {
                 nested_exports.push((
@@ -549,7 +549,7 @@ impl ExportsInfoGetter {
         }
         PrefetchExportsInfoMode::NamedNestedAllExports(names) => {
           let mut exports = IndexMap::new();
-          for (key, value) in exports_info.exports.iter() {
+          for (key, value) in exports_info.exports_with_names() {
             let export_info = value.as_data(mg);
 
             if names.first().is_some_and(|name| name == key) {
@@ -573,7 +573,7 @@ impl ExportsInfoGetter {
         }
         PrefetchExportsInfoMode::Full => {
           let mut exports = IndexMap::new();
-          for (key, value) in exports_info.exports.iter() {
+          for (key, value) in exports_info.exports_with_names() {
             let export_info = value.as_data(mg);
 
             if let Some(nested_exports_info) = export_info.exports_info() {

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -459,17 +459,23 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
 
 #[derive(Debug, Clone)]
 pub struct PrefetchedExportsInfoData<'a> {
-  pub exports: IndexMap<&'a Atom, PrefetchedExportInfoData<'a>>,
-  pub other_exports_info: PrefetchedExportInfoData<'a>,
+  exports: IndexMap<&'a Atom, PrefetchedExportInfoData<'a>>,
+  other_exports_info: PrefetchedExportInfoData<'a>,
 
-  pub side_effects_only_info: PrefetchedExportInfoData<'a>,
-  pub redirect_to: Option<ExportsInfo>,
-  pub id: ExportsInfo,
+  side_effects_only_info: PrefetchedExportInfoData<'a>,
+  redirect_to: Option<ExportsInfo>,
+  id: ExportsInfo,
+}
+
+impl<'a> PrefetchedExportsInfoData<'a> {
+  pub fn id(&self) -> ExportsInfo {
+    self.id
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct PrefetchedExportInfoData<'a> {
-  pub inner: &'a ExportInfoData,
+  inner: &'a ExportInfoData,
   // pub exports_info: Option<ExportsInfo>,
 }
 pub struct ExportsInfoGetter;
@@ -702,7 +708,7 @@ impl ExportsInfoGetter {
   }
 
   pub fn get_provided_exports(info: &PrefetchedExportsInfoWrapper) -> ProvidedExports {
-    if info.data().redirect_to.is_none() {
+    if info.redirect_to().is_none() {
       match info.other_exports_info().provided() {
         Some(ExportProvided::Unknown) => {
           return ProvidedExports::ProvidedAll;
@@ -725,7 +731,7 @@ impl ExportsInfoGetter {
         _ => {}
       }
     }
-    if let Some(redirect) = &info.data().redirect_to {
+    if let Some(redirect) = info.redirect_to() {
       let redirected = info.redirect(*redirect, false);
       let provided_exports = Self::get_provided_exports(&redirected);
       let inner = match provided_exports {

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -33,12 +33,15 @@ pub struct PrefetchedExportsInfoWrapper<'a> {
    * stored in a map to prevent circular references
    * When redirect, this data can be cloned to generate a new PrefetchedExportsInfoWrapper with a new entry
    */
-  pub exports: Arc<HashMap<ExportsInfo, PrefetchedExportsInfoData<'a>>>,
+  exports: Arc<HashMap<ExportsInfo, PrefetchedExportsInfoData<'a>>>,
   /**
    * The entry of the current exports info
    */
-  pub entry: ExportsInfo,
-  pub mode: PrefetchExportsInfoMode<'a>,
+  entry: ExportsInfo,
+  /**
+   * The prefetch mode of the current exports info
+   */
+  mode: PrefetchExportsInfoMode<'a>,
 }
 
 impl<'a> PrefetchedExportsInfoWrapper<'a> {
@@ -592,17 +595,17 @@ impl ExportsInfoGetter {
         }
       };
 
-      let other_exports_info_data = exports_info.other_exports_info.as_data(mg);
+      let other_exports_info_data = exports_info.other_exports_info().as_data(mg);
       if let Some(other_exports) = other_exports_info_data.exports_info() {
         nested_exports.push((other_exports, PrefetchExportsInfoMode::Default));
       }
 
-      let side_effects_only_info_data = exports_info.side_effects_only_info.as_data(mg);
+      let side_effects_only_info_data = exports_info.side_effects_only_info().as_data(mg);
       if let Some(side_exports) = side_effects_only_info_data.exports_info() {
         nested_exports.push((side_exports, PrefetchExportsInfoMode::Default));
       }
 
-      if let Some(redirect_to) = exports_info.redirect_to {
+      if let Some(redirect_to) = exports_info.redirect_to() {
         nested_exports.push((redirect_to, mode.clone()));
       }
 
@@ -618,7 +621,7 @@ impl ExportsInfoGetter {
             inner: side_effects_only_info_data,
             // exports_info: side_effects_only_info_data.exports_info,
           },
-          redirect_to: exports_info.redirect_to,
+          redirect_to: exports_info.redirect_to(),
           id: *id,
         },
       );

--- a/crates/rspack_core/src/exports/mod.rs
+++ b/crates/rspack_core/src/exports/mod.rs
@@ -4,6 +4,8 @@ mod export_info_setter;
 mod exports_info;
 mod exports_info_getter;
 mod exports_info_setter;
+mod referenced_export;
+mod target;
 mod utils;
 
 pub use export_info::*;
@@ -12,4 +14,6 @@ pub use export_info_setter::*;
 pub use exports_info::*;
 pub use exports_info_getter::*;
 pub use exports_info_setter::*;
+pub use referenced_export::*;
+pub use target::*;
 pub use utils::*;

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -1,0 +1,128 @@
+use rspack_collections::UkeySet;
+use rspack_util::atom::Atom;
+
+use crate::{ExportInfo, ExportInfoData, ExportInfoGetter, ModuleGraph, RuntimeSpec, UsageState};
+
+/// refer https://github.com/webpack/webpack/blob/d15c73469fd71cf98734685225250148b68ddc79/lib/FlagDependencyUsagePlugin.js#L64
+#[derive(Clone, Debug)]
+pub enum ExtendedReferencedExport {
+  Array(Vec<Atom>),
+  Export(ReferencedExport),
+}
+
+pub fn is_no_exports_referenced(exports: &[ExtendedReferencedExport]) -> bool {
+  exports.is_empty()
+}
+
+pub fn is_exports_object_referenced(exports: &[ExtendedReferencedExport]) -> bool {
+  matches!(exports[..], [ExtendedReferencedExport::Array(ref arr)] if arr.is_empty())
+}
+
+pub fn create_no_exports_referenced() -> Vec<ExtendedReferencedExport> {
+  vec![]
+}
+
+pub fn create_exports_object_referenced() -> Vec<ExtendedReferencedExport> {
+  vec![ExtendedReferencedExport::Array(vec![])]
+}
+
+impl From<Vec<Atom>> for ExtendedReferencedExport {
+  fn from(value: Vec<Atom>) -> Self {
+    ExtendedReferencedExport::Array(value)
+  }
+}
+impl From<ReferencedExport> for ExtendedReferencedExport {
+  fn from(value: ReferencedExport) -> Self {
+    ExtendedReferencedExport::Export(value)
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct ReferencedExport {
+  pub name: Vec<Atom>,
+  pub can_mangle: bool,
+  pub can_inline: bool,
+}
+
+impl ReferencedExport {
+  pub fn new(name: Vec<Atom>, can_mangle: bool, can_inline: bool) -> Self {
+    Self {
+      name,
+      can_mangle,
+      can_inline,
+    }
+  }
+}
+
+impl Default for ReferencedExport {
+  fn default() -> Self {
+    Self {
+      name: vec![],
+      can_mangle: true,
+      can_inline: true,
+    }
+  }
+}
+
+pub fn collect_referenced_export_items<'a>(
+  module_graph: &'a ModuleGraph,
+  runtime: Option<&'a RuntimeSpec>,
+  referenced_export: &mut Vec<Vec<&'a Atom>>,
+  prefix: Vec<&'a Atom>,
+  export_info: Option<&'a ExportInfoData>,
+  default_points_to_self: bool,
+  already_visited: &mut UkeySet<ExportInfo>,
+) {
+  if let Some(export_info) = export_info {
+    let used = ExportInfoGetter::get_used(export_info, runtime);
+    if used == UsageState::Unused {
+      return;
+    }
+    if already_visited.contains(&export_info.id()) {
+      referenced_export.push(prefix);
+      return;
+    }
+    already_visited.insert(export_info.id());
+    // FIXME: more branch
+    if used != UsageState::OnlyPropertiesUsed {
+      already_visited.remove(&export_info.id());
+      referenced_export.push(prefix);
+      return;
+    }
+    if let Some(exports_info) = module_graph.try_get_exports_info_by_id(
+      &export_info
+        .exports_info()
+        .expect("should have exports info"),
+    ) {
+      for export_info in exports_info.exports.values() {
+        let export_info = export_info.as_data(module_graph);
+
+        collect_referenced_export_items(
+          module_graph,
+          runtime,
+          referenced_export,
+          if default_points_to_self
+            && export_info
+              .name()
+              .map(|name| name == "default")
+              .unwrap_or_default()
+          {
+            prefix.clone()
+          } else {
+            let mut value = prefix.clone();
+            if let Some(name) = export_info.name() {
+              value.push(name);
+            }
+            value
+          },
+          Some(export_info),
+          false,
+          already_visited,
+        );
+      }
+    }
+    already_visited.remove(&export_info.id());
+  } else {
+    referenced_export.push(prefix);
+  }
+}

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -94,7 +94,7 @@ pub fn collect_referenced_export_items<'a>(
         .exports_info()
         .expect("should have exports info"),
     ) {
-      for export_info in exports_info.exports.values() {
+      for export_info in exports_info.exports() {
         let export_info = export_info.as_data(module_graph);
 
         collect_referenced_export_items(

--- a/crates/rspack_core/src/exports/target.rs
+++ b/crates/rspack_core/src/exports/target.rs
@@ -1,0 +1,335 @@
+use std::{collections::VecDeque, rc::Rc, sync::Arc};
+
+use rspack_util::atom::Atom;
+use rustc_hash::FxHashSet as HashSet;
+
+use crate::{
+  DependencyId, ExportInfo, ExportInfoData, ExportInfoGetter, ExportInfoTargetValue, ExportsInfo,
+  ExportsInfoGetter, MaybeDynamicTargetExportInfo, MaybeDynamicTargetExportInfoHashKey,
+  ModuleGraph, ModuleIdentifier, PrefetchExportsInfoMode,
+};
+
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalBinding {
+  ExportInfo(ExportInfo),
+  ExportsInfo(ExportsInfo),
+}
+
+#[derive(Debug, Clone)]
+pub struct UnResolvedExportInfoTarget {
+  pub dependency: Option<DependencyId>,
+  pub export: Option<Vec<Atom>>,
+}
+
+pub type ResolveFilterFnTy<'a> = Rc<dyn Fn(&ResolvedExportInfoTarget) -> bool + 'a>;
+
+#[derive(Debug)]
+pub enum ResolvedExportInfoTargetWithCircular {
+  Target(ResolvedExportInfoTarget),
+  Circular,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolvedExportInfoTarget {
+  pub module: ModuleIdentifier,
+  pub export: Option<Vec<Atom>>,
+  /// using dependency id to retrieve Connection
+  pub dependency: DependencyId,
+}
+
+#[derive(Clone, Debug)]
+pub enum FindTargetResult {
+  NoTarget,
+  NoValidTarget,
+  ValidTarget(FindTargetResultItem),
+}
+
+#[derive(Clone, Debug)]
+pub struct FindTargetResultItem {
+  pub module: ModuleIdentifier,
+  pub export: Option<Vec<Atom>>,
+}
+
+pub fn get_terminal_binding(
+  export_info: &ExportInfoData,
+  mg: &ModuleGraph,
+) -> Option<TerminalBinding> {
+  if export_info.terminal_binding() {
+    return Some(TerminalBinding::ExportInfo(export_info.id()));
+  }
+  let target = get_target(export_info, mg)?;
+  let exports_info = mg.get_exports_info(&target.module);
+  let Some(export) = target.export else {
+    return Some(TerminalBinding::ExportsInfo(exports_info));
+  };
+  ExportsInfoGetter::prefetch(
+    &exports_info,
+    mg,
+    PrefetchExportsInfoMode::NamedNestedExports(&export),
+  )
+  .get_read_only_export_info_recursive(&export)
+  .map(|data| TerminalBinding::ExportInfo(data.id()))
+}
+
+pub fn do_move_target(
+  export_info: &mut ExportInfoData,
+  dependency: DependencyId,
+  target_export: Option<Vec<Atom>>,
+) {
+  export_info.target_mut().clear();
+  export_info.target_mut().insert(
+    None,
+    ExportInfoTargetValue {
+      dependency: Some(dependency),
+      export: target_export,
+      priority: 0,
+    },
+  );
+  export_info.set_target_is_set(true);
+}
+
+pub(crate) fn find_target_from_export_info(
+  export_info: &ExportInfoData,
+  mg: &ModuleGraph,
+  valid_target_module_filter: Arc<impl Fn(&ModuleIdentifier) -> bool>,
+  visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
+) -> FindTargetResult {
+  if !export_info.target_is_set() || export_info.target().is_empty() {
+    return FindTargetResult::NoTarget;
+  }
+  let max_target = ExportInfoGetter::get_max_target(export_info);
+  let raw_target = max_target.values().next();
+  let Some(raw_target) = raw_target else {
+    return FindTargetResult::NoTarget;
+  };
+  let mut target = FindTargetResultItem {
+    module: *raw_target
+      .dependency
+      .and_then(|dep_id| mg.connection_by_dependency_id(&dep_id))
+      .expect("should have connection")
+      .module_identifier(),
+    export: raw_target.export.clone(),
+  };
+  loop {
+    if valid_target_module_filter(&target.module) {
+      return FindTargetResult::ValidTarget(target);
+    }
+    let name = &target.export.as_ref().expect("should have export")[0];
+    let exports_info = mg.get_prefetched_exports_info(
+      &target.module,
+      PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([name])),
+    );
+    let export_info = exports_info.get_export_info_without_mut_module_graph(name);
+    let export_info_hash_key = export_info.as_hash_key();
+    if visited.contains(&export_info_hash_key) {
+      return FindTargetResult::NoTarget;
+    }
+    visited.insert(export_info_hash_key);
+    let new_target = find_target_from_export_info(
+      export_info.to_data(),
+      mg,
+      valid_target_module_filter.clone(),
+      visited,
+    );
+    let new_target = match new_target {
+      FindTargetResult::NoTarget => return FindTargetResult::NoValidTarget,
+      FindTargetResult::NoValidTarget => return FindTargetResult::NoValidTarget,
+      FindTargetResult::ValidTarget(target) => target,
+    };
+    if target.export.as_ref().map(|item| item.len()) == Some(1) {
+      target = new_target;
+    } else {
+      target = FindTargetResultItem {
+        module: new_target.module,
+        export: if let Some(export) = new_target.export {
+          Some(
+            [
+              export,
+              target
+                .export
+                .as_ref()
+                .and_then(|export| export.get(1..).map(|slice| slice.to_vec()))
+                .unwrap_or_default(),
+            ]
+            .concat(),
+          )
+        } else {
+          target
+            .export
+            .and_then(|export| export.get(1..).map(|slice| slice.to_vec()))
+        },
+      }
+    }
+  }
+}
+
+pub fn get_target(
+  export_info: &ExportInfoData,
+  mg: &ModuleGraph,
+) -> Option<ResolvedExportInfoTarget> {
+  get_target_with_filter(export_info, mg, Rc::new(|_| true))
+}
+
+pub(crate) fn get_target_with_filter(
+  export_info: &ExportInfoData,
+  mg: &ModuleGraph,
+  resolve_filter: ResolveFilterFnTy,
+) -> Option<ResolvedExportInfoTarget> {
+  match get_target_from_export_info(export_info, mg, resolve_filter, &mut Default::default()) {
+    Some(ResolvedExportInfoTargetWithCircular::Circular) => None,
+    Some(ResolvedExportInfoTargetWithCircular::Target(target)) => Some(target),
+    None => None,
+  }
+}
+
+pub(crate) fn get_target_from_export_info(
+  export_info: &ExportInfoData,
+  mg: &ModuleGraph,
+  resolve_filter: ResolveFilterFnTy,
+  already_visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
+) -> Option<ResolvedExportInfoTargetWithCircular> {
+  let max_target = ExportInfoGetter::get_max_target(export_info);
+  let mut values = max_target
+    .values()
+    .map(|item| UnResolvedExportInfoTarget {
+      dependency: item.dependency,
+      export: item.export.clone(),
+    })
+    .collect::<VecDeque<_>>();
+  let target = resolve_target(
+    values.pop_front(),
+    already_visited,
+    resolve_filter.clone(),
+    mg,
+  );
+
+  match target {
+    Some(ResolvedExportInfoTargetWithCircular::Circular) => {
+      Some(ResolvedExportInfoTargetWithCircular::Circular)
+    }
+    None => None,
+    Some(ResolvedExportInfoTargetWithCircular::Target(target)) => {
+      for val in values {
+        let resolved_target =
+          resolve_target(Some(val), already_visited, resolve_filter.clone(), mg);
+        match resolved_target {
+          Some(ResolvedExportInfoTargetWithCircular::Circular) => {
+            return Some(ResolvedExportInfoTargetWithCircular::Circular);
+          }
+          Some(ResolvedExportInfoTargetWithCircular::Target(tt)) => {
+            if target.module != tt.module {
+              return None;
+            }
+            if target.export != tt.export {
+              return None;
+            }
+          }
+          None => return None,
+        }
+      }
+      Some(ResolvedExportInfoTargetWithCircular::Target(target))
+    }
+  }
+}
+
+pub(crate) fn get_target_from_maybe_export_info(
+  export_info: &MaybeDynamicTargetExportInfo,
+  mg: &ModuleGraph,
+  resolve_filter: ResolveFilterFnTy,
+  already_visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
+) -> Option<ResolvedExportInfoTargetWithCircular> {
+  let export_info = match export_info {
+    MaybeDynamicTargetExportInfo::Static(export_info) => export_info,
+    MaybeDynamicTargetExportInfo::Dynamic { data, .. } => data,
+  };
+
+  if !export_info.target_is_set() || export_info.target().is_empty() {
+    return None;
+  }
+  let hash_key = MaybeDynamicTargetExportInfoHashKey::ExportInfo(export_info.id());
+  if already_visited.contains(&hash_key) {
+    return Some(ResolvedExportInfoTargetWithCircular::Circular);
+  }
+  already_visited.insert(hash_key);
+  get_target_from_export_info(export_info, mg, resolve_filter, already_visited)
+}
+
+fn resolve_target(
+  input_target: Option<UnResolvedExportInfoTarget>,
+  already_visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
+  resolve_filter: ResolveFilterFnTy,
+  mg: &ModuleGraph,
+) -> Option<ResolvedExportInfoTargetWithCircular> {
+  if let Some(input_target) = input_target {
+    let mut target = ResolvedExportInfoTarget {
+      module: *input_target
+        .dependency
+        .and_then(|dep_id| mg.connection_by_dependency_id(&dep_id))
+        .expect("should have connection")
+        .module_identifier(),
+      export: input_target.export,
+      dependency: input_target.dependency.expect("should have dependency"),
+    };
+    if target.export.is_none() {
+      return Some(ResolvedExportInfoTargetWithCircular::Target(target));
+    }
+    if !resolve_filter(&target) {
+      return Some(ResolvedExportInfoTargetWithCircular::Target(target));
+    }
+    loop {
+      let name = if let Some(export) = target.export.as_ref().and_then(|exports| exports.first()) {
+        export
+      } else {
+        return Some(ResolvedExportInfoTargetWithCircular::Target(target));
+      };
+
+      let exports_info = mg.get_prefetched_exports_info(
+        &target.module,
+        PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([name])),
+      );
+      let maybe_export_info = exports_info.get_export_info_without_mut_module_graph(name);
+      let maybe_export_info_hash_key = maybe_export_info.as_hash_key();
+      if already_visited.contains(&maybe_export_info_hash_key) {
+        return Some(ResolvedExportInfoTargetWithCircular::Circular);
+      }
+      let new_target = get_target_from_maybe_export_info(
+        &maybe_export_info,
+        mg,
+        resolve_filter.clone(),
+        already_visited,
+      );
+
+      match new_target {
+        Some(ResolvedExportInfoTargetWithCircular::Circular) => {
+          return Some(ResolvedExportInfoTargetWithCircular::Circular);
+        }
+        None => return Some(ResolvedExportInfoTargetWithCircular::Target(target)),
+        Some(ResolvedExportInfoTargetWithCircular::Target(t)) => {
+          // SAFETY: if the target.exports is None, program will not reach here
+          let target_exports = target.export.as_ref().expect("should have exports");
+          if target_exports.len() == 1 {
+            target = t;
+            if target.export.is_none() {
+              return Some(ResolvedExportInfoTargetWithCircular::Target(target));
+            }
+          } else {
+            target.module = t.module;
+            target.dependency = t.dependency;
+            target.export = if let Some(mut exports) = t.export {
+              exports.extend_from_slice(&target_exports[1..]);
+              Some(exports)
+            } else {
+              Some(target_exports[1..].to_vec())
+            }
+          }
+        }
+      }
+      if !resolve_filter(&target) {
+        return Some(ResolvedExportInfoTargetWithCircular::Target(target));
+      }
+      already_visited.insert(maybe_export_info_hash_key);
+    }
+  } else {
+    None
+  }
+}

--- a/crates/rspack_core/src/exports/target.rs
+++ b/crates/rspack_core/src/exports/target.rs
@@ -4,9 +4,9 @@ use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  DependencyId, ExportInfo, ExportInfoData, ExportInfoGetter, ExportInfoTargetValue, ExportsInfo,
-  ExportsInfoGetter, MaybeDynamicTargetExportInfo, MaybeDynamicTargetExportInfoHashKey,
-  ModuleGraph, ModuleIdentifier, PrefetchExportsInfoMode,
+  DependencyId, ExportInfo, ExportInfoData, ExportInfoGetter, ExportsInfo, ExportsInfoGetter,
+  MaybeDynamicTargetExportInfo, MaybeDynamicTargetExportInfoHashKey, ModuleGraph, ModuleIdentifier,
+  PrefetchExportsInfoMode,
 };
 
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
@@ -69,23 +69,6 @@ pub fn get_terminal_binding(
   )
   .get_read_only_export_info_recursive(&export)
   .map(|data| TerminalBinding::ExportInfo(data.id()))
-}
-
-pub fn do_move_target(
-  export_info: &mut ExportInfoData,
-  dependency: DependencyId,
-  target_export: Option<Vec<Atom>>,
-) {
-  export_info.target_mut().clear();
-  export_info.target_mut().insert(
-    None,
-    ExportInfoTargetValue {
-      dependency: Some(dependency),
-      export: target_export,
-      priority: 0,
-    },
-  );
-  export_info.set_target_is_set(true);
 }
 
 pub(crate) fn find_target_from_export_info(

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -31,9 +31,9 @@ use crate::{
   AsyncDependenciesBlock, BindingCell, BoxDependency, BoxDependencyTemplate, BoxModuleDependency,
   ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, CompilationAsset, CompilationId,
   CompilerId, CompilerOptions, ConcatenationScope, ConnectionState, Context, ContextModule,
-  DependenciesBlock, DependencyId, ExportInfoGetter, ExportProvided, ExternalModule, ModuleGraph,
-  ModuleLayer, ModuleType, NormalModule, PrefetchExportsInfoMode, RawModule, Resolve,
-  ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver, SourceType,
+  DependenciesBlock, DependencyId, ExportProvided, ExternalModule, ModuleGraph, ModuleLayer,
+  ModuleType, NormalModule, PrefetchExportsInfoMode, RawModule, Resolve, ResolverFactory,
+  RuntimeSpec, SelfModule, SharedPluginDriver, SourceType,
 };
 
 pub struct BuildContext {
@@ -448,10 +448,7 @@ fn get_exports_type_impl(
           .as_ref()
           .map(|info| info.get_read_only_export_info(&name))
         {
-          if matches!(
-            ExportInfoGetter::provided(export_info),
-            Some(ExportProvided::NotProvided)
-          ) {
+          if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
             handle_default(default_object)
           } else {
             let Some(target) = export_info.get_target(mg) else {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -28,12 +28,12 @@ use serde::Serialize;
 
 use crate::{
   concatenated_module::ConcatenatedModule, dependencies_block::dependencies_block_update_hash,
-  AsyncDependenciesBlock, BindingCell, BoxDependency, BoxDependencyTemplate, BoxModuleDependency,
-  ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, CompilationAsset, CompilationId,
-  CompilerId, CompilerOptions, ConcatenationScope, ConnectionState, Context, ContextModule,
-  DependenciesBlock, DependencyId, ExportProvided, ExternalModule, ModuleGraph, ModuleLayer,
-  ModuleType, NormalModule, PrefetchExportsInfoMode, RawModule, Resolve, ResolverFactory,
-  RuntimeSpec, SelfModule, SharedPluginDriver, SourceType,
+  get_target, AsyncDependenciesBlock, BindingCell, BoxDependency, BoxDependencyTemplate,
+  BoxModuleDependency, ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, CompilationAsset,
+  CompilationId, CompilerId, CompilerOptions, ConcatenationScope, ConnectionState, Context,
+  ContextModule, DependenciesBlock, DependencyId, ExportProvided, ExternalModule, ModuleGraph,
+  ModuleLayer, ModuleType, NormalModule, PrefetchExportsInfoMode, RawModule, Resolve,
+  ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver, SourceType,
 };
 
 pub struct BuildContext {
@@ -451,7 +451,7 @@ fn get_exports_type_impl(
           if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
             handle_default(default_object)
           } else {
-            let Some(target) = export_info.get_target(mg) else {
+            let Some(target) = get_target(export_info, mg) else {
               return ExportsType::Dynamic;
             };
             if target

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -590,11 +590,11 @@ impl ParserAndGenerator for CssParserAndGenerator {
           return Ok(concate_source.boxed());
         } else {
           let mg = generate_context.compilation.get_module_graph();
+          let exports_info =
+            mg.get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
           let (ns_obj, left, right) = if self.es_module
             && ExportInfoGetter::get_used(
-              mg.get_exports_info(&module.identifier())
-                .other_exports_info(&mg)
-                .as_data(&mg),
+              exports_info.other_exports_info(),
               generate_context.runtime,
             ) != UsageState::Unused
           {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -354,7 +354,7 @@ impl Dependency for CommonJsExportRequireDependency {
         runtime,
         &mut referenced_exports,
         prefix,
-        Some(export_info.id()),
+        Some(export_info),
         false,
         &mut Default::default(),
       )

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -348,7 +348,6 @@ impl Dependency for CommonJsExportRequireDependency {
         } else {
           vec![]
         })
-        .map(|i| i.to_owned())
         .collect_vec();
       process_export_info(
         mg,
@@ -362,10 +361,10 @@ impl Dependency for CommonJsExportRequireDependency {
     }
 
     referenced_exports
-      .iter()
+      .into_iter()
       .map(|name| {
         ExtendedReferencedExport::Export(ReferencedExport {
-          name: name.to_owned(),
+          name: name.into_iter().map(|i| i.to_owned()).collect_vec(),
           can_mangle: false,
           can_inline: false,
         })

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -105,7 +105,7 @@ impl CommonJsExportRequireDependency {
     };
 
     let no_extra_exports = imported_exports_info.as_ref().is_some_and(|data| {
-      let provided = ExportInfoGetter::provided(data.other_exports_info());
+      let provided = data.other_exports_info().provided();
       matches!(provided, Some(ExportProvided::NotProvided))
     });
 
@@ -134,7 +134,7 @@ impl CommonJsExportRequireDependency {
         unreachable!();
       };
       for (_, export_info) in exports_info.exports() {
-        let name = ExportInfoGetter::name(export_info);
+        let name = export_info.name();
         if matches!(
           ExportInfoGetter::get_used(export_info, runtime),
           UsageState::Unused
@@ -147,7 +147,7 @@ impl CommonJsExportRequireDependency {
           } else if let Some(imported_exports_info) = &imported_exports_info {
             let imported_export_info = imported_exports_info.get_read_only_export_info(name);
             if matches!(
-              ExportInfoGetter::provided(imported_export_info),
+              imported_export_info.provided(),
               Some(ExportProvided::NotProvided)
             ) {
               continue;
@@ -163,10 +163,10 @@ impl CommonJsExportRequireDependency {
         unreachable!();
       };
       for (_, imported_export_info) in imported_exports_info.exports() {
-        let name = ExportInfoGetter::name(imported_export_info);
+        let name = imported_export_info.name();
         if let Some(name) = name {
           if matches!(
-            ExportInfoGetter::provided(imported_export_info),
+            imported_export_info.provided(),
             Some(ExportProvided::NotProvided)
           ) {
             continue;
@@ -326,7 +326,7 @@ impl Dependency for CommonJsExportRequireDependency {
         return get_full_result();
       }
 
-      match ExportInfoGetter::exports_info(export_info) {
+      match export_info.exports_info() {
         Some(v) => exports_info = exports_info.redirect(v, false),
         None => return get_full_result(),
       };
@@ -343,7 +343,7 @@ impl Dependency for CommonJsExportRequireDependency {
     for (_, export_info) in exports_info.exports() {
       let prefix = ids
         .iter()
-        .chain(if let Some(name) = ExportInfoGetter::name(export_info) {
+        .chain(if let Some(name) = export_info.name() {
           vec![name]
         } else {
           vec![]

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -4,13 +4,13 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  module_raw, process_export_info, property_access, to_normal_comment, AsContextDependency,
-  Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyTemplateType, DependencyType, ExportInfoGetter, ExportNameOrSpec,
-  ExportProvided, ExportSpec, ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, ExportsType,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleIdentifier, Nullable, PrefetchExportsInfoMode, ReferencedExport, RuntimeGlobals,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
+  collect_referenced_export_items, module_raw, property_access, to_normal_comment,
+  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportInfoGetter,
+  ExportNameOrSpec, ExportProvided, ExportSpec, ExportsInfoGetter, ExportsOfExportsSpec,
+  ExportsSpec, ExportsType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdentifier, Nullable, PrefetchExportsInfoMode, ReferencedExport,
+  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
 };
 use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
@@ -349,7 +349,7 @@ impl Dependency for CommonJsExportRequireDependency {
           vec![]
         })
         .collect_vec();
-      process_export_info(
+      collect_referenced_export_items(
         mg,
         runtime,
         &mut referenced_exports,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -79,7 +79,7 @@ impl CommonJsExportRequireDependency {
       };
       let nested = nested_exports_info
         .get_nested_exports_info(Some(ids))
-        .map(|data| data.id);
+        .map(|data| data.id());
 
       imported_exports_info =
         nested.map(|id| ExportsInfoGetter::prefetch(&id, mg, PrefetchExportsInfoMode::AllExports));
@@ -99,7 +99,7 @@ impl CommonJsExportRequireDependency {
       };
       let nested = nested_exports_info
         .get_nested_exports_info(Some(&self.names))
-        .map(|data| data.id);
+        .map(|data| data.id());
       exports_info =
         nested.map(|id| ExportsInfoGetter::prefetch(&id, mg, PrefetchExportsInfoMode::AllExports));
     };

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -6,9 +6,9 @@ use rspack_core::{
   module_id, property_access, to_normal_comment, AsContextDependency, Dependency,
   DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange,
   DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoGetter, ExportsType,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, SharedSourceMap, TemplateContext,
-  TemplateReplaceSource, UsedName,
+  ExtendedReferencedExport, FactorizeInfo, GetUsedNameParam, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, SharedSourceMap,
+  TemplateContext, TemplateReplaceSource, UsedName,
 };
 use swc_core::atoms::Atom;
 
@@ -172,18 +172,31 @@ impl DependencyTemplate for CommonJsFullRequireDependencyTemplate {
 
     let require_expr = if let Some(imported_module) =
       module_graph.module_graph_module_by_dependency_id(&dep.id)
-      && let used = ExportsInfoGetter::get_used_name(
-        &module_graph.get_prefetched_exports_info(
-          &imported_module.module_identifier,
-          if dep.names.is_empty() {
-            PrefetchExportsInfoMode::AllExports
-          } else {
-            PrefetchExportsInfoMode::NamedNestedExports(&dep.names)
-          },
-        ),
-        *runtime,
-        &dep.names,
-      )
+      && let used = {
+        if dep.names.is_empty() {
+          let exports_info = ExportsInfoGetter::prefetch_used_info_without_name(
+            &module_graph.get_exports_info(&imported_module.module_identifier),
+            &module_graph,
+            *runtime,
+            false,
+          );
+          ExportsInfoGetter::get_used_name(
+            GetUsedNameParam::WithoutNames(&exports_info),
+            *runtime,
+            &dep.names,
+          )
+        } else {
+          let exports_info = module_graph.get_prefetched_exports_info(
+            &imported_module.module_identifier,
+            PrefetchExportsInfoMode::NamedNestedExports(&dep.names),
+          );
+          ExportsInfoGetter::get_used_name(
+            GetUsedNameParam::WithNames(&exports_info),
+            *runtime,
+            &dep.names,
+          )
+        }
+      }
       && let Some(used) = used
     {
       let comment = to_normal_comment(&property_access(&dep.names, 0));

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -5,8 +5,8 @@ use rspack_core::{
   property_access, rspack_sources::ReplacementEnforce, AsContextDependency, AsModuleDependency,
   Dependency, DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange,
   DependencyTemplate, DependencyTemplateType, DependencyType, ESMExportInitFragment,
-  ExportNameOrSpec, ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
-  ModuleGraphCacheArtifact, PrefetchExportsInfoMode, RuntimeGlobals, SharedSourceMap,
+  ExportNameOrSpec, ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, GetUsedNameParam,
+  ModuleGraph, ModuleGraphCacheArtifact, PrefetchExportsInfoMode, RuntimeGlobals, SharedSourceMap,
   TemplateContext, TemplateReplaceSource, UsedName, DEFAULT_EXPORT,
 };
 use rustc_hash::FxHashSet;
@@ -180,10 +180,10 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
       if let Some(scope) = concatenation_scope {
         scope.register_export(JS_DEFAULT_KEYWORD.clone(), name.to_string());
       } else if let Some(used) = ExportsInfoGetter::get_used_name(
-        &mg.get_prefetched_exports_info(
+        GetUsedNameParam::WithNames(&mg.get_prefetched_exports_info(
           &module_identifier,
           PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&*JS_DEFAULT_KEYWORD])),
-        ),
+        )),
         *runtime,
         std::slice::from_ref(&JS_DEFAULT_KEYWORD),
       ) && let UsedName::Normal(used) = used
@@ -220,10 +220,10 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
           if supports_const { "const" } else { "var" }
         )
       } else if let Some(used) = ExportsInfoGetter::get_used_name(
-        &mg.get_prefetched_exports_info(
+        GetUsedNameParam::WithNames(&mg.get_prefetched_exports_info(
           &module_identifier,
           PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&*JS_DEFAULT_KEYWORD])),
-        ),
+        )),
         *runtime,
         std::slice::from_ref(&JS_DEFAULT_KEYWORD),
       ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -314,11 +314,10 @@ impl ESMExportImportedSpecifierDependency {
       .as_data(module_graph);
 
     let no_extra_exports = matches!(
-      ExportInfoGetter::provided(
-        imported_exports_info
-          .other_exports_info
-          .as_data(module_graph)
-      ),
+      imported_exports_info
+        .other_exports_info
+        .as_data(module_graph)
+        .provided(),
       Some(ExportProvided::NotProvided)
     );
     let no_extra_imports = matches!(
@@ -364,9 +363,7 @@ impl ESMExportImportedSpecifierDependency {
     if no_extra_imports {
       for export_info in exports_info.exports.values() {
         let export_info_data = export_info.as_data(module_graph);
-        let export_name = ExportInfoGetter::name(export_info_data)
-          .cloned()
-          .unwrap_or_default();
+        let export_name = export_info_data.name().cloned().unwrap_or_default();
         if ignored_exports.contains(&export_name)
           || matches!(
             ExportInfoGetter::get_used(export_info_data, runtime),
@@ -381,7 +378,7 @@ impl ESMExportImportedSpecifierDependency {
           .get_read_only_export_info(module_graph, &export_name);
         let imported_export_info_data = imported_export_info.as_data(module_graph);
         if matches!(
-          ExportInfoGetter::provided(imported_export_info_data),
+          imported_export_info_data.provided(),
           Some(ExportProvided::NotProvided)
         ) {
           continue;
@@ -398,7 +395,7 @@ impl ESMExportImportedSpecifierDependency {
 
         exports.insert(export_name.clone());
         if matches!(
-          ExportInfoGetter::provided(imported_export_info_data),
+          imported_export_info_data.provided(),
           Some(ExportProvided::Provided)
         ) {
           continue;
@@ -408,12 +405,13 @@ impl ESMExportImportedSpecifierDependency {
     } else if no_extra_exports {
       for imported_export_info in imported_exports_info.exports.values() {
         let imported_export_info_data = imported_export_info.as_data(module_graph);
-        let imported_export_info_name = ExportInfoGetter::name(imported_export_info_data)
+        let imported_export_info_name = imported_export_info_data
+          .name()
           .cloned()
           .unwrap_or_default();
         if ignored_exports.contains(&imported_export_info_name)
           || matches!(
-            ExportInfoGetter::provided(imported_export_info_data),
+            imported_export_info_data.provided(),
             Some(ExportProvided::NotProvided)
           )
         {
@@ -441,7 +439,7 @@ impl ESMExportImportedSpecifierDependency {
 
         exports.insert(imported_export_info_name.clone());
         if matches!(
-          ExportInfoGetter::provided(imported_export_info_data),
+          imported_export_info_data.provided(),
           Some(ExportProvided::Provided)
         ) {
           continue;
@@ -958,13 +956,10 @@ impl ESMExportImportedSpecifierDependency {
         IndexMap::default();
       for export_info in exports_info.as_data(module_graph).exports.values() {
         let export_info_data = export_info.as_data(module_graph);
-        if !matches!(
-          ExportInfoGetter::provided(export_info_data),
-          Some(ExportProvided::Provided)
-        ) {
+        if !matches!(export_info_data.provided(), Some(ExportProvided::Provided)) {
           continue;
         }
-        let Some(name) = ExportInfoGetter::name(export_info_data) else {
+        let Some(name) = export_info_data.name() else {
           continue;
         };
         if name == "default" {
@@ -1439,12 +1434,9 @@ fn determine_export_assignments(
       for export_info in exports_info.exports.values() {
         let export_info_data = export_info.as_data(module_graph);
         // SAFETY: This is safe because a real export can't export empty string
-        let export_info_name =
-          ExportInfoGetter::name(export_info_data).expect("export name is empty");
-        if matches!(
-          ExportInfoGetter::provided(export_info_data),
-          Some(ExportProvided::Provided)
-        ) && export_info_name != "default"
+        let export_info_name = export_info_data.name().expect("export name is empty");
+        if matches!(export_info_data.provided(), Some(ExportProvided::Provided))
+          && export_info_name != "default"
           && !names.contains(export_info_name)
         {
           names.insert(export_info_name.clone());

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -1309,7 +1309,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
           runtime,
           &mut referenced_exports,
           vec![],
-          Some(partial_namespace_export_info),
+          Some(partial_namespace_export_info.as_data(module_graph)),
           matches!(mode, ExportMode::ReexportFakeNamespaceObject(_)),
           &mut Default::default(),
         );
@@ -1329,7 +1329,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
             runtime,
             &mut referenced_exports,
             item.ids.iter().collect(),
-            Some(item.export_info),
+            Some(item.export_info.as_data(module_graph)),
             false,
             &mut Default::default(),
           );

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -1315,12 +1315,12 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         );
         referenced_exports
           .into_iter()
-          .map(ExtendedReferencedExport::Array)
+          .map(|i| ExtendedReferencedExport::Array(i.into_iter().map(|i| i.to_owned()).collect()))
           .collect::<Vec<_>>()
       }
       ExportMode::NormalReexport(mode) => {
         let mut referenced_exports = vec![];
-        for item in mode.items {
+        for item in &mode.items {
           if item.hidden {
             continue;
           }
@@ -1328,7 +1328,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
             module_graph,
             runtime,
             &mut referenced_exports,
-            item.ids,
+            item.ids.iter().collect(),
             Some(item.export_info),
             false,
             &mut Default::default(),
@@ -1336,7 +1336,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         }
         referenced_exports
           .into_iter()
-          .map(ExtendedReferencedExport::Array)
+          .map(|i| ExtendedReferencedExport::Array(i.into_iter().map(|i| i.to_owned()).collect()))
           .collect::<Vec<_>>()
       }
     }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -341,14 +341,14 @@ impl ESMExportImportedSpecifierDependency {
 
     let no_extra_exports = matches!(
       imported_exports_info
-        .other_exports_info
+        .other_exports_info()
         .as_data(module_graph)
         .provided(),
       Some(ExportProvided::NotProvided)
     );
     let no_extra_imports = matches!(
       ExportInfoGetter::get_used(
-        exports_info.other_exports_info.as_data(module_graph),
+        exports_info.other_exports_info().as_data(module_graph),
         runtime
       ),
       UsageState::Unused
@@ -400,7 +400,7 @@ impl ESMExportImportedSpecifierDependency {
         }
 
         let imported_export_info = imported_exports_info
-          .id
+          .id()
           .get_read_only_export_info(module_graph, &export_name);
         let imported_export_info_data = imported_export_info.as_data(module_graph);
         if matches!(
@@ -444,7 +444,7 @@ impl ESMExportImportedSpecifierDependency {
           continue;
         }
         let export_info = exports_info
-          .id
+          .id()
           .get_read_only_export_info(module_graph, &imported_export_info_name);
         let export_info_data = export_info.as_data(module_graph);
         if matches!(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -740,10 +740,10 @@ impl ESMExportImportedSpecifierDependency {
               runtime_condition,
             )));
           } else {
-            let exprots_info = mg.get_exports_info(imported_module);
+            let exports_info = mg.get_exports_info(imported_module);
             let used_name = if ids.is_empty() {
               let exports_info =
-                ExportsInfoGetter::prefetch_used_info_without_name(&exprots_info, mg, None, false);
+                ExportsInfoGetter::prefetch_used_info_without_name(&exports_info, mg, None, false);
               ExportsInfoGetter::get_used_name(
                 GetUsedNameParam::WithoutNames(&exports_info),
                 None,
@@ -751,7 +751,7 @@ impl ESMExportImportedSpecifierDependency {
               )
             } else {
               let exports_info = ExportsInfoGetter::prefetch(
-                &exprots_info,
+                &exports_info,
                 mg,
                 PrefetchExportsInfoMode::NamedNestedExports(&ids),
               );

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -387,7 +387,7 @@ impl ESMExportImportedSpecifierDependency {
     };
 
     if no_extra_imports {
-      for export_info in exports_info.exports.values() {
+      for export_info in exports_info.exports() {
         let export_info_data = export_info.as_data(module_graph);
         let export_name = export_info_data.name().cloned().unwrap_or_default();
         if ignored_exports.contains(&export_name)
@@ -429,7 +429,7 @@ impl ESMExportImportedSpecifierDependency {
         checked.insert(export_name);
       }
     } else if no_extra_exports {
-      for imported_export_info in imported_exports_info.exports.values() {
+      for imported_export_info in imported_exports_info.exports() {
         let imported_export_info_data = imported_export_info.as_data(module_graph);
         let imported_export_info_name = imported_export_info_data
           .name()
@@ -980,7 +980,7 @@ impl ESMExportImportedSpecifierDependency {
       let exports_info = module_graph.get_exports_info(&imported_module.identifier());
       let mut conflicts: IndexMap<&str, Vec<&Atom>, BuildHasherDefault<FxHasher>> =
         IndexMap::default();
-      for export_info in exports_info.as_data(module_graph).exports.values() {
+      for export_info in exports_info.as_data(module_graph).exports() {
         let export_info_data = export_info.as_data(module_graph);
         if !matches!(export_info_data.provided(), Some(ExportProvided::Provided)) {
           continue;
@@ -1458,7 +1458,7 @@ fn determine_export_assignments(
       let exports_info = module_graph
         .get_exports_info(module_identifier)
         .as_data(module_graph);
-      for export_info in exports_info.exports.values() {
+      for export_info in exports_info.exports() {
         let export_info_data = export_info.as_data(module_graph);
         // SAFETY: This is safe because a real export can't export empty string
         let export_info_name = export_info_data.name().expect("export name is empty");

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -7,9 +7,9 @@ use rspack_core::{
   AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyTemplateType, DependencyType, ESMExportInitFragment, EvaluatedInlinableValue,
-  ExportNameOrSpec, ExportSpec, ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
-  ModuleGraphCacheArtifact, PrefetchExportsInfoMode, SharedSourceMap, TemplateContext,
-  TemplateReplaceSource, UsedName,
+  ExportNameOrSpec, ExportSpec, ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec,
+  GetUsedNameParam, ModuleGraph, ModuleGraphCacheArtifact, PrefetchExportsInfoMode,
+  SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
 };
 use rustc_hash::FxHashSet;
 use swc_core::ecma::atoms::Atom;
@@ -156,8 +156,11 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
       &module.identifier(),
       PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&dep.name])),
     );
-    let used_name =
-      ExportsInfoGetter::get_used_name(&exports_info, *runtime, std::slice::from_ref(&dep.name));
+    let used_name = ExportsInfoGetter::get_used_name(
+      GetUsedNameParam::WithNames(&exports_info),
+      *runtime,
+      std::slice::from_ref(&dep.name),
+    );
     if let Some(used_name) = used_name {
       let used_name = match used_name {
         UsedName::Normal(vec) => {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -8,11 +8,11 @@ use rspack_core::{
   BuildMetaDefaultObject, ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ErrorSpan, ExportInfoGetter, ExportProvided, ExportsInfoGetter, ExportsType,
-  ExtendedReferencedExport, FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey,
-  InitFragmentStage, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  PrefetchExportsInfoMode, ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap,
-  TemplateContext, TemplateReplaceSource,
+  ErrorSpan, ExportProvided, ExportsInfoGetter, ExportsType, ExtendedReferencedExport,
+  FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, PrefetchExportsInfoMode,
+  ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap, TemplateContext,
+  TemplateReplaceSource,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -305,10 +305,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
         let id = &ids[pos];
         pos += 1;
         let export_info = exports_info.get_read_only_export_info(id);
-        if matches!(
-          ExportInfoGetter::provided(export_info),
-          Some(ExportProvided::NotProvided)
-        ) {
+        if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
           let provided_exports = ExportsInfoGetter::get_provided_exports(exports_info);
           let more_info = if let ProvidedExports::ProvidedNames(exports) = &provided_exports {
             if exports.is_empty() {
@@ -339,7 +336,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
           );
           return Some(create_error(msg));
         }
-        let Some(nested_exports_info) = ExportInfoGetter::exports_info(export_info) else {
+        let Some(nested_exports_info) = export_info.exports_info() else {
           maybe_exports_info = None;
           continue;
         };

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -8,10 +8,10 @@ use rspack_core::{
   to_normal_comment, AsContextDependency, ConnectionState, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyCondition, DependencyId, DependencyLocation, DependencyRange,
   DependencyTemplate, DependencyTemplateType, DependencyType, ExportPresenceMode,
-  ExportsInfoGetter, ExportsType, ExtendedReferencedExport, FactorizeInfo, ImportAttributes,
-  JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleReferenceOptions, PrefetchExportsInfoMode, ReferencedExport, RuntimeSpec, SharedSourceMap,
-  TemplateContext, TemplateReplaceSource, UsedByExports, UsedName,
+  ExportsInfoGetter, ExportsType, ExtendedReferencedExport, FactorizeInfo, GetUsedNameParam,
+  ImportAttributes, JavascriptParserOptions, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleReferenceOptions, PrefetchExportsInfoMode, ReferencedExport,
+  RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedByExports, UsedName,
 };
 use rspack_error::Diagnostic;
 use rustc_hash::FxHashSet as HashSet;
@@ -350,17 +350,31 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
         &compilation.module_graph_cache_artifact,
       )
       && {
-        let exports_info = module_graph.get_prefetched_exports_info(
-          con.module_identifier(),
-          if ids.is_empty() {
-            PrefetchExportsInfoMode::AllExports
-          } else {
-            PrefetchExportsInfoMode::NamedNestedExports(ids)
-          },
-        );
-        !ExportsInfoGetter::get_used_name(&exports_info, *runtime, ids)
-          .map(|used| used.is_inlined())
-          .unwrap_or_default()
+        let used_name = if ids.is_empty() {
+          let exports_info = ExportsInfoGetter::prefetch_used_info_without_name(
+            &module_graph.get_exports_info(con.module_identifier()),
+            &module_graph,
+            *runtime,
+            false,
+          );
+          ExportsInfoGetter::get_used_name(
+            GetUsedNameParam::WithoutNames(&exports_info),
+            *runtime,
+            ids,
+          )
+        } else {
+          let exports_info = module_graph.get_prefetched_exports_info(
+            con.module_identifier(),
+            PrefetchExportsInfoMode::NamedNestedExports(ids),
+          );
+          ExportsInfoGetter::get_used_name(
+            GetUsedNameParam::WithNames(&exports_info),
+            *runtime,
+            ids,
+          )
+        };
+
+        !used_name.map(|used| used.is_inlined()).unwrap_or_default()
       }
     {
       return;
@@ -449,14 +463,10 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
         let mut concated_ids = prefixed_ids.clone();
         concated_ids.push(prop.id.clone());
         let Some(new_name) = ExportsInfoGetter::get_used_name(
-          &module_graph.get_prefetched_exports_info(
+          GetUsedNameParam::WithNames(&module_graph.get_prefetched_exports_info(
             &module.identifier(),
-            if concated_ids.is_empty() {
-              PrefetchExportsInfoMode::AllExports
-            } else {
-              PrefetchExportsInfoMode::NamedNestedExports(&concated_ids)
-            },
-          ),
+            PrefetchExportsInfoMode::NamedNestedExports(&concated_ids),
+          )),
           code_generatable_context.runtime,
           &concated_ids,
         )

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -7,9 +7,10 @@ use rspack_core::{
   create_exports_object_referenced, module_raw, AsContextDependency, Compilation, Dependency,
   DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange,
   DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoGetter,
-  ExtendedReferencedExport, FactorizeInfo, InitFragmentKey, InitFragmentStage, ModuleDependency,
-  ModuleGraph, ModuleGraphCacheArtifact, NormalInitFragment, PrefetchExportsInfoMode, RuntimeSpec,
-  SharedSourceMap, TemplateContext, TemplateReplaceSource, UsedName,
+  ExtendedReferencedExport, FactorizeInfo, GetUsedNameParam, InitFragmentKey, InitFragmentStage,
+  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, NormalInitFragment,
+  PrefetchExportsInfoMode, RuntimeSpec, SharedSourceMap, TemplateContext, TemplateReplaceSource,
+  UsedName,
 };
 use rspack_util::ext::DynHash;
 use swc_core::atoms::Atom;
@@ -174,18 +175,31 @@ impl DependencyTemplate for ProvideDependencyTemplate {
       // not find connection, maybe because it's not resolved in make phase, and `bail` is false
       return;
     };
-    let used_name = ExportsInfoGetter::get_used_name(
-      &module_graph.get_prefetched_exports_info(
+
+    let used_name = if dep.ids.is_empty() {
+      let exports_info = ExportsInfoGetter::prefetch_used_info_without_name(
+        &module_graph.get_exports_info(con.module_identifier()),
+        &module_graph,
+        *runtime,
+        false,
+      );
+      ExportsInfoGetter::get_used_name(
+        GetUsedNameParam::WithoutNames(&exports_info),
+        *runtime,
+        &dep.ids,
+      )
+    } else {
+      let exports_info = module_graph.get_prefetched_exports_info(
         con.module_identifier(),
-        if dep.ids.is_empty() {
-          PrefetchExportsInfoMode::AllExports
-        } else {
-          PrefetchExportsInfoMode::NamedNestedExports(&dep.ids)
-        },
-      ),
-      *runtime,
-      &dep.ids,
-    );
+        PrefetchExportsInfoMode::NamedNestedExports(&dep.ids),
+      );
+      ExportsInfoGetter::get_used_name(
+        GetUsedNameParam::WithNames(&exports_info),
+        *runtime,
+        &dep.ids,
+      )
+    };
+
     init_fragments.push(Box::new(NormalInitFragment::new(
       format!(
         "/* provided dependency */ var {} = {}{};\n",

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -89,13 +89,13 @@ impl ExportInfoDependency {
         can_mangle.map(|v| v.to_string())
       }
       "inlinable" => {
-        let inlinable = ExportInfoGetter::inlinable(
-          if let Some(export_info) = exports_info.get_read_only_export_info_recursive(export_name) {
-            export_info
-          } else {
-            exports_info.other_exports_info()
-          },
-        );
+        let inlinable = if let Some(export_info) =
+          exports_info.get_read_only_export_info_recursive(export_name)
+        {
+          export_info.inlinable()
+        } else {
+          exports_info.other_exports_info().inlinable()
+        };
         Some(match inlinable {
           Inlinable::Inlined(inlined) => format!("inlined {}", inlined.render()),
           _ => "no inline".to_string(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use rspack_core::{
-  ConnectionState, DependencyCondition, DependencyConditionFn, DependencyId, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleGraphConnection, RuntimeSpec, UsageState, UsedByExports,
+  ConnectionState, DependencyCondition, DependencyConditionFn, DependencyId, ExportInfoGetter,
+  ExportsInfo, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, RuntimeSpec,
+  UsageState, UsedByExports,
 };
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet;
@@ -27,15 +28,43 @@ impl DependencyConditionFn for UsedByExportsDependencyCondition {
     let module_identifier = mg
       .get_parent_module(&self.dependency_id)
       .expect("should have parent module");
-    let exports_info = mg.get_exports_info(module_identifier);
-    for export_name in self.used_by_exports.iter() {
-      if exports_info.get_used(mg, std::slice::from_ref(export_name), runtime) != UsageState::Unused
-      {
-        return ConnectionState::Active(true);
-      }
-    }
-    ConnectionState::Active(false)
+    ConnectionState::Active(is_connection_active(
+      mg.get_exports_info(module_identifier),
+      &self.used_by_exports,
+      mg,
+      runtime,
+    ))
   }
+}
+
+fn is_connection_active(
+  exports_info: ExportsInfo,
+  used_by_exports: &FxHashSet<Atom>,
+  mg: &ModuleGraph,
+  runtime: Option<&RuntimeSpec>,
+) -> bool {
+  fn is_export_active(
+    name: &Atom,
+    exports_info: &ExportsInfo,
+    mg: &ModuleGraph,
+    runtime: Option<&RuntimeSpec>,
+  ) -> bool {
+    let exports_info = exports_info.as_data(mg);
+    if let Some(export_info) = exports_info.exports.get(name) {
+      let export_info = export_info.as_data(mg);
+      return ExportInfoGetter::get_used(export_info, runtime) != UsageState::Unused;
+    }
+    if let Some(redirect_to) = exports_info.redirect_to {
+      is_export_active(name, &redirect_to, mg, runtime)
+    } else {
+      ExportInfoGetter::get_used(exports_info.other_exports_info.as_data(mg), runtime)
+        != UsageState::Unused
+    }
+  }
+
+  used_by_exports
+    .iter()
+    .any(|name| is_export_active(name, &exports_info, mg, runtime))
 }
 
 // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/InnerGraph.js#L319-L338

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -50,7 +50,7 @@ fn is_connection_active(
     runtime: Option<&RuntimeSpec>,
   ) -> bool {
     let exports_info = exports_info.as_data(mg);
-    if let Some(export_info) = exports_info.exports.get(name) {
+    if let Some(export_info) = exports_info.named_exports(name) {
       let export_info = export_info.as_data(mg);
       return ExportInfoGetter::get_used(export_info, runtime) != UsageState::Unused;
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -54,10 +54,10 @@ fn is_connection_active(
       let export_info = export_info.as_data(mg);
       return ExportInfoGetter::get_used(export_info, runtime) != UsageState::Unused;
     }
-    if let Some(redirect_to) = exports_info.redirect_to {
+    if let Some(redirect_to) = exports_info.redirect_to() {
       is_export_active(name, &redirect_to, mg, runtime)
     } else {
-      ExportInfoGetter::get_used(exports_info.other_exports_info.as_data(mg), runtime)
+      ExportInfoGetter::get_used(exports_info.other_exports_info().as_data(mg), runtime)
         != UsageState::Unused
     }
   }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -3,6 +3,7 @@ use std::collections::hash_map::Entry;
 use indexmap::IndexMap;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
+  get_target,
   incremental::{self, IncrementalPasses},
   ApplyContext, BuildMetaExportsType, Compilation, CompilationFinishModules, CompilerOptions,
   DependenciesBlock, DependencyId, ExportInfoSetter, ExportNameOrSpec, ExportProvided, ExportsInfo,
@@ -310,7 +311,8 @@ impl<'a> FlagDependencyExportsState<'a> {
       }
 
       if let Some(exports) = exports {
-        let nested_exports_info = export_info.create_nested_exports_info(self.mg);
+        let nested_exports_info =
+          ExportInfoSetter::create_nested_exports_info(&export_info, self.mg);
         self.merge_exports(
           nested_exports_info,
           exports,
@@ -345,7 +347,7 @@ impl<'a> FlagDependencyExportsState<'a> {
 
       // Recalculate target exportsInfo
       let export_info_data = export_info.as_data(self.mg);
-      let target = export_info_data.get_target(self.mg);
+      let target = get_target(export_info_data, self.mg);
 
       let mut target_exports_info = None;
       if let Some(target) = target {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -53,7 +53,7 @@ impl<'a> FlagDependencyExportsState<'a> {
       let is_module_without_exports =
         module.build_meta().exports_type == BuildMetaExportsType::Unset;
       if is_module_without_exports {
-        let other_exports_info = exports_info.other_exports_info(self.mg);
+        let other_exports_info = exports_info.as_data(self.mg).other_exports_info;
         if !matches!(
           ExportInfoGetter::provided(other_exports_info.as_data(self.mg)),
           Some(ExportProvided::Unknown)

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -361,7 +361,7 @@ impl<'a> FlagDependencyExportsState<'a> {
         );
         target_exports_info = target_module_exports_info
           .get_nested_exports_info(target.export.as_deref())
-          .map(|data| data.id);
+          .map(|data| data.id());
         match self.dependencies.entry(target.module) {
           Entry::Occupied(mut occ) => {
             occ.get_mut().insert(self.current_module_id);

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -53,7 +53,7 @@ impl<'a> FlagDependencyExportsState<'a> {
       let is_module_without_exports =
         module.build_meta().exports_type == BuildMetaExportsType::Unset;
       if is_module_without_exports {
-        let other_exports_info = exports_info.as_data(self.mg).other_exports_info;
+        let other_exports_info = exports_info.as_data(self.mg).other_exports_info();
         if !matches!(
           other_exports_info.as_data(self.mg).provided(),
           Some(ExportProvided::Unknown)

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -5,10 +5,9 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   incremental::{self, IncrementalPasses},
   ApplyContext, BuildMetaExportsType, Compilation, CompilationFinishModules, CompilerOptions,
-  DependenciesBlock, DependencyId, ExportInfoGetter, ExportInfoSetter, ExportNameOrSpec,
-  ExportProvided, ExportsInfo, ExportsOfExportsSpec, ExportsSpec, Inlinable, Logger, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, Plugin, PluginContext,
-  PrefetchExportsInfoMode,
+  DependenciesBlock, DependencyId, ExportInfoSetter, ExportNameOrSpec, ExportProvided, ExportsInfo,
+  ExportsOfExportsSpec, ExportsSpec, Inlinable, Logger, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleGraphConnection, ModuleIdentifier, Plugin, PluginContext, PrefetchExportsInfoMode,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -55,7 +54,7 @@ impl<'a> FlagDependencyExportsState<'a> {
       if is_module_without_exports {
         let other_exports_info = exports_info.as_data(self.mg).other_exports_info;
         if !matches!(
-          ExportInfoGetter::provided(other_exports_info.as_data(self.mg)),
+          other_exports_info.as_data(self.mg).provided(),
           Some(ExportProvided::Unknown)
         ) {
           exports_info.set_has_provide_info(self.mg);
@@ -283,32 +282,30 @@ impl<'a> FlagDependencyExportsState<'a> {
       };
       let export_info = exports_info.get_export_info(self.mg, &name);
       let export_info_data = export_info.as_data_mut(self.mg);
-      if let Some(provided) = ExportInfoGetter::provided(export_info_data)
+      if let Some(provided) = export_info_data.provided()
         && matches!(
           provided,
           ExportProvided::NotProvided | ExportProvided::Unknown
         )
       {
-        ExportInfoSetter::set_provided(export_info_data, Some(ExportProvided::Provided));
+        export_info_data.set_provided(Some(ExportProvided::Provided));
         self.changed = true;
       }
 
-      if Some(false) != ExportInfoGetter::can_mangle_provide(export_info_data)
-        && can_mangle == Some(false)
-      {
-        ExportInfoSetter::set_can_mangle_provide(export_info_data, Some(false));
+      if Some(false) != export_info_data.can_mangle_provide() && can_mangle == Some(false) {
+        export_info_data.set_can_mangle_provide(Some(false));
         self.changed = true;
       }
 
       if let Some(inlined) = inlinable
-        && !ExportInfoGetter::inlinable(export_info_data).can_inline()
+        && !export_info_data.inlinable().can_inline()
       {
-        ExportInfoSetter::set_inlinable(export_info_data, Inlinable::Inlined(inlined));
+        export_info_data.set_inlinable(Inlinable::Inlined(inlined));
         self.changed = true;
       }
 
-      if terminal_binding && !ExportInfoGetter::terminal_binding(export_info_data) {
-        ExportInfoSetter::set_terminal_binding(export_info_data, true);
+      if terminal_binding && !export_info_data.terminal_binding() {
+        export_info_data.set_terminal_binding(true);
         self.changed = true;
       }
 
@@ -374,15 +371,16 @@ impl<'a> FlagDependencyExportsState<'a> {
       }
 
       let export_info_data = export_info.as_data_mut(self.mg);
-      if ExportInfoGetter::exports_info_owned(export_info_data) {
-        let changed = ExportInfoGetter::exports_info(export_info_data)
+      if export_info_data.exports_info_owned() {
+        let changed = export_info_data
+          .exports_info()
           .expect("should have exports_info when exports_info_owned is true")
           .set_redirect_name_to(self.mg, target_exports_info);
         if changed {
           self.changed = true;
         }
-      } else if ExportInfoGetter::exports_info(export_info_data) != target_exports_info {
-        ExportInfoSetter::set_exports_info(export_info_data, target_exports_info);
+      } else if export_info_data.exports_info() != target_exports_info {
+        export_info_data.set_exports_info(target_exports_info);
         self.changed = true;
       }
     }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -44,7 +44,6 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     }
     let mut q = Queue::new();
     let mg = &mut module_graph;
-    // debug_exports_info!(mg);
     for exports_info in self.exports_info_module_map.keys() {
       exports_info.set_has_use_info(mg);
     }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -5,8 +5,8 @@ use rspack_core::{
   get_entry_runtime, incremental::IncrementalPasses, is_exports_object_referenced,
   is_no_exports_referenced, AsyncDependenciesBlockIdentifier, BuildMetaExportsType, Compilation,
   CompilationOptimizeDependencies, ConnectionState, DependenciesBlock, DependencyId,
-  ExportInfoGetter, ExportInfoSetter, ExportsInfo, ExtendedReferencedExport, GroupOptions,
-  Inlinable, ModuleIdentifier, Plugin, ReferencedExport, RuntimeSpec, UsageState,
+  ExportInfoSetter, ExportsInfo, ExtendedReferencedExport, GroupOptions, Inlinable,
+  ModuleIdentifier, Plugin, ReferencedExport, RuntimeSpec, UsageState,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -332,20 +332,18 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
           for (i, used_export) in used_exports.into_iter().enumerate() {
             let export_info = current_exports_info.get_export_info(&mut module_graph, &used_export);
             if !can_mangle {
-              ExportInfoSetter::set_can_mangle_use(
-                export_info.as_data_mut(&mut module_graph),
-                Some(false),
-              );
+              export_info
+                .as_data_mut(&mut module_graph)
+                .set_can_mangle_use(Some(false));
             }
             if !can_inline {
-              ExportInfoSetter::set_inlinable(
-                export_info.as_data_mut(&mut module_graph),
-                Inlinable::NoByUse,
-              );
+              export_info
+                .as_data_mut(&mut module_graph)
+                .set_inlinable(Inlinable::NoByUse);
             }
             let last_one = i == len - 1;
             if !last_one {
-              let nested_info = ExportInfoGetter::exports_info(export_info.as_data(&module_graph));
+              let nested_info = export_info.as_data(&module_graph).exports_info();
               if let Some(nested_info) = nested_info {
                 let changed_flag = ExportInfoSetter::set_used_conditionally(
                   export_info.as_data_mut(&mut module_graph),

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -978,12 +978,12 @@ impl ModuleConcatenationPlugin {
       let module_graph = compilation.get_module_graph();
       let module_graph_cache = &compilation.module_graph_cache_artifact;
       let exports_info = module_graph.get_exports_info(current_root);
+      let exports_info_data = ExportsInfoGetter::prefetch(
+        &exports_info,
+        &module_graph,
+        PrefetchExportsInfoMode::AllExports,
+      );
       let filtered_runtime = filter_runtime(Some(&chunk_runtime), |r| {
-        let exports_info_data = ExportsInfoGetter::prefetch(
-          &exports_info,
-          &module_graph,
-          PrefetchExportsInfoMode::AllExports,
-        );
         ExportsInfoGetter::is_module_used(&exports_info_data, r)
       });
       let active_runtime = match filtered_runtime {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   concatenated_module::{
     is_esm_dep_like, ConcatenatedInnerModule, ConcatenatedModule, RootModuleContext,
   },
-  filter_runtime,
+  filter_runtime, get_target,
   incremental::IncrementalPasses,
   ApplyContext, Compilation, CompilationOptimizeChunkModules, CompilerOptions, ExportInfoGetter,
   ExportProvided, ExportsInfoGetter, ExtendedReferencedExport, LibIdentOptions, Logger, Module,
@@ -839,7 +839,7 @@ impl ModuleConcatenationPlugin {
           .iter()
           .filter(|export_info| {
             ExportInfoGetter::is_reexport(export_info)
-              && export_info.get_target(&module_graph).is_none()
+              && get_target(export_info, &module_graph).is_none()
           })
           .copied()
           .collect::<Vec<_>>();

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -847,7 +847,8 @@ impl ModuleConcatenationPlugin {
           let cur_bailout_reason = unknown_exports
             .into_iter()
             .map(|export_info| {
-              let name = ExportInfoGetter::name(export_info)
+              let name = export_info
+                .name()
                 .map(|name| name.to_string())
                 .unwrap_or("other exports".to_string());
               format!(
@@ -873,12 +874,7 @@ impl ModuleConcatenationPlugin {
         }
         let unknown_provided_exports = relevant_exports
           .iter()
-          .filter(|export_info| {
-            !matches!(
-              ExportInfoGetter::provided(export_info),
-              Some(ExportProvided::Provided)
-            )
-          })
+          .filter(|export_info| !matches!(export_info.provided(), Some(ExportProvided::Provided)))
           .copied()
           .collect::<Vec<_>>();
 
@@ -886,7 +882,8 @@ impl ModuleConcatenationPlugin {
           let cur_bailout_reason = unknown_provided_exports
             .into_iter()
             .map(|export_info| {
-              let name = ExportInfoGetter::name(export_info)
+              let name = export_info
+                .name()
                 .map(|name| name.to_string())
                 .unwrap_or("other exports".to_string());
               format!(

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -861,7 +861,7 @@ fn can_optimize_connection(
 
     let target = export_info.can_move_target(
       module_graph,
-      Rc::new(|target: &ResolvedExportInfoTarget, _| {
+      Rc::new(|target: &ResolvedExportInfoTarget| {
         side_effects_state_map[&target.module] == ConnectionState::Active(false)
       }),
     )?;
@@ -907,7 +907,7 @@ fn can_optimize_connection(
 
     let target = export_info.get_target_with_filter(
       module_graph,
-      Rc::new(|target: &ResolvedExportInfoTarget, _| {
+      Rc::new(|target: &ResolvedExportInfoTarget| {
         side_effects_state_map[&target.module] == ConnectionState::Active(false)
       }),
     )?;

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -3,6 +3,7 @@ use std::{fmt::Debug, rc::Rc, sync::LazyLock};
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
+  do_move_target,
   incremental::{self, IncrementalPasses, Mutation},
   BoxModule, Compilation, CompilationOptimizeDependencies, ConnectionState, DependencyExtraMeta,
   DependencyId, FactoryMeta, Logger, MaybeDynamicTargetExportInfo, ModuleFactoryCreateData,
@@ -835,7 +836,11 @@ fn do_optimize_connection(
     target_export,
   }) = need_move_target
   {
-    export_info.do_move_target(module_graph, dependency, target_export);
+    do_move_target(
+      export_info.as_data_mut(module_graph),
+      dependency,
+      target_export,
+    );
   }
   (dependency, target_module)
 }
@@ -905,7 +910,7 @@ fn can_optimize_connection(
     );
     let export_info = exports_info.get_export_info_without_mut_module_graph(&ids[0]);
 
-    let target = export_info.get_target_with_filter(
+    let target = export_info.get_target(
       module_graph,
       Rc::new(|target: &ResolvedExportInfoTarget| {
         side_effects_state_map[&target.module] == ConnectionState::Active(false)

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -3,14 +3,13 @@ use std::{fmt::Debug, rc::Rc, sync::LazyLock};
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  do_move_target,
   incremental::{self, IncrementalPasses, Mutation},
   BoxModule, Compilation, CompilationOptimizeDependencies, ConnectionState, DependencyExtraMeta,
-  DependencyId, FactoryMeta, Logger, MaybeDynamicTargetExportInfo, ModuleFactoryCreateData,
-  ModuleGraph, ModuleGraphConnection, ModuleIdentifier, NormalModuleCreateData,
-  NormalModuleFactoryModule, Plugin, PrefetchExportsInfoMode, ResolvedExportInfoTarget,
-  SideEffectsBailoutItemWithSpan, SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget,
-  SideEffectsOptimizeArtifact,
+  DependencyId, ExportInfoSetter, FactoryMeta, Logger, MaybeDynamicTargetExportInfo,
+  ModuleFactoryCreateData, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
+  NormalModuleCreateData, NormalModuleFactoryModule, Plugin, PrefetchExportsInfoMode,
+  ResolvedExportInfoTarget, SideEffectsBailoutItemWithSpan, SideEffectsDoOptimize,
+  SideEffectsDoOptimizeMoveTarget, SideEffectsOptimizeArtifact,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -836,7 +835,7 @@ fn do_optimize_connection(
     target_export,
   }) = need_move_target
   {
-    do_move_target(
+    ExportInfoSetter::do_move_target(
       export_info.as_data_mut(module_graph),
       dependency,
       target_export,

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -299,7 +299,7 @@ fn create_object_for_exports_info(
           continue;
         }
         let new_value = if used == UsageState::OnlyPropertiesUsed
-          && let Some(exports_info) = ExportInfoGetter::exports_info(export_info)
+          && let Some(exports_info) = export_info.exports_info()
         {
           // avoid clone
           let temp = std::mem::replace(value, JsonValue::Null);
@@ -337,7 +337,7 @@ fn create_object_for_exports_info(
           }
           max_used_index = max_used_index.max(i);
           if used == UsageState::OnlyPropertiesUsed
-            && let Some(exports_info) = ExportInfoGetter::exports_info(export_info)
+            && let Some(exports_info) = export_info.exports_info()
           {
             let exports_info =
               ExportsInfoGetter::prefetch(&exports_info, mg, PrefetchExportsInfoMode::AllExports);

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -8,10 +8,10 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier, ApplyContext, BoxModule, Chunk, ChunkUkey, CodeGenerationDataTopLevelDeclarations,
   Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules,
-  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportInfoGetter,
-  ExportInfoSetter, ExportProvided, Filename, LibraryExport, LibraryName, LibraryNonUmdObject,
-  LibraryOptions, ModuleIdentifier, PathData, Plugin, PluginContext, PrefetchExportsInfoMode,
-  RuntimeGlobals, SourceType, UsageState,
+  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportInfoSetter,
+  ExportProvided, Filename, LibraryExport, LibraryName, LibraryNonUmdObject, LibraryOptions,
+  ModuleIdentifier, PathData, Plugin, PluginContext, PrefetchExportsInfoMode, RuntimeGlobals,
+  SourceType, UsageState,
 };
 use rspack_error::{error, error_bail, Result, ToStringResultToRspackResultExt};
 use rspack_hash::RspackHash;
@@ -269,15 +269,10 @@ async fn render_startup(
       module_graph.get_prefetched_exports_info(module, PrefetchExportsInfoMode::AllExports);
     let mut provided = vec![];
     for (_, export_info) in exports_info.exports() {
-      if matches!(
-        ExportInfoGetter::provided(export_info),
-        Some(ExportProvided::NotProvided)
-      ) {
+      if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
         continue;
       }
-      let export_info_name = ExportInfoGetter::name(export_info)
-        .expect("should have name")
-        .to_string();
+      let export_info_name = export_info.name().expect("should have name").to_string();
       provided.push(export_info_name.clone());
       let name_access = property_access([export_info_name], 0);
       source.add(RawStringSource::from(format!(
@@ -477,7 +472,7 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
       let export_info = module_graph.get_export_info(module_identifier, &(export.as_str()).into());
       let info = export_info.as_data_mut(&mut module_graph);
       ExportInfoSetter::set_used(info, UsageState::Used, Some(&runtime));
-      ExportInfoSetter::set_can_mangle_use(info, Some(false));
+      info.set_can_mangle_use(Some(false));
     } else {
       let exports_info = module_graph.get_exports_info(&module_identifier);
       exports_info.set_used_in_unknown_way(&mut module_graph, Some(&runtime));

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -154,7 +154,7 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
       let export_info = module_graph.get_export_info(module_identifier, &(export.as_str()).into());
       let info = export_info.as_data_mut(&mut module_graph);
       ExportInfoSetter::set_used(info, UsageState::Used, Some(&runtime));
-      ExportInfoSetter::set_can_mangle_use(info, Some(false));
+      info.set_can_mangle_use(Some(false));
     } else {
       let exports_info = module_graph.get_exports_info(&module_identifier);
       if self.ns_object_used {

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -175,7 +175,7 @@ async fn render_startup(
     let exports_info =
       module_graph.get_prefetched_exports_info(module_id, PrefetchExportsInfoMode::AllExports);
     for (_, export_info) in exports_info.exports() {
-      let info_name = ExportInfoGetter::name(export_info).expect("should have name");
+      let info_name = export_info.name().expect("should have name");
       let used_name =
         ExportInfoGetter::get_used_name(export_info, Some(info_name), Some(chunk.runtime()))
           .expect("name can't be empty");

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   Compilation, CompilationOptimizeChunkModules, CompilationParams, CompilerCompilation,
   CompilerFinishMake, CompilerOptions, ConcatenatedModule, ConcatenatedModuleExportsDefinitions,
   DependenciesBlock, Dependency, DependencyId, ExportInfoGetter, LibraryOptions, ModuleGraph,
-  ModuleIdentifier, Plugin, PluginContext, RuntimeSpec, UsedNameItem,
+  ModuleIdentifier, Plugin, PluginContext, PrefetchExportsInfoMode, RuntimeSpec, UsedNameItem,
 };
 use rspack_error::{error_bail, Result};
 use rspack_hash::RspackHash;
@@ -172,16 +172,13 @@ async fn render_startup(
     .get::<CodeGenerationExportsFinalNames>()
     .map(|d: &CodeGenerationExportsFinalNames| d.inner())
   {
-    let exports_info = module_graph.get_exports_info(module_id);
-    for export_info in exports_info.ordered_exports(&module_graph) {
-      let info_name =
-        ExportInfoGetter::name(export_info.as_data(&module_graph)).expect("should have name");
-      let used_name = ExportInfoGetter::get_used_name(
-        export_info.as_data(&module_graph),
-        Some(info_name),
-        Some(chunk.runtime()),
-      )
-      .expect("name can't be empty");
+    let exports_info =
+      module_graph.get_prefetched_exports_info(module_id, PrefetchExportsInfoMode::AllExports);
+    for (_, export_info) in exports_info.exports() {
+      let info_name = ExportInfoGetter::name(export_info).expect("should have name");
+      let used_name =
+        ExportInfoGetter::get_used_name(export_info, Some(info_name), Some(chunk.runtime()))
+          .expect("name can't be empty");
 
       let used_name = match used_name {
         UsedNameItem::Inlined(inlined) => {

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -82,15 +82,12 @@ async fn render_startup(
     .expect("should have build meta");
   let exports_type = boxed_module.get_exports_type(&module_graph, boxed_module.build_info().strict);
   for (_, export_info) in exports_info.exports() {
-    if matches!(
-      ExportInfoGetter::provided(export_info),
-      Some(ExportProvided::NotProvided)
-    ) {
+    if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
       continue;
     };
 
     let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
-    let info_name = ExportInfoGetter::name(export_info).expect("should have name");
+    let info_name = export_info.name().expect("should have name");
     let used_name =
       ExportInfoGetter::get_used_name(export_info, Some(info_name), Some(chunk.runtime()))
         .expect("name can't be empty");

--- a/crates/rspack_plugin_merge_duplicate_chunks/Cargo.toml
+++ b/crates/rspack_plugin_merge_duplicate_chunks/Cargo.toml
@@ -8,6 +8,7 @@ version           = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rayon              = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_core        = { workspace = true }
 rspack_error       = { workspace = true }

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -172,19 +172,19 @@ fn is_equally_used(
   b: &RuntimeSpec,
 ) -> bool {
   let info = mg.get_exports_info_by_id(exports_info);
-  if let Some(redirect_to) = &info.redirect_to {
+  if let Some(redirect_to) = &info.redirect_to() {
     if is_equally_used(redirect_to, mg, a, b) {
       return false;
     }
   } else {
-    let other_exports_info = info.other_exports_info.as_data(mg);
+    let other_exports_info = info.other_exports_info().as_data(mg);
     if ExportInfoGetter::get_used(other_exports_info, Some(a))
       != ExportInfoGetter::get_used(other_exports_info, Some(b))
     {
       return false;
     }
   }
-  let side_effects_only_info = info.side_effects_only_info.as_data(mg);
+  let side_effects_only_info = info.side_effects_only_info().as_data(mg);
   if ExportInfoGetter::get_used(side_effects_only_info, Some(a))
     != ExportInfoGetter::get_used(side_effects_only_info, Some(b))
   {

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -190,7 +190,7 @@ fn is_equally_used(
   {
     return false;
   }
-  for export_info in info.exports.values() {
+  for export_info in info.exports() {
     let export_info_data = export_info.as_data(mg);
     if ExportInfoGetter::get_used(export_info_data, Some(a))
       != ExportInfoGetter::get_used(export_info_data, Some(b))

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -1,9 +1,10 @@
 #![feature(let_chains)]
 
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rspack_collections::UkeySet;
 use rspack_core::{
   incremental::Mutation, is_runtime_equal, ChunkUkey, Compilation, CompilationOptimizeChunks,
-  Plugin, PluginContext,
+  ExportInfoGetter, ExportsInfo, ModuleGraph, Plugin, PluginContext, RuntimeSpec,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -92,15 +93,21 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
         }
         if !is_runtime_equal(chunk.runtime(), other_chunk.runtime()) {
           let module_graph = compilation.get_module_graph();
-          for module in compilation
+          let is_all_equal = compilation
             .chunk_graph
-            .get_chunk_modules(&chunk_ukey, &compilation.get_module_graph())
-          {
-            let exports_info = module_graph.get_exports_info(&module.identifier());
-            if !exports_info.is_equally_used(&module_graph, chunk.runtime(), other_chunk.runtime())
-            {
-              continue 'outer;
-            }
+            .get_chunk_modules(&chunk_ukey, &module_graph)
+            .into_par_iter()
+            .all(|module| {
+              let exports_info = module_graph.get_exports_info(&module.identifier());
+              is_equally_used(
+                &exports_info,
+                &module_graph,
+                chunk.runtime(),
+                other_chunk.runtime(),
+              )
+            });
+          if !is_all_equal {
+            continue 'outer;
           }
         }
         if compilation.chunk_graph.can_chunks_be_integrated(
@@ -156,4 +163,40 @@ impl Plugin for MergeDuplicateChunksPlugin {
       .tap(optimize_chunks::new(self));
     Ok(())
   }
+}
+
+fn is_equally_used(
+  exports_info: &ExportsInfo,
+  mg: &ModuleGraph,
+  a: &RuntimeSpec,
+  b: &RuntimeSpec,
+) -> bool {
+  let info = mg.get_exports_info_by_id(exports_info);
+  if let Some(redirect_to) = &info.redirect_to {
+    if is_equally_used(redirect_to, mg, a, b) {
+      return false;
+    }
+  } else {
+    let other_exports_info = info.other_exports_info.as_data(mg);
+    if ExportInfoGetter::get_used(other_exports_info, Some(a))
+      != ExportInfoGetter::get_used(other_exports_info, Some(b))
+    {
+      return false;
+    }
+  }
+  let side_effects_only_info = info.side_effects_only_info.as_data(mg);
+  if ExportInfoGetter::get_used(side_effects_only_info, Some(a))
+    != ExportInfoGetter::get_used(side_effects_only_info, Some(b))
+  {
+    return false;
+  }
+  for export_info in info.exports.values() {
+    let export_info_data = export_info.as_data(mg);
+    if ExportInfoGetter::get_used(export_info_data, Some(a))
+      != ExportInfoGetter::get_used(export_info_data, Some(b))
+    {
+      return false;
+    }
+  }
+  true
 }

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -68,7 +68,8 @@ fn print_exports_info_to_source<F>(
 
   // print the exports
   for export_info in &printed_exports {
-    let export_name: String = ExportInfoGetter::name(export_info)
+    let export_name: String = export_info
+      .name()
       .map(|n| n.to_string())
       .unwrap_or("null".into());
     let provide_info = ExportInfoGetter::get_provided_info(export_info);
@@ -95,7 +96,7 @@ fn print_exports_info_to_source<F>(
 
     source.add(RawStringSource::from(to_comment_with_nl(&export_str)));
 
-    if let Some(exports_info) = &ExportInfoGetter::exports_info(export_info) {
+    if let Some(exports_info) = &export_info.exports_info() {
       let exports_info = ExportsInfoGetter::prefetch(
         exports_info,
         module_graph,
@@ -122,7 +123,7 @@ fn print_exports_info_to_source<F>(
     let target = other_exports_info.get_target(module_graph);
     if target.is_some()
       || !matches!(
-        ExportInfoGetter::provided(other_exports_info),
+        other_exports_info.provided(),
         Some(ExportProvided::NotProvided)
       )
       || ExportInfoGetter::get_used(other_exports_info, None) != UsageState::Unused

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 use rspack_cacheable::with::AsVecConverter;
 use rspack_collections::Identifiable;
 use rspack_core::{
+  get_target,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_comment_with_nl, ApplyContext, BoxModule, BuildMetaExportsType, ChunkGraph,
   ChunkInitFragments, ChunkUkey, Compilation, CompilationParams, CompilerCompilation,
@@ -76,7 +77,7 @@ fn print_exports_info_to_source<F>(
     let usage_info = ExportInfoGetter::get_used_info(export_info);
     let rename_info = ExportInfoGetter::get_rename_info(export_info);
 
-    let target_desc = match export_info.get_target(module_graph) {
+    let target_desc = match get_target(export_info, module_graph) {
       Some(resolve_target) => {
         let target_module = request_shortener(&resolve_target.module);
         match resolve_target.export {
@@ -120,7 +121,7 @@ fn print_exports_info_to_source<F>(
   }
 
   if show_other_exports {
-    let target = other_exports_info.get_target(module_graph);
+    let target = get_target(other_exports_info, module_graph);
     if target.is_some()
       || !matches!(
         other_exports_info.provided(),

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -8,8 +8,8 @@ use futures::future::join_all;
 use rayon::prelude::*;
 use rspack_collections::{DatabaseItem, IdentifierMap, UkeyMap, UkeySet};
 use rspack_core::{
-  Chunk, ChunkByUkey, ChunkGraph, ChunkUkey, Compilation, Module, ModuleGraph, ModuleIdentifier,
-  UsageKey,
+  Chunk, ChunkByUkey, ChunkGraph, ChunkUkey, Compilation, ExportsInfoGetter, Module, ModuleGraph,
+  ModuleIdentifier, PrefetchExportsInfoMode, UsageKey,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_util::fx_hash::FxDashMap;
@@ -99,11 +99,12 @@ impl Combinator {
     module_graph: &ModuleGraph,
     chunk_by_ukey: &ChunkByUkey,
   ) -> Vec<UkeySet<ChunkUkey>> {
-    let exports_info = module_graph.get_exports_info(module_identifier);
+    let exports_info = module_graph
+      .get_prefetched_exports_info(module_identifier, PrefetchExportsInfoMode::AllExports);
     let mut grouped_by_used_exports: FxHashMap<UsageKey, UkeySet<ChunkUkey>> = Default::default();
     for chunk_ukey in module_chunks {
       let chunk = chunk_by_ukey.expect_get(&chunk_ukey);
-      let usage_key = exports_info.get_usage_key(module_graph, Some(chunk.runtime()));
+      let usage_key = ExportsInfoGetter::get_usage_key(&exports_info, Some(chunk.runtime()));
 
       grouped_by_used_exports
         .entry(usage_key)

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -12,10 +12,10 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
   AssetInfo, BoxDependency, BuildMetaExportsType, ChunkGraph, Compilation,
   DependencyType::WasmImport,
-  ExportsInfoGetter, Filename, GenerateContext, Module, ModuleDependency, ModuleGraph, ModuleId,
-  ModuleIdentifier, NormalModule, ParseContext, ParseResult, ParserAndGenerator, PathData,
-  PrefetchExportsInfoMode, RuntimeGlobals, SourceType, StaticExportsDependency, StaticExportsSpec,
-  UsedName,
+  ExportsInfoGetter, Filename, GenerateContext, GetUsedNameParam, Module, ModuleDependency,
+  ModuleGraph, ModuleId, ModuleIdentifier, NormalModule, ParseContext, ParseResult,
+  ParserAndGenerator, PathData, PrefetchExportsInfoMode, RuntimeGlobals, SourceType,
+  StaticExportsDependency, StaticExportsSpec, UsedName,
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_util::{fx_hash::FxHashSet, itoa};
@@ -203,10 +203,10 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
               let dep_name = serde_json::to_string(dep.name()).expect("should be ok.");
               let name = Atom::from(dep.name());
               let Some(UsedName::Normal(used_name)) = ExportsInfoGetter::get_used_name(
-                &module_graph.get_prefetched_exports_info(
+                GetUsedNameParam::WithNames(&module_graph.get_prefetched_exports_info(
                   &mgm.module_identifier,
                   PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&name])),
-                ),
+                )),
                 *runtime,
                 &[dep.name().into()],
               ) else {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Introduce `PrefetchedExportsInfoUsed` to prevent fetching unnecessary named exports which caused the performance degression. Then modify the param of `get_used_name` to enum to support `PrefetchedExportsInfoUsed` for fast path when the names list is empty.
- Unify the way of accessing properties. Set all properties of `ExportsInfoData/ExportInfoData` to private and provide getter/setter to access them. 
- Move `get_target/find_target` related functions to `exports/target.rs`.
- Move referenced export related functions to `exports/referenced_export.rs`, and also rename `process_export_info` to `collect_referenced_export_items` to make the function name more informative

---
> Generate by AI

This pull request introduces multiple changes across several files to enhance the handling of export information and improve code efficiency. The updates include replacing direct field access with getter methods, introducing new enums for clarity, and optimizing hash computation. Below is a breakdown of the most important changes grouped by theme.

### Enhancements to Export Information Handling:
* Replaced direct field access in `ExportInfoData` with getter methods like `info.name()` and `info.global_used()` for better encapsulation and maintainability in `crates/rspack_core/src/exports/export_info_getter.rs`. [[1]](diffhunk://#diff-5e159b75f36463e320bf142ca44e9f4ba0752110a9c02b63781ffe0d180829b0L8-R30) [[2]](diffhunk://#diff-5e159b75f36463e320bf142ca44e9f4ba0752110a9c02b63781ffe0d180829b0L76-R60) [[3]](diffhunk://#diff-5e159b75f36463e320bf142ca44e9f4ba0752110a9c02b63781ffe0d180829b0L124-R91) [[4]](diffhunk://#diff-5e159b75f36463e320bf142ca44e9f4ba0752110a9c02b63781ffe0d180829b0L133-R106) [[5]](diffhunk://#diff-5e159b75f36463e320bf142ca44e9f4ba0752110a9c02b63781ffe0d180829b0L156-R131)
* Updated `get_used_name` and `get_used` methods to use the new getter methods, ensuring consistent access patterns. [[1]](diffhunk://#diff-5e159b75f36463e320bf142ca44e9f4ba0752110a9c02b63781ffe0d180829b0L76-R60) [[2]](diffhunk://#diff-5e159b75f36463e320bf142ca44e9f4ba0752110a9c02b63781ffe0d180829b0L156-R131)

### Code Simplification and Refactoring:
* Introduced `GetUsedNameParam::WithNames` for better parameter clarity in `ExportsInfoGetter::get_used_name` calls. [[1]](diffhunk://#diff-1f5053e8e2768e6587f3ffe961c067c78a013263f3abfa3d79458f34614e8a7cL2268-R2260) [[2]](diffhunk://#diff-1f5053e8e2768e6587f3ffe961c067c78a013263f3abfa3d79458f34614e8a7cL2368-R2362) [[3]](diffhunk://#diff-1f5053e8e2768e6587f3ffe961c067c78a013263f3abfa3d79458f34614e8a7cL2402-R2400)
* Replaced `FindTargetRetEnum` with `FindTargetResult` for more descriptive enum variants in `impl ConcatenatedModule`.

### Prefetching and Hash Optimization:
* Replaced `prefetch` calls with `prefetch_used_info_without_name` or `get_prefetched_exports_info` to improve export information retrieval and reduce unnecessary data fetching. [[1]](diffhunk://#diff-afc7eb392f948c7bf0d87296830f248a102deb867115dca8ad8a287c08147428L49-R55) [[2]](diffhunk://#diff-afc7eb392f948c7bf0d87296830f248a102deb867115dca8ad8a287c08147428L64-R71) [[3]](diffhunk://#diff-1f5053e8e2768e6587f3ffe961c067c78a013263f3abfa3d79458f34614e8a7cL1007-R1016) [[4]](diffhunk://#diff-1f5053e8e2768e6587f3ffe961c067c78a013263f3abfa3d79458f34614e8a7cL1216-R1221) [[5]](diffhunk://#diff-1f5053e8e2768e6587f3ffe961c067c78a013263f3abfa3d79458f34614e8a7cL1105-R1104)
* Optimized hash computation by batching module graph hash calculations into a single loop, reducing redundant operations. [[1]](diffhunk://#diff-a08e45dea9402b61c5f29e8ac8e7d747f0c08fe17be5f9b08592840bdf4c655cR301) [[2]](diffhunk://#diff-a08e45dea9402b61c5f29e8ac8e7d747f0c08fe17be5f9b08592840bdf4c655cL327-R336)

### Enum and API Updates:
* Updated `ExportInfoGetter` methods to utilize the new getter-based API for accessing export details, aligning with the encapsulation changes. [[1]](diffhunk://#diff-5e159b75f36463e320bf142ca44e9f4ba0752110a9c02b63781ffe0d180829b0L124-R91) [[2]](diffhunk://#diff-5e159b75f36463e320bf142ca44e9f4ba0752110a9c02b63781ffe0d180829b0L133-R106)
* Improved readability and maintainability by replacing old enums with more descriptive ones, such as `FindTargetResult`.

### Dependency and Import Adjustments:
* Adjusted imports across files to include new dependencies like `PrefetchExportsInfoMode` and `GetUsedNameParam`. [[1]](diffhunk://#diff-a08e45dea9402b61c5f29e8ac8e7d747f0c08fe17be5f9b08592840bdf4c655cL19-R20) [[2]](diffhunk://#diff-1f5053e8e2768e6587f3ffe961c067c78a013263f3abfa3d79458f34614e8a7cL52-R56) [[3]](diffhunk://#diff-26ce71468538ae66bcee391c32b2bcc82ac16f453fde4406e636e12b0544e2c5L10-R13)

These changes collectively improve the codebase's clarity, performance, and maintainability.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
