### PR TITLE
fix: add `-debugids` to Zod schema

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -1877,8 +1877,14 @@ type DevServerOptions<A extends BasicApplication = BasicApplication, S extends B
     setupMiddlewares?: ((middlewares: DevServerMiddleware[], devServer: Server_4) => DevServerMiddleware[]) | undefined;
 };
 
-// @public
-export type DevTool = false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map";
+// @public (undocumented)
+export type DevTool = false | "eval" | `${DevToolPosition}${DevToolNoSources}${DevToolCheap}source-map${DevToolDebugIds}`;
+
+// @public (undocumented)
+type DevToolCheap = "cheap-" | "cheap-module-" | "";
+
+// @public (undocumented)
+type DevToolDebugIds = "-debugids" | "";
 
 // @public
 export type DevtoolFallbackModuleFilenameTemplate = DevtoolModuleFilenameTemplate;
@@ -1888,6 +1894,12 @@ export type DevtoolModuleFilenameTemplate = string | ((info: any) => any);
 
 // @public
 export type DevtoolNamespace = string;
+
+// @public (undocumented)
+type DevToolNoSources = "nosources-" | "";
+
+// @public
+type DevToolPosition = "inline-" | "hidden-" | "eval-" | "";
 
 // @public (undocumented)
 interface Diagnostic {

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1612,33 +1612,19 @@ export type InfrastructureLogging = {
 /**
  * Configuration used to control the behavior of the Source Map generation.
  */
+type DevToolPosition = "inline-" | "hidden-" | "eval-" | "";
+
+type DevToolNoSources = "nosources-" | "";
+
+type DevToolCheap = "cheap-" | "cheap-module-" | "";
+
+type DevToolDebugIds = "-debugids" | "";
+
+// [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map[-debugids].
 export type DevTool =
 	| false
 	| "eval"
-	| "cheap-source-map"
-	| "cheap-module-source-map"
-	| "source-map"
-	| "inline-cheap-source-map"
-	| "inline-cheap-module-source-map"
-	| "inline-source-map"
-	| "inline-nosources-cheap-source-map"
-	| "inline-nosources-cheap-module-source-map"
-	| "inline-nosources-source-map"
-	| "nosources-cheap-source-map"
-	| "nosources-cheap-module-source-map"
-	| "nosources-source-map"
-	| "hidden-nosources-cheap-source-map"
-	| "hidden-nosources-cheap-module-source-map"
-	| "hidden-nosources-source-map"
-	| "hidden-cheap-source-map"
-	| "hidden-cheap-module-source-map"
-	| "hidden-source-map"
-	| "eval-cheap-source-map"
-	| "eval-cheap-module-source-map"
-	| "eval-source-map"
-	| "eval-nosources-cheap-source-map"
-	| "eval-nosources-cheap-module-source-map"
-	| "eval-nosources-source-map";
+	| `${DevToolPosition}${DevToolNoSources}${DevToolCheap}source-map${DevToolDebugIds}`;
 //#endregion
 
 //#region Node

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -956,34 +956,20 @@ const infrastructureLogging = z.strictObject({
 //#region DevTool
 const devTool = z
 	.literal(false)
+	.or(z.literal("eval"))
 	.or(
-		z.enum([
-			"eval",
-			"cheap-source-map",
-			"cheap-module-source-map",
-			"source-map",
-			"inline-cheap-source-map",
-			"inline-cheap-module-source-map",
-			"inline-source-map",
-			"inline-nosources-cheap-source-map",
-			"inline-nosources-cheap-module-source-map",
-			"inline-nosources-source-map",
-			"nosources-cheap-source-map",
-			"nosources-cheap-module-source-map",
-			"nosources-source-map",
-			"hidden-nosources-cheap-source-map",
-			"hidden-nosources-cheap-module-source-map",
-			"hidden-nosources-source-map",
-			"hidden-cheap-source-map",
-			"hidden-cheap-module-source-map",
-			"hidden-source-map",
-			"eval-cheap-source-map",
-			"eval-cheap-module-source-map",
-			"eval-source-map",
-			"eval-nosources-cheap-source-map",
-			"eval-nosources-cheap-module-source-map",
-			"eval-nosources-source-map"
-		])
+		z.string().refine(
+			val => {
+				// Pattern: [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map[-debugids]
+				const pattern =
+					/^(inline-|hidden-|eval-)?(nosources-)?(cheap-(module-)?)?source-map(-debugids)?$/;
+				return pattern.test(val);
+			},
+			{
+				error:
+					"Expect value to match the pattern: [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map[-debugids]"
+			}
+		) as z.ZodType<t.DevTool>
 	) satisfies z.ZodType<t.DevTool>;
 //#endregion
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Update the Zod schema of `devtool` to support `-debugids` (https://github.com/web-infra-dev/rspack/pull/8943)

Also update the types.

## Related links

<!-- Related issues or discussions. -->

The pattern is copied from https://github.com/web-infra-dev/rspack/pull/9832

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
