### PR TITLE
chore: resolve Renovate configuration error in packageRules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,7 +41,6 @@
 				"inventory"
 			],
 			matchUpdateTypes: ["patch"],
-			rangeStrategy: "auto",
 		},
 		{
 			groupName: "swc",


### PR DESCRIPTION
# Fix Renovate Configuration Error

- Remove conflicting rangeStrategy from patch crates rule
- Fix "packageRules cannot combine both matchUpdateTypes and rangeStrategy" error
- Resolves #11019

## Summary

This PR fixes a Renovate configuration error that was preventing Renovate from creating PRs. The issue was in the "patch crates" package rule which incorrectly combined `matchUpdateTypes` and `rangeStrategy` properties, which is not allowed by Renovate.

The fix removes the conflicting `rangeStrategy: "auto"` from the specific rule, allowing it to inherit the global `rangeStrategy: "bump"` setting instead.

## Related links

- Fixes #11019
- [Renovate documentation on packageRules](https://docs.renovatebot.com/configuration-options/#packagerules)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

@chenjiahan tks