### PR TITLE
fix: generator data url function panic

### DIFF
--- a/crates/node_binding/src/raw_options/raw_module/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_module/mod.rs
@@ -653,6 +653,7 @@ impl From<AssetGeneratorDataUrlFnCtx<'_>> for RawAssetGeneratorDataUrlFnCtx {
     // AssetGeneratorDataUrlFn may be called during the importModule process,
     // at which point the corresponding Module is not present in compilation.moduleGraph.
     // Therefore, we use a raw pointer to allow JavaScript to access the Module.
+    #[allow(clippy::unwrap_used)]
     Self {
       filename: value.filename,
       module: ModuleObject::with_ptr(

--- a/crates/node_binding/src/raw_options/raw_module/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_module/mod.rs
@@ -650,7 +650,8 @@ pub struct RawAssetGeneratorDataUrlFnCtx {
 
 impl From<AssetGeneratorDataUrlFnCtx<'_>> for RawAssetGeneratorDataUrlFnCtx {
   fn from(value: AssetGeneratorDataUrlFnCtx) -> Self {
-    // AssetGeneratorDataUrlFn is called during the make phase, at which point the module cannot be accessed from the moduleGraph.
+    // AssetGeneratorDataUrlFn may be called during the importModule process,
+    // at which point the corresponding Module is not present in compilation.moduleGraph.
     // Therefore, we use a raw pointer to allow JavaScript to access the Module.
     Self {
       filename: value.filename,

--- a/packages/rspack-test-tools/tests/configCases/asset/custom-encoder/index.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/custom-encoder/index.js
@@ -1,0 +1,1 @@
+import "./style.css";

--- a/packages/rspack-test-tools/tests/configCases/asset/custom-encoder/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/custom-encoder/rspack.config.js
@@ -1,0 +1,32 @@
+const rspack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+    mode: "development",
+    plugins: [
+        new rspack.CssExtractRspackPlugin(),
+    ],
+    module: {
+        rules: [
+            {
+                test: /\.png$/,
+                type: "asset/inline",
+                generator: {
+                    dataUrl() {
+                        return "data:image/png;base64,custom-content";
+                    }
+                }
+            },
+            {
+                test: /\.css/,
+                use: [
+                    rspack.CssExtractRspackPlugin.loader,
+                    'css-loader',
+                ],
+            },
+        ]
+    },
+    experiments: {
+        css: false,
+    }
+};

--- a/packages/rspack-test-tools/tests/configCases/asset/custom-encoder/style.css
+++ b/packages/rspack-test-tools/tests/configCases/asset/custom-encoder/style.css
@@ -1,0 +1,3 @@
+.text {
+    background-image: url('../_images/file.png');
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

AssetGeneratorDataUrlFn may be called during the importModule process, at which point the corresponding Module is not present in compilation.moduleGraph.

Therefore, we use a raw pointer to allow JavaScript to access the Module.

Close #10543

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
