### PR TITLE
docs: correct hook usage in HtmlRspackPlugin documentation

### DIFF
--- a/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
@@ -622,11 +622,13 @@ The following code adds an additional `extra-script.js` and generates a `<script
 const AddScriptPlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('AddScriptPlugin', compilation => {
-      HtmlRspackPlugin.getCompilationHooks(
-        compilation,
-      ).beforeAssetTagGeneration.tapPromise('AddScriptPlugin', async data => {
-        data.assets.js.push('extra-script.js');
-      });
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.beforeAssetTagGeneration.tapPromise(
+        'AddScriptPlugin',
+        async data => {
+          data.assets.js.push('extra-script.js');
+        },
+      );
     });
   },
 };
@@ -682,9 +684,8 @@ The following code adds the `specialAttribute` property to all `script` type tag
 const AddAttributePlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('AddAttributePlugin', compilation => {
-      HtmlRspackPlugin.getCompilationHooks(
-        compilation,
-      ).alterAssetTags.tapPromise('AddAttributePlugin', async data => {
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.alterAssetTags.tapPromise('AddAttributePlugin', async data => {
         data.assetTags.scripts = data.assetTags.scripts.map(tag => {
           if (tag.tagName === 'script') {
             tag.attributes.specialAttribute = true;
@@ -731,9 +732,8 @@ The following code moves the `async` `script` tags from `body` to `head`:
 const MoveTagsPlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('MoveTagsPlugin', compilation => {
-      HtmlWebpackPlugin.getCompilationHooks(
-        compilation,
-      ).alterAssetTagGroups.tapPromise('MoveTagsPlugin', async data => {
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.alterAssetTagGroups.tapPromise('MoveTagsPlugin', async data => {
         data.headTags.push(data.headTags.bodyTags.filter(i => i.async));
         data.bodyTags = data.bodyTags.filter(i => !i.async);
       });
@@ -784,11 +784,13 @@ The following code adds `Injected by plugin` at the end of the body. Then the ta
 const InjectContentPlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('InjectContentPlugin', compilation => {
-      HtmlWebpackPlugin.getCompilationHooks(
-        compilation,
-      ).afterTemplateExecution.tapPromise('InjectContentPlugin', async data => {
-        data.html = data.html.replace('</body>', 'Injected by plugin</body>');
-      });
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.afterTemplateExecution.tapPromise(
+        'InjectContentPlugin',
+        async data => {
+          data.html = data.html.replace('</body>', 'Injected by plugin</body>');
+        },
+      );
     });
   },
 };
@@ -830,12 +832,10 @@ The following code adds `Injected by plugin` at the end of the body. It will be 
 const InjectContentPlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('InjectContentPlugin', compilation => {
-      HtmlWebpackPlugin.getCompilationHooks(compilation).beforeEmit.tapPromise(
-        'InjectContentPlugin',
-        async data => {
-          data.html = data.html.replace('</body>', 'Injected by plugin</body>');
-        },
-      );
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.beforeEmit.tapPromise('InjectContentPlugin', async data => {
+        data.html = data.html.replace('</body>', 'Injected by plugin</body>');
+      });
     });
   },
 };

--- a/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
@@ -620,11 +620,13 @@ export default {
 const AddScriptPlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('AddScriptPlugin', compilation => {
-      HtmlRspackPlugin.getCompilationHooks(
-        compilation,
-      ).beforeAssetTagGeneration.tapPromise('AddScriptPlugin', async object => {
-        object.assets.js.push('extra-script.js');
-      });
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.beforeAssetTagGeneration.tapPromise(
+        'AddScriptPlugin',
+        async data => {
+          data.assets.js.push('extra-script.js');
+        },
+      );
     });
   },
 };
@@ -678,10 +680,9 @@ export default {
 const AddAttributePlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('AddAttributePlugin', compilation => {
-      HtmlRspackPlugin.getCompilationHooks(
-        compilation,
-      ).alterAssetTags.tapPromise('AddAttributePlugin', async pluginArgs => {
-        pluginArgs.assetTags.scripts = pluginArgs.assetTags.scripts.map(tag => {
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.alterAssetTags.tapPromise('AddAttributePlugin', async data => {
+        data.assetTags.scripts = data.assetTags.scripts.map(tag => {
           if (tag.tagName === 'script') {
             tag.attributes.specialAttribute = true;
           }
@@ -725,13 +726,10 @@ export default {
 const MoveTagsPlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('MoveTagsPlugin', compilation => {
-      HtmlWebpackPlugin.getCompilationHooks(
-        compilation,
-      ).alterAssetTagGroups.tapPromise('MoveTagsPlugin', async pluginArgs => {
-        pluginArgs.headTags.push(
-          pluginArgs.headTags.bodyTags.filter(i => i.async),
-        );
-        pluginArgs.bodyTags = pluginArgs.bodyTags.filter(i => !i.async);
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.alterAssetTagGroups.tapPromise('MoveTagsPlugin', async data => {
+        data.headTags.push(data.headTags.bodyTags.filter(i => i.async));
+        data.bodyTags = data.bodyTags.filter(i => !i.async);
       });
     });
   },
@@ -778,9 +776,8 @@ export default {
 const InjectContentPlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('InjectContentPlugin', compilation => {
-      HtmlWebpackPlugin.getCompilationHooks(
-        compilation,
-      ).afterTemplateExecution.tapPromise(
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.afterTemplateExecution.tapPromise(
         'InjectContentPlugin',
         async pluginArgs => {
           pluginArgs.html = pluginArgs.html.replace(
@@ -830,15 +827,10 @@ export default {
 const InjectContentPlugin = {
   apply(compiler) {
     compiler.hooks.compilation.tap('InjectContentPlugin', compilation => {
-      HtmlWebpackPlugin.getCompilationHooks(compilation).beforeEmit.tapPromise(
-        'InjectContentPlugin',
-        async pluginArgs => {
-          pluginArgs.html = pluginArgs.html.replace(
-            '</body>',
-            'Injected by plugin</body>',
-          );
-        },
-      );
+      const hooks = HtmlRspackPlugin.getCompilationHooks(compilation);
+      hooks.beforeEmit.tapPromise('InjectContentPlugin', async data => {
+        data.html = data.html.replace('</body>', 'Injected by plugin</body>');
+      });
     });
   },
 };


### PR DESCRIPTION
## Summary

Correct hook usage in html-rspack-plugin documentation, `HtmlWebpackPlugin.getCompilationHooks()` should be `HtmlRspackPlugin.getCompilationHooks()`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
