### PR TITLE
fix: fix_issuer compatibility with incomplete module graph

### DIFF
--- a/crates/rspack_core/src/compiler/make/cutout/fix_issuers.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/fix_issuers.rs
@@ -136,10 +136,14 @@ impl FixIssuers {
       let child_mid = module_graph
         .module_identifier_by_dependency_id(child_dep_id)
         .expect("should module exist");
-      let child_module_issuer = module_graph
-        .module_graph_module_by_identifier(child_mid)
-        .expect("should have module graph module")
-        .issuer();
+      let Some(child_mgm) = module_graph.module_graph_module_by_identifier(child_mid) else {
+        // peresistent cache recovery module graph will lose some module and mgm.
+        // TODO replace to .expect() after all modules are cacheable.
+        self.need_check_modules.insert(*child_mid);
+        continue;
+      };
+
+      let child_module_issuer = child_mgm.issuer();
       if let ModuleIssuer::Some(i) = child_module_issuer
         && i == module_identifier
       {


### PR DESCRIPTION
## Summary

The persistent cache will generate an incomplete module graph because some modules can not be serialized, and the incomplete module graph will make `fix_issuer.analyze_force_build_module` panic.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
