### PR TITLE
chore: enable `fair-sched` for codspeed

### DIFF
--- a/.github/actions/codspeed/action.yaml
+++ b/.github/actions/codspeed/action.yaml
@@ -94,7 +94,9 @@ runs:
         #   curl -fsSL https://github.com/CodSpeedHQ/runner/releases/download/v$RUNNER_VERSION/codspeed-runner-installer.sh | bash -s -- --quiet
         # fi
 
-        cargo install --git https://github.com/CPunisher/runner.git --branch 06-20-feat/valgrind-flags
+        # We can use official official runner if it supports config valgrind flags in the future: https://github.com/CodSpeedHQ/runner/pull/92
+        cargo install --git https://github.com/CPunisher/runner.git --rev 7e87e3c5d93390fb28e4fbd5f3859f3b20d8fc6a
 
         # Run the benchmarks
-        env CODSPEED=debug VALGRIND_FLAGS='--fair-sched=no' codspeed run $RUNNER_ARGS -- '${{ inputs.run }}'
+        # Enable fair sched to make benchmark more stable, see: https://github.com/CodSpeedHQ/runner/pull/91
+        env VALGRIND_FLAGS='--fair-sched=yes' codspeed run $RUNNER_ARGS -- '${{ inputs.run }}'

--- a/.github/actions/codspeed/action.yaml
+++ b/.github/actions/codspeed/action.yaml
@@ -97,4 +97,4 @@ runs:
         cargo install --git https://github.com/CPunisher/runner.git --branch 06-20-feat/valgrind-flags
 
         # Run the benchmarks
-        env CODSPEED=debug VALGRIND_FLAGS='--fair-sched=yes' codspeed run $RUNNER_ARGS -- '${{ inputs.run }}'
+        env CODSPEED=debug VALGRIND_FLAGS='--fair-sched=no' codspeed run $RUNNER_ARGS -- '${{ inputs.run }}'

--- a/.github/actions/codspeed/action.yaml
+++ b/.github/actions/codspeed/action.yaml
@@ -1,0 +1,100 @@
+name: "CodSpeed Performance Analysis"
+description: "Continuous benchmarking and performance checks"
+branding:
+  color: orange
+  icon: activity
+
+author: "Arthur Pastel"
+inputs:
+  token:
+    description: "CodSpeed upload token"
+    required: false
+  run:
+    description: "The command to run the benchmarks"
+    required: true
+
+  working-directory:
+    description: |
+      The directory where the `run` command will be executed.
+      Warning: if you use defaults.working-directory, you must still set this parameter.
+    required: false
+  upload-url:
+    description: "The upload endpoint (for on-premise deployments)"
+    required: false
+
+  runner-version:
+    description: "The version of the runner to use"
+    required: false
+
+  mode:
+    description: |
+      The mode to to run the benchmarks in. The following modes are available:
+      - `instrumentation` (default): Run the benchmarks with instrumentation enabled.
+      - `walltime`: Run the benchmarks with walltime enabled.
+
+      We strongly recommend not changing this mode unless you know what you are doing.
+
+      Using the `walltime` mode on traditional VMs/Hosted Runners will lead to inconsistent data. For the best results, we recommend using CodSpeed Hosted Macro Runners, which are fine-tuned for performance measurement consistency.
+      Check out the [Walltime Instrument Documentation](https://docs.codspeed.io/instruments/walltime/) for more details.
+    required: false
+
+  instruments:
+    description: |
+      Comma separated list of instruments to enable. The following instruments are available:
+      - `mongodb`: MongoDB instrumentation, requires the MongoDB instrument to be enabled for the organization in CodSpeed
+    required: false
+  mongo-uri-env-name:
+    description: |
+      The name of the environment variable containing the MongoDB URI. Requires the `mongodb` instrument to be activated in `instruments`.
+      If the instrumentation is enabled and this value is not set, the user will need to dynamically provide the MongoDB URI to the CodSpeed runner.
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        GH_MATRIX: "${{ toJson(matrix) }}"
+        GH_STRATEGY: "${{ toJson(strategy) }}"
+      run: |
+        # Configure and run codspeed-runner
+        # if [ -n "${{ inputs.runner-version }}" ]; then
+        #   RUNNER_VERSION="${{ inputs.runner-version }}"
+        # else
+        #   RUNNER_VERSION=$(cat $GITHUB_ACTION_PATH/.codspeed-runner-version)
+        # fi
+
+        # Get the runner arguments
+        RUNNER_ARGS=""
+        if [ -n "${{ inputs.token }}" ]; then
+          RUNNER_ARGS="$RUNNER_ARGS --token ${{ inputs.token }}"
+        fi
+        if [ -n "${{ inputs.working-directory }}" ]; then
+          RUNNER_ARGS="$RUNNER_ARGS --working-directory=${{ inputs.working-directory }}"
+        fi
+        if [ -n "${{ inputs.upload-url }}" ]; then
+          RUNNER_ARGS="$RUNNER_ARGS --upload-url=${{ inputs.upload-url }}"
+        fi
+        if [ -n "${{ inputs.mode }}" ]; then
+          RUNNER_ARGS="$RUNNER_ARGS --mode=${{ inputs.mode }}"
+        fi
+        if [ -n "${{ inputs.instruments }}" ]; then
+          RUNNER_ARGS="$RUNNER_ARGS --instruments=${{ inputs.instruments }}"
+        fi
+        if [ -n "${{ inputs.mongo-uri-env-name }}" ]; then
+          RUNNER_ARGS="$RUNNER_ARGS --mongo-uri-env-name=${{ inputs.mongo-uri-env-name }}"
+        fi
+
+        # Install the CodSpeedHQ/runner
+        # head_status=$(curl -I -fsSL -w "%{http_code}" -o /dev/null https://github.com/CodSpeedHQ/runner/releases/download/v$RUNNER_VERSION/codspeed-runner-installer.sh)
+        # if [ "$head_status" -eq 404 ]; then
+        #   echo "Error: Version $RUNNER_VERSION is not available in https://github.com/CodSpeedHQ/runner/releases, please a correct version."
+        #   exit 1
+        # else
+        #   curl -fsSL https://github.com/CodSpeedHQ/runner/releases/download/v$RUNNER_VERSION/codspeed-runner-installer.sh | bash -s -- --quiet
+        # fi
+
+        cargo install --git https://github.com/CPunisher/runner.git --branch 06-20-feat/valgrind-flags
+
+        # Run the benchmarks
+        env CODSPEED=debug VALGRIND_FLAGS='--fair-sched=yes' codspeed run $RUNNER_ARGS -- '${{ inputs.run }}'

--- a/.github/workflows/reusable-build-bench.yml
+++ b/.github/workflows/reusable-build-bench.yml
@@ -76,7 +76,7 @@ jobs:
         run: pnpm run build:js
 
       - name: Run benchmark
-        uses: CodSpeedHQ/action@0010eb0ca6e89b80c88e8edaaa07cfe5f3e6664d # v3
+        uses: ./.github/actions/codspeed
         timeout-minutes: 30
         with:
           run: pnpm run bench:ci

--- a/tasks/benchmark/benches/groups/bundle.rs
+++ b/tasks/benchmark/benches/groups/bundle.rs
@@ -15,9 +15,6 @@ criterion_group!(bundle, bundle_benchmark);
 fn bundle_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("bundle");
 
-  #[cfg(feature = "codspeed")]
-  group.sample_size(10);
-
   let projects: Vec<(&'static str, CompilerBuilderGenerator)> = vec![
     ("basic-react", Arc::new(basic_react::compiler)),
     ("threejs", Arc::new(threejs::compiler)),

--- a/tasks/benchmark/benches/groups/bundle.rs
+++ b/tasks/benchmark/benches/groups/bundle.rs
@@ -22,7 +22,8 @@ fn bundle_benchmark(c: &mut Criterion) {
 
   // Codspeed can only handle to up to 500 threads by default
   let rt = runtime::Builder::new_multi_thread()
-    .max_blocking_threads(256)
+    .worker_threads(1)
+    .max_blocking_threads(1)
     .build()
     .unwrap();
 

--- a/tasks/benchmark/benches/groups/bundle.rs
+++ b/tasks/benchmark/benches/groups/bundle.rs
@@ -15,6 +15,9 @@ criterion_group!(bundle, bundle_benchmark);
 fn bundle_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("bundle");
 
+  #[cfg(feature = "codspeed")]
+  group.sample_size(10);
+
   let projects: Vec<(&'static str, CompilerBuilderGenerator)> = vec![
     ("basic-react", Arc::new(basic_react::compiler)),
     ("threejs", Arc::new(threejs::compiler)),
@@ -22,8 +25,7 @@ fn bundle_benchmark(c: &mut Criterion) {
 
   // Codspeed can only handle to up to 500 threads by default
   let rt = runtime::Builder::new_multi_thread()
-    .worker_threads(1)
-    .max_blocking_threads(1)
+    .max_blocking_threads(256)
     .build()
     .unwrap();
 

--- a/tasks/benchmark/benches/groups/bundle.rs
+++ b/tasks/benchmark/benches/groups/bundle.rs
@@ -22,7 +22,7 @@ fn bundle_benchmark(c: &mut Criterion) {
 
   // Codspeed can only handle to up to 500 threads by default
   let rt = runtime::Builder::new_multi_thread()
-    .max_blocking_threads(256)
+    .max_blocking_threads(1)
     .build()
     .unwrap();
 

--- a/tasks/benchmark/benches/groups/bundle.rs
+++ b/tasks/benchmark/benches/groups/bundle.rs
@@ -22,7 +22,7 @@ fn bundle_benchmark(c: &mut Criterion) {
 
   // Codspeed can only handle to up to 500 threads by default
   let rt = runtime::Builder::new_multi_thread()
-    .max_blocking_threads(1)
+    .max_blocking_threads(256)
     .build()
     .unwrap();
 


### PR DESCRIPTION
## Summary

From my local bench, estimated cpu cycles varies from 0.5% to 1% without fair schedule while it varies less than 0.1% with fair schedule.

See https://valgrind.org/docs/manual/manual-core.html#manual-core.pthreads
> The fairness of the futex based locking produces better reproducibility of thread scheduling for different executions of a multithreaded application.

Noted that lai-callgrind enable it by default: https://iai-callgrind.github.io/iai-callgrind/latest/html/benchmarks/library_benchmarks/important.html

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
