### PR TITLE
docs: improve webpackIgnore for dynamic imports and URL syntax

### DIFF
--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -131,11 +131,29 @@ import(
 
 - **Type:** `boolean`
 
-Disables dynamic import parsing when set to true.
+When set to `true`, Rspack will skip analysis and bundling processing for the dynamic import. This results in:
 
-:::warning
-Note that setting webpackIgnore to true opts out of code splitting.
-:::
+1. The module's dependencies will not be analyzed during build time
+2. The module will not be bundled into a separate chunk file
+3. The import operation will be executed by the browser's native `import()` at runtime
+
+This is particularly useful for dynamically loading ESM third-party libraries from external CDNs, for example:
+
+```js
+import('https://esm.sh/react' /* webpackIgnore: true */).then(React => {
+  console.log(React.version); // 19.0.0
+});
+```
+
+`webpackIgnore` also applies to the `new URL()` syntax. By default, Rspack will parse module identifiers in `new URL()` and bundle the referenced module into the build output. When you need Rspack to skip processing a particular `new URL()`, you can add the `webpackIgnore: true` comment:
+
+```js
+// Rspack will process this URL and bundle './index.css' into the build output
+const url1 = new URL('./index.css', import.meta.url);
+
+// Rspack will ignore this URL and preserve the original module identifier
+const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+```
 
 ##### webpackMode
 

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -130,11 +130,29 @@ import(
 
 - **类型：** `boolean`
 
-设置为 true 时，禁用动态导入解析。
+设置为 `true` 时，Rspack 将跳过对该动态导入的静态分析和打包处理。具体表现为：
 
-:::warning
-当 webpackIgnore 为 true 时，不会将代码分离成为独立的 chunk。
-:::
+1. 构建时不会分析该模块的依赖关系
+2. 该模块不会被打包为独立的 chunk 文件
+3. 导入操作将在运行时由浏览器原生 `import()` 执行
+
+这在需要从外部 CDN 动态加载 ESM 格式的第三方库时特别有用，例如：
+
+```js
+import('https://esm.sh/react' /* webpackIgnore: true */).then(React => {
+  console.log(React.version); // 19.0.0
+});
+```
+
+`webpackIgnore` 同样适用于 `new URL()` 语法。默认情况下，Rspack 会解析 `new URL()` 中的模块标识符，并将其引用的模块打包到构建产物中。当你需要 Rspack 跳过某个 `new URL()` 的处理时，可以添加 `webpackIgnore: true` 注释：
+
+```js
+// Rspack 会处理这个 URL，将 './index.css' 打包到构建产物中
+const url1 = new URL('./index.css', import.meta.url);
+
+// Rspack 会忽略这个 URL，保持原始的模块标识符
+const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+```
 
 ##### webpackMode
 


### PR DESCRIPTION
## Summary

Clarify behavior of the `webpackIgnore` magic comments and provide practical examples for using it with dynamic imports and the `new URL()` syntax.

## Related links

- https://github.com/web-infra-dev/rsbuild/issues/5413

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
