### PR TITLE
fix: should not panic in esm specifier dependency when resolve failed

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -443,9 +443,9 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
     if let Some(referenced_properties) = &dep.referenced_properties_in_destructuring {
       let mut prefixed_ids = ids.to_vec();
 
-      let module = module_graph
-        .get_module_by_dependency_id(&dep.id)
-        .expect("should have imported module");
+      let Some(module) = module_graph.get_module_by_dependency_id(&dep.id) else {
+        return;
+      };
 
       if ids.first().is_some_and(|id| id == "default") {
         let self_module = module_graph

--- a/packages/rspack-test-tools/tests/configCases/mangle-exports/issue-10565/errors.js
+++ b/packages/rspack-test-tools/tests/configCases/mangle-exports/issue-10565/errors.js
@@ -1,0 +1,1 @@
+module.exports = [/Can't resolve '.\/non-exists'/];

--- a/packages/rspack-test-tools/tests/configCases/mangle-exports/issue-10565/index.js
+++ b/packages/rspack-test-tools/tests/configCases/mangle-exports/issue-10565/index.js
@@ -1,0 +1,9 @@
+import { obj3, default as a } from "./non-exists" // enable side effects to ensure reexport is not skipped
+
+it("should not panic", () => {
+	const { aaa, bbb } = obj3;
+	const { ccc, ddd } = a;
+	aaa, bbb;
+	ccc, ddd;
+});
+

--- a/packages/rspack-test-tools/tests/configCases/mangle-exports/issue-10565/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/mangle-exports/issue-10565/rspack.config.js
@@ -1,49 +1,10 @@
-// const { getRuntimeKey } = require("../../../../lib/util/runtime");
-
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: "./index.js",
-	module: {
-		rules: [
-			{
-				resourceQuery: /side-effects/,
-				sideEffects: true
-			}
-		]
-	},
 	optimization: {
 		mangleExports: true,
 		usedExports: true,
 		providedExports: true,
 		concatenateModules: false
-	},
-	plugins: [
-		function getJsonCodeGeneratedSource(compiler) {
-			compiler.hooks.compilation.tap(
-				getJsonCodeGeneratedSource.name,
-				compilation => {
-					compilation.hooks.processAssets.tap(
-						getJsonCodeGeneratedSource.name,
-						() => {
-							for (const module of compilation.modules) {
-								if (module.type === "json") {
-									const { sources } = compilation.codeGenerationResults.get(
-										module,
-										"main"
-									);
-									const source = sources.get("javascript");
-									const file = compilation.getAssetPath("[name].js", {
-										filename: `${module
-											.readableIdentifier(compilation.requestShortener)
-											.replace(/[?#]/g, "_")}.js`
-									});
-									compilation.emitAsset(file, source);
-								}
-							}
-						}
-					);
-				}
-			);
-		}
-	]
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/mangle-exports/issue-10565/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/mangle-exports/issue-10565/rspack.config.js
@@ -1,0 +1,49 @@
+// const { getRuntimeKey } = require("../../../../lib/util/runtime");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	module: {
+		rules: [
+			{
+				resourceQuery: /side-effects/,
+				sideEffects: true
+			}
+		]
+	},
+	optimization: {
+		mangleExports: true,
+		usedExports: true,
+		providedExports: true,
+		concatenateModules: false
+	},
+	plugins: [
+		function getJsonCodeGeneratedSource(compiler) {
+			compiler.hooks.compilation.tap(
+				getJsonCodeGeneratedSource.name,
+				compilation => {
+					compilation.hooks.processAssets.tap(
+						getJsonCodeGeneratedSource.name,
+						() => {
+							for (const module of compilation.modules) {
+								if (module.type === "json") {
+									const { sources } = compilation.codeGenerationResults.get(
+										module,
+										"main"
+									);
+									const source = sources.get("javascript");
+									const file = compilation.getAssetPath("[name].js", {
+										filename: `${module
+											.readableIdentifier(compilation.requestShortener)
+											.replace(/[?#]/g, "_")}.js`
+									});
+									compilation.emitAsset(file, source);
+								}
+							}
+						}
+					);
+				}
+			);
+		}
+	]
+};


### PR DESCRIPTION
## Summary

fix #10565

The module should not exists if it is failed to resolve. It is safe to ignore it and should not panic.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
