### PR TITLE
feat: type reexports presence tolerant

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -2103,6 +2103,11 @@ export interface RawJavascriptParserOptions {
    * @experimental
    */
   inlineConst?: boolean
+  /**
+   * This option is experimental in Rspack only and subject to change or be removed anytime.
+   * @experimental
+   */
+  typeReexportsPresence?: string
 }
 
 export interface RawJsonGeneratorOptions {

--- a/crates/node_binding/src/raw_options/raw_experiments/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_experiments/mod.rs
@@ -44,7 +44,6 @@ impl From<RawExperiments> for Experiments {
       top_level_await: value.top_level_await,
       rspack_future: value.rspack_future.unwrap_or_default().into(),
       cache: normalize_raw_experiment_cache_options(value.cache),
-      inline_const: value.inline_const,
     }
   }
 }

--- a/crates/node_binding/src/raw_options/raw_module/mod.rs
+++ b/crates/node_binding/src/raw_options/raw_module/mod.rs
@@ -16,7 +16,7 @@ use rspack_core::{
   JavascriptParserOptions, JavascriptParserOrder, JavascriptParserUrl, JsonGeneratorOptions,
   JsonParserOptions, ModuleNoParseRule, ModuleNoParseRules, ModuleNoParseTestFn, ModuleOptions,
   ModuleRule, ModuleRuleEffect, ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader,
-  OverrideStrict, ParseOption, ParserOptions, ParserOptionsMap,
+  OverrideStrict, ParseOption, ParserOptions, ParserOptionsMap, TypeReexportPresenceMode,
 };
 use rspack_error::error;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
@@ -292,6 +292,9 @@ pub struct RawJavascriptParserOptions {
   /// This option is experimental in Rspack only and subject to change or be removed anytime.
   /// @experimental
   pub inline_const: Option<bool>,
+  /// This option is experimental in Rspack only and subject to change or be removed anytime.
+  /// @experimental
+  pub type_reexports_presence: Option<String>,
 }
 
 impl From<RawJavascriptParserOptions> for JavascriptParserOptions {
@@ -323,6 +326,9 @@ impl From<RawJavascriptParserOptions> for JavascriptParserOptions {
         .reexport_exports_presence
         .map(|e| ExportPresenceMode::from(e.as_str())),
       strict_export_presence: value.strict_export_presence,
+      type_reexports_presence: value
+        .type_reexports_presence
+        .map(|e| TypeReexportPresenceMode::from(e.as_str())),
       worker: value.worker,
       override_strict: value
         .override_strict

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -3668,8 +3668,6 @@ pub struct ExperimentsBuilder {
   parallel_code_splitting: Option<bool>,
   /// Whether to enable async web assembly.
   async_web_assembly: Option<bool>,
-  /// Whether to enable inline constants.
-  inline_const: Option<bool>,
   // TODO: lazy compilation
 }
 
@@ -3686,7 +3684,6 @@ impl From<Experiments> for ExperimentsBuilder {
       future_defaults: None,
       css: None,
       async_web_assembly: None,
-      inline_const: Some(value.inline_const),
     }
   }
 }
@@ -3704,7 +3701,6 @@ impl From<&mut ExperimentsBuilder> for ExperimentsBuilder {
       css: value.css.take(),
       parallel_code_splitting: value.parallel_code_splitting.take(),
       async_web_assembly: value.async_web_assembly.take(),
-      inline_const: value.inline_const.take(),
     }
   }
 }
@@ -3796,7 +3792,6 @@ impl ExperimentsBuilder {
     w!(self.output_module, false);
 
     let parallel_code_splitting = d!(self.parallel_code_splitting, false);
-    let inline_const = d!(self.inline_const, production);
 
     Ok(Experiments {
       layers,
@@ -3805,7 +3800,6 @@ impl ExperimentsBuilder {
       rspack_future,
       parallel_code_splitting,
       cache,
-      inline_const,
     })
   }
 }

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1396,6 +1396,7 @@ CompilerOptions {
                             strict_export_presence: Some(
                                 false,
                             ),
+                            type_reexports_presence: None,
                             worker: Some(
                                 [
                                     "...",
@@ -1456,7 +1457,6 @@ CompilerOptions {
         top_level_await: true,
         rspack_future: RspackFuture,
         cache: Disabled,
-        inline_const: false,
     },
     node: Some(
         NodeOption {

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -15,7 +15,6 @@ pub struct Experiments {
   pub top_level_await: bool,
   pub rspack_future: RspackFuture,
   pub cache: ExperimentCacheOptions,
-  pub inline_const: bool,
 }
 
 #[allow(clippy::empty_structs_with_brackets)]

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -223,6 +223,25 @@ impl ExportPresenceMode {
 }
 
 #[cacheable]
+#[derive(Debug, Default, Clone, Copy, MergeFrom)]
+pub enum TypeReexportPresenceMode {
+  #[default]
+  NoTolerant,
+  Tolerant,
+  TolerantNoCheck,
+}
+
+impl From<&str> for TypeReexportPresenceMode {
+  fn from(value: &str) -> Self {
+    match value {
+      "tolerant" => Self::Tolerant,
+      "tolerant-no-check" => Self::TolerantNoCheck,
+      _ => Self::NoTolerant,
+    }
+  }
+}
+
+#[cacheable]
 #[derive(Debug, Clone, Copy, MergeFrom)]
 pub enum OverrideStrict {
   Strict,
@@ -254,6 +273,7 @@ pub struct JavascriptParserOptions {
   pub import_exports_presence: Option<ExportPresenceMode>,
   pub reexport_exports_presence: Option<ExportPresenceMode>,
   pub strict_export_presence: Option<bool>,
+  pub type_reexports_presence: Option<TypeReexportPresenceMode>,
   pub worker: Option<Vec<String>>,
   pub override_strict: Option<OverrideStrict>,
   pub import_meta: Option<bool>,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -315,7 +315,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
               parent_module_identifier,
               PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([export_name]))
             ),
-            &[export_name.clone()]
+            std::slice::from_ref(export_name)
           ),
           Some(ExportProvided::Provided)
         )

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -12,12 +12,13 @@ use rspack_core::{
   FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage,
   ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, PrefetchExportsInfoMode,
   ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap, TemplateContext,
-  TemplateReplaceSource,
+  TemplateReplaceSource, TypeReexportPresenceMode,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
   Diagnostic, DiagnosticExt, TraceableError,
 };
+use rustc_hash::FxHashSet;
 use swc_core::ecma::atoms::Atom;
 
 use super::create_resource_identifier_for_esm_dependency;
@@ -294,6 +295,40 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
         Some(ExportProvided::NotProvided)
       )
     {
+      // For type re-export cases:
+      //   1. export { T } from "./types";
+      //   2. import { T } from "./types"; export { T };
+      // Check if the export is really a type export, if it is, then skip the error.
+      let type_reexports_presence = parent_module
+        .as_normal_module()
+        .and_then(|m| m.get_parser_options())
+        .and_then(|o| o.get_javascript())
+        .and_then(|o| o.type_reexports_presence)
+        .unwrap_or_default();
+      if !matches!(type_reexports_presence, TypeReexportPresenceMode::NoTolerant)
+        // TODO: Check the parent module is transpiled from typescript
+        && ids.len() == 1
+        && let export_name = &ids[0]
+        && matches!(
+          ExportsInfoGetter::is_export_provided(
+            &module_graph.get_prefetched_exports_info(
+              parent_module_identifier,
+              PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([export_name]))
+            ),
+            &[export_name.clone()]
+          ),
+          Some(ExportProvided::Provided)
+        )
+      {
+        if matches!(
+          type_reexports_presence,
+          TypeReexportPresenceMode::TolerantNoCheck
+        ) {
+          return None;
+        }
+        // TODO: check if the export is a type export
+        return None;
+      }
       let mut pos = 0;
       let mut maybe_exports_info = Some(module_graph.get_prefetched_exports_info(
         &imported_module_identifier,

--- a/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
@@ -53,6 +53,7 @@ Object {
       },
     },
     topLevelAwait: true,
+    typeReexportsPresence: no-tolerant,
     useInputFileSystem: false,
   },
   externals: undefined,
@@ -197,6 +198,7 @@ Object {
         requireDynamic: true,
         requireResolve: true,
         strictExportPresence: false,
+        typeReexportsPresence: no-tolerant,
         url: true,
         worker: Array [
           ...,

--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/basic.ts
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/basic.ts
@@ -1,0 +1,1 @@
+export { A } from "./types";

--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/index.ts
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/index.ts
@@ -1,0 +1,8 @@
+import { A } from "./basic"
+import { B } from "./with-empty"
+
+export { A, B }
+
+it("should build", () => {
+  expect(true).toBe(true);
+})

--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/rspack.config.js
@@ -1,0 +1,33 @@
+module.exports = /** @type {import("@rspack/core").Configuration} */ ({
+	entry: "./index.ts",
+	resolve: {
+		extensions: ["...", ".ts"]
+	},
+	module: {
+		parser: {
+			javascript: {
+				typeReexportsPresence: "no-tolerant"
+			}
+		},
+		rules: [
+			{
+				test: /\.ts$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								parser: {
+									syntax: "typescript"
+								}
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	experiments: {
+		typeReexportsPresence: "no-tolerant"
+	}
+});

--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/types.ts
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/types.ts
@@ -1,0 +1,2 @@
+export type A = 'A';
+export type B = 'B';

--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/warnings.js
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/warnings.js
@@ -1,0 +1,4 @@
+module.exports = [
+  /export 'A' \(reexported as 'A'\) was not found in '\.\/types' \(module has no exports\)/,
+  /export 'B' \(reexported as 'B'\) was not found in '\.\/types' \(module has no exports\)/,
+];

--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/with-empty.ts
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/no-tolerant/with-empty.ts
@@ -1,0 +1,3 @@
+// @ts-expect-error empty is not a module
+export * from "./empty";
+export { B } from "./types";

--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/tolerant-no-check/index.ts
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/tolerant-no-check/index.ts
@@ -1,0 +1,1 @@
+import "../no-tolerant/index";

--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/tolerant-no-check/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/tolerant-no-check/rspack.config.js
@@ -1,0 +1,33 @@
+module.exports = /** @type {import("@rspack/core").Configuration} */ ({
+	entry: "./index.ts",
+	resolve: {
+		extensions: ["...", ".ts"]
+	},
+	module: {
+		parser: {
+			javascript: {
+				typeReexportsPresence: "tolerant-no-check"
+			}
+		},
+		rules: [
+			{
+				test: /\.ts$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								parser: {
+									syntax: "typescript"
+								}
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	experiments: {
+		typeReexportsPresence: "tolerant-no-check"
+	}
+});

--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/tolerant-no-check/warnings.js
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/tolerant-no-check/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [];

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2526,6 +2526,8 @@ export interface ExperimentsNormalized {
     // (undocumented)
     topLevelAwait?: boolean;
     // (undocumented)
+    typeReexportsPresence?: JavascriptParserOptions["typeReexportsPresence"];
+    // (undocumented)
     useInputFileSystem?: false | RegExp[];
 }
 
@@ -3437,6 +3439,7 @@ export type JavascriptParserOptions = {
     requireResolve?: boolean;
     importDynamic?: boolean;
     inlineConst?: boolean;
+    typeReexportsPresence?: "no-tolerant" | "tolerant" | "tolerant-no-check";
 };
 
 // @public (undocumented)

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2464,6 +2464,7 @@ export type Experiments = {
     parallelLoader?: boolean;
     useInputFileSystem?: UseInputFileSystem;
     inlineConst?: boolean;
+    typeReexportsPresence?: JavascriptParserOptions["typeReexportsPresence"];
 };
 
 // @public (undocumented)

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -580,7 +580,8 @@ function getRawJavascriptParserOptions(
 		requireDynamic: parser.requireDynamic,
 		requireResolve: parser.requireResolve,
 		importDynamic: parser.importDynamic,
-		inlineConst: parser.inlineConst
+		inlineConst: parser.inlineConst,
+		typeReexportsPresence: parser.typeReexportsPresence
 	};
 }
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -106,7 +106,8 @@ export const applyRspackOptionsDefaults = (
 		targetProperties,
 		mode: options.mode,
 		uniqueName: options.output.uniqueName,
-		inlineConst: options.experiments.inlineConst!
+		inlineConst: options.experiments.inlineConst!,
+		typeReexportsPresence: options.experiments.typeReexportsPresence
 	});
 
 	applyOutputDefaults(options.output, {
@@ -261,6 +262,9 @@ const applyExperimentsDefaults = (
 
 	// IGNORE(experiments.inlineConst): Rspack specific configuration for inline constants
 	D(experiments, "inlineConst", false);
+
+	// IGNORE(experiments.typeReexportsPresence): Rspack specific configuration for type reexports presence
+	D(experiments, "typeReexportsPresence", "no-tolerant");
 };
 
 const applybundlerInfoDefaults = (
@@ -285,7 +289,8 @@ const applySnapshotDefaults = (
 
 const applyJavascriptParserOptionsDefaults = (
 	parserOptions: JavascriptParserOptions,
-	inlineConst: boolean
+	inlineConst: boolean,
+	typeReexportsPresence: JavascriptParserOptions["typeReexportsPresence"]
 ) => {
 	D(parserOptions, "dynamicImportMode", "lazy");
 	D(parserOptions, "dynamicImportPrefetch", false);
@@ -302,6 +307,7 @@ const applyJavascriptParserOptionsDefaults = (
 	D(parserOptions, "worker", ["..."]);
 	D(parserOptions, "importMeta", true);
 	D(parserOptions, "inlineConst", inlineConst);
+	D(parserOptions, "typeReexportsPresence", typeReexportsPresence);
 };
 
 const applyJsonGeneratorOptionsDefaults = (
@@ -318,7 +324,8 @@ const applyModuleDefaults = (
 		targetProperties,
 		mode,
 		uniqueName,
-		inlineConst
+		inlineConst,
+		typeReexportsPresence
 	}: {
 		asyncWebAssembly: boolean;
 		css?: boolean;
@@ -326,6 +333,7 @@ const applyModuleDefaults = (
 		mode?: Mode;
 		uniqueName?: string;
 		inlineConst: boolean;
+		typeReexportsPresence: JavascriptParserOptions["typeReexportsPresence"];
 	}
 ) => {
 	assertNotNill(module.parser);
@@ -341,7 +349,11 @@ const applyModuleDefaults = (
 
 	F(module.parser, "javascript", () => ({}));
 	assertNotNill(module.parser.javascript);
-	applyJavascriptParserOptionsDefaults(module.parser.javascript, inlineConst);
+	applyJavascriptParserOptionsDefaults(
+		module.parser.javascript,
+		inlineConst,
+		typeReexportsPresence
+	);
 
 	F(module.parser, JSON_MODULE_TYPE, () => ({}));
 	assertNotNill(module.parser[JSON_MODULE_TYPE]);

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -55,6 +55,7 @@ import type {
 	Incremental,
 	IncrementalPresets,
 	InfrastructureLogging,
+	JavascriptParserOptions,
 	LazyCompilationOptions,
 	LibraryOptions,
 	Loader,
@@ -629,6 +630,7 @@ export interface ExperimentsNormalized {
 	parallelLoader?: boolean;
 	useInputFileSystem?: false | RegExp[];
 	inlineConst?: boolean;
+	typeReexportsPresence?: JavascriptParserOptions["typeReexportsPresence"];
 }
 
 export type IgnoreWarningsNormalized = ((

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1100,6 +1100,9 @@ export type JavascriptParserOptions = {
 
 	/** Inline const values in this module */
 	inlineConst?: boolean;
+
+	/** Whether to tolerant exportsPresence for type reexport */
+	typeReexportsPresence?: "no-tolerant" | "tolerant" | "tolerant-no-check";
 };
 
 export type JsonParserOptions = {

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2726,6 +2726,11 @@ export type Experiments = {
 	 * @default false
 	 */
 	inlineConst?: boolean;
+	/**
+	 * Enable inline constants
+	 * @default false
+	 */
+	typeReexportsPresence?: JavascriptParserOptions["typeReexportsPresence"];
 };
 //#endregion
 

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -581,6 +581,11 @@ const requireDynamic = z.boolean();
 const requireResolve = z.boolean();
 const importDynamic = z.boolean();
 const inlineConst = z.boolean();
+const typeReexportsPresence = z.enum([
+	"no-tolerant",
+	"tolerant",
+	"tolerant-no-check"
+]);
 
 const javascriptParserOptions = z.strictObject({
 	dynamicImportMode: dynamicImportMode.optional(),
@@ -603,7 +608,8 @@ const javascriptParserOptions = z.strictObject({
 	requireDynamic: requireDynamic.optional(),
 	requireResolve: requireResolve.optional(),
 	importDynamic: importDynamic.optional(),
-	inlineConst: inlineConst.optional()
+	inlineConst: inlineConst.optional(),
+	typeReexportsPresence: typeReexportsPresence.optional()
 	// #endregion
 }) satisfies z.ZodType<t.JavascriptParserOptions>;
 
@@ -1337,7 +1343,8 @@ const experiments = z.strictObject({
 	buildHttp: buildHttpOptions.optional(),
 	parallelLoader: z.boolean().optional(),
 	useInputFileSystem: useInputFileSystem.optional(),
-	inlineConst: z.boolean().optional()
+	inlineConst: z.boolean().optional(),
+	typeReexportsPresence: typeReexportsPresence.optional()
 }) satisfies z.ZodType<t.Experiments>;
 //#endregion
 


### PR DESCRIPTION
## Summary

Support tolerant exportsPresence for type re-exports:

```ts
export { T } from "./types.ts";
```

```ts
import { T } from "./types.ts";
export { T }
```

`typeReexportsPresence`:
- `"tolerant-no-check"`: identify this 👆 pattern and ignore the warning/error, this is fast but it may mistakenly ignore warning/error that should have been reported, this is [the same as esbuild](https://github.com/evanw/esbuild/blob/f4159a7b823cd5fe2217da2c30e8873d2f319667/internal/linker/linker.go#L3128)
- `"tolerant"`(not implemented in this PR): identify this 👆 pattern and check whether the export is included in the children modules' `build_info.type_exports`, this won't mistakenly ignore warning/error, but may slower (only on the error/warning path)
- `"no-tolerant"`: the current and default behavior

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
