### PR TITLE
refactor: remove js stats warning

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1291,10 +1291,11 @@ export interface JsStatsCompilation {
   hash?: string
   modules?: Array<JsStatsModule>
   namedChunkGroups?: Array<JsStatsChunkGroup>
-  warnings: Array<JsStatsWarning>
+  warnings: Array<JsStatsError>
 }
 
 export interface JsStatsError {
+  name?: string
   moduleDescriptor?: JsModuleDescriptor
   message: string
   chunkName?: string
@@ -1431,21 +1432,6 @@ export interface JsStatsOptions {
 export interface JsStatsSize {
   sourceType: string
   size: number
-}
-
-export interface JsStatsWarning {
-  moduleDescriptor?: JsModuleDescriptor
-  name?: string
-  message: string
-  chunkName?: string
-  code?: string
-  chunkEntry?: boolean
-  chunkInitial?: boolean
-  file?: string
-  chunkId?: string
-  details?: string
-  stack?: string
-  moduleTrace: Array<JsStatsModuleTrace>
 }
 
 export interface JsTap {

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -649,6 +649,7 @@ impl Stats<'_> {
         );
         let code = d.code().map(|code| code.to_string());
         StatsError {
+          name: d.code().map(|c| c.to_string()),
           message: diagnostic_displayer
             .emit_diagnostic(d)
             .expect("should print diagnostics"),
@@ -676,7 +677,7 @@ impl Stats<'_> {
     f(errors)
   }
 
-  pub fn get_warnings<T>(&self, f: impl Fn(Vec<StatsWarning>) -> T) -> T {
+  pub fn get_warnings<T>(&self, f: impl Fn(Vec<StatsError>) -> T) -> T {
     let mut diagnostic_displayer = DiagnosticDisplayer::new(self.compilation.options.stats.colors);
 
     let module_graph = self.compilation.get_module_graph();
@@ -710,7 +711,7 @@ impl Stats<'_> {
 
         let code = d.code().map(|code| code.to_string());
 
-        StatsWarning {
+        StatsError {
           name: d.code().map(|c| c.to_string()),
           message: diagnostic_displayer
             .emit_diagnostic(d)

--- a/crates/rspack_core/src/stats/struct.rs
+++ b/crates/rspack_core/src/stats/struct.rs
@@ -39,25 +39,6 @@ pub struct ExtendedStatsOptions {
 
 #[derive(Debug)]
 pub struct StatsError<'a> {
-  pub message: String,
-  pub code: Option<String>,
-  pub module_identifier: Option<ModuleIdentifier>,
-  pub module_name: Option<Cow<'a, str>>,
-  pub module_id: Option<ModuleId>,
-  pub loc: Option<String>,
-  pub file: Option<&'a Utf8Path>,
-
-  pub chunk_name: Option<&'a str>,
-  pub chunk_entry: Option<bool>,
-  pub chunk_initial: Option<bool>,
-  pub chunk_id: Option<&'a str>,
-  pub details: Option<String>,
-  pub stack: Option<String>,
-  pub module_trace: Vec<StatsModuleTrace<'a>>,
-}
-
-#[derive(Debug)]
-pub struct StatsWarning<'a> {
   pub name: Option<String>,
   pub message: String,
   pub code: Option<String>,

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -470,7 +470,7 @@ Rspack compiled successfully
 `;
 
 exports[`statsOutput statsOutput/try-require-module should print correct stats for 1`] = `
-WARNING in ./index.js
+WARNING in ./index.js 2:12-31
   ⚠ Module not found: Can't resolve './missing-module' in '<TEST_TOOLS_ROOT>/tests/statsOutputCases/try-require-module'
    ╭─[2:4]
  1 │ try {

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-module/raw-warning.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-module/raw-warning.err
@@ -1,5 +1,6 @@
 Array [
   Object {
+    loc: 4:16-35,
     moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/missing-module/index.js,
     moduleName: ./index.js,
   },

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-module/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-module/stats.err
@@ -1,4 +1,4 @@
-WARNING in ./index.js
+WARNING in ./index.js 4:16-35
   ⚠ Module not found: Can't resolve './missing-module' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/missing-module'
    ╭─[4:8]
  2 │     let errored = false;

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -59,7 +59,6 @@ import type { JsRuntimeModule } from '@rspack/binding';
 import type { JsStats } from '@rspack/binding';
 import type { JsStatsCompilation } from '@rspack/binding';
 import type { JsStatsError } from '@rspack/binding';
-import type { JsStatsWarning } from '@rspack/binding';
 import * as liteTapable from '@rspack/lite-tapable';
 import { Logger } from './logging/Logger';
 import { Module } from '@rspack/binding';
@@ -3923,7 +3922,7 @@ type KnownStatsFactoryContext = {
     makePathsRelative?: ((arg0: string) => string) | undefined;
     compilation?: Compilation | undefined;
     cachedGetErrors?: ((arg0: Compilation) => JsStatsError[]) | undefined;
-    cachedGetWarnings?: ((arg0: Compilation) => JsStatsWarning[]) | undefined;
+    cachedGetWarnings?: ((arg0: Compilation) => JsStatsError[]) | undefined;
     getStatsCompilation: (compilation: Compilation) => JsStatsCompilation;
     getInner: (compilation: Compilation) => JsStats;
 };

--- a/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
@@ -13,8 +13,7 @@ import type {
 	JsOriginRecord,
 	JsStatsAssetInfo,
 	JsStatsError,
-	JsStatsModule,
-	JsStatsWarning
+	JsStatsModule
 } from "@rspack/binding";
 import type { Chunk } from "../Chunk";
 import type { NormalizedStatsOptions } from "../Compilation";
@@ -609,7 +608,7 @@ const EXTRACT_ERROR: Record<
 	string,
 	(
 		object: StatsError,
-		error: JsStatsError | JsStatsWarning,
+		error: JsStatsError,
 		context: KnownStatsFactoryContext,
 		options: StatsOptions,
 		factory: StatsFactory

--- a/packages/rspack/src/stats/StatsFactory.ts
+++ b/packages/rspack/src/stats/StatsFactory.ts
@@ -10,8 +10,7 @@
 import type {
 	JsStats,
 	JsStatsCompilation,
-	JsStatsError,
-	JsStatsWarning
+	JsStatsError
 } from "@rspack/binding";
 import { HookMap, SyncBailHook, SyncWaterfallHook } from "@rspack/lite-tapable";
 
@@ -28,7 +27,7 @@ export type KnownStatsFactoryContext = {
 	// compilationAuxiliaryFileToChunks?: Map<string, Chunk[]> | undefined;
 	// runtime?: RuntimeSpec | undefined;
 	cachedGetErrors?: ((arg0: Compilation) => JsStatsError[]) | undefined;
-	cachedGetWarnings?: ((arg0: Compilation) => JsStatsWarning[]) | undefined;
+	cachedGetWarnings?: ((arg0: Compilation) => JsStatsError[]) | undefined;
 	getStatsCompilation: (compilation: Compilation) => JsStatsCompilation;
 	getInner: (compilation: Compilation) => JsStats;
 };

--- a/packages/rspack/src/stats/statsFactoryUtils.ts
+++ b/packages/rspack/src/stats/statsFactoryUtils.ts
@@ -339,7 +339,7 @@ export type SimpleExtractors = {
 	chunk: ExtractorsByOption<binding.JsStatsChunk, KnownStatsChunk>;
 	chunkOrigin: ExtractorsByOption<JsOriginRecord, StatsChunkOrigin>;
 	error: ExtractorsByOption<binding.JsStatsError, StatsError>;
-	warning: ExtractorsByOption<binding.JsStatsWarning, StatsError>;
+	warning: ExtractorsByOption<binding.JsStatsError, StatsError>;
 	moduleTraceItem: ExtractorsByOption<
 		binding.JsStatsModuleTrace,
 		StatsModuleTraceItem
@@ -725,7 +725,7 @@ export const errorsSpaceLimit = (errors: StatsError[], max: number) => {
 };
 
 export const warningFromStatsWarning = (
-	warning: binding.JsStatsWarning
+	warning: binding.JsStatsError
 ): Error => {
 	const res = new Error(warning.message);
 	res.name = warning.name || "StatsWarning";


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

JsStatsWarning and JsStateError have same data, just keep one.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
