### PR TITLE
fix: `loaderContext.importModule` should return error

### DIFF
--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/loader.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/loader.js
@@ -1,11 +1,11 @@
 /** @type {import('@rspack/test-tools').PitchLoaderDefinitionFunction} */
-module.exports = async function () {
+module.exports = async function (content) {
 	try {
-		const result = await this.importModule("./syntax-error.js");
-
-		// here should be unreachable
-		expect(result).toBe(Symbol('unreachable'));
+		await this.importModule("./syntax-error.js");
 	} catch (e) {
 		expect(e).toBeDefined()
+		return content;
 	}
+	// here should be unreachable
+	throw new Error("unreachable");
 };

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/raw-error.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/raw-error.err
@@ -1,10 +1,5 @@
 Array [
   Object {
-    code: ModuleBuildError,
-    moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/loader.js??ruleSet[1].rules[0].use[0]!<TEST_TOOLS_ROOT>/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/index.js,
-    moduleName: ./index.js,
-  },
-  Object {
     code: ModuleParseError,
     moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/syntax-error.js,
     moduleName: ,

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/stats.err
@@ -1,7 +1,3 @@
-ERROR in ./index.js
-  × Module build failed:
-  ╰─▶   × Final loader(<TEST_TOOLS_ROOT>/tests/diagnosticsCases/module-build-failed/loader-import-syntax-error/loader.js??ruleSet[1].rules[0].use[0]) didn't return a Buffer or String
-
 ERROR in × Module parse failed:
   ╰─▶   × JavaScript parse error: Unexpected eof
          ╭────


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

close: #8536

## Related links

<!-- Related issues or discussions. -->

Fix the wrong test case introduced by https://github.com/web-infra-dev/rspack/pull/8590

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
