### PR TITLE
perf: parallel find new name in concatenated code generation

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -1116,7 +1116,7 @@ impl JsPlugin {
           let context = compilation.options.context.clone();
           let readable_identifier = module.readable_identifier(&context).to_string();
           let splitted_readable_identifier = split_readable_identifier(&readable_identifier);
-          let new_name = find_new_name(name, &all_used_names, &splitted_readable_identifier);
+          let new_name = find_new_name("", name, &all_used_names, &splitted_readable_identifier);
 
           for identifier in refs.iter() {
             let span = identifier.id.span();

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
@@ -330,7 +330,7 @@ Object {
         main.js,
       ],
       filteredModules: undefined,
-      hash: cfe10b32fa6df1ab,
+      hash: f2679505795e0dc5,
       id: 909,
       idHints: Array [],
       initial: true,
@@ -718,7 +718,7 @@ Object {
   errorsCount: 0,
   filteredAssets: undefined,
   filteredModules: undefined,
-  hash: de56093745c27934,
+  hash: 2252b7b6fa0bc796,
   modules: Array [
     Object {
       assets: Array [],

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -58,7 +58,7 @@ runtime modules xx KiB
     [no exports]
     [used exports unknown]
   
-Rspack compiled successfully (cb468c46ad9d7f18)
+Rspack compiled successfully (b6a6c74437c67e0f)
 `;
 
 exports[`statsOutput statsOutput/builtin-swc-loader-parse-error should print correct stats for 1`] = `

--- a/packages/rspack-test-tools/tests/builtinCases/samples/concatenate-modules/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/samples/concatenate-modules/__snapshots__/output.snap.txt
@@ -4,15 +4,15 @@
 "./index.js": (function () {
 
 ;// CONCATENATED MODULE: ./answer.js
-const answer = 103330;
+const _0_answer = 103330;
 
 ;// CONCATENATED MODULE: ./index.js
 
-answer;
+_0_answer;
 
-function index_answer() {}
+function _1_answer() {}
 
-index_answer();
+_1_answer();
 
 function test() {}
 

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-asset-entry/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-asset-entry/rspack.config.js
@@ -47,12 +47,14 @@ module.exports = {
 						const jsContent = assets[js].source().toString();
 
 						const preseveImport =
-							/import\simg_namespaceObject\sfrom ['"]\.\/static\/img\/img\.png['"]/.test(
+							/import\s_0_img_namespaceObject\sfrom ['"]\.\/static\/img\/img\.png['"]/.test(
 								jsContent
 							);
 						assert(preseveImport);
 						const hasExports =
-							/export\s{\simg_namespaceObject\sas\sdefault\s}/.test(jsContent);
+							/export\s{\s_0_img_namespaceObject\sas\sdefault\s}/.test(
+								jsContent
+							);
 						assert(hasExports);
 					});
 				});

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
@@ -30,7 +30,7 @@ module.exports = {
 				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
 					const bundle = Object.values(assets)[0]._value;
 					expect(bundle)
-						.toContain(`var __webpack_exports__cjsInterop = (foo_default());
+						.toContain(`var __webpack_exports__cjsInterop = (_1_foo_default());
 export { external_module as defaultImport, namedImport, __webpack_exports__cjsInterop as cjsInterop };`);
 					expect(bundle).toContain(
 						'import external_module, { namedImport } from "external-module";'

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/__snapshot__/e.js.txt
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/__snapshot__/e.js.txt
@@ -62,13 +62,13 @@ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj
 const foo = 'foo'
 
 // EXTERNAL MODULE: ./e/bar.cjs
-var bar = __webpack_require__(997);
-var bar_default = /*#__PURE__*/__webpack_require__.n(bar);
+var _1_bar = __webpack_require__(997);
+var _1_bar_default = /*#__PURE__*/__webpack_require__.n(_1_bar);
 ;// CONCATENATED MODULE: ./e/index.js
 
 
 
 
 
-var __webpack_exports__bar = (bar_default());
+var __webpack_exports__bar = (_1_bar_default());
 export { foo, __webpack_exports__bar as bar };

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/__snapshot__/f.js.txt
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/__snapshot__/f.js.txt
@@ -67,8 +67,8 @@ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj
 /************************************************************************/
 
 // EXTERNAL MODULE: ./f/bar.cjs
-var bar = __webpack_require__(441);
-var bar_default = /*#__PURE__*/__webpack_require__.n(bar);
+var _0_bar = __webpack_require__(441);
+var _0_bar_default = /*#__PURE__*/__webpack_require__.n(_0_bar);
 ;// CONCATENATED MODULE: ./f/foo.js
 const foo = 'foo'
 
@@ -76,7 +76,7 @@ const foo = 'foo'
 
 
 
-const value = foo + (bar_default())
+const value = foo + (_0_bar_default())
 
 
 

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/__snapshot__/g.js.txt
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/__snapshot__/g.js.txt
@@ -60,12 +60,12 @@ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj
 /************************************************************************/
 
 // EXTERNAL MODULE: ./g/foo.js
-var foo = __webpack_require__(974);
-var foo_default = /*#__PURE__*/__webpack_require__.n(foo);
+var _0_foo = __webpack_require__(974);
+var _0_foo_default = /*#__PURE__*/__webpack_require__.n(_0_foo);
 ;// CONCATENATED MODULE: ./g/index.js
 
 
 
 
-var __webpack_exports__foo = (foo_default());
+var __webpack_exports__foo = (_0_foo_default());
 export { __webpack_exports__foo as foo };

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/__snapshot__/h.js.txt
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/__snapshot__/h.js.txt
@@ -29,5 +29,5 @@ __webpack_require__.p = "";
 /************************************************************************/
 
 ;// CONCATENATED MODULE: ./h/file.png
-const file_namespaceObject = __webpack_require__.p + "fc90103f80b6abc6.png";
-export { file_namespaceObject as default };
+const _0_file_namespaceObject = __webpack_require__.p + "fc90103f80b6abc6.png";
+export { _0_file_namespaceObject as default };

--- a/packages/rspack-test-tools/tests/configCases/rstest/module-path-names/index.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/module-path-names/index.js
@@ -6,8 +6,8 @@ const sourceDir = path.resolve(__dirname, "../../../../configCases/rstest/module
 it("Insert module path names with concatenateModules", () => {
 	const content = fs.readFileSync(path.resolve(__dirname, "modulePathName.js"), "utf-8");
 	// __dirname and __filename renamed after concatenation
-	expect(content).toContain(`const foo_filename = ${JSON.stringify(path.resolve(sourceDir, "./foo.js"))}`);
-	expect(content).toContain(`const foo_dirname = ${JSON.stringify(path.resolve(sourceDir, "."))}`);
+	expect(content).toContain(`const _0_foo_filename = ${JSON.stringify(path.resolve(sourceDir, "./foo.js"))}`);
+	expect(content).toContain(`const _0_foo_dirname = ${JSON.stringify(path.resolve(sourceDir, "."))}`);
 
 	expect(content).toContain(`const metaFile1 = ${JSON.stringify(path.resolve(sourceDir, "./foo.js"))}`)
 	expect(content).toContain(`const metaDir1 = ${JSON.stringify(path.resolve(sourceDir, "."))}`)

--- a/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
+++ b/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
@@ -70,24 +70,24 @@ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj
 "use strict";
 
 // EXTERNAL MODULE: ../../normalModuleFactory​#afterResolve/request/a.js
-var a = __webpack_require__("../../normalModuleFactory​#afterResolve/request/a.js");
-var a_default = /*#__PURE__*/__webpack_require__.n(a);
+var _0_a = __webpack_require__("../../normalModuleFactory​#afterResolve/request/a.js");
+var _0_a_default = /*#__PURE__*/__webpack_require__.n(_0_a);
 // EXTERNAL MODULE: ../../normalModuleFactory​#afterResolve/request/c.js
-var c = __webpack_require__("../../normalModuleFactory​#afterResolve/request/c.js");
-var c_default = /*#__PURE__*/__webpack_require__.n(c);
+var _1_c = __webpack_require__("../../normalModuleFactory​#afterResolve/request/c.js");
+var _1_c_default = /*#__PURE__*/__webpack_require__.n(_1_c);
 ;// CONCATENATED MODULE: external "fs"
-const external_fs_namespaceObject = require("fs");
-var external_fs_default = /*#__PURE__*/__webpack_require__.n(external_fs_namespaceObject);
+const _2_external_fs_namespaceObject = require("fs");
+var _2_external_fs_default = /*#__PURE__*/__webpack_require__.n(_2_external_fs_namespaceObject);
 ;// CONCATENATED MODULE: ../../normalModuleFactory​#afterResolve/request/request.js
 
 
 
 
 it("should modify request by after resolve hook", () => {
-	expect((a_default())).toBe("a");
-	expect((c_default())).toBe("b");
+	expect((_0_a_default())).toBe("a");
+	expect((_1_c_default())).toBe("b");
 	const ext = ".js";
-	expect(external_fs_default().readFileSync(__filename, "utf-8")).toContain("request/c" + ext);
+	expect(_2_external_fs_default().readFileSync(__filename, "utf-8")).toContain("request/c" + ext);
 });
 
 })();

--- a/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
+++ b/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
@@ -70,24 +70,24 @@ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj
 "use strict";
 
 // EXTERNAL MODULE: ../../normalModuleFactory​#afterResolve/resource/a.js
-var a = __webpack_require__("../../normalModuleFactory​#afterResolve/resource/a.js");
-var a_default = /*#__PURE__*/__webpack_require__.n(a);
+var _0_a = __webpack_require__("../../normalModuleFactory​#afterResolve/resource/a.js");
+var _0_a_default = /*#__PURE__*/__webpack_require__.n(_0_a);
 // EXTERNAL MODULE: ../../normalModuleFactory​#afterResolve/resource/b.js
-var b = __webpack_require__("../../normalModuleFactory​#afterResolve/resource/b.js");
-var b_default = /*#__PURE__*/__webpack_require__.n(b);
+var _1_b = __webpack_require__("../../normalModuleFactory​#afterResolve/resource/b.js");
+var _1_b_default = /*#__PURE__*/__webpack_require__.n(_1_b);
 ;// CONCATENATED MODULE: external "fs"
-const external_fs_namespaceObject = require("fs");
-var external_fs_default = /*#__PURE__*/__webpack_require__.n(external_fs_namespaceObject);
+const _2_external_fs_namespaceObject = require("fs");
+var _2_external_fs_default = /*#__PURE__*/__webpack_require__.n(_2_external_fs_namespaceObject);
 ;// CONCATENATED MODULE: ../../normalModuleFactory​#afterResolve/resource/resource.js
 
 
 
 
 it("should modify resource by after resolve hook", () => {
-	expect((a_default())).toBe("a");
-	expect((b_default())).toBe("c");
+	expect((_0_a_default())).toBe("a");
+	expect((_1_b_default())).toBe("c");
 	const ext = ".js";
-	expect(external_fs_default().readFileSync(__filename, "utf-8")).toContain("resource/b" + ext);
+	expect(_2_external_fs_default().readFileSync(__filename, "utf-8")).toContain("resource/b" + ext);
 });
 
 })();

--- a/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
+++ b/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
@@ -70,24 +70,24 @@ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj
 "use strict";
 
 // EXTERNAL MODULE: ../../normalModuleFactory​#resolve/resource/a.js
-var a = __webpack_require__("../../normalModuleFactory​#resolve/resource/a.js");
-var a_default = /*#__PURE__*/__webpack_require__.n(a);
+var _0_a = __webpack_require__("../../normalModuleFactory​#resolve/resource/a.js");
+var _0_a_default = /*#__PURE__*/__webpack_require__.n(_0_a);
 // EXTERNAL MODULE: ../../normalModuleFactory​#resolve/resource/b.js
-var b = __webpack_require__("../../normalModuleFactory​#resolve/resource/b.js");
-var b_default = /*#__PURE__*/__webpack_require__.n(b);
+var _1_b = __webpack_require__("../../normalModuleFactory​#resolve/resource/b.js");
+var _1_b_default = /*#__PURE__*/__webpack_require__.n(_1_b);
 ;// CONCATENATED MODULE: external "fs"
-const external_fs_namespaceObject = require("fs");
-var external_fs_default = /*#__PURE__*/__webpack_require__.n(external_fs_namespaceObject);
+const _2_external_fs_namespaceObject = require("fs");
+var _2_external_fs_default = /*#__PURE__*/__webpack_require__.n(_2_external_fs_namespaceObject);
 ;// CONCATENATED MODULE: ../../normalModuleFactory​#resolve/resource/resource.js
 
 
 
 
 it("should modify resource by resolve hook", () => {
-	expect((a_default())).toBe("a");
-	expect((b_default())).toBe("c");
+	expect((_0_a_default())).toBe("a");
+	expect((_1_b_default())).toBe("c");
 	const ext = ".js";
-	expect(external_fs_default().readFileSync(__filename, "utf-8")).toContain("resource/b" + ext);
+	expect(_2_external_fs_default().readFileSync(__filename, "utf-8")).toContain("resource/b" + ext);
 });
 
 })();


### PR DESCRIPTION
## Summary

> This PR should not be merged before full discussion

Parallel finding names of concatenated modules. Using module index to make sure that the names will not conflict.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
