### PR TITLE
perf: improve mangle plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4827,6 +4827,7 @@ dependencies = [
  "rspack_collections",
  "rspack_core",
  "rspack_error",
+ "rspack_futures",
  "rspack_hash",
  "rspack_hook",
  "rspack_plugin_javascript",

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -20,6 +20,7 @@ rspack_base64            = { workspace = true }
 rspack_collections       = { workspace = true }
 rspack_core              = { workspace = true }
 rspack_error             = { workspace = true }
+rspack_futures           = { workspace = true }
 rspack_hash              = { workspace = true }
 rspack_hook              = { workspace = true }
 rspack_plugin_javascript = { workspace = true }

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -17,7 +17,7 @@ use rspack_core::{
   AssetInfo, Chunk, ChunkUkey, Compilation, CompilationAsset, CompilationProcessAssets, Filename,
   Logger, ModuleIdentifier, PathData, Plugin, PluginContext,
 };
-use rspack_error::{error, miette::IntoDiagnostic, Result};
+use rspack_error::{error, miette::IntoDiagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::{asset_condition::AssetConditions, identifier::make_paths_absolute};
@@ -252,53 +252,77 @@ impl SourceMapDevToolPlugin {
       })
       .collect::<HashMap<_, _>>();
 
-    let module_source_names = source_map_modules.values().collect::<Vec<_>>();
     let mut module_to_source_name = match &self.module_filename_template {
-      ModuleFilenameTemplate::String(s) => {
-        let tasks = module_source_names
-          .into_iter()
-          .map(|(file, module_or_source)| async move {
-            if let ModuleOrSource::Source(source) = module_or_source {
-              if SCHEMA_SOURCE_REGEXP.is_match(source) {
-                return Ok((module_or_source, source.to_string()));
-              }
-            }
+      ModuleFilenameTemplate::String(template) => {
+        let source_names = rspack_futures::scope::<_, Result<_>>(|token| {
+          source_map_modules.values()
+            .for_each(|(file, module_or_source)| {
+              let s = unsafe {
+                token.used((
+                  self.namespace.as_str(),
+                  &compilation,
+                  file,
+                  module_or_source,
+                  file_to_chunk,
+                  template,
+                ))
+              };
+              s.spawn(
+                |(namespace, compilation, file, module_or_source, file_to_chunk, template)| async move {
+                  if let ModuleOrSource::Source(source) = module_or_source {
+                    if SCHEMA_SOURCE_REGEXP.is_match(source) {
+                      return Ok(source.to_string());
+                    }
+                  }
 
-            let chunk = file_to_chunk.get(file);
-            let path_data = PathData::default()
-              .chunk_id_optional(
-                chunk.and_then(|c| c.id(&compilation.chunk_ids_artifact).map(|id| id.as_str())),
-              )
-              .chunk_name_optional(chunk.and_then(|c| c.name()))
-              .chunk_hash_optional(chunk.and_then(|c| {
-                c.rendered_hash(
-                  &compilation.chunk_hashes_artifact,
-                  compilation.options.output.hash_digest_length,
-                )
-              }));
+                  let chunk = file_to_chunk.get(file);
+                  let path_data = PathData::default()
+                    .chunk_id_optional(
+                      chunk
+                        .and_then(|c| c.id(&compilation.chunk_ids_artifact).map(|id| id.as_str())),
+                    )
+                    .chunk_name_optional(chunk.and_then(|c| c.name()))
+                    .chunk_hash_optional(chunk.and_then(|c| {
+                      c.rendered_hash(
+                        &compilation.chunk_hashes_artifact,
+                        compilation.options.output.hash_digest_length,
+                      )
+                    }));
 
-            let filename = Filename::from(self.namespace.as_str());
-            let namespace = compilation.get_path(&filename, path_data).await?;
+                  let filename = Filename::from(namespace);
+                  let namespace = compilation.get_path(&filename, path_data).await?;
 
-            let source_name = ModuleFilenameHelpers::create_filename_of_string_template(
-              module_or_source,
-              compilation,
-              s,
-              output_options,
-              &namespace,
-            );
-            Ok((module_or_source, source_name))
-          })
-          .collect::<Vec<_>>();
+                  let source_name = ModuleFilenameHelpers::create_filename_of_string_template(
+                    module_or_source,
+                    compilation,
+                    template,
+                    &compilation.options.output,
+                    &namespace,
+                  );
+                  Ok(source_name)
+                },
+              );
+            })
+        })
+        .await
+        .into_iter()
+        .map(|r| r.to_rspack_result())
+        .collect::<Result<Vec<_>>>()?;
 
-        join_all(tasks)
-          .await
-          .into_iter()
-          .collect::<Result<HashMap<_, _>>>()?
+        let mut res = HashMap::default();
+
+        for ((_, module_or_source), source_name) in
+          source_map_modules.values().zip(source_names.into_iter())
+        {
+          res.insert(module_or_source, source_name?);
+        }
+
+        res
       }
       ModuleFilenameTemplate::Fn(f) => {
-        let tasks = module_source_names
-          .into_iter()
+        // the tsfn will be called sync in javascript side so there is no need to use rspack futures to parallelize it
+        let tasks = source_map_modules
+          .values()
           .map(|(_, module_or_source)| async move {
             if let ModuleOrSource::Source(source) = module_or_source {
               if SCHEMA_SOURCE_REGEXP.is_match(source) {

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -1,9 +1,11 @@
 use std::sync::LazyLock;
 
+use itertools::Itertools;
+use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
   incremental::IncrementalPasses, ApplyContext, BuildMetaExportsType, Compilation,
-  CompilationOptimizeCodeGeneration, CompilerOptions, ExportInfoGetter, ExportProvided,
+  CompilationOptimizeCodeGeneration, CompilerOptions, ExportInfo, ExportInfoGetter, ExportProvided,
   ExportsInfo, ExportsInfoGetter, ModuleGraph, Plugin, PluginContext, PrefetchExportsInfoMode,
   PrefetchedExportsInfoWrapper, UsageState,
 };
@@ -43,6 +45,21 @@ impl MangleExportsPlugin {
   }
 }
 
+#[derive(Debug)]
+enum Manglable {
+  CanNotMangle(Atom),
+  CanMangle(Atom),
+  Mangled,
+}
+
+#[derive(Debug)]
+struct ExportInfoCache {
+  id: ExportInfo,
+  deterministic: bool,
+  exports_info: Option<ExportsInfo>,
+  can_mangle: Manglable,
+}
+
 #[plugin_hook(CompilationOptimizeCodeGeneration for MangleExportsPlugin)]
 async fn optimize_code_generation(&self, compilation: &mut Compilation) -> Result<()> {
   if let Some(diagnostic) = compilation.incremental.disable_passes(
@@ -60,19 +77,128 @@ async fn optimize_code_generation(&self, compilation: &mut Compilation) -> Resul
   // We don't do that cause we don't have this option
   let mut mg = compilation.get_module_graph_mut();
   let module_id_list = mg.modules().keys().cloned().collect::<Vec<_>>();
+
+  let mut exports_info_cache = FxHashMap::default();
+
+  let mut q = module_id_list
+    .iter()
+    .filter_map(|id| {
+      let (Some(mgm), Some(module)) = (
+        mg.module_graph_module_by_identifier(id),
+        mg.module_by_identifier(id),
+      ) else {
+        return None;
+      };
+      let is_namespace = matches!(
+        module.build_meta().exports_type,
+        BuildMetaExportsType::Namespace
+      );
+      Some((mgm.exports, is_namespace))
+    })
+    .collect_vec();
+
+  while !q.is_empty() {
+    let items = std::mem::take(&mut q);
+    let batch = items
+      .par_iter()
+      .filter_map(|(exports_info, is_namespace)| {
+        let mut avoid_mangle_non_provided = !is_namespace;
+        let deterministic = self.deterministic;
+        let exports_info_data =
+          ExportsInfoGetter::prefetch(exports_info, &mg, PrefetchExportsInfoMode::AllExports);
+        let export_list = {
+          if !can_mangle(&exports_info_data) {
+            return None;
+          }
+          if !avoid_mangle_non_provided && deterministic {
+            for (_, export_info) in exports_info_data.exports() {
+              if !matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
+                avoid_mangle_non_provided = true;
+                break;
+              }
+            }
+          }
+          exports_info_data
+            .exports()
+            .map(|(_, export_info)| export_info)
+            .collect::<Vec<_>>()
+        };
+
+        Some((
+          *exports_info,
+          export_list
+            .iter()
+            .map(|export_info_data| {
+              let can_mangle = if !ExportInfoGetter::has_used_name(export_info_data) {
+                let name = export_info_data
+                  .name()
+                  .expect("the name of export_info inserted in exports_info can not be `None`")
+                  .clone();
+                let can_not_mangle = ExportInfoGetter::can_mangle(export_info_data) != Some(true)
+                  || (name.len() == 1 && MANGLE_NAME_NORMAL_REG.is_match(name.as_str()))
+                  || (deterministic
+                    && name.len() == 2
+                    && MANGLE_NAME_DETERMINISTIC_REG.is_match(name.as_str()))
+                  || (avoid_mangle_non_provided
+                    && !matches!(export_info_data.provided(), Some(ExportProvided::Provided)));
+
+                if can_not_mangle {
+                  Manglable::CanNotMangle(name)
+                } else {
+                  Manglable::CanMangle(name)
+                }
+              } else {
+                Manglable::Mangled
+              };
+
+              let nested_exports_info = if export_info_data.exports_info_owned() {
+                let used = ExportInfoGetter::get_used(export_info_data, None);
+                if used == UsageState::OnlyPropertiesUsed || used == UsageState::Unused {
+                  export_info_data.exports_info()
+                } else {
+                  None
+                }
+              } else {
+                None
+              };
+
+              ExportInfoCache {
+                id: export_info_data.id(),
+                deterministic,
+                exports_info: nested_exports_info,
+                can_mangle,
+              }
+            })
+            .collect_vec(),
+        ))
+      })
+      .collect::<Vec<_>>();
+
+    for (exports_info, export_list) in batch {
+      q.extend(
+        export_list
+          .iter()
+          .filter_map(|export_info_cache| export_info_cache.exports_info.map(|e| (e, false)))
+          .filter(|(e, _)| !exports_info_cache.contains_key(e)),
+      );
+      exports_info_cache.insert(exports_info, export_list);
+    }
+  }
+
   for identifier in module_id_list {
-    let (Some(mgm), Some(module)) = (
+    let (Some(mgm), Some(_)) = (
       mg.module_graph_module_by_identifier(&identifier),
       mg.module_by_identifier(&identifier),
     ) else {
       continue;
     };
-    let is_namespace = matches!(
-      module.build_meta().exports_type,
-      BuildMetaExportsType::Namespace
-    );
     let exports_info = mgm.exports;
-    mangle_exports_info(&mut mg, self.deterministic, exports_info, is_namespace);
+    mangle_exports_info(
+      &mut mg,
+      self.deterministic,
+      exports_info,
+      &exports_info_cache,
+    );
   }
   Ok(())
 }
@@ -103,69 +229,36 @@ fn mangle_exports_info(
   mg: &mut ModuleGraph,
   deterministic: bool,
   exports_info: ExportsInfo,
-  is_namespace: bool,
+  exports_info_cache: &FxHashMap<ExportsInfo, Vec<ExportInfoCache>>,
 ) {
   let mut used_names = FxHashSet::default();
   let mut mangleable_exports = Vec::new();
-  let mut avoid_mangle_non_provided = !is_namespace;
-
-  let export_list = {
-    let exports_info =
-      ExportsInfoGetter::prefetch(&exports_info, mg, PrefetchExportsInfoMode::AllExports);
-    if !can_mangle(&exports_info) {
-      return;
-    }
-    if !avoid_mangle_non_provided && deterministic {
-      for (_, export_info) in exports_info.exports() {
-        if !matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
-          avoid_mangle_non_provided = true;
-          break;
-        }
-      }
-    }
-    exports_info
-      .exports()
-      .map(|(_, export_info)| export_info.id())
-      .collect::<Vec<_>>()
+  let Some(export_list) = exports_info_cache.get(&exports_info) else {
+    return;
   };
 
-  for export_info in export_list {
-    let export_info_data = export_info.as_data_mut(mg);
-    if !ExportInfoGetter::has_used_name(export_info_data) {
-      let name = export_info_data
-        .name()
-        .expect("the name of export_info inserted in exports_info can not be `None`")
-        .clone();
-      let can_not_mangle = ExportInfoGetter::can_mangle(export_info_data) != Some(true)
-        || (name.len() == 1 && MANGLE_NAME_NORMAL_REG.is_match(name.as_str()))
-        || (deterministic
-          && name.len() == 2
-          && MANGLE_NAME_DETERMINISTIC_REG.is_match(name.as_str()))
-        || (avoid_mangle_non_provided
-          && !matches!(export_info_data.provided(), Some(ExportProvided::Provided)));
+  let mut mangleable_export_names = FxHashMap::default();
 
-      if can_not_mangle {
-        export_info_data.set_used_name(name.clone());
+  for export_info in export_list {
+    match &export_info.can_mangle {
+      Manglable::CanNotMangle(name) => {
+        export_info.id.as_data_mut(mg).set_used_name(name.clone());
         used_names.insert(name.to_string());
-      } else {
-        mangleable_exports.push(export_info);
-      };
+      }
+      Manglable::CanMangle(name) => {
+        mangleable_export_names.insert(export_info.id, name.clone());
+        mangleable_exports.push(export_info.id);
+      }
+      Manglable::Mangled => {}
     }
 
-    // we need to re get export info to avoid extending immutable borrow lifetime
-    let export_info_data = export_info.as_data(mg);
-    if export_info_data.exports_info_owned() {
-      let used = ExportInfoGetter::get_used(export_info_data, None);
-      if used == UsageState::OnlyPropertiesUsed || used == UsageState::Unused {
-        mangle_exports_info(
-          mg,
-          deterministic,
-          export_info_data
-            .exports_info()
-            .expect("should have exports info id"),
-          false,
-        );
-      }
+    if let Some(nested_exports_info) = export_info.exports_info {
+      mangle_exports_info(
+        mg,
+        export_info.deterministic,
+        nested_exports_info,
+        exports_info_cache,
+      );
     }
   }
 
@@ -174,8 +267,18 @@ fn mangle_exports_info(
     let mut export_info_used_name = FxHashMap::default();
     assign_deterministic_ids(
       mangleable_exports,
-      |e| e.as_data(mg).name().expect("should have name").to_string(),
-      |a, b| compare_strings_numeric(a.as_data(mg).name(), b.as_data(mg).name()),
+      |e| {
+        mangleable_export_names
+          .get(&e)
+          .expect("should have name")
+          .to_string()
+      },
+      |a, b| {
+        compare_strings_numeric(
+          Some(mangleable_export_names.get(a).expect("should have name")),
+          Some(mangleable_export_names.get(b).expect("should have name")),
+        )
+      },
       |e, id| {
         let name = number_to_identifier(id as u32);
         let size = used_names.len();
@@ -211,10 +314,18 @@ fn mangle_exports_info(
       }
     }
 
-    used_exports
-      .sort_by(|a, b| compare_strings_numeric(a.as_data(mg).name(), b.as_data(mg).name()));
-    unused_exports
-      .sort_by(|a, b| compare_strings_numeric(a.as_data(mg).name(), b.as_data(mg).name()));
+    used_exports.sort_by(|a, b| {
+      compare_strings_numeric(
+        Some(mangleable_export_names.get(a).expect("should have name")),
+        Some(mangleable_export_names.get(b).expect("should have name")),
+      )
+    });
+    unused_exports.sort_by(|a, b| {
+      compare_strings_numeric(
+        Some(mangleable_export_names.get(a).expect("should have name")),
+        Some(mangleable_export_names.get(b).expect("should have name")),
+      )
+    });
 
     let mut i = 0;
     for list in [used_exports, unused_exports] {


### PR DESCRIPTION
## Summary

- parallel calulating exports info mangle info in `MangleExportsPlugin`
- parallel generating filename of string template in `SourceMapDevToolPlugin::map_assets`

Before:
![image](https://github.com/user-attachments/assets/f4096d85-98a9-4183-bc4e-0854ae79e56e)
![image](https://github.com/user-attachments/assets/58a626fd-acff-43ff-957e-4a3d9b32066e)

After:
![image](https://github.com/user-attachments/assets/28ff4b1c-e35c-4a7d-aa55-d2feddb5eece)
![image](https://github.com/user-attachments/assets/8cd36509-25a8-4685-a708-8925a6dc2a79)





## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
