### PR TITLE
feat(wasm): align panic handler with native

### DIFF
--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -428,6 +428,7 @@ const _: () = {
   static __CTOR: unsafe extern "C" fn() = init;
 
   unsafe extern "C" fn init() {
+    panic::install_panic_handler();
     let rt = tokio::runtime::Builder::new_multi_thread()
       .max_blocking_threads(1)
       .enable_all()


### PR DESCRIPTION
## Summary

I find that we can directly reuse the panic handler in wasm.

Before:
<img width="1212" alt="c093001e7a01f8d265c1cab54898e1f4" src="https://github.com/user-attachments/assets/318db068-6662-4177-a18b-a9a335cf871a" />


After:
<img width="1221" alt="496406d99c2e0df4d465f9fae8512773" src="https://github.com/user-attachments/assets/77c5fb65-30e5-43f6-9def-71197dab1fad" />


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
