### PR TITLE
fix(tracing): support call register & cleanup multi times

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -2608,6 +2608,8 @@ export interface RealDependencyLocation {
 }
 
 /**
+ * this is a process level tracing, which means it would be shared by all compilers in the same process
+ * only the first call would take effect, the following calls would be ignored
  * Some code is modified based on
  * https://github.com/swc-project/swc/blob/d1d0607158ab40463d1b123fed52cc526eba8385/bindings/binding_core_node/src/util.rs#L29-L58
  * Apache-2.0 licensed

--- a/packages/rspack-test-tools/tests/compilerCases/tracing.js
+++ b/packages/rspack-test-tools/tests/compilerCases/tracing.js
@@ -1,0 +1,13 @@
+/** @type {import('../..').TCompilerCaseConfig} */
+module.exports = {
+	description: "support call register global trace and cleanup global trace multi times",
+	async check(_, compiler, __) {
+		await compiler.rspack.experiments.globalTrace.register('info', 'logger', 'stdout');
+		await compiler.rspack.experiments.globalTrace.register('info', 'logger', 'stdout');
+		await compiler.rspack.experiments.globalTrace.cleanup();
+		await compiler.rspack.experiments.globalTrace.cleanup();
+		await compiler.rspack.experiments.globalTrace.register('info', 'logger', 'stdout');
+		await compiler.rspack.experiments.globalTrace.cleanup();
+
+	}
+}

--- a/packages/rspack/src/trace/index.ts
+++ b/packages/rspack/src/trace/index.ts
@@ -18,6 +18,7 @@ type PartialChromeEvent = MakeOptional<ChromeEvent, "ts" | "ph">;
 // this is a tracer for nodejs
 // FIXME: currently we only support chrome layer and do nothing for logger layer
 export class JavaScriptTracer {
+	static state: "uninitialized" | "on" | "off" = "uninitialized";
 	// baseline time, we use offset time for tracing to align with rust side time
 	static startTime: bigint;
 	static events: ChromeEvent[];
@@ -28,12 +29,18 @@ export class JavaScriptTracer {
 	static session: import("node:inspector").Session;
 	// plugin counter for different channel in trace viewer, choose 100 to avoid conflict with known tracks
 	private static counter = 10000;
+	/**
+	 * only first call take effects, subsequent calls will be ignored
+	 * @param layer tracing layer
+	 * @param output tracing output file path
+	 */
 	static async initJavaScriptTrace(layer: string, output: string) {
 		const { Session } = await import("node:inspector");
 		this.session = new Session();
 		this.layer = layer;
 		this.output = output;
 		this.events = [];
+		this.state = "on";
 		this.startTime = process.hrtime.bigint(); // use microseconds
 	}
 	static uuid() {
@@ -47,12 +54,17 @@ export class JavaScriptTracer {
 		}
 	}
 	/**
-	 *
+	 * only first call take effects, subsequent calls will be ignored
 	 * @param isEnd true means we are at the end of tracing,and can append ']' to close the json
 	 * @returns
 	 */
 	static async cleanupJavaScriptTrace() {
-		if (!this.layer) {
+		if (this.state === "uninitialized") {
+			throw new Error(
+				"JavaScriptTracer is not initialized, please call initJavaScriptTrace first"
+			);
+		}
+		if (!this.layer || this.state === "off") {
 			return;
 		}
 		const profileHandler = (
@@ -101,7 +113,7 @@ export class JavaScriptTracer {
 				});
 			}
 		};
-		return new Promise<void>((resolve, reject) => {
+		await new Promise<void>((resolve, reject) => {
 			this.session.post("Profiler.stop", (err, params) => {
 				if (err) {
 					reject(err);
@@ -115,6 +127,7 @@ export class JavaScriptTracer {
 				}
 			});
 		});
+		this.state = "off";
 	}
 	// get elapsed time since start(nanoseconds same as rust side timestamp)
 	static getTs() {


### PR DESCRIPTION
## Summary
support call register & cleanup trace multi times and since tracing is process level so only the first call will take effect and following call will be ignored.
This will simplify logic for multi compiler, so users can easily register tracing in plugin
## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
