### PR TITLE
fix: use regress to parse regex syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,9 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ef7fa9ed0256d64a688a3747d0fef7a88851c18a5e1d57f115f38ec2e09366"
+checksum = "145bb27393fe455dd64d6cbc8d059adfa392590a45eadf079c01b11857e7b010"
 dependencies = [
  "hashbrown 0.15.2",
  "memchr",
@@ -5106,6 +5106,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "regex",
+ "regress",
  "ropey",
  "rspack_cacheable",
  "rspack_collections",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ quote               = { version = "1.0.38", default-features = false }
 rayon               = { version = "1.10.0", default-features = false }
 regex               = { version = "1.11.1", default-features = false }
 regex-syntax        = { version = "0.8.5", default-features = false, features = ["std"] }
-regress             = { version = "0.10.1", default-features = false }
+regress             = { version = "0.10.4", default-features = false, features = ["pattern"] }
 ropey               = { version = "1.6.1", default-features = false }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.0", default-features = false }
 rspack_sources      = { version = "0.4.8", default-features = false }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -20,6 +20,7 @@ num-bigint = { workspace = true }
 once_cell = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
+regress = { workspace = true, features = ["pattern"] }
 ropey = { workspace = true }
 rspack_cacheable = { workspace = true }
 rspack_collections = { workspace = true }

--- a/packages/rspack-test-tools/tests/configCases/context/issue-10889/index.js
+++ b/packages/rspack-test-tools/tests/configCases/context/issue-10889/index.js
@@ -1,6 +1,6 @@
 
 // https://github.com/web-infra-dev/rspack/issues/10889
-describe('should parse invalid regex syntax', () => {
+it('should parse invalid regex syntax', () => {
 	const foo = '`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?'.replace(
 		/[-/\\^$*+?.()|[\]{}]/g,
 		'\\$&'

--- a/packages/rspack-test-tools/tests/configCases/context/issue-10889/index.js
+++ b/packages/rspack-test-tools/tests/configCases/context/issue-10889/index.js
@@ -1,0 +1,10 @@
+
+// https://github.com/web-infra-dev/rspack/issues/10889
+describe('should parse invalid regex syntax', () => {
+	const foo = '`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?'.replace(
+		/[-/\\^$*+?.()|[\]{}]/g,
+		'\\$&'
+	);
+	console.log('foo')
+})
+


### PR DESCRIPTION
## Summary
close #10889 
this may bring performance regression since regress is much slower than regex crate
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
