### PR TITLE
perf: napi source map serialize and deserialize

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -919,7 +919,7 @@ export interface JsLoaderContext {
   content: null | Buffer
   additionalData?: any
   __internal__parseMeta: Record<string, string>
-  sourceMap?: Buffer
+  sourceMap?: SourceMap
   cacheable: boolean
   fileDependencies: Array<string>
   contextDependencies: Array<string>
@@ -2721,6 +2721,16 @@ export interface RegisterJsTaps {
   registerRsdoctorPluginModuleIdsTaps: (stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorModuleIdsPatch) => Promise<boolean | undefined>); stage: number; }>
   registerRsdoctorPluginModuleSourcesTaps: (stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorModuleSourcesPatch) => Promise<boolean | undefined>); stage: number; }>
   registerRsdoctorPluginAssetsTaps: (stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorAssetPatch) => Promise<boolean | undefined>); stage: number; }>
+}
+
+export interface SourceMap {
+  file?: string
+  sources?: Array<string | undefined | null>
+  sourceRoot?: string
+  sourcesContent?: Array<string | undefined | null>
+  names?: Array<string | undefined | null>
+  mappings?: string
+  debugId?: string
 }
 
 export interface SourceMapDevToolPluginOptions {

--- a/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   diagnostics::CapturedLoaderError, AdditionalData, LoaderContext, NormalModuleLoaderShouldYield,
   NormalModuleLoaderStartYielding, RunnerContext, BUILTIN_LOADER_PREFIX,
 };
-use rspack_error::{miette::IntoDiagnostic, Result, ToStringResultToRspackResultExt};
+use rspack_error::{miette::IntoDiagnostic, Result};
 use rspack_hook::plugin_hook;
 use rspack_loader_runner::State as LoaderState;
 
@@ -143,17 +143,7 @@ pub(crate) fn merge_loader_context(
       Some(content)
     }
   };
-  let source_map = from
-    .source_map
-    .as_ref()
-    .map(|s| {
-      rspack_core::rspack_sources::SourceMap::from_json(
-        // SAFETY: `sourceMap` is serialized by JavaScript from a JSON object. This is an invariant should be followed on the JavaScript side.
-        unsafe { str::from_utf8_unchecked(s) },
-      )
-    })
-    .transpose()
-    .to_rspack_result()?;
+  let source_map = from.source_map.map(Into::into);
   let additional_data = from.additional_data.take().map(|data| {
     let mut additional = AdditionalData::default();
     additional.insert(data);

--- a/crates/rspack_binding_api/src/source.rs
+++ b/crates/rspack_binding_api/src/source.rs
@@ -331,7 +331,7 @@ pub struct SourceMap {
   pub source_root: Option<String>,
   pub sources_content: Option<Vec<Option<String>>>,
   pub names: Option<Vec<Option<String>>>,
-  pub mappings: String,
+  pub mappings: Option<String>,
   pub debug_id: Option<String>,
 }
 
@@ -363,7 +363,7 @@ impl From<&rspack_core::rspack_sources::SourceMap> for SourceMap {
           .map(|name| Some(name.to_string()))
           .collect::<Vec<_>>(),
       ),
-      mappings: value.mappings().to_string(),
+      mappings: Some(value.mappings().to_string()),
       debug_id: value.get_debug_id().map(|id| id.to_string()),
     }
   }
@@ -371,6 +371,7 @@ impl From<&rspack_core::rspack_sources::SourceMap> for SourceMap {
 
 impl From<SourceMap> for rspack_core::rspack_sources::SourceMap {
   fn from(value: SourceMap) -> Self {
+    let mappings = value.mappings.unwrap_or_default();
     let sources = value
       .sources
       .unwrap_or_default()
@@ -390,7 +391,7 @@ impl From<SourceMap> for rspack_core::rspack_sources::SourceMap {
       .map(|name| name.unwrap_or_default())
       .collect::<Vec<_>>();
     let mut map =
-      rspack_core::rspack_sources::SourceMap::new(value.mappings, sources, sources_content, names);
+      rspack_core::rspack_sources::SourceMap::new(mappings, sources, sources_content, names);
     map.set_source_root(value.source_root);
     map.set_debug_id(value.debug_id);
     map

--- a/crates/rspack_binding_api/src/source.rs
+++ b/crates/rspack_binding_api/src/source.rs
@@ -3,8 +3,7 @@ use std::{hash::Hash, sync::Arc};
 use napi_derive::napi;
 use rspack_core::rspack_sources::{
   BoxSource, CachedSource, ConcatSource, MapOptions, OriginalSource, RawBufferSource, RawSource,
-  RawStringSource, ReplaceSource, Source, SourceExt, SourceMap, SourceMapSource,
-  WithoutOriginalOptions,
+  RawStringSource, ReplaceSource, Source, SourceExt, SourceMapSource, WithoutOriginalOptions,
 };
 use rspack_napi::napi::bindgen_prelude::*;
 
@@ -26,7 +25,7 @@ impl<'s> From<JsCompatSource<'s>> for BoxSource {
     match value.source {
       Either::A(string) => {
         if let Some(map) = value.map {
-          match SourceMap::from_slice(map.as_ref()).ok() {
+          match rspack_core::rspack_sources::SourceMap::from_slice(map.as_ref()).ok() {
             Some(source_map) => SourceMapSource::new(WithoutOriginalOptions {
               value: string,
               name: "inmemory://from js",
@@ -55,7 +54,7 @@ impl From<JsCompatSourceOwned> for BoxSource {
     match value.source {
       Either::A(string) => {
         if let Some(map) = value.map {
-          match SourceMap::from_slice(map.as_ref()).ok() {
+          match rspack_core::rspack_sources::SourceMap::from_slice(map.as_ref()).ok() {
             Some(source_map) => SourceMapSource::new(WithoutOriginalOptions {
               value: string,
               name: "inmemory://from js",
@@ -323,4 +322,77 @@ fn to_webpack_map(source: &dyn Source) -> Result<Option<String>> {
   let map = source.map(&MapOptions::default());
 
   map.map(|m| m.to_json()).transpose().to_napi_result()
+}
+
+#[napi(object)]
+pub struct SourceMap {
+  pub file: Option<String>,
+  pub sources: Option<Vec<Option<String>>>,
+  pub source_root: Option<String>,
+  pub sources_content: Option<Vec<Option<String>>>,
+  pub names: Option<Vec<Option<String>>>,
+  pub mappings: String,
+  pub debug_id: Option<String>,
+}
+
+impl From<&rspack_core::rspack_sources::SourceMap> for SourceMap {
+  fn from(value: &rspack_core::rspack_sources::SourceMap) -> Self {
+    SourceMap {
+      file: value.file().map(|file| file.to_string()),
+      sources: Some(
+        value
+          .sources()
+          .iter()
+          .map(|source| Some(source.to_string()))
+          .collect::<Vec<_>>(),
+      ),
+      source_root: value
+        .source_root()
+        .map(|source_root| source_root.to_string()),
+      sources_content: Some(
+        value
+          .sources_content()
+          .iter()
+          .map(|content| Some(content.to_string()))
+          .collect::<Vec<_>>(),
+      ),
+      names: Some(
+        value
+          .names()
+          .iter()
+          .map(|name| Some(name.to_string()))
+          .collect::<Vec<_>>(),
+      ),
+      mappings: value.mappings().to_string(),
+      debug_id: value.get_debug_id().map(|id| id.to_string()),
+    }
+  }
+}
+
+impl From<SourceMap> for rspack_core::rspack_sources::SourceMap {
+  fn from(value: SourceMap) -> Self {
+    let sources = value
+      .sources
+      .unwrap_or_default()
+      .into_iter()
+      .map(|source| source.unwrap_or_default())
+      .collect::<Vec<_>>();
+    let sources_content = value
+      .sources_content
+      .unwrap_or_default()
+      .into_iter()
+      .map(|source| source.unwrap_or_default())
+      .collect::<Vec<_>>();
+    let names = value
+      .names
+      .unwrap_or_default()
+      .into_iter()
+      .map(|name| name.unwrap_or_default())
+      .collect::<Vec<_>>();
+    let mut map =
+      rspack_core::rspack_sources::SourceMap::new(value.mappings, sources, sources_content, names);
+    map.set_source_root(value.source_root);
+    map.set_debug_id(value.debug_id);
+    map
+  }
 }

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -38,13 +38,7 @@ import {
 	isUseSourceMap
 } from "../config/adapterRuleUse";
 import { JavaScriptTracer } from "../trace";
-import {
-	isNil,
-	serializeObject,
-	stringifyLoaderObject,
-	toBuffer,
-	toObject
-} from "../util";
+import { isNil, stringifyLoaderObject, toBuffer } from "../util";
 import { createHash } from "../util/createHash";
 import {
 	absolutify,
@@ -217,16 +211,6 @@ export class LoaderObject {
 
 	static __to_binding(loader: LoaderObject): JsLoaderItem {
 		return loader.loaderItem;
-	}
-}
-
-class JsSourceMap {
-	static __from_binding(map?: Buffer) {
-		return isNil(map) ? undefined : toObject(map);
-	}
-
-	static __to_binding(map?: object) {
-		return serializeObject(map);
 	}
 }
 
@@ -1055,7 +1039,7 @@ export async function runLoaders(
 			}
 			case JsLoaderState.Normal: {
 				let content = context.content;
-				let sourceMap = JsSourceMap.__from_binding(context.sourceMap);
+				let sourceMap = context.sourceMap;
 				let additionalData = context.additionalData;
 
 				while (loaderContext.loaderIndex >= 0) {
@@ -1085,7 +1069,7 @@ export async function runLoaders(
 				}
 
 				context.content = isNil(content) ? null : toBuffer(content);
-				context.sourceMap = JsSourceMap.__to_binding(sourceMap);
+				context.sourceMap = sourceMap;
 				context.additionalData = additionalData || undefined;
 				context.__internal__utf8Hint = typeof content === "string";
 

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -1045,7 +1045,7 @@ export async function runLoaders(
 					if (hasArg) {
 						const [content, sourceMap, additionalData] = args;
 						context.content = isNil(content) ? null : toBuffer(content);
-						context.sourceMap = serializeObject(sourceMap);
+						context.sourceMap = sourceMap;
 						context.additionalData = additionalData || undefined;
 						break;
 					}

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -1029,7 +1029,7 @@ export async function runLoaders(
 					if (hasArg) {
 						const [content, sourceMap, additionalData] = args;
 						context.content = isNil(content) ? null : toBuffer(content);
-						context.sourceMap = sourceMap;
+						context.sourceMap = sourceMap || undefined;
 						context.additionalData = additionalData || undefined;
 						break;
 					}
@@ -1069,7 +1069,7 @@ export async function runLoaders(
 				}
 
 				context.content = isNil(content) ? null : toBuffer(content);
-				context.sourceMap = sourceMap;
+				context.sourceMap = sourceMap || undefined;
 				context.additionalData = additionalData || undefined;
 				context.__internal__utf8Hint = typeof content === "string";
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Performance Benchmark for N-API Source Map transmission ways

```rs
// Method 1: String
#[napi]
pub fn send_source_map_by_string(json: String) -> Result<()> {
  let mut slice = json.as_bytes().to_vec();
  let _map: SourceMap = simd_json::serde::from_slice(&mut slice).unwrap();
  Ok(())
}

// Method 2: Buffer
#[napi]
pub fn send_source_map_by_buffer(buffer: BufferSlice) -> Result<()> {
  let mut slice = buffer.to_vec();
  let _map: SourceMap = simd_json::serde::from_slice(&mut slice).unwrap();
  Ok(())
}

// Method 3: Direct object
#[napi]
pub fn send_source_map_by_object(_object: SourceMap) -> Result<()> {
  Ok(())
}
```

JavaScript benchmark:

```js
console.log("send source map by string", measure(() => {
    sendSourceMapByString(JSON.stringify(json));
}));

console.log("send source map by buffer", measure(() => {
    sendSourceMapByBuffer(Buffer.from(JSON.stringify(json)));
}));

console.log("send source map by object", measure(() => {
    sendSourceMapByObject(json);
}));
```

Benchmark results:

```
Buffer:                   2,375,041 ns
String:                   1,845,042 ns
Direct object:            110,083 ns
```

You can see the benchmark details here: https://github.com/SyMind/napi-class-vs-object/blob/main/bench.js#L429

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
