### PR TITLE
docs: remove the guideline of tailwindcss v4 in postcss-loader

### DIFF
--- a/website/docs/en/guide/optimization/profile.mdx
+++ b/website/docs/en/guide/optimization/profile.mdx
@@ -38,8 +38,6 @@ If you need to use some Babel plugins for custom transformations, configure babe
 
 [postcss-loader](https://github.com/postcss/postcss-loader) compiles CSS code based on PostCSS, which is often used with PostCSS plugins to downgrade CSS syntax, add vendor prefixes, etc. You can replace PostCSS with the faster Lightning CSS by using Rspack's built-in [builtin:lightningcss-loader](/guide/features/builtin-lightningcss-loader).
 
-If your project uses the PostCSS plugin for Tailwind CSS v3, you may need to wait for the release of Tailwind CSS v4, which is based on Rust and Lightning CSS and will provide significant performance improvements. For more details, see [Open-sourcing our progress on Tailwind CSS v4.0](https://tailwindcss.com/blog/tailwindcss-v4-alpha).
-
 ### terser-webpack-plugin
 
 [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin) minifies JavaScript code based on Terser. You can replace Terser with the faster SWC minimizer by using Rspack's built-in [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin).

--- a/website/docs/zh/guide/optimization/profile.mdx
+++ b/website/docs/zh/guide/optimization/profile.mdx
@@ -40,8 +40,6 @@ RSPACK_PROFILE=ALL rspack build
 
 [postcss-loader](https://github.com/postcss/postcss-loader) 基于 PostCSS 来编译 CSS 代码，通常会配合 PostCSS 插件进行 CSS 语法降级、添加浏览器前缀等，可以将 PostCSS 替换为更快的 Lightning CSS，使用 Rspack 内置的 [builtin:lightningcss-loader](/guide/features/builtin-lightningcss-loader) 即可。
 
-如果项目里使用了 Tailwind CSS v3 的 PostCSS 插件，则需要等待 Tailwind CSS v4 版本发布，该版本基于 Rust 和 Lightning CSS 实现，性能会有显著提升，详见 [Open-sourcing our progress on Tailwind CSS v4.0](https://tailwindcss.com/blog/tailwindcss-v4-alpha)。
-
 ### terser-webpack-plugin
 
 [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin) 基于 Terser 来压缩 JavaScript 代码，可以将 Terser 替换为更快的 SWC minimizer，使用 Rspack 内置的 [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin) 即可。


### PR DESCRIPTION
## Summary

Tailwindcss v4 still replies on postcss so we need to remove the wrong guideline.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
