### PR TITLE
fix(schema): add `jsc.output.charset` of swc-loader

### DIFF
--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -405,7 +405,12 @@ const ZodSwcJscConfig = z.strictObject({
 	baseUrl: z.string().optional(),
 	paths: z.record(z.string(), z.string().array()).optional(),
 	minify: ZodSwcJsMinifyOptions.optional(),
-	preserveAllComments: z.boolean().optional()
+	preserveAllComments: z.boolean().optional(),
+	output: z
+		.strictObject({
+			charset: z.enum(["utf8", "ascii"]).optional()
+		})
+		.optional()
 }) satisfies z.ZodType<JscConfig>;
 
 const ZodSwcBaseModuleConfig = z.strictObject({


### PR DESCRIPTION
## Summary

Add Zod schema for the  `jsc.output.charset` option of `builtin:swc-loader`.

Ref: https://github.com/swc-project/swc/pull/10567

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
