### PR TITLE
fix: avoid unnecessary full hash runtime for css extract

### DIFF
--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -523,9 +523,7 @@ async fn runtime_requirement_in_tree(
   if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS)
     || runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS)
   {
-    if let Some(chunk_filename) = self.options.chunk_filename.template()
-      && chunk_filename.contains("hash")
-    {
+    if self.options.chunk_filename.has_hash_placeholder() {
       runtime_requirements_mut.insert(RuntimeGlobals::GET_FULL_HASH);
     }
 

--- a/packages/rspack-test-tools/tests/configCases/css-extract/with-contenthash/index.css
+++ b/packages/rspack-test-tools/tests/configCases/css-extract/with-contenthash/index.css
@@ -1,0 +1,3 @@
+.text {
+    color: blue;
+}

--- a/packages/rspack-test-tools/tests/configCases/css-extract/with-contenthash/index.js
+++ b/packages/rspack-test-tools/tests/configCases/css-extract/with-contenthash/index.js
@@ -1,0 +1,7 @@
+it("should not contain full hash runtime module", async () => {
+  await import("./index.css");
+
+  const chunk = __non_webpack_require__("fs").readFileSync(__filename, "utf-8");
+  const hashRuntime = ["__webpack_require__", "h"].join(".") // use join() here to avoid compile time evaluation
+  expect(chunk).not.toContain(hashRuntime);
+});

--- a/packages/rspack-test-tools/tests/configCases/css-extract/with-contenthash/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css-extract/with-contenthash/rspack.config.js
@@ -1,0 +1,23 @@
+const { CssExtractRspackPlugin } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "web",
+	node: {
+		__filename: false
+	},
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [CssExtractRspackPlugin.loader, "css-loader"],
+				type: "javascript/auto"
+			}
+		]
+	},
+	plugins: [
+		new CssExtractRspackPlugin({
+			filename: "[name][contenthash].css"
+		})
+	]
+};


### PR DESCRIPTION
## Summary

checkout added test case

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
