### PR TITLE
fix: lint error when any package.json modified

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -8,5 +8,5 @@ export default {
 		// ignore staged file list; execute x without extra args
 		() => "pnpm run x ae ci"
 	],
-	"package.json": "pnpm run check-dependency-version"
+	"package.json": () => "pnpm run check-dependency-version"
 };


### PR DESCRIPTION
## Summary
Lint failed when `package.json` modiefied, eg

```txt
✖ pnpm run check-dependency-version:
error: too many arguments. Expected 1 argument but got 2.
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
