### PR TITLE
fix(create-rspack): remove verbatimModuleSyntax

### DIFF
--- a/packages/create-rspack/template-react-ts/tsconfig.json
+++ b/packages/create-rspack/template-react-ts/tsconfig.json
@@ -9,7 +9,6 @@
 
     /* modules */
     "module": "ESNext",
-    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/create-rspack/template-vanilla-ts/tsconfig.json
+++ b/packages/create-rspack/template-vanilla-ts/tsconfig.json
@@ -9,7 +9,6 @@
     /* modules */
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
 

--- a/packages/create-rspack/template-vue-ts/tsconfig.json
+++ b/packages/create-rspack/template-vue-ts/tsconfig.json
@@ -10,7 +10,6 @@
 
     /* modules */
     "module": "ESNext",
-    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary

Remove `verbatimModuleSyntax: true` from create-rspack's tsconfig.json.

When using Node <= 22.x and ts-node, `verbatimModuleSyntax: true` will cause an error:

```bash
rspack.config.ts:1:10 - error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.

1 import { defineConfig } from "@rspack/cli";
```

## Related links

- resolve https://github.com/web-infra-dev/rspack/issues/10815
- https://github.com/web-infra-dev/rspack/pull/10674

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
