### PR TITLE
chore(ci): add size threadhold

### DIFF
--- a/.github/actions/binary-limit/action.yml
+++ b/.github/actions/binary-limit/action.yml
@@ -3,9 +3,9 @@ name: Binary Size Limit
 description: Compare binary size with default
 
 inputs:
-  percentage-threshold:
-    description: "the"
-    default: "5"
+  size-threshold:
+    description: "the increase size limit in bytes, default is 50kb"
+    default: "51200"
     required: false
 
 runs:
@@ -16,5 +16,6 @@ runs:
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:
         script: |
+          const limit = parseInt("${{ inputs.size-threshold }}") || 51200;
           const action = require("./.github/actions/binary-limit/binary-limit-script.js");
-          await action({github, context});
+          await action({github, context, limit});

--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -99,8 +99,9 @@ const DATA_URL_BASE =
 function compareBinarySize(headSize, baseSize, context, baseCommit) {
 	const message = baseCommit.commit.message.split("\n")[0];
 	const author = baseCommit.commit.author.name;
+	const headSha = context.payload.pull_request?.head.sha || context.sha;
 
-	const info = `> Comparing [\`${context.sha.slice(0, 7)}\`](${context.payload.repository.html_url}/commit/${context.sha}) to  [${message} by ${author}](${baseCommit.html_url})\n\n`;
+	const info = `> Comparing [\`${headSha.slice(0, 7)}\`](${context.payload.repository.html_url}/commit/${headSha}) to  [${message} by ${author}](${baseCommit.html_url})\n\n`;
 
 	const diff = headSize - baseSize;
 	const percentage = (Math.abs(diff / baseSize) * 100).toFixed(2);

--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -2,8 +2,9 @@ const fs = require("node:fs");
 
 /**
  * @param {import("@octokit/rest")} github
+ * @param {Number} limit
  */
-module.exports = async function action({ github, context }) {
+module.exports = async function action({ github, context, limit }) {
 	const commits = await github.rest.repos.listCommits({
 		owner: context.repo.owner,
 		repo: context.repo.repo,
@@ -38,9 +39,19 @@ module.exports = async function action({ github, context }) {
 		"./crates/node_binding/rspack.linux-x64-gnu.node"
 	).size;
 
-	const comment = compareBinarySize(headSize, baseSize, baseCommit);
+	console.log(`Base commit size: ${baseSize}`);
+	console.log(`Head commit size: ${headSize}`);
+
+	const comment = compareBinarySize(headSize, baseSize, context, baseCommit);
 
 	await commentToPullRequest(github, context, comment);
+
+	const increasedSize = headSize - baseSize;
+	if (increasedSize > limit) {
+		throw new Error(
+			`Binary size increased by ${increasedSize} bytes, exceeding the limit of ${limit} bytes`
+		);
+	}
 };
 
 async function commentToPullRequest(github, context, comment) {
@@ -85,11 +96,11 @@ const SIZE_LIMIT_HEADING = "## 📦 Binary Size-limit";
 const DATA_URL_BASE =
 	"https://raw.githubusercontent.com/web-infra-dev/rspack-ecosystem-benchmark/data";
 
-function compareBinarySize(headSize, baseSize, baseCommit) {
+function compareBinarySize(headSize, baseSize, context, baseCommit) {
 	const message = baseCommit.commit.message.split("\n")[0];
 	const author = baseCommit.commit.author.name;
 
-	const info = `> Comparing binary size with Commit: [${message} by ${author}](${baseCommit.html_url})\n\n`;
+	const info = `> Comparing [\`${context.sha.slice(0, 7)}\`](${context.payload.repository.html_url}/commit/${context.sha}) to  [${message} by ${author}](${baseCommit.html_url})\n\n`;
 
 	const diff = headSize - baseSize;
 	const percentage = (Math.abs(diff / baseSize) * 100).toFixed(2);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,8 @@ jobs:
         test-windows,
         test-mac,
         test-wasm,
-        check-changed
+        check-changed,
+        size-limit
       ]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
@@ -135,7 +136,7 @@ jobs:
       - name: Log
         run: echo ${{ join(needs.*.result, ',') }}
       - name: Test check
-        if: ${{ needs.check-changed.outputs.code_changed == 'true' && join(needs.*.result, ',')!='success,success,success,success,success,success' }}
+        if: ${{ needs.check-changed.outputs.code_changed == 'true' && join(needs.*.result, ',')!='success,success,success,success,success,success,success' }}
         run: echo "Tess Failed" && exit 1
       - name: No check to Run test
         run: echo "Success"

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -55,3 +55,6 @@ jobs:
 
       - name: Binary Size-limit
         uses: ./.github/actions/binary-limit
+        with:
+          # 50k 50*1024
+          size-threshold: 51200


### PR DESCRIPTION
## Summary

1. Add bytes threshold to limit binary size increasing too fast
2. Add Comparing base to the comment of Action Bot

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
