### PR TITLE
perf: reduce memory allocation in `esm_export_imported_specifier_dependency`

### DIFF
--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -168,7 +168,7 @@ pub enum ExportMode {
   ReexportFakeNamespaceObject(ExportModeFakeNamespaceObject),
   ReexportUndefined(ExportModeReexportUndefined),
   NormalReexport(ExportModeNormalReexport),
-  DynamicReexport(ExportModeDynamicReexport),
+  DynamicReexport(Box<ExportModeDynamicReexport>),
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -157,44 +157,68 @@ pub struct NormalReexportItem {
   pub export_info: ExportInfo,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum ExportModeType {
+#[derive(Debug, Clone)]
+pub enum ExportMode {
   Missing,
-  Unused,
-  EmptyStar,
-  ReexportDynamicDefault,
-  ReexportNamedDefault,
-  ReexportNamespaceObject,
-  ReexportFakeNamespaceObject,
-  ReexportUndefined,
-  NormalReexport,
-  DynamicReexport,
+  Unused(ExportModeUnused),
+  EmptyStar(ExportModeEmptyStar),
+  ReexportDynamicDefault(ExportModeReexportDynamicDefault),
+  ReexportNamedDefault(ExportModeReexportNamedDefault),
+  ReexportNamespaceObject(ExportModeReexportNamespaceObject),
+  ReexportFakeNamespaceObject(ExportModeFakeNamespaceObject),
+  ReexportUndefined(ExportModeReexportUndefined),
+  NormalReexport(ExportModeNormalReexport),
+  DynamicReexport(ExportModeDynamicReexport),
 }
 
 #[derive(Debug, Clone)]
-pub struct ExportMode {
-  /// corresponding to `type` field in webpack's `EpxortMode`
-  pub ty: ExportModeType,
-  pub items: Option<Vec<NormalReexportItem>>,
-  pub name: Option<Atom>,
-  pub fake_type: u8,
-  pub partial_namespace_export_info: Option<ExportInfo>,
-  pub ignored: Option<HashSet<Atom>>,
+pub struct ExportModeUnused {
+  pub name: Atom,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportModeEmptyStar {
   pub hidden: Option<HashSet<Atom>>,
 }
 
-impl ExportMode {
-  pub fn new(ty: ExportModeType) -> Self {
-    Self {
-      ty,
-      items: None,
-      name: None,
-      fake_type: 0,
-      partial_namespace_export_info: None,
-      ignored: None,
-      hidden: None,
-    }
-  }
+#[derive(Debug, Clone)]
+pub struct ExportModeReexportDynamicDefault {
+  pub name: Atom,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportModeReexportNamedDefault {
+  pub name: Atom,
+  pub partial_namespace_export_info: ExportInfo,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportModeReexportNamespaceObject {
+  pub name: Atom,
+  pub partial_namespace_export_info: ExportInfo,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportModeFakeNamespaceObject {
+  pub name: Atom,
+  pub fake_type: u8,
+  pub partial_namespace_export_info: ExportInfo,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportModeReexportUndefined {
+  pub name: Atom,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportModeNormalReexport {
+  pub items: Vec<NormalReexportItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportModeDynamicReexport {
+  pub ignored: HashSet<Atom>,
+  pub hidden: Option<HashSet<Atom>>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -37,7 +37,7 @@ pub use runtime_requirements_dependency::{
   RuntimeRequirementsDependency, RuntimeRequirementsDependencyTemplate,
 };
 pub use runtime_template::*;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
 pub use span::SpanExt;
 pub use static_exports_dependency::{StaticExportsDependency, StaticExportsSpec};
@@ -106,8 +106,8 @@ pub struct ExportsSpec {
   pub terminal_binding: Option<bool>,
   pub from: Option<ModuleGraphConnection>,
   pub dependencies: Option<Vec<ModuleIdentifier>>,
-  pub hide_export: Option<Vec<Atom>>,
-  pub exclude_exports: Option<Vec<Atom>>,
+  pub hide_export: Option<FxHashSet<Atom>>,
+  pub exclude_exports: Option<FxHashSet<Atom>>,
 }
 
 pub trait DependencyConditionFn: Sync + Send {

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -129,7 +129,7 @@ impl ExportsInfo {
     &self,
     mg: &mut ModuleGraph,
     can_mangle: bool,
-    exclude_exports: Option<Vec<Atom>>,
+    exclude_exports: &Option<Vec<Atom>>,
     target_key: Option<DependencyId>,
     target_module: Option<DependencyId>,
     priority: Option<u8>,

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -4,6 +4,7 @@ use either::Either;
 use rspack_cacheable::cacheable;
 use rspack_collections::{impl_item_ukey, Ukey, UkeySet};
 use rspack_util::atom::Atom;
+use rustc_hash::FxHashSet;
 use serde::Serialize;
 
 use super::{
@@ -129,7 +130,7 @@ impl ExportsInfo {
     &self,
     mg: &mut ModuleGraph,
     can_mangle: bool,
-    exclude_exports: &Option<Vec<Atom>>,
+    exclude_exports: &Option<FxHashSet<Atom>>,
     target_key: Option<DependencyId>,
     target_module: Option<DependencyId>,
     priority: Option<u8>,

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -130,7 +130,7 @@ impl ExportsInfo {
     &self,
     mg: &mut ModuleGraph,
     can_mangle: bool,
-    exclude_exports: &Option<FxHashSet<Atom>>,
+    exclude_exports: Option<&FxHashSet<Atom>>,
     target_key: Option<DependencyId>,
     target_module: Option<DependencyId>,
     priority: Option<u8>,
@@ -138,7 +138,7 @@ impl ExportsInfo {
     let mut changed = false;
 
     if let Some(exclude_exports) = &exclude_exports {
-      for name in exclude_exports {
+      for name in exclude_exports.iter() {
         self.get_export_info(mg, name);
       }
     }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -285,10 +285,10 @@ impl ESMExportImportedSpecifierDependency {
       }
       ExportMode::NormalReexport(ExportModeNormalReexport { items })
     } else {
-      ExportMode::DynamicReexport(ExportModeDynamicReexport {
+      ExportMode::DynamicReexport(Box::new(ExportModeDynamicReexport {
         ignored: ignored_exports,
         hidden,
-      })
+      }))
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -1068,9 +1068,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
       }
       ExportMode::EmptyStar(mode) => Some(ExportsSpec {
         exports: ExportsOfExportsSpec::Names(vec![]),
-        hide_export: mode
-          .hidden
-          .map(|hidden| hidden.into_iter().collect::<Vec<_>>()),
+        hide_export: mode.hidden,
         dependencies: Some(vec![*mg
           .module_identifier_by_dependency_id(self.id())
           .expect("should have module")]),
@@ -1175,16 +1173,13 @@ impl Dependency for ESMExportImportedSpecifierDependency {
           exports: ExportsOfExportsSpec::UnknownExports,
           from: from.cloned(),
           can_mangle: Some(false),
-          hide_export: mode
-            .hidden
-            .clone()
-            .map(|hidden| hidden.into_iter().collect::<Vec<_>>()),
+          hide_export: mode.hidden.clone(),
           exclude_exports: {
             let mut exclude_exports = mode.ignored;
             if let Some(hidden) = mode.hidden {
               exclude_exports.extend(hidden);
             }
-            Some(exclude_exports.into_iter().collect::<Vec<_>>())
+            Some(exclude_exports)
           },
           dependencies: Some(vec![*from.expect("should have module").module_identifier()]),
           ..Default::default()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -526,7 +526,7 @@ impl ESMExportImportedSpecifierDependency {
       }
       ExportMode::Unused(ExportModeUnused { name }) => fragments.push(
         NormalInitFragment::new(
-          to_normal_comment(&format!("unused ESM reexport {}", name)),
+          to_normal_comment(&format!("unused ESM reexport {name}")),
           InitFragmentStage::StageESMExports,
           1,
           InitFragmentKey::unique(),

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -59,7 +59,7 @@ impl<'a> FlagDependencyExportsState<'a> {
           Some(ExportProvided::Unknown)
         ) {
           exports_info.set_has_provide_info(self.mg);
-          exports_info.set_unknown_exports_provided(self.mg, false, None, None, None, None);
+          exports_info.set_unknown_exports_provided(self.mg, false, &None, None, None, None);
           continue;
         }
       }
@@ -74,11 +74,12 @@ impl<'a> FlagDependencyExportsState<'a> {
       q.enqueue(module_id);
     }
 
+    let mut exports_specs_from_dependencies: IndexMap<DependencyId, ExportsSpec> =
+      IndexMap::default();
     while let Some(module_id) = q.dequeue() {
       self.changed = false;
       self.current_module_id = module_id;
-      let mut exports_specs_from_dependencies: IndexMap<DependencyId, ExportsSpec> =
-        IndexMap::default();
+      exports_specs_from_dependencies.clear();
 
       self.mg_cache.freeze();
       self.process_dependencies_block(
@@ -89,8 +90,8 @@ impl<'a> FlagDependencyExportsState<'a> {
       self.mg_cache.unfreeze();
 
       let exports_info = self.mg.get_exports_info(&module_id);
-      for (dep_id, exports_spec) in exports_specs_from_dependencies.into_iter() {
-        self.process_exports_spec(dep_id, exports_spec, exports_info);
+      for (dep_id, exports_spec) in exports_specs_from_dependencies.iter() {
+        self.process_exports_spec(*dep_id, exports_spec, exports_info);
       }
       if self.changed {
         self.notify_dependencies(&mut q);
@@ -164,7 +165,7 @@ impl<'a> FlagDependencyExportsState<'a> {
   pub fn process_exports_spec(
     &mut self,
     dep_id: DependencyId,
-    export_desc: ExportsSpec,
+    export_desc: &ExportsSpec,
     exports_info: ExportsInfo,
   ) {
     let exports = &export_desc.exports;
@@ -173,7 +174,7 @@ impl<'a> FlagDependencyExportsState<'a> {
     let global_priority = &export_desc.priority;
     let global_terminal_binding = export_desc.terminal_binding.unwrap_or(false);
     let export_dependencies = &export_desc.dependencies;
-    if let Some(hide_export) = export_desc.hide_export {
+    if let Some(hide_export) = &export_desc.hide_export {
       for name in hide_export.iter() {
         ExportInfoSetter::unset_target(
           exports_info
@@ -188,7 +189,7 @@ impl<'a> FlagDependencyExportsState<'a> {
         if exports_info.set_unknown_exports_provided(
           self.mg,
           global_can_mangle.unwrap_or_default(),
-          export_desc.exclude_exports,
+          &export_desc.exclude_exports,
           global_from.map(|_| dep_id),
           global_from.map(|_| dep_id),
           *global_priority,

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -59,7 +59,7 @@ impl<'a> FlagDependencyExportsState<'a> {
           Some(ExportProvided::Unknown)
         ) {
           exports_info.set_has_provide_info(self.mg);
-          exports_info.set_unknown_exports_provided(self.mg, false, &None, None, None, None);
+          exports_info.set_unknown_exports_provided(self.mg, false, None, None, None, None);
           continue;
         }
       }
@@ -189,7 +189,7 @@ impl<'a> FlagDependencyExportsState<'a> {
         if exports_info.set_unknown_exports_provided(
           self.mg,
           global_can_mangle.unwrap_or_default(),
-          &export_desc.exclude_exports,
+          export_desc.exclude_exports.as_ref(),
           global_from.map(|_| dep_id),
           global_from.map(|_| dep_id),
           *global_priority,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Some performance improvements after https://github.com/web-infra-dev/rspack/pull/10584

1. Split `ExportsMode` to enum variants and box the `DynamicReexport` case since it's larger than other variants. Data size: 112 bytes -> 40 bytes. This change also eliminates unnecessary `Option::expect`.
2. Avoid unnecessary `Vec` to `HashSet` reallocation. The data structures I change from `Vec` to `HashSet` in this pr are actually `Set`s in webpack.
3. Use `map.clear` rather than reallocate a new map in the loop.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
