### PR TITLE
perf(logger): calculate trace only when needed

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -787,22 +787,26 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 						);
 					}
 				}
-				let trace: string[] | undefined;
-				switch (type) {
-					case LogType.warn:
-					case LogType.error:
-					case LogType.trace:
-						trace = cutOffLoaderExecution(new Error("Trace").stack!)
-							.split("\n")
-							.slice(3);
-						break;
-				}
+
 				const logEntry: LogEntry = {
 					time: Date.now(),
 					type,
 					args,
-					trace
+					get trace() {
+						let trace: string[] | undefined;
+						switch (type) {
+							case LogType.warn:
+							case LogType.error:
+							case LogType.trace:
+								trace = cutOffLoaderExecution(new Error("Trace").stack!)
+									.split("\n")
+									.slice(3);
+								break;
+						}
+						return trace;
+					}
 				};
+
 				if (this.hooks.log.call(logName, logEntry) === undefined) {
 					if (logEntry.type === LogType.profileEnd) {
 						if (typeof console.profileEnd === "function") {


### PR DESCRIPTION
## Summary

In large projects, loaders such as sass-loader or less-loader may emit a lot of warnings. In this case, Rspack will incur significant performance overhead in order to calculate the Error trace.

In an internal project, Less 4.3.0 emits 350,000 warnings. This PR changes the calculation of traces to on-demand, which can reduce the build time of the project from 40s+ to 20s.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
