### PR TITLE
fix: failed to resolve `browserslist:env` from target

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/ecma-version/browserslist-config-env/.browserslistrc
+++ b/packages/rspack-test-tools/tests/configCases/ecma-version/browserslist-config-env/.browserslistrc
@@ -1,0 +1,7 @@
+maintained node versions
+
+[app]
+chrome 100
+
+[server]
+node 20

--- a/packages/rspack-test-tools/tests/configCases/ecma-version/browserslist-config-env/index.js
+++ b/packages/rspack-test-tools/tests/configCases/ecma-version/browserslist-config-env/index.js
@@ -1,0 +1,1 @@
+it("should compile and run the test", function() {});

--- a/packages/rspack-test-tools/tests/configCases/ecma-version/browserslist-config-env/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/ecma-version/browserslist-config-env/rspack.config.js
@@ -1,0 +1,39 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: `browserslist:app`,
+	plugins: [
+		compiler => {
+			compiler.hooks.compilation.tap("Test", compilation => {
+				expect(compilation.outputOptions.environment).toMatchInlineSnapshot(`
+			Object {
+			  arrowFunction: true,
+			  asyncFunction: true,
+			  bigIntLiteral: true,
+			  const: true,
+			  destructuring: true,
+			  document: true,
+			  dynamicImport: true,
+			  dynamicImportInWorker: true,
+			  forOf: true,
+			  globalThis: true,
+			  module: true,
+			  nodePrefixForCoreModules: false,
+			  optionalChaining: true,
+			  templateLiteral: true,
+			}
+		`);
+				expect(compilation.options.externalsPresets).toMatchInlineSnapshot(`
+			Object {
+			  electron: false,
+			  electronMain: false,
+			  electronPreload: false,
+			  electronRenderer: false,
+			  node: false,
+			  nwjs: false,
+			  web: true,
+			}
+		`);
+			});
+		}
+	]
+};


### PR DESCRIPTION
## Summary

Fix failed to resolve `browserslist:env` from the `target` configuration:

1. Added a new `env_or_query` field to the `BrowserslistHandlerConfig` struct to accommodate ambiguous input strings that could represent either an environment name or a query string.
2. Modified the `load_browserslist` function to handle `env_or_query` by first attempting to resolve it as a query string and, if that fails, treating it as an environment name.

## Related links

- resolve https://github.com/web-infra-dev/rspack/issues/10655

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
