### PR TITLE
fix: make color-backtrace optional for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,9 +209,9 @@ rate-limit = { existing-packages = 70, new-packages = 70 }
 # This is for local development
 [profile.dev]
 codegen-units = 16
-debug         = 2       # debug build will cause runtime panic if codegen-unints is default
+debug         = 2        # debug build will cause runtime panic if codegen-unints is default
 incremental   = true
-panic         = "abort"
+panic         = "unwind" # only enable unwind for dev profile to help debugging panic cause it generate bigger size for release profile
 
 [profile.release-debug]
 codegen-units = 16
@@ -230,8 +230,8 @@ panic     = "abort"
 strip     = true
 
 [profile.codspeed]
-inherits = "release"
 debug    = "full"
+inherits = "release"
 strip    = "none"
 lto      = "off"
 

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -44,7 +44,7 @@ tracing-subscriber = { workspace = true }
 napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi7", "compat-mode"] }
 napi-derive = { workspace = true, features = ["compat-mode"] }
 
-color-backtrace = "0.7.0"
+color-backtrace = { version = "0.7.0", optional = true }
 
 derive_more                            = { workspace = true, features = ["debug"] }
 futures                                = { workspace = true }

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -64,6 +64,9 @@ async function build() {
 			features.push("sftrace-setup");
 			envs.RUSTFLAGS = "-Zinstrument-xray=always";
 		}
+		if (values.profile === "dev" || !values.profile) {
+			features.push("color-backtrace");
+		}
 		if (features.length) {
 			args.push("--features " + features.join(","));
 		}

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -437,7 +437,7 @@ fn init() {
       sftrace_setup::setup();
     }
   }
-
+  #[cfg(feature = "color-backtrace")]
   panic::install_panic_handler();
   // control the number of blocking threads, similar as https://github.com/tokio-rs/tokio/blob/946401c345d672d357693740bc51f77bc678c5c4/tokio/src/loom/std/mod.rs#L93
   const ENV_BLOCKING_THREADS: &str = "RSPACK_BLOCKING_THREADS";

--- a/crates/node_binding/src/panic.rs
+++ b/crates/node_binding/src/panic.rs
@@ -1,6 +1,6 @@
-use color_backtrace::{default_output_stream, BacktracePrinter};
-
+#[cfg(feature = "color-backtrace")]
 pub fn install_panic_handler() {
+  use color_backtrace::{default_output_stream, BacktracePrinter};
   let panic_handler = BacktracePrinter::default()
     .message("Panic occurred at runtime. Please file an issue on GitHub with the backtrace below: https://github.com/web-infra-dev/rspack/issues")
     .add_frame_filter(Box::new(|frames| {


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
since we use abort `panic=abort` in release and it will not generate meaningful backtrace, so color-backtrace seems meanless and can be removed for release profile to reduce binary size.
we can also enable `panic = unwind` for dev profile to help debugging panic problem in development environment

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
