### PR TITLE
fix: do not test version in canary builds

### DIFF
--- a/packages/rspack/src/util/bindingVersionCheck.ts
+++ b/packages/rspack/src/util/bindingVersionCheck.ts
@@ -12,7 +12,7 @@ export const checkVersion = () => {
 	}
 
 	// In canary version, version bump is done after binding is built.
-	// And to export `EXPECTED_RSPACK_CORE_VERSION` in binding, it relys on the bumped version of @rspack/core.
+	// And to export `EXPECTED_RSPACK_CORE_VERSION` in binding, it relies on the bumped version of @rspack/core.
 	// So we can't check the version of @rspack/core and @rspack/binding in canary version.
 	// Here we ignore version check for canary version.
 	if (CORE_VERSION.includes("canary")) {


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

In canary version, version bump is done after binding is built.
And to export `EXPECTED_RSPACK_CORE_VERSION` in binding, it relys on the bumped version of @rspack/core.
So we can't check the version of @rspack/core and @rspack/binding in canary version.
Here we ignore version check for canary version.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
