### PR TITLE
feat(binding-builder): export workspace version

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -2716,6 +2716,8 @@ export interface RegisterJsTaps {
   registerRsdoctorPluginAssetsTaps: (stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorAssetPatch) => Promise<boolean | undefined>); stage: number; }>
 }
 
+export const RSPACK_BINDING_WORKSPACE_VERSION: string
+
 export interface SourceMapDevToolPluginOptions {
   append?: (false | null) | string | Function
   columns?: boolean

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -124,6 +124,10 @@ use tracing_subscriber::{
 };
 pub use utils::*;
 
+// Export Rust workspace version
+#[napi]
+pub const RSPACK_BINDING_WORKSPACE_VERSION: &str = rspack_workspace::rspack_workspace_version!();
+
 thread_local! {
   pub static COMPILER_REFERENCES: RefCell<UkeyMap<CompilerId, WeakReference<JsCompiler>>> = Default::default();
 }

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -467,7 +467,7 @@ impl<'a> JavaScriptTransformer<'a> {
           }) {
             // swc errors includes plugin error;
             let error_msg = err.to_pretty_string();
-            let swc_core_version = rspack_workspace::rspack_swc_core_version();
+            let swc_core_version = rspack_workspace::rspack_swc_core_version!();
             // FIXME: with_help has bugs, use with_help when diagnostic print is fixed
             let help_msg = formatdoc!{"
               The version of the SWC Wasm plugin you're using might not be compatible with `builtin:swc-loader`.

--- a/crates/rspack_workspace/src/lib.rs
+++ b/crates/rspack_workspace/src/lib.rs
@@ -1,18 +1,27 @@
 // Run `cargo codegen` to generate the file.
-mod generated;
+#[doc(hidden)]
+pub mod generated;
 
-pub use generated::{rspack_pkg_version, rspack_swc_core_version};
-
+/// The version of the JavaScript `@rspack/core` package.
 #[macro_export]
 macro_rules! rspack_pkg_version {
   () => {
-    $crate::rspack_pkg_version()
+    $crate::generated::rspack_pkg_version()
   };
 }
 
+/// The version of the Rust workspace in the root `Cargo.toml` of the repository.
+#[macro_export]
+macro_rules! rspack_workspace_version {
+  () => {
+    $crate::generated::rspack_workspace_version()
+  };
+}
+
+/// The version of the `swc_core` package used in the current workspace.
 #[macro_export]
 macro_rules! rspack_swc_core_version {
   () => {
-    $crate::rspack_swc_core_version()
+    $crate::generated::rspack_swc_core_version()
   };
 }

--- a/tasks/codegen/src/main.rs
+++ b/tasks/codegen/src/main.rs
@@ -34,6 +34,9 @@ fn generate_workspace_versions(out_path: &str) -> Result<()> {
   let manifest =
     cargo_toml::Manifest::from_str(&cargo_toml_content).expect("Should parse cargo toml");
   let workspace = manifest.workspace.unwrap();
+
+  let workspace_version = workspace.package.unwrap().version.unwrap();
+
   let swc_core_version = workspace
     .dependencies
     .get("swc_core")
@@ -69,6 +72,11 @@ pub const fn rspack_swc_core_version() -> &'static str {{
 /// The version of the JavaScript `@rspack/core` package.
 pub const fn rspack_pkg_version() -> &'static str {{
   "{rspack_version}"
+}}
+
+/// The version of the Rust workspace in the root `Cargo.toml` of the repository.
+pub const fn rspack_workspace_version() -> &'static str {{
+  "{workspace_version}"
 }}
 "#
   );


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR exports crate versions defined in root `Cargo.toml` in crate `rspack_binding_api` as `RSPACK_BINDING_WORKSPACE_VERSION`.

We're planning to detect binding version (a.k.a crate version) in `@rspack/core` to check the compatibility between JS and Rust packages or crates.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
