### PR TITLE
chore: don't measure compiler builder

### DIFF
--- a/tasks/benchmark/benches/groups/bundle.rs
+++ b/tasks/benchmark/benches/groups/bundle.rs
@@ -15,9 +15,6 @@ criterion_group!(bundle, bundle_benchmark);
 fn bundle_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("bundle");
 
-  #[cfg(feature = "codspeed")]
-  group.sample_size(10);
-
   let projects: Vec<(&'static str, CompilerBuilderGenerator)> = vec![
     ("basic-react", Arc::new(basic_react::compiler)),
     ("threejs", Arc::new(threejs::compiler)),

--- a/tasks/benchmark/benches/groups/bundle.rs
+++ b/tasks/benchmark/benches/groups/bundle.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use criterion::{criterion_group, Criterion};
-use rspack_tasks::within_compiler_context_for_testing;
+use rspack_tasks::{within_compiler_context, within_compiler_context_sync, CompilerContext};
 use tokio::runtime;
 
 use crate::groups::bundle::util::{derive_projects, CompilerBuilderGenerator};
@@ -31,13 +31,21 @@ fn bundle_benchmark(c: &mut Criterion) {
 
   for (id, get_compiler) in derive_projects(projects) {
     group.bench_function(format!("bundle@{id}"), |b| {
-      b.to_async(&rt).iter(|| async {
-        within_compiler_context_for_testing(async {
-          let mut compiler = get_compiler();
-          compiler.build().unwrap().run().await.unwrap();
-        })
-        .await
-      });
+      b.to_async(&rt).iter_batched(
+        || {
+          let compiler_context = Arc::new(CompilerContext::new());
+          (
+            compiler_context.clone(),
+            within_compiler_context_sync(compiler_context, || get_compiler().build().unwrap()),
+          )
+        },
+        |(compiler_context, mut compiler)| {
+          within_compiler_context(compiler_context, async move {
+            compiler.run().await.unwrap();
+          })
+        },
+        criterion::BatchSize::PerIteration,
+      );
     });
   }
 }


### PR DESCRIPTION
## Summary

It's my fault that I measure the cost of `CompilerBuilder::build`, which introduces some inaccuracy.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
