### PR TITLE
chore(ci): including codspeed perfermance comparison into required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,9 @@ jobs:
         run: bash .github/actions/codspeed/check-comment.sh
 
   test_required_check:
+    # this job will be used for GitHub actions to determine required job success or not;
+    # When code changed, it will check if any of the test jobs failed.
+    # When *only* doc changed, it will run as success directly
     name: Test Required Check
     needs: [check-codspeed, test-linux, test-windows, test-mac, check-changed]
     if: ${{ always() && !cancelled() }}

--- a/tasks/benchmark/benches/groups/bundle.rs
+++ b/tasks/benchmark/benches/groups/bundle.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use criterion::{criterion_group, Criterion};
-use rspack_tasks::within_compiler_context_for_testing;
+use rspack_tasks::{within_compiler_context, within_compiler_context_sync, CompilerContext};
 use tokio::runtime;
 
 use crate::groups::bundle::util::{derive_projects, CompilerBuilderGenerator};
@@ -14,9 +14,6 @@ criterion_group!(bundle, bundle_benchmark);
 
 fn bundle_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("bundle");
-
-  #[cfg(feature = "codspeed")]
-  group.sample_size(10);
 
   let projects: Vec<(&'static str, CompilerBuilderGenerator)> = vec![
     ("basic-react", Arc::new(basic_react::compiler)),
@@ -31,13 +28,21 @@ fn bundle_benchmark(c: &mut Criterion) {
 
   for (id, get_compiler) in derive_projects(projects) {
     group.bench_function(format!("bundle@{id}"), |b| {
-      b.to_async(&rt).iter(|| async {
-        within_compiler_context_for_testing(async {
-          let mut compiler = get_compiler();
-          compiler.build().unwrap().run().await.unwrap();
-        })
-        .await
-      });
+      b.to_async(&rt).iter_batched(
+        || {
+          let compiler_context = Arc::new(CompilerContext::new());
+          (
+            compiler_context.clone(),
+            within_compiler_context_sync(compiler_context, || get_compiler().build().unwrap()),
+          )
+        },
+        |(compiler_context, mut compiler)| {
+          within_compiler_context(compiler_context, async move {
+            compiler.run().await.unwrap();
+          })
+        },
+        criterion::BatchSize::PerIteration,
+      );
     });
   }
 }


### PR DESCRIPTION
Codspeed performance comparison is a neutral *Check*. And it's written by codspeed's GitHub App.
So we can't get the comparison result in workflow directly.

Here we use a workaround to get the comparison result by taking advance of Codspeed's pull request comment.

After comparison, Codspeed will write/update [comment](https://codspeed.io/docs/integrations/ci/buildkite#3-check-the-results) to the pull request about the performance status.

So we can poll pull request's codspeed bot's comment, check if it contains the commit id of current CI targeted. If so we get the latest comparison, then we do a simple grep to see if the pull request degrade the performance or not, then fail or pass the CI checking.

1. The polling is written in the `check-comment.sh`
2. The polling action should be put in `CI.yaml` other than `reusable-build-bench.yml`; it seems that codspeed will write/update comment after job finishes, so if put polling in `reusable-build-bench.yml`, it will trigger a dead-lock


Here is a failure log: https://github.com/web-infra-dev/rspack/actions/runs/15863460473/job/44726161423?pr=10782#step:3:9
Here is a success log: https://github.com/web-infra-dev/rspack/actions/runs/15865447682/job/44731781135#step:3:9