### PR TITLE
perf(zod/v4): disable Zod JIT

### DIFF
--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -5,6 +5,10 @@ import { getZodSwcLoaderOptionsSchema } from "../builtin-loader/swc/types";
 import type * as t from "./types";
 import { anyFunction, numberOrInfinity } from "./utils";
 
+z.config({
+	jitless: true
+});
+
 const filenameTemplate = z.string() satisfies z.ZodType<t.FilenameTemplate>;
 
 const filename = filenameTemplate.or(


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Zod V4 uses `new Function` to compile `z.object()` schema by default to make next parse faster.

https://github.com/colinhacks/zod/blob/d5e23683cab94dfd89be8a57193e33187a09ee2d/packages/zod/src/v4/core/schemas.ts#L1794

But since Rspack would only parse most of the schema only a single time, it would have better performance to use jitless mode.

For `examples/react`, this would reduce the time of `schema.safeParse` from 3.5 ms to 0.9 ms on my laptop.

## Related links

<!-- Related issues or discussions. -->

issue: #10467 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
