### PR TITLE
refactor: remove `redirect_to` in exports info

### DIFF
--- a/crates/rspack_core/src/exports/export_info_setter.rs
+++ b/crates/rspack_core/src/exports/export_info_setter.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 use rspack_util::atom::Atom;
 
 use super::{ExportInfoData, ExportInfoTargetValue, Inlinable, UsageFilterFnTy, UsageState};
-use crate::{DependencyId, ExportsInfo, ExportsInfoData, ModuleGraph, Nullable, RuntimeSpec};
+use crate::{DependencyId, ExportsInfo, Nullable, RuntimeSpec};
 
 impl ExportInfoData {
   pub fn reset_provide_info(&mut self) {
@@ -210,31 +210,6 @@ impl ExportInfoData {
       changed = true;
     }
     changed
-  }
-
-  pub fn create_nested_exports_info(&mut self, mg: &mut ModuleGraph) -> ExportsInfo {
-    if self.exports_info_owned() {
-      return self
-        .exports_info()
-        .expect("should have exports_info when exports_info is true");
-    }
-
-    self.set_exports_info_owned(true);
-    let new_exports_info = ExportsInfoData::default();
-    let new_exports_info_id = new_exports_info.id();
-
-    self.set_exports_info_owned(true);
-    self.set_exports_info(Some(new_exports_info_id));
-
-    mg.set_exports_info(new_exports_info_id, new_exports_info);
-    new_exports_info_id.set_has_provide_info(mg);
-    let old_exports_info = self.exports_info();
-    if let Some(exports_info) = old_exports_info {
-      exports_info
-        .as_data_mut(mg)
-        .set_redirect_name_to(Some(new_exports_info_id));
-    }
-    new_exports_info_id
   }
 
   pub fn set_has_use_info(&mut self, nested_exports_info: &mut Vec<ExportsInfo>) {

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -41,9 +41,6 @@ impl ExportsInfo {
       .side_effects_only_info_mut()
       .reset_provide_info();
     exports_info.other_exports_info_mut().reset_provide_info();
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      redirect_to.reset_provide_info(mg);
-    }
   }
 
   /// # Panic
@@ -59,16 +56,12 @@ impl ExportsInfo {
         export_info.set_can_mangle_provide(Some(true));
       }
     }
-    if let Some(redirect) = exports_info.redirect_to() {
-      redirect.set_has_provide_info(mg);
-    } else {
-      let other_exports_info = exports_info.other_exports_info_mut();
-      if other_exports_info.provided().is_none() {
-        other_exports_info.set_provided(Some(ExportProvided::NotProvided));
-      }
-      if other_exports_info.can_mangle_provide().is_none() {
-        other_exports_info.set_can_mangle_provide(Some(true));
-      }
+    let other_exports_info = exports_info.other_exports_info_mut();
+    if other_exports_info.provided().is_none() {
+      other_exports_info.set_provided(Some(ExportProvided::NotProvided));
+    }
+    if other_exports_info.can_mangle_provide().is_none() {
+      other_exports_info.set_can_mangle_provide(Some(true));
     }
   }
 
@@ -117,34 +110,24 @@ impl ExportsInfo {
       }
     }
 
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      changed |= redirect_to.set_unknown_exports_provided(
-        mg,
-        can_mangle,
-        exclude_exports,
-        target_key,
-        target_module,
-        priority,
-      );
-    } else {
-      let other_exports_info_data = exports_info.other_exports_info_mut();
-      if !matches!(
-        other_exports_info_data.provided(),
-        Some(ExportProvided::Provided | ExportProvided::Unknown)
-      ) {
-        other_exports_info_data.set_provided(Some(ExportProvided::Unknown));
-        changed = true;
-      }
-
-      if let Some(target_key) = target_key {
-        other_exports_info_data.set_target(Some(target_key), target_module, None, priority);
-      }
-
-      if !can_mangle && other_exports_info_data.can_mangle_provide() != Some(false) {
-        other_exports_info_data.set_can_mangle_provide(Some(false));
-        changed = true;
-      }
+    let other_exports_info_data = exports_info.other_exports_info_mut();
+    if !matches!(
+      other_exports_info_data.provided(),
+      Some(ExportProvided::Provided | ExportProvided::Unknown)
+    ) {
+      other_exports_info_data.set_provided(Some(ExportProvided::Unknown));
+      changed = true;
     }
+
+    if let Some(target_key) = target_key {
+      other_exports_info_data.set_target(Some(target_key), target_module, None, priority);
+    }
+
+    if !can_mangle && other_exports_info_data.can_mangle_provide() != Some(false) {
+      other_exports_info_data.set_can_mangle_provide(Some(false));
+      changed = true;
+    }
+
     changed
   }
 
@@ -152,9 +135,6 @@ impl ExportsInfo {
     let exports_info = self.as_data_mut(mg);
     if let Some(export_info) = exports_info.named_exports(name) {
       return export_info.id();
-    }
-    if let Some(redirect) = exports_info.redirect_to() {
-      return redirect.get_export_info(mg, name);
     }
 
     let other_export_info = exports_info.other_exports_info();
@@ -173,14 +153,10 @@ impl ExportsInfo {
     exports_info
       .side_effects_only_info_mut()
       .set_has_use_info(&mut nested_exports_info);
-    if let Some(redirect) = exports_info.redirect_to() {
-      redirect.set_has_use_info(mg);
-    } else {
-      let other_exports_info = exports_info.other_exports_info_mut();
-      other_exports_info.set_has_use_info(&mut nested_exports_info);
-      if other_exports_info.can_mangle_use().is_none() {
-        other_exports_info.set_can_mangle_use(Some(true));
-      }
+    let other_exports_info = exports_info.other_exports_info_mut();
+    other_exports_info.set_has_use_info(&mut nested_exports_info);
+    if other_exports_info.can_mangle_use().is_none() {
+      other_exports_info.set_can_mangle_use(Some(true));
     }
 
     for nested_exports_info in nested_exports_info {
@@ -195,17 +171,12 @@ impl ExportsInfo {
       let flag = export_info.set_used_without_info(runtime);
       changed |= flag;
     }
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      let flag = redirect_to.set_used_without_info(mg, runtime);
-      changed |= flag;
-    } else {
-      let other_exports_info = exports_info.other_exports_info_mut();
-      let flag = other_exports_info.set_used(UsageState::NoInfo, None);
-      changed |= flag;
-      if other_exports_info.can_mangle_use() != Some(false) {
-        other_exports_info.set_can_mangle_use(Some(false));
-        changed = true;
-      }
+    let other_exports_info = exports_info.other_exports_info_mut();
+    let flag = other_exports_info.set_used(UsageState::NoInfo, None);
+    changed |= flag;
+    if other_exports_info.can_mangle_use() != Some(false) {
+      other_exports_info.set_can_mangle_use(Some(false));
+      changed = true;
     }
     changed
   }
@@ -238,23 +209,17 @@ impl ExportsInfo {
         changed = true;
       }
     }
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      if redirect_to.set_used_in_unknown_way(mg, runtime) {
-        changed = true;
-      }
-    } else {
-      let other_exports_info = exports_info.other_exports_info_mut();
-      if other_exports_info.set_used_conditionally(
-        Box::new(|value| value < &UsageState::Unknown),
-        UsageState::Unknown,
-        runtime,
-      ) {
-        changed = true;
-      }
-      if other_exports_info.can_mangle_use() != Some(false) {
-        other_exports_info.set_can_mangle_use(Some(false));
-        changed = true;
-      }
+    let other_exports_info = exports_info.other_exports_info_mut();
+    if other_exports_info.set_used_conditionally(
+      Box::new(|value| value < &UsageState::Unknown),
+      UsageState::Unknown,
+      runtime,
+    ) {
+      changed = true;
+    }
+    if other_exports_info.can_mangle_use() != Some(false) {
+      other_exports_info.set_can_mangle_use(Some(false));
+      changed = true;
     }
     changed
   }
@@ -274,7 +239,6 @@ pub struct ExportsInfoData {
   other_exports_info: ExportInfoData,
 
   side_effects_only_info: ExportInfoData,
-  redirect_to: Option<ExportsInfo>,
   id: ExportsInfo,
 }
 
@@ -285,7 +249,6 @@ impl Default for ExportsInfoData {
       exports: BTreeMap::default(),
       other_exports_info: ExportInfoData::new(id, None, None),
       side_effects_only_info: ExportInfoData::new(id, Some("*side effects only*".into()), None),
-      redirect_to: None,
       id,
     }
   }
@@ -294,10 +257,6 @@ impl Default for ExportsInfoData {
 impl ExportsInfoData {
   pub fn id(&self) -> ExportsInfo {
     self.id
-  }
-
-  pub fn redirect_to(&self) -> Option<ExportsInfo> {
-    self.redirect_to
   }
 
   pub fn other_exports_info(&self) -> &ExportInfoData {
@@ -330,9 +289,5 @@ impl ExportsInfoData {
 
   pub fn exports_mut(&mut self) -> &mut BTreeMap<Atom, ExportInfoData> {
     &mut self.exports
-  }
-
-  pub fn set_redirect_to(&mut self, id: Option<ExportsInfo>) {
-    self.redirect_to = id;
   }
 }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -73,18 +73,11 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   pub fn other_exports_info(&self) -> &ExportInfoData {
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(&self.entry) {
-      return self.get_other_in_exports_info(&redirect);
-    }
     self.get_other_in_exports_info(&self.entry)
   }
 
   pub fn side_effects_only_info(&self) -> &ExportInfoData {
     self.get_side_effects_in_exports_info(&self.entry)
-  }
-
-  pub fn redirect_to(&self) -> Option<ExportsInfo> {
-    self.get_redirect_to_in_exports_info(&self.entry)
   }
 
   pub fn exports(&self) -> impl Iterator<Item = (&Atom, &ExportInfoData)> {
@@ -105,14 +98,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
       .get(exports_info)
       .expect("should have nested exports info");
     data.side_effects_only_info()
-  }
-
-  fn get_redirect_to_in_exports_info(&self, exports_info: &ExportsInfo) -> Option<ExportsInfo> {
-    let data = self
-      .exports
-      .get(exports_info)
-      .expect("should have nested exports info");
-    data.redirect_to()
   }
 
   fn get_exports_in_exports_info(
@@ -149,9 +134,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   ) -> &ExportInfoData {
     if let Some(export_info) = self.get_named_export_in_exports_info(exports_info, name) {
       return export_info;
-    }
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(exports_info) {
-      return self.get_read_only_export_info_impl(&redirect, name);
     }
     self.get_other_in_exports_info(exports_info)
   }
@@ -223,17 +205,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
       }
       list.push(export_info);
     }
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(exports_info) {
-      for export_info in self.get_relevant_exports_impl(&redirect, runtime) {
-        let name = export_info.name();
-        if self
-          .get_named_export_in_exports_info(exports_info, name.unwrap_or(&"".into()))
-          .is_none()
-        {
-          list.push(export_info);
-        }
-      }
-    }
 
     let other_export_info = self.get_other_in_exports_info(exports_info);
     if !matches!(
@@ -255,17 +226,15 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     exports_info: &ExportsInfo,
     runtime: Option<&RuntimeSpec>,
   ) -> UsedExports {
-    if self.get_redirect_to_in_exports_info(exports_info).is_none() {
-      match self
-        .get_other_in_exports_info(exports_info)
-        .get_used(runtime)
-      {
-        UsageState::NoInfo => return UsedExports::Unknown,
-        UsageState::Unknown | UsageState::OnlyPropertiesUsed | UsageState::Used => {
-          return UsedExports::UsedNamespace(true);
-        }
-        _ => (),
+    match self
+      .get_other_in_exports_info(exports_info)
+      .get_used(runtime)
+    {
+      UsageState::NoInfo => return UsedExports::Unknown,
+      UsageState::Unknown | UsageState::OnlyPropertiesUsed | UsageState::Used => {
+        return UsedExports::UsedNamespace(true);
       }
+      _ => (),
     }
 
     let mut res = vec![];
@@ -279,15 +248,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
             res.push(name);
           }
         }
-        _ => (),
-      }
-    }
-
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(exports_info) {
-      let inner = self.get_used_exports_impl(&redirect, runtime);
-      match inner {
-        UsedExports::UsedNames(v) => res.extend(v),
-        UsedExports::Unknown | UsedExports::UsedNamespace(true) => return inner,
         _ => (),
       }
     }
@@ -311,20 +271,19 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   fn get_provided_exports_impl(&self, exports_info: &ExportsInfo) -> ProvidedExports {
-    if self.get_redirect_to_in_exports_info(exports_info).is_none() {
-      match self.get_other_in_exports_info(exports_info).provided() {
-        Some(ExportProvided::Unknown) => {
-          return ProvidedExports::ProvidedAll;
-        }
-        Some(ExportProvided::Provided) => {
-          return ProvidedExports::ProvidedAll;
-        }
-        None => {
-          return ProvidedExports::Unknown;
-        }
-        _ => {}
+    match self.get_other_in_exports_info(exports_info).provided() {
+      Some(ExportProvided::Unknown) => {
+        return ProvidedExports::ProvidedAll;
       }
+      Some(ExportProvided::Provided) => {
+        return ProvidedExports::ProvidedAll;
+      }
+      None => {
+        return ProvidedExports::Unknown;
+      }
+      _ => {}
     }
+
     let mut ret = vec![];
     for (_, export_info) in self.get_exports_in_exports_info(exports_info) {
       match export_info.provided() {
@@ -332,19 +291,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
           ret.push(export_info.name().cloned().unwrap_or("".into()));
         }
         _ => {}
-      }
-    }
-    if let Some(exports_info) = self.get_redirect_to_in_exports_info(exports_info) {
-      let provided_exports = self.get_provided_exports_impl(&exports_info);
-      let inner = match provided_exports {
-        ProvidedExports::Unknown => return ProvidedExports::Unknown,
-        ProvidedExports::ProvidedAll => return ProvidedExports::ProvidedAll,
-        ProvidedExports::ProvidedNames(arr) => arr,
-      };
-      for item in inner {
-        if !ret.contains(&item) {
-          ret.push(item);
-        }
       }
     }
     ProvidedExports::ProvidedNames(ret)
@@ -367,9 +313,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   ) -> MaybeDynamicTargetExportInfo {
     if let Some(export_info) = self.get_named_export_in_exports_info(exports_info, name) {
       return MaybeDynamicTargetExportInfo::Static(export_info);
-    }
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(exports_info) {
-      return self.get_export_info_without_mut_module_graph_impl(&redirect, name);
     }
 
     MaybeDynamicTargetExportInfo::Dynamic {
@@ -435,12 +378,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   pub fn is_used(&self, runtime: Option<&RuntimeSpec>) -> bool {
-    if let Some(redirect) = self.redirect_to() {
-      let redirected = self.redirect(redirect, false);
-      if redirected.is_used(runtime) {
-        return true;
-      }
-    } else if self.other_exports_info().get_used(runtime) != UsageState::Unused {
+    if self.other_exports_info().get_used(runtime) != UsageState::Unused {
       return true;
     }
 
@@ -496,15 +434,9 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   pub fn get_usage_key(&self, runtime: Option<&RuntimeSpec>) -> UsageKey {
-    // only expand capacity when this has redirect_to
     let mut key = UsageKey(Vec::with_capacity(self.exports().count() + 2));
 
-    if let Some(redirect_to) = self.redirect_to() {
-      let redirected = self.redirect(redirect_to, false);
-      key.add(Either::Left(Box::new(redirected.get_usage_key(runtime))));
-    } else {
-      key.add(Either::Right(self.other_exports_info().get_used(runtime)));
-    };
+    key.add(Either::Right(self.other_exports_info().get_used(runtime)));
 
     key.add(Either::Right(
       self.side_effects_only_info().get_used(runtime),
@@ -604,10 +536,6 @@ impl ExportsInfoGetter {
         nested_exports.push((side_exports, PrefetchExportsInfoMode::Default));
       }
 
-      if let Some(redirect_to) = exports_info.redirect_to() {
-        nested_exports.push((redirect_to, mode.clone()));
-      }
-
       res.insert(*id, exports_info);
 
       for (nested_exports_info, nested_mode) in nested_exports {
@@ -646,11 +574,7 @@ impl ExportsInfoGetter {
         mg: &ModuleGraph,
       ) -> bool {
         let exports_info = info.as_data(mg);
-        if let Some(redirect) = exports_info.redirect_to() {
-          if is_exports_info_used(&redirect, runtime, mg) {
-            return true;
-          }
-        } else if exports_info.other_exports_info().get_used(runtime) != UsageState::Unused {
+        if exports_info.other_exports_info().get_used(runtime) != UsageState::Unused {
           return true;
         }
 
@@ -718,9 +642,6 @@ impl ExportsInfoGetter {
           UsedNameItem::Inlined(inlined) => return Some(UsedName::Inlined(inlined)),
           UsedNameItem::Str(first) => vec![first],
         };
-        if names.len() == 1 {
-          return Some(UsedName::Normal(arr));
-        }
         if let Some(exports_info) = &export_info.exports_info()
           && export_info.get_used(runtime) == UsageState::OnlyPropertiesUsed
         {

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -1,14 +1,6 @@
-use crate::{ExportsInfo, ExportsInfoData, RuntimeSpec, UsageState};
+use crate::{ExportsInfoData, RuntimeSpec, UsageState};
 
 impl ExportsInfoData {
-  pub fn set_redirect_name_to(&mut self, id: Option<ExportsInfo>) -> bool {
-    if self.redirect_to() == id {
-      return false;
-    }
-    self.set_redirect_to(id);
-    true
-  }
-
   pub fn set_used_for_side_effects_only(&mut self, runtime: Option<&RuntimeSpec>) -> bool {
     self.side_effects_only_info_mut().set_used_conditionally(
       Box::new(|value| value == &UsageState::Unused),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use rspack_cacheable::{
   cacheable, cacheable_dyn,
   with::{AsPreset, Skip},
@@ -369,6 +370,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
                 exports
                   .iter()
                   .map(|e| e.as_str())
+                  .sorted_unstable()
                   .collect::<Vec<_>>()
                   .join(", ")
               )

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -53,11 +53,7 @@ fn is_connection_active(
     if let Some(export_info) = exports_info.named_exports(name) {
       return export_info.get_used(runtime) != UsageState::Unused;
     }
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      is_export_active(name, &redirect_to, mg, runtime)
-    } else {
-      exports_info.other_exports_info().get_used(runtime) != UsageState::Unused
-    }
+    exports_info.other_exports_info().get_used(runtime) != UsageState::Unused
   }
 
   used_by_exports

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -339,12 +339,12 @@ pub fn merge_exports(
     }
 
     if let Some(exports) = exports {
+      // create nested exports info
       let nested_exports_info = if export_info_data.exports_info_owned() {
         export_info_data
           .exports_info()
           .expect("should have exports_info when exports_info is true")
       } else {
-        let old_exports_info = export_info_data.exports_info();
         let new_exports_info = ExportsInfoData::default();
         let new_exports_info_id = new_exports_info.id();
         export_info_data.set_exports_info(Some(new_exports_info_id));
@@ -352,11 +352,6 @@ pub fn merge_exports(
         mg.set_exports_info(new_exports_info_id, new_exports_info);
 
         new_exports_info_id.set_has_provide_info(mg);
-        if let Some(exports_info) = old_exports_info {
-          exports_info
-            .as_data_mut(mg)
-            .set_redirect_name_to(Some(new_exports_info_id));
-        }
         new_exports_info_id
       };
 
@@ -396,6 +391,7 @@ pub fn merge_exports(
 
     // Recalculate target exportsInfo
     let export_info_data = export_info.as_data(mg);
+
     let target = get_target(export_info_data, mg);
 
     let mut target_exports_info = None;
@@ -417,11 +413,12 @@ pub fn merge_exports(
 
     let export_info_data = export_info.as_data_mut(mg);
     if export_info_data.exports_info_owned() {
-      changed |= export_info_data
-        .exports_info()
-        .expect("should have exports_info when exports_info_owned is true")
-        .as_data_mut(mg)
-        .set_redirect_name_to(target_exports_info);
+      if export_info_data.exports_info() != target_exports_info
+        && let Some(target_exports_info) = target_exports_info
+      {
+        export_info_data.set_exports_info(Some(target_exports_info));
+        changed = true;
+      }
     } else if export_info_data.exports_info() != target_exports_info {
       export_info_data.set_exports_info(target_exports_info);
       changed = true;

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -300,6 +300,7 @@ fn create_object_for_exports_info(
         }
         let new_value = if used == UsageState::OnlyPropertiesUsed
           && let Some(exports_info) = export_info.exports_info()
+          && matches!(value, JsonValue::Object(_) | JsonValue::Array(_))
         {
           // avoid clone
           let temp = std::mem::replace(value, JsonValue::Null);

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -172,15 +172,9 @@ fn is_equally_used(
   b: &RuntimeSpec,
 ) -> bool {
   let info = exports_info.as_data(mg);
-  if let Some(redirect_to) = &info.redirect_to() {
-    if is_equally_used(redirect_to, mg, a, b) {
-      return false;
-    }
-  } else {
-    let other_exports_info = info.other_exports_info();
-    if other_exports_info.get_used(Some(a)) != other_exports_info.get_used(Some(b)) {
-      return false;
-    }
+  let other_exports_info = info.other_exports_info();
+  if other_exports_info.get_used(Some(a)) != other_exports_info.get_used(Some(b)) {
+    return false;
   }
   let side_effects_only_info = info.side_effects_only_info();
   if side_effects_only_info.get_used(Some(a)) != side_effects_only_info.get_used(Some(b)) {

--- a/tests/webpack-test/cases/parsing/missing-export-warning-nested/warnings.js
+++ b/tests/webpack-test/cases/parsing/missing-export-warning-nested/warnings.js
@@ -9,10 +9,10 @@ module.exports = [
 		/export 'x'.'y'.'C' \(imported as 'm'\) was not found in '.\/a' \(possible exports: Z, c, z\)/
 	],
 	[
-		/export 'x'.'y'.'z'.'D' \(imported as 'm'\) was not found in '.\/a' \(possible exports: default, d\)/
+		/export 'x'.'y'.'z'.'D' \(imported as 'm'\) was not found in '.\/a' \(possible exports: d, default\)/
 	],
 	[
-		/export 'x'.'y'.'z'.'v' \(imported as 'm'\) was not found in '.\/a' \(possible exports: default, d\)/
+		/export 'x'.'y'.'z'.'v' \(imported as 'm'\) was not found in '.\/a' \(possible exports: d, default\)/
 	],
 	[
 		/export 'p' \(imported as 'm'\) was not found in '.\/a' \(possible exports: a, x\)/


### PR DESCRIPTION
## Summary

Remove `exports_info_data.redirect_to` which has made our architecture extremely complex. It is only used for handling json tree shaking.

In fact, since there are `exports_info` and `exports_info_owned` on `export_info`, when `exports_info_owned` is `false`, it means that `export_info` points to the `exports_info` of other modules, and when it is `true`, it represents a nested `exports_info`.

Therefore, we can handle JSON by directly bridging `export_info` to `nested_exports_info`, which is also consistent with the way of handling javascript.

Since the previous [PR](https://github.com/web-infra-dev/rspack/pull/10849) merged the `export_info_map` and `exports_info_map`, after removing redirect_to, it will greatly avoid recursive operations based on the module graph. Therefore, the performance compatible code previously used during recursive processing can be removed, which will be handled in the next PR.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
