### PR TITLE
chore: add release crates workflow

### DIFF
--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -21,8 +21,6 @@ jobs:
   rust_tests:
     name: Run Rust Tests
     uses: ./.github/workflows/reusable-rust-test.yml
-    with:
-      save-cache: ${{ github.ref_name == 'main' }}
 
   rust_test_miri:
     name: Rust test miri

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -18,112 +18,11 @@ on:
     tags-ignore:
       - "**"
 jobs:
-  check-changed:
-    runs-on: ubuntu-latest
-    name: Check Source Changed
-    outputs:
-      code_changed: ${{ steps.filter.outputs.code_changed == 'true' }}
-      document_changed: ${{ steps.filter.outputs.document_changed == 'true' }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: filter
-        with:
-          predicate-quantifier: "every"
-          filters: |
-            code_changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!website/**"
-            document_changed:
-              - "website/**"
-  rust_check:
-    name: Rust check
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS ||  '"ubuntu-22.04"') }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
-        with:
-          save-if: true
-          key: check
-
-      - name: Run Cargo Check
-        run: cargo check --workspace --all-targets --locked # Not using --release because it uses too much cache, and is also slow.
-
-      - name: Run Clippy
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: clippy
-          args: --workspace --all-targets --tests -- -D warnings
-
-      - name: Run rustfmt
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Install tapo
-        run: cargo install taplo-cli --locked
-      - name: Run toml format check
-        run: taplo format --check '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'
-
-  rust_unused_dependencies:
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    name: Check Rust Dependencies
-    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: ./.github/actions/rustup
-        with:
-          key: check
-
-      - name: Install cargo-deny
-        uses: taiki-e/install-action@726a5c9e4be3a589bab5f60185f0cdde7ed4498e # v2
-        with:
-          tool: cargo-deny@0.16
-      - name: Check licenses
-        run: cargo deny check license bans
-
-      - uses: cargo-bins/cargo-binstall@8aac5aa2bf0dfaa2863eccad9f43c68fe40e5ec8 # v1.14.1
-      - run: cargo binstall --no-confirm cargo-shear@1.1.12 --force
-      - run: cargo shear
-
-  rust_test:
-    name: Rust test
-    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
-        with:
-          save-if: true
-          key: test
-
-      # Compile test without debug info for reducing the CI cache size
-      - name: Change profile.test
-        shell: bash
-        run: |
-          echo '[profile.test]' >> Cargo.toml
-          echo 'debug = false' >> Cargo.toml
-      - name: Run rspack test
-        run: |
-          cargo test --workspace \
-            --exclude rspack_binding_api \
-            --exclude rspack_node \
-            --exclude rspack_binding_builder \
-            --exclude rspack_binding_builder_macros \
-            --exclude rspack_binding_builder_testing \
-            --exclude rspack_binding_build \
-            --exclude rspack_napi \
-            -- --nocapture
+  rust_tests:
+    name: Run Rust Tests
+    uses: ./.github/workflows/reusable-rust-test.yml
+    with:
+      save-cache: ${{ github.ref_name == 'main' }}
 
   rust_test_miri:
     name: Rust test miri
@@ -158,14 +57,14 @@ jobs:
     # When code changed, it will check if any of the test jobs failed.
     # When *only* doc changed, it will run as success directly
     name: Rust Test Required Check
-    needs: [rust_test, rust_check, check-changed]
+    needs: [rust_tests]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Log
-        run: echo ${{ join(needs.*.result, ',') }}
+        run: echo ${{ needs.*.result }}
       - name: Test check
-        if: ${{ needs.check-changed.outputs.code_changed == 'true' && join(needs.*.result, ',')!='success,success,success' }}
-        run: echo "Tess Failed" && exit 1
+        if: ${{ needs.rust_tests.result != 'success' }}
+        run: echo "Tests Failed" && exit 1
       - name: No check to Run test
         run: echo "Success"

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -9,17 +9,10 @@ on:
         required: true
         default: false
 
-permissions:
-  contents: write
-  # To publish packages with provenance
-  id-token: write
-
 jobs:
   rust_tests:
     name: Run Rust Tests
     uses: ./.github/workflows/reusable-rust-test.yml
-    with:
-      save-cache: true
 
   release_crates:
     name: Release Crates

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable-rust-test.yml
 
   release_crates:
+    environment: crate
     name: Release Crates
     runs-on: ubuntu-latest
     needs: [rust_tests]

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,0 +1,48 @@
+name: Release Crates
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        description: "DryRun release"
+        required: true
+        default: false
+
+permissions:
+  contents: write
+  # To publish packages with provenance
+  id-token: write
+
+jobs:
+  rust_tests:
+    name: Run Rust Tests
+    uses: ./.github/workflows/reusable-rust-test.yml
+    with:
+      save-cache: true
+
+  release_crates:
+    name: Release Crates
+    runs-on: ubuntu-latest
+    needs: [rust_tests]
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          save-if: true
+          key: release
+
+      - name: Install cargo-workspaces
+        run: cargo install cargo-workspaces --locked
+
+      - name: Publish Crates
+        run: |
+          ./x crate-publish ${{ inputs.dry_run && '--dry-run' || '' }} --token $CARGO_REGISTRY_TOKEN
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -8,6 +8,11 @@ on:
         description: "DryRun release"
         required: true
         default: false
+      push_tags:
+        type: boolean
+        description: "Push tags to repository"
+        required: true
+        default: true
 
 jobs:
   rust_tests:
@@ -36,6 +41,6 @@ jobs:
 
       - name: Publish Crates
         run: |
-          ./x crate-publish ${{ inputs.dry_run && '--dry-run' || '' }} --token $CARGO_REGISTRY_TOKEN
+          ./x crate-publish --token $CARGO_REGISTRY_TOKEN ${{ inputs.dry_run && '--dry-run' || '' }} ${{ inputs.push_tags && '--push-tags' || '' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -1,0 +1,132 @@
+name: Reusable Rust Test
+
+on:
+  workflow_call:
+    inputs:
+      save-cache:
+        description: "Whether to save cache"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  check-changed:
+    runs-on: ubuntu-latest
+    name: Check Source Changed
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code_changed == 'true' }}
+      document_changed: ${{ steps.filter.outputs.document_changed == 'true' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: filter
+        with:
+          filters: |
+            code_changed:
+              - "!**/*.md"
+              - "!**/*.mdx"
+              - "!website/**"
+            document_changed:
+              - "website/**"
+
+  rust_check:
+    name: Rust check
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS ||  '"ubuntu-22.04"') }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          save-if: ${{ inputs.save-cache }}
+          key: check
+
+      - name: Run Cargo Check
+        run: cargo check --workspace --all-targets --locked
+
+      - name: Run Clippy
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
+        with:
+          command: clippy
+          args: --workspace --all-targets --tests -- -D warnings
+
+      - name: Run rustfmt
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Install tapo
+        run: cargo install taplo-cli --locked
+      - name: Run toml format check
+        run: taplo format --check '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'
+
+  rust_unused_dependencies:
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    name: Check Rust Dependencies
+    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: ./.github/actions/rustup
+        with:
+          key: check
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@726a5c9e4be3a589bab5f60185f0cdde7ed4498e # v2
+        with:
+          tool: cargo-deny@0.16
+      - name: Check licenses
+        run: cargo deny check license bans
+
+      - uses: cargo-bins/cargo-binstall@8aac5aa2bf0dfaa2863eccad9f43c68fe40e5ec8 # v1.14.1
+      - run: cargo binstall --no-confirm cargo-shear@1.1.12 --force
+      - run: cargo shear
+
+  rust_test:
+    name: Rust test
+    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          save-if: ${{ inputs.save-cache }}
+          key: test
+
+      # Compile test without debug info for reducing the CI cache size
+      - name: Change profile.test
+        shell: bash
+        run: |
+          echo '[profile.test]' >> Cargo.toml
+          echo 'debug = false' >> Cargo.toml
+      - name: Run rspack test
+        run: |
+          cargo test --workspace \
+            --exclude rspack_binding_api \
+            --exclude rspack_node \
+            --exclude rspack_binding_builder \
+            --exclude rspack_binding_builder_macros \
+            --exclude rspack_binding_builder_testing \
+            --exclude rspack_binding_build \
+            --exclude rspack_napi \
+            -- --nocapture
+
+  test_required_check:
+    name: Rust Test Required Check
+    needs: [rust_test, rust_check, rust_unused_dependencies, check-changed]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log
+        run: echo ${{ join(needs.*.result, ',') }}
+      - name: Test check
+        if: ${{ needs.check-changed.outputs.code_changed == 'true' && join(needs.*.result, ',')!='success,success,success,success' }}
+        run: echo "Tests Failed" && exit 1
+      - name: No check to Run test
+        run: echo "Success"

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -2,12 +2,6 @@ name: Reusable Rust Test
 
 on:
   workflow_call:
-    inputs:
-      save-cache:
-        description: "Whether to save cache"
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   check-changed:
@@ -40,7 +34,7 @@ jobs:
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:
-          save-if: ${{ inputs.save-cache }}
+          save-if: true
           key: check
 
       - name: Run Cargo Check
@@ -96,7 +90,7 @@ jobs:
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:
-          save-if: ${{ inputs.save-cache }}
+          save-if: true
           key: test
 
       # Compile test without debug info for reducing the CI cache size

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_javascript_compiler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,23 +10,10 @@ edition       = "2021"
 homepage      = "https://rspack.rs/"
 license       = "MIT"
 repository    = "https://github.com/web-infra-dev/rspack"
+version       = "0.2.0"
 
 [workspace.metadata.cargo-shear]
-ignored = [
-  "swc",
-  "rspack_plugin_dynamic",
-  "rspack_builtin",
-  "rspack_loader",
-  "rspack_identifier",
-  "rspack_testing",
-  "rspack_plugin_emit",
-  "rspack_collection",
-  "rspack_deps_graph",
-  "rspack_plugin_mini_css_extract",
-  "rspack_binding",
-  "rspack_plugin_merge",
-  "rspack",
-]
+ignored = ["swc", "rspack"]
 [workspace.dependencies]
 anyhow             = { version = "1.0.95", features = ["backtrace"] }
 anymap             = { package = "anymap3", version = "1.0.1" }
@@ -122,21 +109,16 @@ rspack_binding_build                   = { version = "0.2.0", path = "crates/rsp
 rspack_binding_builder                 = { version = "0.2.0", path = "crates/rspack_binding_builder" }
 rspack_binding_builder_macros          = { version = "0.2.0", path = "crates/rspack_binding_builder_macros" }
 rspack_browserslist                    = { version = "0.2.0", path = "crates/rspack_browserslist" }
-rspack_builtin                         = { version = "0.2.0", path = "crates/rspack_builtin" }
 rspack_cacheable                       = { version = "0.2.0", path = "crates/rspack_cacheable" }
-rspack_collection                      = { version = "0.2.0", path = "crates/rspack_collection" }
 rspack_collections                     = { version = "0.2.0", path = "crates/rspack_collections" }
 rspack_core                            = { version = "0.2.0", path = "crates/rspack_core" }
-rspack_deps_graph                      = { version = "0.2.0", path = "crates/rspack_deps_graph" }
 rspack_error                           = { version = "0.2.0", path = "crates/rspack_error" }
 rspack_fs                              = { version = "0.2.0", path = "crates/rspack_fs" }
 rspack_futures                         = { version = "0.2.0", path = "crates/rspack_futures" }
 rspack_hash                            = { version = "0.2.0", path = "crates/rspack_hash" }
 rspack_hook                            = { version = "0.2.0", path = "crates/rspack_hook" }
-rspack_identifier                      = { version = "0.2.0", path = "crates/rspack_identifier" }
 rspack_ids                             = { version = "0.2.0", path = "crates/rspack_ids" }
-rspack_javascript_compiler             = { version = "*", path = "crates/rspack_javascript_compiler" }
-rspack_loader                          = { version = "0.2.0", path = "crates/rspack_loader" }
+rspack_javascript_compiler             = { version = "0.2.0", path = "crates/rspack_javascript_compiler" }
 rspack_loader_lightningcss             = { version = "0.2.0", path = "crates/rspack_loader_lightningcss" }
 rspack_loader_preact_refresh           = { version = "0.2.0", path = "crates/rspack_loader_preact_refresh" }
 rspack_loader_react_refresh            = { version = "0.2.0", path = "crates/rspack_loader_react_refresh" }
@@ -157,9 +139,7 @@ rspack_plugin_css                      = { version = "0.2.0", path = "crates/rsp
 rspack_plugin_css_chunking             = { version = "0.2.0", path = "crates/rspack_plugin_css_chunking" }
 rspack_plugin_devtool                  = { version = "0.2.0", path = "crates/rspack_plugin_devtool" }
 rspack_plugin_dll                      = { version = "0.2.0", path = "crates/rspack_plugin_dll" }
-rspack_plugin_dynamic                  = { version = "0.2.0", path = "crates/rspack_plugin_dynamic" }
 rspack_plugin_dynamic_entry            = { version = "0.2.0", path = "crates/rspack_plugin_dynamic_entry" }
-rspack_plugin_emit                     = { version = "0.2.0", path = "crates/rspack_plugin_emit" }
 rspack_plugin_ensure_chunk_conditions  = { version = "0.2.0", path = "crates/rspack_plugin_ensure_chunk_conditions" }
 rspack_plugin_entry                    = { version = "0.2.0", path = "crates/rspack_plugin_entry" }
 rspack_plugin_externals                = { version = "0.2.0", path = "crates/rspack_plugin_externals" }
@@ -173,10 +153,8 @@ rspack_plugin_lazy_compilation         = { version = "0.2.0", path = "crates/rsp
 rspack_plugin_library                  = { version = "0.2.0", path = "crates/rspack_plugin_library" }
 rspack_plugin_lightning_css_minimizer  = { version = "0.2.0", path = "crates/rspack_plugin_lightning_css_minimizer" }
 rspack_plugin_limit_chunk_count        = { version = "0.2.0", path = "crates/rspack_plugin_limit_chunk_count" }
-rspack_plugin_merge                    = { version = "0.2.0", path = "crates/rspack_plugin_merge" }
 rspack_plugin_merge_duplicate_chunks   = { version = "0.2.0", path = "crates/rspack_plugin_merge_duplicate_chunks" }
 rspack_plugin_mf                       = { version = "0.2.0", path = "crates/rspack_plugin_mf" }
-rspack_plugin_mini_css_extract         = { version = "0.2.0", path = "crates/rspack_plugin_mini_css_extract" }
 rspack_plugin_module_info_header       = { version = "0.2.0", path = "crates/rspack_plugin_module_info_header" }
 rspack_plugin_no_emit_on_errors        = { version = "0.2.0", path = "crates/rspack_plugin_no_emit_on_errors" }
 rspack_plugin_progress                 = { version = "0.2.0", path = "crates/rspack_plugin_progress" }
@@ -202,7 +180,6 @@ rspack_storage                         = { version = "0.2.0", path = "crates/rsp
 rspack_swc_plugin_import               = { version = "0.2.0", path = "crates/swc_plugin_import" }
 rspack_swc_plugin_ts_collector         = { version = "0.2.0", path = "crates/swc_plugin_ts_collector" }
 rspack_tasks                           = { version = "0.2.0", path = "crates/rspack_tasks" }
-rspack_testing                         = { version = "0.2.0", path = "crates/rspack_testing" }
 rspack_tracing                         = { version = "0.2.0", path = "crates/rspack_tracing" }
 rspack_tracing_perfetto                = { version = "0.2.0", path = "crates/rspack_tracing_perfetto" }
 rspack_util                            = { version = "0.2.0", path = "crates/rspack_util" }

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -5,7 +5,7 @@ license           = "MIT"
 name              = "rspack_node"
 publish           = false
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [features]
 full = ["loaders"]

--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_allocator"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/rspack_base64/Cargo.toml
+++ b/crates/rspack_base64/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_base64"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 base64-simd = { version = "0.8.0", features = ["alloc"] }

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -7,9 +7,8 @@ edition.workspace       = true
 homepage.workspace      = true
 license.workspace       = true
 name                    = "rspack_binding_api"
-publish                 = false
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [features]
 debug_tool    = ["rspack_core/debug_tool"]

--- a/crates/rspack_binding_build/Cargo.toml
+++ b/crates/rspack_binding_build/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace      = true
 license.workspace       = true
 name                    = "rspack_binding_build"
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [dependencies]
 napi-build = { workspace = true }

--- a/crates/rspack_binding_builder/Cargo.toml
+++ b/crates/rspack_binding_builder/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace      = true
 license.workspace       = true
 name                    = "rspack_binding_builder"
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [features]
 plugin = ["rspack_binding_api/plugin"]

--- a/crates/rspack_binding_builder_macros/Cargo.toml
+++ b/crates/rspack_binding_builder_macros/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace      = true
 license.workspace       = true
 name                    = "rspack_binding_builder_macros"
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [lib]
 proc-macro = true

--- a/crates/rspack_binding_builder_testing/Cargo.toml
+++ b/crates/rspack_binding_builder_testing/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace       = true
 name                    = "rspack_binding_builder_testing"
 publish                 = false
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/rspack_browserslist/Cargo.toml
+++ b/crates/rspack_browserslist/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace      = true
 license.workspace       = true
 name                    = "rspack_browserslist"
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [dependencies]
 browserslist-rs = { workspace = true }

--- a/crates/rspack_cacheable/Cargo.toml
+++ b/crates/rspack_cacheable/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_cacheable"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [features]
 noop = []

--- a/crates/rspack_cacheable_test/Cargo.toml
+++ b/crates/rspack_cacheable_test/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_cacheable_test"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_collections/Cargo.toml
+++ b/crates/rspack_collections/Cargo.toml
@@ -6,7 +6,7 @@ homepage.workspace      = true
 license                 = "MIT"
 name                    = "rspack_collections"
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [dependencies]
 dashmap          = { workspace = true }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_core"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 anymap = { workspace = true }

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_error"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_fs/Cargo.toml
+++ b/crates/rspack_fs/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_fs"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 async-trait  = { workspace = true }

--- a/crates/rspack_futures/Cargo.toml
+++ b/crates/rspack_futures/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_futures"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 rspack_tasks = { workspace = true }

--- a/crates/rspack_hash/Cargo.toml
+++ b/crates/rspack_hash/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_hash"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 md4              = "0.10.2"

--- a/crates/rspack_hook/Cargo.toml
+++ b/crates/rspack_hook/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_hook"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_ids/Cargo.toml
+++ b/crates/rspack_ids/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_ids"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_javascript_compiler/Cargo.toml
+++ b/crates/rspack_javascript_compiler/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace      = true
 license.workspace       = true
 name                    = "rspack_javascript_compiler"
 repository.workspace    = true
-version                 = "0.1.0"
+version.workspace       = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/rspack_loader_lightningcss/Cargo.toml
+++ b/crates/rspack_loader_lightningcss/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_loader_lightningcss"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_loader_preact_refresh/Cargo.toml
+++ b/crates/rspack_loader_preact_refresh/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_loader_preact_refresh"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_loader_react_refresh/Cargo.toml
+++ b/crates/rspack_loader_react_refresh/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_loader_react_refresh"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_loader_runner"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 [dependencies]
 anymap      = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/rspack_loader_swc/Cargo.toml
+++ b/crates/rspack_loader_swc/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_loader_swc"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [package.metadata.cargo-shear]
 ignored = ["swc"]
@@ -32,7 +32,7 @@ serde                          = { workspace = true, features = ["derive"] }
 serde_json                     = { workspace = true }
 swc                            = { workspace = true, features = ["manual-tokio-runtime"] }
 swc_config                     = { workspace = true }
-swc_core                       = { workspace = true, features = ["base", "ecma_ast", "common"] }
+swc_core                       = { workspace = true, features = ["base", "ecma_ast", "common", "ecma_preset_env"] }
 tokio                          = { workspace = true }
 tracing                        = { workspace = true }
 

--- a/crates/rspack_loader_testing/Cargo.toml
+++ b/crates/rspack_loader_testing/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_loader_testing"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_location/Cargo.toml
+++ b/crates/rspack_location/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_location"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 itoa             = { workspace = true }

--- a/crates/rspack_macros/Cargo.toml
+++ b/crates/rspack_macros/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_macros"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 [lib]
 proc-macro = true
 
@@ -13,4 +13,4 @@ proc-macro = true
 json        = { workspace = true }
 proc-macro2 = { workspace = true }
 quote       = { workspace = true }
-syn         = { workspace = true, features = ["full"] }
+syn         = { workspace = true, features = ["full", "visit-mut"] }

--- a/crates/rspack_macros_test/Cargo.toml
+++ b/crates/rspack_macros_test/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_macros_test"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 [dev-dependencies]
 async-trait        = { workspace = true }
 rspack_cacheable   = { workspace = true }

--- a/crates/rspack_napi/Cargo.toml
+++ b/crates/rspack_napi/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_napi"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_napi_macros/Cargo.toml
+++ b/crates/rspack_napi_macros/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_napi_macros"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 [lib]
 proc-macro = true
 

--- a/crates/rspack_paths/Cargo.toml
+++ b/crates/rspack_paths/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_paths"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_plugin_asset/Cargo.toml
+++ b/crates/rspack_plugin_asset/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_asset"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_banner/Cargo.toml
+++ b/crates/rspack_plugin_banner/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_banner"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_circular_dependencies/Cargo.toml
+++ b/crates/rspack_plugin_circular_dependencies/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_circular_dependencies"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 cow-utils          = { workspace = true }

--- a/crates/rspack_plugin_context_replacement/Cargo.toml
+++ b/crates/rspack_plugin_context_replacement/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_context_replacement"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 rspack_core  = { workspace = true }

--- a/crates/rspack_plugin_copy/Cargo.toml
+++ b/crates/rspack_plugin_copy/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_copy"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 [dependencies]
 dashmap      = { workspace = true }
 derive_more  = { workspace = true, features = ["debug"] }

--- a/crates/rspack_plugin_css/Cargo.toml
+++ b/crates/rspack_plugin_css/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_css"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 [dependencies]
 async-trait           = { workspace = true }
 cow-utils             = { workspace = true }

--- a/crates/rspack_plugin_css_chunking/Cargo.toml
+++ b/crates/rspack_plugin_css_chunking/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_css_chunking"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 indexmap           = { workspace = true }

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_devtool"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_dll/Cargo.toml
+++ b/crates/rspack_plugin_dll/Cargo.toml
@@ -5,7 +5,7 @@ homepage.workspace = true
 license            = "MIT"
 name               = "rspack_plugin_dll"
 repository         = "https://github.com/web-infra-dev/rspack"
-version            = "0.2.0"
+version.workspace  = true
 
 [dependencies]
 rspack_cacheable        = { workspace = true }

--- a/crates/rspack_plugin_dynamic_entry/Cargo.toml
+++ b/crates/rspack_plugin_dynamic_entry/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_dynamic_entry"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_ensure_chunk_conditions/Cargo.toml
+++ b/crates/rspack_plugin_ensure_chunk_conditions/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_ensure_chunk_conditions"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_entry/Cargo.toml
+++ b/crates/rspack_plugin_entry/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_entry"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_externals/Cargo.toml
+++ b/crates/rspack_plugin_externals/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_externals"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_extract_css/Cargo.toml
+++ b/crates/rspack_plugin_extract_css/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_extract_css"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 [dependencies]
 async-trait              = { workspace = true }
 cow-utils                = { workspace = true }

--- a/crates/rspack_plugin_hmr/Cargo.toml
+++ b/crates/rspack_plugin_hmr/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_hmr"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 rspack_cacheable         = { workspace = true }

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_html"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 [features]
 default = []
 

--- a/crates/rspack_plugin_ignore/Cargo.toml
+++ b/crates/rspack_plugin_ignore/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_ignore"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_javascript"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 [dependencies]
 anymap = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/rspack_plugin_json/Cargo.toml
+++ b/crates/rspack_plugin_json/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_json"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_lazy_compilation/Cargo.toml
+++ b/crates/rspack_plugin_lazy_compilation/Cargo.toml
@@ -6,7 +6,7 @@ homepage.workspace      = true
 license                 = "MIT"
 name                    = "rspack_plugin_lazy_compilation"
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/rspack_plugin_library/Cargo.toml
+++ b/crates/rspack_plugin_library/Cargo.toml
@@ -6,7 +6,7 @@ homepage.workspace      = true
 license                 = "MIT"
 name                    = "rspack_plugin_library"
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_lightning_css_minimizer"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_limit_chunk_count/Cargo.toml
+++ b/crates/rspack_plugin_limit_chunk_count/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_limit_chunk_count"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_merge_duplicate_chunks/Cargo.toml
+++ b/crates/rspack_plugin_merge_duplicate_chunks/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_merge_duplicate_chunks"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_mf/Cargo.toml
+++ b/crates/rspack_plugin_mf/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_mf"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_module_info_header/Cargo.toml
+++ b/crates/rspack_plugin_module_info_header/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_module_info_header"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_no_emit_on_errors/Cargo.toml
+++ b/crates/rspack_plugin_no_emit_on_errors/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_no_emit_on_errors"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_progress/Cargo.toml
+++ b/crates/rspack_plugin_progress/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_progress"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_real_content_hash"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_remove_duplicate_modules/Cargo.toml
+++ b/crates/rspack_plugin_remove_duplicate_modules/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_remove_duplicate_modules"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rspack_plugin_remove_empty_chunks/Cargo.toml
+++ b/crates/rspack_plugin_remove_empty_chunks/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_remove_empty_chunks"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_rsdoctor/Cargo.toml
+++ b/crates/rspack_plugin_rsdoctor/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_rsdoctor"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_rslib/Cargo.toml
+++ b/crates/rspack_plugin_rslib/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-description = "Rslib native plugin"
-edition     = "2021"
-license     = "MIT"
-name        = "rspack_plugin_rslib"
-repository  = "https://github.com/web-infra-dev/rspack"
-version     = "0.2.0"
+description       = "Rslib native plugin"
+edition           = "2021"
+license           = "MIT"
+name              = "rspack_plugin_rslib"
+repository        = "https://github.com/web-infra-dev/rspack"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_rstest/Cargo.toml
+++ b/crates/rspack_plugin_rstest/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-description = "Rstest native plugin"
-edition     = "2021"
-license     = "MIT"
-name        = "rspack_plugin_rstest"
-repository  = "https://github.com/web-infra-dev/rspack"
-version     = "0.2.0"
+description       = "Rstest native plugin"
+edition           = "2021"
+license           = "MIT"
+name              = "rspack_plugin_rstest"
+repository        = "https://github.com/web-infra-dev/rspack"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_runtime/Cargo.toml
+++ b/crates/rspack_plugin_runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_runtime"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_runtime_chunk/Cargo.toml
+++ b/crates/rspack_plugin_runtime_chunk/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_runtime_chunk"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_schemes"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_plugin_size_limits/Cargo.toml
+++ b/crates/rspack_plugin_size_limits/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_size_limits"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_split_chunks/Cargo.toml
+++ b/crates/rspack_plugin_split_chunks/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_split_chunks"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_plugin_sri/Cargo.toml
+++ b/crates/rspack_plugin_sri/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_sri"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_swc_js_minimizer"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_plugin_warn_sensitive_module/Cargo.toml
+++ b/crates/rspack_plugin_warn_sensitive_module/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_warn_sensitive_module"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 cow-utils          = { workspace = true }

--- a/crates/rspack_plugin_wasm/Cargo.toml
+++ b/crates/rspack_plugin_wasm/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_wasm"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_plugin_web_worker_template/Cargo.toml
+++ b/crates/rspack_plugin_web_worker_template/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_web_worker_template"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_plugin_worker/Cargo.toml
+++ b/crates/rspack_plugin_worker/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_plugin_worker"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_regex/Cargo.toml
+++ b/crates/rspack_regex/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_regex"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_storage/Cargo.toml
+++ b/crates/rspack_storage/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_storage"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rspack_tasks/Cargo.toml
+++ b/crates/rspack_tasks/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace      = true
 license.workspace       = true
 name                    = "rspack_tasks"
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [dependencies]
 tokio = { workspace = true }

--- a/crates/rspack_tracing/Cargo.toml
+++ b/crates/rspack_tracing/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_tracing"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/crates/rspack_tracing_perfetto/Cargo.toml
+++ b/crates/rspack_tracing_perfetto/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace      = true
 license.workspace       = true
 name                    = "rspack_tracing_perfetto"
 repository.workspace    = true
-version                 = "0.2.0"
+version.workspace       = true
 
 [dependencies]
 bytes               = { version = "*" }

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_util"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/swc_plugin_import/Cargo.toml
+++ b/crates/swc_plugin_import/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_swc_plugin_import"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 cow-utils  = { workspace = true }

--- a/crates/swc_plugin_ts_collector/Cargo.toml
+++ b/crates/swc_plugin_ts_collector/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license           = "MIT"
 name              = "rspack_swc_plugin_ts_collector"
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [dependencies]
 rustc-hash = { workspace = true }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -639,6 +639,9 @@ importers:
       '@actions/core':
         specifier: 1.11.1
         version: 1.11.1
+      '@iarna/toml':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
@@ -1698,6 +1701,9 @@ packages:
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
+
+  '@iarna/toml@3.0.0':
+    resolution: {integrity: sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -8762,6 +8768,8 @@ snapshots:
     optional: true
 
   '@fastify/busboy@2.1.1': {}
+
+  '@iarna/toml@3.0.0': {}
 
   '@iconify/types@2.0.0': {}
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -19,6 +19,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "glob":"^11.0.2",
     "semver": "^7.7.2",
-    "zx": "8.6.1"
+    "zx": "8.6.1",
+    "@iarna/toml": "^3.0.0"
   }
 }

--- a/scripts/release/cargo-version.mjs
+++ b/scripts/release/cargo-version.mjs
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import TOML from "@iarna/toml";
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+
+/**
+ * Read the version from the workspace root Cargo.toml file
+ * @returns {string} The version string from Cargo.toml
+ * @throws {Error} If the Cargo.toml file cannot be read or parsed
+ */
+export function getCargoVersion() {
+	try {
+		const cargoTomlPath = resolve(__dirname, "..", "..", "Cargo.toml");
+		const cargoTomlContent = readFileSync(cargoTomlPath, "utf8");
+		const parsed = TOML.parse(cargoTomlContent);
+
+		const version = parsed.workspace?.package?.version;
+
+		if (!version) {
+			throw new Error(
+				"No version found in Cargo.toml workspace.package or package section"
+			);
+		}
+
+		return version;
+	} catch (error) {
+		console.error("Error reading Cargo.toml:", error);
+		throw error;
+	}
+}
+
+/**
+ * Create a tag name with the specified prefix and version
+ * @param {string} version - The version string
+ * @param {string} prefix - The prefix for the tag (default: "crates@")
+ * @returns {string} The formatted tag name
+ */
+export function createTagName(version, prefix = "crates@") {
+	return `${prefix}${version}`;
+}

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -5,7 +5,7 @@ license           = "MIT"
 name              = "rspack_benchmark"
 publish           = false
 repository        = "https://github.com/web-infra-dev/rspack"
-version           = "0.2.0"
+version.workspace = true
 
 [features]
 codspeed = ["criterion2/codspeed"]

--- a/tasks/release-check/Cargo.toml
+++ b/tasks/release-check/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace       = true
 homepage.workspace      = true
 license.workspace       = true
 name                    = "release-check"
+publish                 = false
 repository.workspace    = true
 version                 = "0.1.0"
 

--- a/x.mjs
+++ b/x.mjs
@@ -247,6 +247,59 @@ program
 	});
 
 program
+	.command("crate-version")
+	.argument("<version>", "version")
+	.description("update crate version with cargo-workspaces")
+	.action(async version => {
+		await $`which cargo-workspaces || echo "cargo-workspaces is not installed, please install it first with \`cargo install cargo-workspaces\`"`;
+
+		const args = [
+			"workspaces",
+			"version",
+			"--exact", // Use exact version `=`
+			"--allow-branch",
+			"release-crates/*", // Specify which branches to allow from
+			"--no-git-push", // Do not push generated commit and tags to git remote
+			"--tag-prefix",
+			"crates@", // Customize tag prefix (can be empty)
+			"--force",
+			"rspack*", // Always include targeted crates matched by glob even when there are no changes
+			"--no-individual-tags", // Do not tag individual versions for crates
+			"--yes", // Skip confirmation prompt
+			"custom",
+			version // Increment versions by custom value (BUMP + CUSTOM args)
+		];
+
+		await $`cargo ${args}`;
+	});
+
+program
+	.command("crate-publish")
+	.description("publish crate with cargo-workspaces")
+	.option("--token <token>", "The token to use for accessing the registry")
+	.option("--dry-run", "Runs in dry-run mode")
+	.action(async options => {
+		await $`which cargo-workspaces || echo "cargo-workspaces is not installed, please install it first with \`cargo install cargo-workspaces\`"`;
+
+		const args = [
+			"workspaces",
+			"publish",
+			"--publish-as-is", // Publish crates from the current commit without versioning
+			"--locked" // Assert that `Cargo.lock` will remain unchanged
+		];
+
+		if (options.token) {
+			args.push("--token", options.token); // The token to use for accessing the registry
+		}
+
+		if (options.dryRun) {
+			args.push("--dry-run"); // Runs in dry-run mode
+		}
+
+		await $`cargo ${args}`;
+	});
+
+program
 	.command("version")
 	.argument("<bump_version>", "bump version to (major|minor|patch|snapshot)")
 	.option("--pre <string>", "pre-release tag")

--- a/x.mjs
+++ b/x.mjs
@@ -264,11 +264,9 @@ program
 			"--allow-branch",
 			"release-crates/*", // Specify which branches to allow from
 			"--no-git-push", // Do not push generated commit and tags to git remote
-			"--tag-prefix",
-			"crates@", // Customize tag prefix (can be empty)
+			"--no-git-tag", // Do not tag versions in git, we will tag them in `crate-publish`
 			"--force",
 			"rspack*", // Always include targeted crates matched by glob even when there are no changes
-			"--no-individual-tags", // Do not tag individual versions for crates
 			"--yes", // Skip confirmation prompt
 			"custom",
 			version // Increment versions by custom value (BUMP + CUSTOM args)


### PR DESCRIPTION
## Summary


This PR contains these changes:
- Unified package version to `workspace.package.version`: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table. 
- Added command `x crate-version` to create a version change
- Added command `x crate-publish` to publish crates
- Added CI workflow `release-crates` to publish crates by manual dispatch
- Refactored CI workflow `ci-rust` to a split workflow `reusable-rust-test` to support checking in workflow `release-crates`

`x crate-version` will use exact version to ensure the consistencies between each dependency. (for example `version = "=0.3.0"`)

All newly added x commands are internally driven by `cargo-workspaces`

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

[cargo-workspaces](https://github.com/pksunkara/cargo-workspaces?tab=readme-ov-file#publish)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
