### PR TITLE
fix: binding version check not work

### DIFF
--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -13,10 +13,6 @@ const externalAlias = ({ request }: { request?: string }, callback) => {
 		}
 	}
 
-	if (/..\/package\.json/.test(request!)) {
-		return callback(null, "../package.json");
-	}
-
 	if (new RegExp(/^tinypool$/).test(request!)) {
 		return callback(null, "../compiled/tinypool/dist/index.js");
 	}
@@ -34,7 +30,7 @@ const commonLibConfig: LibConfig = {
 		}
 	},
 	output: {
-		externals: [externalAlias],
+		externals: ["@rspack/binding/package.json", externalAlias],
 		minify: {
 			js: true,
 			jsOptions: {


### PR DESCRIPTION
## Summary

Fix the binding version check not work.

The `@rspack/binding/package.json` module should be externalized correctly to ensure that Rspack can get the current version of the binding package.

### Before

<img width="876" alt="Screenshot 2025-06-25 at 16 09 23" src="https://github.com/user-attachments/assets/c667bc87-4e13-400d-bacb-354dccd63cd0" />

### After

<img width="865" alt="Screenshot 2025-06-25 at 16 09 02" src="https://github.com/user-attachments/assets/4d36e7d2-3fbc-4b03-b871-c0b554ca7870" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
