### PR TITLE
refactor: use symbol defined in `binding_api` to ensure the version consistency 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,6 +2809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd02a8ea3974a47a795a239f8831e5186c265c8624a4e56d538836c47305b312"
 dependencies = [
  "convert_case 0.8.0",
+ "ctor",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -2824,6 +2825,7 @@ dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
  "quote",
+ "semver",
  "syn 2.0.95",
 ]
 

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -22,7 +22,7 @@ ignored = ["napi-derive"]
 [dependencies]
 rspack_binding_api = { workspace = true }
 
-napi-derive = { workspace = true, features = ["compat-mode"] }
+napi-derive = { workspace = true, features = ["compat-mode", "type-def"] }
 
 [build-dependencies]
 rspack_binding_build = { workspace = true }

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -564,6 +564,12 @@ export interface CssChunkingPluginOptions {
   exclude?: RegExp
 }
 
+/**
+ * Expected version of @rspack/core to the current binding version
+ * @internal
+ */
+export const EXPECTED_RSPACK_CORE_VERSION: string
+
 export declare function formatDiagnostic(diagnostic: JsDiagnostic): ExternalObject<'Diagnostic'>
 
 export interface JsAddingRuntimeModule {
@@ -2715,8 +2721,6 @@ export interface RegisterJsTaps {
   registerRsdoctorPluginModuleSourcesTaps: (stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorModuleSourcesPatch) => Promise<boolean | undefined>); stage: number; }>
   registerRsdoctorPluginAssetsTaps: (stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorAssetPatch) => Promise<boolean | undefined>); stage: number; }>
 }
-
-export const RSPACK_BINDING_WORKSPACE_VERSION: string
 
 export interface SourceMapDevToolPluginOptions {
   append?: (false | null) | string | Function

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -124,9 +124,11 @@ use tracing_subscriber::{
 };
 pub use utils::*;
 
-// Export Rust workspace version
+// Export expected @rspack/core version
+/// Expected version of @rspack/core to the current binding version
+/// @internal
 #[napi]
-pub const RSPACK_BINDING_WORKSPACE_VERSION: &str = rspack_workspace::rspack_workspace_version!();
+pub const EXPECTED_RSPACK_CORE_VERSION: &str = rspack_workspace::rspack_pkg_version!();
 
 thread_local! {
   pub static COMPILER_REFERENCES: RefCell<UkeyMap<CompilerId, WeakReference<JsCompiler>>> = Default::default();

--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -130,15 +130,9 @@ const codmodPlugin: RsbuildPlugin = {
 		 */
 		function replaceBinding(root): Edit[] {
 			const binding = root.find(`module.exports = require("@rspack/binding");`);
-			const bindingPkg = root.find(
-				`module.exports = require("@rspack/binding/package.json");`
-			);
 			return [
 				binding.replace(
 					`module.exports = require(process.env.RSPACK_BINDING ? process.env.RSPACK_BINDING : "@rspack/binding");`
-				),
-				bindingPkg.replace(
-					`module.exports = require(process.env.RSPACK_BINDING ? require("node:path").resolve(process.env.RSPACK_BINDING, './package.json') : "@rspack/binding/package.json");`
 				)
 			];
 		}

--- a/packages/rspack/src/util/bindingVersionCheck.ts
+++ b/packages/rspack/src/util/bindingVersionCheck.ts
@@ -1,138 +1,33 @@
-import { readdirSync } from "node:fs";
-import path from "node:path";
+import * as binding from "@rspack/binding";
 
-const NodePlatformArchToAbi: Record<
-	string,
-	Record<string, string | Record<string, string>>
-> = {
-	android: {
-		arm64: "",
-		arm: "eabi"
-	},
-	win32: {
-		x64: "msvc",
-		ia32: "msvc",
-		arm64: "msvc"
-	},
-	darwin: {
-		x64: "",
-		arm64: ""
-	},
-	freebsd: {
-		x64: ""
-	},
-	linux: {
-		x64: {
-			musl: "musl",
-			gnu: "gnu"
-		},
-		arm64: {
-			musl: "musl",
-			gnu: "gnu"
-		},
-		arm: "gnueabihf"
-	}
-};
-
-function isMusl() {
-	// @ts-expect-error getReport returns an object containing header object
-	const { glibcVersionRuntime } = process.report.getReport().header;
-	return !glibcVersionRuntime;
-}
-
-const BINDING_VERSION = require("@rspack/binding/package.json").version;
 const CORE_VERSION = RSPACK_VERSION;
-
-const getAddonPlatformArchAbi = () => {
-	const { platform, arch } = process;
-	let binding = "";
-	binding += platform;
-
-	const abi = NodePlatformArchToAbi[platform][arch];
-	if (abi === undefined) return new Error(`unsupported cpu arch: ${arch}`);
-	binding += `-${arch}`;
-
-	if (typeof abi === "string") {
-		binding += abi.length ? `-${abi}` : "";
-	} else if (typeof abi === "object") {
-		binding += `-${abi[isMusl() ? "musl" : "gnu"]}`;
-	} else {
-		return new Error(`unsupported abi: ${abi}`);
-	}
-
-	return binding;
-};
-
-/**
- * Error: version checked with error
- * null: version checked without any error
- * undefined: version to be checked
- */
-let result: Error | undefined | null;
 
 /**
  * Check if these version matches:
- * `@rspack/core`, `@rspack/binding`, `@rspack/binding-<platform>-<arch>-<abi>`
+ * `@rspack/core`, Binding version
  */
 export const checkVersion = () => {
-	if (result !== undefined) {
-		return result;
+	if (CORE_VERSION === binding.EXPECTED_RSPACK_CORE_VERSION) {
+		return null;
 	}
 
-	const platformArchAbi = getAddonPlatformArchAbi();
-	if (platformArchAbi instanceof Error) {
-		return (result = platformArchAbi);
-	}
-
-	let ADDON_VERSION: string;
-	try {
-		const BINDING_PKG_DIR = path.dirname(
-			require.resolve("@rspack/binding/package.json")
-		);
-
-		const isLocal = readdirSync(BINDING_PKG_DIR).some(
-			item =>
-				item === `rspack.${platformArchAbi}.node` || "rspack.wasm32-wasi.wasm"
-		);
-
-		if (isLocal) {
-			// Treat addon version the same as binding version if running locally
-			ADDON_VERSION = BINDING_VERSION;
-		} else {
-			// Fetch addon package if installed from remote
-			try {
-				ADDON_VERSION = require(
-					require.resolve(`@rspack/binding-${platformArchAbi}/package.json`, {
-						paths: [BINDING_PKG_DIR]
-					})
-				).version;
-			} catch {
-				// Wasm fallback
-				ADDON_VERSION = require(
-					require.resolve("@rspack/binding-wasm32-wasi/package.json", {
-						paths: [BINDING_PKG_DIR]
-					})
-				).version;
-			}
-		}
-	} catch (error: any) {
-		if (error instanceof Error) {
-			return (result = new Error(
-				`${error.toString()}. Maybe you forget to install the correct addon package ${`@rspack/binding-${platformArchAbi}`} or forget to build binding locally?`
-			));
-		}
-		return (result = new Error(error));
-	}
-
-	const isMatch = [CORE_VERSION, BINDING_VERSION, ADDON_VERSION].every(
-		(v, _, arr) => v === arr[0]
+	return new Error(
+		errorMessage(CORE_VERSION, binding.EXPECTED_RSPACK_CORE_VERSION)
 	);
+};
 
-	if (!isMatch) {
-		return (result = new Error(
-			`Unmatched version @rspack/core@${CORE_VERSION}, @rspack/binding@${BINDING_VERSION}, @rspack/binding-${platformArchAbi}@${ADDON_VERSION}.\nRspack requires these versions to be the same or you may have installed the wrong version. Otherwise, Rspack may not work properly.`
-		));
+const errorMessage = (coreVersion: string, expectedCoreVersion: string) => {
+	if (process.env.RSPACK_BINDING) {
+		return `Unmatched version @rspack/core@${coreVersion} and binding version.
+
+Help:
+	Looks like you are using a custom binding (via environment variable 'RSPACK_BINDING=${process.env.RSPACK_BINDING}'). The expected version of @rspack/core to the current binding is ${expectedCoreVersion}.
+`;
 	}
 
-	return (result = null);
+	return `Unmatched version @rspack/core@${coreVersion} and @rspack/binding.
+
+Help:
+	Please ensure the version of @rspack/binding and @rspack/core is the same.
+`;
 };


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR refactored the original version detecting strategy with a less error-prone strategy.

The new strategy is to let binding export an expected `@rspack/core` version. This version will later be checked within `@rspack/core` to ensure its version consistency.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
