### PR TITLE
fix: clear compiled modules from active modules

### DIFF
--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -209,7 +209,7 @@ impl Module for LazyCompilationProxyModule {
     );
 
     let keep_active = format!(
-      "var dispose = client.keepAlive({{ data: data, active: {}, module: module, onError: onError }})",
+      "var dispose = client.activate({{ data: data, active: {}, module: module, onError: onError }})",
       block.is_some()
     );
 
@@ -242,12 +242,10 @@ impl Module for LazyCompilationProxyModule {
         if (module.hot) {{
           module.hot.accept();
           module.hot.accept({}, function() {{ module.hot.invalidate(); }});
-          module.hot.dispose(function(data) {{ delete data.resolveSelf; dispose(data); }});
+          module.hot.dispose(function(data) {{ delete data.resolveSelf; }});
           if (module.hot.data && module.hot.data.resolveSelf)
             module.hot.data.resolveSelf(module.exports);
         }}
-        function onError() {{ /* ignore */ }}
-        {}
         ",
         module_namespace_promise(
           &mut template_ctx,
@@ -261,7 +259,6 @@ impl Module for LazyCompilationProxyModule {
           ChunkGraph::get_module_id(&compilation.module_ids_artifact, *module)
             .expect("should have module id")
         ),
-        keep_active,
       ))
     } else {
       RawStringSource::from(format!(

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
@@ -10,7 +10,7 @@
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 69
 - Update: main.LAST_HASH.hot-update.js, size: 582
-- Update: modules_demo_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1430
+- Update: modules_demo_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1268
 
 ## Manifest
 
@@ -84,12 +84,10 @@ var data = __LAZY_ID__
         if (module.hot) {
           module.hot.accept();
           module.hot.accept("./modules/demo.js", function() { module.hot.invalidate(); });
-          module.hot.dispose(function(data) { delete data.resolveSelf; dispose(data); });
+          module.hot.dispose(function(data) { delete data.resolveSelf; });
           if (module.hot.data && module.hot.data.resolveSelf)
             module.hot.data.resolveSelf(module.exports);
         }
-        function onError() { /* ignore */ }
-        var dispose = client.keepAlive({ data: data, active: true, module: module, onError: onError })
         
 
 }),

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
@@ -11,7 +11,7 @@
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 71
 - Update: main.LAST_HASH.hot-update.js, size: 582
-- Update: modules_module_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1448
+- Update: modules_module_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1286
 
 ## Manifest
 
@@ -85,12 +85,10 @@ var data = __LAZY_ID__
         if (module.hot) {
           module.hot.accept();
           module.hot.accept("./modules/module.js", function() { module.hot.invalidate(); });
-          module.hot.dispose(function(data) { delete data.resolveSelf; dispose(data); });
+          module.hot.dispose(function(data) { delete data.resolveSelf; });
           if (module.hot.data && module.hot.data.resolveSelf)
             module.hot.data.resolveSelf(module.exports);
         }
-        function onError() { /* ignore */ }
-        var dispose = client.keepAlive({ data: data, active: true, module: module, onError: onError })
         
 
 }),

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/module-test/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/module-test/__snapshots__/web/1.snap.txt
@@ -10,7 +10,7 @@
 - Bundle: moduleB_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 64
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: moduleA_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1392
+- Update: moduleA_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1230
 
 ## Manifest
 
@@ -69,12 +69,10 @@ var data = "0"
         if (module.hot) {
           module.hot.accept();
           module.hot.accept("./moduleA.js", function() { module.hot.invalidate(); });
-          module.hot.dispose(function(data) { delete data.resolveSelf; dispose(data); });
+          module.hot.dispose(function(data) { delete data.resolveSelf; });
           if (module.hot.data && module.hot.data.resolveSelf)
             module.hot.data.resolveSelf(module.exports);
         }
-        function onError() { /* ignore */ }
-        var dispose = client.keepAlive({ data: data, active: true, module: module, onError: onError })
         
 
 }),

--- a/packages/rspack/hot/lazy-compilation-node.js
+++ b/packages/rspack/hot/lazy-compilation-node.js
@@ -8,7 +8,7 @@ var urlBase = decodeURIComponent(__resourceQuery.slice(1));
  * @param {{ data: string, onError: (err: Error) => void, active: boolean, module: module }} options options
  * @returns {() => void} function to destroy response
  */
-exports.keepAlive = function (options) {
+exports.activate = function (options) {
 	var data = options.data;
 	var onError = options.onError;
 	var active = options.active;


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

When modules are compiled, they should be removed from the compiled map, otherwise it will be passed to server in next compiling, causing the url get longer by time

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
