### PR TITLE
chore: support separated cargo check for crate publishing

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -18,6 +18,9 @@ jobs:
   rust_tests:
     name: Run Rust Tests
     uses: ./.github/workflows/reusable-rust-test.yml
+    with:
+      # Use separated strategy to check all crates
+      cargo-check-strategy: "separated"
 
   release_crates:
     environment: crate

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -2,6 +2,12 @@ name: Reusable Rust Test
 
 on:
   workflow_call:
+    inputs:
+      cargo-check-strategy:
+        type: string
+        required: false
+        default: "all"
+        description: "Strategy for cargo check: all (default) or separated"
 
 jobs:
   check-changed:
@@ -40,8 +46,21 @@ jobs:
       - name: Run Cargo codegen
         run: cargo codegen
 
-      - name: Run Cargo Check
+      - name: Install cargo-binstall
+        if: ${{ inputs.cargo-check-strategy == 'separated' }}
+        uses: cargo-bins/cargo-binstall@8aac5aa2bf0dfaa2863eccad9f43c68fe40e5ec8 # v1.14.1
+
+      - name: Install cargo-workspaces
+        if: ${{ inputs.cargo-check-strategy == 'separated' }}
+        run: cargo binstall --no-confirm cargo-workspaces@0.4.0 --force
+
+      - name: Run Cargo Check (all strategy)
+        if: ${{ inputs.cargo-check-strategy == 'all' }}
         run: cargo check --workspace --all-targets --locked
+
+      - name: Run Cargo Check (separated strategy)
+        if: ${{ inputs.cargo-check-strategy == 'separated' }}
+        run: cargo workspaces exec cargo check --all-targets --locked
 
       - name: Run Clippy
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1

--- a/x.mjs
+++ b/x.mjs
@@ -317,7 +317,8 @@ program
 			"workspaces",
 			"publish",
 			"--publish-as-is", // Publish crates from the current commit without versioning
-			"--allow-dirty" // Allow publishing even if the workspace is dirty. `cargo codegen` will generate `crates/rspack_workspace/src/generated.rs`
+			"--allow-dirty", // Allow publishing even if the workspace is dirty. `cargo codegen` will generate `crates/rspack_workspace/src/generated.rs`
+			"--no-verify" // Skip verification of the workspace. This was pre-checked by `release-crates.yml` with `cargo check` with `separated` strategy
 			// Commented `--locked` flag
 			// because some dev-deps refer to workspace members with versions rspack_swc_plugin_ts_collector
 			// and these workspace members are to be removed in release. This would cause `Cargo.lock` to be updated.

--- a/x.mjs
+++ b/x.mjs
@@ -317,7 +317,7 @@ program
 			"workspaces",
 			"publish",
 			"--publish-as-is", // Publish crates from the current commit without versioning
-			"--allow-dirty", // Allow publishing even if the workspace is dirty. `cargo codegen` will generate `crates/rspack_workspace/src/generated.rs`
+			"--no-remove-dev-deps", // Do not remove dev-dependencies from `Cargo.lock`, otherwise the `Cargo.toml` will be updated and dirty check will fail
 			"--no-verify" // Skip verification of the workspace. This was pre-checked by `release-crates.yml` with `cargo check` with `separated` strategy
 			// Commented `--locked` flag
 			// because some dev-deps refer to workspace members with versions rspack_swc_plugin_ts_collector


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Added cargo-check-strategy "separated" to reusable-rust-test.yml. In crate publishing, separated strategy will be executed to mimick the cargo publish verification step. This PR also adds `--no-verify` flag to `cargo publish` to skip the verification step.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
