### PR TITLE
perf: inline module graph partials

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -47,7 +47,7 @@ pub fn save_module_graph(
   storage: &Arc<dyn Storage>,
   context: &CacheableContext,
 ) {
-  let mg = ModuleGraph::new(vec![partial], None);
+  let mg = ModuleGraph::new([Some(partial), None], None);
   for identifier in revoked_modules {
     storage.remove(SCOPE, identifier.as_bytes());
   }
@@ -124,7 +124,7 @@ pub async fn recovery_module_graph(
 ) -> Result<(ModuleGraphPartial, HashSet<DependencyId>)> {
   let mut need_check_dep = vec![];
   let mut partial = ModuleGraphPartial::default();
-  let mut mg = ModuleGraph::new(vec![], Some(&mut partial));
+  let mut mg = ModuleGraph::new([None, None], Some(&mut partial));
   storage
     .load(SCOPE)
     .await?

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -430,14 +430,17 @@ impl Compilation {
   pub fn get_module_graph(&self) -> ModuleGraph {
     if let Some(other_module_graph) = &self.other_module_graph {
       ModuleGraph::new(
-        vec![
-          self.make_artifact.get_module_graph_partial(),
-          other_module_graph,
+        [
+          Some(self.make_artifact.get_module_graph_partial()),
+          Some(other_module_graph),
         ],
         None,
       )
     } else {
-      ModuleGraph::new(vec![self.make_artifact.get_module_graph_partial()], None)
+      ModuleGraph::new(
+        [Some(self.make_artifact.get_module_graph_partial()), None],
+        None,
+      )
     }
   }
 
@@ -464,12 +467,12 @@ impl Compilation {
   pub fn get_module_graph_mut(&mut self) -> ModuleGraph {
     if let Some(other) = &mut self.other_module_graph {
       ModuleGraph::new(
-        vec![self.make_artifact.get_module_graph_partial()],
+        [Some(self.make_artifact.get_module_graph_partial()), None],
         Some(other),
       )
     } else {
       ModuleGraph::new(
-        vec![],
+        [None, None],
         Some(self.make_artifact.get_module_graph_partial_mut()),
       )
     }

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -49,10 +49,10 @@ pub struct MakeArtifact {
 
 impl MakeArtifact {
   pub fn get_module_graph(&self) -> ModuleGraph {
-    ModuleGraph::new(vec![&self.module_graph_partial], None)
+    ModuleGraph::new([Some(&self.module_graph_partial), None], None)
   }
   pub fn get_module_graph_mut(&mut self) -> ModuleGraph {
-    ModuleGraph::new(vec![], Some(&mut self.module_graph_partial))
+    ModuleGraph::new([None, None], Some(&mut self.module_graph_partial))
   }
   // TODO remove it
   pub fn get_module_graph_partial(&self) -> &ModuleGraphPartial {
@@ -64,7 +64,7 @@ impl MakeArtifact {
   }
 
   fn revoke_module(&mut self, module_identifier: &ModuleIdentifier) -> Vec<BuildDependency> {
-    let mut mg = ModuleGraph::new(vec![], Some(&mut self.module_graph_partial));
+    let mut mg = ModuleGraph::new([None, None], Some(&mut self.module_graph_partial));
     let module = mg
       .module_by_identifier(module_identifier)
       .expect("should have module");
@@ -116,7 +116,7 @@ impl MakeArtifact {
   }
 
   pub fn revoke_dependency(&mut self, dep_id: &DependencyId, force: bool) -> Vec<BuildDependency> {
-    let mut mg = ModuleGraph::new(vec![], Some(&mut self.module_graph_partial));
+    let mut mg = ModuleGraph::new([None, None], Some(&mut self.module_graph_partial));
 
     let revoke_dep_ids = if self.make_failed_dependencies.remove(dep_id) {
       // make failed dependencies clean it.

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -65,7 +65,7 @@ impl MakeTaskContext {
 
   // TODO use module graph with make artifact
   pub fn get_module_graph_mut(partial: &mut ModuleGraphPartial) -> ModuleGraph {
-    ModuleGraph::new(vec![], Some(partial))
+    ModuleGraph::new([None, None], Some(partial))
   }
 
   // TODO remove it after incremental rebuild cover all stage

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -112,11 +112,9 @@ impl<'a> ModuleGraph<'a> {
       return Some(r);
     }
 
-    for item in self.partials.iter().rev() {
-      if let Some(item) = item {
-        if let Some(r) = f(item) {
-          return Some(r);
-        }
+    for item in self.partials.iter().rev().flatten() {
+      if let Some(r) = f(item) {
+        return Some(r);
       }
     }
     None
@@ -136,12 +134,10 @@ impl<'a> ModuleGraph<'a> {
     let active_exist = f_exist(active_partial);
     if !active_exist {
       let mut search_result = None;
-      for item in self.partials.iter().rev() {
-        if let Some(item) = item {
-          if let Some(r) = f(item) {
-            search_result = Some(r);
-            break;
-          }
+      for item in self.partials.iter().rev().flatten() {
+        if let Some(r) = f(item) {
+          search_result = Some(r);
+          break;
         }
       }
       if let Some(search_result) = search_result {
@@ -155,14 +151,12 @@ impl<'a> ModuleGraph<'a> {
   /// Return an unordered iterator of modules
   pub fn modules(&self) -> IdentifierMap<&BoxModule> {
     let mut res = IdentifierMap::default();
-    for item in self.partials.iter() {
-      if let Some(item) = item {
-        for (k, v) in &item.modules {
-          if let Some(v) = v {
-            res.insert(*k, v);
-          } else {
-            res.remove(k);
-          }
+    for item in self.partials.iter().flatten() {
+      for (k, v) in &item.modules {
+        if let Some(v) = v {
+          res.insert(*k, v);
+        } else {
+          res.remove(k);
         }
       }
     }
@@ -180,14 +174,12 @@ impl<'a> ModuleGraph<'a> {
 
   pub fn module_graph_modules(&self) -> IdentifierMap<&ModuleGraphModule> {
     let mut res = IdentifierMap::default();
-    for item in self.partials.iter() {
-      if let Some(item) = item {
-        for (k, v) in &item.module_graph_modules {
-          if let Some(v) = v {
-            res.insert(*k, v);
-          } else {
-            res.remove(k);
-          }
+    for item in self.partials.iter().flatten() {
+      for (k, v) in &item.module_graph_modules {
+        if let Some(v) = v {
+          res.insert(*k, v);
+        } else {
+          res.remove(k);
         }
       }
     }
@@ -629,14 +621,12 @@ impl<'a> ModuleGraph<'a> {
 
   pub fn dependencies(&self) -> HashMap<DependencyId, &BoxDependency> {
     let mut res = HashMap::default();
-    for item in self.partials.iter() {
-      if let Some(item) = item {
-        for (k, v) in &item.dependencies {
-          if let Some(v) = v {
-            res.insert(*k, v);
-          } else {
-            res.remove(k);
-          }
+    for item in self.partials.iter().flatten() {
+      for (k, v) in &item.dependencies {
+        if let Some(v) = v {
+          res.insert(*k, v);
+        } else {
+          res.remove(k);
         }
       }
     }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -93,13 +93,13 @@ pub struct ModuleGraphPartial {
 
 #[derive(Debug, Default)]
 pub struct ModuleGraph<'a> {
-  partials: Vec<&'a ModuleGraphPartial>,
+  partials: [Option<&'a ModuleGraphPartial>; 2],
   active: Option<&'a mut ModuleGraphPartial>,
 }
 
 impl<'a> ModuleGraph<'a> {
   pub fn new(
-    partials: Vec<&'a ModuleGraphPartial>,
+    partials: [Option<&'a ModuleGraphPartial>; 2],
     active: Option<&'a mut ModuleGraphPartial>,
   ) -> Self {
     Self { partials, active }
@@ -113,8 +113,10 @@ impl<'a> ModuleGraph<'a> {
     }
 
     for item in self.partials.iter().rev() {
-      if let Some(r) = f(item) {
-        return Some(r);
+      if let Some(item) = item {
+        if let Some(r) = f(item) {
+          return Some(r);
+        }
       }
     }
     None
@@ -135,9 +137,11 @@ impl<'a> ModuleGraph<'a> {
     if !active_exist {
       let mut search_result = None;
       for item in self.partials.iter().rev() {
-        if let Some(r) = f(item) {
-          search_result = Some(r);
-          break;
+        if let Some(item) = item {
+          if let Some(r) = f(item) {
+            search_result = Some(r);
+            break;
+          }
         }
       }
       if let Some(search_result) = search_result {
@@ -152,11 +156,13 @@ impl<'a> ModuleGraph<'a> {
   pub fn modules(&self) -> IdentifierMap<&BoxModule> {
     let mut res = IdentifierMap::default();
     for item in self.partials.iter() {
-      for (k, v) in &item.modules {
-        if let Some(v) = v {
-          res.insert(*k, v);
-        } else {
-          res.remove(k);
+      if let Some(item) = item {
+        for (k, v) in &item.modules {
+          if let Some(v) = v {
+            res.insert(*k, v);
+          } else {
+            res.remove(k);
+          }
         }
       }
     }
@@ -175,11 +181,13 @@ impl<'a> ModuleGraph<'a> {
   pub fn module_graph_modules(&self) -> IdentifierMap<&ModuleGraphModule> {
     let mut res = IdentifierMap::default();
     for item in self.partials.iter() {
-      for (k, v) in &item.module_graph_modules {
-        if let Some(v) = v {
-          res.insert(*k, v);
-        } else {
-          res.remove(k);
+      if let Some(item) = item {
+        for (k, v) in &item.module_graph_modules {
+          if let Some(v) = v {
+            res.insert(*k, v);
+          } else {
+            res.remove(k);
+          }
         }
       }
     }
@@ -622,11 +630,13 @@ impl<'a> ModuleGraph<'a> {
   pub fn dependencies(&self) -> HashMap<DependencyId, &BoxDependency> {
     let mut res = HashMap::default();
     for item in self.partials.iter() {
-      for (k, v) in &item.dependencies {
-        if let Some(v) = v {
-          res.insert(*k, v);
-        } else {
-          res.remove(k);
+      if let Some(item) = item {
+        for (k, v) in &item.dependencies {
+          if let Some(v) = v {
+            res.insert(*k, v);
+          } else {
+            res.remove(k);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

There are at most two partials in the module graph. We may inline them to avoid allocating vectors.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
