### PR TITLE
perf: cache ordered modules ids while sorting chunks

### DIFF
--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -77,6 +77,8 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     })
     .collect::<UkeyMap<_, _>>();
 
+  let mut ordered_chunk_modules_cache = Default::default();
+
   assign_deterministic_ids(
     chunks,
     |chunk| {
@@ -93,6 +95,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
         &compilation.module_ids_artifact,
         a,
         b,
+        &mut ordered_chunk_modules_cache,
       )
     },
     |chunk, id| {

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -10,7 +10,7 @@ use itertools::{
   Itertools,
 };
 use regex::Regex;
-use rspack_collections::DatabaseItem;
+use rspack_collections::{DatabaseItem, UkeyMap};
 use rspack_core::{
   compare_runtime, BoxModule, Chunk, ChunkGraph, ChunkGroupByUkey, ChunkUkey, Compilation,
   ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact,
@@ -120,7 +120,7 @@ pub fn get_hash(s: impl Hash, length: usize) -> String {
 pub fn assign_deterministic_ids<T>(
   mut items: Vec<T>,
   get_name: impl Fn(&T) -> String,
-  comparator: impl Fn(&T, &T) -> Ordering,
+  comparator: impl FnMut(&T, &T) -> Ordering,
   mut assign_id: impl FnMut(&T, usize) -> bool,
   ranges: &[usize],
   expand_factor: usize,
@@ -356,25 +356,42 @@ pub fn assign_ascending_chunk_ids(chunks: &[ChunkUkey], compilation: &mut Compil
   }
 }
 
-fn compare_chunks_by_modules(
+fn compare_chunks_by_modules<'a>(
   chunk_graph: &ChunkGraph,
   module_graph: &ModuleGraph,
-  module_ids: &ModuleIdsArtifact,
+  module_ids: &'a ModuleIdsArtifact,
   a: &Chunk,
   b: &Chunk,
+  ordered_chunk_modules_cache: &mut UkeyMap<ChunkUkey, Vec<Option<&'a str>>>,
 ) -> Ordering {
-  let a_modules = chunk_graph.get_ordered_chunk_modules(&a.ukey(), module_graph);
-  let b_modules = chunk_graph.get_ordered_chunk_modules(&b.ukey(), module_graph);
+  let a_ukey = a.ukey();
+  let b_ukey = b.ukey();
+  let a_modules = ordered_chunk_modules_cache
+    .entry(a_ukey)
+    .or_insert_with(|| {
+      chunk_graph
+        .get_ordered_chunk_modules(&a_ukey, module_graph)
+        .into_iter()
+        .map(|m| ChunkGraph::get_module_id(module_ids, m.identifier()).map(|s| s.as_str()))
+        .collect_vec()
+    })
+    .clone();
+  let b_modules = ordered_chunk_modules_cache
+    .entry(b_ukey)
+    .or_insert_with(|| {
+      chunk_graph
+        .get_ordered_chunk_modules(&b_ukey, module_graph)
+        .into_iter()
+        .map(|m| ChunkGraph::get_module_id(module_ids, m.identifier()).map(|s| s.as_str()))
+        .collect_vec()
+    })
+    .clone();
 
-  let ordering = a_modules
+  a_modules
     .into_iter()
     .zip_longest(b_modules)
     .find_map(|pair| match pair {
-      Both(a_module, b_module) => {
-        let a_module_id =
-          ChunkGraph::get_module_id(module_ids, a_module.identifier()).map(|s| s.as_str());
-        let b_module_id =
-          ChunkGraph::get_module_id(module_ids, b_module.identifier()).map(|s| s.as_str());
+      Both(a_module_id, b_module_id) => {
         let ordering = compare_ids(
           a_module_id.unwrap_or_default(),
           b_module_id.unwrap_or_default(),
@@ -387,9 +404,7 @@ fn compare_chunks_by_modules(
       Left(_) => Some(Ordering::Greater),
       Right(_) => Some(Ordering::Less),
     })
-    .unwrap_or(Ordering::Equal);
-
-  ordering
+    .unwrap_or(Ordering::Equal)
 }
 
 fn compare_chunks_by_groups(
@@ -406,13 +421,14 @@ fn compare_chunks_by_groups(
   a_groups.cmp_by(b_groups, |a, b| a.cmp(&b))
 }
 
-pub fn compare_chunks_natural(
+pub fn compare_chunks_natural<'a>(
   chunk_graph: &ChunkGraph,
   module_graph: &ModuleGraph,
   chunk_group_by_ukey: &ChunkGroupByUkey,
-  module_ids: &ModuleIdsArtifact,
+  module_ids: &'a ModuleIdsArtifact,
   a: &Chunk,
   b: &Chunk,
+  ordered_chunk_modules_cache: &mut UkeyMap<ChunkUkey, Vec<Option<&'a str>>>,
 ) -> Ordering {
   let name_ordering = compare_ids(a.name().unwrap_or_default(), b.name().unwrap_or_default());
   if name_ordering != Ordering::Equal {
@@ -424,7 +440,14 @@ pub fn compare_chunks_natural(
     return runtime_ordering;
   }
 
-  let modules_ordering = compare_chunks_by_modules(chunk_graph, module_graph, module_ids, a, b);
+  let modules_ordering = compare_chunks_by_modules(
+    chunk_graph,
+    module_graph,
+    module_ids,
+    a,
+    b,
+    ordered_chunk_modules_cache,
+  );
   if modules_ordering != Ordering::Equal {
     return modules_ordering;
   }

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -98,6 +98,8 @@ fn assign_named_chunk_ids(
   let name_to_items_keys = name_to_items.keys().cloned().collect::<FxHashSet<_>>();
   let mut unnamed_items = vec![];
 
+  let mut ordered_chunk_modules_cache = Default::default();
+
   for (name, mut items) in name_to_items {
     if name.is_empty() {
       for item in items {
@@ -123,6 +125,7 @@ fn assign_named_chunk_ids(
           &compilation.module_ids_artifact,
           a,
           b,
+          &mut ordered_chunk_modules_cache,
         )
       });
       let mut i = 0;
@@ -155,6 +158,7 @@ fn assign_named_chunk_ids(
       &compilation.module_ids_artifact,
       a,
       b,
+      &mut ordered_chunk_modules_cache,
     )
   });
   unnamed_items

--- a/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
@@ -28,6 +28,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
   let module_ids = &compilation.module_ids_artifact;
   let chunk_graph = &compilation.chunk_graph;
   let module_graph = &compilation.get_module_graph();
+  let mut ordered_chunk_modules_cache = Default::default();
 
   let chunks = compilation
     .chunk_by_ukey
@@ -41,6 +42,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
         module_ids,
         a,
         b,
+        &mut ordered_chunk_modules_cache,
       )
     })
     .map(|chunk| chunk.ukey())

--- a/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
@@ -62,6 +62,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<
     occurs_in_initial_chunks_map.insert(chunk.ukey(), occurs);
   }
 
+  let mut ordered_chunk_modules_cache = Default::default();
   let chunks = compilation
     .chunk_by_ukey
     .values()
@@ -88,6 +89,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<
         &compilation.module_ids_artifact,
         a,
         b,
+        &mut ordered_chunk_modules_cache,
       )
     })
     .map(|chunk| chunk.ukey())


### PR DESCRIPTION
## Summary

The comparator will be called too many times, and then the `get_orded_chunk_modules()` will also be called many times with the same chunk ukey. So just add them too cache.

Before:
![image](https://github.com/user-attachments/assets/378b0288-2537-4b85-83d4-e3168465b055)


After:
![image](https://github.com/user-attachments/assets/1ddbe270-2de4-4e73-a410-6b40fa669029)



## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
