### PR TITLE
fix(tracing): disable emit tracing event when call cleanup

### DIFF
--- a/packages/rspack-test-tools/tests/compilerCases/tracing.js
+++ b/packages/rspack-test-tools/tests/compilerCases/tracing.js
@@ -1,0 +1,13 @@
+/** @type {import('../..').TCompilerCaseConfig} */
+module.exports = {
+	description: "support call register global trace and cleanup global trace multi times",
+	async check(_, compiler, __) {
+		await compiler.rspack.experiments.globalTrace.register('info', 'logger', 'stdout');
+		await compiler.rspack.experiments.globalTrace.register('info', 'logger', 'stdout');
+		await compiler.rspack.experiments.globalTrace.cleanup();
+		await compiler.rspack.experiments.globalTrace.cleanup();
+		await compiler.rspack.experiments.globalTrace.register('info', 'logger', 'stdout');
+		await compiler.rspack.experiments.globalTrace.cleanup();
+
+	}
+}


### PR DESCRIPTION
## Summary
stop emit tracing event after calling cleanup 

## Related links
fix #10858 
<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
