### PR TITLE
fix(wasm): use `parking_lot` nightly to avoid panic in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4167,6 +4167,7 @@ dependencies = [
  "napi",
  "napi-derive",
  "once_cell",
+ "parking_lot",
  "ropey",
  "rspack_allocator",
  "rspack_browserslist",

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -110,7 +110,7 @@ rustc-hash                             = { workspace = true }
 serde                                  = { workspace = true }
 serde_json                             = { workspace = true }
 swc_core                               = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
-tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing"] }
+tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot"] }
 ustr                                   = { workspace = true }
 
 [package.metadata.cargo-shear]
@@ -124,4 +124,3 @@ parking_lot = { version = "=0.12.3", features = ["nightly"] }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rspack_tracing = { workspace = true }
 sftrace-setup  = { workspace = true, optional = true }
-tokio          = { workspace = true, features = ["parking_lot"] }

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -113,6 +113,14 @@ swc_core                               = { workspace = true, default-features = 
 tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing"] }
 ustr                                   = { workspace = true }
 
+[package.metadata.cargo-shear]
+ignored = ["parking_lot"]
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+# Pin parking_lot version to the same version within the workspace
+# Explicitly adding features `nightly` to turn on wasm atomic support
+parking_lot = { version = "=0.12.3", features = ["nightly"] }
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rspack_tracing = { workspace = true }
 sftrace-setup  = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

Turn on `wasm_atomic` in `parking_lot`.
See: https://github.com/Amanieu/parking_lot/blob/master/core/src/thread_parker/wasm_atomic.rs

This fixes `Parking not supported on this platform` issue in wasm.

This also makes it possible to start multiple tokio workers.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
