### PR TITLE
refactor: use length as id instead of module id for lazy compilation

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -1646,6 +1646,7 @@ export type TTestConfig<T extends ECompilerType> = {
     modules?: Record<string, Object>;
     timeout?: number;
     concurrent?: boolean;
+    snapshotContent?(content: string): string;
     checkSteps?: boolean;
 };
 

--- a/packages/rspack-test-tools/src/processor/hot-step.ts
+++ b/packages/rspack-test-tools/src/processor/hot-step.ts
@@ -226,7 +226,12 @@ export class HotSnapshotProcessor<
 			}
 		}
 
-		const replaceContent = (str: string) => {
+		const replaceContent = (rawStr: string) => {
+			let str = rawStr;
+			const replaceContentConfig = context.getTestConfig().snapshotContent;
+			if (replaceContentConfig) {
+				str = replaceContentConfig(str);
+			}
 			return normalizePlaceholder(
 				Object.entries(hashes)
 					.reduce((str, [raw, replacement]) => {

--- a/packages/rspack-test-tools/src/processor/snapshot.ts
+++ b/packages/rspack-test-tools/src/processor/snapshot.ts
@@ -68,11 +68,16 @@ export class SnapshotProcessor<
 		const snapshotFileFilter =
 			this._snapshotOptions.snapshotFileFilter ||
 			((file: string) => file.endsWith(".js") && !file.includes("runtime.js"));
+
 		const fileContents = Object.entries(compilation.assets)
 			.filter(([file]) => snapshotFileFilter(file))
 			.map(([file, source]) => {
 				const tag = path.extname(file).slice(1) || "txt";
-				const content = this.serializeEachFile(source.source().toString());
+				let content = this.serializeEachFile(source.source().toString());
+				const testConfig = context.getTestConfig();
+				if (testConfig.snapshotContent) {
+					content = testConfig.snapshotContent(content);
+				}
 
 				return `\`\`\`${tag} title=${file}\n${content}\n\`\`\``;
 			});

--- a/packages/rspack-test-tools/src/type.ts
+++ b/packages/rspack-test-tools/src/type.ts
@@ -220,6 +220,7 @@ export type TTestConfig<T extends ECompilerType> = {
 	modules?: Record<string, Object>;
 	timeout?: number;
 	concurrent?: boolean;
+	snapshotContent?(content: string): string;
 
 	// Only valid for Hot tests
 	checkSteps?: boolean;

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
@@ -10,7 +10,7 @@
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 69
 - Update: main.LAST_HASH.hot-update.js, size: 582
-- Update: modules_demo_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1590
+- Update: modules_demo_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1430
 
 ## Manifest
 
@@ -79,7 +79,7 @@ self["webpackHotUpdate"]("modules_demo_js_lazy-compilation-proxy", {
   \*********************************************************************************************************************/
 (function (module, __unused_webpack_exports, __webpack_require__) {
 var client = __webpack_require__("../../../../../rspack/hot/lazy-compilation-web.js?http%3A%2F%2Flocalhost%3APORT%2Flazy-compilation-using-");
-var data = "<TEST_TOOLS_ROOT>/dist/helper/loaders/hot-update.js%3F%3FruleSet%5B1%5D.rules%5B0%5D.use%5B0%5D!<TEST_TOOLS_ROOT>/tests/hotCases/lazy-compilation/context/modules/demo.js"
+var data = __LAZY_ID__
         module.exports = __webpack_require__.e(/*! import() */ "modules_demo_js").then(__webpack_require__.bind(__webpack_require__, /*! ./modules/demo.js */ "./modules/demo.js"));
         if (module.hot) {
           module.hot.accept();

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
@@ -11,7 +11,7 @@
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 71
 - Update: main.LAST_HASH.hot-update.js, size: 582
-- Update: modules_module_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1610
+- Update: modules_module_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1448
 
 ## Manifest
 
@@ -80,7 +80,7 @@ self["webpackHotUpdate"]("modules_module_js_lazy-compilation-proxy", {
   \***********************************************************************************************************************/
 (function (module, __unused_webpack_exports, __webpack_require__) {
 var client = __webpack_require__("../../../../../rspack/hot/lazy-compilation-web.js?http%3A%2F%2Flocalhost%3APORT%2Flazy-compilation-using-");
-var data = "<TEST_TOOLS_ROOT>/dist/helper/loaders/hot-update.js%3F%3FruleSet%5B1%5D.rules%5B0%5D.use%5B0%5D!<TEST_TOOLS_ROOT>/tests/hotCases/lazy-compilation/context/modules/module.js"
+var data = __LAZY_ID__
         module.exports = __webpack_require__.e(/*! import() */ "modules_module_js").then(__webpack_require__.bind(__webpack_require__, /*! ./modules/module.js */ "./modules/module.js"));
         if (module.hot) {
           module.hot.accept();

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/test.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/test.config.js
@@ -1,4 +1,12 @@
+const RE = /var data = "\d*"/g;
+
 module.exports = {
 	documentType: "fake",
-	checkSteps: false
+	checkSteps: false,
+	snapshotContent(
+		/**@type {string} */
+		content
+	) {
+		return content.replaceAll(RE, "var data = __LAZY_ID__");
+	}
 };

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/module-test/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/module-test/__snapshots__/web/1.snap.txt
@@ -10,7 +10,7 @@
 - Bundle: moduleB_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 64
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: moduleA_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1559
+- Update: moduleA_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1392
 
 ## Manifest
 
@@ -64,7 +64,7 @@ self["webpackHotUpdate"]("moduleA_js_lazy-compilation-proxy", {
   \*********************************************************************************************************************/
 (function (module, __unused_webpack_exports, __webpack_require__) {
 var client = __webpack_require__("../../../../../rspack/hot/lazy-compilation-web.js?http%3A%2F%2Flocalhost%3APORT%2Flazy-compilation-using-");
-var data = "<TEST_TOOLS_ROOT>/dist/helper/loaders/hot-update.js%3F%3FruleSet%5B1%5D.rules%5B0%5D.use%5B0%5D!<TEST_TOOLS_ROOT>/tests/hotCases/lazy-compilation/module-test/moduleA.js"
+var data = "0"
         module.exports = __webpack_require__.e(/*! import() */ "moduleA_js").then(__webpack_require__.bind(__webpack_require__, /*! ./moduleA.js */ "./moduleA.js"));
         if (module.hot) {
           module.hot.accept();


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

fix #9829

Use a map to record a mapping between module id and number, when passing what modules should be compiled, use the number id to avoid long url

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
