### PR TITLE
refactor: use import default

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -11,7 +11,7 @@ import { AssetInfo } from '@rspack/binding';
 import { AsyncDependenciesBlock } from '@rspack/binding';
 import { AsyncParallelHook } from '@rspack/lite-tapable';
 import { AsyncSeriesBailHook } from '@rspack/lite-tapable';
-import * as binding from '@rspack/binding';
+import binding from '@rspack/binding';
 import { Buffer as Buffer_2 } from 'buffer';
 import { BuiltinPlugin } from '@rspack/binding';
 import { BuiltinPluginName } from '@rspack/binding';

--- a/packages/rspack/src/BuildInfo.ts
+++ b/packages/rspack/src/BuildInfo.ts
@@ -1,5 +1,5 @@
 import util from "node:util";
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import type { Source } from "webpack-sources";
 
 const $assets: unique symbol = Symbol("assets");

--- a/packages/rspack/src/CodeGenerationResults.ts
+++ b/packages/rspack/src/CodeGenerationResults.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import { JsSource } from "./util/source";
 
 Object.defineProperty(binding.Sources.prototype, "get", {

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -18,7 +18,7 @@ import type {
 	JsPathData,
 	JsRuntimeModule
 } from "@rspack/binding";
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 
 export type { AssetInfo } from "@rspack/binding";
 

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -7,7 +7,7 @@
  * Copyright (c) JS Foundation and other contributors
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
-import type * as binding from "@rspack/binding";
+import type binding from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
 import type Watchpack from "watchpack";
 import type { Source } from "webpack-sources";

--- a/packages/rspack/src/ConcatenatedModule.ts
+++ b/packages/rspack/src/ConcatenatedModule.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import type { Source } from "webpack-sources";
 import { JsSource } from "./util/source";
 

--- a/packages/rspack/src/ContextModule.ts
+++ b/packages/rspack/src/ContextModule.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import type { Source } from "webpack-sources";
 import { JsSource } from "./util/source";
 

--- a/packages/rspack/src/ExternalModule.ts
+++ b/packages/rspack/src/ExternalModule.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import type { Source } from "webpack-sources";
 import { JsSource } from "./util/source";
 

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import type { Source } from "webpack-sources";
 import type { ResourceData } from "./Resolver";
 import { JsSource } from "./util/source";

--- a/packages/rspack/src/NativeWatchFileSystem.ts
+++ b/packages/rspack/src/NativeWatchFileSystem.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import type Watchpack from "watchpack";
 import type { FileSystemInfoEntry, Watcher, WatchFileSystem } from "./util/fs";
 

--- a/packages/rspack/src/NormalModule.ts
+++ b/packages/rspack/src/NormalModule.ts
@@ -1,5 +1,5 @@
 import util from "node:util";
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
 import type { Source } from "webpack-sources";
 import type { Compilation } from "./Compilation";

--- a/packages/rspack/src/NormalModuleFactory.ts
+++ b/packages/rspack/src/NormalModuleFactory.ts
@@ -1,4 +1,4 @@
-import type * as binding from "@rspack/binding";
+import type binding from "@rspack/binding";
 
 import * as liteTapable from "@rspack/lite-tapable";
 import type { ResolveData, ResourceDataWithData } from "./Module";

--- a/packages/rspack/src/Resolver.ts
+++ b/packages/rspack/src/Resolver.ts
@@ -1,4 +1,4 @@
-import type * as binding from "@rspack/binding";
+import type binding from "@rspack/binding";
 import { getRawResolve, type Resolve } from "./config";
 import type { ResolveCallback } from "./config/adapterRuleUse";
 

--- a/packages/rspack/src/ResolverFactory.ts
+++ b/packages/rspack/src/ResolverFactory.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import { getRawResolve, type Resolve } from "./config";
 import { Resolver } from "./Resolver";
 

--- a/packages/rspack/src/RspackError.ts
+++ b/packages/rspack/src/RspackError.ts
@@ -1,4 +1,4 @@
-import type * as binding from "@rspack/binding";
+import type binding from "@rspack/binding";
 
 export type { RspackError } from "@rspack/binding";
 export type RspackSeverity = binding.JsRspackSeverity;

--- a/packages/rspack/src/Stats.ts
+++ b/packages/rspack/src/Stats.ts
@@ -7,7 +7,7 @@
  * Copyright (c) JS Foundation and other contributors
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
-import type * as binding from "@rspack/binding";
+import type binding from "@rspack/binding";
 
 import type { Compilation } from "./Compilation";
 import type { StatsOptions, StatsValue } from "./config";

--- a/packages/rspack/src/builtin-plugin/CssChunkingPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/CssChunkingPlugin.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 
 import { create } from "./base";
 

--- a/packages/rspack/src/builtin-plugin/RuntimePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RuntimePlugin.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
 
 import type { Chunk } from "../Chunk";

--- a/packages/rspack/src/builtin-plugin/base.ts
+++ b/packages/rspack/src/builtin-plugin/base.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 
 import type { Compiler, RspackPluginInstance } from "..";
 

--- a/packages/rspack/src/builtin-plugin/html-plugin/taps.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/taps.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import type { CreatePartialRegisters } from "../../taps/types";
 import { getPluginOptions, type HtmlRspackPluginOptions } from "./options";
 import { HtmlRspackPlugin } from "./plugin";

--- a/packages/rspack/src/stats/statsFactoryUtils.ts
+++ b/packages/rspack/src/stats/statsFactoryUtils.ts
@@ -1,4 +1,4 @@
-import type * as binding from "@rspack/binding";
+import type binding from "@rspack/binding";
 
 import type { JsOriginRecord } from "@rspack/binding";
 import type { Compilation } from "../Compilation";

--- a/packages/rspack/src/taps/compilation.ts
+++ b/packages/rspack/src/taps/compilation.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import { tryRunOrWebpackError } from "../lib/HookWebpackError";
 import type { Module } from "../Module";
 import {

--- a/packages/rspack/src/taps/compiler.ts
+++ b/packages/rspack/src/taps/compiler.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import type { CreatePartialRegisters } from "./types";
 
 export const createCompilerHooksRegisters: CreatePartialRegisters<

--- a/packages/rspack/src/taps/contextModuleFactory.ts
+++ b/packages/rspack/src/taps/contextModuleFactory.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import {
 	ContextModuleFactoryAfterResolveData,
 	ContextModuleFactoryBeforeResolveData

--- a/packages/rspack/src/taps/javascriptModules.ts
+++ b/packages/rspack/src/taps/javascriptModules.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import { JavascriptModulesPlugin } from "../builtin-plugin";
 import { createHash } from "../util/createHash";
 import type { CreatePartialRegisters } from "./types";

--- a/packages/rspack/src/taps/normalModuleFactory.ts
+++ b/packages/rspack/src/taps/normalModuleFactory.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 import type { ResolveData } from "../Module";
 import type { NormalModuleCreateData } from "../NormalModuleFactory";
 import type { CreatePartialRegisters } from "./types";

--- a/packages/rspack/src/taps/types.ts
+++ b/packages/rspack/src/taps/types.ts
@@ -1,4 +1,4 @@
-import type * as binding from "@rspack/binding";
+import type binding from "@rspack/binding";
 import type * as liteTapable from "@rspack/lite-tapable";
 import type { Compiler } from "../Compiler";
 

--- a/packages/rspack/src/util/bindingVersionCheck.ts
+++ b/packages/rspack/src/util/bindingVersionCheck.ts
@@ -1,4 +1,4 @@
-import * as binding from "@rspack/binding";
+import binding from "@rspack/binding";
 
 const CORE_VERSION = RSPACK_VERSION;
 


### PR DESCRIPTION
## Summary

This is a more friendly way to use `@rspack/binding` because it always exports entire `exports` object.

1. https://github.com/web-infra-dev/rspack/blob/b1f67f50fe7ee5cc543d0b6d6a548af4f907544e/crates/node_binding/binding.js#L231
2. https://github.com/web-infra-dev/rspack/blob/b1f67f50fe7ee5cc543d0b6d6a548af4f907544e/crates/node_binding/rspack.wasi-browser.js#L63
3. https://github.com/web-infra-dev/rspack/blob/b1f67f50fe7ee5cc543d0b6d6a548af4f907544e/crates/node_binding/rspack.wasi.cjs#L122


Actually the main purpose of this pr is:
1. rspack directly define properties for `exports` so napi cannot generate corresponding types and export statement. https://github.com/web-infra-dev/rspack/blob/b1f67f50fe7ee5cc543d0b6d6a548af4f907544e/crates/rspack_binding_api/src/module.rs#L25
2. So these properties are invalid with `import * as binding from "@rspack/binding"` if `@rspack/binding` is an esm https://github.com/web-infra-dev/rspack/blob/b1f67f50fe7ee5cc543d0b6d6a548af4f907544e/crates/node_binding/rspack.wasi-browser.js#L63

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
