### PR TITLE
chore: Use relr for relocs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -43,7 +43,10 @@ rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains,-al
 
 # To be able to run unit tests on Linux, support compilation to 'x86_64-unknown-linux-gnu'.
 [target.'cfg(target_os = "linux")']
-rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols"]
+rustflags = [
+  "-Clink-args=-Wl,--warn-unresolved-symbols",
+  "-Clink-args=-Wl,--pack-dyn-relocs=relr"
+]
 
 # To be able to run unit tests on Windows, support compilation to 'x86_64-pc-windows-msvc'.
 # Use Hybrid CRT to reduce the size of the binary (Coming by default with Windows 10 and later versions).


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This argument make linker to use relr instead of rela, which reduces the size of linux product by about 4M.

see https://maskray.me/blog/2021-10-31-relative-relocations-and-relr

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
