### PR TITLE
fix: skip non-resource link tags in SRI plugin

### DIFF
--- a/crates/rspack_plugin_sri/src/html.rs
+++ b/crates/rspack_plugin_sri/src/html.rs
@@ -117,6 +117,40 @@ async fn process_tag_group(
   Ok(())
 }
 
+// Get the `src` or `href` attribute of a tag if it is a script
+// or link tag that needs SRI.
+fn get_tag_src(tag: &HtmlPluginTag) -> Option<String> {
+  // Handle script tags with src attribute
+  if tag.tag_name == "script" {
+    return get_tag_attribute(tag, "src");
+  }
+
+  // Handle link tags that need SRI
+  if tag.tag_name == "link" {
+    let Some(href) = get_tag_attribute(tag, "href") else {
+      return None;
+    };
+
+    let Some(rel) = get_tag_attribute(tag, "rel") else {
+      return None;
+    };
+
+    // Only process link tags that load actual resources
+    let needs_sri = rel == "stylesheet"
+      || rel == "modulepreload"
+      || (rel == "preload" && {
+        let as_attr = get_tag_attribute(tag, "as");
+        as_attr.as_deref() == Some("script") || as_attr.as_deref() == Some("style")
+      });
+
+    if needs_sri {
+      return Some(href);
+    }
+  }
+
+  None
+}
+
 async fn process_tag(
   tag: &HtmlPluginTag,
   public_path: &str,
@@ -133,7 +167,7 @@ async fn process_tag(
     return Ok(None);
   }
 
-  let Some(tag_src) = get_tag_attribute(tag, "href").or(get_tag_attribute(tag, "src")) else {
+  let Some(tag_src) = get_tag_src(tag) else {
     return Ok(None);
   };
 

--- a/crates/rspack_plugin_sri/src/html.rs
+++ b/crates/rspack_plugin_sri/src/html.rs
@@ -127,13 +127,8 @@ fn get_tag_src(tag: &HtmlPluginTag) -> Option<String> {
 
   // Handle link tags that need SRI
   if tag.tag_name == "link" {
-    let Some(href) = get_tag_attribute(tag, "href") else {
-      return None;
-    };
-
-    let Some(rel) = get_tag_attribute(tag, "rel") else {
-      return None;
-    };
+    let href = get_tag_attribute(tag, "href")?;
+    let rel = get_tag_attribute(tag, "rel")?;
 
     // Only process link tags that load actual resources
     let needs_sri = rel == "stylesheet"

--- a/packages/rspack-test-tools/tests/configCases/sri/link-tags/index.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/link-tags/index.js
@@ -1,0 +1,11 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should not process link tags that are not modulepreload, preload, or stylesheet", () => {
+	const htmlPath = path.join(__dirname, "./index.html");
+	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
+	expect(htmlContent).toContain('<script crossorigin defer integrity');
+	expect(htmlContent).toContain('<link href="https://example.com" rel="dns-prefetch">');
+	expect(htmlContent).toContain('<link href="https://example.com" rel="preconnect">');
+	expect(htmlContent).toContain('<link href="https://example.com" rel="prefetch">');
+});

--- a/packages/rspack-test-tools/tests/configCases/sri/link-tags/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/link-tags/rspack.config.js
@@ -1,0 +1,61 @@
+const { rspack } = require("@rspack/core");
+
+class AddLinksPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("AddLinksPlugin", compilation => {
+			rspack.HtmlRspackPlugin.getCompilationHooks(
+				compilation
+			).alterAssetTagGroups.tapPromise("AddLinksPlugin", async data => {
+				data.headTags.push(
+					{
+						tagName: "link",
+						attributes: {
+							href: "https://example.com",
+							rel: "dns-prefetch"
+						},
+						voidTag: true
+					},
+					{
+						tagName: "link",
+						attributes: {
+							href: "https://example.com",
+							rel: "preconnect"
+						},
+						voidTag: true
+					},
+					{
+						tagName: "link",
+						attributes: {
+							rel: "prefetch",
+							href: "https://example.com"
+						},
+						voidTag: true
+					}
+				);
+			});
+		});
+	}
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "web",
+	entry: {
+		main: "./index.js"
+	},
+	externals: {
+		path: "require('path')",
+		fs: "require('fs')"
+	},
+	node: {
+		__dirname: false
+	},
+	output: {
+		crossOriginLoading: "anonymous"
+	},
+	plugins: [
+		new rspack.HtmlRspackPlugin(),
+		new rspack.experiments.SubresourceIntegrityPlugin(),
+		new AddLinksPlugin()
+	]
+};

--- a/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
@@ -337,16 +337,37 @@ function isErrorWithCode<T extends Error>(obj: T): boolean {
 	);
 }
 
+/**
+ * Get the `src` or `href` attribute of a tag if it is a script
+ * or link tag that needs SRI.
+ */
 function getTagSrc(tag: HtmlTagObject): string | undefined {
-	if (!["script", "link"].includes(tag.tagName) || !tag.attributes) {
+	if (!tag.attributes) {
 		return undefined;
 	}
-	if (typeof tag.attributes.href === "string") {
-		return tag.attributes.href;
-	}
-	if (typeof tag.attributes.src === "string") {
+
+	// Handle script tags with src attribute
+	if (tag.tagName === "script" && typeof tag.attributes.src === "string") {
 		return tag.attributes.src;
 	}
+
+	// Handle link tags that need SRI
+	if (tag.tagName === "link" && typeof tag.attributes.href === "string") {
+		const rel = tag.attributes.rel;
+		if (typeof rel !== "string") {
+			return undefined;
+		}
+
+		// Only process link tags that load actual resources
+		const needsSRI =
+			rel === "stylesheet" ||
+			rel === "modulepreload" ||
+			(rel === "preload" &&
+				(tag.attributes.as === "script" || tag.attributes.as === "style"));
+
+		return needsSRI ? tag.attributes.href : undefined;
+	}
+
 	return undefined;
 }
 


### PR DESCRIPTION
## Summary

Updated `getTagSrc()` to only process `<link>` tags that actually load resources requiring SRI:

- Process: `stylesheet`, `modulepreload`, `preload` (script/style only)  
- Skip: `dns-prefetch`, `preconnect`, `prefetch`, `icon`, etc.

This prevents unnecessary SRI processing on hint/metadata tags and improves plugin accuracy.

## Related links

See MDN:

![image](https://github.com/user-attachments/assets/6025d315-e28f-4466-aa5b-901171bcf4f7)

- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#integrity
- resolve https://github.com/web-infra-dev/rsbuild/issues/5445
- https://github.com/waysact/webpack-subresource-integrity/issues/179
- https://github.com/waysact/webpack-subresource-integrity/pull/238

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
