### PR TITLE
refactor: remove `oneshot`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,12 +3125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
-name = "oneshot"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
-
-[[package]]
 name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4747,7 +4741,6 @@ name = "rspack_napi"
 version = "0.2.1-alpha.1"
 dependencies = [
  "napi",
- "oneshot",
  "rspack_error",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ mimalloc            = { version = "0.2.4", package = "mimalloc-rspack", default-
 mime_guess          = { version = "2.0.5", default-features = false, features = ["rev-mappings"] }
 num-bigint          = { version = "0.4.6", default-features = false }
 once_cell           = { version = "1.20.2", default-features = false }
-oneshot             = { version = "0.1.8", default-features = false, features = ["std", "async"] }
 owo-colors          = { version = "4.0.0", default-features = false }
 parcel_sourcemap    = { version = "2.1.1", default-features = false }
 paste               = { version = "1.0.15", default-features = false }

--- a/crates/rspack_napi/Cargo.toml
+++ b/crates/rspack_napi/Cargo.toml
@@ -9,7 +9,6 @@ version.workspace = true
 
 [dependencies]
 napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi7"] }
-oneshot      = { workspace = true }
 rspack_error = { workspace = true }
 serde_json   = { workspace = true }
 tokio        = { workspace = true, features = ["sync"] }

--- a/crates/rspack_napi/src/threadsafe_function.rs
+++ b/crates/rspack_napi/src/threadsafe_function.rs
@@ -10,8 +10,8 @@ use napi::{
   threadsafe_function::{ThreadsafeFunction as RawThreadsafeFunction, ThreadsafeFunctionCallMode},
   Env, JsValue, Status, Unknown, ValueType,
 };
-use oneshot::Receiver;
 use rspack_error::{Error, Result};
+use tokio::sync::oneshot::{self, Receiver};
 
 use crate::{JsCallback, NapiErrorToRspackErrorExt};
 
@@ -63,7 +63,7 @@ impl<T: 'static + JsValuesTupleIntoVec, R> FromNapiValue for ThreadsafeFunction<
 
 impl<T: 'static + JsValuesTupleIntoVec, R> ThreadsafeFunction<T, R> {
   async fn resolve_error(&self, err: napi::Error) -> Error {
-    let (tx, rx) = tokio::sync::oneshot::channel::<rspack_error::Error>();
+    let (tx, rx) = oneshot::channel::<rspack_error::Error>();
     ERROR_RESOLVER
       .get()
       // SAFETY: The error resolver is initialized in `FromNapiValue::from_napi_value` and it's the only way to create a tsfn.


### PR DESCRIPTION
## Summary

We have refactored tsfn related functions to async ones, so here we can use `tokio::sync::oneshot` to replace `oneshot`. 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
