### PR TITLE
perf: cache get exports type on module graph cache

### DIFF
--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -50,7 +50,7 @@ impl ModuleGraphCacheArtifactInner {
       Some(value) => value,
       None => {
         let value = f();
-        self.get_exports_type_cache.set(key, value.clone());
+        self.get_exports_type_cache.set(key, value);
         value
       }
     }
@@ -115,7 +115,7 @@ pub(super) mod get_exports_type {
 
     pub fn get(&self, key: &GetExportsTypeCacheKey) -> Option<ExportsType> {
       let inner = self.cache.read().expect("should get lock");
-      inner.get(key).cloned()
+      inner.get(key)
     }
 
     pub fn set(&self, key: GetExportsTypeCacheKey, value: ExportsType) {

--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -115,7 +115,7 @@ pub(super) mod get_exports_type {
 
     pub fn get(&self, key: &GetExportsTypeCacheKey) -> Option<ExportsType> {
       let inner = self.cache.read().expect("should get lock");
-      inner.get(key)
+      inner.get(key).copied()
     }
 
     pub fn set(&self, key: GetExportsTypeCacheKey, value: ExportsType) {

--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -5,11 +5,12 @@ use std::sync::{
 
 pub use determine_export_assignments::DetermineExportAssignmentsKey;
 use determine_export_assignments::*;
+use get_exports_type::*;
 use get_mode::*;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::atoms::Atom;
 
-use crate::{DependencyId, ExportInfo, RuntimeKey};
+use crate::{DependencyId, ExportInfo, ExportsType, RuntimeKey};
 pub type ModuleGraphCacheArtifact = Arc<ModuleGraphCacheArtifactInner>;
 
 /// This is a rust port of `ModuleGraph.cached` and `ModuleGraph.dependencyCacheProvide` in webpack.
@@ -21,17 +22,38 @@ pub struct ModuleGraphCacheArtifactInner {
   freezed: AtomicBool,
   get_mode_cache: GetModeCache,
   determine_export_assignments_cache: DetermineExportAssignmentsCache,
+  get_exports_type_cache: GetExportsTypeCache,
 }
 
 impl ModuleGraphCacheArtifactInner {
   pub fn freeze(&self) {
     self.get_mode_cache.freeze();
     self.determine_export_assignments_cache.freeze();
+    self.get_exports_type_cache.freeze();
     self.freezed.store(true, Ordering::Release);
   }
 
   pub fn unfreeze(&self) {
     self.freezed.store(false, Ordering::Release);
+  }
+
+  pub fn cached_get_exports_type<F: FnOnce() -> ExportsType>(
+    &self,
+    key: GetExportsTypeCacheKey,
+    f: F,
+  ) -> ExportsType {
+    if !self.freezed.load(Ordering::Acquire) {
+      return f();
+    }
+
+    match self.get_exports_type_cache.get(&key) {
+      Some(value) => value,
+      None => {
+        let value = f();
+        self.get_exports_type_cache.set(key, value.clone());
+        value
+      }
+    }
   }
 
   pub fn cached_get_mode<F: FnOnce() -> ExportMode>(
@@ -71,6 +93,37 @@ impl ModuleGraphCacheArtifactInner {
           .set(key, value.clone());
         value
       }
+    }
+  }
+}
+
+pub(super) mod get_exports_type {
+  use super::*;
+  use crate::{ExportsType, ModuleIdentifier};
+
+  pub type GetExportsTypeCacheKey = (ModuleIdentifier, bool);
+
+  #[derive(Debug, Default)]
+  pub struct GetExportsTypeCache {
+    cache: RwLock<HashMap<GetExportsTypeCacheKey, ExportsType>>,
+  }
+
+  impl GetExportsTypeCache {
+    pub fn freeze(&self) {
+      self.cache.write().expect("should get lock").clear();
+    }
+
+    pub fn get(&self, key: &GetExportsTypeCacheKey) -> Option<ExportsType> {
+      let inner = self.cache.read().expect("should get lock");
+      inner.get(key).cloned()
+    }
+
+    pub fn set(&self, key: GetExportsTypeCacheKey, value: ExportsType) {
+      self
+        .cache
+        .write()
+        .expect("should get lock")
+        .insert(key, value);
     }
   }
 }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -325,7 +325,9 @@ impl ChunkGraph {
         .module_by_identifier(module_identifier)
         .expect("should have module")
         .as_ref();
-      module.get_exports_type(&mg, strict).hash(&mut hasher);
+      module
+        .get_exports_type(&mg, &compilation.module_graph_cache_artifact, strict)
+        .hash(&mut hasher);
       hash_modules.push(module);
     }
     let hash_results = hash_modules

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -963,6 +963,7 @@ impl Module for ConcatenatedModule {
       {
         let final_name = Self::get_final_name(
           &compilation.get_module_graph(),
+          &compilation.module_graph_cache_artifact,
           referenced_info_id,
           export_name,
           &mut module_to_info_map,
@@ -1026,6 +1027,7 @@ impl Module for ConcatenatedModule {
       exports_map.insert(used_name.clone(), {
         let final_name = Self::get_final_name(
           &compilation.get_module_graph(),
+          &compilation.module_graph_cache_artifact,
           &root_module_id,
           [name.clone()].to_vec(),
           &mut module_to_info_map,
@@ -1217,6 +1219,7 @@ impl Module for ConcatenatedModule {
           {
             let final_name = Self::get_final_name(
               &compilation.get_module_graph(),
+              &compilation.module_graph_cache_artifact,
               module_info_id,
               vec![export_info.name().cloned().unwrap_or("".into())],
               &mut module_to_info_map,
@@ -1955,6 +1958,7 @@ impl ConcatenatedModule {
   #[allow(clippy::too_many_arguments)]
   fn get_final_name(
     module_graph: &ModuleGraph,
+    module_graph_cache: &ModuleGraphCacheArtifact,
     info: &ModuleIdentifier,
     export_name: Vec<Atom>,
     module_to_info_map: &mut IdentifierIndexMap<ModuleInfo>,
@@ -1968,6 +1972,7 @@ impl ConcatenatedModule {
   ) -> String {
     let binding = Self::get_final_binding(
       module_graph,
+      module_graph_cache,
       info,
       export_name.clone(),
       module_to_info_map,
@@ -2042,6 +2047,7 @@ impl ConcatenatedModule {
   #[allow(clippy::too_many_arguments)]
   fn get_final_binding(
     mg: &ModuleGraph,
+    mg_cache: &ModuleGraphCacheArtifact,
     info_id: &ModuleIdentifier,
     mut export_name: Vec<Atom>,
     module_to_info_map: &mut IdentifierIndexMap<ModuleInfo>,
@@ -2059,7 +2065,7 @@ impl ConcatenatedModule {
     let module = mg
       .module_by_identifier(&info.id())
       .expect("should have module");
-    let exports_type = module.get_exports_type(mg, strict_esm_module);
+    let exports_type = module.get_exports_type(mg, mg_cache, strict_esm_module);
 
     if export_name.is_empty() {
       match exports_type {
@@ -2335,6 +2341,7 @@ impl ConcatenatedModule {
                 .build_meta();
               return Self::get_final_binding(
                 mg,
+                mg_cache,
                 &ref_info.id(),
                 if let Some(reexport_export) = reexport.export {
                   [reexport_export.clone(), export_name[1..].to_vec()].concat()

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -234,6 +234,7 @@ impl ContextModule {
     for (module_id, dep) in sorted_modules {
       let exports_type = get_exports_type_with_strict(
         &compilation.get_module_graph(),
+        &compilation.module_graph_cache_artifact,
         dep,
         matches!(
           self.options.context_options.namespace_object,

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -82,7 +82,7 @@ impl Dependency for ContextElementDependency {
   fn get_referenced_exports(
     &self,
     module_graph: &ModuleGraph,
-    _module_graph_cache: &ModuleGraphCacheArtifact,
+    module_graph_cache: &ModuleGraphCacheArtifact,
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ExtendedReferencedExport> {
     if let Some(referenced_exports) = &self.referenced_exports {
@@ -107,7 +107,7 @@ impl Dependency for ContextElementDependency {
         let exports_type = is_strict.and_then(|is_strict| {
           module_graph
             .get_module_by_dependency_id(&self.id)
-            .map(|m| m.get_exports_type(module_graph, is_strict))
+            .map(|m| m.get_exports_type(module_graph, module_graph_cache, is_strict))
         });
 
         if let Some(exports_type) = exports_type

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -32,8 +32,8 @@ use crate::{
   BoxModuleDependency, ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, CompilationAsset,
   CompilationId, CompilerId, CompilerOptions, ConcatenationScope, ConnectionState, Context,
   ContextModule, DependenciesBlock, DependencyId, ExportProvided, ExternalModule, ModuleGraph,
-  ModuleLayer, ModuleType, NormalModule, PrefetchExportsInfoMode, RawModule, Resolve,
-  ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver, SourceType,
+  ModuleGraphCacheArtifact, ModuleLayer, ModuleType, NormalModule, PrefetchExportsInfoMode,
+  RawModule, Resolve, ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver, SourceType,
 };
 
 pub struct BuildContext {
@@ -279,8 +279,15 @@ pub trait Module:
     self.build_info().module_argument
   }
 
-  fn get_exports_type(&self, module_graph: &ModuleGraph, strict: bool) -> ExportsType {
-    get_exports_type_impl(self.identifier(), self.build_meta(), module_graph, strict)
+  fn get_exports_type(
+    &self,
+    module_graph: &ModuleGraph,
+    module_graph_cache: &ModuleGraphCacheArtifact,
+    strict: bool,
+  ) -> ExportsType {
+    module_graph_cache.cached_get_exports_type((self.identifier(), strict), || {
+      get_exports_type_impl(self.identifier(), self.build_meta(), module_graph, strict)
+    })
   }
 
   fn get_strict_esm_module(&self) -> bool {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -65,6 +65,7 @@ impl CommonJsExportRequireDependency {
   fn get_star_reexports(
     &self,
     mg: &ModuleGraph,
+    mg_cache: &ModuleGraphCacheArtifact,
     runtime: Option<&RuntimeSpec>,
     imported_module: &ModuleIdentifier,
   ) -> Option<FxHashSet<Atom>> {
@@ -124,7 +125,7 @@ impl CommonJsExportRequireDependency {
     let is_namespace_import = matches!(
       mg.module_by_identifier(imported_module)
         .expect("Should get imported module")
-        .get_exports_type(mg, false),
+        .get_exports_type(mg, mg_cache, false),
       ExportsType::Namespace
     );
 
@@ -214,7 +215,7 @@ impl Dependency for CommonJsExportRequireDependency {
   fn get_exports(
     &self,
     mg: &ModuleGraph,
-    _mg_cache: &ModuleGraphCacheArtifact,
+    mg_cache: &ModuleGraphCacheArtifact,
   ) -> Option<ExportsSpec> {
     let ids = self.get_ids(mg);
 
@@ -240,7 +241,9 @@ impl Dependency for CommonJsExportRequireDependency {
       })
     } else if self.names.is_empty() {
       let from = mg.connection_by_dependency_id(&self.id)?;
-      if let Some(reexport_info) = self.get_star_reexports(mg, None, from.module_identifier()) {
+      if let Some(reexport_info) =
+        self.get_star_reexports(mg, mg_cache, None, from.module_identifier())
+      {
         Some(ExportsSpec {
           exports: ExportsOfExportsSpec::Names(
             reexport_info

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -77,14 +77,14 @@ impl Dependency for CommonJsFullRequireDependency {
   fn get_referenced_exports(
     &self,
     module_graph: &ModuleGraph,
-    _module_graph_cache: &ModuleGraphCacheArtifact,
+    module_graph_cache: &ModuleGraphCacheArtifact,
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ExtendedReferencedExport> {
     if self.is_call
       && module_graph
         .module_graph_module_by_dependency_id(&self.id)
         .and_then(|mgm| module_graph.module_by_identifier(&mgm.module_identifier))
-        .map(|m| m.get_exports_type(module_graph, false))
+        .map(|m| m.get_exports_type(module_graph, module_graph_cache, false))
         .is_some_and(|t| !matches!(t, ExportsType::Namespace))
     {
       if self.names.is_empty() {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -186,7 +186,8 @@ impl ESMExportImportedSpecifierDependency {
     if is_name_unused {
       return ExportMode::Unused(ExportModeUnused { name: "*".into() });
     }
-    let imported_exports_type = get_exports_type(module_graph, id, parent_module);
+    let imported_exports_type =
+      get_exports_type(module_graph, module_graph_cache, id, parent_module);
     let ids = self.get_ids(module_graph);
 
     // Special handling for reexporting the default export
@@ -1317,6 +1318,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         self,
         ids,
         module_graph,
+        module_graph_cache,
         self
           .name
           .as_ref()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -229,6 +229,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
   module_dependency: &T,
   ids: &[Atom],
   module_graph: &ModuleGraph,
+  module_graph_cache: &ModuleGraphCacheArtifact,
   additional_msg: String,
   should_error: bool,
 ) -> Option<Diagnostic> {
@@ -242,8 +243,11 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
   let parent_module = module_graph
     .module_by_identifier(parent_module_identifier)
     .expect("should have module");
-  let exports_type =
-    imported_module.get_exports_type(module_graph, parent_module.build_meta().strict_esm_module);
+  let exports_type = imported_module.get_exports_type(
+    module_graph,
+    module_graph_cache,
+    parent_module.build_meta().strict_esm_module,
+  );
   let create_error = |message: String| {
     let (severity, title) = if should_error {
       (Severity::Error, "ESModulesLinkingError")

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -194,7 +194,7 @@ impl Dependency for ESMImportSpecifierDependency {
   fn get_diagnostics(
     &self,
     module_graph: &ModuleGraph,
-    _module_graph_cache: &ModuleGraphCacheArtifact,
+    module_graph_cache: &ModuleGraphCacheArtifact,
   ) -> Option<Vec<Diagnostic>> {
     let module = module_graph.get_parent_module(&self.id)?;
     let module = module_graph.module_by_identifier(module)?;
@@ -205,6 +205,7 @@ impl Dependency for ESMImportSpecifierDependency {
         self,
         self.get_ids(module_graph),
         module_graph,
+        module_graph_cache,
         format!("(imported as '{}')", self.name),
         should_error,
       )
@@ -217,7 +218,7 @@ impl Dependency for ESMImportSpecifierDependency {
   fn get_referenced_exports(
     &self,
     module_graph: &ModuleGraph,
-    _module_graph_cache: &ModuleGraphCacheArtifact,
+    module_graph_cache: &ModuleGraphCacheArtifact,
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ExtendedReferencedExport> {
     let mut ids = self.get_ids(module_graph);
@@ -233,7 +234,8 @@ impl Dependency for ESMImportSpecifierDependency {
       let parent_module = module_graph
         .get_parent_module(&self.id)
         .expect("should have parent module");
-      let exports_type = get_exports_type(module_graph, &self.id, parent_module);
+      let exports_type =
+        get_exports_type(module_graph, module_graph_cache, &self.id, parent_module);
       match exports_type {
         ExportsType::DefaultOnly | ExportsType::DefaultWithNamed => {
           if ids.len() == 1 {
@@ -448,8 +450,13 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
           .get_parent_module(&dep.id)
           .and_then(|id| module_graph.module_by_identifier(id))
           .expect("should have parent module");
-        let exports_type =
-          module.get_exports_type(&module_graph, self_module.build_meta().strict_esm_module);
+        let exports_type = module.get_exports_type(
+          &module_graph,
+          &code_generatable_context
+            .compilation
+            .module_graph_cache_artifact,
+          self_module.build_meta().strict_esm_module,
+        );
         if matches!(
           exports_type,
           ExportsType::DefaultOnly | ExportsType::DefaultWithNamed

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -17,6 +17,7 @@ pub fn create_import_dependency_referenced_exports(
   dependency_id: &DependencyId,
   referenced_exports: &Option<Vec<Atom>>,
   mg: &ModuleGraph,
+  mg_cache: &ModuleGraphCacheArtifact,
 ) -> Vec<ExtendedReferencedExport> {
   if let Some(referenced_exports) = referenced_exports {
     let mut refs = vec![];
@@ -35,7 +36,7 @@ pub fn create_import_dependency_referenced_exports(
         else {
           return create_exports_object_referenced();
         };
-        let exports_type = imported_module.get_exports_type(mg, strict);
+        let exports_type = imported_module.get_exports_type(mg, mg_cache, strict);
         if matches!(
           exports_type,
           ExportsType::DefaultOnly | ExportsType::DefaultWithNamed
@@ -122,10 +123,15 @@ impl Dependency for ImportDependency {
   fn get_referenced_exports(
     &self,
     module_graph: &rspack_core::ModuleGraph,
-    _module_graph_cache: &ModuleGraphCacheArtifact,
+    module_graph_cache: &ModuleGraphCacheArtifact,
     _runtime: Option<&rspack_core::RuntimeSpec>,
   ) -> Vec<rspack_core::ExtendedReferencedExport> {
-    create_import_dependency_referenced_exports(&self.id, &self.referenced_exports, module_graph)
+    create_import_dependency_referenced_exports(
+      &self.id,
+      &self.referenced_exports,
+      module_graph,
+      module_graph_cache,
+    )
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -79,10 +79,15 @@ impl Dependency for ImportEagerDependency {
   fn get_referenced_exports(
     &self,
     module_graph: &rspack_core::ModuleGraph,
-    _module_graph_cache: &ModuleGraphCacheArtifact,
+    module_graph_cache: &ModuleGraphCacheArtifact,
     _runtime: Option<&rspack_core::RuntimeSpec>,
   ) -> Vec<rspack_core::ExtendedReferencedExport> {
-    create_import_dependency_referenced_exports(&self.id, &self.referenced_exports, module_graph)
+    create_import_dependency_referenced_exports(
+      &self.id,
+      &self.referenced_exports,
+      module_graph,
+      module_graph_cache,
+    )
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -80,7 +80,11 @@ async fn render_startup(
   let boxed_module = module_graph
     .module_by_identifier(module)
     .expect("should have build meta");
-  let exports_type = boxed_module.get_exports_type(&module_graph, boxed_module.build_info().strict);
+  let exports_type = boxed_module.get_exports_type(
+    &module_graph,
+    &compilation.module_graph_cache_artifact,
+    boxed_module.build_info().strict,
+  );
   for (_, export_info) in exports_info.exports() {
     if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
       continue;


### PR DESCRIPTION
## Summary

Save `module.get_exports_type` on `module_graph_cache`. This exports type is calculated from `build_meta` + `strict` + `exports_info.get_target`. So it is safe to be cached just like `get_mode`. 

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
