### PR TITLE
chore: remove prebundle config for enhanced-resolve

### DIFF
--- a/packages/rspack/prebundle.config.mjs
+++ b/packages/rspack/prebundle.config.mjs
@@ -1,8 +1,4 @@
 // @ts-check
-import { copyFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-
 /** @type {import('prebundle').Config} */
 export default {
 	dependencies: [
@@ -16,26 +12,6 @@ export default {
 			name: "watchpack",
 			externals: {
 				"graceful-fs": "../graceful-fs/index.js"
-			}
-		},
-		{
-			name: "enhanced-resolve",
-			externals: {
-				tapable: "@rspack/lite-tapable",
-				"graceful-fs": "../graceful-fs/index.js"
-			},
-			afterBundle({ depPath, distPath }) {
-				copyFileSync(
-					join(depPath, "lib/CachedInputFileSystem.js"),
-					join(distPath, "CachedInputFileSystem.js")
-				);
-
-				// Rspack only depend on the `CachedInputFileSystem` module of enhanced-resolve
-				// so we can remove the index chunk because it is not used
-				unlinkSync(join(distPath, "index.js"));
-
-				// add an empty CachedInputFileSystem.d.ts file to prevent ts error
-				writeFileSync(join(distPath, "CachedInputFileSystem.d.ts"), "");
 			}
 		},
 		{

--- a/packages/rspack/tsconfig.json
+++ b/packages/rspack/tsconfig.json
@@ -10,10 +10,6 @@
       "@swc/types": ["./compiled/@swc/types"],
       "graceful-fs": ["./compiled/graceful-fs"],
       "browserslist-load-config": ["./compiled/browserslist-load-config"],
-      "enhanced-resolve": ["./compiled/enhanced-resolve"],
-      "enhanced-resolve/lib/CachedInputFileSystem": [
-        "./compiled/enhanced-resolve/CachedInputFileSystem"
-      ],
       "webpack-sources": ["./compiled/webpack-sources"],
       "tinypool": ["./compiled/tinypool"]
     }


### PR DESCRIPTION
## Summary

I noticed that the prebundle config for `enhanced-resolve` is redundant, since `enhanced-resolve/lib/CachedInputFileSystem` has already been bundled by Rslib. The prebundled version of enhanced-resolve is never used. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
