### PR TITLE
refactor: remove debug_assert for remove_available_modules

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/available_modules.rs
+++ b/crates/rspack_core/src/build_chunk_graph/available_modules.rs
@@ -9,71 +9,26 @@ use crate::Compilation;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AvailableModules {
-  #[cfg(debug_assertions)]
-  available_modules: rspack_collections::IdentifierSet,
-
-  #[cfg(not(debug_assertions))]
   available_modules: num_bigint::BigUint,
 }
 
 impl AvailableModules {
   pub fn union(&self, other: &Self) -> Self {
-    #[cfg(debug_assertions)]
-    {
-      Self {
-        available_modules: self
-          .available_modules
-          .iter()
-          .chain(&other.available_modules)
-          .copied()
-          .collect(),
-      }
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
-      Self {
-        available_modules: &self.available_modules | &other.available_modules,
-      }
+    Self {
+      available_modules: &self.available_modules | &other.available_modules,
     }
   }
 
   pub fn intersect(&self, other: &Self) -> Self {
-    #[cfg(debug_assertions)]
-    {
-      Self {
-        available_modules: self
-          .available_modules
-          .intersection(&other.available_modules)
-          .copied()
-          .collect(),
-      }
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
-      Self {
-        available_modules: &self.available_modules & &other.available_modules,
-      }
+    Self {
+      available_modules: &self.available_modules & &other.available_modules,
     }
   }
 
-  #[cfg(debug_assertions)]
-  pub fn is_module_available(&self, module: crate::ModuleIdentifier) -> bool {
-    self.available_modules.contains(&module)
-  }
-
-  #[cfg(not(debug_assertions))]
   pub fn is_module_available(&self, module: u64) -> bool {
     self.available_modules.bit(module)
   }
 
-  #[cfg(debug_assertions)]
-  pub fn add(&mut self, module: crate::ModuleIdentifier) {
-    self.available_modules.insert(module);
-  }
-
-  #[cfg(not(debug_assertions))]
   pub fn add(&mut self, module: u64) {
     self.available_modules.set_bit(module, true);
   }
@@ -193,16 +148,10 @@ pub fn remove_available_modules(
     };
 
     chunk.chunk_modules_mut().retain(|module_identifier| {
-      let module = {
-        #[cfg(debug_assertions)]
-        {
-          *module_identifier
-        }
-        #[cfg(not(debug_assertions))]
-        {
-          ordinal_by_modules.get(module_identifier).copied().unwrap()
-        }
-      };
+      let module = ordinal_by_modules
+        .get(module_identifier)
+        .copied()
+        .expect("should have module ordinal");
 
       let in_parent = available.is_module_available(module);
 

--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -739,7 +739,6 @@ impl CodeSplitter {
     Ok(runtime)
   }
 
-  #[cfg(not(debug_assertions))]
   fn get_module_ordinal(&self, m: ModuleIdentifier) -> u64 {
     *self
       .module_ordinal
@@ -832,16 +831,7 @@ impl CodeSplitter {
             continue;
           }
 
-          let module = {
-            #[cfg(debug_assertions)]
-            {
-              target_module
-            }
-            #[cfg(not(debug_assertions))]
-            {
-              self.get_module_ordinal(target_module)
-            }
-          };
+          let module = self.get_module_ordinal(target_module);
           if ctx.module_ordinal.is_module_available(module) {
             // we already include this module
             continue;


### PR DESCRIPTION
## Summary

Don't use HashSet for intersection in debug binary, or it will affect performance for release-debug binary

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
