### PR TITLE
docs: introduce @swc/react-compiler to make react-compiler fast

### DIFF
--- a/website/docs/en/guide/tech/react.mdx
+++ b/website/docs/en/guide/tech/react.mdx
@@ -207,8 +207,10 @@ export default {
       {
         // Must be run before 'builtin:swc-loader' to ensure that the file is processed by the React Compiler
         // So we add it to the beginning of the rule
-        test: (resource) => /\.jsx$/.test(resource) && isReactCompilerRequiredSync(fs.readFileSync(resource)),
-        loader: 'babel-loader'
+        test: resource =>
+          /\.jsx$/.test(resource) &&
+          isReactCompilerRequiredSync(fs.readFileSync(resource)),
+        loader: 'babel-loader',
       },
     ],
   },

--- a/website/docs/zh/guide/tech/react.mdx
+++ b/website/docs/zh/guide/tech/react.mdx
@@ -204,15 +204,15 @@ export default {
       {
         // Must be run before 'builtin:swc-loader' to ensure that the file is processed by the React Compiler
         // So we add it to the beginning of the rule
-        test: (resource) => /\.jsx$/.test(resource) && isReactCompilerRequiredSync(fs.readFileSync(resource)),
-        loader: 'babel-loader'
+        test: resource =>
+          /\.jsx$/.test(resource) &&
+          isReactCompilerRequiredSync(fs.readFileSync(resource)),
+        loader: 'babel-loader',
       },
     ],
   },
 };
 ```
-
-
 
 4. 创建 `babel.config.js` 并配置插件：
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
We are introducing a recommendation to use `@swc/react-compiler` for pre-compilation to reduce the number of files processed by `babel-loader`, which is known to add significant compilation time.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
