### PR TITLE
chore: update lightningcss crate to 1.0.0-alpha.67

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,9 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -2463,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.64"
+version = "1.0.0-alpha.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a296273515b1036d06fce6c1d6bfc11347083458e1765ae4a70d6288cdb15521"
+checksum = "798fba4e1205eed356b8ed7754cc3f7f04914e27855ca641409f4a532e992149"
 dependencies = [
  "ahash 0.8.12",
  "bitflags 2.9.1",
@@ -3139,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "parcel_selectors"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccbc6fb560df303a44e511618256029410efbc87779018f751ef12c488271fe"
+checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ insta              = { version = "1.42.0" }
 itertools          = { version = "0.14.0" }
 itoa               = { version = "1.0.14" }
 json               = { version = "0.12.4" }
-lightningcss       = { version = "1.0.0-alpha.64", default-features = false, features = ["grid", "serde"] }
+lightningcss       = { version = "1.0.0-alpha.67", default-features = false, features = ["serde"] }
 linked_hash_set    = { version = "0.1.5" }
 mimalloc           = { version = "0.2.4", package = "mimalloc-rspack" }
 mime_guess         = { version = "2.0.5" }


### PR DESCRIPTION
## Summary
to make renovate can auto update and grid feature is enabled by default now
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
