### PR TITLE
perf: reduce bundle size of zod v4

### DIFF
--- a/packages/rspack/src/builtin-loader/swc/pluginImport.ts
+++ b/packages/rspack/src/builtin-loader/swc/pluginImport.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 
 type RawStyleConfig = {
 	styleLibraryDirectory?: string;

--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -25,7 +25,7 @@ import type {
 	UmdConfig
 } from "@swc/types";
 import type { Assumptions } from "@swc/types/assumptions";
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 import { numberOrInfinity } from "../../config/utils";
 import { memoize } from "../../util/memoize";
 import {

--- a/packages/rspack/src/builtin-plugin/IgnorePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/IgnorePlugin.ts
@@ -2,7 +2,7 @@ import {
 	BuiltinPluginName,
 	type RawIgnorePluginOptions
 } from "@rspack/binding";
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 
 import { anyFunction } from "../config/utils";
 import { memoize } from "../util/memoize";

--- a/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
@@ -25,7 +25,7 @@ import {
 	RegisterJsTapKind
 } from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 import { type Compilation, checkCompilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import type { CreatePartialRegisters } from "../taps/types";

--- a/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
@@ -8,7 +8,7 @@ import {
 	type RawSubresourceIntegrityPluginOptions
 } from "@rspack/binding";
 import type { AsyncSeriesWaterfallHook } from "@rspack/lite-tapable";
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 import type { Compilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import type { CrossOriginLoading } from "../config/types";

--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 import { Compilation } from "../../Compilation";
 import { anyFunction } from "../../config/utils";
 import { memoize } from "../../util/memoize";

--- a/packages/rspack/src/config/utils.ts
+++ b/packages/rspack/src/config/utils.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 
 // Zod v4 doesn't support Infinity, so we need to use a custom type
 // See: https://github.com/colinhacks/zod/issues/4721

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1,6 +1,6 @@
 import nodePath from "node:path";
 import { createErrorMap, fromZodError } from "zod-validation-error/v4";
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 import { getZodSwcLoaderOptionsSchema } from "../builtin-loader/swc/types";
 import type * as t from "./types";
 import { anyFunction, numberOrInfinity } from "./utils";

--- a/packages/rspack/src/lib/DllPlugin.ts
+++ b/packages/rspack/src/lib/DllPlugin.ts
@@ -8,7 +8,7 @@
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
 
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 import type { Compiler } from "../Compiler";
 import { LibManifestPlugin } from "../builtin-plugin";
 import { DllEntryPlugin } from "../builtin-plugin/DllEntryPlugin";

--- a/packages/rspack/src/lib/DllReferencePlugin.ts
+++ b/packages/rspack/src/lib/DllReferencePlugin.ts
@@ -9,7 +9,7 @@
  */
 
 import type { JsBuildMeta } from "@rspack/binding";
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 import type { CompilationParams } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import { DllReferenceAgencyPlugin } from "../builtin-plugin";


### PR DESCRIPTION
## Summary

- before:

```
File (cjs0)     Size       
dist/index.js   863.2 kB
```

- after:

```
File (cjs0)     Size       
dist/index.js   847.3 kB
```

## Related links

see https://github.com/colinhacks/zod/issues/4433#issuecomment-2921500831

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
