### PR TITLE
chore(ci): size-limit  ignore comment error

### DIFF
--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -44,7 +44,11 @@ module.exports = async function action({ github, context, limit }) {
 
 	const comment = compareBinarySize(headSize, baseSize, context, baseCommit);
 
-	await commentToPullRequest(github, context, comment);
+	try {
+		await commentToPullRequest(github, context, comment);
+	} catch (e) {
+		console.error("Failed to comment on pull request:", e);
+	}
 
 	const increasedSize = headSize - baseSize;
 	if (increasedSize > limit) {


### PR DESCRIPTION
## Summary
Pull Request from forked Rspack repo's CI fails, due to its github token isn't allowed to comment on the pull request.
Just ignore then comment error, the action should fail only when size limit hit.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
