### PR TITLE
perf: pre-allocate codegen buffer

### DIFF
--- a/crates/rspack_javascript_compiler/src/compiler/minify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/minify.rs
@@ -184,6 +184,7 @@ impl JavaScriptCompiler {
           );
 
           let print_options = PrintOptions {
+            source_len: fm.byte_length(),
             source_map: self.cm.clone(),
             target,
             source_map_config: SourceMapConfig {

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -328,6 +328,7 @@ impl<'a> JavaScriptTransformer<'a> {
     };
 
     let print_options = PrintOptions {
+      source_len: self.fm.byte_length(),
       source_map: self.cm.clone(),
       target,
       source_map_config,


### PR DESCRIPTION
## Summary

When I'm profiling `swc_ecma_minifier`, I notice that reallocation of codegen buffer takes lots of time(1%-2%). I find oxc's codegen does this optimization: https://github.com/oxc-project/oxc/blob/b8b3530cd1ca7127d20bbd3794294657cf7578d3/crates/oxc_codegen/src/lib.rs#L193C19-L193C26

Since rspack doesn't use swc's codegen api, we can do this directly in rspack.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
