### PR TITLE
chore: release v1.4.0-rc.0

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "binding.js",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-wasm32-wasi",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.wasi.cjs",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-x64-msvc",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-x64-msvc.node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "license": "MIT",
   "description": "The fast Rust-based web bundler with webpack-compatible API",
   "private": true,

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "description": "CLI for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/test-tools",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "license": "MIT",
   "description": "Test tools for rspack",
   "main": "dist/index.js",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-rc.0",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "The fast Rust-based web bundler with webpack-compatible API",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at release/v1.4.0-rc.0 -->

## What's Changed
### Performance Improvements ⚡
* perf(logger): calculate trace only when needed by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10683
* perf(ci): move benchmark building to self-hosted by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10680
* perf: inline module graph partials by @CPunisher in https://github.com/web-infra-dev/rspack/pull/10727
* perf: improve zod references to reduce bundle size by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10738
* perf(zod/v4): disable Zod JIT by @colinaaa in https://github.com/web-infra-dev/rspack/pull/10739
* perf: cache get exports type on module graph cache by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/10741
* perf: parallel get runtime hash of concatenated modules by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/10744
* perf: parallel get concatenated imports when enter module by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/10747
### New Features 🎉
* feat: extend target type to include es2023, es2024, and es2025 by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10700
* feat(ci): upload perf data by commit when PR merged by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10715
* feat: support preamble in swc minifier  by @CPunisher in https://github.com/web-infra-dev/rspack/pull/10713
* feat(create-rspack): update tsconfig.json by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10674
* feat: add support for SHA-256 by @pgoldberg in https://github.com/web-infra-dev/rspack/pull/10553
* feat: type reexports presence tolerant by @ahabhgk in https://github.com/web-infra-dev/rspack/pull/10719
* feat(zod/v4): upgrade to Zod V4 by @colinaaa in https://github.com/web-infra-dev/rspack/pull/10678
* feat(ci): use full match only to find self-hosted build caches  by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10724
* feat(rstest): support manual mock by @fi3ework in https://github.com/web-infra-dev/rspack/pull/10625
* feat: introduce rspack_tasks  by @hardfist in https://github.com/web-infra-dev/rspack/pull/10699
### Bug Fixes 🐞
* fix: generator data url function panic by @SyMind in https://github.com/web-infra-dev/rspack/pull/10682
* fix(binding): remove Node 10 compatibility code by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10685
* fix(ci): linux x86 native build hardcoded profile by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10693
* fix: failed to resolve `browserslist:env` from target by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10730
* fix: add `-debugids` to Zod schema by @colinaaa in https://github.com/web-infra-dev/rspack/pull/10728
* fix: `loaderContext.importModule` should return error by @colinaaa in https://github.com/web-infra-dev/rspack/pull/10750
### Refactor 🔨
* refactor(zod/v4): use `.superRefine()` for `builtin:swc-loader` by @colinaaa in https://github.com/web-infra-dev/rspack/pull/10679
* refactor: js api readableIdentifier in module by @SyMind in https://github.com/web-infra-dev/rspack/pull/10686
* refactor:  fast fail  matrix testing  to better utilizing CI runner by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10687
* refactor: move codspeed build to self-hosted by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10688
* refactor: prefetch exports info data of getters part 3 by @LingyuCoder in https://github.com/web-infra-dev/rspack/pull/10652
* refactor: remove unnecessary callback by @hardfist in https://github.com/web-infra-dev/rspack/pull/10714
* refactor: prefer native build for better speed by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10725
* refactor(zod/v4): replace deprecated `.superRefine()` by @colinaaa in https://github.com/web-infra-dev/rspack/pull/10729
### Document Updates 📖
* docs: add some clarification of module-graph-partial by @hardfist in https://github.com/web-infra-dev/rspack/pull/10684
* docs: use assets.rspack.dev by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10692
* docs: update lazyCompilationMiddleware interface by @JSerFeng in https://github.com/web-infra-dev/rspack/pull/10695
* docs: update tracing doc typo by @hardfist in https://github.com/web-infra-dev/rspack/pull/10723
### Other Changes
* chore: fix release-debug build for windows by @quininer in https://github.com/web-infra-dev/rspack/pull/10649
* chore: release 1.4.0-beta.1 by @CPunisher in https://github.com/web-infra-dev/rspack/pull/10681
* chore: remove rspack.dev redirect by @hardfist in https://github.com/web-infra-dev/rspack/pull/10691
* chore(workflow): simplify PR template by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10701
* chore(deps): update dependency @rslib/core to v0.10.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10703
* chore(deps): update dependency axios to ^1.10.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10705
* chore(deps): update dependency terser to v5.43.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10709
* chore(deps): update dependency ts-jest to v29.4.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10710
* chore(deps): update dependency acorn to ^8.15.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10704
* chore(benchmark): add rspack benchcases  by @h-a-n-a in https://github.com/web-infra-dev/rspack/pull/9345
* chore(benchmark): limit parallel forks in vitest by @CPunisher in https://github.com/web-infra-dev/rspack/pull/10718
* chore(CI): fix codspeed build in GitHub hosted runner by @stormslowly in https://github.com/web-infra-dev/rspack/pull/10720
* chore: add diff artifact action by @CPunisher in https://github.com/web-infra-dev/rspack/pull/10731
* chore: remove prebundle config for enhanced-resolve by @chenjiahan in https://github.com/web-infra-dev/rspack/pull/10736
* chore(deps): update dependency create-rstack to v1.5.1 by @renovate in https://github.com/web-infra-dev/rspack/pull/10752
* chore(deps): update dependency rspress-plugin-sitemap to ^1.2.0 by @renovate in https://github.com/web-infra-dev/rspack/pull/10753

## New Contributors
* @pgoldberg made their first contribution in https://github.com/web-infra-dev/rspack/pull/10553

**Full Changelog**: https://github.com/web-infra-dev/rspack/compare/v1.4.0-beta.1...v1.4.0-rc.0