### PR TITLE
refactor: remove export info map on module graph

### DIFF
--- a/crates/rspack_binding_api/src/exports_info.rs
+++ b/crates/rspack_binding_api/src/exports_info.rs
@@ -108,7 +108,7 @@ impl JsExportsInfo {
       &module_graph,
       PrefetchExportsInfoMode::Nested(&names),
     );
-    let used = ExportsInfoGetter::get_used(&exports_info, &names, runtime.as_ref());
+    let used = exports_info.get_used(&names, runtime.as_ref());
     Ok(used as u32)
   }
 }

--- a/crates/rspack_binding_api/src/exports_info.rs
+++ b/crates/rspack_binding_api/src/exports_info.rs
@@ -106,7 +106,7 @@ impl JsExportsInfo {
     let exports_info = ExportsInfoGetter::prefetch(
       &self.exports_info,
       &module_graph,
-      PrefetchExportsInfoMode::NamedNestedExports(&names),
+      PrefetchExportsInfoMode::Nested(&names),
     );
     let used = ExportsInfoGetter::get_used(&exports_info, &names, runtime.as_ref());
     Ok(used as u32)

--- a/crates/rspack_binding_api/src/module_graph.rs
+++ b/crates/rspack_binding_api/src/module_graph.rs
@@ -90,7 +90,7 @@ impl JsModuleGraph {
       }
     };
     let exports_info = module_graph
-      .get_prefetched_exports_info(&js_module.identifier, PrefetchExportsInfoMode::AllExports);
+      .get_prefetched_exports_info(&js_module.identifier, PrefetchExportsInfoMode::Default);
     let used_exports = exports_info.get_used_exports(Some(&RuntimeSpec::new(runtime)));
     Ok(match used_exports {
       rspack_core::UsedExports::Unknown => None,

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -15,8 +15,8 @@ use super::Storage;
 use crate::{
   cache::persistent::cacheable_context::CacheableContext, AsyncDependenciesBlock,
   AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, DependencyId, DependencyParents,
-  ExportInfoData, ExportsInfoData, ModuleGraph, ModuleGraphConnection, ModuleGraphModule,
-  ModuleGraphPartial, RayonConsumer,
+  ExportsInfoData, ModuleGraph, ModuleGraphConnection, ModuleGraphModule, ModuleGraphPartial,
+  RayonConsumer,
 };
 
 const SCOPE: &str = "occasion_make_module_graph";
@@ -159,13 +159,9 @@ pub async fn recovery_module_graph(
         mg.add_block(Box::new(block));
       }
       // recovery exports/export info
-      let other_exports_info = ExportInfoData::new(None, None);
-      let side_effects_only_info = ExportInfoData::new(Some("*side effects only*".into()), None);
-      let exports_info = ExportsInfoData::new(other_exports_info.id(), side_effects_only_info.id());
+      let exports_info = ExportsInfoData::new();
       mgm.exports = exports_info.id();
       mg.set_exports_info(exports_info.id(), exports_info);
-      mg.set_export_info(side_effects_only_info.id(), side_effects_only_info);
-      mg.set_export_info(other_exports_info.id(), other_exports_info);
 
       mg.add_module_graph_module(mgm);
       mg.add_module(module);

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -159,7 +159,7 @@ pub async fn recovery_module_graph(
         mg.add_block(Box::new(block));
       }
       // recovery exports/export info
-      let exports_info = ExportsInfoData::new();
+      let exports_info = ExportsInfoData::default();
       mgm.exports = exports_info.id();
       mg.set_exports_info(exports_info.id(), exports_info);
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1479,7 +1479,6 @@ impl Compilation {
   #[instrument("Compilation:seal", skip_all)]
   pub async fn seal(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     self.other_module_graph = Some(ModuleGraphPartial::default());
-    self.get_module_graph_mut().prepare_export_info_map();
 
     if !self.options.mode.is_development() {
       self.module_static_cache_artifact.freeze();

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -115,7 +115,7 @@ impl Task<MakeTaskContext> for FactorizeTask {
       create_data.context_dependencies,
       create_data.missing_dependencies,
     );
-    let exports_info = ExportsInfoData::new();
+    let exports_info = ExportsInfoData::default();
     Ok(vec![Box::new(FactorizeResultTask {
       original_module_identifier: self.original_module_identifier,
       factory_result,

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -7,9 +7,9 @@ use super::{add::AddTask, MakeTaskContext};
 use crate::{
   module_graph::ModuleGraphModule,
   utils::task_loop::{Task, TaskResult, TaskType},
-  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, ExportInfoData,
-  ExportsInfoData, FactorizeInfo, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult,
-  ModuleIdentifier, ModuleLayer, ModuleProfile, Resolve, ResolverFactory,
+  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, ExportsInfoData,
+  FactorizeInfo, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier,
+  ModuleLayer, ModuleProfile, Resolve, ResolverFactory,
 };
 
 #[derive(Debug)]
@@ -115,30 +115,16 @@ impl Task<MakeTaskContext> for FactorizeTask {
       create_data.context_dependencies,
       create_data.missing_dependencies,
     );
-    let other_exports_info = ExportInfoData::new(None, None);
-    let side_effects_only_info = ExportInfoData::new(Some("*side effects only*".into()), None);
-    let exports_info = ExportsInfoData::new(other_exports_info.id(), side_effects_only_info.id());
+    let exports_info = ExportsInfoData::new();
     Ok(vec![Box::new(FactorizeResultTask {
       original_module_identifier: self.original_module_identifier,
       factory_result,
       dependencies: create_data.dependencies,
       current_profile: self.current_profile,
-      exports_info_related: ExportsInfoRelated {
-        exports_info,
-        other_exports_info,
-        side_effects_info: side_effects_only_info,
-      },
+      exports_info_related: exports_info,
       factorize_info,
     })])
   }
-}
-
-/// a struct temporarily used creating ExportsInfo
-#[derive(Debug)]
-pub struct ExportsInfoRelated {
-  pub exports_info: ExportsInfoData,
-  pub other_exports_info: ExportInfoData,
-  pub side_effects_info: ExportInfoData,
 }
 
 #[derive(Debug)]
@@ -149,7 +135,7 @@ pub struct FactorizeResultTask {
   pub factory_result: Option<ModuleFactoryResult>,
   pub dependencies: Vec<BoxDependency>,
   pub current_profile: Option<Box<ModuleProfile>>,
-  pub exports_info_related: ExportsInfoRelated,
+  pub exports_info_related: ExportsInfoData,
   pub factorize_info: FactorizeInfo,
 }
 
@@ -217,22 +203,10 @@ impl Task<MakeTaskContext> for FactorizeResultTask {
       return Ok(vec![]);
     };
     let module_identifier = module.identifier();
-    let mut mgm =
-      ModuleGraphModule::new(module.identifier(), exports_info_related.exports_info.id());
+    let mut mgm = ModuleGraphModule::new(module.identifier(), exports_info_related.id());
     mgm.set_issuer_if_unset(original_module_identifier);
 
-    module_graph.set_exports_info(
-      exports_info_related.exports_info.id(),
-      exports_info_related.exports_info,
-    );
-    module_graph.set_export_info(
-      exports_info_related.side_effects_info.id(),
-      exports_info_related.side_effects_info,
-    );
-    module_graph.set_export_info(
-      exports_info_related.other_exports_info.id(),
-      exports_info_related.other_exports_info,
-    );
+    module_graph.set_exports_info(exports_info_related.id(), exports_info_related);
     tracing::trace!("Module created: {}", &module_identifier);
 
     Ok(vec![Box::new(AddTask {

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1102,8 +1102,8 @@ impl Module for ConcatenatedModule {
       .expect("should have box module");
     let strict_esm_module = root_module.build_meta().strict_esm_module;
 
-    let exports_info = module_graph
-      .get_prefetched_exports_info(&root_module_id, PrefetchExportsInfoMode::AllExports);
+    let exports_info =
+      module_graph.get_prefetched_exports_info(&root_module_id, PrefetchExportsInfoMode::Default);
     let mut exports_final_names: Vec<(String, String)> = vec![];
 
     for (_, export_info) in exports_info.exports() {
@@ -1310,7 +1310,7 @@ impl Module for ConcatenatedModule {
 
         let mut ns_obj = Vec::new();
         let exports_info = module_graph
-          .get_prefetched_exports_info(module_info_id, PrefetchExportsInfoMode::AllExports);
+          .get_prefetched_exports_info(module_info_id, PrefetchExportsInfoMode::Default);
         for (_, export_info) in exports_info.exports() {
           if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
             continue;
@@ -2378,10 +2378,8 @@ impl ConcatenatedModule {
       }
     }
 
-    let exports_info = mg.get_prefetched_exports_info(
-      &info.id(),
-      PrefetchExportsInfoMode::NamedNestedExports(&export_name),
-    );
+    let exports_info =
+      mg.get_prefetched_exports_info(&info.id(), PrefetchExportsInfoMode::Nested(&export_name));
     // webpack use `get_exports_info` here, https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L377-L377
     // But in our arch, there is no way to modify module graph during code_generation phase, so we use `get_export_info_without_mut_module_graph` instead.`
     let export_info = exports_info.get_export_info_without_mut_module_graph(&export_name[0]);

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -50,10 +50,10 @@ use crate::{
   CodeGenerationDataTopLevelDeclarations, CodeGenerationExportsFinalNames,
   CodeGenerationPublicPathAutoReplace, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
   ConcatenationScope, ConditionalInitFragment, ConnectionState, Context, DependenciesBlock,
-  DependencyId, DependencyType, ErrorSpan, ExportInfoGetter, ExportProvided, ExportsArgument,
-  ExportsInfoGetter, ExportsType, FactoryMeta, GetUsedNameParam, IdentCollector, InitFragment,
-  InitFragmentStage, LibIdentOptions, MaybeDynamicTargetExportInfoHashKey, Module, ModuleArgument,
-  ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, ModuleLayer,
+  DependencyId, DependencyType, ErrorSpan, ExportProvided, ExportsArgument, ExportsInfoGetter,
+  ExportsType, FactoryMeta, GetUsedNameParam, IdentCollector, InitFragment, InitFragmentStage,
+  LibIdentOptions, MaybeDynamicTargetExportInfoHashKey, Module, ModuleArgument, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, ModuleLayer,
   ModuleStaticCacheArtifact, ModuleType, PrefetchExportsInfoMode, Resolve, RuntimeCondition,
   RuntimeGlobals, RuntimeSpec, SourceType, SpanExt, UsageState, UsedName, UsedNameItem,
   DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
@@ -1111,7 +1111,7 @@ impl Module for ConcatenatedModule {
       if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
         continue;
       }
-      let used_name = ExportInfoGetter::get_used_name(export_info, None, runtime);
+      let used_name = export_info.get_used_name(None, runtime);
 
       let Some(used_name) = used_name else {
         unused_exports.insert(name);
@@ -1140,7 +1140,7 @@ impl Module for ConcatenatedModule {
         exports_final_names.push((used_name.to_string(), final_name.name.clone()));
         format!(
           "/* {} */ {}",
-          if ExportInfoGetter::is_reexport(export_info) {
+          if export_info.is_reexport() {
             "reexport"
           } else {
             "binding"
@@ -1201,7 +1201,7 @@ impl Module for ConcatenatedModule {
 
     let exports_info =
       module_graph.get_prefetched_exports_info(&self.id(), PrefetchExportsInfoMode::Default);
-    let used = ExportInfoGetter::get_used(exports_info.other_exports_info(), runtime);
+    let used = exports_info.other_exports_info().get_used(runtime);
     // Add ESM compatibility flag (must be first because of possible circular dependencies)
     if used != UsageState::Unused {
       should_add_esm_flag = true
@@ -1316,9 +1316,7 @@ impl Module for ConcatenatedModule {
             continue;
           }
 
-          if let Some(UsedNameItem::Str(used_name)) =
-            ExportInfoGetter::get_used_name(export_info, None, runtime)
-          {
+          if let Some(UsedNameItem::Str(used_name)) = export_info.get_used_name(None, runtime) {
             let final_name = Self::get_final_name(
               &compilation.get_module_graph(),
               &compilation.module_graph_cache_artifact,

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -217,7 +217,7 @@ pub fn export_from_import(
     let used_name = match ExportsInfoGetter::get_used_name(
       GetUsedNameParam::WithNames(&compilation.get_module_graph().get_prefetched_exports_info(
         &module_identifier,
-        PrefetchExportsInfoMode::NamedNestedExports(export_name),
+        PrefetchExportsInfoMode::Nested(export_name),
       )),
       *runtime,
       export_name,

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -182,7 +182,7 @@ impl ExportInfoData {
 
   pub fn id(&self) -> ExportInfo {
     ExportInfo {
-      exports_info: self.belongs_to.clone(),
+      exports_info: self.belongs_to,
       export_name: if let Some(name) = &self.name {
         if name == "*side effects only*" {
           ExportName::SideEffects

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -4,8 +4,8 @@ use rspack_util::atom::Atom;
 use rustc_hash::FxHashMap as HashMap;
 
 use super::{
-  ExportInfoGetter, ExportInfoTargetValue, ExportProvided, ExportsInfo, Inlinable,
-  ResolvedExportInfoTarget, ResolvedExportInfoTargetWithCircular, UsageState,
+  ExportInfoTargetValue, ExportProvided, ExportsInfo, Inlinable, ResolvedExportInfoTarget,
+  ResolvedExportInfoTargetWithCircular, UsageState,
 };
 use crate::{
   find_target_from_export_info, get_target_from_maybe_export_info, get_target_with_filter,
@@ -325,7 +325,7 @@ impl<'a> MaybeDynamicTargetExportInfo<'a> {
   }
 
   fn get_max_target(&self) -> Cow<HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
-    ExportInfoGetter::get_max_target(self.to_data())
+    self.to_data().get_max_target()
   }
 
   pub fn find_target(

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -1,45 +1,59 @@
-use std::{
-  borrow::Cow,
-  hash::Hash,
-  sync::{atomic::Ordering::Relaxed, Arc},
-};
+use std::{borrow::Cow, hash::Hash, sync::Arc};
 
-use rspack_collections::{impl_item_ukey, Ukey};
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashMap as HashMap;
-use serde::Serialize;
 
 use super::{
   ExportInfoGetter, ExportInfoTargetValue, ExportProvided, ExportsInfo, Inlinable,
   ResolvedExportInfoTarget, ResolvedExportInfoTargetWithCircular, UsageState,
-  NEXT_EXPORT_INFO_UKEY,
 };
 use crate::{
   find_target_from_export_info, get_target_from_maybe_export_info, get_target_with_filter,
   DependencyId, FindTargetResult, ModuleGraph, ModuleIdentifier, ResolveFilterFnTy,
 };
 
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
-pub struct ExportInfo(Ukey);
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum ExportName {
+  Other,
+  SideEffects,
+  Named(Atom),
+}
 
-impl_item_ukey!(ExportInfo);
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct ExportInfo {
+  exports_info: ExportsInfo,
+  export_name: ExportName,
+}
 
 impl ExportInfo {
-  fn new() -> Self {
-    Self(NEXT_EXPORT_INFO_UKEY.fetch_add(1, Relaxed).into())
-  }
-
   pub fn as_data<'a>(&self, mg: &'a ModuleGraph) -> &'a ExportInfoData {
-    mg.get_export_info_by_id(self)
+    let exports_info = self.exports_info.as_data(mg);
+    let export_info = match &self.export_name {
+      ExportName::Other => exports_info.other_exports_info(),
+      ExportName::SideEffects => exports_info.side_effects_only_info(),
+      ExportName::Named(name) => exports_info
+        .named_exports(name)
+        .expect("should have named export"),
+    };
+    export_info
   }
 
   pub fn as_data_mut<'a>(&self, mg: &'a mut ModuleGraph) -> &'a mut ExportInfoData {
-    mg.get_export_info_mut_by_id(self)
+    let exports_info = self.exports_info.as_data_mut(mg);
+    let export_info = match &self.export_name {
+      ExportName::Other => exports_info.other_exports_info_mut(),
+      ExportName::SideEffects => exports_info.side_effects_only_info_mut(),
+      ExportName::Named(name) => exports_info
+        .named_exports_mut(name)
+        .expect("should have named export"),
+    };
+    export_info
   }
 }
 
 #[derive(Debug, Clone)]
 pub struct ExportInfoData {
+  belongs_to: ExportsInfo,
   // the name could be `null` you could refer https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad4153d/lib/ExportsInfo.js#L78
   name: Option<Atom>,
   /// this is mangled name, https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/ExportsInfo.js#L1181-L1188
@@ -53,7 +67,6 @@ pub struct ExportInfoData {
   // only specific export info can be inlined, so other_export_info.inlinable is always NoByProvide
   inlinable: Inlinable,
   terminal_binding: bool,
-  id: ExportInfo,
   exports_info: Option<ExportsInfo>,
   exports_info_owned: bool,
   has_use_in_runtime_info: bool,
@@ -62,7 +75,11 @@ pub struct ExportInfoData {
 }
 
 impl ExportInfoData {
-  pub fn new(name: Option<Atom>, init_from: Option<&ExportInfoData>) -> Self {
+  pub fn new(
+    belongs_to: ExportsInfo,
+    name: Option<Atom>,
+    init_from: Option<&ExportInfoData>,
+  ) -> Self {
     let used_name = init_from.and_then(|init_from| init_from.used_name.clone());
     let global_used = init_from.and_then(|init_from| init_from.global_used);
     let used_in_runtime = init_from.and_then(|init_from| init_from.used_in_runtime.clone());
@@ -105,6 +122,7 @@ impl ExportInfoData {
       })
       .unwrap_or_default();
     Self {
+      belongs_to,
       name,
       used_name,
       used_in_runtime,
@@ -113,7 +131,6 @@ impl ExportInfoData {
       can_mangle_provide,
       terminal_binding,
       target_is_set: init_from.map(|init| init.target_is_set).unwrap_or_default(),
-      id: ExportInfo::new(),
       exports_info: None,
       exports_info_owned: false,
       has_use_in_runtime_info,
@@ -164,7 +181,18 @@ impl ExportInfoData {
   }
 
   pub fn id(&self) -> ExportInfo {
-    self.id
+    ExportInfo {
+      exports_info: self.belongs_to.clone(),
+      export_name: if let Some(name) = &self.name {
+        if name == "*side effects only*" {
+          ExportName::SideEffects
+        } else {
+          ExportName::Named(name.clone())
+        }
+      } else {
+        ExportName::Other
+      },
+    }
   }
 
   pub fn exports_info(&self) -> Option<ExportsInfo> {

--- a/crates/rspack_core/src/exports/export_info_setter.rs
+++ b/crates/rspack_core/src/exports/export_info_setter.rs
@@ -234,10 +234,7 @@ impl ExportInfoSetter {
     }
 
     info.set_exports_info_owned(true);
-    let other_exports_info = ExportInfoData::new(None, None);
-    let side_effects_only_info = ExportInfoData::new(Some("*side effects only*".into()), None);
-    let new_exports_info =
-      ExportsInfoData::new(other_exports_info.id(), side_effects_only_info.id());
+    let new_exports_info = ExportsInfoData::new();
     let new_exports_info_id = new_exports_info.id();
 
     let old_exports_info = info.exports_info();
@@ -245,8 +242,6 @@ impl ExportInfoSetter {
     info.set_exports_info(Some(new_exports_info_id));
 
     mg.set_exports_info(new_exports_info_id, new_exports_info);
-    mg.set_export_info(other_exports_info.id(), other_exports_info);
-    mg.set_export_info(side_effects_only_info.id(), side_effects_only_info);
 
     new_exports_info_id.set_has_provide_info(mg);
     if let Some(exports_info) = old_exports_info {
@@ -255,8 +250,7 @@ impl ExportInfoSetter {
     new_exports_info_id
   }
 
-  pub fn set_has_use_info(info: &ExportInfo, mg: &mut ModuleGraph) {
-    let info = info.as_data_mut(mg);
+  pub fn set_has_use_info(info: &mut ExportInfoData, nested_exports_info: &mut Vec<ExportsInfo>) {
     if !info.has_use_in_runtime_info() {
       info.set_has_use_in_runtime_info(true);
     }
@@ -266,7 +260,7 @@ impl ExportInfoSetter {
     if info.exports_info_owned()
       && let Some(exports_info) = info.exports_info()
     {
-      exports_info.set_has_use_info(mg);
+      nested_exports_info.push(exports_info);
     }
   }
 }

--- a/crates/rspack_core/src/exports/export_info_setter.rs
+++ b/crates/rspack_core/src/exports/export_info_setter.rs
@@ -220,7 +220,7 @@ impl ExportInfoData {
     }
 
     self.set_exports_info_owned(true);
-    let new_exports_info = ExportsInfoData::new();
+    let new_exports_info = ExportsInfoData::default();
     let new_exports_info_id = new_exports_info.id();
 
     self.set_exports_info_owned(true);

--- a/crates/rspack_core/src/exports/export_info_setter.rs
+++ b/crates/rspack_core/src/exports/export_info_setter.rs
@@ -3,34 +3,30 @@ use std::collections::hash_map::Entry;
 use rspack_util::atom::Atom;
 
 use super::{ExportInfoData, ExportInfoTargetValue, Inlinable, UsageFilterFnTy, UsageState};
-use crate::{
-  DependencyId, ExportInfo, ExportsInfo, ExportsInfoData, ModuleGraph, Nullable, RuntimeSpec,
-};
+use crate::{DependencyId, ExportsInfo, ExportsInfoData, ModuleGraph, Nullable, RuntimeSpec};
 
-pub struct ExportInfoSetter;
-
-impl ExportInfoSetter {
-  pub fn reset_provide_info(info: &mut ExportInfoData) {
-    info.set_provided(None);
-    info.set_can_mangle_provide(None);
-    info.set_inlinable(Inlinable::NoByProvide);
-    info.set_exports_info(None);
-    info.set_exports_info_owned(false);
-    info.set_target_is_set(false);
-    info.target_mut().clear();
-    info.set_terminal_binding(false);
+impl ExportInfoData {
+  pub fn reset_provide_info(&mut self) {
+    self.set_provided(None);
+    self.set_can_mangle_provide(None);
+    self.set_inlinable(Inlinable::NoByProvide);
+    self.set_exports_info(None);
+    self.set_exports_info_owned(false);
+    self.set_target_is_set(false);
+    self.target_mut().clear();
+    self.set_terminal_binding(false);
   }
 
-  pub fn unset_target(info: &mut ExportInfoData, key: &DependencyId) -> bool {
-    if !info.target_is_set() {
+  pub fn unset_target(&mut self, key: &DependencyId) -> bool {
+    if !self.target_is_set() {
       false
     } else {
-      info.target_mut().remove(&Some(*key)).is_some()
+      self.target_mut().remove(&Some(*key)).is_some()
     }
   }
 
   pub fn set_target(
-    info: &mut ExportInfoData,
+    &mut self,
     key: Option<DependencyId>,
     dependency: Option<DependencyId>,
     export_name: Option<&Nullable<Vec<Atom>>>,
@@ -42,8 +38,8 @@ impl ExportInfoSetter {
       None => None,
     };
     let normalized_priority = priority.unwrap_or(0);
-    if !info.target_is_set() {
-      info.target_mut().insert(
+    if !self.target_is_set() {
+      self.target_mut().insert(
         key,
         ExportInfoTargetValue {
           dependency,
@@ -51,15 +47,15 @@ impl ExportInfoSetter {
           priority: normalized_priority,
         },
       );
-      info.set_target_is_set(true);
+      self.set_target_is_set(true);
       return true;
     }
-    let Some(old_target) = info.target_mut().get_mut(&key) else {
+    let Some(old_target) = self.target_mut().get_mut(&key) else {
       if dependency.is_none() {
         return false;
       }
 
-      info.target_mut().insert(
+      self.target_mut().insert(
         key,
         ExportInfoTargetValue {
           dependency,
@@ -82,13 +78,9 @@ impl ExportInfoSetter {
     false
   }
 
-  pub fn do_move_target(
-    export_info: &mut ExportInfoData,
-    dependency: DependencyId,
-    target_export: Option<Vec<Atom>>,
-  ) {
-    export_info.target_mut().clear();
-    export_info.target_mut().insert(
+  pub fn do_move_target(&mut self, dependency: DependencyId, target_export: Option<Vec<Atom>>) {
+    self.target_mut().clear();
+    self.target_mut().insert(
       None,
       ExportInfoTargetValue {
         dependency: Some(dependency),
@@ -96,16 +88,12 @@ impl ExportInfoSetter {
         priority: 0,
       },
     );
-    export_info.set_target_is_set(true);
+    self.set_target_is_set(true);
   }
 
-  pub fn set_used(
-    info: &mut ExportInfoData,
-    new_value: UsageState,
-    runtime: Option<&RuntimeSpec>,
-  ) -> bool {
+  pub fn set_used(&mut self, new_value: UsageState, runtime: Option<&RuntimeSpec>) -> bool {
     if let Some(runtime) = runtime {
-      let used_in_runtime = info.used_in_runtime_mut();
+      let used_in_runtime = self.used_in_runtime_mut();
       let mut changed = false;
       for &k in runtime.iter() {
         match used_in_runtime.entry(k) {
@@ -129,25 +117,25 @@ impl ExportInfoSetter {
         }
       }
       if used_in_runtime.is_empty() {
-        info.set_used_in_runtime(None);
+        self.set_used_in_runtime(None);
         changed = true;
       }
       return changed;
-    } else if info.global_used() != Some(new_value) {
-      info.set_global_used(Some(new_value));
+    } else if self.global_used() != Some(new_value) {
+      self.set_global_used(Some(new_value));
       return true;
     }
     false
   }
 
   pub fn set_used_conditionally(
-    info: &mut ExportInfoData,
+    &mut self,
     condition: UsageFilterFnTy<UsageState>,
     new_value: UsageState,
     runtime: Option<&RuntimeSpec>,
   ) -> bool {
     if let Some(runtime) = runtime {
-      let used_in_runtime = info.used_in_runtime_mut();
+      let used_in_runtime = self.used_in_runtime_mut();
       let mut changed = false;
 
       for &k in runtime.iter() {
@@ -172,93 +160,92 @@ impl ExportInfoSetter {
         }
       }
       if used_in_runtime.is_empty() {
-        info.set_used_in_runtime(None);
+        self.set_used_in_runtime(None);
         changed = true;
       }
       return changed;
-    } else if let Some(global_used) = info.global_used() {
+    } else if let Some(global_used) = self.global_used() {
       if global_used != new_value && condition(&global_used) {
-        info.set_global_used(Some(new_value));
+        self.set_global_used(Some(new_value));
         return true;
       }
     } else {
-      info.set_global_used(Some(new_value));
+      self.set_global_used(Some(new_value));
       return true;
     }
     false
   }
 
-  pub fn set_used_in_unknown_way(info: &mut ExportInfoData, runtime: Option<&RuntimeSpec>) -> bool {
+  pub fn set_used_in_unknown_way(&mut self, runtime: Option<&RuntimeSpec>) -> bool {
     let mut changed = false;
 
-    if ExportInfoSetter::set_used_conditionally(
-      info,
+    if self.set_used_conditionally(
       Box::new(|value| value < &UsageState::Unknown),
       UsageState::Unknown,
       runtime,
     ) {
       changed = true;
     }
-    if info.can_mangle_use() != Some(false) {
-      info.set_can_mangle_use(Some(false));
+    if self.can_mangle_use() != Some(false) {
+      self.set_can_mangle_use(Some(false));
       changed = true;
     }
-    if info.inlinable().can_inline() {
-      info.set_inlinable(Inlinable::NoByUse);
+    if self.inlinable().can_inline() {
+      self.set_inlinable(Inlinable::NoByUse);
       changed = true;
     }
     changed
   }
 
-  pub fn set_used_without_info(info: &mut ExportInfoData, runtime: Option<&RuntimeSpec>) -> bool {
+  pub fn set_used_without_info(&mut self, runtime: Option<&RuntimeSpec>) -> bool {
     let mut changed = false;
-    let flag = ExportInfoSetter::set_used(info, UsageState::NoInfo, runtime);
+    let flag = self.set_used(UsageState::NoInfo, runtime);
     changed |= flag;
-    if info.can_mangle_use() != Some(false) {
-      info.set_can_mangle_use(Some(false));
+    if self.can_mangle_use() != Some(false) {
+      self.set_can_mangle_use(Some(false));
       changed = true;
     }
-    if info.inlinable().can_inline() {
-      info.set_inlinable(Inlinable::NoByUse);
+    if self.inlinable().can_inline() {
+      self.set_inlinable(Inlinable::NoByUse);
       changed = true;
     }
     changed
   }
 
-  pub fn create_nested_exports_info(info: &ExportInfo, mg: &mut ModuleGraph) -> ExportsInfo {
-    let info = info.as_data_mut(mg);
-    if info.exports_info_owned() {
-      return info
+  pub fn create_nested_exports_info(&mut self, mg: &mut ModuleGraph) -> ExportsInfo {
+    if self.exports_info_owned() {
+      return self
         .exports_info()
         .expect("should have exports_info when exports_info is true");
     }
 
-    info.set_exports_info_owned(true);
+    self.set_exports_info_owned(true);
     let new_exports_info = ExportsInfoData::new();
     let new_exports_info_id = new_exports_info.id();
 
-    let old_exports_info = info.exports_info();
-    info.set_exports_info_owned(true);
-    info.set_exports_info(Some(new_exports_info_id));
+    self.set_exports_info_owned(true);
+    self.set_exports_info(Some(new_exports_info_id));
 
     mg.set_exports_info(new_exports_info_id, new_exports_info);
-
     new_exports_info_id.set_has_provide_info(mg);
+    let old_exports_info = self.exports_info();
     if let Some(exports_info) = old_exports_info {
-      exports_info.set_redirect_name_to(mg, Some(new_exports_info_id));
+      exports_info
+        .as_data_mut(mg)
+        .set_redirect_name_to(Some(new_exports_info_id));
     }
     new_exports_info_id
   }
 
-  pub fn set_has_use_info(info: &mut ExportInfoData, nested_exports_info: &mut Vec<ExportsInfo>) {
-    if !info.has_use_in_runtime_info() {
-      info.set_has_use_in_runtime_info(true);
+  pub fn set_has_use_info(&mut self, nested_exports_info: &mut Vec<ExportsInfo>) {
+    if !self.has_use_in_runtime_info() {
+      self.set_has_use_in_runtime_info(true);
     }
-    if info.can_mangle_use().is_none() {
-      info.set_can_mangle_use(Some(true));
+    if self.can_mangle_use().is_none() {
+      self.set_can_mangle_use(Some(true));
     }
-    if info.exports_info_owned()
-      && let Some(exports_info) = info.exports_info()
+    if self.exports_info_owned()
+      && let Some(exports_info) = self.exports_info()
     {
       nested_exports_info.push(exports_info);
     }

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -148,17 +148,6 @@ impl ExportsInfo {
     changed
   }
 
-  pub fn get_read_only_export_info(&self, mg: &ModuleGraph, name: &Atom) -> ExportInfo {
-    let exports_info = self.as_data(mg);
-    if let Some(export_info) = exports_info.named_exports(name) {
-      return export_info.id();
-    }
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      return redirect_to.get_read_only_export_info(mg, name);
-    }
-    exports_info.other_exports_info().id()
-  }
-
   pub fn get_export_info(&self, mg: &mut ModuleGraph, name: &Atom) -> ExportInfo {
     let exports_info = self.as_data_mut(mg);
     if let Some(export_info) = exports_info.named_exports(name) {

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -258,21 +258,6 @@ impl ExportsInfo {
     }
     changed
   }
-
-  pub fn set_used_for_side_effects_only(
-    &self,
-    mg: &mut ModuleGraph,
-    runtime: Option<&RuntimeSpec>,
-  ) -> bool {
-    let exports_info = self.as_data_mut(mg);
-    exports_info
-      .side_effects_only_info_mut()
-      .set_used_conditionally(
-        Box::new(|value| value == &UsageState::Unused),
-        UsageState::Used,
-        runtime,
-      )
-  }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -304,28 +304,26 @@ pub struct ExportsInfoData {
   id: ExportsInfo,
 }
 
-impl ExportsInfoData {
-  pub fn new() -> Self {
+impl Default for ExportsInfoData {
+  fn default() -> Self {
     let id = ExportsInfo::new();
     Self {
       exports: BTreeMap::default(),
-      other_exports_info: ExportInfoData::new(id.clone(), None, None),
-      side_effects_only_info: ExportInfoData::new(
-        id.clone(),
-        Some("*side effects only*".into()),
-        None,
-      ),
+      other_exports_info: ExportInfoData::new(id, None, None),
+      side_effects_only_info: ExportInfoData::new(id, Some("*side effects only*".into()), None),
       redirect_to: None,
       id,
     }
   }
+}
 
+impl ExportsInfoData {
   pub fn id(&self) -> ExportsInfo {
     self.id
   }
 
   pub fn redirect_to(&self) -> Option<ExportsInfo> {
-    self.redirect_to.clone()
+    self.redirect_to
   }
 
   pub fn other_exports_info(&self) -> &ExportInfoData {

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -35,29 +35,23 @@ impl ExportsInfo {
   // ExportProvideInfo is created by FlagDependencyExportsPlugin, and should not mutate after create
   // ExportUsedInfo is created by FlagDependencyUsagePlugin or Plugin::finish_modules, and should not mutate after create
   pub fn reset_provide_info(&self, mg: &mut ModuleGraph) {
-    let exports = self.as_data(mg).exports().copied().collect::<Vec<_>>();
-    for export_info in exports {
-      ExportInfoSetter::reset_provide_info(export_info.as_data_mut(mg));
+    let exports_info = self.as_data_mut(mg);
+    for export_info in exports_info.exports_mut().values_mut() {
+      ExportInfoSetter::reset_provide_info(export_info);
     }
-    let side_effects_only_info = self.as_data(mg).side_effects_only_info();
-    let other_exports_info = self.as_data(mg).other_exports_info();
-    let redirect_to = self.as_data(mg).redirect_to();
-    ExportInfoSetter::reset_provide_info(side_effects_only_info.as_data_mut(mg));
-    if let Some(redirect_to) = redirect_to {
+    ExportInfoSetter::reset_provide_info(exports_info.side_effects_only_info_mut());
+    ExportInfoSetter::reset_provide_info(exports_info.other_exports_info_mut());
+    if let Some(redirect_to) = exports_info.redirect_to() {
       redirect_to.reset_provide_info(mg);
     }
-    ExportInfoSetter::reset_provide_info(other_exports_info.as_data_mut(mg));
   }
 
   /// # Panic
   /// it will panic if you provide a export info that does not exists in the module graph
   pub fn set_has_provide_info(&self, mg: &mut ModuleGraph) {
-    let exports_info = self.as_data(mg);
-    let redirect_id = exports_info.redirect_to();
-    let other_exports_info_id = exports_info.other_exports_info();
-    let export_id_list = exports_info.exports().copied().collect::<Vec<_>>();
-    for export_info_id in export_id_list {
-      let export_info = mg.get_export_info_mut_by_id(&export_info_id);
+    let exports_info = self.as_data_mut(mg);
+
+    for export_info in exports_info.exports_mut().values_mut() {
       if export_info.provided().is_none() {
         export_info.set_provided(Some(ExportProvided::NotProvided));
       }
@@ -65,10 +59,10 @@ impl ExportsInfo {
         export_info.set_can_mangle_provide(Some(true));
       }
     }
-    if let Some(redirect) = redirect_id {
+    if let Some(redirect) = exports_info.redirect_to() {
       redirect.set_has_provide_info(mg);
     } else {
-      let other_exports_info = mg.get_export_info_mut_by_id(&other_exports_info_id);
+      let other_exports_info = exports_info.other_exports_info_mut();
       if other_exports_info.provided().is_none() {
         other_exports_info.set_provided(Some(ExportProvided::NotProvided));
       }
@@ -104,36 +98,32 @@ impl ExportsInfo {
       }
     }
 
-    let exports_info = self.as_data(mg);
-    let redirect_to = exports_info.redirect_to();
-    let other_exports_info = exports_info.other_exports_info();
-    let exports_id_list = exports_info.exports().copied().collect::<Vec<_>>();
-    for export_info in exports_id_list {
-      let export_info_data = export_info.as_data_mut(mg);
-      if !can_mangle && export_info_data.can_mangle_provide() != Some(false) {
-        export_info_data.set_can_mangle_provide(Some(false));
+    let exports_info = self.as_data_mut(mg);
+    for export_info in exports_info.exports_mut().values_mut() {
+      if !can_mangle && export_info.can_mangle_provide() != Some(false) {
+        export_info.set_can_mangle_provide(Some(false));
         changed = true;
       }
       if let Some(exclude_exports) = &exclude_exports {
-        if let Some(export_name) = export_info_data.name()
+        if let Some(export_name) = export_info.name()
           && exclude_exports.contains(export_name)
         {
           continue;
         }
       }
       if !matches!(
-        export_info_data.provided(),
+        export_info.provided(),
         Some(ExportProvided::Provided | ExportProvided::Unknown)
       ) {
-        export_info_data.set_provided(Some(ExportProvided::Unknown));
+        export_info.set_provided(Some(ExportProvided::Unknown));
         changed = true;
       }
       if let Some(target_key) = target_key {
-        let name = export_info_data
+        let name = export_info
           .name()
           .map(|name| Nullable::Value(vec![name.clone()]));
         ExportInfoSetter::set_target(
-          export_info_data,
+          export_info,
           Some(target_key),
           target_module,
           name.as_ref(),
@@ -142,7 +132,7 @@ impl ExportsInfo {
       }
     }
 
-    if let Some(redirect_to) = redirect_to {
+    if let Some(redirect_to) = exports_info.redirect_to() {
       changed |= redirect_to.set_unknown_exports_provided(
         mg,
         can_mangle,
@@ -152,7 +142,7 @@ impl ExportsInfo {
         priority,
       );
     } else {
-      let other_exports_info_data = other_exports_info.as_data_mut(mg);
+      let other_exports_info_data = exports_info.other_exports_info_mut();
       if !matches!(
         other_exports_info_data.provided(),
         Some(ExportProvided::Provided | ExportProvided::Unknown)
@@ -181,86 +171,72 @@ impl ExportsInfo {
 
   pub fn get_read_only_export_info(&self, mg: &ModuleGraph, name: &Atom) -> ExportInfo {
     let exports_info = self.as_data(mg);
-    let redirect_to = exports_info.redirect_to();
-    let other_exports_info = exports_info.other_exports_info();
-    let export_info = exports_info.named_exports(name);
-    if let Some(export_info) = export_info {
-      return *export_info;
+    if let Some(export_info) = exports_info.named_exports(name) {
+      return export_info.id();
     }
-    if let Some(redirect_to) = redirect_to {
+    if let Some(redirect_to) = exports_info.redirect_to() {
       return redirect_to.get_read_only_export_info(mg, name);
     }
-    other_exports_info
+    exports_info.other_exports_info().id()
   }
 
   pub fn get_export_info(&self, mg: &mut ModuleGraph, name: &Atom) -> ExportInfo {
-    let exports_info: &ExportsInfoData = self.as_data(mg);
-    let redirect_id = exports_info.redirect_to();
-    let other_exports_info_id = exports_info.other_exports_info();
-    let export_info_id = exports_info.named_exports(name);
-    if let Some(export_info_id) = export_info_id {
-      return *export_info_id;
-    }
-    if let Some(redirect_id) = redirect_id {
-      return redirect_id.get_export_info(mg, name);
-    }
-
-    let other_export_info = other_exports_info_id.as_data(mg);
-    let new_info = ExportInfoData::new(Some(name.clone()), Some(other_export_info));
-    let new_info_id = new_info.id();
-    mg.set_export_info(new_info_id, new_info);
-
     let exports_info = self.as_data_mut(mg);
-    exports_info.exports_mut().insert(name.clone(), new_info_id);
+    if let Some(export_info) = exports_info.named_exports(name) {
+      return export_info.id();
+    }
+    if let Some(redirect) = exports_info.redirect_to() {
+      return redirect.get_export_info(mg, name);
+    }
+
+    let other_export_info = exports_info.other_exports_info();
+    let new_info = ExportInfoData::new(*self, Some(name.clone()), Some(other_export_info));
+    let new_info_id = new_info.id();
+    exports_info.exports_mut().insert(name.clone(), new_info);
     new_info_id
   }
 
   pub fn set_has_use_info(&self, mg: &mut ModuleGraph) {
-    let exports_info = self.as_data(mg);
-    let side_effects_only_info_id = exports_info.side_effects_only_info();
-    let redirect_to_id = exports_info.redirect_to();
-    let other_exports_info_id = exports_info.other_exports_info();
-    // this clone aiming to avoid use the mutable ref and immutable ref at the same time.
-    let export_id_list = exports_info.exports().copied().collect::<Vec<_>>();
-    for export_info in export_id_list {
-      ExportInfoSetter::set_has_use_info(&export_info, mg);
+    let mut nested_exports_info = vec![];
+    let exports_info = self.as_data_mut(mg);
+    for export_info in exports_info.exports_mut().values_mut() {
+      ExportInfoSetter::set_has_use_info(export_info, &mut nested_exports_info);
     }
-    ExportInfoSetter::set_has_use_info(&side_effects_only_info_id, mg);
-    if let Some(redirect) = redirect_to_id {
+    ExportInfoSetter::set_has_use_info(
+      exports_info.side_effects_only_info_mut(),
+      &mut nested_exports_info,
+    );
+    if let Some(redirect) = exports_info.redirect_to() {
       redirect.set_has_use_info(mg);
     } else {
-      ExportInfoSetter::set_has_use_info(&other_exports_info_id, mg);
-      let other_exports_info = mg.get_export_info_mut_by_id(&other_exports_info_id);
+      let other_exports_info = exports_info.other_exports_info_mut();
+      ExportInfoSetter::set_has_use_info(other_exports_info, &mut nested_exports_info);
       if other_exports_info.can_mangle_use().is_none() {
         other_exports_info.set_can_mangle_use(Some(true));
       }
+    }
+
+    for nested_exports_info in nested_exports_info {
+      nested_exports_info.set_has_use_info(mg);
     }
   }
 
   pub fn set_used_without_info(&self, mg: &mut ModuleGraph, runtime: Option<&RuntimeSpec>) -> bool {
     let mut changed = false;
     let exports_info = self.as_data_mut(mg);
-    let redirect = exports_info.redirect_to();
-    let other_exports_info_id = exports_info.other_exports_info();
-    // avoid use ref and mut ref at the same time
-    let export_info_id_list = exports_info.exports().copied().collect::<Vec<_>>();
-    for export_info_id in export_info_id_list {
-      let flag = ExportInfoSetter::set_used_without_info(export_info_id.as_data_mut(mg), runtime);
+    for export_info in exports_info.exports_mut().values_mut() {
+      let flag = ExportInfoSetter::set_used_without_info(export_info, runtime);
       changed |= flag;
     }
-    if let Some(redirect_to) = redirect {
+    if let Some(redirect_to) = exports_info.redirect_to() {
       let flag = redirect_to.set_used_without_info(mg, runtime);
       changed |= flag;
     } else {
-      let flag = ExportInfoSetter::set_used(
-        other_exports_info_id.as_data_mut(mg),
-        UsageState::NoInfo,
-        None,
-      );
+      let other_exports_info = exports_info.other_exports_info_mut();
+      let flag = ExportInfoSetter::set_used(other_exports_info, UsageState::NoInfo, None);
       changed |= flag;
-      let other_export_info = mg.get_export_info_mut_by_id(&other_exports_info_id);
-      if other_export_info.can_mangle_use() != Some(false) {
-        other_export_info.set_can_mangle_use(Some(false));
+      if other_exports_info.can_mangle_use() != Some(false) {
+        other_exports_info.set_can_mangle_use(Some(false));
         changed = true;
       }
     }
@@ -274,9 +250,7 @@ impl ExportsInfo {
   ) -> bool {
     let mut changed = false;
     let exports_info = self.as_data_mut(mg);
-    let export_info_id_list = exports_info.exports().copied().collect::<Vec<_>>();
-    for export_info_id in export_info_id_list {
-      let export_info = export_info_id.as_data_mut(mg);
+    for export_info in exports_info.exports_mut().values_mut() {
       if !matches!(export_info.provided(), Some(ExportProvided::Provided)) {
         continue;
       }
@@ -291,29 +265,26 @@ impl ExportsInfo {
     runtime: Option<&RuntimeSpec>,
   ) -> bool {
     let mut changed = false;
-    let exports_info = self.as_data(mg);
-    let export_info_id_list = exports_info.exports().copied().collect::<Vec<_>>();
-    let redirect_to_id = exports_info.redirect_to();
-    let other_exports_info_id = exports_info.other_exports_info();
-    for export_info_id in export_info_id_list {
-      if ExportInfoSetter::set_used_in_unknown_way(export_info_id.as_data_mut(mg), runtime) {
+    let exports_info = self.as_data_mut(mg);
+    for export_info in exports_info.exports_mut().values_mut() {
+      if ExportInfoSetter::set_used_in_unknown_way(export_info, runtime) {
         changed = true;
       }
     }
-    if let Some(redirect_to) = redirect_to_id {
+    if let Some(redirect_to) = exports_info.redirect_to() {
       if redirect_to.set_used_in_unknown_way(mg, runtime) {
         changed = true;
       }
     } else {
+      let other_exports_info = exports_info.other_exports_info_mut();
       if ExportInfoSetter::set_used_conditionally(
-        other_exports_info_id.as_data_mut(mg),
+        other_exports_info,
         Box::new(|value| value < &UsageState::Unknown),
         UsageState::Unknown,
         runtime,
       ) {
         changed = true;
       }
-      let other_exports_info = mg.get_export_info_mut_by_id(&other_exports_info_id);
       if other_exports_info.can_mangle_use() != Some(false) {
         other_exports_info.set_can_mangle_use(Some(false));
         changed = true;
@@ -327,10 +298,9 @@ impl ExportsInfo {
     mg: &mut ModuleGraph,
     runtime: Option<&RuntimeSpec>,
   ) -> bool {
-    let exports_info = self.as_data(mg);
-    let side_effects_only_info_id = exports_info.side_effects_only_info();
+    let exports_info = self.as_data_mut(mg);
     ExportInfoSetter::set_used_conditionally(
-      side_effects_only_info_id.as_data_mut(mg),
+      exports_info.side_effects_only_info_mut(),
       Box::new(|value| value == &UsageState::Unused),
       UsageState::Used,
       runtime,
@@ -340,7 +310,7 @@ impl ExportsInfo {
 
 #[derive(Debug, Clone)]
 pub struct ExportsInfoData {
-  exports: BTreeMap<Atom, ExportInfo>,
+  exports: BTreeMap<Atom, ExportInfoData>,
 
   /// other export info is a strange name and hard to understand
   /// it has 2 meanings:
@@ -349,21 +319,26 @@ pub struct ExportsInfoData {
   /// 2. it is used to flag if the whole exportsInfo can be statically analyzed. In many commonjs
   ///    case, we can not statically analyze the exportsInfo, its other_export_info.provided will
   ///    be ExportProvided::Unknown
-  other_exports_info: ExportInfo,
+  other_exports_info: ExportInfoData,
 
-  side_effects_only_info: ExportInfo,
+  side_effects_only_info: ExportInfoData,
   redirect_to: Option<ExportsInfo>,
   id: ExportsInfo,
 }
 
 impl ExportsInfoData {
-  pub fn new(other_exports_info: ExportInfo, side_effects_only_info: ExportInfo) -> Self {
+  pub fn new() -> Self {
+    let id = ExportsInfo::new();
     Self {
       exports: BTreeMap::default(),
-      other_exports_info,
-      side_effects_only_info,
+      other_exports_info: ExportInfoData::new(id.clone(), None, None),
+      side_effects_only_info: ExportInfoData::new(
+        id.clone(),
+        Some("*side effects only*".into()),
+        None,
+      ),
       redirect_to: None,
-      id: ExportsInfo::new(),
+      id,
     }
   }
 
@@ -372,30 +347,38 @@ impl ExportsInfoData {
   }
 
   pub fn redirect_to(&self) -> Option<ExportsInfo> {
-    self.redirect_to
+    self.redirect_to.clone()
   }
 
-  pub fn other_exports_info(&self) -> ExportInfo {
-    self.other_exports_info
+  pub fn other_exports_info(&self) -> &ExportInfoData {
+    &self.other_exports_info
   }
 
-  pub fn side_effects_only_info(&self) -> ExportInfo {
-    self.side_effects_only_info
+  pub fn other_exports_info_mut(&mut self) -> &mut ExportInfoData {
+    &mut self.other_exports_info
   }
 
-  pub fn exports(&self) -> impl Iterator<Item = &ExportInfo> {
-    self.exports.values()
+  pub fn side_effects_only_info(&self) -> &ExportInfoData {
+    &self.side_effects_only_info
   }
 
-  pub fn exports_with_names(&self) -> impl Iterator<Item = (&Atom, &ExportInfo)> {
-    self.exports.iter()
+  pub fn side_effects_only_info_mut(&mut self) -> &mut ExportInfoData {
+    &mut self.side_effects_only_info
   }
 
-  pub fn named_exports(&self, name: &Atom) -> Option<&ExportInfo> {
+  pub fn named_exports(&self, name: &Atom) -> Option<&ExportInfoData> {
     self.exports.get(name)
   }
 
-  pub fn exports_mut(&mut self) -> &mut BTreeMap<Atom, ExportInfo> {
+  pub fn named_exports_mut(&mut self, name: &Atom) -> Option<&mut ExportInfoData> {
+    self.exports.get_mut(name)
+  }
+
+  pub fn exports(&self) -> &BTreeMap<Atom, ExportInfoData> {
+    &self.exports
+  }
+
+  pub fn exports_mut(&mut self) -> &mut BTreeMap<Atom, ExportInfoData> {
     &mut self.exports
   }
 

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -1,5 +1,11 @@
-use crate::ExportsInfoData;
+use crate::{ExportsInfo, ExportsInfoData};
 
-pub struct ExportsInfoSetter;
-
-impl ExportsInfoData {}
+impl ExportsInfoData {
+  pub fn set_redirect_name_to(&mut self, id: Option<ExportsInfo>) -> bool {
+    if self.redirect_to() == id {
+      return false;
+    }
+    self.set_redirect_to(id);
+    true
+  }
+}

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -1,35 +1,5 @@
+use crate::ExportsInfoData;
+
 pub struct ExportsInfoSetter;
 
-// impl ExportsInfoSetter {
-//   // TODO: remove this, we should refactor ExportInfo into ExportName and ExportProvideInfo and ExportUsedInfo
-//   // ExportProvideInfo is created by FlagDependencyExportsPlugin, and should not mutate after create
-//   // ExportUsedInfo is created by FlagDependencyUsagePlugin or Plugin::finish_modules, and should not mutate after create
-//   pub fn reset_provide_info(info: &mut ExportsInfoData, mg: &mut ModuleGraph) {
-//     for export_info in info.exports_mut().values_mut() {
-//       ExportInfoSetter::reset_provide_info(export_info);
-//     }
-//     ExportInfoSetter::reset_provide_info(info.other_exports_info_mut());
-//     ExportInfoSetter::reset_provide_info(info.side_effects_only_info_mut());
-//     if let Some(redirect_to) = info.redirect_to() {
-//       redirect_to.as_data_mut(mg).reset_provide_info(mg);
-//     }
-//   }
-// }
-
-// impl ExportsInfoData {
-//   pub fn set_has_use_info(&mut self, mg: &mut ModuleGraph) {
-//     for export_info in self.exports_mut().values_mut() {
-//       ExportInfoSetter::set_has_use_info(export_info, mg);
-//     }
-//     ExportInfoSetter::set_has_use_info(self.side_effects_only_info_mut(), mg);
-//     if let Some(redirect) = self.redirect_to() {
-//       redirect.as_data_mut(mg).set_has_use_info(mg);
-//     } else {
-//       let other_exports_info = self.other_exports_info_mut();
-//       ExportInfoSetter::set_has_use_info(other_exports_info, mg);
-//       if other_exports_info.can_mangle_use().is_none() {
-//         other_exports_info.set_can_mangle_use(Some(true));
-//       }
-//     }
-//   }
-// }
+impl ExportsInfoData {}

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -1,4 +1,4 @@
-use crate::{ExportsInfo, ExportsInfoData};
+use crate::{ExportsInfo, ExportsInfoData, RuntimeSpec, UsageState};
 
 impl ExportsInfoData {
   pub fn set_redirect_name_to(&mut self, id: Option<ExportsInfo>) -> bool {
@@ -7,5 +7,13 @@ impl ExportsInfoData {
     }
     self.set_redirect_to(id);
     true
+  }
+
+  pub fn set_used_for_side_effects_only(&mut self, runtime: Option<&RuntimeSpec>) -> bool {
+    self.side_effects_only_info_mut().set_used_conditionally(
+      Box::new(|value| value == &UsageState::Unused),
+      UsageState::Used,
+      runtime,
+    )
   }
 }

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -1,5 +1,35 @@
 pub struct ExportsInfoSetter;
 
-impl ExportsInfoSetter {
-  // TODO
-}
+// impl ExportsInfoSetter {
+//   // TODO: remove this, we should refactor ExportInfo into ExportName and ExportProvideInfo and ExportUsedInfo
+//   // ExportProvideInfo is created by FlagDependencyExportsPlugin, and should not mutate after create
+//   // ExportUsedInfo is created by FlagDependencyUsagePlugin or Plugin::finish_modules, and should not mutate after create
+//   pub fn reset_provide_info(info: &mut ExportsInfoData, mg: &mut ModuleGraph) {
+//     for export_info in info.exports_mut().values_mut() {
+//       ExportInfoSetter::reset_provide_info(export_info);
+//     }
+//     ExportInfoSetter::reset_provide_info(info.other_exports_info_mut());
+//     ExportInfoSetter::reset_provide_info(info.side_effects_only_info_mut());
+//     if let Some(redirect_to) = info.redirect_to() {
+//       redirect_to.as_data_mut(mg).reset_provide_info(mg);
+//     }
+//   }
+// }
+
+// impl ExportsInfoData {
+//   pub fn set_has_use_info(&mut self, mg: &mut ModuleGraph) {
+//     for export_info in self.exports_mut().values_mut() {
+//       ExportInfoSetter::set_has_use_info(export_info, mg);
+//     }
+//     ExportInfoSetter::set_has_use_info(self.side_effects_only_info_mut(), mg);
+//     if let Some(redirect) = self.redirect_to() {
+//       redirect.as_data_mut(mg).set_has_use_info(mg);
+//     } else {
+//       let other_exports_info = self.other_exports_info_mut();
+//       ExportInfoSetter::set_has_use_info(other_exports_info, mg);
+//       if other_exports_info.can_mangle_use().is_none() {
+//         other_exports_info.set_can_mangle_use(Some(true));
+//       }
+//     }
+//   }
+// }

--- a/crates/rspack_core/src/exports/mod.rs
+++ b/crates/rspack_core/src/exports/mod.rs
@@ -9,10 +9,8 @@ mod target;
 mod utils;
 
 pub use export_info::*;
-pub use export_info_setter::*;
 pub use exports_info::*;
 pub use exports_info_getter::*;
-pub use exports_info_setter::*;
 pub use referenced_export::*;
 pub use target::*;
 pub use utils::*;

--- a/crates/rspack_core/src/exports/mod.rs
+++ b/crates/rspack_core/src/exports/mod.rs
@@ -9,7 +9,6 @@ mod target;
 mod utils;
 
 pub use export_info::*;
-pub use export_info_getter::*;
 pub use export_info_setter::*;
 pub use exports_info::*;
 pub use exports_info_getter::*;

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -1,8 +1,7 @@
-use rspack_collections::UkeySet;
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet;
 
-use crate::{ExportInfo, ExportInfoData, ExportInfoGetter, ModuleGraph, RuntimeSpec, UsageState};
+use crate::{ExportInfo, ExportInfoData, ModuleGraph, RuntimeSpec, UsageState};
 
 /// refer https://github.com/webpack/webpack/blob/d15c73469fd71cf98734685225250148b68ddc79/lib/FlagDependencyUsagePlugin.js#L64
 #[derive(Clone, Debug)]
@@ -75,7 +74,7 @@ pub fn collect_referenced_export_items<'a>(
   already_visited: &mut FxHashSet<ExportInfo>,
 ) {
   if let Some(export_info) = export_info {
-    let used = ExportInfoGetter::get_used(export_info, runtime);
+    let used = export_info.get_used(runtime);
     if used == UsageState::Unused {
       return;
     }

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -74,21 +74,21 @@ pub fn collect_referenced_export_items<'a>(
   already_visited: &mut FxHashSet<ExportInfo>,
 ) {
   if let Some(export_info) = export_info {
+    let export_info_id = export_info.id();
     let used = export_info.get_used(runtime);
     if used == UsageState::Unused {
       return;
     }
-    if already_visited.contains(&export_info.id()) {
+    if already_visited.contains(&export_info_id) {
       referenced_export.push(prefix);
       return;
     }
-    already_visited.insert(export_info.id());
     // FIXME: more branch
     if used != UsageState::OnlyPropertiesUsed {
-      already_visited.remove(&export_info.id());
       referenced_export.push(prefix);
       return;
     }
+    already_visited.insert(export_info_id);
     if let Some(exports_info) = module_graph.try_get_exports_info_by_id(
       &export_info
         .exports_info()

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -1,5 +1,6 @@
 use rspack_collections::UkeySet;
 use rspack_util::atom::Atom;
+use rustc_hash::FxHashSet;
 
 use crate::{ExportInfo, ExportInfoData, ExportInfoGetter, ModuleGraph, RuntimeSpec, UsageState};
 
@@ -71,7 +72,7 @@ pub fn collect_referenced_export_items<'a>(
   prefix: Vec<&'a Atom>,
   export_info: Option<&'a ExportInfoData>,
   default_points_to_self: bool,
-  already_visited: &mut UkeySet<ExportInfo>,
+  already_visited: &mut FxHashSet<ExportInfo>,
 ) {
   if let Some(export_info) = export_info {
     let used = ExportInfoGetter::get_used(export_info, runtime);

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -94,9 +94,7 @@ pub fn collect_referenced_export_items<'a>(
         .exports_info()
         .expect("should have exports info"),
     ) {
-      for export_info in exports_info.exports() {
-        let export_info = export_info.as_data(module_graph);
-
+      for export_info in exports_info.exports().values() {
         collect_referenced_export_items(
           module_graph,
           runtime,

--- a/crates/rspack_core/src/exports/target.rs
+++ b/crates/rspack_core/src/exports/target.rs
@@ -62,13 +62,9 @@ pub fn get_terminal_binding(
   let Some(export) = target.export else {
     return Some(TerminalBinding::ExportsInfo(exports_info));
   };
-  ExportsInfoGetter::prefetch(
-    &exports_info,
-    mg,
-    PrefetchExportsInfoMode::NamedNestedExports(&export),
-  )
-  .get_read_only_export_info_recursive(&export)
-  .map(|data| TerminalBinding::ExportInfo(data.id()))
+  ExportsInfoGetter::prefetch(&exports_info, mg, PrefetchExportsInfoMode::Nested(&export))
+    .get_read_only_export_info_recursive(&export)
+    .map(|data| TerminalBinding::ExportInfo(data.id()))
 }
 
 pub(crate) fn find_target_from_export_info(
@@ -98,10 +94,8 @@ pub(crate) fn find_target_from_export_info(
       return FindTargetResult::ValidTarget(target);
     }
     let name = &target.export.as_ref().expect("should have export")[0];
-    let exports_info = mg.get_prefetched_exports_info(
-      &target.module,
-      PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([name])),
-    );
+    let exports_info =
+      mg.get_prefetched_exports_info(&target.module, PrefetchExportsInfoMode::Default);
     let export_info = exports_info.get_export_info_without_mut_module_graph(name);
     let export_info_hash_key = export_info.as_hash_key();
     if visited.contains(&export_info_hash_key) {
@@ -266,10 +260,8 @@ fn resolve_target(
         return Some(ResolvedExportInfoTargetWithCircular::Target(target));
       };
 
-      let exports_info = mg.get_prefetched_exports_info(
-        &target.module,
-        PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([name])),
-      );
+      let exports_info =
+        mg.get_prefetched_exports_info(&target.module, PrefetchExportsInfoMode::Default);
       let maybe_export_info = exports_info.get_export_info_without_mut_module_graph(name);
       let maybe_export_info_hash_key = maybe_export_info.as_hash_key();
       if already_visited.contains(&maybe_export_info_hash_key) {

--- a/crates/rspack_core/src/exports/target.rs
+++ b/crates/rspack_core/src/exports/target.rs
@@ -4,7 +4,7 @@ use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  DependencyId, ExportInfo, ExportInfoData, ExportInfoGetter, ExportsInfo, ExportsInfoGetter,
+  DependencyId, ExportInfo, ExportInfoData, ExportsInfo, ExportsInfoGetter,
   MaybeDynamicTargetExportInfo, MaybeDynamicTargetExportInfoHashKey, ModuleGraph, ModuleIdentifier,
   PrefetchExportsInfoMode,
 };
@@ -80,7 +80,7 @@ pub(crate) fn find_target_from_export_info(
   if !export_info.target_is_set() || export_info.target().is_empty() {
     return FindTargetResult::NoTarget;
   }
-  let max_target = ExportInfoGetter::get_max_target(export_info);
+  let max_target = export_info.get_max_target();
   let raw_target = max_target.values().next();
   let Some(raw_target) = raw_target else {
     return FindTargetResult::NoTarget;
@@ -171,7 +171,7 @@ pub(crate) fn get_target_from_export_info(
   resolve_filter: ResolveFilterFnTy,
   already_visited: &mut HashSet<MaybeDynamicTargetExportInfoHashKey>,
 ) -> Option<ResolvedExportInfoTargetWithCircular> {
-  let max_target = ExportInfoGetter::get_max_target(export_info);
+  let max_target = export_info.get_max_target();
   let mut values = max_target
     .values()
     .map(|item| UnResolvedExportInfoTarget {

--- a/crates/rspack_core/src/exports/target.rs
+++ b/crates/rspack_core/src/exports/target.rs
@@ -9,7 +9,7 @@ use crate::{
   PrefetchExportsInfoMode,
 };
 
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub enum TerminalBinding {
   ExportInfo(ExportInfo),
   ExportsInfo(ExportsInfo),

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -431,7 +431,7 @@ impl ExternalModule {
 
           if let Some(concatenation_scope) = concatenation_scope {
             let exports_info = module_graph
-              .get_prefetched_exports_info(&self.identifier(), PrefetchExportsInfoMode::AllExports);
+              .get_prefetched_exports_info(&self.identifier(), PrefetchExportsInfoMode::Default);
             let used_exports = exports_info.get_used_exports(runtime);
             let meta = &self.dependency_meta.attributes;
             let attributes = meta.as_ref().map(|meta| {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -451,10 +451,8 @@ fn get_exports_type_impl(
         }
 
         let name = Atom::from("__esModule");
-        let exports_info = mg.get_prefetched_exports_info_optional(
-          &identifier,
-          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter([&name])),
-        );
+        let exports_info =
+          mg.get_prefetched_exports_info_optional(&identifier, PrefetchExportsInfoMode::Default);
         if let Some(export_info) = exports_info
           .as_ref()
           .map(|info| info.get_read_only_export_info(&name))

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1085,12 +1085,6 @@ impl<'a> ModuleGraph<'a> {
     &mgm.optimization_bailout
   }
 
-  pub fn get_read_only_export_info(&self, id: &ModuleIdentifier, name: Atom) -> Option<ExportInfo> {
-    self
-      .module_graph_module_by_identifier(id)
-      .map(|mgm| mgm.exports.get_read_only_export_info(self, &name))
-  }
-
   pub fn get_condition_state(
     &self,
     connection: &ModuleGraphConnection,

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1107,11 +1107,8 @@ impl<'a> ModuleGraph<'a> {
     names: &[Atom],
   ) -> Option<ExportProvided> {
     self.module_graph_module_by_identifier(id).and_then(|mgm| {
-      let exports_info = ExportsInfoGetter::prefetch(
-        &mgm.exports,
-        self,
-        PrefetchExportsInfoMode::NamedNestedExports(names),
-      );
+      let exports_info =
+        ExportsInfoGetter::prefetch(&mgm.exports, self, PrefetchExportsInfoMode::Nested(names));
       ExportsInfoGetter::is_export_provided(&exports_info, names)
     })
   }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -17,8 +17,8 @@ mod connection;
 pub use connection::*;
 
 use crate::{
-  BoxDependency, BoxModule, DependencyCondition, DependencyId, ExportInfo, ExportInfoData,
-  ExportsInfo, ExportsInfoData, ModuleIdentifier,
+  BoxDependency, BoxModule, DependencyCondition, DependencyId, ExportInfo, ExportsInfo,
+  ExportsInfoData, ModuleIdentifier,
 };
 
 // TODO Here request can be used Atom
@@ -85,7 +85,6 @@ pub struct ModuleGraphPartial {
 
   // Module's ExportsInfo is also a part of ModuleGraph
   exports_info_map: UkeyMap<ExportsInfo, ExportsInfoData>,
-  export_info_map: UkeyMap<ExportInfo, ExportInfoData>,
   // TODO try move condition as connection field
   connection_to_condition: HashMap<DependencyId, DependencyCondition>,
   dep_meta_map: HashMap<DependencyId, DependencyExtraMeta>,
@@ -1070,44 +1069,6 @@ impl<'a> ModuleGraph<'a> {
       panic!("should have active partial");
     };
     active_partial.exports_info_map.insert(id, info);
-  }
-
-  pub fn get_export_info_by_id(&self, id: &ExportInfo) -> &ExportInfoData {
-    self
-      .loop_partials(|p| p.export_info_map.get(id))
-      .expect("should have export info")
-  }
-
-  pub fn get_export_info_mut_by_id(&mut self, id: &ExportInfo) -> &mut ExportInfoData {
-    self
-      .loop_partials_mut(
-        |p| p.export_info_map.contains_key(id),
-        |p, search_result| {
-          p.export_info_map.insert(*id, search_result);
-        },
-        |p| p.export_info_map.get(id).cloned(),
-        |p| p.export_info_map.get_mut(id),
-      )
-      .expect("should have export info")
-  }
-
-  pub fn prepare_export_info_map(&mut self) {
-    let _ = self
-      .loop_partials_mut::<UkeyMap<ExportInfo, ExportInfoData>, UkeyMap<ExportInfo, ExportInfoData>>(
-        |_| false,
-        |p, search_result| {
-          let _ = std::mem::replace::<UkeyMap<ExportInfo, ExportInfoData>>(&mut p.export_info_map, search_result);
-        },
-        |p| Some(p.export_info_map.clone()),
-        |p| Some(&mut p.export_info_map),
-      );
-  }
-
-  pub fn set_export_info(&mut self, id: ExportInfo, info: ExportInfoData) {
-    let Some(active_partial) = &mut self.active else {
-      panic!("should have active partial");
-    };
-    active_partial.export_info_map.insert(id, info);
   }
 
   pub fn get_optimization_bailout_mut(&mut self, id: &ModuleIdentifier) -> &mut Vec<String> {

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1103,7 +1103,7 @@ impl<'a> ModuleGraph<'a> {
     self.module_graph_module_by_identifier(id).and_then(|mgm| {
       let exports_info =
         ExportsInfoGetter::prefetch(&mgm.exports, self, PrefetchExportsInfoMode::Nested(names));
-      ExportsInfoGetter::is_export_provided(&exports_info, names)
+      exports_info.is_export_provided(names)
     })
   }
 

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -17,8 +17,8 @@ mod connection;
 pub use connection::*;
 
 use crate::{
-  BoxDependency, BoxModule, DependencyCondition, DependencyId, ExportInfo, ExportsInfo,
-  ExportsInfoData, ModuleIdentifier,
+  BoxDependency, BoxModule, DependencyCondition, DependencyId, ExportsInfo, ExportsInfoData,
+  ModuleIdentifier,
 };
 
 // TODO Here request can be used Atom
@@ -814,12 +814,6 @@ impl<'a> ModuleGraph<'a> {
         |p| p.module_graph_modules.get_mut(identifier),
       )?
       .as_mut()
-  }
-
-  /// refer https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/ModuleGraph.js#L582-L585
-  pub fn get_export_info(&mut self, module_id: ModuleIdentifier, export_name: &Atom) -> ExportInfo {
-    let exports_info = self.get_exports_info(&module_id);
-    exports_info.get_export_info(self, export_name)
   }
 
   pub fn get_ordered_outgoing_connections(

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -1072,7 +1072,7 @@ impl Stats<'_> {
       {
         let module_graph = self.compilation.get_module_graph();
         let exports_info = module_graph
-          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::AllExports);
+          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
         let used_exports = exports_info.get_used_exports(None);
         match used_exports {
           UsedExports::Unknown => Some(StatsUsedExports::Null),
@@ -1089,7 +1089,7 @@ impl Stats<'_> {
         if !executed && self.compilation.options.optimization.provided_exports {
           let module_graph = self.compilation.get_module_graph();
           let exports_info = module_graph
-            .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::AllExports);
+            .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
           let provided_exports = exports_info.get_provided_exports();
           match provided_exports {
             ProvidedExports::ProvidedNames(v) => Some(v),

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -117,11 +117,11 @@ pub fn get_hash(s: impl Hash, length: usize) -> String {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn assign_deterministic_ids<T: Copy>(
+pub fn assign_deterministic_ids<T>(
   mut items: Vec<T>,
-  get_name: impl Fn(T) -> String,
+  get_name: impl Fn(&T) -> String,
   comparator: impl Fn(&T, &T) -> Ordering,
-  mut assign_id: impl FnMut(T, usize) -> bool,
+  mut assign_id: impl FnMut(&T, usize) -> bool,
   ranges: &[usize],
   expand_factor: usize,
   extra_space: usize,
@@ -145,10 +145,10 @@ pub fn assign_deterministic_ids<T: Copy>(
   }
 
   for item in items {
-    let ident = get_name(item);
+    let ident = get_name(&item);
     let mut i = salt;
     let mut id = get_number_hash(&format!("{ident}{}", itoa!(i)), range);
-    while !assign_id(item, id) {
+    while !assign_id(&item, id) {
       i += 1;
       id = get_number_hash(&format!("{ident}{}", itoa!(i)), range);
     }

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -16,10 +16,10 @@ use rspack_core::{
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
   BoxDependencyTemplate, BoxModuleDependency, BuildMetaDefaultObject, BuildMetaExportsType,
   ChunkGraph, Compilation, ConstDependency, CssExportsConvention, Dependency, DependencyId,
-  DependencyRange, DependencyType, ExportInfoGetter, GenerateContext, LocalIdentName, Module,
-  ModuleGraph, ModuleIdentifier, ModuleInitFragments, ModuleType, NormalModule, ParseContext,
-  ParseResult, ParserAndGenerator, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec,
-  SourceType, TemplateContext, UsageState,
+  DependencyRange, DependencyType, GenerateContext, LocalIdentName, Module, ModuleGraph,
+  ModuleIdentifier, ModuleInitFragments, ModuleType, NormalModule, ParseContext, ParseResult,
+  ParserAndGenerator, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, SourceType,
+  TemplateContext, UsageState,
 };
 use rspack_error::{
   miette::Diagnostic, IntoTWithDiagnosticArray, Result, RspackSeverity, TWithDiagnosticArray,
@@ -593,10 +593,10 @@ impl ParserAndGenerator for CssParserAndGenerator {
           let exports_info =
             mg.get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
           let (ns_obj, left, right) = if self.es_module
-            && ExportInfoGetter::get_used(
-              exports_info.other_exports_info(),
-              generate_context.runtime,
-            ) != UsageState::Unused
+            && exports_info
+              .other_exports_info()
+              .get_used(generate_context.runtime)
+              != UsageState::Unused
           {
             (RuntimeGlobals::MAKE_NAMESPACE_OBJECT.name(), "(", ")")
           } else {
@@ -711,7 +711,7 @@ fn get_used_exports<'a>(
         .map(|info| info.get_read_only_export_info(&Atom::from(name.as_str())));
 
       if let Some(export_info) = export_info {
-        ExportInfoGetter::get_used(export_info, runtime) != UsageState::Unused
+        export_info.get_used(runtime) != UsageState::Unused
       } else {
         true
       }
@@ -750,10 +750,7 @@ fn get_unused_local_ident(
           .map(|info| info.get_read_only_export_info(name));
 
         if let Some(export_info) = export_info {
-          matches!(
-            ExportInfoGetter::get_used(export_info, runtime),
-            UsageState::Unused
-          )
+          matches!(export_info.get_used(runtime), UsageState::Unused)
         } else {
           false
         }

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -693,15 +693,8 @@ fn get_used_exports<'a>(
   runtime: Option<&RuntimeSpec>,
   mg: &ModuleGraph,
 ) -> IndexMap<&'a str, &'a IndexSet<CssExport>> {
-  let exports_names = exports
-    .iter()
-    .map(|(name, _)| Atom::from(name.as_str()))
-    .collect::<Vec<_>>();
-
-  let exports_info = mg.get_prefetched_exports_info_optional(
-    &identifier,
-    PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter(exports_names.iter())),
-  );
+  let exports_info =
+    mg.get_prefetched_exports_info_optional(&identifier, PrefetchExportsInfoMode::Default);
 
   exports
     .iter()
@@ -736,10 +729,8 @@ fn get_unused_local_ident(
     .iter()
     .map(|(name, _)| Atom::from(name.as_str()))
     .collect::<Vec<_>>();
-  let exports_info = mg.get_prefetched_exports_info_optional(
-    &identifier,
-    PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter(exports_names.iter())),
-  );
+  let exports_info =
+    mg.get_prefetched_exports_info_optional(&identifier, PrefetchExportsInfoMode::Default);
 
   CodeGenerationDataUnusedLocalIdent {
     idents: exports_names

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -142,7 +142,7 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
 
       if let Some(ident) = ident {
         let exports_info = module_graph
-          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::AllExports);
+          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
 
         let provided_exports = match ExportsInfoGetter::get_provided_exports(&exports_info) {
           ProvidedExports::ProvidedNames(vec) => Some(DllManifestContentItemExports::Vec(vec)),

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -1,8 +1,8 @@
 use rspack_collections::DatabaseItem;
 use rspack_core::{
   ApplyContext, ChunkGraph, Compilation, CompilerEmit, CompilerOptions, Context, EntryDependency,
-  ExportsInfoGetter, Filename, LibIdentOptions, PathData, Plugin, PluginContext,
-  PrefetchExportsInfoMode, ProvidedExports, SourceType,
+  Filename, LibIdentOptions, PathData, Plugin, PluginContext, PrefetchExportsInfoMode,
+  ProvidedExports, SourceType,
 };
 use rspack_error::{Error, Result, ToStringResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
@@ -144,7 +144,7 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
         let exports_info = module_graph
           .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
 
-        let provided_exports = match ExportsInfoGetter::get_provided_exports(&exports_info) {
+        let provided_exports = match exports_info.get_provided_exports() {
           ProvidedExports::ProvidedNames(vec) => Some(DllManifestContentItemExports::Vec(vec)),
           ProvidedExports::ProvidedAll => Some(DllManifestContentItemExports::True),
           _ => None,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -69,10 +69,8 @@ impl CommonJsExportRequireDependency {
     imported_module: &ModuleIdentifier,
   ) -> Option<FxHashSet<Atom>> {
     let ids = self.get_ids(mg);
-    let mut imported_exports_info = Some(mg.get_prefetched_exports_info(
-      imported_module,
-      PrefetchExportsInfoMode::NamedNestedAllExports(ids),
-    ));
+    let mut imported_exports_info =
+      Some(mg.get_prefetched_exports_info(imported_module, PrefetchExportsInfoMode::Nested(ids)));
 
     if !ids.is_empty() {
       let Some(nested_exports_info) = &imported_exports_info else {
@@ -83,14 +81,14 @@ impl CommonJsExportRequireDependency {
         .map(|data| data.id());
 
       imported_exports_info =
-        nested.map(|id| ExportsInfoGetter::prefetch(&id, mg, PrefetchExportsInfoMode::AllExports));
+        nested.map(|id| ExportsInfoGetter::prefetch(&id, mg, PrefetchExportsInfoMode::Default));
     }
 
     let mut exports_info = Some(
       mg.get_prefetched_exports_info(
         mg.get_parent_module(&self.id)
           .expect("Should get parent module"),
-        PrefetchExportsInfoMode::NamedNestedAllExports(&self.names),
+        PrefetchExportsInfoMode::Nested(&self.names),
       ),
     );
 
@@ -102,7 +100,7 @@ impl CommonJsExportRequireDependency {
         .get_nested_exports_info(Some(&self.names))
         .map(|data| data.id());
       exports_info =
-        nested.map(|id| ExportsInfoGetter::prefetch(&id, mg, PrefetchExportsInfoMode::AllExports));
+        nested.map(|id| ExportsInfoGetter::prefetch(&id, mg, PrefetchExportsInfoMode::Default));
     };
 
     let no_extra_exports = imported_exports_info.as_ref().is_some_and(|data| {
@@ -313,7 +311,7 @@ impl Dependency for CommonJsExportRequireDependency {
     let mut exports_info = mg.get_prefetched_exports_info(
       mg.get_parent_module(&self.id)
         .expect("Can not get parent module"),
-      PrefetchExportsInfoMode::NamedNestedAllExports(&self.names),
+      PrefetchExportsInfoMode::Nested(&self.names),
     );
 
     for name in &self.names {
@@ -466,7 +464,7 @@ impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
     } else {
       let exports_info = mg.get_prefetched_exports_info(
         &module.identifier(),
-        PrefetchExportsInfoMode::NamedNestedExports(&dep.names),
+        PrefetchExportsInfoMode::Nested(&dep.names),
       );
       ExportsInfoGetter::get_used_name(
         GetUsedNameParam::WithNames(&exports_info),
@@ -494,9 +492,9 @@ impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
         GetUsedNameParam::WithNames(&mg.get_prefetched_exports_info(
           &imported_module.identifier(),
           if ids.is_empty() {
-            PrefetchExportsInfoMode::AllExports
+            PrefetchExportsInfoMode::Default
           } else {
-            PrefetchExportsInfoMode::NamedNestedExports(ids)
+            PrefetchExportsInfoMode::Nested(ids)
           },
         )),
         *runtime,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -6,12 +6,11 @@ use rspack_cacheable::{
 use rspack_core::{
   collect_referenced_export_items, module_raw, property_access, to_normal_comment,
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportInfoGetter,
-  ExportNameOrSpec, ExportProvided, ExportSpec, ExportsInfoGetter, ExportsOfExportsSpec,
-  ExportsSpec, ExportsType, ExtendedReferencedExport, FactorizeInfo, GetUsedNameParam,
-  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, Nullable,
-  PrefetchExportsInfoMode, ReferencedExport, RuntimeGlobals, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource, UsageState, UsedName,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportNameOrSpec,
+  ExportProvided, ExportSpec, ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, ExportsType,
+  ExtendedReferencedExport, FactorizeInfo, GetUsedNameParam, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdentifier, Nullable, PrefetchExportsInfoMode, ReferencedExport,
+  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
 };
 use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
@@ -113,7 +112,7 @@ impl CommonJsExportRequireDependency {
 
     let no_extra_imports = exports_info.as_ref().is_some_and(|data| {
       matches!(
-        ExportInfoGetter::get_used(data.other_exports_info(), runtime),
+        data.other_exports_info().get_used(runtime),
         UsageState::Unused
       )
     });
@@ -137,10 +136,7 @@ impl CommonJsExportRequireDependency {
       };
       for (_, export_info) in exports_info.exports() {
         let name = export_info.name();
-        if matches!(
-          ExportInfoGetter::get_used(export_info, runtime),
-          UsageState::Unused
-        ) {
+        if matches!(export_info.get_used(runtime), UsageState::Unused) {
           continue;
         }
         if let Some(name) = name {
@@ -175,7 +171,7 @@ impl CommonJsExportRequireDependency {
           }
           if let Some(exports_info) = &exports_info {
             let export_info = exports_info.get_read_only_export_info(name);
-            let used = ExportInfoGetter::get_used(export_info, runtime);
+            let used = export_info.get_used(runtime);
             if matches!(used, UsageState::Unused) {
               continue;
             }
@@ -322,7 +318,7 @@ impl Dependency for CommonJsExportRequireDependency {
 
     for name in &self.names {
       let export_info = exports_info.get_read_only_export_info(name);
-      let used = ExportInfoGetter::get_used(export_info, runtime);
+      let used = export_info.get_used(runtime);
       if matches!(used, UsageState::Unused) {
         return vec![ExtendedReferencedExport::Array(vec![])];
       }
@@ -337,7 +333,7 @@ impl Dependency for CommonJsExportRequireDependency {
     }
 
     if !matches!(
-      ExportInfoGetter::get_used(exports_info.other_exports_info(), runtime),
+      exports_info.other_exports_info().get_used(runtime),
       UsageState::Unused
     ) {
       return get_full_result();

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -182,7 +182,7 @@ impl DependencyTemplate for CommonJsExportsDependencyTemplate {
     } else {
       let exports_info = module_graph.get_prefetched_exports_info(
         &module.identifier(),
-        PrefetchExportsInfoMode::NamedNestedExports(&dep.names),
+        PrefetchExportsInfoMode::Nested(&dep.names),
       );
       ExportsInfoGetter::get_used_name(
         GetUsedNameParam::WithNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -188,7 +188,7 @@ impl DependencyTemplate for CommonJsFullRequireDependencyTemplate {
         } else {
           let exports_info = module_graph.get_prefetched_exports_info(
             &imported_module.module_identifier,
-            PrefetchExportsInfoMode::NamedNestedExports(&dep.names),
+            PrefetchExportsInfoMode::Nested(&dep.names),
           );
           ExportsInfoGetter::get_used_name(
             GetUsedNameParam::WithNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -158,7 +158,7 @@ impl DependencyTemplate for CommonJsSelfReferenceDependencyTemplate {
       } else {
         let exports_info = module_graph.get_prefetched_exports_info(
           &module.identifier(),
-          PrefetchExportsInfoMode::NamedNestedExports(&dep.names),
+          PrefetchExportsInfoMode::Nested(&dep.names),
         );
         ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportInfoGetter,
-  InitFragmentKey, InitFragmentStage, ModuleGraph, NormalInitFragment, PrefetchExportsInfoMode,
-  RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsageState,
+  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, InitFragmentKey,
+  InitFragmentStage, ModuleGraph, NormalInitFragment, PrefetchExportsInfoMode, RuntimeGlobals,
+  TemplateContext, TemplateReplaceSource, UsageState,
 };
 use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
@@ -58,7 +58,9 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
       &module.identifier(),
       PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&name])),
     );
-    let used = ExportInfoGetter::get_used(exports_info.get_read_only_export_info(&name), *runtime);
+    let used = exports_info
+      .get_read_only_export_info(&name)
+      .get_used(*runtime);
     if !matches!(used, UsageState::Unused) {
       runtime_requirements.insert(RuntimeGlobals::MAKE_NAMESPACE_OBJECT);
       runtime_requirements.insert(RuntimeGlobals::EXPORTS);

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -4,7 +4,6 @@ use rspack_core::{
   InitFragmentStage, ModuleGraph, NormalInitFragment, PrefetchExportsInfoMode, RuntimeGlobals,
   TemplateContext, TemplateReplaceSource, UsageState,
 };
-use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
 
 // Mark module `__esModule`.
@@ -54,10 +53,8 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
     let name = Atom::from("__esModule");
-    let exports_info = module_graph.get_prefetched_exports_info(
-      &module.identifier(),
-      PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&name])),
-    );
+    let exports_info = module_graph
+      .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
     let used = exports_info
       .get_read_only_export_info(&name)
       .get_used(*runtime);

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -9,7 +9,6 @@ use rspack_core::{
   ModuleGraph, ModuleGraphCacheArtifact, PrefetchExportsInfoMode, RuntimeGlobals, SharedSourceMap,
   TemplateContext, TemplateReplaceSource, UsedName, DEFAULT_EXPORT,
 };
-use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
 
 use crate::parser_plugin::JS_DEFAULT_KEYWORD;
@@ -181,10 +180,9 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
       if let Some(scope) = concatenation_scope {
         scope.register_export(JS_DEFAULT_KEYWORD.clone(), name.to_string());
       } else if let Some(used) = ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(&mg.get_prefetched_exports_info(
-          &module_identifier,
-          PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&*JS_DEFAULT_KEYWORD])),
-        )),
+        GetUsedNameParam::WithNames(
+          &mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default),
+        ),
         *runtime,
         std::slice::from_ref(&JS_DEFAULT_KEYWORD),
       ) && let UsedName::Normal(used) = used
@@ -221,10 +219,9 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
           if supports_const { "const" } else { "var" }
         )
       } else if let Some(used) = ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(&mg.get_prefetched_exports_info(
-          &module_identifier,
-          PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&*JS_DEFAULT_KEYWORD])),
-        )),
+        GetUsedNameParam::WithNames(
+          &mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default),
+        ),
         *runtime,
         std::slice::from_ref(&JS_DEFAULT_KEYWORD),
       ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -160,15 +160,10 @@ impl ESMExportImportedSpecifierDependency {
       .get_parent_module(id)
       .expect("should have parent module");
     let exports_info = module_graph.get_exports_info(parent_module);
-    let rename = name.clone();
     let exports_info_data = ExportsInfoGetter::prefetch(
       &exports_info,
       module_graph,
-      if let Some(ref name) = rename {
-        PrefetchExportsInfoMode::NamedExports(HashSet::from_iter(vec![name]))
-      } else {
-        PrefetchExportsInfoMode::Default
-      },
+      PrefetchExportsInfoMode::Default,
     );
 
     let is_name_unused = if let Some(ref name) = name {
@@ -277,16 +272,8 @@ impl ESMExportImportedSpecifierDependency {
         return ExportMode::EmptyStar(ExportModeEmptyStar { hidden });
       }
 
-      let exports_info_data = module_graph.get_prefetched_exports_info(
-        parent_module,
-        if let Some(hidden) = &hidden {
-          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter(
-            exports.iter().chain(hidden.iter()),
-          ))
-        } else {
-          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter(exports.iter()))
-        },
-      );
+      let exports_info_data =
+        module_graph.get_prefetched_exports_info(parent_module, PrefetchExportsInfoMode::Default);
 
       let mut items = exports
         .iter()
@@ -556,10 +543,8 @@ impl ESMExportImportedSpecifierDependency {
         .boxed(),
       ),
       ExportMode::ReexportDynamicDefault(ExportModeReexportDynamicDefault { name }) => {
-        let exports_info = mg.get_prefetched_exports_info(
-          &module_identifier,
-          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter(vec![&name])),
-        );
+        let exports_info =
+          mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
         let used_name = ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithNames(&exports_info),
           None,
@@ -579,10 +564,8 @@ impl ESMExportImportedSpecifierDependency {
         fragments.push(init_fragment);
       }
       ExportMode::ReexportNamedDefault(mode) => {
-        let exports_info = mg.get_prefetched_exports_info(
-          &module_identifier,
-          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter(vec![&mode.name])),
-        );
+        let exports_info =
+          mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
         let used_name = ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithNames(&exports_info),
           None,
@@ -601,10 +584,8 @@ impl ESMExportImportedSpecifierDependency {
         fragments.push(init_fragment);
       }
       ExportMode::ReexportNamespaceObject(mode) => {
-        let exports_info = mg.get_prefetched_exports_info(
-          &module_identifier,
-          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter(vec![&mode.name])),
-        );
+        let exports_info =
+          mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
         let used_name = ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithNames(&exports_info),
           None,
@@ -625,10 +606,8 @@ impl ESMExportImportedSpecifierDependency {
       }
       ExportMode::ReexportFakeNamespaceObject(mode) => {
         // TODO: reexport fake namespace object
-        let exports_info = mg.get_prefetched_exports_info(
-          &module_identifier,
-          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter(vec![&mode.name])),
-        );
+        let exports_info =
+          mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
         let used_name = ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithNames(&exports_info),
           None,
@@ -638,10 +617,8 @@ impl ESMExportImportedSpecifierDependency {
         self.get_reexport_fake_namespace_object_fragments(ctxt, key, &import_var, mode.fake_type);
       }
       ExportMode::ReexportUndefined(mode) => {
-        let exports_info = mg.get_prefetched_exports_info(
-          &module_identifier,
-          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter(vec![&mode.name])),
-        );
+        let exports_info =
+          mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
         let used_name = ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithNames(&exports_info),
           None,
@@ -664,15 +641,8 @@ impl ESMExportImportedSpecifierDependency {
         let imported_module = mg
           .module_identifier_by_dependency_id(&self.id)
           .expect("should have imported module identifier");
-        let names = mode
-          .items
-          .iter()
-          .map(|item| item.name.clone())
-          .collect::<Vec<_>>();
-        let exports_info = mg.get_prefetched_exports_info(
-          &module_identifier,
-          PrefetchExportsInfoMode::NamedExports(HashSet::from_iter(names.iter())),
-        );
+        let exports_info =
+          mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
         for item in mode.items.into_iter() {
           let NormalReexportItem {
             name,
@@ -739,7 +709,7 @@ impl ESMExportImportedSpecifierDependency {
               let exports_info = ExportsInfoGetter::prefetch(
                 &exports_info,
                 mg,
-                PrefetchExportsInfoMode::NamedNestedExports(&ids),
+                PrefetchExportsInfoMode::Nested(&ids),
               );
               ExportsInfoGetter::get_used_name(
                 GetUsedNameParam::WithNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -167,8 +167,7 @@ impl ESMExportImportedSpecifierDependency {
     );
 
     let is_name_unused = if let Some(ref name) = name {
-      ExportsInfoGetter::get_used(&exports_info_data, std::slice::from_ref(name), runtime)
-        == UsageState::Unused
+      exports_info_data.get_used(std::slice::from_ref(name), runtime) == UsageState::Unused
     } else {
       !ExportsInfoGetter::prefetch_used_info_without_name(
         &exports_info,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -13,16 +13,16 @@ use rspack_core::{
   Dependency, DependencyCategory, DependencyCodeGeneration, DependencyCondition,
   DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyTemplateType, DependencyType, DetermineExportAssignmentsKey, ESMExportInitFragment,
-  ExportInfoGetter, ExportMode, ExportModeDynamicReexport, ExportModeEmptyStar,
-  ExportModeFakeNamespaceObject, ExportModeNormalReexport, ExportModeReexportDynamicDefault,
-  ExportModeReexportNamedDefault, ExportModeReexportNamespaceObject, ExportModeReexportUndefined,
-  ExportModeUnused, ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfo,
-  ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
-  FactorizeInfo, GetUsedNameParam, ImportAttributes, InitFragmentExt, InitFragmentKey,
-  InitFragmentStage, JavascriptParserOptions, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, NormalInitFragment, NormalReexportItem,
-  PrefetchExportsInfoMode, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SharedSourceMap,
-  StarReexportsInfo, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
+  ExportMode, ExportModeDynamicReexport, ExportModeEmptyStar, ExportModeFakeNamespaceObject,
+  ExportModeNormalReexport, ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
+  ExportModeReexportNamespaceObject, ExportModeReexportUndefined, ExportModeUnused,
+  ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfo, ExportsInfoGetter,
+  ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport, FactorizeInfo,
+  GetUsedNameParam, ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, NormalInitFragment, NormalReexportItem, PrefetchExportsInfoMode,
+  RuntimeCondition, RuntimeGlobals, RuntimeSpec, SharedSourceMap, StarReexportsInfo,
+  TemplateContext, TemplateReplaceSource, UsageState, UsedName,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -352,7 +352,7 @@ impl ESMExportImportedSpecifierDependency {
       Some(ExportProvided::NotProvided)
     );
     let no_extra_imports = matches!(
-      ExportInfoGetter::get_used(exports_info.other_exports_info(), runtime),
+      exports_info.other_exports_info().get_used(runtime),
       UsageState::Unused
     );
 
@@ -392,10 +392,7 @@ impl ESMExportImportedSpecifierDependency {
       for export_info in exports_info.exports().values() {
         let export_name = export_info.name().cloned().unwrap_or_default();
         if ignored_exports.contains(&export_name)
-          || matches!(
-            ExportInfoGetter::get_used(export_info, runtime),
-            UsageState::Unused
-          )
+          || matches!(export_info.get_used(runtime), UsageState::Unused)
         {
           continue;
         }
@@ -444,7 +441,7 @@ impl ESMExportImportedSpecifierDependency {
           .id()
           .get_read_only_export_info(module_graph, &imported_export_info_name);
         if matches!(
-          ExportInfoGetter::get_used(export_info.as_data(module_graph), runtime),
+          export_info.as_data(module_graph).get_used(runtime),
           UsageState::Unused
         ) {
           continue;

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -1053,13 +1053,14 @@ impl ESMExportImportedSpecifierDependency {
         if conflicting_module.identifier() == imported_module.identifier() {
           continue;
         }
-        let Some(conflicting_export_info) =
-          module_graph.get_read_only_export_info(&conflicting_module.identifier(), name.to_owned())
+        let Some(conflicting_export_info) = module_graph
+          .get_exports_info(&conflicting_module.identifier())
+          .as_data(module_graph)
+          .named_exports(name)
         else {
           continue;
         };
-        let Some(conflicting_target) =
-          get_terminal_binding(conflicting_export_info.as_data(module_graph), module_graph)
+        let Some(conflicting_target) = get_terminal_binding(conflicting_export_info, module_graph)
         else {
           continue;
         };

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -11,7 +11,6 @@ use rspack_core::{
   GetUsedNameParam, ModuleGraph, ModuleGraphCacheArtifact, PrefetchExportsInfoMode,
   SharedSourceMap, TSEnumValue, TemplateContext, TemplateReplaceSource, UsedName,
 };
-use rustc_hash::FxHashSet;
 use swc_core::ecma::atoms::Atom;
 
 // Create _webpack_require__.d(__webpack_exports__, {}) for each export.
@@ -178,7 +177,7 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
         let export_name = &[dep.name.clone(), enum_key.clone()];
         let exports_info = module_graph.get_prefetched_exports_info(
           &module.identifier(),
-          PrefetchExportsInfoMode::NamedNestedExports(export_name),
+          PrefetchExportsInfoMode::Nested(export_name),
         );
         let enum_member_used_name = ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithNames(&exports_info),
@@ -192,10 +191,8 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
       }
     }
 
-    let exports_info = module_graph.get_prefetched_exports_info(
-      &module.identifier(),
-      PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&dep.name])),
-    );
+    let exports_info = module_graph
+      .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
     let Some(used_name) = ExportsInfoGetter::get_used_name(
       GetUsedNameParam::WithNames(&exports_info),
       *runtime,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -18,7 +18,6 @@ use rspack_error::{
   miette::{MietteDiagnostic, Severity},
   Diagnostic, DiagnosticExt, TraceableError,
 };
-use rustc_hash::FxHashSet;
 use swc_core::ecma::atoms::Atom;
 
 use super::create_resource_identifier_for_esm_dependency;
@@ -299,7 +298,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
     let imported_module_identifier = imported_module.identifier();
     let exports_info = module_graph.get_prefetched_exports_info(
       &imported_module_identifier,
-      PrefetchExportsInfoMode::NamedNestedExports(ids),
+      PrefetchExportsInfoMode::Nested(ids),
     );
     if (!matches!(exports_type, ExportsType::DefaultWithNamed) || ids[0] != "default")
       && matches!(
@@ -330,7 +329,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
           ExportsInfoGetter::is_export_provided(
             &module_graph.get_prefetched_exports_info(
               parent_module_identifier,
-              PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([name]))
+              PrefetchExportsInfoMode::Default
             ),
             std::slice::from_ref(name)
           ),
@@ -355,7 +354,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       let mut pos = 0;
       let mut maybe_exports_info = Some(module_graph.get_prefetched_exports_info(
         &imported_module_identifier,
-        PrefetchExportsInfoMode::NamedNestedAllExports(ids),
+        PrefetchExportsInfoMode::Nested(ids),
       ));
       while pos < ids.len()
         && let Some(exports_info) = &maybe_exports_info

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -8,11 +8,11 @@ use rspack_core::{
   BuildMetaDefaultObject, ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ErrorSpan, ExportProvided, ExportsInfoGetter, ExportsType, ExtendedReferencedExport,
-  FactorizeInfo, ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage,
-  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
-  PrefetchExportsInfoMode, ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap,
-  TemplateContext, TemplateReplaceSource, TypeReexportPresenceMode,
+  ErrorSpan, ExportProvided, ExportsType, ExtendedReferencedExport, FactorizeInfo,
+  ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleDependency,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, PrefetchExportsInfoMode,
+  ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap, TemplateContext,
+  TemplateReplaceSource, TypeReexportPresenceMode,
 };
 use rspack_error::{
   miette::{MietteDiagnostic, Severity},
@@ -302,7 +302,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
     );
     if (!matches!(exports_type, ExportsType::DefaultWithNamed) || ids[0] != "default")
       && matches!(
-        ExportsInfoGetter::is_export_provided(&exports_info, ids),
+        exports_info.is_export_provided(ids),
         Some(ExportProvided::NotProvided)
       )
     {
@@ -326,13 +326,9 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
         .is_some()
         && ids.len() == 1
         && matches!(
-          ExportsInfoGetter::is_export_provided(
-            &module_graph.get_prefetched_exports_info(
-              parent_module_identifier,
-              PrefetchExportsInfoMode::Default
-            ),
-            std::slice::from_ref(name)
-          ),
+          module_graph
+            .get_prefetched_exports_info(parent_module_identifier, PrefetchExportsInfoMode::Default)
+            .is_export_provided(std::slice::from_ref(name)),
           Some(ExportProvided::Provided)
         )
       {
@@ -363,7 +359,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
         pos += 1;
         let export_info = exports_info.get_read_only_export_info(id);
         if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
-          let provided_exports = ExportsInfoGetter::get_provided_exports(exports_info);
+          let provided_exports = exports_info.get_provided_exports();
           let more_info = if let ProvidedExports::ProvidedNames(exports) = &provided_exports {
             if exports.is_empty() {
               " (module has no exports)".to_string()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -369,7 +369,7 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
         } else {
           let exports_info = module_graph.get_prefetched_exports_info(
             con.module_identifier(),
-            PrefetchExportsInfoMode::NamedNestedExports(ids),
+            PrefetchExportsInfoMode::Nested(ids),
           );
           ExportsInfoGetter::get_used_name(
             GetUsedNameParam::WithNames(&exports_info),
@@ -474,7 +474,7 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
         let Some(new_name) = ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithNames(&module_graph.get_prefetched_exports_info(
             &module.identifier(),
-            PrefetchExportsInfoMode::NamedNestedExports(&concated_ids),
+            PrefetchExportsInfoMode::Nested(&concated_ids),
           )),
           code_generatable_context.runtime,
           &concated_ids,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -191,7 +191,7 @@ impl DependencyTemplate for ProvideDependencyTemplate {
     } else {
       let exports_info = module_graph.get_prefetched_exports_info(
         con.module_identifier(),
-        PrefetchExportsInfoMode::NamedNestedExports(&dep.ids),
+        PrefetchExportsInfoMode::Nested(&dep.ids),
       );
       ExportsInfoGetter::get_used_name(
         GetUsedNameParam::WithNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -4,9 +4,8 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportProvided,
-  ExportsInfoGetter, Inlinable, PrefetchExportsInfoMode, TemplateContext, TemplateReplaceSource,
-  UsageState, UsedExports,
+  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportProvided, Inlinable,
+  PrefetchExportsInfoMode, TemplateContext, TemplateReplaceSource, UsageState, UsedExports,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -102,11 +101,11 @@ impl ExportInfoDependency {
         })
       }
       "used" => {
-        let used = ExportsInfoGetter::get_used(&exports_info, export_name, *runtime);
+        let used = exports_info.get_used(export_name, *runtime);
         Some((!matches!(used, UsageState::Unused)).to_string())
       }
       "useInfo" => {
-        let used_state = ExportsInfoGetter::get_used(&exports_info, export_name, *runtime);
+        let used_state = exports_info.get_used(export_name, *runtime);
         Some(
           (match used_state {
             UsageState::Used => "true",
@@ -118,16 +117,16 @@ impl ExportInfoDependency {
           .to_owned(),
         )
       }
-      "provideInfo" => {
-        ExportsInfoGetter::is_export_provided(&exports_info, export_name).map(|provided| {
+      "provideInfo" => exports_info
+        .is_export_provided(export_name)
+        .map(|provided| {
           (match provided {
             ExportProvided::Provided => "true",
             ExportProvided::NotProvided => "false",
             ExportProvided::Unknown => "null",
           })
           .to_owned()
-        })
-      }
+        }),
       _ => None,
     }
   }

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -4,9 +4,9 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportInfoGetter,
-  ExportProvided, ExportsInfoGetter, Inlinable, PrefetchExportsInfoMode, TemplateContext,
-  TemplateReplaceSource, UsageState, UsedExports,
+  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportProvided,
+  ExportsInfoGetter, Inlinable, PrefetchExportsInfoMode, TemplateContext, TemplateReplaceSource,
+  UsageState, UsedExports,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -82,9 +82,9 @@ impl ExportInfoDependency {
         let can_mangle = if let Some(export_info) =
           exports_info.get_read_only_export_info_recursive(export_name)
         {
-          ExportInfoGetter::can_mangle(export_info)
+          export_info.can_mangle()
         } else {
-          ExportInfoGetter::can_mangle(exports_info.other_exports_info())
+          exports_info.other_exports_info().can_mangle()
         };
         can_mangle.map(|v| v.to_string())
       }

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -54,7 +54,7 @@ impl ExportInfoDependency {
 
     if export_name.is_empty() && prop == "usedExports" {
       let exports_info = module_graph
-        .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::AllExports);
+        .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
       let used_exports = exports_info.get_used_exports(*runtime);
       return Some(match used_exports {
         UsedExports::Unknown => "null".to_owned(),
@@ -74,7 +74,7 @@ impl ExportInfoDependency {
 
     let exports_info = module_graph.get_prefetched_exports_info(
       &module_identifier,
-      PrefetchExportsInfoMode::NamedNestedExports(export_name),
+      PrefetchExportsInfoMode::Nested(export_name),
     );
 
     match prop.to_string().as_str() {

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -8,7 +8,6 @@ use rspack_core::{
   RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedByExports,
 };
 use rspack_util::ext::DynHash;
-use rustc_hash::FxHashSet;
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -41,11 +40,8 @@ impl PureExpressionDependency {
       Some(UsedByExports::Bool(false)) => RuntimeCondition::Boolean(false),
       Some(UsedByExports::Set(ref set)) => {
         let module_graph = compilation.get_module_graph();
-        let names = set.iter().collect::<FxHashSet<_>>();
-        let exports_info = module_graph.get_prefetched_exports_info(
-          &self.module_identifier,
-          PrefetchExportsInfoMode::NamedExports(names),
-        );
+        let exports_info = module_graph
+          .get_prefetched_exports_info(&self.module_identifier, PrefetchExportsInfoMode::Default);
         filter_runtime(runtime, |cur_runtime| {
           set.iter().any(|id| {
             ExportsInfoGetter::get_used(&exports_info, std::slice::from_ref(id), cur_runtime)

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -3,7 +3,7 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   filter_runtime, runtime_condition_expression, AsContextDependency, AsModuleDependency,
   Compilation, ConnectionState, Dependency, DependencyCodeGeneration, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyTemplateType, ExportsInfoGetter, ModuleGraph,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, ModuleGraph,
   ModuleGraphCacheArtifact, ModuleIdentifier, PrefetchExportsInfoMode, RuntimeCondition,
   RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState, UsedByExports,
 };
@@ -44,8 +44,7 @@ impl PureExpressionDependency {
           .get_prefetched_exports_info(&self.module_identifier, PrefetchExportsInfoMode::Default);
         filter_runtime(runtime, |cur_runtime| {
           set.iter().any(|id| {
-            ExportsInfoGetter::get_used(&exports_info, std::slice::from_ref(id), cur_runtime)
-              != UsageState::Unused
+            exports_info.get_used(std::slice::from_ref(id), cur_runtime) != UsageState::Unused
           })
         })
       }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -154,8 +154,7 @@ impl DependencyConditionFn for InlineValueDependencyCondition {
     if ids.is_empty() {
       return bailout;
     }
-    let exports_info =
-      mg.get_prefetched_exports_info(module, PrefetchExportsInfoMode::NamedNestedExports(ids));
+    let exports_info = mg.get_prefetched_exports_info(module, PrefetchExportsInfoMode::Nested(ids));
     if matches!(
       ExportsInfoGetter::get_used_name(GetUsedNameParam::WithNames(&exports_info), runtime, ids),
       Some(UsedName::Inlined(_))

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use rspack_core::{
-  ConnectionState, DependencyCondition, DependencyConditionFn, DependencyId, ExportInfoGetter,
-  ExportsInfo, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, RuntimeSpec,
-  UsageState, UsedByExports,
+  ConnectionState, DependencyCondition, DependencyConditionFn, DependencyId, ExportsInfo,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, RuntimeSpec, UsageState,
+  UsedByExports,
 };
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet;
@@ -51,12 +51,12 @@ fn is_connection_active(
   ) -> bool {
     let exports_info = exports_info.as_data(mg);
     if let Some(export_info) = exports_info.named_exports(name) {
-      return ExportInfoGetter::get_used(export_info, runtime) != UsageState::Unused;
+      return export_info.get_used(runtime) != UsageState::Unused;
     }
     if let Some(redirect_to) = exports_info.redirect_to() {
       is_export_active(name, &redirect_to, mg, runtime)
     } else {
-      ExportInfoGetter::get_used(exports_info.other_exports_info(), runtime) != UsageState::Unused
+      exports_info.other_exports_info().get_used(runtime) != UsageState::Unused
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -51,14 +51,12 @@ fn is_connection_active(
   ) -> bool {
     let exports_info = exports_info.as_data(mg);
     if let Some(export_info) = exports_info.named_exports(name) {
-      let export_info = export_info.as_data(mg);
       return ExportInfoGetter::get_used(export_info, runtime) != UsageState::Unused;
     }
     if let Some(redirect_to) = exports_info.redirect_to() {
       is_export_active(name, &redirect_to, mg, runtime)
     } else {
-      ExportInfoGetter::get_used(exports_info.other_exports_info().as_data(mg), runtime)
-        != UsageState::Unused
+      ExportInfoGetter::get_used(exports_info.other_exports_info(), runtime) != UsageState::Unused
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -78,10 +78,7 @@ impl<'a> FlagDependencyExportsState<'a> {
         == BuildMetaExportsType::Unset
       {
         let other_exports_info = exports_info.as_data(self.mg).other_exports_info();
-        if !matches!(
-          other_exports_info.as_data(self.mg).provided(),
-          Some(ExportProvided::Unknown)
-        ) {
+        if !matches!(other_exports_info.provided(), Some(ExportProvided::Unknown)) {
           exports_info.set_has_provide_info(self.mg);
           exports_info.set_unknown_exports_provided(self.mg, false, None, None, None, None);
           continue;

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -268,7 +268,6 @@ impl<'a> FlagDependencyExportsState<'a> {
       }
 
       if let Some(exports) = exports {
-        let export_info_data = export_info.as_data_mut(self.mg);
         let nested_exports_info = if export_info_data.exports_info_owned() {
           export_info_data
             .exports_info()

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -275,9 +275,9 @@ impl<'a> FlagDependencyExportsState<'a> {
             .expect("should have exports_info when exports_info is true")
         } else {
           let old_exports_info = export_info_data.exports_info();
-          let new_exports_info = ExportsInfoData::new();
+          let new_exports_info = ExportsInfoData::default();
           let new_exports_info_id = new_exports_info.id();
-          export_info_data.set_exports_info(Some(new_exports_info_id.clone()));
+          export_info_data.set_exports_info(Some(new_exports_info_id));
           export_info_data.set_exports_info_owned(true);
           self
             .mg
@@ -334,7 +334,7 @@ impl<'a> FlagDependencyExportsState<'a> {
         let target_module_exports_info = self.mg.get_prefetched_exports_info(
           &target.module,
           if let Some(names) = &target.export {
-            PrefetchExportsInfoMode::NamedNestedExports(names)
+            PrefetchExportsInfoMode::Nested(names)
           } else {
             PrefetchExportsInfoMode::Default
           },

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -155,7 +155,8 @@ impl<'a> FlagDependencyExportsState<'a> {
       }
       ExportsOfExportsSpec::NoExports => {}
       ExportsOfExportsSpec::Names(ele) => {
-        let (merge_changed, merge_dependencies) = self.merge_exports(
+        let (merge_changed, merge_dependencies) = merge_exports(
+          self.mg,
           module_id,
           exports_info,
           ele,
@@ -178,185 +179,6 @@ impl<'a> FlagDependencyExportsState<'a> {
       }
     }
 
-    (changed, dependencies)
-  }
-
-  pub fn merge_exports(
-    &mut self,
-    module_id: &ModuleIdentifier,
-    exports_info: ExportsInfo,
-    exports: &Vec<ExportNameOrSpec>,
-    global_export_info: DefaultExportInfo,
-    dep_id: DependencyId,
-  ) -> (bool, Vec<(ModuleIdentifier, ModuleIdentifier)>) {
-    let mut changed = false;
-    let mut dependencies = vec![];
-    for export_name_or_spec in exports {
-      let (
-        name,
-        can_mangle,
-        terminal_binding,
-        exports,
-        from,
-        from_export,
-        priority,
-        hidden,
-        inlinable,
-      ) = match export_name_or_spec {
-        ExportNameOrSpec::String(name) => (
-          name.clone(),
-          global_export_info.can_mangle,
-          global_export_info.terminal_binding,
-          None::<&Vec<ExportNameOrSpec>>,
-          global_export_info.from.cloned(),
-          None::<&rspack_core::Nullable<Vec<Atom>>>,
-          global_export_info.priority,
-          false,
-          None,
-        ),
-        ExportNameOrSpec::ExportSpec(spec) => (
-          spec.name.clone(),
-          match spec.can_mangle {
-            Some(v) => Some(v),
-            None => global_export_info.can_mangle,
-          },
-          spec
-            .terminal_binding
-            .unwrap_or(global_export_info.terminal_binding),
-          spec.exports.as_ref(),
-          if spec.from.is_some() {
-            spec.from.clone()
-          } else {
-            global_export_info.from.cloned()
-          },
-          spec.export.as_ref(),
-          match spec.priority {
-            Some(v) => Some(v),
-            None => global_export_info.priority,
-          },
-          spec.hidden.unwrap_or(false),
-          spec.inlinable.as_ref(),
-        ),
-      };
-      let export_info = exports_info.get_export_info(self.mg, &name);
-      let export_info_data = export_info.as_data_mut(self.mg);
-      if let Some(provided) = export_info_data.provided()
-        && matches!(
-          provided,
-          ExportProvided::NotProvided | ExportProvided::Unknown
-        )
-      {
-        export_info_data.set_provided(Some(ExportProvided::Provided));
-        changed = true;
-      }
-
-      if Some(false) != export_info_data.can_mangle_provide() && can_mangle == Some(false) {
-        export_info_data.set_can_mangle_provide(Some(false));
-        changed = true;
-      }
-
-      if let Some(inlined) = inlinable
-        && !export_info_data.inlinable().can_inline()
-      {
-        export_info_data.set_inlinable(Inlinable::Inlined(inlined.clone()));
-        changed = true;
-      }
-
-      if terminal_binding && !export_info_data.terminal_binding() {
-        export_info_data.set_terminal_binding(true);
-        changed = true;
-      }
-
-      if let Some(exports) = exports {
-        let nested_exports_info = if export_info_data.exports_info_owned() {
-          export_info_data
-            .exports_info()
-            .expect("should have exports_info when exports_info is true")
-        } else {
-          let old_exports_info = export_info_data.exports_info();
-          let new_exports_info = ExportsInfoData::default();
-          let new_exports_info_id = new_exports_info.id();
-          export_info_data.set_exports_info(Some(new_exports_info_id));
-          export_info_data.set_exports_info_owned(true);
-          self
-            .mg
-            .set_exports_info(new_exports_info_id, new_exports_info);
-
-          new_exports_info_id.set_has_provide_info(self.mg);
-          if let Some(exports_info) = old_exports_info {
-            exports_info
-              .as_data_mut(self.mg)
-              .set_redirect_name_to(Some(new_exports_info_id));
-          }
-          new_exports_info_id
-        };
-
-        let (merge_changed, merge_dependencies) = self.merge_exports(
-          module_id,
-          nested_exports_info,
-          exports,
-          global_export_info.clone(),
-          dep_id,
-        );
-        changed |= merge_changed;
-        dependencies.extend(merge_dependencies);
-      }
-
-      // shadowing the previous `export_info_mut` to reduce the mut borrow life time,
-      // because `create_nested_exports_info` needs `&mut ModuleGraph`
-      let export_info_data = export_info.as_data_mut(self.mg);
-      if let Some(from) = from {
-        changed |= if hidden {
-          export_info_data.unset_target(&dep_id)
-        } else {
-          let fallback = rspack_core::Nullable::Value(vec![name.clone()]);
-          let export_name = if let Some(from) = from_export {
-            Some(from)
-          } else {
-            Some(&fallback)
-          };
-          export_info_data.set_target(
-            Some(dep_id),
-            Some(from.dependency_id),
-            export_name,
-            priority,
-          )
-        }
-      }
-
-      // Recalculate target exportsInfo
-      let export_info_data = export_info.as_data(self.mg);
-      let target = get_target(export_info_data, self.mg);
-
-      let mut target_exports_info = None;
-      if let Some(target) = target {
-        let target_module_exports_info = self.mg.get_prefetched_exports_info(
-          &target.module,
-          if let Some(names) = &target.export {
-            PrefetchExportsInfoMode::Nested(names)
-          } else {
-            PrefetchExportsInfoMode::Default
-          },
-        );
-        target_exports_info = target_module_exports_info
-          .get_nested_exports_info(target.export.as_deref())
-          .map(|data| data.id());
-
-        dependencies.push((target.module, *module_id));
-      }
-
-      let export_info_data = export_info.as_data_mut(self.mg);
-      if export_info_data.exports_info_owned() {
-        changed |= export_info_data
-          .exports_info()
-          .expect("should have exports_info when exports_info_owned is true")
-          .as_data_mut(self.mg)
-          .set_redirect_name_to(target_exports_info);
-      } else if export_info_data.exports_info() != target_exports_info {
-        export_info_data.set_exports_info(target_exports_info);
-        changed = true;
-      }
-    }
     (changed, dependencies)
   }
 }
@@ -457,4 +279,182 @@ fn collect_module_exports_specs(
     .collect::<FxIndexMap<DependencyId, ExportsSpec>>();
   // mg_cache.unfreeze();
   Some(res)
+}
+
+pub fn merge_exports(
+  mg: &mut ModuleGraph,
+  module_id: &ModuleIdentifier,
+  exports_info: ExportsInfo,
+  exports: &Vec<ExportNameOrSpec>,
+  global_export_info: DefaultExportInfo,
+  dep_id: DependencyId,
+) -> (bool, Vec<(ModuleIdentifier, ModuleIdentifier)>) {
+  let mut changed = false;
+  let mut dependencies = vec![];
+  for export_name_or_spec in exports {
+    let (
+      name,
+      can_mangle,
+      terminal_binding,
+      exports,
+      from,
+      from_export,
+      priority,
+      hidden,
+      inlinable,
+    ) = match export_name_or_spec {
+      ExportNameOrSpec::String(name) => (
+        name.clone(),
+        global_export_info.can_mangle,
+        global_export_info.terminal_binding,
+        None::<&Vec<ExportNameOrSpec>>,
+        global_export_info.from.cloned(),
+        None::<&rspack_core::Nullable<Vec<Atom>>>,
+        global_export_info.priority,
+        false,
+        None,
+      ),
+      ExportNameOrSpec::ExportSpec(spec) => (
+        spec.name.clone(),
+        match spec.can_mangle {
+          Some(v) => Some(v),
+          None => global_export_info.can_mangle,
+        },
+        spec
+          .terminal_binding
+          .unwrap_or(global_export_info.terminal_binding),
+        spec.exports.as_ref(),
+        if spec.from.is_some() {
+          spec.from.clone()
+        } else {
+          global_export_info.from.cloned()
+        },
+        spec.export.as_ref(),
+        match spec.priority {
+          Some(v) => Some(v),
+          None => global_export_info.priority,
+        },
+        spec.hidden.unwrap_or(false),
+        spec.inlinable.as_ref(),
+      ),
+    };
+    let export_info = exports_info.get_export_info(mg, &name);
+    let export_info_data = export_info.as_data_mut(mg);
+    if let Some(provided) = export_info_data.provided()
+      && matches!(
+        provided,
+        ExportProvided::NotProvided | ExportProvided::Unknown
+      )
+    {
+      export_info_data.set_provided(Some(ExportProvided::Provided));
+      changed = true;
+    }
+
+    if Some(false) != export_info_data.can_mangle_provide() && can_mangle == Some(false) {
+      export_info_data.set_can_mangle_provide(Some(false));
+      changed = true;
+    }
+
+    if let Some(inlined) = inlinable
+      && !export_info_data.inlinable().can_inline()
+    {
+      export_info_data.set_inlinable(Inlinable::Inlined(inlined.clone()));
+      changed = true;
+    }
+
+    if terminal_binding && !export_info_data.terminal_binding() {
+      export_info_data.set_terminal_binding(true);
+      changed = true;
+    }
+
+    if let Some(exports) = exports {
+      let nested_exports_info = if export_info_data.exports_info_owned() {
+        export_info_data
+          .exports_info()
+          .expect("should have exports_info when exports_info is true")
+      } else {
+        let old_exports_info = export_info_data.exports_info();
+        let new_exports_info = ExportsInfoData::default();
+        let new_exports_info_id = new_exports_info.id();
+        export_info_data.set_exports_info(Some(new_exports_info_id));
+        export_info_data.set_exports_info_owned(true);
+        mg.set_exports_info(new_exports_info_id, new_exports_info);
+
+        new_exports_info_id.set_has_provide_info(mg);
+        if let Some(exports_info) = old_exports_info {
+          exports_info
+            .as_data_mut(mg)
+            .set_redirect_name_to(Some(new_exports_info_id));
+        }
+        new_exports_info_id
+      };
+
+      let (merge_changed, merge_dependencies) = merge_exports(
+        mg,
+        module_id,
+        nested_exports_info,
+        exports,
+        global_export_info.clone(),
+        dep_id,
+      );
+      changed |= merge_changed;
+      dependencies.extend(merge_dependencies);
+    }
+
+    // shadowing the previous `export_info_mut` to reduce the mut borrow life time,
+    // because `create_nested_exports_info` needs `&mut ModuleGraph`
+    let export_info_data = export_info.as_data_mut(mg);
+    if let Some(from) = from {
+      changed |= if hidden {
+        export_info_data.unset_target(&dep_id)
+      } else {
+        let fallback = rspack_core::Nullable::Value(vec![name.clone()]);
+        let export_name = if let Some(from) = from_export {
+          Some(from)
+        } else {
+          Some(&fallback)
+        };
+        export_info_data.set_target(
+          Some(dep_id),
+          Some(from.dependency_id),
+          export_name,
+          priority,
+        )
+      }
+    }
+
+    // Recalculate target exportsInfo
+    let export_info_data = export_info.as_data(mg);
+    let target = get_target(export_info_data, mg);
+
+    let mut target_exports_info = None;
+    if let Some(target) = target {
+      let target_module_exports_info = mg.get_prefetched_exports_info(
+        &target.module,
+        if let Some(names) = &target.export {
+          PrefetchExportsInfoMode::Nested(names)
+        } else {
+          PrefetchExportsInfoMode::Default
+        },
+      );
+      target_exports_info = target_module_exports_info
+        .get_nested_exports_info(target.export.as_deref())
+        .map(|data| data.id());
+
+      dependencies.push((target.module, *module_id));
+    }
+
+    let export_info_data = export_info.as_data_mut(mg);
+    if export_info_data.exports_info_owned() {
+      changed |= export_info_data
+        .exports_info()
+        .expect("should have exports_info when exports_info_owned is true")
+        .as_data_mut(mg)
+        .set_redirect_name_to(target_exports_info);
+    } else if export_info_data.exports_info() != target_exports_info {
+      export_info_data.set_exports_info(target_exports_info);
+      changed = true;
+    }
+  }
+  (changed, dependencies)
 }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -422,8 +422,9 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       {
         return;
       }
-      let changed_flag =
-        mgm_exports_info.set_used_for_side_effects_only(&mut module_graph, runtime.as_ref());
+      let changed_flag = mgm_exports_info
+        .as_data_mut(&mut module_graph)
+        .set_used_for_side_effects_only(runtime.as_ref());
       if changed_flag {
         batch.push((module_id, runtime));
       }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -5,9 +5,9 @@ use rspack_collections::{Identifier, IdentifierMap, UkeyMap};
 use rspack_core::{
   get_entry_runtime, incremental::IncrementalPasses, is_exports_object_referenced,
   is_no_exports_referenced, AsyncDependenciesBlockIdentifier, BuildMetaExportsType, Compilation,
-  CompilationOptimizeDependencies, ConnectionState, DependenciesBlock, DependencyId,
-  ExportInfoSetter, ExportsInfo, ExtendedReferencedExport, GroupOptions, Inlinable,
-  ModuleIdentifier, Plugin, ReferencedExport, RuntimeSpec, UsageState,
+  CompilationOptimizeDependencies, ConnectionState, DependenciesBlock, DependencyId, ExportsInfo,
+  ExtendedReferencedExport, GroupOptions, Inlinable, ModuleIdentifier, Plugin, ReferencedExport,
+  RuntimeSpec, UsageState,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -368,8 +368,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
             if !last_one {
               let nested_info = export_info.exports_info();
               if let Some(nested_info) = nested_info {
-                let changed_flag = ExportInfoSetter::set_used_conditionally(
-                  export_info,
+                let changed_flag = export_info.set_used_conditionally(
                   Box::new(|used| used == &UsageState::Unused),
                   UsageState::OnlyPropertiesUsed,
                   runtime.as_ref(),
@@ -392,8 +391,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
               }
             }
 
-            let changed_flag = ExportInfoSetter::set_used_conditionally(
-              export_info,
+            let changed_flag = export_info.set_used_conditionally(
               Box::new(|v| v != &UsageState::Used),
               UsageState::Used,
               runtime.as_ref(),

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -269,7 +269,7 @@ fn mangle_exports_info(
       mangleable_exports,
       |e| {
         mangleable_export_names
-          .get(&e)
+          .get(e)
           .expect("should have name")
           .to_string()
       },

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -246,8 +246,8 @@ fn mangle_exports_info(
         used_names.insert(name.to_string());
       }
       Manglable::CanMangle(name) => {
-        mangleable_export_names.insert(export_info.id, name.clone());
-        mangleable_exports.push(export_info.id);
+        mangleable_export_names.insert(export_info.id.clone(), name.clone());
+        mangleable_exports.push(export_info.id.clone());
       }
       Manglable::Mangled => {}
     }
@@ -286,7 +286,7 @@ fn mangle_exports_info(
         if size == used_names.len() {
           false
         } else {
-          export_info_used_name.insert(e, name);
+          export_info_used_name.insert(e.clone(), name);
           true
         }
       },

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -105,7 +105,7 @@ async fn optimize_code_generation(&self, compilation: &mut Compilation) -> Resul
         let mut avoid_mangle_non_provided = !is_namespace;
         let deterministic = self.deterministic;
         let exports_info_data =
-          ExportsInfoGetter::prefetch(exports_info, &mg, PrefetchExportsInfoMode::AllExports);
+          ExportsInfoGetter::prefetch(exports_info, &mg, PrefetchExportsInfoMode::Default);
         let export_list = {
           if !can_mangle(&exports_info_data) {
             return None;

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -13,9 +13,9 @@ use rspack_core::{
   },
   filter_runtime, get_cached_readable_identifier, get_target,
   incremental::IncrementalPasses,
-  ApplyContext, Compilation, CompilationOptimizeChunkModules, CompilerOptions, ExportInfoGetter,
-  ExportProvided, ExportsInfoGetter, ExtendedReferencedExport, LibIdentOptions, Logger, Module,
-  ModuleExt, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleGraphModule,
+  ApplyContext, Compilation, CompilationOptimizeChunkModules, CompilerOptions, ExportProvided,
+  ExportsInfoGetter, ExtendedReferencedExport, LibIdentOptions, Logger, Module, ModuleExt,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleGraphModule,
   ModuleIdentifier, Plugin, PluginContext, PrefetchExportsInfoMode, ProvidedExports,
   RuntimeCondition, RuntimeSpec, SourceType,
 };
@@ -857,8 +857,7 @@ impl ModuleConcatenationPlugin {
         let unknown_exports = relevant_exports
           .iter()
           .filter(|export_info| {
-            ExportInfoGetter::is_reexport(export_info)
-              && get_target(export_info, &module_graph).is_none()
+            export_info.is_reexport() && get_target(export_info, &module_graph).is_none()
           })
           .copied()
           .collect::<Vec<_>>();
@@ -870,11 +869,7 @@ impl ModuleConcatenationPlugin {
                 .name()
                 .map(|name| name.to_string())
                 .unwrap_or("other exports".to_string());
-              format!(
-                "{} : {}",
-                name,
-                ExportInfoGetter::get_used_info(export_info)
-              )
+              format!("{} : {}", name, export_info.get_used_info())
             })
             .collect::<Vec<String>>()
             .join(", ");
@@ -908,8 +903,8 @@ impl ModuleConcatenationPlugin {
               format!(
                 "{} : {} and {}",
                 name,
-                ExportInfoGetter::get_provided_info(export_info),
-                ExportInfoGetter::get_used_info(export_info),
+                export_info.get_provided_info(),
+                export_info.get_used_info(),
               )
             })
             .collect::<Vec<String>>()

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1066,9 +1066,7 @@ impl ModuleConcatenationPlugin {
         &module_graph,
         PrefetchExportsInfoMode::Default,
       );
-      let filtered_runtime = filter_runtime(Some(runtime), |r| {
-        ExportsInfoGetter::is_module_used(&exports_info_data, r)
-      });
+      let filtered_runtime = filter_runtime(Some(runtime), |r| exports_info_data.is_module_used(r));
       let active_runtime = match filtered_runtime {
         RuntimeCondition::Boolean(true) => Some(runtime.clone()),
         RuntimeCondition::Boolean(false) => None,

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -852,7 +852,7 @@ impl ModuleConcatenationPlugin {
         }
 
         let exports_info =
-          module_graph.get_prefetched_exports_info(&module_id, PrefetchExportsInfoMode::AllExports);
+          module_graph.get_prefetched_exports_info(&module_id, PrefetchExportsInfoMode::Default);
         let relevant_exports = exports_info.get_relevant_exports(None);
         let unknown_exports = relevant_exports
           .iter()
@@ -991,7 +991,7 @@ impl ModuleConcatenationPlugin {
         let exports_info_data = ExportsInfoGetter::prefetch(
           &exports_info,
           &module_graph,
-          PrefetchExportsInfoMode::AllExports,
+          PrefetchExportsInfoMode::Default,
         );
         let provided_names = matches!(
           exports_info_data.get_provided_exports(),
@@ -1064,7 +1064,7 @@ impl ModuleConcatenationPlugin {
       let exports_info_data = ExportsInfoGetter::prefetch(
         &exports_info,
         &module_graph,
-        PrefetchExportsInfoMode::AllExports,
+        PrefetchExportsInfoMode::Default,
       );
       let filtered_runtime = filter_runtime(Some(runtime), |r| {
         ExportsInfoGetter::is_module_used(&exports_info_data, r)

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -5,11 +5,11 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   incremental::{self, IncrementalPasses, Mutation},
   BoxModule, Compilation, CompilationOptimizeDependencies, ConnectionState, DependencyExtraMeta,
-  DependencyId, ExportInfoSetter, FactoryMeta, Logger, MaybeDynamicTargetExportInfo,
-  ModuleFactoryCreateData, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
-  NormalModuleCreateData, NormalModuleFactoryModule, Plugin, PrefetchExportsInfoMode,
-  ResolvedExportInfoTarget, SideEffectsBailoutItemWithSpan, SideEffectsDoOptimize,
-  SideEffectsDoOptimizeMoveTarget, SideEffectsOptimizeArtifact,
+  DependencyId, FactoryMeta, Logger, MaybeDynamicTargetExportInfo, ModuleFactoryCreateData,
+  ModuleGraph, ModuleGraphConnection, ModuleIdentifier, NormalModuleCreateData,
+  NormalModuleFactoryModule, Plugin, PrefetchExportsInfoMode, ResolvedExportInfoTarget,
+  SideEffectsBailoutItemWithSpan, SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget,
+  SideEffectsOptimizeArtifact,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -838,11 +838,9 @@ fn do_optimize_connection(
     target_export,
   }) = need_move_target
   {
-    ExportInfoSetter::do_move_target(
-      export_info.as_data_mut(module_graph),
-      dependency,
-      target_export,
-    );
+    export_info
+      .as_data_mut(module_graph)
+      .do_move_target(dependency, target_export);
   }
   (dependency, target_module)
 }

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -14,7 +14,6 @@ use rspack_core::{
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{AssertUtf8, Utf8Path};
-use rustc_hash::FxHashSet;
 use sugar_path::SugarPath;
 use swc_core::{
   common::{comments, comments::Comments, Span, Spanned, SyntaxContext, GLOBALS},
@@ -858,10 +857,8 @@ fn can_optimize_connection(
   if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>()
     && let Some(name) = &dep.name
   {
-    let exports_info = module_graph.get_prefetched_exports_info(
-      &original_module,
-      PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([name])),
-    );
+    let exports_info =
+      module_graph.get_prefetched_exports_info(&original_module, PrefetchExportsInfoMode::Default);
     let export_info = exports_info.get_export_info_without_mut_module_graph(name);
 
     let target = export_info.can_move_target(
@@ -906,7 +903,7 @@ fn can_optimize_connection(
   {
     let exports_info = module_graph.get_prefetched_exports_info(
       connection.module_identifier(),
-      PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&ids[0]])),
+      PrefetchExportsInfoMode::Default,
     );
     let export_info = exports_info.get_export_info_without_mut_module_graph(&ids[0]);
 

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -182,7 +182,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           .as_ref()
           .expect("should have json data");
         let exports_info = module_graph
-          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::AllExports);
+          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
 
         let final_json = match json_data {
           json::JsonValue::Object(_) | json::JsonValue::Array(_)
@@ -304,7 +304,7 @@ fn create_object_for_exports_info(
           // avoid clone
           let temp = std::mem::replace(value, JsonValue::Null);
           let exports_info =
-            ExportsInfoGetter::prefetch(&exports_info, mg, PrefetchExportsInfoMode::AllExports);
+            ExportsInfoGetter::prefetch(&exports_info, mg, PrefetchExportsInfoMode::Default);
           create_object_for_exports_info(temp, &exports_info, runtime, mg)
         } else {
           std::mem::replace(value, JsonValue::Null)
@@ -340,7 +340,7 @@ fn create_object_for_exports_info(
             && let Some(exports_info) = export_info.exports_info()
           {
             let exports_info =
-              ExportsInfoGetter::prefetch(&exports_info, mg, PrefetchExportsInfoMode::AllExports);
+              ExportsInfoGetter::prefetch(&exports_info, mg, PrefetchExportsInfoMode::Default);
             Some(create_object_for_exports_info(
               item,
               &exports_info,

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -15,8 +15,8 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   diagnostics::ModuleParseError,
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
-  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, CompilerOptions, ExportInfoGetter,
-  ExportsInfoGetter, GenerateContext, Module, ModuleGraph, ParseOption, ParserAndGenerator, Plugin,
+  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, CompilerOptions, ExportsInfoGetter,
+  GenerateContext, Module, ModuleGraph, ParseOption, ParserAndGenerator, Plugin,
   PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper, RuntimeGlobals, RuntimeSpec, SourceType,
   UsageState, UsedNameItem, NAMESPACE_OBJECT_EXPORT,
 };
@@ -187,7 +187,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
         let final_json = match json_data {
           json::JsonValue::Object(_) | json::JsonValue::Array(_)
             if matches!(
-              ExportInfoGetter::get_used(exports_info.other_exports_info(), *runtime),
+              exports_info.other_exports_info().get_used(*runtime),
               UsageState::Unused
             ) =>
           {
@@ -280,7 +280,7 @@ fn create_object_for_exports_info(
   runtime: Option<&RuntimeSpec>,
   mg: &ModuleGraph,
 ) -> JsonValue {
-  if ExportInfoGetter::get_used(exports_info.other_exports_info(), runtime) != UsageState::Unused {
+  if exports_info.other_exports_info().get_used(runtime) != UsageState::Unused {
     return data;
   }
 
@@ -294,7 +294,7 @@ fn create_object_for_exports_info(
       let mut used_pair = vec![];
       for (key, value) in obj.iter_mut() {
         let export_info = exports_info.get_read_only_export_info(&key.into());
-        let used = ExportInfoGetter::get_used(export_info, runtime);
+        let used = export_info.get_used(runtime);
         if used == UsageState::Unused {
           continue;
         }
@@ -309,9 +309,9 @@ fn create_object_for_exports_info(
         } else {
           std::mem::replace(value, JsonValue::Null)
         };
-        let UsedNameItem::Str(used_name) =
-          ExportInfoGetter::get_used_name(export_info, Some(&(key.into())), runtime)
-            .expect("should have used name")
+        let UsedNameItem::Str(used_name) = export_info
+          .get_used_name(Some(&(key.into())), runtime)
+          .expect("should have used name")
         else {
           continue;
         };
@@ -331,7 +331,7 @@ fn create_object_for_exports_info(
         .enumerate()
         .map(|(i, item)| {
           let export_info = exports_info.get_read_only_export_info(&itoa!(i).into());
-          let used = ExportInfoGetter::get_used(export_info, runtime);
+          let used = export_info.get_used(runtime);
           if used == UsageState::Unused {
             return None;
           }
@@ -352,10 +352,9 @@ fn create_object_for_exports_info(
           }
         })
         .collect::<Vec<_>>();
-      let arr_length_used = ExportInfoGetter::get_used(
-        exports_info.get_read_only_export_info(&"length".into()),
-        runtime,
-      );
+      let arr_length_used = exports_info
+        .get_read_only_export_info(&"length".into())
+        .get_used(runtime);
       let array_length_when_used = match arr_length_used {
         UsageState::Unused => None,
         _ => Some(original_len),

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -469,7 +469,9 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
   for (runtime, export, module_identifier) in runtime_info {
     let mut module_graph = compilation.get_module_graph_mut();
     if let Some(export) = export {
-      let export_info = module_graph.get_export_info(module_identifier, &(export.as_str()).into());
+      let export_info = module_graph
+        .get_exports_info(&module_identifier)
+        .get_export_info(&mut module_graph, &(export.as_str()).into());
       let info = export_info.as_data_mut(&mut module_graph);
       ExportInfoSetter::set_used(info, UsageState::Used, Some(&runtime));
       info.set_can_mangle_use(Some(false));

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -8,10 +8,9 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier, ApplyContext, BoxModule, Chunk, ChunkUkey, CodeGenerationDataTopLevelDeclarations,
   Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules,
-  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportInfoSetter,
-  ExportProvided, Filename, LibraryExport, LibraryName, LibraryNonUmdObject, LibraryOptions,
-  ModuleIdentifier, PathData, Plugin, PluginContext, PrefetchExportsInfoMode, RuntimeGlobals,
-  SourceType, UsageState,
+  CompilationParams, CompilerCompilation, CompilerOptions, EntryData, ExportProvided, Filename,
+  LibraryExport, LibraryName, LibraryNonUmdObject, LibraryOptions, ModuleIdentifier, PathData,
+  Plugin, PluginContext, PrefetchExportsInfoMode, RuntimeGlobals, SourceType, UsageState,
 };
 use rspack_error::{error, error_bail, Result, ToStringResultToRspackResultExt};
 use rspack_hash::RspackHash;
@@ -473,7 +472,7 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
         .get_exports_info(&module_identifier)
         .get_export_info(&mut module_graph, &(export.as_str()).into());
       let info = export_info.as_data_mut(&mut module_graph);
-      ExportInfoSetter::set_used(info, UsageState::Used, Some(&runtime));
+      info.set_used(UsageState::Used, Some(&runtime));
       info.set_can_mangle_use(Some(false));
     } else {
       let exports_info = module_graph.get_exports_info(&module_identifier);

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -265,7 +265,7 @@ async fn render_startup(
     let export_target = access_with_init(&full_name_resolved, self.options.prefix.len(), true);
     let module_graph = compilation.get_module_graph();
     let exports_info =
-      module_graph.get_prefetched_exports_info(module, PrefetchExportsInfoMode::AllExports);
+      module_graph.get_prefetched_exports_info(module, PrefetchExportsInfoMode::Default);
     let mut provided = vec![];
     for (_, export_info) in exports_info.exports() {
       if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -5,8 +5,8 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   ApplyContext, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationFinishModules, CompilationParams, CompilerCompilation, CompilerOptions, EntryData,
-  ExportInfoSetter, LibraryExport, LibraryOptions, LibraryType, ModuleIdentifier, Plugin,
-  PluginContext, RuntimeGlobals, UsageState,
+  LibraryExport, LibraryOptions, LibraryType, ModuleIdentifier, Plugin, PluginContext,
+  RuntimeGlobals, UsageState,
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
@@ -155,7 +155,7 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
         .get_exports_info(&module_identifier)
         .get_export_info(&mut module_graph, &(export.as_str()).into());
       let info = export_info.as_data_mut(&mut module_graph);
-      ExportInfoSetter::set_used(info, UsageState::Used, Some(&runtime));
+      info.set_used(UsageState::Used, Some(&runtime));
       info.set_can_mangle_use(Some(false));
     } else {
       let exports_info = module_graph.get_exports_info(&module_identifier);

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -151,7 +151,9 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
   for (runtime, export, module_identifier) in runtime_info {
     let mut module_graph = compilation.get_module_graph_mut();
     if let Some(export) = export {
-      let export_info = module_graph.get_export_info(module_identifier, &(export.as_str()).into());
+      let export_info = module_graph
+        .get_exports_info(&module_identifier)
+        .get_export_info(&mut module_graph, &(export.as_str()).into());
       let info = export_info.as_data_mut(&mut module_graph);
       ExportInfoSetter::set_used(info, UsageState::Used, Some(&runtime));
       info.set_can_mangle_use(Some(false));

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -6,8 +6,8 @@ use rspack_core::{
   to_identifier, ApplyContext, BoxDependency, ChunkUkey, CodeGenerationExportsFinalNames,
   Compilation, CompilationOptimizeChunkModules, CompilationParams, CompilerCompilation,
   CompilerFinishMake, CompilerOptions, ConcatenatedModule, ConcatenatedModuleExportsDefinitions,
-  DependenciesBlock, Dependency, DependencyId, ExportInfoGetter, LibraryOptions, ModuleGraph,
-  ModuleIdentifier, Plugin, PluginContext, PrefetchExportsInfoMode, RuntimeSpec, UsedNameItem,
+  DependenciesBlock, Dependency, DependencyId, LibraryOptions, ModuleGraph, ModuleIdentifier,
+  Plugin, PluginContext, PrefetchExportsInfoMode, RuntimeSpec, UsedNameItem,
 };
 use rspack_error::{error_bail, Result};
 use rspack_hash::RspackHash;
@@ -176,9 +176,9 @@ async fn render_startup(
       module_graph.get_prefetched_exports_info(module_id, PrefetchExportsInfoMode::AllExports);
     for (_, export_info) in exports_info.exports() {
       let info_name = export_info.name().expect("should have name");
-      let used_name =
-        ExportInfoGetter::get_used_name(export_info, Some(info_name), Some(chunk.runtime()))
-          .expect("name can't be empty");
+      let used_name = export_info
+        .get_used_name(Some(info_name), Some(chunk.runtime()))
+        .expect("name can't be empty");
 
       let used_name = match used_name {
         UsedNameItem::Inlined(inlined) => {

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -173,7 +173,7 @@ async fn render_startup(
     .map(|d: &CodeGenerationExportsFinalNames| d.inner())
   {
     let exports_info =
-      module_graph.get_prefetched_exports_info(module_id, PrefetchExportsInfoMode::AllExports);
+      module_graph.get_prefetched_exports_info(module_id, PrefetchExportsInfoMode::Default);
     for (_, export_info) in exports_info.exports() {
       let info_name = export_info.name().expect("should have name");
       let used_name = export_info

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -4,8 +4,8 @@ use rspack_core::{
   property_access,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier, ApplyContext, ChunkUkey, Compilation, CompilationParams, CompilerCompilation,
-  CompilerOptions, ExportInfoGetter, ExportProvided, ExportsType, LibraryOptions, ModuleGraph,
-  ModuleIdentifier, Plugin, PluginContext, PrefetchExportsInfoMode, UsedNameItem,
+  CompilerOptions, ExportProvided, ExportsType, LibraryOptions, ModuleGraph, ModuleIdentifier,
+  Plugin, PluginContext, PrefetchExportsInfoMode, UsedNameItem,
 };
 use rspack_error::{error_bail, Result};
 use rspack_hash::RspackHash;
@@ -92,9 +92,9 @@ async fn render_startup(
 
     let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
     let info_name = export_info.name().expect("should have name");
-    let used_name =
-      ExportInfoGetter::get_used_name(export_info, Some(info_name), Some(chunk.runtime()))
-        .expect("name can't be empty");
+    let used_name = export_info
+      .get_used_name(Some(info_name), Some(chunk.runtime()))
+      .expect("name can't be empty");
     let var_name = format!("__webpack_exports__{}", to_identifier(info_name));
 
     if info_name == "default"

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -76,7 +76,7 @@ async fn render_startup(
     ));
   }
   let exports_info =
-    module_graph.get_prefetched_exports_info(module, PrefetchExportsInfoMode::AllExports);
+    module_graph.get_prefetched_exports_info(module, PrefetchExportsInfoMode::Default);
   let boxed_module = module_graph
     .module_by_identifier(module)
     .expect("should have build meta");

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -4,7 +4,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rspack_collections::UkeySet;
 use rspack_core::{
   incremental::Mutation, is_runtime_equal, ChunkUkey, Compilation, CompilationOptimizeChunks,
-  ExportInfoGetter, ExportsInfo, ModuleGraph, Plugin, PluginContext, RuntimeSpec,
+  ExportsInfo, ModuleGraph, Plugin, PluginContext, RuntimeSpec,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -178,23 +178,17 @@ fn is_equally_used(
     }
   } else {
     let other_exports_info = info.other_exports_info();
-    if ExportInfoGetter::get_used(other_exports_info, Some(a))
-      != ExportInfoGetter::get_used(other_exports_info, Some(b))
-    {
+    if other_exports_info.get_used(Some(a)) != other_exports_info.get_used(Some(b)) {
       return false;
     }
   }
   let side_effects_only_info = info.side_effects_only_info();
-  if ExportInfoGetter::get_used(side_effects_only_info, Some(a))
-    != ExportInfoGetter::get_used(side_effects_only_info, Some(b))
-  {
+  if side_effects_only_info.get_used(Some(a)) != side_effects_only_info.get_used(Some(b)) {
     return false;
   }
   for export_info in info.exports().values() {
     let export_info_data = export_info;
-    if ExportInfoGetter::get_used(export_info_data, Some(a))
-      != ExportInfoGetter::get_used(export_info_data, Some(b))
-    {
+    if export_info_data.get_used(Some(a)) != export_info_data.get_used(Some(b)) {
       return false;
     }
   }

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -177,21 +177,21 @@ fn is_equally_used(
       return false;
     }
   } else {
-    let other_exports_info = info.other_exports_info().as_data(mg);
+    let other_exports_info = info.other_exports_info();
     if ExportInfoGetter::get_used(other_exports_info, Some(a))
       != ExportInfoGetter::get_used(other_exports_info, Some(b))
     {
       return false;
     }
   }
-  let side_effects_only_info = info.side_effects_only_info().as_data(mg);
+  let side_effects_only_info = info.side_effects_only_info();
   if ExportInfoGetter::get_used(side_effects_only_info, Some(a))
     != ExportInfoGetter::get_used(side_effects_only_info, Some(b))
   {
     return false;
   }
-  for export_info in info.exports() {
-    let export_info_data = export_info.as_data(mg);
+  for export_info in info.exports().values() {
+    let export_info_data = export_info;
     if ExportInfoGetter::get_used(export_info_data, Some(a))
       != ExportInfoGetter::get_used(export_info_data, Some(b))
     {

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -171,7 +171,7 @@ fn is_equally_used(
   a: &RuntimeSpec,
   b: &RuntimeSpec,
 ) -> bool {
-  let info = mg.get_exports_info_by_id(exports_info);
+  let info = exports_info.as_data(mg);
   if let Some(redirect_to) = &info.redirect_to() {
     if is_equally_used(redirect_to, mg, a, b) {
       return false;

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -60,8 +60,9 @@ fn print_exports_info_to_source<F>(
     }
   }
   let mut show_other_exports = false;
-  if !already_printed.contains(&other_exports_info.id()) {
-    already_printed.insert(other_exports_info.id());
+  let other_exports_info_id = other_exports_info.id();
+  if !already_printed.contains(&other_exports_info_id) {
+    already_printed.insert(other_exports_info_id);
     show_other_exports = true;
   } else {
     already_printed_exports += 1;

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -9,9 +9,9 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_comment_with_nl, ApplyContext, BoxModule, BuildMetaExportsType, ChunkGraph,
   ChunkInitFragments, ChunkUkey, Compilation, CompilationParams, CompilerCompilation,
-  CompilerOptions, ExportInfo, ExportInfoGetter, ExportProvided, ExportsInfoGetter, Module,
-  ModuleGraph, ModuleIdentifier, Plugin, PluginContext, PrefetchExportsInfoMode,
-  PrefetchedExportsInfoWrapper, UsageState,
+  CompilerOptions, ExportInfo, ExportProvided, ExportsInfoGetter, Module, ModuleGraph,
+  ModuleIdentifier, Plugin, PluginContext, PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper,
+  UsageState,
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
@@ -73,9 +73,9 @@ fn print_exports_info_to_source<F>(
       .name()
       .map(|n| n.to_string())
       .unwrap_or("null".into());
-    let provide_info = ExportInfoGetter::get_provided_info(export_info);
-    let usage_info = ExportInfoGetter::get_used_info(export_info);
-    let rename_info = ExportInfoGetter::get_rename_info(export_info);
+    let provide_info = export_info.get_provided_info();
+    let usage_info = export_info.get_used_info();
+    let rename_info = export_info.get_rename_info();
 
     let target_desc = match get_target(export_info, module_graph) {
       Some(resolve_target) => {
@@ -127,7 +127,7 @@ fn print_exports_info_to_source<F>(
         other_exports_info.provided(),
         Some(ExportProvided::NotProvided)
       )
-      || ExportInfoGetter::get_used(other_exports_info, None) != UsageState::Unused
+      || other_exports_info.get_used(None) != UsageState::Unused
     {
       let title = if !printed_exports.is_empty() || already_printed_exports > 0 {
         "other exports"
@@ -135,8 +135,8 @@ fn print_exports_info_to_source<F>(
         "exports"
       };
 
-      let provide_info = ExportInfoGetter::get_provided_info(other_exports_info);
-      let used_info = ExportInfoGetter::get_used_info(other_exports_info);
+      let provide_info = other_exports_info.get_provided_info();
+      let used_info = other_exports_info.get_used_info();
       let target_desc = match target {
         Some(resolve_target) => {
           format!(" -> {}", request_shortener(&resolve_target.module))

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -98,11 +98,8 @@ fn print_exports_info_to_source<F>(
     source.add(RawStringSource::from(to_comment_with_nl(&export_str)));
 
     if let Some(exports_info) = &export_info.exports_info() {
-      let exports_info = ExportsInfoGetter::prefetch(
-        exports_info,
-        module_graph,
-        PrefetchExportsInfoMode::AllExports,
-      );
+      let exports_info =
+        ExportsInfoGetter::prefetch(exports_info, module_graph, PrefetchExportsInfoMode::Default);
       print_exports_info_to_source(
         source,
         &format!("{ident}  "),
@@ -245,7 +242,7 @@ async fn render_js_module_package(
     let module_graph = compilation.get_module_graph();
 
     let exports_info = module_graph
-      .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::AllExports);
+      .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
 
     if !matches!(export_type, BuildMetaExportsType::Unset) {
       let request_shortener = |id: &ModuleIdentifier| {

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -8,8 +8,8 @@ use futures::future::join_all;
 use rayon::prelude::*;
 use rspack_collections::{DatabaseItem, IdentifierMap, UkeyMap, UkeySet};
 use rspack_core::{
-  Chunk, ChunkByUkey, ChunkGraph, ChunkUkey, Compilation, ExportsInfoGetter, Module, ModuleGraph,
-  ModuleIdentifier, PrefetchExportsInfoMode, UsageKey,
+  Chunk, ChunkByUkey, ChunkGraph, ChunkUkey, Compilation, Module, ModuleGraph, ModuleIdentifier,
+  PrefetchExportsInfoMode, UsageKey,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_util::fx_hash::FxDashMap;
@@ -104,7 +104,7 @@ impl Combinator {
     let mut grouped_by_used_exports: FxHashMap<UsageKey, UkeySet<ChunkUkey>> = Default::default();
     for chunk_ukey in module_chunks {
       let chunk = chunk_by_ukey.expect_get(&chunk_ukey);
-      let usage_key = ExportsInfoGetter::get_usage_key(&exports_info, Some(chunk.runtime()));
+      let usage_key = exports_info.get_usage_key(Some(chunk.runtime()));
 
       grouped_by_used_exports
         .entry(usage_key)

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -99,8 +99,8 @@ impl Combinator {
     module_graph: &ModuleGraph,
     chunk_by_ukey: &ChunkByUkey,
   ) -> Vec<UkeySet<ChunkUkey>> {
-    let exports_info = module_graph
-      .get_prefetched_exports_info(module_identifier, PrefetchExportsInfoMode::AllExports);
+    let exports_info =
+      module_graph.get_prefetched_exports_info(module_identifier, PrefetchExportsInfoMode::Default);
     let mut grouped_by_used_exports: FxHashMap<UsageKey, UkeySet<ChunkUkey>> = Default::default();
     for chunk_ukey in module_chunks {
       let chunk = chunk_by_ukey.expect_get(&chunk_ukey);

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -18,7 +18,7 @@ use rspack_core::{
   StaticExportsDependency, StaticExportsSpec, UsedName,
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
-use rspack_util::{fx_hash::FxHashSet, itoa};
+use rspack_util::itoa;
 use swc_core::atoms::Atom;
 use wasmparser::{Import, Parser, Payload};
 
@@ -201,11 +201,10 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
                 .expect("should be wasm import dependency");
 
               let dep_name = serde_json::to_string(dep.name()).expect("should be ok.");
-              let name = Atom::from(dep.name());
               let Some(UsedName::Normal(used_name)) = ExportsInfoGetter::get_used_name(
                 GetUsedNameParam::WithNames(&module_graph.get_prefetched_exports_info(
                   &mgm.module_identifier,
-                  PrefetchExportsInfoMode::NamedExports(FxHashSet::from_iter([&name])),
+                  PrefetchExportsInfoMode::Default,
                 )),
                 *runtime,
                 &[dep.name().into()],


### PR DESCRIPTION
## Summary

Integrate the export info into the exports info to reduce the time spent on searching for export info data. During the seal phase, a layer of partial instances is added to the module graph, causing a loop partial operation for each query, which incurs significant performance overhead. Moreover, export info is seldom used alone, and an export info must belong to an exports info. Therefore, they can be integrated. 

And also this PR refactors some things below:
- modify ExportInfo to `(ExportsInfo, Atom)` and keep the `as_data/as_data_mut` methods to find the data by finding ExportsInfoData first and then get its named export info data.
- no need to prefetch named exports any more, so just remove them and retain the logic of "nested".
- remove ExportInfoGetter and ExportInfoSetter, and extends the methods to ExportInfoData, finish the rerfactoring
- remove export info related methods on module graph and export info id.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
