### PR TITLE
feat: implement Default trait for ExtendedStatsOptions struct

### DIFF
--- a/crates/rspack_core/src/stats/struct.rs
+++ b/crates/rspack_core/src/stats/struct.rs
@@ -37,6 +37,36 @@ pub struct ExtendedStatsOptions {
   pub warnings: bool,
 }
 
+impl Default for ExtendedStatsOptions {
+  fn default() -> Self {
+    Self {
+      chunks: true,
+      chunk_modules: true,
+      errors: true,
+      warnings: true,
+      assets: true,
+      hash: true,
+
+      cached_modules: false,
+      chunk_group_auxiliary: false,
+      chunk_group_children: false,
+      chunk_groups: false,
+      chunk_relations: false,
+      depth: false,
+      entrypoints: EntrypointsStatsOption::Bool(false),
+      ids: false,
+      modules: false,
+      module_assets: false,
+      nested_modules: false,
+      optimization_bailout: false,
+      provided_exports: false,
+      reasons: false,
+      source: false,
+      used_exports: false,
+    }
+  }
+}
+
 #[derive(Debug)]
 pub struct StatsError<'a> {
   pub name: Option<String>,


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Add `Default` implementation for `ExtendedStatsOptions` to provide sensible default values for build statistics output.

**Changes:**
- Implement `Default` trait for `ExtendedStatsOptions`
- Enable essential fields by default: `chunks`, `chunk_modules`, `errors`, `warnings`, `assets`, and `hash`
- Keep detailed/verbose options disabled by default to maintain clean output

**Rationale:**
Previously, `ExtendedStatsOptions` had no default values, requiring users to manually configure every field. This implementation provides a balanced default configuration that shows the most commonly needed information (errors, warnings, chunks, assets, and hashes) while keeping verbose options like module details, source code, and debug information disabled by default.

## Related links

<!-- Related issues or discussions. -->

<!-- Add links to related issues or discussions if any -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).