### PR TITLE
docs: make copyright year dynamic

### DIFF
--- a/website/theme/pages/index.tsx
+++ b/website/theme/pages/index.tsx
@@ -10,7 +10,7 @@ const CopyRight = () => {
             Rspack is free and open source software released under the MIT
             license.
           </p>
-          <p>© 2022-present ByteDance Inc.</p>
+          <p>© {new Date().getFullYear()} ByteDance Inc.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary

Documentation:
- Replace the static “© 2022-present ByteDance Inc.” line with a JavaScript expression that inserts the current year

## Appearance

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/90fe4461-7415-49f9-83e5-8f299d57ac6c) | ![after](https://github.com/user-attachments/assets/63922617-1836-4485-8e3e-df8e2a394e02) | 

## Related links

[web-infra-dev/rspress #2362 comment](https://github.com/web-infra-dev/rspress/pull/2362#pullrequestreview-3003788546)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
