### PR TITLE
Replace std::collections::HashMap with rustc_hash::FxHashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,7 @@ dependencies = [
  "rspack_macros",
  "rspack_resolver",
  "rspack_sources",
+ "rustc-hash 2.1.1",
  "serde_json",
  "smol_str",
  "swc_core",
@@ -4919,6 +4920,7 @@ dependencies = [
  "rspack_hook",
  "rspack_paths",
  "rspack_util",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sha2",
@@ -5052,6 +5054,7 @@ dependencies = [
  "rspack_hash",
  "rspack_hook",
  "rspack_util",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -5218,6 +5221,7 @@ dependencies = [
  "rspack_hook",
  "rspack_plugin_javascript",
  "rspack_util",
+ "rustc-hash 2.1.1",
  "swc_core",
  "tracing",
 ]
@@ -5293,6 +5297,7 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_util",
+ "rustc-hash 2.1.1",
  "tracing",
 ]
 
@@ -5513,6 +5518,7 @@ name = "rspack_tracing"
 version = "0.2.0"
 dependencies = [
  "rspack_tracing_perfetto",
+ "rustc-hash 2.1.1",
  "tracing-subscriber",
 ]
 

--- a/crates/node_binding/src/codegen_result.rs
+++ b/crates/node_binding/src/codegen_result.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use napi_derive::napi;
 use rspack_core::{get_runtime_key, CodeGenerationResult, CodeGenerationResults};
+use rustc_hash::FxHashMap as HashMap;
 
 #[napi(object)]
 #[derive(Debug)]

--- a/crates/node_binding/src/html.rs
+++ b/crates/node_binding/src/html.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use cow_utils::CowUtils;
 use napi::Either;
 use napi_derive::napi;
@@ -10,6 +8,7 @@ use rspack_plugin_html::{
   AfterEmitData, AfterTemplateExecutionData, AlterAssetTagGroupsData, AlterAssetTagsData,
   BeforeAssetTagGenerationData, BeforeEmitData,
 };
+use rustc_hash::FxHashMap as HashMap;
 
 #[napi(object)]
 pub struct JsHtmlPluginTag {

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -108,7 +108,7 @@ use rspack_macros::rspack_version;
 use rspack_tracing::{PerfettoTracer, StdoutTracer, TraceEvent, Tracer};
 pub use rstest::*;
 pub use runtime::*;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet as HashSet};
 pub use source::*;
 pub use stats::*;
 pub use swc::*;
@@ -287,8 +287,6 @@ impl JsCompiler {
     removed_files: Vec<String>,
     f: Function<'static>,
   ) -> Result<(), ErrorCode> {
-    use std::collections::HashSet;
-
     unsafe {
       self.run(reference, |compiler, guard| {
         callbackify(

--- a/crates/node_binding/src/options/raw_resolve.rs
+++ b/crates/node_binding/src/options/raw_resolve.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use napi::Either;
 use napi_derive::napi;
 use rspack_core::{
@@ -8,6 +6,7 @@ use rspack_core::{
 };
 use rspack_error::error;
 use rspack_regex::RspackRegex;
+use rustc_hash::FxHashMap as HashMap;
 
 pub type AliasValue = serde_json::Value;
 

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_css_extract.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_css_extract.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use napi_derive::napi;
 use rspack_plugin_extract_css::plugin::{CssExtractOptions, InsertType};
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::JsFilename;
 

--- a/crates/node_binding/src/raw_options/raw_builtins/raw_html.rs
+++ b/crates/node_binding/src/raw_options/raw_builtins/raw_html.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr};
+use std::str::FromStr;
 
 use napi::bindgen_prelude::{Either3, Promise};
 use napi_derive::napi;
@@ -10,6 +10,7 @@ use rspack_plugin_html::{
   },
   sri::HtmlSriHashFunction,
 };
+use rustc_hash::FxHashMap as HashMap;
 
 pub type RawHtmlScriptLoading = String;
 pub type RawHtmlInject = String;

--- a/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_size.rs
+++ b/crates/node_binding/src/raw_options/raw_split_chunks/raw_split_chunk_size.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use napi_derive::napi;
 use rspack_plugin_split_chunks::SplitChunkSizes;
+use rustc_hash::FxHashMap as HashMap;
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]

--- a/crates/node_binding/src/trace_event.rs
+++ b/crates/node_binding/src/trace_event.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use napi::bindgen_prelude::BigInt;
 use napi_derive::napi;
+use rustc_hash::FxHashMap as HashMap;
 
 #[napi(object)]
 #[derive(Debug)]

--- a/crates/rspack/src/builder/browserslist_target.rs
+++ b/crates/rspack/src/builder/browserslist_target.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 use super::target::TargetProperties;
 
 // Macro for defining HashMaps with less boilerplate
 macro_rules! hashmap {
     ($( $key: expr => $val: expr ),* $(,)?) => {{
-         let mut map = ::std::collections::HashMap::new();
+         let mut map = ::rustc_hash::FxHashMap::default();
          $( map.insert($key, $val); )*
          map
     }}

--- a/crates/rspack_cacheable/Cargo.toml
+++ b/crates/rspack_cacheable/Cargo.toml
@@ -22,6 +22,7 @@ rkyv            = { workspace = true }
 rspack_macros   = { workspace = true }
 rspack_resolver = { workspace = true }
 rspack_sources  = { workspace = true }
+rustc-hash      = { workspace = true }
 serde_json      = { workspace = true }
 smol_str        = { workspace = true }
 swc_core        = { workspace = true, features = ["ecma_ast"] }

--- a/crates/rspack_cacheable/src/dyn/validation.rs
+++ b/crates/rspack_cacheable/src/dyn/validation.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use rkyv::bytecheck::CheckBytes;
+use rustc_hash::FxHashMap as HashMap;
 
 use super::VTablePtr;
 use crate::{DeserializeError, Validator};

--- a/crates/rspack_cacheable/src/with/as_map.rs
+++ b/crates/rspack_cacheable/src/with/as_map.rs
@@ -133,10 +133,9 @@ where
 }
 
 // for HashMap
-impl<K, V, S> AsMapConverter for std::collections::HashMap<K, V, S>
+impl<K, V> AsMapConverter for rustc_hash::FxHashMap<K, V>
 where
   K: std::cmp::Eq + std::hash::Hash,
-  S: core::hash::BuildHasher + Default,
 {
   type Key = K;
   type Value = V;
@@ -149,7 +148,7 @@ where
   fn from(
     data: impl Iterator<Item = Result<(Self::Key, Self::Value), DeserializeError>>,
   ) -> Result<Self, DeserializeError> {
-    data.collect::<Result<std::collections::HashMap<K, V, S>, DeserializeError>>()
+    data.collect::<Result<rustc_hash::FxHashMap<K, V>, DeserializeError>>()
   }
 }
 

--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -433,8 +433,7 @@ impl CodeSplitter {
     compilation: &mut Compilation,
   ) -> Result<Vec<CreateChunkRoot>> {
     // determine runtime and chunkLoading
-    let mut entry_runtime: std::collections::HashMap<&str, RuntimeSpec, rustc_hash::FxBuildHasher> =
-      HashMap::default();
+    let mut entry_runtime: rustc_hash::FxHashMap<&str, RuntimeSpec> = HashMap::default();
     let mut diagnostics = vec![];
     for entry in compilation.entries.keys() {
       let mut visited = vec![];

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -4,7 +4,7 @@ use rspack_collections::{DatabaseItem, IdentifierMap};
 use rspack_error::Result;
 use rspack_hash::RspackHashDigest;
 use rspack_paths::ArcPath;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet, FxHashSet as HashSet};
 
 use crate::{
   chunk_graph_chunk::ChunkId,
@@ -21,8 +21,8 @@ impl Compiler {
   ))]
   pub async fn rebuild(
     &mut self,
-    changed_files: std::collections::HashSet<String>,
-    deleted_files: std::collections::HashSet<String>,
+    changed_files: HashSet<String>,
+    deleted_files: HashSet<String>,
   ) -> Result<()> {
     let records = CompilationRecords::record(&self.compilation);
 

--- a/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use itertools::Itertools;
 use rspack_collections::DatabaseItem;
 use rspack_core::{
@@ -8,6 +6,7 @@ use rspack_core::{
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::id_helpers::{assign_ascending_chunk_ids, compare_chunks_natural};
 
@@ -44,7 +43,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<
   let chunk_graph = &compilation.chunk_graph;
   let module_graph = &compilation.get_module_graph();
   let chunk_group_by_ukey = &compilation.chunk_group_by_ukey;
-  let mut occurs_in_initial_chunks_map = HashMap::new();
+  let mut occurs_in_initial_chunks_map = HashMap::default();
 
   for chunk in compilation.chunk_by_ukey.values() {
     let mut occurs = 0;

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -23,6 +23,7 @@ rspack_error      = { workspace = true }
 rspack_hook       = { workspace = true }
 rspack_paths      = { workspace = true }
 rspack_util       = { workspace = true }
+rustc-hash        = { workspace = true }
 serde             = { workspace = true, features = ["derive"] }
 serde_json        = { workspace = true }
 sha2              = { workspace = true }

--- a/crates/rspack_plugin_html/src/config.rs
+++ b/crates/rspack_plugin_html/src/config.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashMap, fmt, path::PathBuf, str::FromStr};
+use std::{fmt, path::PathBuf, str::FromStr};
 
 use futures::future::BoxFuture;
 use rspack_core::{Compilation, PublicPath};
 use rspack_error::Result;
+use rustc_hash::FxHashMap as HashMap;
 use serde::Serialize;
 use sugar_path::SugarPath;
 

--- a/crates/rspack_plugin_html/src/tag.rs
+++ b/crates/rspack_plugin_html/src/tag.rs
@@ -1,7 +1,7 @@
 use core::fmt;
-use std::collections::HashMap;
 
 use itertools::Itertools;
+use rustc_hash::FxHashMap as HashMap;
 use serde::{
   de::{MapAccess, Visitor},
   ser::SerializeMap,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
@@ -46,7 +46,7 @@ fn create_provide_dep(
   None
 }
 
-type ProvideValue = std::collections::HashMap<String, Vec<String>>;
+type ProvideValue = rustc_hash::FxHashMap<String, Vec<String>>;
 
 #[plugin]
 #[derive(Default, Debug, Clone)]

--- a/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
@@ -20,6 +20,7 @@ rspack_error = { workspace = true }
 rspack_hash  = { workspace = true }
 rspack_hook  = { workspace = true }
 rspack_util  = { workspace = true }
+rustc-hash   = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing", "ropey"]

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(let_chains)]
 
 use std::{
-  collections::HashSet,
   hash::Hash,
   sync::{Arc, LazyLock, RwLock},
 };
@@ -218,7 +217,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
               .map(|exclude| Features::from_bits_truncate(*exclude))
               .unwrap_or(Features::empty()),
           };
-          let mut unused_symbols = HashSet::from_iter(minimizer_options.unused_symbols.clone());
+          let mut unused_symbols = std::collections::HashSet::from_iter(minimizer_options.unused_symbols.clone());
           if self.options.remove_unused_local_idents
             && let Some(css_unused_idents) = original.info.css_unused_idents.take()
           {

--- a/crates/rspack_plugin_rstest/Cargo.toml
+++ b/crates/rspack_plugin_rstest/Cargo.toml
@@ -16,6 +16,7 @@ rspack_error             = { workspace = true }
 rspack_hook              = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
 rspack_util              = { workspace = true }
+rustc-hash               = { workspace = true }
 swc_core                 = { workspace = true }
 tracing                  = { workspace = true }
 

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -48,7 +48,7 @@ impl RstestPlugin {
   fn update_source(
     &self,
     old: BoxSource,
-    replace_map: &std::collections::HashMap<String, MockFlagPos>,
+    replace_map: &rustc_hash::FxHashMap<String, MockFlagPos>,
   ) -> BoxSource {
     let old_source = old.to_owned();
     let mut replace = ReplaceSource::new(old_source);
@@ -150,8 +150,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 
   let regex =
     regex::Regex::new(r"\/\* RSTEST:MOCK_(.*?):(.*?) \*\/").expect("should initialize `Regex`");
-  let mut pos_map: std::collections::HashMap<String, MockFlagPos> =
-    std::collections::HashMap::new();
+  let mut pos_map: rustc_hash::FxHashMap<String, MockFlagPos> = rustc_hash::FxHashMap::default();
 
   for file in files {
     let _res = compilation.update_asset(file.as_str(), |old, info| {

--- a/crates/rspack_plugin_size_limits/Cargo.toml
+++ b/crates/rspack_plugin_size_limits/Cargo.toml
@@ -14,6 +14,7 @@ rspack_core  = { workspace = true }
 rspack_error = { workspace = true }
 rspack_hook  = { workspace = true }
 rspack_util  = { workspace = true }
+rustc-hash   = { workspace = true }
 tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_size_limits/src/lib.rs
+++ b/crates/rspack_plugin_size_limits/src/lib.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use derive_more::Debug;
 use futures::future::BoxFuture;
 use rspack_core::{
@@ -9,6 +7,7 @@ use rspack_core::{
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::size::format_size;
+use rustc_hash::FxHashMap as HashMap;
 
 pub type AssetFilterFn = Box<dyn for<'a> Fn(&'a str) -> BoxFuture<'a, Result<bool>> + Sync + Send>;
 

--- a/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
+++ b/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
@@ -1,7 +1,5 @@
 // https://github.com/webpack/webpack/blob/main/lib/WarnCaseSensitiveModulesPlugin.js
 
-use std::collections::HashMap;
-
 use cow_utils::CowUtils;
 use rspack_collections::{Identifier, IdentifierSet};
 use rspack_core::{
@@ -10,7 +8,7 @@ use rspack_core::{
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::{FxBuildHasher, FxHashMap as HashMap, FxHashMap};
 
 #[plugin]
 #[derive(Debug, Default)]

--- a/crates/rspack_tracing/Cargo.toml
+++ b/crates/rspack_tracing/Cargo.toml
@@ -10,4 +10,5 @@ version           = "0.2.0"
 [features]
 [dependencies]
 rspack_tracing_perfetto = { workspace = true }
+rustc-hash              = { workspace = true }
 tracing-subscriber      = { workspace = true, features = ["env-filter", "json"] }

--- a/crates/rspack_tracing/src/perfetto.rs
+++ b/crates/rspack_tracing/src/perfetto.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Write};
+use std::io::Write;
 
 use rspack_tracing_perfetto::{
   idl,
@@ -10,6 +10,7 @@ use rspack_tracing_perfetto::{
   prost::Message,
   BytesMut, PerfettoLayer,
 };
+use rustc_hash::FxHashMap as HashMap;
 static JAVASCRIPT_ANALYSIS_TRACK: &str = "JavaScript Analysis";
 use crate::{tracer::Layered, Tracer};
 #[derive(Default)]

--- a/crates/rspack_tracing/src/tracer.rs
+++ b/crates/rspack_tracing/src/tracer.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use rustc_hash::FxHashMap as HashMap;
 use tracing_subscriber::{Layer, Registry};
 #[derive(Debug)]
 pub struct TraceEvent {


### PR DESCRIPTION
This is all automatic generated by copilot agent 
This commit replaces all usages of std::collections::HashMap with rustc_hash::FxHashMap throughout the rspack codebase for better performance.

FxHashMap provides significantly better performance for string keys and is already widely used in the Rust ecosystem for performance-critical applications like rustc itself.

Changes:
- Replace import statements: std::collections::HashMap -> rustc_hash::FxHashMap as HashMap
- Update type annotations to use FxHashMap
- Add rustc-hash dependency to crates that needed it
- Handle special cases where external APIs (like LightningCSS) still require std HashMap
- Update HashMap construction from ::new() to ::default() where needed

All tests pass and compilation succeeds with these changes.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
