### PR TITLE
chore: Enable allocator track for sftrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,6 +4115,7 @@ name = "rspack_allocator"
 version = "0.2.0"
 dependencies = [
  "mimalloc-rspack",
+ "sftrace-setup",
 ]
 
 [[package]]

--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -7,6 +7,9 @@ repository        = "https://github.com/web-infra-dev/rspack"
 version           = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+sftrace-setup = { workspace = true, optional = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 # Turned on `local_dynamic_tls` to avoid issue: https://github.com/microsoft/mimalloc/issues/147
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] }

--- a/crates/rspack_allocator/src/lib.rs
+++ b/crates/rspack_allocator/src/lib.rs
@@ -1,3 +1,10 @@
 #[global_allocator]
 #[cfg(not(any(miri, target_family = "wasm")))]
+#[cfg(not(feature = "sftrace-setup"))]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[global_allocator]
+#[cfg(not(any(miri, target_family = "wasm")))]
+#[cfg(feature = "sftrace-setup")]
+static GLOBAL: sftrace_setup::SftraceAllocator<mimalloc::MiMalloc> =
+  sftrace_setup::SftraceAllocator(mimalloc::MiMalloc);

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -9,6 +9,7 @@ version           = "0.2.0"
 
 [features]
 plugin = ["rspack_loader_swc/plugin"]
+sftrace-setup = [ "dep:sftrace-setup", "rspack_allocator/sftrace-setup" ]
 
 [dependencies]
 anyhow                   = { workspace = true }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

We updated the sftrace allocator so that it does not call the sftrace symbol when sftrace is not enabled, so we can always trace allocator calls in the debug profile without affect normal execution.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
