### PR TITLE
perf: parallel get chunk full name in deterministic ids plugin

### DIFF
--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -1,4 +1,5 @@
-use rspack_collections::DatabaseItem;
+use rayon::prelude::*;
+use rspack_collections::{DatabaseItem, UkeyMap};
 use rspack_core::{
   incremental::IncrementalPasses, ApplyContext, CompilationChunkIds, CompilerOptions, Plugin,
   PluginContext,
@@ -60,16 +61,29 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
   let mut chunk_key_to_id =
     FxHashMap::with_capacity_and_hasher(chunks.len(), FxBuildHasher::default());
 
+  let chunk_names = chunks
+    .par_iter()
+    .map(|chunk| {
+      (
+        chunk.ukey(),
+        get_full_chunk_name(
+          chunk,
+          chunk_graph,
+          &module_graph,
+          module_graph_cache,
+          &context,
+        ),
+      )
+    })
+    .collect::<UkeyMap<_, _>>();
+
   assign_deterministic_ids(
     chunks,
     |chunk| {
-      get_full_chunk_name(
-        chunk,
-        chunk_graph,
-        &module_graph,
-        module_graph_cache,
-        &context,
-      )
+      chunk_names
+        .get(&chunk.ukey())
+        .expect("should have generated full chunk name")
+        .to_string()
     },
     |a, b| {
       compare_chunks_natural(


### PR DESCRIPTION
## Summary

parallel get chunk full name in deterministic ids plugin

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
