### PR TITLE
chore: release 1.4.0-beta.1

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "binding.js",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-wasm32-wasi",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.wasi.cjs",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-x64-msvc",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-x64-msvc.node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "license": "MIT",
   "description": "The fast Rust-based web bundler with webpack-compatible API",
   "private": true,

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "description": "CLI for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/test-tools",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "license": "MIT",
   "description": "Test tools for rspack",
   "main": "dist/index.js",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "The fast Rust-based web bundler with webpack-compatible API",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Performance Improvements ⚡
* perf: introduce `ModuleGraphCache` and cache the result of `get_mode` and `determine_export_assignments` by @CPunisher in https://github.com/web-infra-dev/rspack/pull/10584
* perf: when removed files we donot need rebuild the original module by @SyMind in https://github.com/web-infra-dev/rspack/pull/10648
* perf: reduce memory allocation in `esm_export_imported_specifier_dependency` by @CPunisher in https://github.com/web-infra-dev/rspack/pull/10657
* perf: create zod schema on demand by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10669
### New Features 🎉
* feat: add swc transformSync and minifySync api by @GiveMe-A-Name in https://github.com/web-infra-dev/rspack/pull/10640
* feat: inline const for leaf modules by @ahabhgk in https://github.com/web-infra-dev/rspack/pull/10451
### Bug Fixes 🐞
* fix: change bailout_reason to array in rsdoctor native plugin by @easy1090 in https://github.com/web-infra-dev/rspack/pull/10653
* fix(schema): add `jsc.output.charset` of swc-loader by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10668
### Refactor 🔨
* refactor: make merge modified files and removed files by @jerrykingxyz in https://github.com/web-infra-dev/rspack/pull/10662
### Other Changes
* chore: release v1.4.0-beta.0 by @h-a-n-a in https://github.com/web-infra-dev/rspack/pull/10647
* chore(wasm): cleanup useless `start/shutdownAsyncRuntime` and exports by @CPunisher in https://github.com/web-infra-dev/rspack/pull/10659
* chore(workflow): update changelog generator to include refactor label by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10656
* chore: update team members by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10667
* chore(deps): update dependency core-js to v3.43.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10665
* chore(deps): update dependency tsx to ^4.20.3 by @renovate in https://github.com/web-infra-dev/rspack/pull/10666
* chore: bump swc to 27.0.4 by @GiveMe-A-Name in https://github.com/web-infra-dev/rspack/pull/10660
* chore(deps): update dependency path-serializer to v0.5.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10671
* chore(deps): update dependency terser to v5.42.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10672
* chore(deps): update dependency zod-validation-error to v3.5.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10673
* chore(deps): update dependency @playwright/test to v1.53.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10196
* chore(wasm): publish wasi binding 2 by @CPunisher in https://github.com/web-infra-dev/rspack/pull/10645
* chore(ci): use windows self hosted by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10579
* refactor!: lazy compilation middleware supports multiCompiler and use config from compiler instance by @JSerFeng in https://github.com/web-infra-dev/rspack/pull/9828


**Full Changelog**: https://github.com/web-infra-dev/rspack/compare/v1.4.0-beta.0...v1.4.0-beta.1