### PR TITLE
fix: type error with the pre-bundled watchpack package

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,3 @@
-package.json
-
 # Ignore generated
 dist/
 compiled/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,7 +2,7 @@ package.json
 
 # Ignore generated
 dist/
-packages/rspack/src/config/schema.check.js
+compiled/
 
 # Ignore lock files
 pnpm-lock.yaml

--- a/packages/rspack/prebundle.config.mjs
+++ b/packages/rspack/prebundle.config.mjs
@@ -5,32 +5,27 @@ import { join } from "node:path";
 /** @type {import('prebundle').Config} */
 export default {
 	dependencies: [
+		"@swc/types",
+		"graceful-fs",
+		"browserslist-load-config",
 		{
 			name: "webpack-sources",
 			copyDts: true
 		},
-		"graceful-fs",
-		"browserslist-load-config",
 		{
 			name: "watchpack",
 			externals: {
 				"graceful-fs": "../graceful-fs/index.js"
 			},
 			afterBundle(task) {
+				const importStatement = "import fs from 'graceful-fs';";
 				const dtsPath = join(task.distPath, "index.d.ts");
 				const content = readFileSync(dtsPath, "utf-8");
-				// Ensure the type of graceful-fs is imported from the correct path
 				writeFileSync(
 					dtsPath,
-					content.replace(
-						"from 'graceful-fs'",
-						"from '../graceful-fs/index.js'"
-					)
+					content.replace(importStatement, `// @ts-ignore\n${importStatement}`)
 				);
 			}
-		},
-		{
-			name: "@swc/types"
 		}
 	]
 };

--- a/packages/rspack/prebundle.config.mjs
+++ b/packages/rspack/prebundle.config.mjs
@@ -1,4 +1,7 @@
 // @ts-check
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 /** @type {import('prebundle').Config} */
 export default {
 	dependencies: [
@@ -12,6 +15,18 @@ export default {
 			name: "watchpack",
 			externals: {
 				"graceful-fs": "../graceful-fs/index.js"
+			},
+			afterBundle(task) {
+				const dtsPath = join(task.distPath, "index.d.ts");
+				const content = readFileSync(dtsPath, "utf-8");
+				// Ensure the type of graceful-fs is imported from the correct path
+				writeFileSync(
+					dtsPath,
+					content.replace(
+						"from 'graceful-fs'",
+						"from '../graceful-fs/index.js'"
+					)
+				);
 			}
 		},
 		{

--- a/packages/rspack/tsconfig.api.extractor.json
+++ b/packages/rspack/tsconfig.api.extractor.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-   "paths": {}
+    "paths": {}
   }
 }


### PR DESCRIPTION
## Summary

Update the prebundle config to fix the type error with the pre-bundled watchpack package.

Fix an error when `skipLibCheck` is `false` in user project:

<img width="1218" alt="Screenshot 2025-07-07 at 17 23 44" src="https://github.com/user-attachments/assets/f64e3c6b-267c-483d-961c-0643632590bb" />

## Note

I added the `// @ts-ignore` comment to fix this instead of aliasing the dts path to `../compiled/graceful-fs` as api-extractor can not handle the graceful-fs types as expected:

<img width="1182" alt="Screenshot 2025-07-07 at 17 36 59" src="https://github.com/user-attachments/assets/fc793a5a-ff4b-4964-bf97-d3456244e050" />

> See https://github.com/microsoft/rushstack/pull/3528

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
