### PR TITLE
feat(CI): upload perf data by commit when PR merged

### DIFF
--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -118,6 +118,16 @@ jobs:
           echo "$result"
           echo "diff-result=${result//$'\n'/'@@'}" >> $GITHUB_OUTPUT
 
+      - name: Upload benchmark result
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        id: upload-benchmark-data
+        run: |
+          RSPACK_DIR=$(pwd)
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          cd rspack-ecosystem-benchmark
+          RSPACK_DIR="$RSPACK_DIR" GITHUB_ACTOR=x-access-token node bin/upload.js ${{ secrets.PERF_DATA_TOKEN }} ${{ github.sha }}
+
   comment-compare-results:
     runs-on: ubuntu-latest
     needs: [create-comment, bench]


### PR DESCRIPTION
## Summary
After PR merged and benchmark executed, its perf data will upload to 
https://github.com/web-infra-dev/rspack-ecosystem-benchmark/tree/data/commits 
for analysizing which commit introduced problem or improved 

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
