### PR TITLE
feat(rspack): add create fn exporter

### DIFF
--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -127,6 +127,7 @@ export { EnvironmentPlugin } from "./lib/EnvironmentPlugin";
 export { LoaderOptionsPlugin } from "./lib/LoaderOptionsPlugin";
 export { LoaderTargetPlugin } from "./lib/LoaderTargetPlugin";
 export { NormalModuleReplacementPlugin } from "./lib/NormalModuleReplacementPlugin";
+export { create } from "./builtin-plugin/base"
 
 import {
 	FetchCompileAsyncWasmPlugin,

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -127,7 +127,7 @@ export { EnvironmentPlugin } from "./lib/EnvironmentPlugin";
 export { LoaderOptionsPlugin } from "./lib/LoaderOptionsPlugin";
 export { LoaderTargetPlugin } from "./lib/LoaderTargetPlugin";
 export { NormalModuleReplacementPlugin } from "./lib/NormalModuleReplacementPlugin";
-export { create as unStableDefineRspackPlugin } from "./builtin-plugin/base"
+export { create as unStableDefineRspackPlugin } from "./builtin-plugin/base";
 
 import {
 	FetchCompileAsyncWasmPlugin,

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -127,7 +127,7 @@ export { EnvironmentPlugin } from "./lib/EnvironmentPlugin";
 export { LoaderOptionsPlugin } from "./lib/LoaderOptionsPlugin";
 export { LoaderTargetPlugin } from "./lib/LoaderTargetPlugin";
 export { NormalModuleReplacementPlugin } from "./lib/NormalModuleReplacementPlugin";
-export { create } from "./builtin-plugin/base"
+export { create as defineRspackPlugin } from "./builtin-plugin/base"
 
 import {
 	FetchCompileAsyncWasmPlugin,

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -127,7 +127,7 @@ export { EnvironmentPlugin } from "./lib/EnvironmentPlugin";
 export { LoaderOptionsPlugin } from "./lib/LoaderOptionsPlugin";
 export { LoaderTargetPlugin } from "./lib/LoaderTargetPlugin";
 export { NormalModuleReplacementPlugin } from "./lib/NormalModuleReplacementPlugin";
-export { create as defineRspackPlugin } from "./builtin-plugin/base"
+export { create as unStableDefineRspackPlugin } from "./builtin-plugin/base"
 
 import {
 	FetchCompileAsyncWasmPlugin,


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

I need to customize a Rust-based plugin and would prefer to directly use built-in functions when bridging at the JS layer.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
