### PR TITLE
refactor: avoid exposing `Ref` and `RefMut` of `DashMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,7 +4784,6 @@ dependencies = [
  "async-trait",
  "cow-utils",
  "css-module-lexer",
- "dashmap 6.1.0",
  "heck 0.5.0",
  "indexmap 2.7.1",
  "once_cell",
@@ -4968,7 +4967,6 @@ version = "0.2.1-alpha.1"
 dependencies = [
  "anyhow",
  "cow-utils",
- "dashmap 6.1.0",
  "futures",
  "itertools 0.14.0",
  "path-clean 1.0.1",
@@ -5013,7 +5011,6 @@ dependencies = [
  "async-trait",
  "bitflags 2.9.1",
  "cow-utils",
- "dashmap 6.1.0",
  "either",
  "fast-glob",
  "indexmap 2.7.1",
@@ -5216,7 +5213,6 @@ name = "rspack_plugin_real_content_hash"
 version = "0.2.1-alpha.1"
 dependencies = [
  "aho-corasick",
- "dashmap 6.1.0",
  "derive_more 1.0.0",
  "indexmap 2.7.1",
  "once_cell",
@@ -5260,7 +5256,6 @@ name = "rspack_plugin_rsdoctor"
 version = "0.2.1-alpha.1"
 dependencies = [
  "async-trait",
- "dashmap 6.1.0",
  "futures",
  "indexmap 2.7.1",
  "rayon",
@@ -5311,7 +5306,6 @@ version = "0.2.1-alpha.1"
 dependencies = [
  "async-trait",
  "cow-utils",
- "dashmap 6.1.0",
  "derive_more 1.0.0",
  "futures",
  "indexmap 2.7.1",
@@ -5407,7 +5401,6 @@ version = "0.2.1-alpha.1"
 dependencies = [
  "async-trait",
  "cow-utils",
- "dashmap 6.1.0",
  "derive_more 1.0.0",
  "futures",
  "indexmap 2.7.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,6 +5229,7 @@ dependencies = [
  "rspack_hook",
  "rspack_util",
  "rustc-hash 2.1.1",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ dependencies = [
  "swc_core",
  "swc_ecma_lexer",
  "swc_node_comments",
+ "tokio",
  "tracing",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,6 +4987,7 @@ dependencies = [
  "swc_core",
  "swc_html",
  "swc_html_minifier",
+ "tokio",
  "tracing",
  "urlencoding",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,8 +386,10 @@ opt-level = "s"
 # This is for CI build based on release but with faster build time
 [profile.ci]
 codegen-units = 256
+debug         = "full"
 inherits      = "release"
 lto           = false
+strip         = false
 ## reduce little optimization to reduce build time
 opt-level = 2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,10 +386,8 @@ opt-level = "s"
 # This is for CI build based on release but with faster build time
 [profile.ci]
 codegen-units = 256
-debug         = "full"
 inherits      = "release"
 lto           = false
-strip         = false
 ## reduce little optimization to reduce build time
 opt-level = 2
 

--- a/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
+++ b/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
@@ -438,7 +438,8 @@ async fn js_hooks_adapter_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> rspack_error::Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks
     .chunk_hash
     .intercept(self.register_javascript_modules_chunk_hash_taps.clone());

--- a/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
+++ b/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
@@ -508,7 +508,8 @@ async fn rsdoctor_hooks_adapter_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> rspack_error::Result<()> {
-  let mut hooks = RsdoctorPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = RsdoctorPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks
     .module_graph
     .intercept(self.register_rsdoctor_plugin_module_graph_taps.clone());

--- a/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
+++ b/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
@@ -489,7 +489,8 @@ async fn runtime_hooks_adapter_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> rspack_error::Result<()> {
-  let mut hooks = RuntimePlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = RuntimePlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks
     .create_script
     .intercept(self.register_runtime_plugin_create_script_taps.clone());

--- a/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
+++ b/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
@@ -453,7 +453,8 @@ async fn html_hooks_adapter_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> rspack_error::Result<()> {
-  let mut hooks = HtmlRspackPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = HtmlRspackPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.before_asset_tag_generation.intercept(
     self
       .register_html_plugin_before_asset_tag_generation_taps

--- a/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
@@ -253,7 +253,7 @@ impl CodeSplittingCache {
       for module_map in self.new_code_splitter.module_deps.values() {
         if let Some(outgoings) = module_map.get(&module) {
           newly_added_module = false;
-          let (outgoings, _blocks) = outgoings.value();
+          let (outgoings, _blocks) = outgoings.as_ref();
           for out in outgoings {
             previous_outgoings.insert(*out);
           }

--- a/crates/rspack_plugin_css/Cargo.toml
+++ b/crates/rspack_plugin_css/Cargo.toml
@@ -9,7 +9,6 @@ version.workspace = true
 async-trait           = { workspace = true }
 cow-utils             = { workspace = true }
 css-module-lexer      = { workspace = true }
-dashmap               = { workspace = true }
 heck                  = { workspace = true }
 indexmap              = { workspace = true }
 once_cell             = { workspace = true }

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -71,7 +71,8 @@ async fn eval_devtool_plugin_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks
     .render_module_content
     .tap(eval_devtool_plugin_render_module_content::new(self));

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -68,7 +68,8 @@ async fn eval_source_map_devtool_plugin_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks
     .render_module_content
     .tap(eval_source_map_devtool_plugin_render_module_content::new(

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -11,7 +11,6 @@ default = []
 [dependencies]
 anyhow            = { workspace = true }
 cow-utils         = { workspace = true }
-dashmap           = { workspace = true }
 futures           = { workspace = true }
 itertools         = { workspace = true }
 path-clean        = { workspace = true }

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -30,6 +30,7 @@ sugar_path        = { workspace = true }
 swc_core          = { workspace = true }
 swc_html          = { workspace = true }
 swc_html_minifier = { workspace = true, features = ["custom-css-minifier"] }
+tokio             = { workspace = true, features = ["sync"] }
 tracing           = { workspace = true }
 urlencoding       = { workspace = true }
 

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -10,7 +10,6 @@ anymap = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 cow-utils = { workspace = true }
-dashmap = { workspace = true }
 either = { workspace = true }
 fast-glob = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -51,6 +51,7 @@ swc_core = { workspace = true, features = [
 ] }
 swc_ecma_lexer = { workspace = true }
 swc_node_comments = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -18,8 +18,10 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   hooks
+    .write()
+    .await
     .render_module_content
     .tap(render_module_content::new(self));
   Ok(())

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -46,13 +46,14 @@ use swc_core::{
   common::{FileName, Spanned, SyntaxContext},
   ecma::transforms::base::resolver,
 };
+use tokio::sync::RwLock;
 
 use crate::runtime::{
   render_chunk_modules, render_module, render_runtime_modules, stringify_array,
 };
 
 static COMPILATION_HOOKS_MAP: LazyLock<
-  FxDashMap<CompilationId, Box<JavascriptModulesPluginHooks>>,
+  FxDashMap<CompilationId, Arc<RwLock<JavascriptModulesPluginHooks>>>,
 > = LazyLock::new(Default::default);
 
 #[derive(Debug, Clone)]
@@ -104,21 +105,18 @@ pub struct JsPlugin {
 }
 
 impl JsPlugin {
-  pub fn get_compilation_hooks(
-    id: CompilationId,
-  ) -> dashmap::mapref::one::Ref<'static, CompilationId, Box<JavascriptModulesPluginHooks>> {
+  pub fn get_compilation_hooks(id: CompilationId) -> Arc<RwLock<JavascriptModulesPluginHooks>> {
     if !COMPILATION_HOOKS_MAP.contains_key(&id) {
       COMPILATION_HOOKS_MAP.insert(id, Default::default());
     }
     COMPILATION_HOOKS_MAP
       .get(&id)
       .expect("should have js plugin drive")
+      .clone()
   }
 
-  pub fn get_compilation_hooks_mut(
-    id: CompilationId,
-  ) -> dashmap::mapref::one::RefMut<'static, CompilationId, Box<JavascriptModulesPluginHooks>> {
-    COMPILATION_HOOKS_MAP.entry(id).or_default()
+  pub fn get_compilation_hooks_mut(id: CompilationId) -> Arc<RwLock<JavascriptModulesPluginHooks>> {
+    COMPILATION_HOOKS_MAP.entry(id).or_default().clone()
   }
 
   pub fn render_require(&self, chunk_ukey: &ChunkUkey, compilation: &Compilation) -> Vec<Cow<str>> {
@@ -352,7 +350,12 @@ impl JsPlugin {
             allow_inline_startup = false;
           }
           let hooks = JsPlugin::get_compilation_hooks(compilation.id());
-          let bailout = hooks.inline_in_runtime_bailout.call(compilation).await?;
+          let bailout = hooks
+            .read()
+            .await
+            .inline_in_runtime_bailout
+            .call(compilation)
+            .await?;
           if allow_inline_startup && let Some(bailout) = bailout {
             buf2.push(format!("// This entry module can't be inlined because {bailout}").into());
             allow_inline_startup = false;
@@ -555,6 +558,8 @@ impl JsPlugin {
     }
     if !all_strict && all_modules.iter().all(|m| m.build_info().strict) {
       if let Some(strict_bailout) = hooks
+        .read()
+        .await
         .strict_runtime_bailout
         .call(compilation, chunk_ukey)
         .await?
@@ -693,6 +698,8 @@ impl JsPlugin {
           Some(format!("it uses a non-standard name for the exports ({exports_argument}).").into())
         } else {
           hooks
+            .read()
+            .await
             .embed_in_runtime_bailout
             .call(compilation, m, chunk)
             .await?
@@ -743,6 +750,8 @@ impl JsPlugin {
         source: startup_sources.boxed(),
       };
       hooks
+        .read()
+        .await
         .render_startup
         .call(
           compilation,
@@ -762,6 +771,8 @@ impl JsPlugin {
         source: RawStringSource::from(startup.join("\n") + "\n").boxed(),
       };
       hooks
+        .read()
+        .await
         .render_startup
         .call(
           compilation,
@@ -791,6 +802,8 @@ impl JsPlugin {
       source: final_source,
     };
     hooks
+      .read()
+      .await
       .render
       .call(compilation, chunk_ukey, &mut render_source)
       .await?;
@@ -1160,6 +1173,8 @@ impl JsPlugin {
     let mut sources = ConcatSource::default();
     if !all_strict && chunk_modules.iter().all(|m| m.build_info().strict) {
       if let Some(strict_bailout) = hooks
+        .read()
+        .await
         .strict_runtime_bailout
         .call(compilation, chunk_ukey)
         .await?
@@ -1185,6 +1200,8 @@ impl JsPlugin {
       source: chunk_modules_source,
     };
     hooks
+      .read()
+      .await
       .render_chunk
       .call(compilation, chunk_ukey, &mut render_source)
       .await?;
@@ -1197,6 +1214,8 @@ impl JsPlugin {
       source: source_with_fragments,
     };
     hooks
+      .read()
+      .await
       .render
       .call(compilation, chunk_ukey, &mut render_source)
       .await?;
@@ -1215,7 +1234,13 @@ impl JsPlugin {
     hasher: &mut RspackHash,
   ) -> Result<()> {
     let hooks = Self::get_compilation_hooks(compilation.id());
-    hooks.chunk_hash.call(compilation, chunk_ukey, hasher).await
+    hooks
+      .read()
+      .await
+      .chunk_hash
+      .call(compilation, chunk_ukey, hasher)
+      .await?;
+    Ok(())
   }
 
   #[inline]

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -145,6 +145,8 @@ pub async fn render_module(
   };
 
   hooks
+    .read()
+    .await
     .render_module_content
     .call(
       compilation,
@@ -241,6 +243,8 @@ pub async fn render_module(
     };
 
     hooks
+      .read()
+      .await
       .render_module_container
       .call(
         compilation,
@@ -254,6 +258,8 @@ pub async fn render_module(
     let mut post_module_package = post_module_container;
 
     hooks
+      .read()
+      .await
       .render_module_package
       .call(
         compilation,
@@ -268,6 +274,8 @@ pub async fn render_module(
     sources.boxed()
   } else {
     hooks
+      .read()
+      .await
       .render_module_package
       .call(
         compilation,

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -80,7 +80,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.render.tap(render::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -197,7 +197,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.render.tap(render::new(self));
   hooks.render_startup.tap(render_startup::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -63,7 +63,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.render_startup.tap(render_startup::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -422,7 +422,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.render_startup.tap(render_startup::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
 

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -48,7 +48,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.render_startup.tap(render_startup::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -71,7 +71,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.render.tap(render::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -85,7 +85,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.render.tap(render::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -171,11 +171,14 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut js_hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
-  js_hooks
-    .render_module_package
-    .tap(render_js_module_package::new(self));
-  js_hooks.chunk_hash.tap(chunk_hash::new(self));
+  {
+    let js_hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+    let mut js_hooks = js_hooks.write().await;
+    js_hooks
+      .render_module_package
+      .tap(render_js_module_package::new(self));
+    js_hooks.chunk_hash.tap(chunk_hash::new(self));
+  }
 
   let mut css_hooks = CssPlugin::get_compilation_hooks_mut(compilation.id());
   css_hooks

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -180,8 +180,10 @@ async fn compilation(
     js_hooks.chunk_hash.tap(chunk_hash::new(self));
   }
 
-  let mut css_hooks = CssPlugin::get_compilation_hooks_mut(compilation.id());
+  let css_hooks = CssPlugin::get_compilation_hooks_mut(compilation.id());
   css_hooks
+    .write()
+    .await
     .render_module_package
     .tap(render_css_module_package::new(self));
 

--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -22,6 +22,7 @@ rspack_hash    = { workspace = true }
 rspack_hook    = { workspace = true }
 rspack_util    = { workspace = true }
 rustc-hash     = { workspace = true }
+tokio          = { workspace = true, features = ["sync"] }
 tracing        = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -9,7 +9,6 @@ version.workspace = true
 
 [dependencies]
 aho-corasick   = { workspace = true }
-dashmap        = { workspace = true }
 derive_more    = { workspace = true, features = ["debug"] }
 indexmap       = { workspace = true }
 once_cell      = { workspace = true }

--- a/crates/rspack_plugin_rsdoctor/Cargo.toml
+++ b/crates/rspack_plugin_rsdoctor/Cargo.toml
@@ -9,7 +9,6 @@ version.workspace = true
 
 [dependencies]
 async-trait        = { workspace = true }
-dashmap            = { workspace = true }
 futures            = { workspace = true }
 indexmap           = { workspace = true }
 rayon              = { workspace = true }

--- a/crates/rspack_plugin_runtime/Cargo.toml
+++ b/crates/rspack_plugin_runtime/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 [dependencies]
 async-trait              = { workspace = true }
 cow-utils                = { workspace = true }
-dashmap                  = { workspace = true }
 derive_more              = { workspace = true, features = ["debug"] }
 futures                  = { workspace = true }
 indexmap                 = { workspace = true }

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -29,7 +29,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   hooks.render_chunk.tap(render_chunk::new(self));
   Ok(())
@@ -157,6 +158,8 @@ async fn render_chunk(
           source: start_up_source,
         };
         hooks
+          .read()
+          .await
           .render_startup
           .call(
             compilation,

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -32,7 +32,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   hooks.render_chunk.tap(render_chunk::new(self));
   Ok(())
@@ -161,6 +162,8 @@ async fn render_chunk(
       source: start_up_source,
     };
     hooks
+      .read()
+      .await
       .render_startup
       .call(
         compilation,

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -35,7 +35,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.render_chunk.tap(render_chunk::new(self));
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())
@@ -241,6 +242,8 @@ async fn render_chunk(
       source: RawStringSource::from(startup_source.join("\n")).boxed(),
     };
     hooks
+      .read()
+      .await
       .render_startup
       .call(
         compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -240,6 +240,8 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
 
       let chunk_ukey = self.chunk.expect("The chunk should be attached");
       let res = hooks
+        .read()
+        .await
         .link_prefetch
         .call(LinkPrefetchData {
           code: link_prefetch_code,
@@ -322,6 +324,8 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
 
       let chunk_ukey = self.chunk.expect("The chunk should be attached");
       let res = hooks
+        .read()
+        .await
         .link_preload
         .call(LinkPreloadData {
           code: link_preload_code,

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
@@ -137,6 +137,8 @@ impl RuntimeModule for LoadScriptRuntimeModule {
     let hooks = RuntimePlugin::get_compilation_hooks(compilation.id());
     let chunk_ukey = self.chunk_ukey;
     let res = hooks
+      .read()
+      .await
       .create_script
       .call(CreateScriptData {
         code: create_script_code,

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -236,6 +236,8 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
 
         let chunk_ukey = self.chunk.expect("The chunk should be attached");
         let res = hooks
+          .read()
+          .await
           .link_prefetch
           .call(LinkPrefetchData {
             code: link_prefetch_code,
@@ -298,6 +300,8 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
 
         let chunk_ukey = self.chunk.expect("The chunk should be attached");
         let res = hooks
+          .read()
+          .await
           .link_preload
           .call(LinkPreloadData {
             code: link_preload_code,

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -169,7 +169,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())
 }

--- a/crates/rspack_plugin_sri/Cargo.toml
+++ b/crates/rspack_plugin_sri/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 [dependencies]
 async-trait                     = { workspace = true }
 cow-utils                       = { workspace = true }
-dashmap                         = { workspace = true }
 derive_more                     = { workspace = true, features = ["debug"] }
 futures                         = { workspace = true }
 indexmap                        = { workspace = true }

--- a/crates/rspack_plugin_sri/src/asset.rs
+++ b/crates/rspack_plugin_sri/src/asset.rs
@@ -11,6 +11,7 @@ use rspack_error::{Diagnostic, Result};
 use rspack_hook::plugin_hook;
 use rspack_plugin_real_content_hash::RealContentHashPluginUpdateHash;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use tokio::sync::RwLock;
 
 use crate::{
   config::IntegrityHtmlPlugin,
@@ -222,34 +223,37 @@ fn digest_chunks(compilation: &Compilation) -> Vec<HashSet<ChunkUkey>> {
   batches
 }
 
-fn add_minssing_integrities(
+async fn add_minssing_integrities(
   assets: &CompilationAssets,
-  integrities: &mut HashMap<String, String>,
+  integrities: Arc<RwLock<HashMap<String, String>>>,
   hash_func_names: &Vec<SubresourceIntegrityHashFunction>,
 ) {
-  let new_integrities = assets
-    .par_iter()
-    .filter_map(|(src, asset)| {
-      if integrities.contains_key(src) {
-        return None;
-      }
-      asset.source.as_ref().map(|s| {
-        let content = s.source();
-        let integrity = compute_integrity(hash_func_names, &content);
-        (src.clone(), integrity)
+  let new_integrities = {
+    let integrities = integrities.read().await;
+    assets
+      .par_iter()
+      .filter_map(|(src, asset)| {
+        if integrities.contains_key(src) {
+          return None;
+        }
+        asset.source.as_ref().map(|s| {
+          let content = s.source();
+          let integrity = compute_integrity(hash_func_names, &content);
+          (src.clone(), integrity)
+        })
       })
-    })
-    .collect::<HashMap<_, _>>();
+      .collect::<HashMap<_, _>>()
+  };
 
-  integrities.extend(new_integrities);
+  integrities.write().await.extend(new_integrities);
 }
 
 #[plugin_hook(CompilationProcessAssets for SubresourceIntegrityPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE - 1)]
 pub async fn handle_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let integrities = process_chunks(&self.options.hash_func_names, compilation);
-  let mut compilation_integrities =
+  let compilation_integrities =
     SubresourceIntegrityPlugin::get_compilation_integrities_mut(compilation.id());
-  compilation_integrities.extend(integrities);
+  compilation_integrities.write().await.extend(integrities);
 
   if matches!(
     self.options.html_plugin,
@@ -257,9 +261,10 @@ pub async fn handle_assets(&self, compilation: &mut Compilation) -> Result<()> {
   ) {
     add_minssing_integrities(
       compilation.assets(),
-      &mut compilation_integrities,
+      compilation_integrities.clone(),
       &self.options.hash_func_names,
-    );
+    )
+    .await;
   }
 
   if matches!(
@@ -268,7 +273,7 @@ pub async fn handle_assets(&self, compilation: &mut Compilation) -> Result<()> {
   ) {
     if let Some(integrity_callback) = &self.options.integrity_callback {
       integrity_callback(IntegrityCallbackData {
-        integerities: compilation_integrities.clone(),
+        integerities: compilation_integrities.read().await.clone(),
       })
       .await?;
     }
@@ -306,9 +311,11 @@ pub async fn update_hash(
   assets: &[Arc<dyn Source>],
   old_hash: &str,
 ) -> Result<Option<String>> {
-  let mut compilation_integrities =
+  let compilation_integrities =
     SubresourceIntegrityPlugin::get_compilation_integrities_mut(compilation.id());
   let key = compilation_integrities
+    .read()
+    .await
     .iter()
     .filter_map(|(k, v)| {
       if v == old_hash {
@@ -321,7 +328,10 @@ pub async fn update_hash(
   if let (Some(key), Some(asset)) = (key, assets.first()) {
     let content = asset.source();
     let new_integrity = compute_integrity(&self.options.hash_func_names, &content);
-    compilation_integrities.insert(key, new_integrity.clone());
+    compilation_integrities
+      .write()
+      .await
+      .insert(key, new_integrity.clone());
     return Ok(Some(new_integrity));
   }
   Ok(None)

--- a/crates/rspack_plugin_sri/src/html.rs
+++ b/crates/rspack_plugin_sri/src/html.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures::future::join_all;
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_hook::plugin_hook;
@@ -8,6 +10,7 @@ use rspack_plugin_html::{
   HtmlPluginBeforeAssetTagGeneration,
 };
 use rustc_hash::FxHashMap as HashMap;
+use tokio::sync::RwLock;
 
 use crate::{
   config::ArcFs, integrity::compute_integrity, util::normalize_path, SRICompilationContext,
@@ -16,27 +19,27 @@ use crate::{
 
 async fn handle_html_plugin_assets(
   data: &mut BeforeAssetTagGenerationData,
-  compilation_integrities: &mut HashMap<String, String>,
+  compilation_integrities: Arc<RwLock<HashMap<String, String>>>,
 ) -> Result<()> {
-  let normalized_integrities = get_normalized_integrities(compilation_integrities);
+  let normalized_integrities = get_normalized_integrities(compilation_integrities.clone()).await;
 
-  let js_integrity = data
-    .assets
-    .js
-    .iter()
-    .map(|asset| {
-      get_integrity_chechsum_for_asset(asset, compilation_integrities, &normalized_integrities)
-    })
-    .collect::<Vec<_>>();
+  let js_integrity = join_all(data.assets.js.iter().map(|asset| {
+    get_integrity_chechsum_for_asset(
+      asset,
+      compilation_integrities.clone(),
+      &normalized_integrities,
+    )
+  }))
+  .await;
 
-  let css_integrity = data
-    .assets
-    .css
-    .iter()
-    .map(|asset| {
-      get_integrity_chechsum_for_asset(asset, compilation_integrities, &normalized_integrities)
-    })
-    .collect::<Vec<_>>();
+  let css_integrity = join_all(data.assets.css.iter().map(|asset| {
+    get_integrity_chechsum_for_asset(
+      asset,
+      compilation_integrities.clone(),
+      &normalized_integrities,
+    )
+  }))
+  .await;
 
   data.assets.js_integrity = Some(js_integrity);
   data.assets.css_integrity = Some(css_integrity);
@@ -47,16 +50,16 @@ async fn handle_html_plugin_assets(
 async fn handle_html_plugin_tags(
   data: &mut AlterAssetTagGroupsData,
   hash_func_names: &Vec<SubresourceIntegrityHashFunction>,
-  integrities: &HashMap<String, String>,
+  integrities: Arc<RwLock<HashMap<String, String>>>,
   ctx: &SRICompilationContext,
 ) -> Result<()> {
-  let normalized_integrities = get_normalized_integrities(integrities);
+  let normalized_integrities = get_normalized_integrities(integrities.clone()).await;
 
   process_tag_group(
     &mut data.head_tags,
     &data.public_path,
     hash_func_names,
-    integrities,
+    integrities.clone(),
     &normalized_integrities,
     ctx,
   )
@@ -78,7 +81,7 @@ async fn process_tag_group(
   tags: &mut [HtmlPluginTag],
   public_path: &str,
   hash_func_names: &Vec<SubresourceIntegrityHashFunction>,
-  integrities: &HashMap<String, String>,
+  integrities: Arc<RwLock<HashMap<String, String>>>,
   normalized_integrities: &HashMap<String, String>,
   ctx: &SRICompilationContext,
 ) -> Result<()> {
@@ -86,7 +89,7 @@ async fn process_tag_group(
     process_tag(
       tag,
       public_path,
-      integrities,
+      integrities.clone(),
       normalized_integrities,
       hash_func_names,
       ctx,
@@ -149,7 +152,7 @@ fn get_tag_src(tag: &HtmlPluginTag) -> Option<String> {
 async fn process_tag(
   tag: &HtmlPluginTag,
   public_path: &str,
-  integrities: &HashMap<String, String>,
+  integrities: Arc<RwLock<HashMap<String, String>>>,
   normalized_integrities: &HashMap<String, String>,
   hash_func_names: &Vec<SubresourceIntegrityHashFunction>,
   ctx: &SRICompilationContext,
@@ -168,7 +171,7 @@ async fn process_tag(
 
   let src = get_asset_path(&tag_src, public_path);
   if let Some(integrity) =
-    get_integrity_chechsum_for_asset(&src, integrities, normalized_integrities)
+    get_integrity_chechsum_for_asset(&src, integrities, normalized_integrities).await
   {
     return Ok(Some(integrity));
   }
@@ -196,11 +199,12 @@ fn get_asset_path(src: &str, public_path: &str) -> String {
     .unwrap_or_else(|| decoded_src.to_string())
 }
 
-fn get_integrity_chechsum_for_asset(
+async fn get_integrity_chechsum_for_asset(
   src: &str,
-  integrities: &HashMap<String, String>,
+  integrities: Arc<RwLock<HashMap<String, String>>>,
   normalized_integrities: &HashMap<String, String>,
 ) -> Option<String> {
+  let integrities = integrities.read().await;
   if let Some(integrity) = integrities.get(src) {
     return Some(integrity.clone());
   }
@@ -209,8 +213,12 @@ fn get_integrity_chechsum_for_asset(
   normalized_integrities.get(&normalized_src).cloned()
 }
 
-fn get_normalized_integrities(integrities: &HashMap<String, String>) -> HashMap<String, String> {
+async fn get_normalized_integrities(
+  integrities: Arc<RwLock<HashMap<String, String>>>,
+) -> HashMap<String, String> {
   integrities
+    .read()
+    .await
     .iter()
     .map(|(key, value)| (normalize_path(key).into_owned(), value.clone()))
     .collect::<HashMap<_, _>>()
@@ -232,9 +240,9 @@ pub async fn before_asset_tag_generation(
   &self,
   mut data: BeforeAssetTagGenerationData,
 ) -> Result<BeforeAssetTagGenerationData> {
-  let mut compilation_integrities =
+  let compilation_integrities =
     SubresourceIntegrityPlugin::get_compilation_integrities_mut(data.compilation_id);
-  handle_html_plugin_assets(&mut data, &mut compilation_integrities).await?;
+  handle_html_plugin_assets(&mut data, compilation_integrities).await?;
   Ok(data)
 }
 
@@ -249,7 +257,7 @@ pub async fn alter_asset_tag_groups(
   handle_html_plugin_tags(
     &mut data,
     &self.options.hash_func_names,
-    &compilation_integrities,
+    compilation_integrities,
     &ctx,
   )
   .await?;

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -29,10 +29,10 @@ use runtime::{create_script, handle_runtime, link_preload};
 use rustc_hash::FxHashMap as HashMap;
 use tokio::sync::RwLock;
 
-static COMPILATION_INTEGRITY_MAP: LazyLock<
-  FxDashMap<CompilationId, Arc<RwLock<HashMap<String, String>>>>,
-> = LazyLock::new(Default::default);
+type CompilationIntegrityMap =
+  LazyLock<FxDashMap<CompilationId, Arc<RwLock<HashMap<String, String>>>>>;
 
+static COMPILATION_INTEGRITY_MAP: CompilationIntegrityMap = LazyLock::new(Default::default);
 static COMPILATION_CONTEXT_MAP: LazyLock<FxDashMap<CompilationId, Arc<SRICompilationContext>>> =
   LazyLock::new(Default::default);
 

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -5,7 +5,7 @@ mod integrity;
 mod runtime;
 mod util;
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use asset::{detect_unresolved_integrity, handle_assets, update_hash};
 use config::SRICompilationContext;
@@ -27,11 +27,13 @@ use rspack_plugin_runtime::RuntimePlugin;
 use rspack_util::fx_hash::FxDashMap;
 use runtime::{create_script, handle_runtime, link_preload};
 use rustc_hash::FxHashMap as HashMap;
+use tokio::sync::RwLock;
 
-static COMPILATION_INTEGRITY_MAP: LazyLock<FxDashMap<CompilationId, HashMap<String, String>>> =
-  LazyLock::new(Default::default);
+static COMPILATION_INTEGRITY_MAP: LazyLock<
+  FxDashMap<CompilationId, Arc<RwLock<HashMap<String, String>>>>,
+> = LazyLock::new(Default::default);
 
-static COMPILATION_CONTEXT_MAP: LazyLock<FxDashMap<CompilationId, SRICompilationContext>> =
+static COMPILATION_CONTEXT_MAP: LazyLock<FxDashMap<CompilationId, Arc<SRICompilationContext>>> =
   LazyLock::new(Default::default);
 
 #[plugin]
@@ -45,33 +47,31 @@ impl SubresourceIntegrityPlugin {
     Self::new_inner(options)
   }
 
-  pub fn get_compilation_sri_context(
-    id: CompilationId,
-  ) -> dashmap::mapref::one::Ref<'static, CompilationId, SRICompilationContext> {
+  pub fn get_compilation_sri_context(id: CompilationId) -> Arc<SRICompilationContext> {
     COMPILATION_CONTEXT_MAP
       .get(&id)
       .expect("should have sri context")
+      .clone()
   }
 
   pub fn set_compilation_sri_context(id: CompilationId, ctx: SRICompilationContext) {
-    COMPILATION_CONTEXT_MAP.insert(id, ctx);
+    COMPILATION_CONTEXT_MAP.insert(id, Arc::new(ctx));
   }
 
-  pub fn get_compilation_integrities(
-    id: CompilationId,
-  ) -> dashmap::mapref::one::Ref<'static, CompilationId, HashMap<String, String>> {
+  pub fn get_compilation_integrities(id: CompilationId) -> Arc<RwLock<HashMap<String, String>>> {
     if !COMPILATION_INTEGRITY_MAP.contains_key(&id) {
       COMPILATION_INTEGRITY_MAP.insert(id, Default::default());
     }
     COMPILATION_INTEGRITY_MAP
       .get(&id)
       .expect("should have compilation integrities")
+      .clone()
   }
 
   pub fn get_compilation_integrities_mut(
     id: CompilationId,
-  ) -> dashmap::mapref::one::RefMut<'static, CompilationId, HashMap<String, String>> {
-    COMPILATION_INTEGRITY_MAP.entry(id).or_default()
+  ) -> Arc<RwLock<HashMap<String, String>>> {
+    COMPILATION_INTEGRITY_MAP.entry(id).or_default().clone()
   }
 }
 

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -126,7 +126,8 @@ async fn handle_compilation(
     .tap(link_preload::new(self));
 
   if matches!(self.options.html_plugin, IntegrityHtmlPlugin::NativePlugin) {
-    let mut html_plugin_hooks = HtmlRspackPlugin::get_compilation_hooks_mut(compilation.id());
+    let html_plugin_hooks = HtmlRspackPlugin::get_compilation_hooks_mut(compilation.id());
+    let mut html_plugin_hooks = html_plugin_hooks.write().await;
     html_plugin_hooks
       .before_asset_tag_generation
       .tap(before_asset_tag_generation::new(self));

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -101,11 +101,14 @@ async fn handle_compilation(
   };
   SubresourceIntegrityPlugin::set_compilation_sri_context(compilation.id(), ctx);
 
-  let mut real_content_hash_plugin_hooks =
-    RealContentHashPlugin::get_compilation_hooks_mut(compilation.id());
-  real_content_hash_plugin_hooks
-    .update_hash
-    .tap(update_hash::new(self));
+  {
+    let real_content_hash_plugin_hooks =
+      RealContentHashPlugin::get_compilation_hooks_mut(compilation.id());
+    let mut real_content_hash_plugin_hooks = real_content_hash_plugin_hooks.write().await;
+    real_content_hash_plugin_hooks
+      .update_hash
+      .tap(update_hash::new(self));
+  }
 
   if matches!(
     compilation.options.output.cross_origin_loading,

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -120,13 +120,16 @@ async fn handle_compilation(
     ));
   }
 
-  let mut runtime_plugin_hooks = RuntimePlugin::get_compilation_hooks_mut(compilation.id());
-  runtime_plugin_hooks
-    .create_script
-    .tap(create_script::new(self));
-  runtime_plugin_hooks
-    .link_preload
-    .tap(link_preload::new(self));
+  {
+    let runtime_plugin_hooks = RuntimePlugin::get_compilation_hooks_mut(compilation.id());
+    let mut runtime_plugin_hooks = runtime_plugin_hooks.write().await;
+    runtime_plugin_hooks
+      .create_script
+      .tap(create_script::new(self));
+    runtime_plugin_hooks
+      .link_preload
+      .tap(link_preload::new(self));
+  }
 
   if matches!(self.options.html_plugin, IntegrityHtmlPlugin::NativePlugin) {
     let html_plugin_hooks = HtmlRspackPlugin::get_compilation_hooks_mut(compilation.id());

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -138,7 +138,8 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let mut hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
   hooks.chunk_hash.tap(js_chunk_hash::new(self));
   Ok(())
 }


### PR DESCRIPTION
## Summary

Currently some functions  return `Ref` or `RefMut` of `DashMap`, which holds the inner sync rwlocks. When the `Ref`s are used across `.await`, deadlocks may happen.

So this pr wrapper all values of dashmap with `Arc<T>` or `Arc<tokio::sync::RwLock<T>>` depending on their usages. 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
