### PR TITLE
fix(rstest): bugs

### DIFF
--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -84,7 +84,7 @@ pub fn module_id_rstest(
   }
 }
 
-const WEBPACK_REQUIRE_IMPORT_ACTUAL: &str = "__webpack_require__.import_actual";
+const WEBPACK_REQUIRE_IMPORT_ACTUAL: &str = "__webpack_require__.rstest_import_actual";
 
 // To support use `__webpack_require__.import_actual` for `importActual`.
 fn module_namespace_promise_rstest(

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -23,6 +23,7 @@ pub struct MockMethodDependency {
 pub enum MockMethod {
   Mock,
   Unmock,
+  Hoisted,
 }
 
 impl MockMethodDependency {
@@ -71,7 +72,6 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
     code_generatable_context: &mut TemplateContext,
   ) {
     let TemplateContext { init_fragments, .. } = code_generatable_context;
-
     let dep = dep
       .as_any()
       .downcast_ref::<MockMethodDependency>()
@@ -81,18 +81,19 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
     let hoist_flag = match dep.method {
       MockMethod::Mock => "MOCK",
       MockMethod::Unmock => "UNMOCK",
+      MockMethod::Hoisted => "HOISTED",
     };
 
     let mock_method = match dep.method {
-      MockMethod::Mock => "set_mock",
-      MockMethod::Unmock => "unmock",
+      MockMethod::Mock => "rstest_set_mock",
+      MockMethod::Unmock => "rstest_unmock",
+      MockMethod::Hoisted => "rstest_hoisted",
     };
 
     if dep.hoist {
-      // Placeholder of hoist target.
       let init = NormalInitFragment::new(
         format!("/* RSTEST:{hoist_flag}_PLACEHOLDER:{request} */;"),
-        InitFragmentStage::StageConstants,
+        InitFragmentStage::StageESMImports,
         0,
         InitFragmentKey::Const(format!("retest mock_hoist {request}")),
         None,

--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/importActual.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/importActual.js
@@ -1,9 +1,9 @@
 import { foo } from './src/barrel'
 
-rs.mock('./src/foo')
+rstest.mock('./src/foo')
 
 it('importActual should works', async () => {
 	expect(foo).toBe('mocked_foo')
-	const originalFoo = await rs.importActual('./src/foo')
+	const originalFoo = await rstest.importActual('./src/foo')
 	expect(originalFoo.value).toBe('foo')
 })

--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/rspack.config.js
@@ -19,24 +19,24 @@ if (typeof __webpack_require__ === 'undefined') {
   return;
 }
 
-__webpack_require__.before_mocked_modules = {};
+__webpack_require__.rstest_original_modules = {};
 
-__webpack_require__.reset_modules = () => {
+__webpack_require__.rstest_reset_modules = () => {
   __webpack_module_cache__ = {};
 }
 
-__webpack_require__.unmock = (id) => {
+__webpack_require__.rstest_unmock = (id) => {
   delete __webpack_module_cache__[id]
 }
 
-__webpack_require__.import_actual = __webpack_require__.require_actual = (id) => {
-  const beforeMock = __webpack_require__.before_mocked_modules[id];
+__webpack_require__.rstest_import_actual = __webpack_require__.rstest_require_actual = (id) => {
+  const beforeMock = __webpack_require__.rstest_original_modules[id];
   return beforeMock;
 }
 
-__webpack_require__.set_mock = (id, modFactory) => {
+__webpack_require__.rstest_set_mock = (id, modFactory) => {
   if (typeof modFactory === 'string' || typeof modFactory === 'number') {
-    __webpack_require__.before_mocked_modules[id] = __webpack_require__(id);
+    __webpack_require__.rstest_original_modules[id] = __webpack_require__(id);
     __webpack_module_cache__[id] = { exports: __webpack_require__(modFactory) };
   } else if (typeof modFactory === 'function') {
     __webpack_module_cache__[id] = { exports: modFactory() };


### PR DESCRIPTION
## Summary

- [x] unify runtime module prefix with `rstest_`.
- [x] handle `rstest` the same way as `rs`.
- [x] add `rs.hoisted` method, which will only perform hoisting process
- [x] use `to_string` of `Utf8PathBuf` to handle both `./` and `../` case in path
- [ ] handle static import order conflicts with hoisting. (not fully resolved, partial resolved by using `StageESMImports`)
   ![image](https://github.com/user-attachments/assets/b7d8a7a0-1778-4562-98e5-61e8353c8ef2)

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
