### PR TITLE
fix: handle zod type error when skipLibCheck is false

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@ast-grep/napi": "^0.37.0",
+    "@rsbuild/core": "^1.4.4",
     "@rslib/core": "0.10.0",
     "@swc/core": "1.12.0",
     "@swc/types": "0.1.22",

--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -25,8 +25,8 @@ import type {
 	UmdConfig
 } from "@swc/types";
 import type { Assumptions } from "@swc/types/assumptions";
-import * as z from "zod/v4";
 import { numberOrInfinity } from "../../config/utils";
+import { z } from "../../config/zod";
 import { memoize } from "../../util/memoize";
 import type { CollectTypeScriptInfoOptions } from "./collectTypeScriptInfo";
 import type { PluginImportOptions } from "./pluginImport";

--- a/packages/rspack/src/builtin-plugin/IgnorePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/IgnorePlugin.ts
@@ -2,9 +2,8 @@ import {
 	BuiltinPluginName,
 	type RawIgnorePluginOptions
 } from "@rspack/binding";
-import * as z from "zod/v4";
-
 import { anyFunction } from "../config/utils";
+import { z } from "../config/zod";
 import { memoize } from "../util/memoize";
 import { validate } from "../util/validate";
 import { create } from "./base";

--- a/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
@@ -25,9 +25,9 @@ import {
 	RegisterJsTapKind
 } from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
-import * as z from "zod/v4";
 import { type Compilation, checkCompilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
+import { z } from "../config/zod";
 import type { CreatePartialRegisters } from "../taps/types";
 import { memoize } from "../util/memoize";
 import { validate } from "../util/validate";

--- a/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
@@ -8,10 +8,10 @@ import {
 	type RspackError
 } from "@rspack/binding";
 import type { AsyncSeriesWaterfallHook } from "@rspack/lite-tapable";
-import * as z from "zod/v4";
 import type { Compilation } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import type { CrossOriginLoading } from "../config/types";
+import { z } from "../config/zod";
 import { memoize } from "../util/memoize";
 import { validate } from "../util/validate";
 import { create } from "./base";

--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -1,6 +1,6 @@
-import * as z from "zod/v4";
 import { Compilation } from "../../Compilation";
 import { anyFunction } from "../../config/utils";
+import { z } from "../../config/zod";
 import { memoize } from "../../util/memoize";
 import { validate } from "../../util/validate";
 

--- a/packages/rspack/src/config/utils.ts
+++ b/packages/rspack/src/config/utils.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/v4";
+import { z } from "./zod";
 
 // Zod v4 doesn't support Infinity, so we need to use a custom type
 // See: https://github.com/colinhacks/zod/issues/4721

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -10,6 +10,8 @@ z.config({
 	jitless: true
 });
 
+export { z };
+
 export const getExternalsTypeSchema = memoize(
 	() =>
 		z.enum([

--- a/packages/rspack/src/lib/DllPlugin.ts
+++ b/packages/rspack/src/lib/DllPlugin.ts
@@ -8,11 +8,11 @@
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
 
-import * as z from "zod/v4";
 import type { Compiler } from "../Compiler";
 import { LibManifestPlugin } from "../builtin-plugin";
 import { DllEntryPlugin } from "../builtin-plugin/DllEntryPlugin";
 import { FlagAllModulesAsUsedPlugin } from "../builtin-plugin/FlagAllModulesAsUsedPlugin";
+import { z } from "../config/zod";
 import { memoize } from "../util/memoize";
 import { validate } from "../util/validate";
 

--- a/packages/rspack/src/lib/DllReferencePlugin.ts
+++ b/packages/rspack/src/lib/DllReferencePlugin.ts
@@ -9,11 +9,11 @@
  */
 
 import type { JsBuildMeta } from "@rspack/binding";
-import * as z from "zod/v4";
 import type { CompilationParams } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import { DllReferenceAgencyPlugin } from "../builtin-plugin";
 import { numberOrInfinity } from "../config/utils";
+import { z } from "../config/zod";
 import { makePathsRelative } from "../util/identifier";
 import { memoize } from "../util/memoize";
 import { validate } from "../util/validate";

--- a/packages/rspack/src/util/validate.ts
+++ b/packages/rspack/src/util/validate.ts
@@ -1,5 +1,5 @@
 import { createErrorMap, fromZodError } from "zod-validation-error/v4";
-import type { z } from "zod/v4";
+import type { z } from "../config/zod";
 
 export class ValidationError extends Error {
 	constructor(message: string) {

--- a/packages/rspack/tsconfig.json
+++ b/packages/rspack/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "resolveJsonModule": true,
     "emitDeclarationOnly": true,
     "paths": {
       "watchpack": ["./compiled/watchpack"],
@@ -14,9 +13,5 @@
       "tinypool": ["./compiled/tinypool"]
     }
   },
-  "include": ["src", "src/**/*.json"],
-  "exclude": ["src/config/schema.check.js", "src/container/default.runtime.js"],
-  "ts-node": {
-    "transpileOnly": true
-  }
+  "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,9 @@ importers:
       '@ast-grep/napi':
         specifier: ^0.37.0
         version: 0.37.0
+      '@rsbuild/core':
+        specifier: ^1.4.4
+        version: 1.4.4
       '@rslib/core':
         specifier: 0.10.0
         version: 0.10.0(@microsoft/api-extractor@7.52.8(@types/node@20.19.0))(typescript@5.8.3)
@@ -798,7 +801,7 @@ importers:
         version: 3.43.0
       css-loader:
         specifier: ^7.1.2
-        version: 7.1.2(@rspack/core@1.4.3(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17)))
+        version: 7.1.2(@rspack/core@1.4.4(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17)))
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -983,7 +986,7 @@ importers:
         version: 1.9.4
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.3)
+        version: 1.3.2(@rsbuild/core@1.4.4)
       '@rspress/plugin-algolia':
         specifier: 2.0.0-beta.19
         version: 2.0.0-beta.19(@algolia/client-search@5.25.0)(@rspress/runtime@2.0.0-beta.19)(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.3)
@@ -1016,10 +1019,10 @@ importers:
         version: 3.6.2
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.4.3)
+        version: 1.0.3(@rsbuild/core@1.4.4)
       rsbuild-plugin-open-graph:
         specifier: 1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.3)
+        version: 1.0.2(@rsbuild/core@1.4.4)
       rspress:
         specifier: 2.0.0-beta.19
         version: 2.0.0-beta.19(@types/react@19.1.7)(acorn@8.15.0)(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17)))
@@ -2528,8 +2531,8 @@ packages:
     engines: {node: '>=16.10.0'}
     hasBin: true
 
-  '@rsbuild/core@1.4.3':
-    resolution: {integrity: sha512-97vmVaOXUxID85cVSDFHLFmDfeJTR4SoOHbn7kknkEeZFg3wHlDYhx+lbQPOZf+toHOm8d1w1LlunxVkCAdHLg==}
+  '@rsbuild/core@1.4.4':
+    resolution: {integrity: sha512-JN/AUT9yN4JkbVLAPnrWu9q5Q0EQVrzDzlK5jHT/nbWWA4z1HYWFSdI1iuK8+nwfQ4zEOQalVv1+Jlk+qV7HoQ==}
     engines: {node: '>=16.10.0'}
     hasBin: true
 
@@ -2566,8 +2569,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.4.3':
-    resolution: {integrity: sha512-YwPYWvo+WhdQgb76ZnH6m4sXClcRJJ5UB3Qj7xABKDQNJ62MaczWHEPfh2LM4iSJ1IWMo9dW4yeEXa7U9aE94w==}
+  '@rspack/binding-darwin-arm64@1.4.4':
+    resolution: {integrity: sha512-r5Vr1DcKXemYfJhNabRTpRonZvzyRq8H7ggDJqxWpIR+SGmtZ62hErSic8DBFeEF5k8SZc5in6L4YXUZgYaibg==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2581,8 +2584,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.4.3':
-    resolution: {integrity: sha512-aynWl0uCfIVfzDiZtSA6l75U8zyIc0UBa0p/ZETHrIQlBHPKDmxVIOlpbJWprilw5i4a3nWbadKCzvb0Gb92iA==}
+  '@rspack/binding-darwin-x64@1.4.4':
+    resolution: {integrity: sha512-fyHjrug2xT3CU3nqzviL41I1PfJOv2/5T1+TdME8GzM5grWI1XFnCcXXocKhGuEpv6xHFdRZz9x7C9k7uQ4UCw==}
     cpu: [x64]
     os: [darwin]
 
@@ -2596,8 +2599,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.4.3':
-    resolution: {integrity: sha512-x6OlSqt4esxj5hAZq+aPSG1pbNtjLPDw3cnQlfqv04kJO6MOwrH+j4DPc+/Q2qKdFzLw807eyvKd3O9leu+iPg==}
+  '@rspack/binding-linux-arm64-gnu@1.4.4':
+    resolution: {integrity: sha512-8UDmKFUgrt4w/sBHZtixBppAC+ObOwRbm3oSMhZMn+T3+BhBSDCUXhbGQDiKc7WG04cxyGhvwIocBckkdb1rSg==}
     cpu: [arm64]
     os: [linux]
 
@@ -2611,8 +2614,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.4.3':
-    resolution: {integrity: sha512-6aCa76fW8WlSBc0bJKXLSql79NoFlua4b+59XN1kZln+yLstgicFiJSvAnw+9U7mrl7IP9UmVWTw3JBnHUtw4A==}
+  '@rspack/binding-linux-arm64-musl@1.4.4':
+    resolution: {integrity: sha512-Wtf9WR6VXYa1Y+uTa5uaTBcTX0eVzyM6d/0pLS6qJgwLYN4wOvi0VcOctLkUNaMpA72TsmGOnls8QBsDPLZRtg==}
     cpu: [arm64]
     os: [linux]
 
@@ -2626,8 +2629,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.4.3':
-    resolution: {integrity: sha512-N2kUPPVjkky9KlK/a1QXvRivtTS0RJ1ZGRfkacycOTcKwB3nvrz6IqYOFhIst9Wjed677KELKP5zZv/VImfY7Q==}
+  '@rspack/binding-linux-x64-gnu@1.4.4':
+    resolution: {integrity: sha512-vc0e6ZkXJIVwHXDfkxFb62e/OpX0KuekjvD+rzs7A122Nt7R37YSilqGpZXWDlqlRjJlBxA73ORakJORsR3oww==}
     cpu: [x64]
     os: [linux]
 
@@ -2641,8 +2644,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.4.3':
-    resolution: {integrity: sha512-SAzoCLCHQMFoQ41i9APIfE2ndv3JT5LkPvl6V1FmiFRgZwH0jVKpIybulZtgLNgNh4nFIYES0+2XK8dZ28YR5g==}
+  '@rspack/binding-linux-x64-musl@1.4.4':
+    resolution: {integrity: sha512-PL5iL2CbdDZwI6MBOfTQnryqT9esjPDZP6a2bxbT+IiyWyBoZjCXnjwYOB5dvIL4Hyrma8XJFwT5dAlFvGrzyQ==}
     cpu: [x64]
     os: [linux]
 
@@ -2650,8 +2653,8 @@ packages:
     resolution: {integrity: sha512-3WvfHY7NvzORek3FcQWLI/B8wQ7NZe0e0Bub9GyLNVxe5Bi+dxnSzEg6E7VsjbUzKnYufJA0hDKbEJ2qCMvpdw==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@1.4.3':
-    resolution: {integrity: sha512-jrakte9rA3a+VfRqm4Qa3o+MI4lfYZGqQTdpWyC9GLi3USxyaU55hGYdd/TtGvDY82KvJfGTV8o+LRn0Pl77OA==}
+  '@rspack/binding-wasm32-wasi@1.4.4':
+    resolution: {integrity: sha512-/+uq1R+xzXknBDbcZWR0sbQwasZ2maPDSJ1rsnlBG6lQc447HbuwwZqjMpD8+TjpNunAS1E1mHuxql5IbL5UKg==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.4.0-beta.0':
@@ -2664,8 +2667,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.4.3':
-    resolution: {integrity: sha512-Tho05w0sUWKe7avQYYGwaL5xNDFRav4A4Su5DTCC6mQeokbndg0Lk7jtyYIp9ZHCStUOojR4PY/4zG918ky95w==}
+  '@rspack/binding-win32-arm64-msvc@1.4.4':
+    resolution: {integrity: sha512-8advF9WPaq4HndjeYIsUX7GNPMqJ8vTalZLdF1bJ0c1PXyp3igyG6ruJeJ4vsXT3/HmVy1AmK3FzHRmy7AT5Mw==}
     cpu: [arm64]
     os: [win32]
 
@@ -2679,8 +2682,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.4.3':
-    resolution: {integrity: sha512-Hc8tC30FvW5h8r3wW7C0pqY5b5BlMk0Y7vi03Zt60r8WqmeNINvAsjzyifHikD4S4lyQQO4CGXZOzSBWUcYesw==}
+  '@rspack/binding-win32-ia32-msvc@1.4.4':
+    resolution: {integrity: sha512-I3BqOEu8gHoMvxECdHS+a+fPMipzO3yrI+0uBjzeJY7UpkD9hjNH6MU2xTI8FxUDY2XYNbJv1EJkXd72VzSpaA==}
     cpu: [ia32]
     os: [win32]
 
@@ -2694,8 +2697,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.4.3':
-    resolution: {integrity: sha512-D+I6fl6Phq8+VElvf3sVTh+bqatk9Rjtgh4l2D7elIUkBguT5nAY3SX5wE/7iYnSdOBbP5mghU4exOG7NYqJYA==}
+  '@rspack/binding-win32-x64-msvc@1.4.4':
+    resolution: {integrity: sha512-8Ju4ZSbBS6VLcgf53OTJcfMWYIR0pHSdHhfYZC16Vb5weWa89Hh0v3ClA0PqSt1hnAAFCMMOM9CcAPwk8P3gIg==}
     cpu: [x64]
     os: [win32]
 
@@ -2705,8 +2708,8 @@ packages:
   '@rspack/binding@1.4.2':
     resolution: {integrity: sha512-NdTLlA20ufD0thFvDIwwPk+bX9yo3TDE4XjfvZYbwFyYvBgqJOWQflnbwLgvSTck0MSTiOqWIqpR88ymAvWTqg==}
 
-  '@rspack/binding@1.4.3':
-    resolution: {integrity: sha512-bDKAruEbEdlozi8NkLrC0H+e/CfWuQgxi08akofLBp227Nd/n0yLF4VWaUkZr4lSbMJQBxXPattryDijDnoLwA==}
+  '@rspack/binding@1.4.4':
+    resolution: {integrity: sha512-Z4Ir04eLbq5BwkSF74h/dBtkbTpcGrMtmi5b6YqMvFtGrT12R6K3P58hnXmrxqypKncbW4rI0JJOYkQa+gMteg==}
 
   '@rspack/core@1.4.0-beta.0':
     resolution: {integrity: sha512-rFDM8Un/ap+05omHlTgMGpIJnXiHXnkt9qNKrnWVgvIprngrusWMb/SWrLDxKZeC7MVxuXBfTHMyMpyKIpjSkw==}
@@ -2726,8 +2729,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@1.4.3':
-    resolution: {integrity: sha512-zWdAXleiYZ+SlappgDbjsoBWIQzyYJX5WwPXmoQnHJPb4K+zmjCL8MRfdIMIxXcg5IiQsBfiWY/lYhaZ2Jc0EA==}
+  '@rspack/core@1.4.4':
+    resolution: {integrity: sha512-TqEUHXbG5zNQ72djFfEg2A1/RoQF57QUhBU22ZLspbr3GcWmHou6noAa6i7lMn47RE4LWVnNyOCyMZyjXrrvYA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -9619,7 +9622,7 @@ snapshots:
       core-js: 3.43.0
       jiti: 2.4.2
 
-  '@rsbuild/core@1.4.3':
+  '@rsbuild/core@1.4.4':
     dependencies:
       '@rspack/core': 1.4.2(@swc/helpers@0.5.17)
       '@rspack/lite-tapable': 1.0.1
@@ -9627,17 +9630,17 @@ snapshots:
       core-js: 3.43.0
       jiti: 2.4.2
 
-  '@rsbuild/plugin-react@1.3.2(@rsbuild/core@1.4.3)':
+  '@rsbuild/plugin-react@1.3.2(@rsbuild/core@1.4.4)':
     dependencies:
-      '@rsbuild/core': 1.4.3
+      '@rsbuild/core': 1.4.4
       '@rspack/plugin-react-refresh': 1.4.3(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.3.2(@rsbuild/core@1.4.3)':
+  '@rsbuild/plugin-sass@1.3.2(@rsbuild/core@1.4.4)':
     dependencies:
-      '@rsbuild/core': 1.4.3
+      '@rsbuild/core': 1.4.4
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.4
@@ -9659,7 +9662,7 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.4.2':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.4.3':
+  '@rspack/binding-darwin-arm64@1.4.4':
     optional: true
 
   '@rspack/binding-darwin-x64@1.4.0-beta.0':
@@ -9668,7 +9671,7 @@ snapshots:
   '@rspack/binding-darwin-x64@1.4.2':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.4.3':
+  '@rspack/binding-darwin-x64@1.4.4':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.4.0-beta.0':
@@ -9677,7 +9680,7 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.4.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.4.3':
+  '@rspack/binding-linux-arm64-gnu@1.4.4':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.4.0-beta.0':
@@ -9686,7 +9689,7 @@ snapshots:
   '@rspack/binding-linux-arm64-musl@1.4.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.4.3':
+  '@rspack/binding-linux-arm64-musl@1.4.4':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.4.0-beta.0':
@@ -9695,7 +9698,7 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.4.2':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.4.3':
+  '@rspack/binding-linux-x64-gnu@1.4.4':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.4.0-beta.0':
@@ -9704,7 +9707,7 @@ snapshots:
   '@rspack/binding-linux-x64-musl@1.4.2':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.4.3':
+  '@rspack/binding-linux-x64-musl@1.4.4':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.4.2':
@@ -9712,7 +9715,7 @@ snapshots:
       '@napi-rs/wasm-runtime': 0.2.11
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.4.3':
+  '@rspack/binding-wasm32-wasi@1.4.4':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.11
     optional: true
@@ -9723,7 +9726,7 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.4.2':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.4.3':
+  '@rspack/binding-win32-arm64-msvc@1.4.4':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.4.0-beta.0':
@@ -9732,7 +9735,7 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@1.4.2':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.4.3':
+  '@rspack/binding-win32-ia32-msvc@1.4.4':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.4.0-beta.0':
@@ -9741,7 +9744,7 @@ snapshots:
   '@rspack/binding-win32-x64-msvc@1.4.2':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.4.3':
+  '@rspack/binding-win32-x64-msvc@1.4.4':
     optional: true
 
   '@rspack/binding@1.4.0-beta.0':
@@ -9769,18 +9772,18 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.4.2
       '@rspack/binding-win32-x64-msvc': 1.4.2
 
-  '@rspack/binding@1.4.3':
+  '@rspack/binding@1.4.4':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.4.3
-      '@rspack/binding-darwin-x64': 1.4.3
-      '@rspack/binding-linux-arm64-gnu': 1.4.3
-      '@rspack/binding-linux-arm64-musl': 1.4.3
-      '@rspack/binding-linux-x64-gnu': 1.4.3
-      '@rspack/binding-linux-x64-musl': 1.4.3
-      '@rspack/binding-wasm32-wasi': 1.4.3
-      '@rspack/binding-win32-arm64-msvc': 1.4.3
-      '@rspack/binding-win32-ia32-msvc': 1.4.3
-      '@rspack/binding-win32-x64-msvc': 1.4.3
+      '@rspack/binding-darwin-arm64': 1.4.4
+      '@rspack/binding-darwin-x64': 1.4.4
+      '@rspack/binding-linux-arm64-gnu': 1.4.4
+      '@rspack/binding-linux-arm64-musl': 1.4.4
+      '@rspack/binding-linux-x64-gnu': 1.4.4
+      '@rspack/binding-linux-x64-musl': 1.4.4
+      '@rspack/binding-wasm32-wasi': 1.4.4
+      '@rspack/binding-win32-arm64-msvc': 1.4.4
+      '@rspack/binding-win32-ia32-msvc': 1.4.4
+      '@rspack/binding-win32-x64-msvc': 1.4.4
     optional: true
 
   '@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17)':
@@ -9799,10 +9802,10 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.17
 
-  '@rspack/core@1.4.3(@swc/helpers@0.5.17)':
+  '@rspack/core@1.4.4(@swc/helpers@0.5.17)':
     dependencies:
       '@module-federation/runtime-tools': 0.15.0
-      '@rspack/binding': 1.4.3
+      '@rspack/binding': 1.4.4
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
       '@swc/helpers': 0.5.17
@@ -9843,8 +9846,8 @@ snapshots:
       '@mdx-js/loader': 3.1.0(acorn@8.15.0)(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17)))
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       '@mdx-js/react': 3.1.0(@types/react@19.1.7)(react@19.1.0)
-      '@rsbuild/core': 1.4.3
-      '@rsbuild/plugin-react': 1.3.2(@rsbuild/core@1.4.3)
+      '@rsbuild/core': 1.4.4
+      '@rsbuild/plugin-react': 1.3.2(@rsbuild/core@1.4.4)
       '@rspress/mdx-rs': 0.6.6
       '@rspress/plugin-last-updated': 2.0.0-beta.19
       '@rspress/plugin-medium-zoom': 2.0.0-beta.19(@rspress/runtime@2.0.0-beta.19)
@@ -9968,7 +9971,7 @@ snapshots:
 
   '@rspress/shared@2.0.0-beta.19':
     dependencies:
-      '@rsbuild/core': 1.4.3
+      '@rsbuild/core': 1.4.4
       '@shikijs/rehype': 3.4.2
       gray-matter: 4.0.3
       lodash-es: 4.17.21
@@ -11378,7 +11381,7 @@ snapshots:
 
   cspell-ban-words@0.0.4: {}
 
-  css-loader@7.1.2(@rspack/core@1.4.3(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17))):
+  css-loader@7.1.2(@rspack/core@1.4.4(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.4)
       postcss: 8.5.4
@@ -11389,7 +11392,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      '@rspack/core': 1.4.3(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.4(@swc/helpers@0.5.17)
       webpack: 5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17))
 
   css-loader@7.1.2(@rspack/core@packages+rspack)(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17))):
@@ -14792,13 +14795,13 @@ snapshots:
       '@microsoft/api-extractor': 7.52.8(@types/node@20.19.0)
       typescript: 5.8.3
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.4.3):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.4.4):
     optionalDependencies:
-      '@rsbuild/core': 1.4.3
+      '@rsbuild/core': 1.4.4
 
-  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.4.3):
+  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.4.4):
     optionalDependencies:
-      '@rsbuild/core': 1.4.3
+      '@rsbuild/core': 1.4.4
 
   rspack-plugin-virtual-module@1.0.1:
     dependencies:
@@ -14810,7 +14813,7 @@ snapshots:
 
   rspress@2.0.0-beta.19(@types/react@19.1.7)(acorn@8.15.0)(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17))):
     dependencies:
-      '@rsbuild/core': 1.4.3
+      '@rsbuild/core': 1.4.4
       '@rspress/core': 2.0.0-beta.19(@types/react@19.1.7)(acorn@8.15.0)(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17)))
       '@rspress/shared': 2.0.0-beta.19
       cac: 6.7.14


### PR DESCRIPTION
## Summary

The `zod` dependency is bundled by Rslib. Since Rspack's public APIs do not depend on `zod` types, we add `@ts-ignore` to prevent type errors when users set `skipLibCheck: false` in their tsconfig.json file.

<img width="1218" alt="Screenshot 2025-07-07 at 15 45 35" src="https://github.com/user-attachments/assets/5cc5001b-05f3-4c04-86f5-c87ac1b0a566" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
