### PR TITLE
chore(workflow): skip ecosystem CI and benchmark in forked repos

### DIFF
--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   build:
     name: Test Linux
+    if: github.repository == 'web-infra-dev/rspack'
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: x86_64-unknown-linux-gnu
@@ -38,6 +39,7 @@ jobs:
       prefer_docker: false
 
   create-comment:
+    if: github.repository == 'web-infra-dev/rspack'
     runs-on: ubuntu-latest
     outputs:
       comment-id: ${{ steps.create-comment.outputs.result }}
@@ -71,6 +73,7 @@ jobs:
             return comment.id
 
   bench:
+    if: github.repository == 'web-infra-dev/rspack'
     needs: [build]
     runs-on: [self-hosted, benchmark]
     outputs:
@@ -129,9 +132,9 @@ jobs:
           RSPACK_DIR="$RSPACK_DIR" GITHUB_ACTOR=x-access-token node bin/upload.js ${{ secrets.PERF_DATA_TOKEN }} ${{ github.sha }}
 
   comment-compare-results:
+    if: github.repository == 'web-infra-dev/rspack' && !cancelled()
     runs-on: ubuntu-latest
     needs: [create-comment, bench]
-    if: ${{ !cancelled() }}
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -47,10 +47,12 @@ permissions:
 jobs:
   get-runner-labels:
     name: Get Runner Labels
+    if: github.repository == 'web-infra-dev/rspack'
     uses: ./.github/workflows/get-runner-labels.yml
 
   build:
     name: Test Linux
+    if: github.repository == 'web-infra-dev/rspack'
     needs: [get-runner-labels]
     uses: ./.github/workflows/reusable-build.yml
     with:
@@ -61,6 +63,7 @@ jobs:
       bench: false
 
   create-comment:
+    if: github.repository == 'web-infra-dev/rspack'
     runs-on: ubuntu-latest
     outputs:
       comment-id: ${{ steps.create-comment.outputs.result }}
@@ -94,6 +97,7 @@ jobs:
             return comment.id
 
   calculate-eco-ci-suite:
+    if: github.repository == 'web-infra-dev/rspack'
     runs-on: ubuntu-latest
     outputs:
       suites: ${{ steps.calculate.outputs.result }}
@@ -126,6 +130,7 @@ jobs:
             })
 
   eco-ci:
+    if: github.repository == 'web-infra-dev/rspack'
     needs: [build, calculate-eco-ci-suite]
     strategy:
       matrix: ${{fromJson(needs.calculate-eco-ci-suite.outputs.suites)}}
@@ -199,9 +204,9 @@ jobs:
           path: ${{ matrix.suite }}.json
 
   comment-compare-results:
+    if: github.repository == 'web-infra-dev/rspack' && !cancelled()
     runs-on: ubuntu-latest
     needs: [create-comment, eco-ci]
-    if: ${{ !cancelled() }}
     steps:
       - name: Download Result
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

Skip the ecosystem CI and ecosystem benchmark in forked repos. These can only be run on the main repo.

## Related links

- Currently, there are some failed notificaiton on the forked repo, such as: https://github.com/mantou132/rspack/commit/7a9febeb254885269f1daee3165c59923f00125f#commitcomment-161535990

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
