### PR TITLE
perf: improve concatenated modules plugin

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1652,6 +1652,7 @@ impl Module for ConcatenatedModule {
   fn get_side_effects_connection_state(
     &self,
     _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
     _module_chain: &mut IdentifierSet,
     _connection_state_cache: &mut IdentifierMap<ConnectionState>,
   ) -> ConnectionState {

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -72,6 +72,7 @@ pub trait Dependency:
   fn get_module_evaluation_side_effects_state(
     &self,
     _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
     _module_chain: &mut IdentifierSet,
     _connection_state_cache: &mut IdentifierMap<ConnectionState>,
   ) -> ConnectionState {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -379,6 +379,7 @@ pub trait Module:
   fn get_side_effects_connection_state(
     &self,
     _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
     _module_chain: &mut IdentifierSet,
     _connection_state_cache: &mut IdentifierMap<ConnectionState>,
   ) -> ConnectionState {

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1017,13 +1017,10 @@ impl<'a> ModuleGraph<'a> {
   }
 
   pub fn get_exports_info(&self, module_identifier: &ModuleIdentifier) -> ExportsInfo {
-    let mgm = self
-      .module_graph_module_by_identifier(module_identifier)
-      .expect("should have mgm");
     self
-      .loop_partials(|p| p.exports_info_map.get(&mgm.exports))
-      .expect("should have exports info")
-      .id()
+      .module_graph_module_by_identifier(module_identifier)
+      .expect("should have mgm")
+      .exports
   }
 
   pub fn get_prefetched_exports_info_optional<'b>(

--- a/crates/rspack_plugin_extract_css/src/css_dependency.rs
+++ b/crates/rspack_plugin_extract_css/src/css_dependency.rs
@@ -3,7 +3,7 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AffectType, AsContextDependency, AsDependencyCodeGeneration, ConnectionState, Dependency,
   DependencyCategory, DependencyId, DependencyRange, DependencyType, FactorizeInfo,
-  ModuleDependency, ModuleGraph,
+  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
 };
 use rspack_paths::ArcPath;
 use rustc_hash::FxHashSet;
@@ -99,6 +99,7 @@ impl Dependency for CssDependency {
   fn get_module_evaluation_side_effects_state(
     &self,
     _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
     _module_chain: &mut IdentifierSet,
     _connection_state_cache: &mut IdentifierMap<ConnectionState>,
   ) -> ConnectionState {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -106,6 +106,7 @@ impl Dependency for ESMExportExpressionDependency {
   fn get_module_evaluation_side_effects_state(
     &self,
     _module_graph: &rspack_core::ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
     _module_chain: &mut IdentifierSet,
     _connection_state_cache: &mut IdentifierMap<rspack_core::ConnectionState>,
   ) -> rspack_core::ConnectionState {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -1282,6 +1282,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
   fn get_module_evaluation_side_effects_state(
     &self,
     _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
     _module_chain: &mut IdentifierSet,
     _connection_state_cache: &mut IdentifierMap<ConnectionState>,
   ) -> ConnectionState {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -105,6 +105,7 @@ impl Dependency for ESMExportSpecifierDependency {
   fn get_module_evaluation_side_effects_state(
     &self,
     _module_graph: &rspack_core::ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
     _module_chain: &mut IdentifierSet,
     _connection_state_cache: &mut IdentifierMap<rspack_core::ConnectionState>,
   ) -> rspack_core::ConnectionState {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -524,6 +524,7 @@ impl Dependency for ESMImportSideEffectDependency {
   fn get_module_evaluation_side_effects_state(
     &self,
     module_graph: &ModuleGraph,
+    module_graph_cache: &ModuleGraphCacheArtifact,
     module_chain: &mut IdentifierSet,
     connection_state_cache: &mut IdentifierMap<ConnectionState>,
   ) -> ConnectionState {
@@ -531,7 +532,12 @@ impl Dependency for ESMImportSideEffectDependency {
       .module_identifier_by_dependency_id(&self.id)
       .and_then(|module_identifier| module_graph.module_by_identifier(module_identifier))
     {
-      module.get_side_effects_connection_state(module_graph, module_chain, connection_state_cache)
+      module.get_side_effects_connection_state(
+        module_graph,
+        module_graph_cache,
+        module_chain,
+        connection_state_cache,
+      )
     } else {
       ConnectionState::Active(true)
     }
@@ -563,12 +569,13 @@ impl DependencyConditionFn for ESMImportSideEffectDependencyCondition {
     conn: &rspack_core::ModuleGraphConnection,
     _runtime: Option<&RuntimeSpec>,
     module_graph: &ModuleGraph,
-    _module_graph_cache: &ModuleGraphCacheArtifact,
+    module_graph_cache: &ModuleGraphCacheArtifact,
   ) -> ConnectionState {
     let id = *conn.module_identifier();
     if let Some(module) = module_graph.module_by_identifier(&id) {
       module.get_side_effects_connection_state(
         module_graph,
+        module_graph_cache,
         &mut IdentifierSet::default(),
         &mut IdentifierMap::default(),
       )

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -176,6 +176,7 @@ impl Dependency for ESMImportSpecifierDependency {
   fn get_module_evaluation_side_effects_state(
     &self,
     _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
     _module_chain: &mut IdentifierSet,
     _connection_state_cache: &mut IdentifierMap<ConnectionState>,
   ) -> ConnectionState {

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -4,8 +4,8 @@ use rspack_core::{
   filter_runtime, runtime_condition_expression, AsContextDependency, AsModuleDependency,
   Compilation, ConnectionState, Dependency, DependencyCodeGeneration, DependencyId,
   DependencyRange, DependencyTemplate, DependencyTemplateType, ExportsInfoGetter, ModuleGraph,
-  ModuleIdentifier, PrefetchExportsInfoMode, RuntimeCondition, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource, UsageState, UsedByExports,
+  ModuleGraphCacheArtifact, ModuleIdentifier, PrefetchExportsInfoMode, RuntimeCondition,
+  RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedByExports,
 };
 use rspack_util::ext::DynHash;
 use rustc_hash::FxHashSet;
@@ -79,6 +79,7 @@ impl Dependency for PureExpressionDependency {
   fn get_module_evaluation_side_effects_state(
     &self,
     _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
     _module_chain: &mut IdentifierSet,
     _connection_state_cache: &mut IdentifierMap<ConnectionState>,
   ) -> ConnectionState {

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -675,6 +675,7 @@ async fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<O
         *module_identifier,
         module.get_side_effects_connection_state(
           &module_graph,
+          &compilation.module_graph_cache_artifact,
           &mut Default::default(),
           &mut Default::default(),
         ),


### PR DESCRIPTION
## Summary

- Add `cached_get_side_effects_connection_state` to prevent running `module.get_side_effects_connection_state` multiple times in normal modules
- Introduce `NoRuntimeModuleCache` in the Concatenated modules plugin to calculate module information unrelated to the runtime in parallel.

Before:
![image](https://github.com/user-attachments/assets/8366b95b-653f-4d39-82ef-7d801398808d)


After:
![image](https://github.com/user-attachments/assets/9cb2492d-95df-420f-b622-445f916b5512)

## Related links





## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
