### PR TITLE
fix(rstest): put Rstest plugin in `experiments` field

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/rspack.config.js
@@ -1,5 +1,7 @@
 const path = require("path");
-const { RstestPlugin } = require("@rspack/core");
+const {
+	experiments: { RstestPlugin }
+} = require("@rspack/core");
 
 class RstestSimpleRuntimePlugin {
 	constructor() {}

--- a/packages/rspack-test-tools/tests/configCases/rstest/module-path-names/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/module-path-names/rspack.config.js
@@ -1,5 +1,7 @@
 const path = require("path");
-const { RstestPlugin } = require("@rspack/core");
+const {
+	experiments: { RstestPlugin }
+} = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = [

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2498,6 +2498,8 @@ interface Experiments_2 {
     // (undocumented)
     RsdoctorPlugin: typeof RsdoctorPlugin;
     // (undocumented)
+    RstestPlugin: typeof RstestPlugin;
+    // (undocumented)
     SubresourceIntegrityPlugin: typeof SubresourceIntegrityPlugin;
     // (undocumented)
     swc: {
@@ -6356,7 +6358,6 @@ declare namespace rspackExports {
         ProvidePlugin,
         DefinePlugin,
         ProgressPlugin,
-        RstestPlugin,
         EntryPlugin,
         DynamicEntryPlugin,
         ExternalsPlugin,
@@ -6782,7 +6783,7 @@ export type RspackSeverity = binding.JsRspackSeverity;
 export const rspackVersion: string;
 
 // @public (undocumented)
-export const RstestPlugin: {
+const RstestPlugin: {
     new (rstest: RawRstestPluginOptions): {
         name: BuiltinPluginName;
         _args: [rstest: RawRstestPluginOptions];

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -108,7 +108,6 @@ export { IgnorePlugin, type IgnorePluginOptions } from "./builtin-plugin";
 export { ProvidePlugin } from "./builtin-plugin";
 export { DefinePlugin } from "./builtin-plugin";
 export { ProgressPlugin } from "./builtin-plugin";
-export { RstestPlugin } from "./builtin-plugin";
 export { EntryPlugin } from "./builtin-plugin";
 export { DynamicEntryPlugin } from "./builtin-plugin";
 export { ExternalsPlugin } from "./builtin-plugin";
@@ -210,6 +209,7 @@ import { RuntimeChunkPlugin } from "./builtin-plugin";
 import { SplitChunksPlugin } from "./builtin-plugin";
 import { RemoveDuplicateModulesPlugin } from "./builtin-plugin";
 import { RsdoctorPlugin } from "./builtin-plugin";
+import { RstestPlugin } from "./builtin-plugin";
 import { CssChunkingPlugin } from "./builtin-plugin";
 
 interface Optimize {
@@ -352,6 +352,7 @@ interface Experiments {
 	};
 	RemoveDuplicateModulesPlugin: typeof RemoveDuplicateModulesPlugin;
 	RsdoctorPlugin: typeof RsdoctorPlugin;
+	RstestPlugin: typeof RstestPlugin;
 	SubresourceIntegrityPlugin: typeof SubresourceIntegrityPlugin;
 	lazyCompilationMiddleware: typeof lazyCompilationMiddleware;
 	swc: {
@@ -384,6 +385,12 @@ export const experiments: Experiments = {
 	 * @internal
 	 */
 	RsdoctorPlugin,
+	/**
+	 * Note: This plugin is unstable yet
+	 *
+	 * @internal
+	 */
+	RstestPlugin,
 	SubresourceIntegrityPlugin,
 	lazyCompilationMiddleware,
 	swc: {


### PR DESCRIPTION
## Summary

Place the Rstest plugin in the `experiments` field, similar to how Rsdoctor does it, to prevent misuse by users.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
