### PR TITLE
perf: remove visitor feature of lightningcss

### DIFF
--- a/crates/rspack_loader_lightningcss/Cargo.toml
+++ b/crates/rspack_loader_lightningcss/Cargo.toml
@@ -10,7 +10,7 @@ version           = "0.2.0"
 [dependencies]
 async-trait          = { workspace = true }
 derive_more          = { workspace = true, features = ["debug"] }
-lightningcss         = { workspace = true, features = ["sourcemap", "visitor", "into_owned"] }
+lightningcss         = { workspace = true, features = ["sourcemap", "into_owned"] }
 parcel_sourcemap     = { workspace = true }
 rspack_browserslist  = { workspace = true }
 rspack_cacheable     = { workspace = true }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
it seems visitor feature is used for js visitor api which we don't use 
## Related links
<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
