### PR TITLE
fix(test): js folder create confliction

### DIFF
--- a/tests/webpack-test/WatchTestCases.template.js
+++ b/tests/webpack-test/WatchTestCases.template.js
@@ -70,7 +70,7 @@ const describeCases = config => {
 		});
 		beforeAll(() => {
 			let dest = path.join(__dirname, "js");
-			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
+			if (!fs.existsSync(dest)) fs.mkdirSync(dest, { recursive: true });
 			dest = path.join(__dirname, "js", config.name + "-src");
 			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
 		});


### PR DESCRIPTION
## Summary
Fix watch case setup unstable.

Due to the `js` folder create conflict with different test suits.

```txt
2025-06-19T11:24:16.9140356Z     EEXIST: file already exists, mkdir '/home/runner/_work/rspack/rspack/tests/webpack-test/js'
2025-06-19T11:24:16.9140711Z 
2025-06-19T11:24:16.9140999Z       71 | 		beforeAll(() => {
2025-06-19T11:24:16.9141548Z       72 | 			let dest = path.join(__dirname, "js");
2025-06-19T11:24:16.9142236Z     > 73 | 			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
2025-06-19T11:24:16.9142758Z          | 			                             ^
2025-06-19T11:24:16.9143434Z       74 | 			dest = path.join(__dirname, "js", config.name + "-src");
2025-06-19T11:24:16.9144130Z       75 | 			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
2025-06-19T11:24:16.9144551Z       76 | 		});
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
