### PR TITLE
perf: prepare module outgoings for code splitting

### DIFF
--- a/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
@@ -253,7 +253,7 @@ impl CodeSplittingCache {
       for module_map in self.new_code_splitter.module_deps.values() {
         if let Some(outgoings) = module_map.get(&module) {
           newly_added_module = false;
-          let (outgoings, _blocks) = outgoings.as_ref();
+          let (outgoings, _blocks) = outgoings;
           for out in outgoings {
             previous_outgoings.insert(*out);
           }


### PR DESCRIPTION
## Summary

Prepare module outgoings for code splitting while generating chunk graph.

Before: 2.8s
![image](https://github.com/user-attachments/assets/e8a0d2e8-a71f-456d-b52a-eacd736ce27a)

After: 1.7s
![image](https://github.com/user-attachments/assets/6270e463-e962-4b4d-b196-3db04621a771)
![image](https://github.com/user-attachments/assets/a816de0f-a133-4987-8812-b21c0703f30c)


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
