### PR TITLE
fix: use AhoCorasick for real content hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,6 +5229,7 @@ dependencies = [
 name = "rspack_plugin_real_content_hash"
 version = "0.2.0"
 dependencies = [
+ "aho-corasick",
  "dashmap 6.1.0",
  "derive_more 1.0.0",
  "indexmap 2.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ignored = [
   "rspack",
 ]
 [workspace.dependencies]
+aho-corasick       = { version = "1.1.3" }
 anyhow             = { version = "1.0.95", features = ["backtrace"] }
 anymap             = { package = "anymap3", version = "1.0.1" }
 async-recursion    = { version = "1.1.1" }

--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -8,6 +8,7 @@ version           = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aho-corasick   = { workspace = true }
 dashmap        = { workspace = true }
 derive_more    = { workspace = true, features = ["debug"] }
 indexmap       = { workspace = true }

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -116,7 +116,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   hash_list.par_sort_by(|a, b| b.len().cmp(&a.len()));
   let hash_regexp = {
     RegexBuilder::new(&hash_list.join("|"))
-      .size_limit(std::usize::MAX)
+      .size_limit(usize::MAX)
       .build()
       .expect("Invalid regex")
   };


### PR DESCRIPTION
## Summary


fix #10798

~~The regex input source can be trust since those are content hash of the asset, which are generated by ourself, since this is only a check so should be fine to "skip" the check~~

AhoCorasick is perfect for the case

Can't found a good way to setup a test
<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
