### PR TITLE
docs: use rspack.rs as the homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "bench:ci": "pnpm run bench:prepare && cargo codspeed run && pnpm --filter bench run bench",
     "bench:prepare": "node ./scripts/bench/setup.mjs"
   },
-  "homepage": "https://rspack.dev",
+  "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

This pull request includes a minor update to the `homepage` field in the `package.json` file, changing the website URL from `https://rspack.dev` to `https://rspack.rs`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
