### PR TITLE
fix: update swc to 31.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6585,9 +6585,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "31.0.1"
+version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5682aa43a46b47ecab50e60b012ba18ea83978c8fa1fa8fad0c86b4825ec643"
+checksum = "4fe7787e59eccca32521b3a49a80c6957f8c44270f3967bdef23f9921482c4eb"
 dependencies = [
  "par-core",
  "swc",
@@ -6873,9 +6873,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lexer"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f7b2ef4e431183454b1aa8d21d0cb25c13593b7da8b0215a0602a4599ed749"
+checksum = "180810f860c9128eb74b970da8826e0d86fd8f99808c2fbe224cc5c714af2b70"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
@@ -6955,9 +6955,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84ef9d621665426e0d617fa019c45b88118b25a8b0a2a7f47f6b8077ee87486"
+checksum = "98c059cc69b577ca26d5bc1efdb022c7ee3e186637b6b355bb2f6660491a6ed1"
 dependencies = [
  "either",
  "num-bigint",
@@ -7179,9 +7179,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "22.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be4f7717acdf482d5294aa66423b82849e7987214b8d041d075e1854dc9e7a2"
+checksum = "8cd6178c6de84b8090d0c8229441ab8a57829b8502b30d44b8f2ae927fea2c0a"
 dependencies = [
  "base64",
  "bytes-str",
@@ -7239,9 +7239,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "18.0.3"
+version = "18.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a10317f9c04f6345d22fc86f94f8a38a7d5b4ce0fc77b3846658a2c887776"
+checksum = "21c9a1dda55bddf62dae2130640452813ad70df9014450852b94753b154885ec"
 dependencies = [
  "indexmap 2.7.1",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,8 +123,8 @@ rkyv      = { version = "=0.8.8", default-features = false, features = ["std", "
 pnp                 = { version = "0.9.0", default-features = false }
 swc                 = { version = "=30.0.0", default-features = false }
 swc_config          = { version = "=3.1.1", default-features = false }
-swc_core            = { version = "=31.0.1", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_lexer      = { version = "=19.0.0", default-features = false }
+swc_core            = { version = "=31.1.0", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_lexer      = { version = "=19.0.1", default-features = false }
 swc_ecma_minifier   = { version = "=25.0.0", default-features = false }
 swc_error_reporters = { version = "=15.0.1", default-features = false }
 swc_html            = { version = "=24.0.1", default-features = false }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Update the swc version so it contains the fix for the typescript typings in ambient context. (see https://github.com/swc-project/swc/pull/10802)

As I understand it - the fix is part of the 31.1.0

## Related links

<!-- Related issues or discussions. -->

Referensed in the swc repo:
- https://github.com/swc-project/swc/pull/10802
- https://github.com/swc-project/swc/issues/10800

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
