### PR TITLE
perf: parallel drop AST of concated module infos

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -1116,7 +1116,7 @@ impl JsPlugin {
           let context = compilation.options.context.clone();
           let readable_identifier = module.readable_identifier(&context).to_string();
           let splitted_readable_identifier = split_readable_identifier(&readable_identifier);
-          let new_name = find_new_name(name, &all_used_names, None, &splitted_readable_identifier);
+          let new_name = find_new_name(name, &all_used_names, &splitted_readable_identifier);
 
           for identifier in refs.iter() {
             let span = identifier.id.span();


### PR DESCRIPTION
## Summary

There is no need to keep the ASTs and drop them together.

Before:
![image](https://github.com/user-attachments/assets/3e810eff-466f-422e-985f-8e79690a7a40)

After:
![image](https://github.com/user-attachments/assets/84ee1707-dd8d-4789-b21c-0a62841f0f2c)


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
