### PR TITLE
fix: fix not printing backtrace when panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -749,6 +749,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2123a5984bd52ca861c66f66a9ab9883b27115c607f801f86c1bc2a84eb69f0f"
 dependencies = [
+ "backtrace",
  "termcolor",
 ]
 
@@ -2571,7 +2572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ camino              = { version = "1.1.9", default-features = false }
 cargo_toml          = { version = "0.21.0", default-features = false }
 cfg-if              = { version = "1.0.1", default-features = false }
 clap                = { version = "4.5.41", default-features = false }
-color-backtrace     = { version = "0.7.0", default-features = false }
+color-backtrace     = { version = "0.7.0", default-features = false, features = ["use-backtrace-crate"] }
 concat-string       = { version = "1.0.1", default-features = false }
 cow-utils           = { version = "0.1.3", default-features = false }
 criterion2          = { default-features = false, version = "2.0.0", features = ["async_tokio"] }

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -11,10 +11,11 @@ version.workspace = true
 crate-type = ["cdylib"]
 
 [features]
-debug_tool    = ["rspack_binding_api/debug_tool"]
-plugin        = ["rspack_binding_api/plugin"]
-sftrace-setup = ["rspack_binding_api/sftrace-setup"]
-info-level    = ["tracing/release_max_level_info"]
+color-backtrace = ["rspack_binding_api/color-backtrace"]
+debug_tool      = ["rspack_binding_api/debug_tool"]
+info-level      = ["tracing/release_max_level_info"]
+plugin          = ["rspack_binding_api/plugin"]
+sftrace-setup   = ["rspack_binding_api/sftrace-setup"]
 
 [package.metadata.cargo-shear]
 # Adding napi-derive as a dependency to workaround an issue where `dts` will no longer work without it.
@@ -24,7 +25,7 @@ ignored = ["napi-derive", "tracing"]
 rspack_binding_api = { workspace = true }
 
 napi-derive = { workspace = true, features = ["compat-mode", "type-def"] }
-tracing = { workspace = true }
+tracing     = { workspace = true }
 
 [build-dependencies]
 rspack_binding_build = { workspace = true }

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -60,6 +60,9 @@ async function build() {
 			features.push("plugin");
 		}
 		args.push("--no-dts-cache");
+		if (!values.profile || values.profile === "dev") {
+			features.push("color-backtrace");
+		}
 		if (values.profile === "release-debug" &&
 			(!process.env.RUST_TARGET || process.env.RUST_TARGET.includes("linux") || process.env.RUST_TARGET.includes("darwin"))
 		) {

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -11,9 +11,10 @@ repository.workspace    = true
 version.workspace       = true
 
 [features]
-debug_tool    = ["rspack_core/debug_tool"]
-plugin        = ["rspack_loader_swc/plugin"]
-sftrace-setup = ["dep:sftrace-setup", "rspack_allocator/sftrace-setup"]
+color-backtrace = ["dep:color-backtrace"]
+debug_tool      = ["rspack_core/debug_tool"]
+plugin          = ["rspack_loader_swc/plugin"]
+sftrace-setup   = ["dep:sftrace-setup", "rspack_allocator/sftrace-setup"]
 
 [dependencies]
 anyhow                   = { workspace = true }
@@ -49,7 +50,7 @@ tracing-subscriber = { workspace = true }
 napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi7", "compat-mode"] }
 napi-derive = { workspace = true, features = ["compat-mode"] }
 
-color-backtrace = { workspace = true }
+color-backtrace = { workspace = true, optional = true }
 
 derive_more                            = { workspace = true, features = ["debug"] }
 futures                                = { workspace = true }


### PR DESCRIPTION
## Summary
backtrace@0.3.74 has weird bug that cause backtrace::Backtrace::new return empty frames which cause panic not print backtrace in panic_handler,  update to 0.3.75 fix this issue
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
