### PR TITLE
fix: add error handling for invalid browserslist configuration

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/target/invalid-browserslist/errors.js
+++ b/packages/rspack-test-tools/tests/configCases/target/invalid-browserslist/errors.js
@@ -1,3 +1,3 @@
 module.exports = [
-  [/Rspack cannot parse browserslist query from 'target' configuration./]
+  [/Rspack cannot parse the browserslist query./]
 ];

--- a/packages/rspack-test-tools/tests/configCases/target/invalid-browserslist/errors.js
+++ b/packages/rspack-test-tools/tests/configCases/target/invalid-browserslist/errors.js
@@ -1,0 +1,3 @@
+module.exports = [
+  [/Rspack cannot parse browserslist query from 'target' configuration./]
+];

--- a/packages/rspack-test-tools/tests/configCases/target/invalid-browserslist/index.js
+++ b/packages/rspack-test-tools/tests/configCases/target/invalid-browserslist/index.js
@@ -1,0 +1,2 @@
+it("should compile", () => {
+});

--- a/packages/rspack-test-tools/tests/configCases/target/invalid-browserslist/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/target/invalid-browserslist/rspack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "browserslist:Chrome>=9999"
+};

--- a/packages/rspack/src/config/target.ts
+++ b/packages/rspack/src/config/target.ts
@@ -150,6 +150,12 @@ The recommended way is to add a 'browserslist' key to your package.json and list
 You can also more options via the 'target' option: 'browserslist' / 'browserslist:env' / 'browserslist:query' / 'browserslist:path-to-config' / 'browserslist:path-to-config:env'`);
 			}
 
+			if (Array.isArray(browsers) && browsers.length === 0) {
+				throw new Error(
+					"Rspack cannot parse browserslist query from 'target' configuration. This may happen when the query contains version requirements that exceed the supported range in the browserslist-rs database. Check your browserslist configuration for invalid version numbers."
+				);
+			}
+
 			const browserslistTargetHandler = getBrowserslistTargetHandler();
 			return browserslistTargetHandler.resolve(browsers);
 		}

--- a/packages/rspack/src/config/target.ts
+++ b/packages/rspack/src/config/target.ts
@@ -152,7 +152,7 @@ You can also more options via the 'target' option: 'browserslist' / 'browserslis
 
 			if (Array.isArray(browsers) && browsers.length === 0) {
 				throw new Error(
-					"Rspack cannot parse browserslist query from 'target' configuration. This may happen when the query contains version requirements that exceed the supported range in the browserslist-rs database. Check your browserslist configuration for invalid version numbers."
+					"Rspack cannot parse the browserslist query. This may happen when the query contains version requirements that exceed the supported range in the browserslist-rs database. Check your browserslist configuration for invalid version numbers."
 				);
 			}
 


### PR DESCRIPTION
## Summary

Add error handling for invalid browserslist configuration, such as:

```js
export default {
  target: "browserslist:Chrome>=9999"
};
```

### Current error

The current error is the same as webpack:

<img width="1219" alt="Screenshot 2025-07-03 at 14 17 13" src="https://github.com/user-attachments/assets/5a73b165-8b03-4da4-9933-ea9cd22a847a" />

### New error

The new error message is more precise:

<img width="1225" alt="Screenshot 2025-07-03 at 14 36 22" src="https://github.com/user-attachments/assets/b4025971-8ba6-4e31-8a8c-cbe048a8e00a" />

## Related links

resolve https://github.com/web-infra-dev/rsbuild/issues/5525

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
