### PR TITLE
chore(ci): CI.yml failed due to size-limit skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,17 @@ jobs:
       - name: Log
         run: echo ${{ join(needs.*.result, ',') }}
       - name: Test check
-        if: ${{ needs.check-changed.outputs.code_changed == 'true' && join(needs.*.result, ',')!='success,success,success,success,success,success,success' }}
+        if: ${{ needs.check-changed.outputs.code_changed == 'true'
+          && github.event_name == 'pull_request'
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success' }}
         run: echo "Tess Failed" && exit 1
+
+      - name: Test check
+        if: ${{ needs.check-changed.outputs.code_changed == 'true'
+          && github.event_name != 'pull_request'
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,skipped' }}
+        run: echo "Tess Failed" && exit 1
+
       - name: No check to Run test
         run: echo "Success"
 


### PR DESCRIPTION
## Summary
size-limit will not be run in main push event, wil fail the CI test require check
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
