### PR TITLE
ci: fix rewrite-factorize-request test case

### DIFF
--- a/tests/e2e/cases/make/rewrite-factorize-request/index.test.ts
+++ b/tests/e2e/cases/make/rewrite-factorize-request/index.test.ts
@@ -1,14 +1,20 @@
 import { expect, test } from "@/fixtures";
 
-test.skip("should compile", async ({ page, fileAction, rspack }) => {
-	await expect(page.getByText("2")).toBeVisible();
+async function expect_content(page: any, data: string) {
+	await expect(async () => {
+		await page.reload();
+		expect(await page.locator("div").innerText()).toBe(data);
+	}).toPass();
+}
+
+test("should compile", async ({ page, fileAction, rspack }) => {
+	await expect_content(page, "2");
 
 	fileAction.updateFile("file.js", content => content.replace("1", "2"));
 
-	await page.reload();
-	await expect(page.getByText("4")).toBeVisible();
+	await expect_content(page, "4");
 
 	fileAction.updateFile("file.js", content => content.replace("2", "3"));
-	await page.reload();
-	await expect(page.getByText("6")).toBeVisible();
+
+	await expect_content(page, "6");
 });

--- a/tests/e2e/fixtures/pathInfo.ts
+++ b/tests/e2e/fixtures/pathInfo.ts
@@ -30,6 +30,11 @@ async function calcPathInfo(
 		await fs.remove(tempProjectDir);
 	}
 	await fs.copy(testProjectDir, tempProjectDir);
+	for (const modulePath of Object.keys(require.cache)) {
+		if (modulePath.startsWith(tempProjectDir)) {
+			delete require.cache[modulePath];
+		}
+	}
 
 	return {
 		testFile,


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
The e2e tests copy test cases to a temporary directory named with a number. When the test is running, the previous and next tests using the same path loader may cause mutual contamination. This PR adds the relevant require.cache cleanup operation

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
