### PR TITLE
fix: ensure reexport is backtracked for provided exports

### DIFF
--- a/packages/rspack-test-tools/tests/normalCases/esm/reexport-with-cycle/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/esm/reexport-with-cycle/index.js
@@ -1,0 +1,5 @@
+import { f } from "./reexport"
+
+it("should have correct value", () => {
+  expect(f()).toBe(1);
+})

--- a/packages/rspack-test-tools/tests/normalCases/esm/reexport-with-cycle/lib.js
+++ b/packages/rspack-test-tools/tests/normalCases/esm/reexport-with-cycle/lib.js
@@ -1,0 +1,4 @@
+import { value } from "./reexport"
+
+export const f = () => 1;
+export const g = () => value;

--- a/packages/rspack-test-tools/tests/normalCases/esm/reexport-with-cycle/reexport.js
+++ b/packages/rspack-test-tools/tests/normalCases/esm/reexport-with-cycle/reexport.js
@@ -1,0 +1,2 @@
+export * from "./lib"
+export const value = 42;

--- a/packages/rspack-test-tools/tests/normalCases/esm/reexport-with-cycle/warnings.js
+++ b/packages/rspack-test-tools/tests/normalCases/esm/reexport-with-cycle/warnings.js
@@ -1,0 +1,1 @@
+module.exports = []; // should not have any warnings


### PR DESCRIPTION
## Summary

Collect dependent modules that need to backtrack at the end of the batch, to make sure dependent modules are backtracking its provided exports again, and now it doesn't need to be ordered

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
