### PR TITLE
fix: works with async mock factory

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -228,7 +228,7 @@ pub struct JavascriptParser<'parser> {
   pub additional_data: Option<AdditionalData>,
   pub parse_meta: FxHashMap<String, String>,
   pub(crate) comments: Option<&'parser dyn Comments>,
-  pub(crate) build_meta: &'parser mut BuildMeta,
+  pub build_meta: &'parser mut BuildMeta,
   pub build_info: &'parser mut BuildInfo,
   pub resource_data: &'parser ResourceData,
   pub(crate) plugin_drive: Rc<JavaScriptParserPluginDrive>,

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -1,10 +1,18 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, DependencyCodeGeneration, DependencyRange,
-  DependencyTemplate, DependencyTemplateType, DependencyType, InitFragmentExt, InitFragmentKey,
-  InitFragmentStage, NormalInitFragment, TemplateContext, TemplateReplaceSource,
+  import_statement, AsContextDependency, AsModuleDependency, ConditionalInitFragment,
+  DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  NormalInitFragment, RuntimeCondition, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::common::Span;
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub enum Position {
+  Before,
+  After,
+}
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -16,12 +24,15 @@ pub struct MockMethodDependency {
   request: String,
   hoist: bool,
   method: MockMethod,
+  module_dep_id: Option<DependencyId>,
+  position: Position,
 }
 
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MockMethod {
   Mock,
+  DoMock,
   Unmock,
   Hoisted,
 }
@@ -33,6 +44,8 @@ impl MockMethodDependency {
     request: String,
     hoist: bool,
     method: MockMethod,
+    module_dep_id: Option<DependencyId>,
+    position: Position,
   ) -> Self {
     Self {
       call_expr_span,
@@ -40,6 +53,8 @@ impl MockMethodDependency {
       request,
       hoist,
       method,
+      module_dep_id,
+      position,
     }
   }
 }
@@ -71,7 +86,13 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
     source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {
-    let TemplateContext { init_fragments, .. } = code_generatable_context;
+    let TemplateContext {
+      module,
+      runtime_requirements,
+      compilation,
+      init_fragments,
+      ..
+    } = code_generatable_context;
     let dep = dep
       .as_any()
       .downcast_ref::<MockMethodDependency>()
@@ -80,25 +101,52 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
 
     let hoist_flag = match dep.method {
       MockMethod::Mock => "MOCK",
+      MockMethod::DoMock => "", // won't be used.
       MockMethod::Unmock => "UNMOCK",
       MockMethod::Hoisted => "HOISTED",
     };
 
     let mock_method = match dep.method {
-      MockMethod::Mock => "rstest_set_mock",
+      MockMethod::Mock => "rstest_mock",
+      MockMethod::DoMock => "rstest_do_mock",
       MockMethod::Unmock => "rstest_unmock",
       MockMethod::Hoisted => "rstest_hoisted",
     };
 
-    if dep.hoist {
-      let init = NormalInitFragment::new(
-        format!("/* RSTEST:{hoist_flag}_PLACEHOLDER:{request} */;"),
-        InitFragmentStage::StageESMImports,
-        0,
-        InitFragmentKey::Const(format!("retest mock_hoist {request}")),
-        None,
-      );
-      init_fragments.push(init.boxed());
+    // Hoist placeholder init fragment.
+    let init = NormalInitFragment::new(
+      format!("/* RSTEST:{hoist_flag}_PLACEHOLDER:{request} */;"),
+      InitFragmentStage::StageESMImports,
+      match dep.position {
+        Position::Before => 0,
+        Position::After => i32::MAX - 1,
+      },
+      InitFragmentKey::Const(format!("rstest mock_hoist {request}")),
+      None,
+    );
+    init_fragments.push(init.boxed());
+
+    if dep.method == MockMethod::Mock {
+      if let Some(module_dep_id) = dep.module_dep_id {
+        let content: (String, String) = import_statement(
+          *module,
+          compilation,
+          runtime_requirements,
+          &module_dep_id,
+          request,
+          false,
+        );
+
+        // Redeclaration init fragment.
+        init_fragments.push(Box::new(ConditionalInitFragment::new(
+          format!("{}{}", content.0, content.1),
+          InitFragmentStage::StageAsyncESMImports,
+          i32::MAX,
+          InitFragmentKey::ESMImport(format!("{} {}", request, "mock")),
+          None,
+          RuntimeCondition::Boolean(true),
+        )));
+      }
     }
 
     // Start before hoist.
@@ -125,7 +173,7 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
       range.end, // count the trailing semicolon
       range.end,
       if dep.hoist {
-        format!("/* RSTEST:{hoist_flag}_HOIST_END:{request} */")
+        format!("\n/* RSTEST:{hoist_flag}_HOIST_END:{request} */")
       } else {
         "".to_string()
       }

--- a/crates/rspack_plugin_rstest/src/module_path_name_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/module_path_name_dependency.rs
@@ -76,7 +76,7 @@ impl DependencyTemplate for ModulePathNameDependencyTemplate {
             ),
             InitFragmentStage::StageConstants,
             0,
-            InitFragmentKey::Const(format!("retest __filename {}", m.id())),
+            InitFragmentKey::Const(format!("rstest __filename {}", m.id())),
             None,
           );
 
@@ -94,7 +94,7 @@ impl DependencyTemplate for ModulePathNameDependencyTemplate {
               ),
               InitFragmentStage::StageConstants,
               0,
-              InitFragmentKey::Const(format!("retest __dirname {}", m.id())),
+              InitFragmentKey::Const(format!("rstest __dirname {}", m.id())),
               None,
             );
 

--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/rspack.config.js
@@ -19,27 +19,96 @@ if (typeof __webpack_require__ === 'undefined') {
   return;
 }
 
+const originalRequire = __webpack_require__;
+__webpack_require__ = function(...args) {
+  try {
+    return originalRequire(...args);
+  } catch (e) {
+    const errMsg = e.message ?? e.toString();
+    if (errMsg.includes('__webpack_modules__[moduleId] is not a function')) {
+      throw new Error(\`Cannot find module '\${args[0]}'\`)
+    }
+    throw e;
+  }
+};
+
+Object.keys(originalRequire).forEach(key => {
+  __webpack_require__[key] = originalRequire[key];
+});
+
 __webpack_require__.rstest_original_modules = {};
 
 __webpack_require__.rstest_reset_modules = () => {
-  __webpack_module_cache__ = {};
+  const mockedIds = Object.keys(__webpack_require__.rstest_original_modules)
+  Object.keys(__webpack_module_cache__).forEach(id => {
+    // Do not reset mocks registry.
+    if (!mockedIds.includes(id)) {
+      delete __webpack_module_cache__[id];
+    }
+  });
 }
 
 __webpack_require__.rstest_unmock = (id) => {
   delete __webpack_module_cache__[id]
 }
 
-__webpack_require__.rstest_import_actual = __webpack_require__.rstest_require_actual = (id) => {
-  const beforeMock = __webpack_require__.rstest_original_modules[id];
-  return beforeMock;
+__webpack_require__.rstest_require_actual = __webpack_require__.rstest_import_actual = (id) => {
+  const originalModule = __webpack_require__.rstest_original_modules[id];
+  // Use fallback module if the module is not mocked.
+  const fallbackMod = __webpack_require__(id);
+  return originalModule ? originalModule : fallbackMod;
 }
 
-__webpack_require__.rstest_set_mock = (id, modFactory) => {
+__webpack_require__.rstest_exec = async (id, modFactory) => {
+  if (__webpack_module_cache__) {
+    let asyncFactory = __webpack_module_cache__[id];
+    if (asyncFactory && asyncFactory.constructor.name === 'AsyncFunction') {
+      await asyncFactory();
+    }
+  }
+};
+
+__webpack_require__.rstest_mock = (id, modFactory) => {
+  let requiredModule = undefined
+  try {
+    requiredModule = __webpack_require__(id);
+  } catch {
+    // TODO: non-resolved module
+  } finally {
+    __webpack_require__.rstest_original_modules[id] = requiredModule;
+  }
   if (typeof modFactory === 'string' || typeof modFactory === 'number') {
-    __webpack_require__.rstest_original_modules[id] = __webpack_require__(id);
     __webpack_module_cache__[id] = { exports: __webpack_require__(modFactory) };
   } else if (typeof modFactory === 'function') {
-    __webpack_module_cache__[id] = { exports: modFactory() };
+    if (modFactory.constructor.name === 'AsyncFunction') {
+        __webpack_module_cache__[id] = async () => {
+          const exports = await modFactory();
+          __webpack_require__.r(exports);
+          __webpack_module_cache__[id] = { exports, id, loaded: true };
+      }
+    } else {
+      const exports = modFactory();
+      __webpack_require__.r(exports);
+      __webpack_module_cache__[id] = { exports, id, loaded: true };
+    }
+  }
+};
+
+__webpack_require__.rstest_do_mock = (id, modFactory) => {
+  let requiredModule = undefined
+  try {
+    requiredModule = __webpack_require__(id);
+  } catch {
+    // TODO: non-resolved module
+  } finally {
+    __webpack_require__.rstest_original_modules[id] = requiredModule;
+  }
+  if (typeof modFactory === 'string' || typeof modFactory === 'number') {
+    __webpack_module_cache__[id] = { exports: __webpack_require__(modFactory) };
+  } else if (typeof modFactory === 'function') {
+    const exports = modFactory();
+    __webpack_require__.r(exports);
+    __webpack_module_cache__[id] = { exports, id, loaded: true };
   }
 };
 `;

--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/test.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/test.js
@@ -6,5 +6,5 @@ const content = fs.readFileSync(file, 'utf-8');
 
 it ('mocked modules should be hoisted', () => {
 	const afterTopOfFile = content.indexOf('TOP_OF_FILE');
-	expect(afterTopOfFile).toBeGreaterThan(content.lastIndexOf('__webpack_require__.set_mock'));
+	expect(afterTopOfFile).toBeGreaterThan(content.lastIndexOf('__webpack_require__.mock'));
 })


### PR DESCRIPTION
## Summary

**The runtime code modification and integration test case is added in Rstest repository https://github.com/web-infra-dev/rstest/pull/389.**

This PR is to resolve two main issues in Rstest mock side:

1. **Issue:** mock hoist order conflict: if the mock for `../src/c` is hoisted to a position that is too top, the mock factory in `../src/c` will access an uninitialized (undefined) `rs` object.

	**Solution:** When a mock factory exists, hoist `.mock` to the placeholder by using `InitFragmentStage::StageAsyncESMImports` and set its `position` to the maximum. Additionally, add the line `var _src_c__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__("./mock/src/c.ts");` to refresh the reference to `_src_c__WEBPACK_IMPORTED_MODULE_1__`.

	```js
	import { expect, it, rs } from '@rstest/core';
	import { c } from '../src/c';
	import { d } from '../src/d';
	
	// To test async mocking factory.
	rs.mock('../src/c', async () => {
	  return {
	    c: rs.fn(),
	    d,
	  };
	});
	
	it('mocked c', async () => {
	  // @ts-expect-error: It has been mocked.
	  c('c');
	  expect(c).toHaveBeenCalledWith('c');
	  expect(d).toBe(4);
	});
	```

2. **Issue:** async mock factory: In the example below, the async function in the mock factory must be awaited before executing the test case.

	**Solution**: For the `.mock` method with a mock factory, insert the line `await __webpack_require__.rstest_exec("../src/d")`. Additionally, mark all modules with a factory in their `.mock` methods as `async` (TLA) so that the previously mentioned `await` can be used with the module TLA.

	```js
	import { d } from '../src/d';
	
	// To test async mocking factory.
	rs.mock('../src/d', async () => {
	  await sleep(1000);
	  return {
	    d: rs.fn(),
	  };
	});
	
	it('mocked d', async () => {
	  // @ts-expect-error: It has been mocked.
	  d('string1');
	  expect(d).toHaveBeenCalledWith('string1');
	});
	```

Here's an image to helping understand what init fragments are injected.

<img width="996" height="408" alt="image" src="https://github.com/user-attachments/assets/2850b740-f0ff-4b68-bd4d-6aed9f3187c1" />




<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
