### PR TITLE
perf: avoid duplicate calculations in executor task

### DIFF
--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -130,11 +130,10 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
     let mut has_error = false;
 
     while let Some(m) = queue.pop_front() {
-      // to avoid duplicate calculate in https://github.com/web-infra-dev/rspack/issues/10987
-      if modules.contains(&m) {
+      // to avoid duplicate calculations in https://github.com/web-infra-dev/rspack/issues/10987
+      if !modules.insert(m) {
         continue;
       }
-      modules.insert(m);
       let module = mg.module_by_identifier(&m).expect("should have module");
       let build_info = module.build_info();
       execute_result

--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -130,6 +130,10 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
     let mut has_error = false;
 
     while let Some(m) = queue.pop_front() {
+      // to avoid duplicate calculate in https://github.com/web-infra-dev/rspack/issues/10987
+      if modules.contains(&m) {
+        continue;
+      }
       modules.insert(m);
       let module = mg.module_by_identifier(&m).expect("should have module");
       let build_info = module.build_info();
@@ -168,7 +172,6 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
           }
         }
       }
-
       for dep_id in module.get_dependencies() {
         if !has_error && make_failed_dependencies.contains(dep_id) {
           let dep = mg.dependency_by_id(dep_id).expect("should dep exist");


### PR DESCRIPTION
## Summary
close #10987
The build hang is caused by redundant computation in ExecutorTask, resulting in approximately 90⁴ (i.e., 90×90×90×90) calculations, as seen in [this file](https://github.com/mjames-c/rspack-bug-10987/blob/main/src/dep-1.css)
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
