### PR TITLE
chore: proxy extract arguments to napi as cargo options

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -1,12 +1,14 @@
 const path = require("path");
 const { readFileSync, writeFileSync } = require("fs");
-const { values } = require("util").parseArgs({
+const { values, positionals } = require("util").parseArgs({
 	args: process.argv.slice(2),
 	options: {
 		profile: {
 			type: "string"
 		}
-	}
+	},
+	strict: true,
+	allowPositionals: true
 });
 
 const { spawn } = require("child_process");
@@ -66,6 +68,12 @@ async function build() {
 		}
 		if (features.length) {
 			args.push("--features " + features.join(","));
+		}
+
+		if (positionals.length > 0) {
+			// napi need `--` to separate options and positional arguments.
+			args.push("--");
+			args.push(...positionals);
 		}
 
 		console.log(`Run command: napi ${args.join(" ")}`);


### PR DESCRIPTION
## Summary
I want to do `cargo build --timings` to analyze building time consumings; I have to modify `crates/node_binding/scripts/build.js` to acheive that.

after PR, it will be easier.

```bash
npm run build:dev -- -- --timings
#                 │   │
#                 │   └─ for scripts/build.js positional parsing
#                 └─ for npm positional parsing
# or
pnpm run build:dev -- --timings
```



<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
