### PR TITLE
chore: Use symbol mangling v0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -34,6 +34,7 @@ rustflags = [
   "-Aclippy::default_constructed_unit_structs",
   "-Zshare-generics=y", # make the current crate share its generic instantiations
   "-Zthreads=8", # parallel frontend https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
+  "-Csymbol-mangling-version=v0", # symbol mangling v0 https://doc.rust-lang.org/stable/rustc/symbol-mangling/v0.html
 ]
 
 # Fix napi breaking in test environment <https://github.com/napi-rs/napi-rs/issues/1005#issuecomment-1011034770>


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This uses the symbol v0 format, which keep more type information in symbol name (instead of a hash), helpful with debug.

before:
```
tokio::task::task_local::LocalKey<T>::scope_inner::hc4ba6c00f4da77d0
```

after:
```
<tokio[a487a48989429aa3]::task::task_local::LocalKey<alloc[afc79f7023c726bc]::sync::Arc<rspack_tasks[29e80a6a17ff8576]::CompilerContext>>>::scope_inner::<..>
```

This will cause the debug product to increase in size, but should have no effect after stripped.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
