### PR TITLE
fix: getModuleChunksIterable was mistakenly deleted

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-test/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/cache-group-test/rspack.config.js
@@ -13,6 +13,7 @@ module.exports = {
 						expect(module.size()).toBe(5);
 						expect(moduleGraph.isAsync(module)).toBe(false);
 						expect(chunkGraph.getModuleChunks(module).length).toBe(1);
+						expect(Array.from(chunkGraph.getModuleChunksIterable(module)).length).toBe(1);
 						return true;
 					}
 				}

--- a/packages/rspack/src/ChunkGraph.ts
+++ b/packages/rspack/src/ChunkGraph.ts
@@ -19,6 +19,28 @@ Object.defineProperty(ChunkGraph.prototype, "getOrderedChunkModulesIterable", {
 	}
 });
 
+Object.defineProperty(ChunkGraph.prototype, "getModuleChunksIterable", {
+	enumerable: true,
+	configurable: true,
+	value(this: ChunkGraph, module: Module): Iterable<Chunk> {
+		return this.getModuleChunks(module);
+	}
+});
+
+Object.defineProperty(ChunkGraph.prototype, "getOrderedChunkModulesIterable", {
+	enumerable: true,
+	configurable: true,
+	value(
+		this: ChunkGraph,
+		chunk: Chunk,
+		compareFn: (a: Module, b: Module) => number
+	): Iterable<Module> {
+		const modules = this.getChunkModules(chunk);
+		modules.sort(compareFn);
+		return modules;
+	}
+});
+
 Object.defineProperty(ChunkGraph.prototype, "getModuleHash", {
 	enumerable: true,
 	configurable: true,
@@ -29,6 +51,7 @@ Object.defineProperty(ChunkGraph.prototype, "getModuleHash", {
 
 declare module "@rspack/binding" {
 	interface Chunk {
+		getModuleChunksIterable(module: Module): Iterable<Chunk>;
 		getOrderedChunkModulesIterable(
 			chunk: Chunk,
 			compareFn: (a: Module, b: Module) => number


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Fix the getModulus ChunksIterable method was mistakenly deleted.

Relate https://github.com/web-infra-dev/rspack/pull/10502

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
