### PR TITLE
fix: should not generate SRI for empty mf chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,6 +5503,7 @@ dependencies = [
  "rspack_hook",
  "rspack_paths",
  "rspack_plugin_html",
+ "rspack_plugin_mf",
  "rspack_plugin_real_content_hash",
  "rspack_plugin_runtime",
  "rspack_util",

--- a/crates/rspack_plugin_mf/src/lib.rs
+++ b/crates/rspack_plugin_mf/src/lib.rs
@@ -11,9 +11,11 @@ pub use container::{
   module_federation_runtime_plugin::ModuleFederationRuntimePlugin,
 };
 pub use sharing::{
+  consume_shared_module::ConsumeSharedModule,
   consume_shared_plugin::{
     ConsumeOptions, ConsumeSharedPlugin, ConsumeSharedPluginOptions, ConsumeVersion,
   },
+  provide_shared_module::ProvideSharedModule,
   provide_shared_plugin::{ProvideOptions, ProvideSharedPlugin, ProvideVersion},
   share_runtime_module::{
     CodeGenerationDataShareInit, DataInitStage, ShareInitData, ShareRuntimeModule,

--- a/crates/rspack_plugin_sri/Cargo.toml
+++ b/crates/rspack_plugin_sri/Cargo.toml
@@ -26,6 +26,7 @@ rspack_hash                     = { workspace = true }
 rspack_hook                     = { workspace = true }
 rspack_paths                    = { workspace = true }
 rspack_plugin_html              = { workspace = true }
+rspack_plugin_mf                = { workspace = true }
 rspack_plugin_real_content_hash = { workspace = true }
 rspack_plugin_runtime           = { workspace = true }
 rspack_util                     = { workspace = true }

--- a/crates/rspack_plugin_sri/src/runtime.rs
+++ b/crates/rspack_plugin_sri/src/runtime.rs
@@ -6,6 +6,7 @@ use rspack_core::{
 };
 use rspack_error::{error, Result};
 use rspack_hook::plugin_hook;
+use rspack_plugin_mf::{ConsumeSharedModule, ProvideSharedModule};
 use rspack_plugin_runtime::{
   CreateScriptData, LinkPreloadData, RuntimePluginCreateScript, RuntimePluginLinkPreload,
 };
@@ -72,12 +73,23 @@ impl RuntimeModule for SRIHashVariableRuntimeModule {
         Some((id, rendered_hash))
       })
       .collect::<HashMap<_, _>>();
+
+    let module_graph = compilation.get_module_graph();
     let all_chunks = find_chunks(&self.chunk, compilation)
       .into_iter()
       .filter_map(|c| {
         let chunk = compilation.chunk_by_ukey.get(&c)?;
         let id = chunk.id(&compilation.chunk_ids_artifact)?;
-        if include_chunks.contains_key(id) {
+        let has_modules = compilation
+          .chunk_graph
+          .get_chunk_modules(&c, &module_graph)
+          .iter()
+          .any(|m| {
+            m.downcast_ref::<ConsumeSharedModule>().is_none()
+              && m.downcast_ref::<ProvideSharedModule>().is_none()
+          });
+
+        if has_modules && include_chunks.contains_key(id) {
           Some(id)
         } else {
           None

--- a/packages/rspack-test-tools/tests/configCases/sri/mf/index.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/mf/index.js
@@ -1,0 +1,5 @@
+import('./render');
+
+it("should compile", async () => {
+})
+

--- a/packages/rspack-test-tools/tests/configCases/sri/mf/node_modules/react-dom/index.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/mf/node_modules/react-dom/index.js
@@ -1,0 +1,1 @@
+module.exports = "react-dom";

--- a/packages/rspack-test-tools/tests/configCases/sri/mf/node_modules/react-dom/package.json
+++ b/packages/rspack-test-tools/tests/configCases/sri/mf/node_modules/react-dom/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "react-dom",
+  "version": "19.1.0",
+  "main": "index.js"
+}

--- a/packages/rspack-test-tools/tests/configCases/sri/mf/node_modules/react/index.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/mf/node_modules/react/index.js
@@ -1,0 +1,1 @@
+module.exports = "react";

--- a/packages/rspack-test-tools/tests/configCases/sri/mf/node_modules/react/package.json
+++ b/packages/rspack-test-tools/tests/configCases/sri/mf/node_modules/react/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "react",
+  "version": "19.1.0",
+  "main": "index.js"
+}

--- a/packages/rspack-test-tools/tests/configCases/sri/mf/render.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/mf/render.js
@@ -1,0 +1,4 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export { React, ReactDOM };

--- a/packages/rspack-test-tools/tests/configCases/sri/mf/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/mf/rspack.config.js
@@ -1,0 +1,31 @@
+const { experiments, container } = require("@rspack/core");
+
+module.exports = {
+	target: "web",
+	optimization: {
+		moduleIds: "named"
+	},
+	plugins: [
+		new experiments.SubresourceIntegrityPlugin(),
+		new container.ModuleFederationPlugin({
+			name: "app",
+			filename: "remoteEntry.js",
+			exposes: {
+				"./render": "./render.js"
+			},
+			shared: {
+				react: {
+					singleton: true,
+					requiredVersion: "^19.0.0"
+				},
+				"react-dom": {
+					singleton: true,
+					requiredVersion: "^19.0.0"
+				}
+			}
+		})
+	],
+	output: {
+		crossOriginLoading: "anonymous"
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/sri/mf/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/mf/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return [];
+	}
+};


### PR DESCRIPTION
## Summary

fix https://github.com/web-infra-dev/rspack/issues/10545

This bug will also occur in the webpack and webpack-subresource-integrity. If a chunk is added and it only has modules that are generated by module federation shared plugin, then the asset of this chunk will not be created and the SRI plugin will not generate hash and replace the placeholder in the runtime module.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
