### PR TITLE
feat(tracing): add tracing bench preset for benchmark

### DIFF
--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -18,6 +18,9 @@ use rspack_core::{
 use rspack_error::Diagnostic;
 use rspack_fs::{IntermediateFileSystem, NativeFileSystem, ReadableFileSystem};
 use rspack_tasks::{within_compiler_context_sync, CompilerContext, CURRENT_COMPILER_CONTEXT};
+use rspack_util::tracing_preset::{
+  TRACING_ALL_PRESET, TRACING_BENCH_TARGET, TRACING_OVERVIEW_PRESET,
+};
 
 use crate::{
   fs_node::{NodeFileSystem, ThreadsafeNodeFS},
@@ -496,6 +499,12 @@ pub fn register_global_trace(
   #[napi(ts_arg_type = " \"logger\" | \"perfetto\" ")] layer: String,
   output: String,
 ) -> anyhow::Result<()> {
+  let filter = match filter.as_str() {
+    "OVERVIEW" => TRACING_OVERVIEW_PRESET,
+    "ALL" => TRACING_ALL_PRESET,
+    "BENCH" => TRACING_BENCH_TARGET,
+    _ => filter.as_str(),
+  };
   GLOBAL_TRACE_STATE.with(|state| {
     let mut state = state.borrow_mut();
     if let TraceState::Off = *state {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -30,7 +30,7 @@ use rspack_hook::define_hook;
 use rspack_paths::ArcPath;
 use rspack_sources::{BoxSource, CachedSource, SourceExt};
 use rspack_tasks::CompilerContext;
-use rspack_util::itoa;
+use rspack_util::{itoa, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 use tracing::instrument;
 
@@ -921,7 +921,7 @@ impl Compilation {
     ukey
   }
 
-  #[instrument("Compilation:make", skip_all)]
+  #[instrument("Compilation:make",target=TRACING_BENCH_TARGET, skip_all)]
   pub async fn make(&mut self) -> Result<()> {
     self.make_artifact.reset_dependencies_incremental_info();
     // run module_executor
@@ -963,7 +963,7 @@ impl Compilation {
       .collect::<Vec<_>>()))
   }
 
-  #[instrument("Compilation:code_generation", skip_all)]
+  #[instrument("Compilation:code_generation",target=TRACING_BENCH_TARGET, skip_all)]
   async fn code_generation(&mut self, modules: IdentifierSet) -> Result<()> {
     let logger = self.get_logger("rspack.Compilation");
     let mut codegen_cache_counter = match self.options.cache {
@@ -1097,7 +1097,7 @@ impl Compilation {
     Ok(())
   }
 
-  #[instrument("Compilation:create_module_assets", skip_all)]
+  #[instrument("Compilation:create_module_assets",target=TRACING_BENCH_TARGET, skip_all)]
   async fn create_module_assets(&mut self, _plugin_driver: SharedPluginDriver) {
     let mut chunk_asset_map = vec![];
     let mut module_assets = vec![];
@@ -1135,7 +1135,7 @@ impl Compilation {
     }
   }
 
-  #[instrument("Compilation::create_chunk_assets", skip_all)]
+  #[instrument("Compilation::create_chunk_assets",target=TRACING_BENCH_TARGET, skip_all)]
   async fn create_chunk_assets(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     if self.options.output.filename.has_hash_placeholder()
       || self.options.output.chunk_filename.has_hash_placeholder()
@@ -1271,7 +1271,7 @@ impl Compilation {
     Ok(())
   }
 
-  #[instrument("Compilation:process_assets", skip_all)]
+  #[instrument("Compilation:process_assets",target=TRACING_BENCH_TARGET, skip_all)]
   async fn process_assets(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     plugin_driver
       .compilation_hooks
@@ -1290,7 +1290,7 @@ impl Compilation {
       .await
   }
 
-  #[instrument("Compilation:after_seal", skip_all)]
+  #[instrument("Compilation:after_seal", target=TRACING_BENCH_TARGET,skip_all)]
   async fn after_seal(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     plugin_driver.compilation_hooks.after_seal.call(self).await
   }
@@ -1335,7 +1335,7 @@ impl Compilation {
     self.chunk_group_by_ukey.expect_get(ukey)
   }
 
-  #[instrument("Compilation:finish", skip_all)]
+  #[instrument("Compilation:finish",target=TRACING_BENCH_TARGET, skip_all)]
   pub async fn finish(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     // clean up the entry deps
     let make_artifact = std::mem::take(&mut self.make_artifact);
@@ -2016,7 +2016,7 @@ impl Compilation {
     Ok(())
   }
 
-  #[instrument(name = "Compilation:process_chunks_runtime_requirements", skip_all)]
+  #[instrument(name = "Compilation:process_chunks_runtime_requirements", target=TRACING_BENCH_TARGET skip_all)]
   pub async fn process_chunks_runtime_requirements(
     &mut self,
     chunks: UkeySet<ChunkUkey>,
@@ -2165,7 +2165,7 @@ impl Compilation {
     &mut Compilation
   );
 
-  #[instrument(name = "Compilation:create_hash", skip_all)]
+  #[instrument(name = "Compilation:create_hash",target=TRACING_BENCH_TARGET, skip_all)]
   pub async fn create_hash(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     let logger = self.get_logger("rspack.Compilation");
 

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -12,7 +12,7 @@ use rspack_hook::define_hook;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_sources::BoxSource;
 use rspack_tasks::{within_compiler_context, CompilerContext};
-use rspack_util::node_path::NodePath;
+use rspack_util::{node_path::NodePath, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::FxHashMap as HashMap;
 use tracing::instrument;
 
@@ -212,7 +212,7 @@ impl Compiler {
     within_compiler_context(compiler_context, self.build_inner()).await?;
     Ok(())
   }
-  #[instrument("Compiler:build", skip_all)]
+  #[instrument("Compiler:build",target=TRACING_BENCH_TARGET, skip_all)]
   async fn build_inner(&mut self) -> Result<()> {
     self.old_cache.end_idle();
     // TODO: clear the outdated cache entries in resolver,
@@ -264,7 +264,7 @@ impl Compiler {
     Ok(())
   }
 
-  #[instrument("Compiler:compile", skip_all)]
+  #[instrument("Compiler:compile", target=TRACING_BENCH_TARGET,skip_all)]
   async fn compile(&mut self) -> Result<()> {
     let mut compilation_params = self.new_compilation_params();
     // FOR BINDING SAFETY:

--- a/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
@@ -2,6 +2,7 @@ use futures::Future;
 use indexmap::IndexMap;
 use rspack_collections::{IdentifierIndexMap, IdentifierIndexSet};
 use rspack_error::Result;
+use rspack_util::tracing_preset::TRACING_BENCH_TARGET;
 use rustc_hash::FxHashMap as HashMap;
 use tracing::instrument;
 
@@ -283,7 +284,7 @@ impl CodeSplittingCache {
   }
 }
 
-#[instrument(skip_all)]
+#[instrument(name = "Compilation:code_splitting",target=TRACING_BENCH_TARGET, skip_all)]
 pub(crate) async fn use_code_splitting_cache<'a, T, F>(
   compilation: &'a mut Compilation,
   task: T,

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -10,7 +10,9 @@ use rspack_collections::UkeyMap;
 use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
+use rspack_util::tracing_preset::TRACING_BENCH_TARGET;
 use rustc_hash::FxHashMap;
+use tracing::instrument;
 
 use crate::{common::FallbackCacheGroup, module_group::ModuleGroup, CacheGroup, SplitChunkSizes};
 
@@ -39,7 +41,7 @@ impl SplitChunksPlugin {
       options.hide_path_info.unwrap_or(false),
     )
   }
-
+  #[instrument(name = "Compilation:SplitChunks",target=TRACING_BENCH_TARGET, skip_all)]
   async fn inner_impl(&self, compilation: &mut Compilation) -> Result<()> {
     let logger = compilation.get_logger(self.name());
     let start = logger.time("prepare module group map");

--- a/crates/rspack_tracing/src/stdout.rs
+++ b/crates/rspack_tracing/src/stdout.rs
@@ -14,7 +14,7 @@ impl Tracer for StdoutTracer {
     Some(
       fmt::layer()
         .json() // Use JSON format for structured logging for easier parsing and debugging
-        .with_file(true)
+        .with_file(false)
         // To keep track of the closing point of spans
         .with_span_events(FmtSpan::CLOSE)
         .with_writer(trace_writer.make_writer())

--- a/crates/rspack_util/src/lib.rs
+++ b/crates/rspack_util/src/lib.rs
@@ -19,6 +19,7 @@ pub mod size;
 pub mod source_map;
 pub mod swc;
 pub mod test;
+pub mod tracing_preset;
 
 use std::future::Future;
 

--- a/crates/rspack_util/src/tracing_preset.rs
+++ b/crates/rspack_util/src/tracing_preset.rs
@@ -1,12 +1,12 @@
 use std::sync::LazyLock;
 
 // contain all tracing info and used for detailed analysis for rspack developers
-pub static TRACING_ALL_PRESET: &'static str = "trace";
+pub static TRACING_ALL_PRESET: &str = "trace";
 // contain tracing info useful for rspack users
-pub static TRACING_OVERVIEW_PRESET: &'static str = "info";
+pub static TRACING_OVERVIEW_PRESET: &str = "info";
 
 // only contain most important tracing info useful for rspack benchmark, don't add too much noise here
 pub static TRACING_BENCH_PRESET: LazyLock<String> =
   LazyLock::new(|| format!("off,{TRACING_BENCH_TARGET}=info"));
 
-pub static TRACING_BENCH_TARGET: &'static str = "rspack_compilation_main";
+pub static TRACING_BENCH_TARGET: &str = "rspack_compilation_main";

--- a/crates/rspack_util/src/tracing_preset.rs
+++ b/crates/rspack_util/src/tracing_preset.rs
@@ -1,0 +1,12 @@
+use std::sync::LazyLock;
+
+// contain all tracing info and used for detailed analysis for rspack developers
+pub static TRACING_ALL_PRESET: &'static str = "trace";
+// contain tracing info useful for rspack users
+pub static TRACING_OVERVIEW_PRESET: &'static str = "info";
+
+// only contain most important tracing info useful for rspack benchmark, don't add too much noise here
+pub static TRACING_BENCH_PRESET: LazyLock<String> =
+  LazyLock::new(|| format!("off,{TRACING_BENCH_TARGET}=info"));
+
+pub static TRACING_BENCH_TARGET: &'static str = "rspack_compilation_main";

--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -6,25 +6,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { rspack } from "@rspack/core";
-
-const overviewTraceFilter = "info";
-const allTraceFilter = "trace";
 const defaultRustTraceLayer = "perfetto";
-
-enum TracePreset {
-	OVERVIEW = "OVERVIEW", // contains overview trace events
-	ALL = "ALL" // contains all trace events
-}
-
-function resolveLayer(value: string): string {
-	if (value === TracePreset.OVERVIEW) {
-		return overviewTraceFilter;
-	}
-	if (value === TracePreset.ALL) {
-		return allTraceFilter;
-	}
-	return value;
-}
 
 export async function applyProfile(
 	filterValue: string,
@@ -60,11 +42,9 @@ export async function applyProfile(
 		traceOutput = path.resolve(defaultOutputDir, traceOutput);
 	}
 
-	const filter = resolveLayer(filterValue);
-
 	await ensureFileDir(traceOutput);
 	await rspack.experiments.globalTrace.register(
-		filter,
+		filterValue,
 		traceLayer,
 		traceOutput
 	);


### PR DESCRIPTION
## Summary
* move preset logic into rspack_binding so it can be used in rspack js api
* add bench preset for benchmark analysis important phase
```sh
 RSPACK_TRACE_LAYER=logger  RSPACK_PROFILE=BENCH node bin/rspack.js -c 'examples/basic/rspack.config.cjs'
```
![image](https://github.com/user-attachments/assets/d48eb12a-2588-4cc6-9ea6-1c18c5209e25)


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
