### PR TITLE
fix: chunk_graph_module maybe undefined while compiling

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -147,6 +147,15 @@ impl ChunkGraph {
       .unwrap_or_else(|| panic!("Module({module_identifier}) should be added before using"))
   }
 
+  pub(crate) fn get_chunk_graph_module(
+    &self,
+    module_identifier: ModuleIdentifier,
+  ) -> Option<&ChunkGraphModule> {
+    self
+      .chunk_graph_module_by_module_identifier
+      .get(&module_identifier)
+  }
+
   pub(crate) fn get_chunk_graph_module_mut(
     &mut self,
     module_identifier: ModuleIdentifier,
@@ -165,8 +174,10 @@ impl ChunkGraph {
   }
 
   pub fn get_number_of_module_chunks(&self, module_identifier: ModuleIdentifier) -> usize {
-    let cgm = self.expect_chunk_graph_module(module_identifier);
-    cgm.chunks.len()
+    self
+      .get_chunk_graph_module(module_identifier)
+      .map(|cgm| cgm.chunks.len())
+      .unwrap_or(0)
   }
 
   pub fn set_module_runtime_requirements(

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -147,6 +147,7 @@ impl ChunkGraph {
       .unwrap_or_else(|| panic!("Module({module_identifier}) should be added before using"))
   }
 
+  /// Returns a reference to the `ChunkGraphModule` associated with the given `module_identifier`, if it exists.
   pub(crate) fn get_chunk_graph_module(
     &self,
     module_identifier: ModuleIdentifier,
@@ -173,6 +174,7 @@ impl ChunkGraph {
     &chunk_graph_module.chunks
   }
 
+  /// Returns the number of chunks that the specified module is part of.
   pub fn get_number_of_module_chunks(&self, module_identifier: ModuleIdentifier) -> usize {
     self
       .get_chunk_graph_module(module_identifier)

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -176,8 +176,7 @@ impl ChunkGraph {
   pub fn get_number_of_module_chunks(&self, module_identifier: ModuleIdentifier) -> usize {
     self
       .get_chunk_graph_module(module_identifier)
-      .map(|cgm| cgm.chunks.len())
-      .unwrap_or(0)
+      .map_or(0, |cgm| cgm.chunks.len())
   }
 
   pub fn set_module_runtime_requirements(

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -963,7 +963,7 @@ impl Stats<'_> {
               })
               .collect::<Vec<_>>()
           })
-          .unwrap_or(vec![])
+          .unwrap_or_default()
       };
       chunks.sort_unstable();
       stats.chunks = Some(chunks);

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -948,18 +948,22 @@ impl Stats<'_> {
         self
           .compilation
           .chunk_graph
-          .expect_chunk_graph_module(mgm.module_identifier)
-          .chunks
-          .iter()
-          .filter_map(|k| {
-            self
-              .compilation
-              .chunk_by_ukey
-              .expect_get(k)
-              .id(&self.compilation.chunk_ids_artifact)
-              .map(|id| id.as_str())
+          .get_chunk_graph_module(mgm.module_identifier)
+          .map(|cgm| {
+            cgm
+              .chunks
+              .iter()
+              .filter_map(|k| {
+                self
+                  .compilation
+                  .chunk_by_ukey
+                  .expect_get(k)
+                  .id(&self.compilation.chunk_ids_artifact)
+                  .map(|id| id.as_str())
+              })
+              .collect::<Vec<_>>()
           })
-          .collect()
+          .unwrap_or(vec![])
       };
       chunks.sort_unstable();
       stats.chunks = Some(chunks);

--- a/packages/rspack-test-tools/tests/compilerCases/stats.js
+++ b/packages/rspack-test-tools/tests/compilerCases/stats.js
@@ -1,0 +1,27 @@
+class MyPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap("Plugin", compilation => {
+      compilation.hooks.finishModules.tap("Plugin", _ => {
+        const stats = compilation.getStats().toJson({
+          all: false,
+          modules: true,
+        });
+        const modules = stats.modules;
+
+        expect(modules).toBeDefined();
+      });
+    });
+  }
+}
+
+/** @type {import('../..').TCompilerCaseConfig} */
+module.exports = {
+  description: "should not panic get stats when chunkGraphModule is not available",
+  options(context) {
+    return {
+      context: context.getSource(),
+      entry: "./d",
+      plugins: [new MyPlugin()]
+    };
+  }
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

User maybe get stats while rspack is compiling.
When moduleGraph is built, but chunkGraph is not built finished, the module relative chunk_graph_module maybe undefined.
We should not panic in this case.

## Related links
fix: #10997
<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
