### PR TITLE
refactor: disable parallel code splitting by default

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/build_chunk_graph/incremental.rs
@@ -9,7 +9,6 @@ use tracing::instrument;
 
 use super::code_splitter::{CgiUkey, CodeSplitter, DependenciesBlockIdentifier};
 use crate::{
-  build_chunk_graph::code_splitter::{ProcessBlock, QueueAction},
   incremental::{IncrementalPasses, Mutation},
   is_runtime_equal, AsyncDependenciesBlockIdentifier, ChunkGroupUkey, ChunkUkey, Compilation,
   GroupOptions, ModuleIdentifier, RuntimeSpec,
@@ -102,7 +101,7 @@ impl CodeSplitter {
       .expect("when we have cgi ukey, we have cgi");
 
     for block in chunk_group_info.outgoing_blocks.iter() {
-      if let Some(infos) = self.block_owner.get_mut(&block) {
+      if let Some(infos) = self.block_owner.get_mut(block) {
         infos.remove(&cgi_ukey);
       }
     }
@@ -243,9 +242,7 @@ impl CodeSplitter {
 
       let cg = child_cgi.chunk_group;
 
-      if let Some(child_edges) = self.invalidate_chunk_group(cg, compilation)? {
-        edges.extend(child_edges);
-      }
+      self.invalidate_chunk_group(cg, compilation)?;
     }
 
     if let Some(name) = chunk_group_name

--- a/crates/rspack_core/src/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/build_chunk_graph/incremental.rs
@@ -435,16 +435,16 @@ impl CodeSplitter {
       self.mask_by_chunk.insert(*chunk, mask);
     }
 
-    if !enable_incremental {
-      return Ok(());
-    }
-
     self.stat_invalidated_chunk_group = 0;
     self.stat_invalidated_caches = 0;
     self.stat_use_cache = 0;
     self.stat_chunk_group_created = 0;
     self.stat_cache_miss_by_available_modules = 0;
     self.stat_cache_miss_by_cant_rebuild = 0;
+
+    if !enable_incremental {
+      return Ok(());
+    }
 
     let (affected_modules, removed_modules) = if let Some(mutations) = compilation
       .incremental

--- a/crates/rspack_core/src/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/build_chunk_graph/incremental.rs
@@ -482,12 +482,15 @@ impl CodeSplitter {
         .copied(),
     );
 
-    for m in removed_modules {
-      for module_map in self.block_modules_runtime_map.values_mut() {
-        module_map.swap_remove(&DependenciesBlockIdentifier::Module(m));
-      }
+    if !removed_modules.is_empty() {
+      // TODO:
+      // if we have removed module, we should invalidate its
+      // incomings, but we cannot get its incomings at present,
+      self.block_modules_runtime_map.clear();
 
-      self.invalidate_from_module(m, compilation)?;
+      for m in removed_modules {
+        self.invalidate_from_module(m, compilation)?;
+      }
     }
 
     for m in affected_modules {

--- a/crates/rspack_core/src/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/build_chunk_graph/mod.rs
@@ -29,6 +29,8 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
   }
 
   splitter.split(compilation)?;
+
+  // remove empty chunk groups
   splitter.remove_orphan(compilation)?;
 
   // make sure all module (weak dependency particularly) has a cgm

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -298,11 +298,7 @@ pub fn get_full_chunk_name(
   let full_module_names = chunk_graph
     .get_chunk_root_modules(&chunk.ukey(), module_graph, module_graph_cache)
     .iter()
-    .map(|id| {
-      module_graph
-        .module_by_identifier(id)
-        .expect("Module not found")
-    })
+    .filter_map(|id| module_graph.module_by_identifier(id))
     .map(|module| get_full_module_name(module, context))
     .collect::<Vec<_>>();
 

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -298,7 +298,11 @@ pub fn get_full_chunk_name(
   let full_module_names = chunk_graph
     .get_chunk_root_modules(&chunk.ukey(), module_graph, module_graph_cache)
     .iter()
-    .filter_map(|id| module_graph.module_by_identifier(id))
+    .map(|id| {
+      module_graph
+        .module_by_identifier(id)
+        .expect("Module not found")
+    })
     .map(|module| get_full_module_name(module, context))
     .collect::<Vec<_>>();
 

--- a/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
@@ -44,7 +44,7 @@ Object {
     inlineEnum: false,
     layers: false,
     lazyCompilation: false,
-    parallelCodeSplitting: true,
+    parallelCodeSplitting: false,
     parallelLoader: false,
     rspackFuture: Object {
       bundlerInfo: Object {

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/entry-runtime-error/raw-error.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/entry-runtime-error/raw-error.err
@@ -1,7 +1,6 @@
 Array [
   Object {},
   Object {
-    chunkEntry: true,
     chunkInitial: true,
     chunkName: b1,
   },

--- a/packages/rspack-test-tools/tests/statsAPICases/verbose-time.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/verbose-time.js
@@ -72,6 +72,15 @@ module.exports = {
 		<t> ensure min size fit: X ms
 		<t> process module group map: X ms
 		<t> ensure max size fit: X ms
+
+		LOG from rspack.buildChunkGraph
+		<t> prepare entrypoints: X ms
+		<t> process queue: X ms
+		<t> extend chunkGroup runtime: X ms
+		    8 queue items processed (4 blocks)
+		    0 chunk groups connected
+		    0 chunk groups processed for merging (0 module sets)
+		    0 chunk group info updated (0 already connected chunk groups reconnected)
 	`);
 	}
 };

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -248,7 +248,7 @@ const applyExperimentsDefaults = (
 	// rspackFuture.bundlerInfo default value is applied after applyDefaults
 
 	// IGNORE(experiments.parallelCodeSplitting): Rspack specific configuration for new code splitting algorithm
-	D(experiments, "parallelCodeSplitting", true);
+	D(experiments, "parallelCodeSplitting", false);
 
 	// IGNORE(experiments.parallelLoader): Rspack specific configuration for parallel loader execution
 	D(experiments, "parallelLoader", false);

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -475,9 +475,9 @@ cacheable modules xx bytes
   ./entry-xxx.js xx bytes [built] [code generated]
   ./dynamic.js xx bytes [built] [code generated]
 
-ERROR in × It's not allowed to load an initial chunk on demand. The chunk name \\"entry3\\" is already used by an entrypoint.
-
 ERROR in × It's not allowed to load an initial chunk on demand. The chunk name \\"entry2\\" is already used by an entrypoint.
+
+ERROR in × It's not allowed to load an initial chunk on demand. The chunk name \\"entry3\\" is already used by an entrypoint.
 
 Rspack x.x.x compiled with 2 errors in X.23"
 `;
@@ -1501,14 +1501,14 @@ asset normal.js xx bytes {615} [emitted] (name: normal)
 asset prefetched2.js xx bytes {424} [emitted] (name: prefetched2)
 asset prefetched3.js xx bytes {182} [emitted] (name: prefetched3)
 Entrypoint main xx KiB = main.js
-  prefetch: prefetched2.js {424} (name: prefetched2), prefetched.js {674} (name: prefetched), prefetched3.js {182} (name: prefetched3)
+  prefetch: prefetched.js {674} (name: prefetched), prefetched3.js {182} (name: prefetched3), prefetched2.js {424} (name: prefetched2)
 chunk {182} (runtime: main) prefetched3.js (prefetched3) xx bytes <{909}> [rendered]
 chunk {424} (runtime: main) prefetched2.js (prefetched2) xx bytes <{909}> [rendered]
 chunk {481} (runtime: main) inner.js (inner) xx bytes <{674}> [rendered]
 chunk {615} (runtime: main) normal.js (normal) xx bytes <{909}> [rendered]
 chunk {674} (runtime: main) prefetched.js (prefetched) xx bytes <{909}> >{481}< >{857}< (prefetch: {857} {481}) [rendered]
 chunk {857} (runtime: main) inner2.js (inner2) xx bytes <{674}> [rendered]
-chunk {909} (runtime: main) main.js (main) xx bytes (javascript) xx KiB (runtime) >{182}< >{424}< >{615}< >{674}< (prefetch: {424} {674} {182}) [entry] [rendered]"
+chunk {909} (runtime: main) main.js (main) xx bytes (javascript) xx KiB (runtime) >{182}< >{424}< >{615}< >{674}< (prefetch: {674} {182} {424}) [entry] [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for prefetch-preload-mixed 1`] = `
@@ -1534,14 +1534,14 @@ asset normal.js xx bytes [emitted] (name: normal)
 asset preloaded2.js xx bytes [emitted] (name: preloaded2)
 asset preloaded3.js xx bytes [emitted] (name: preloaded3)
 Entrypoint main xx KiB = main.js
-  preload: preloaded2.js {577} (name: preloaded2), preloaded.js {154} (name: preloaded), preloaded3.js {551} (name: preloaded3)
+  preload: preloaded.js {154} (name: preloaded), preloaded3.js {551} (name: preloaded3), preloaded2.js {577} (name: preloaded2)
 chunk (runtime: main) preloaded.js (preloaded) xx bytes (preload: {857} {481}) [rendered]
 chunk (runtime: main) inner.js (inner) xx bytes [rendered]
 chunk (runtime: main) preloaded3.js (preloaded3) xx bytes [rendered]
 chunk (runtime: main) preloaded2.js (preloaded2) xx bytes [rendered]
 chunk (runtime: main) normal.js (normal) xx bytes [rendered]
 chunk (runtime: main) inner2.js (inner2) xx bytes [rendered]
-chunk (runtime: main) main.js (main) xx bytes (javascript) xx KiB (runtime) (preload: {577} {154} {551}) [entry] [rendered]"
+chunk (runtime: main) main.js (main) xx bytes (javascript) xx KiB (runtime) (preload: {154} {551} {577}) [entry] [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -344,6 +344,10 @@ Starting from v1.4.0, Rspack enables incremental builds for all phases by defaul
 
 Enabling this configuration will activate a new multi-threaded code splitting algorithm. If your project includes many dynamic imports and doesn't have cyclic chunks, this can greatly reduce the time spent on the code splitting process.
 
+:::info
+Enabled by default in versions 1.3.0 to 1.4.8, and disabled by default in version 1.4.9 and later.
+:::
+
 ```js title="rspack.config.mjs"
 export default {
   experiments: {

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -340,9 +340,9 @@ Starting from v1.4.0, Rspack enables incremental builds for all phases by defaul
 <ApiMeta addedVersion="1.2.0" />
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `false`
 
-Enabling this configuration will activate a new multi-threaded code splitting algorithm. If your project includes many dynamic imports, this can greatly reduce the time spent on the code splitting process. Enabled by default since version 1.3.0.
+Enabling this configuration will activate a new multi-threaded code splitting algorithm. If your project includes many dynamic imports and doesn't have cyclic chunks, this can greatly reduce the time spent on the code splitting process.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -344,6 +344,10 @@ Rspack 在 v1.4.0 后默认使用 `'advance-silent'` 开启所有阶段的增量
 
 开启后会启用新的多线程 code splitting 算法，如果你的项目中包含较多的动态引用，并且不包含循环 chunk，开启后可以显著降低 code splitting 阶段耗时。
 
+:::info
+1.3.0 至 1.4.8 版本默认开启，1.4.9 版本后默认关闭。
+:::
+
 ```js title="rspack.config.mjs"
 export default {
   experiments: {

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -340,9 +340,9 @@ Rspack 在 v1.4.0 后默认使用 `'advance-silent'` 开启所有阶段的增量
 <ApiMeta addedVersion="1.2.0" />
 
 - **类型：** `boolean`
-- **默认值：** `true`
+- **默认值：** `false`
 
-开启后会启用新的多线程 code splitting 算法，如果你的项目中包含较多的动态引用，开启后可以显著降低 code splitting 阶段耗时，1.3.0 版本默认开启。
+开启后会启用新的多线程 code splitting 算法，如果你的项目中包含较多的动态引用，并且不包含循环 chunk，开启后可以显著降低 code splitting 阶段耗时。
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary


As we have bugs in current parallelCodeSplitting algorithm, and poor performance in some specific cases, we decide switch to previous behavior, which is stable in all cases

But no worry, we'll make the previous algorithm more performant, and make it parallel as well, you can enable `experiments.parallelCodeSplitting` to check the improvement.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
