### PR TITLE
perf(wasm): set lto=fat and cgu=1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,12 +402,10 @@ split-debuginfo = "off"
 strip           = false
 
 [profile.release-wasi]
-codegen-units = 16
-debug         = 'full'
-inherits      = "release"
-lto           = "thin"
-opt-level     = "s"
-strip         = "none"
+debug     = 'full'
+inherits  = "release"
+opt-level = "s"
+strip     = "none"
 
 
 # the following lints rules are from https://github.com/biomejs/biome/blob/4bd3d6f09642952ee14445ed56af81a73796cea1/Cargo.toml#L7C1-L75C1


### PR DESCRIPTION
## Summary

I'm not sure why this is not set before. At that time I just copy the config from rolldown, but they have updated the config so we can sync.

Wasm size: 36.75MB -> 28.88MB

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
