### PR TITLE
fix: always rebuild error module

### DIFF
--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -388,6 +388,10 @@ pub trait Module:
 
   fn need_build(&self) -> bool {
     !self.build_info().cacheable
+      || self
+        .diagnostics()
+        .iter()
+        .any(|item| matches!(item.severity(), rspack_error::RspackSeverity::Error))
   }
 
   fn depends_on(&self, modified_file: &HashSet<ArcPath>) -> bool {

--- a/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/__snapshots__/web/0.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case rebuild-abnormal-module: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: bundle.js
+
+## Manifest
+
+
+## Update

--- a/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/__snapshots__/web/2.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/__snapshots__/web/2.snap.txt
@@ -1,0 +1,119 @@
+# Case rebuild-abnormal-module: Step 2
+
+## Changed Files
+- file.js
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 28
+- Update: main.LAST_HASH.hot-update.js, size: 970
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./file.js
+- ./loader.js!./a.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["webpackHotUpdate"]("main", {
+"./file.js": 
+/*!*****************!*\
+  !*** ./file.js ***!
+  \*****************/
+(function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+});
+/* ESM default export */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+
+
+}),
+"./loader.js!./a.js": 
+/*!**************************!*\
+  !*** ./loader.js!./a.js ***!
+  \**************************/
+(function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+});
+/* ESM default export */ const __WEBPACK_DEFAULT_EXPORT__ = ("a");
+
+
+}),
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+
+## Runtime
+### Status
+
+```txt
+check => prepare => dispose => apply => fail
+```
+
+
+
+### JavaScript
+
+#### Outdated
+
+Outdated Modules:
+- ./file.js
+- ./loader.js!./a.js
+
+
+Outdated Dependencies:
+```json
+{
+  "./index.js": [
+    "./file.js",
+    "./loader.js!./a.js"
+  ]
+}
+```
+
+#### Updated
+
+Updated Modules:
+- ./file.js
+- ./loader.js!./a.js
+
+Updated Runtime:
+- `__webpack_require__.h`
+
+
+#### Callback
+
+Accepted Callback:
+- ./file.js
+
+Disposed Callback:

--- a/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/a.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/errors1.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/errors1.js
@@ -1,0 +1,1 @@
+module.exports = [[/Expression expected/]];

--- a/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/file.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/file.js
@@ -1,0 +1,5 @@
+export default 1;
+---
+export default 2;
+---
+export default 3;

--- a/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/index.js
@@ -1,0 +1,14 @@
+import "./loader.js!./a.js";
+import index from "./file";
+
+it("should rebuild abnormal module success", async () => {
+	expect(index).toBe(1);
+	await NEXT_HMR().catch(err => {
+		expect(err.message).toMatch(/Expression expected/);
+	});
+	expect(index).toBe(1);
+	await NEXT_HMR().catch(err => {
+		expect(err.message).not.toMatch(/Expression expected/);
+	});
+	expect(index).toBe(1);
+});

--- a/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/loader.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/rebuild-abnormal-module/loader.js
@@ -1,0 +1,10 @@
+let times = 0;
+
+module.exports = async function (code) {
+	times++;
+	if (times === 2) {
+		return ")))";
+	}
+	this.cacheable(false);
+	return code.replace("<times>", times);
+};


### PR DESCRIPTION
## Summary

Align with webpack, modules should always be rebuilt if they have errors.

<!-- Describe what this PR does and why. -->

## Related links

- https://github.com/web-infra-dev/rspack/issues/10698

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
