### PR TITLE
fix: snapshot not work for renamed files

### DIFF
--- a/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/strategy.rs
@@ -66,7 +66,12 @@ impl StrategyHelper {
   /// get path file modified time
   async fn modified_time(&self, path: &Path) -> Option<u64> {
     if let Ok(info) = self.fs.metadata(path.assert_utf8()).await {
-      Some(info.mtime_ms)
+      // return the larger of ctime and mtime
+      if info.ctime_ms > info.mtime_ms {
+        Some(info.ctime_ms)
+      } else {
+        Some(info.mtime_ms)
+      }
     } else {
       None
     }

--- a/crates/rspack_fs/src/file_metadata.rs
+++ b/crates/rspack_fs/src/file_metadata.rs
@@ -16,6 +16,7 @@ pub struct FileMetadata {
 }
 
 impl FileMetadata {
+  #[allow(unused_variables)]
   fn get_ctime_ms(metadata: &Metadata) -> u64 {
     #[cfg(unix)]
     {
@@ -24,10 +25,7 @@ impl FileMetadata {
       let ctime_ms = ctime * 1000 + ctime_nsec / 1_000_000;
       return ctime_ms as u64;
     }
-    #[cfg(windows)]
-    {
-      return std::os::windows::fs::MetadataExt::change_time(metadata).unwrap_or_default();
-    }
+    // windows not support ctime
     #[allow(unreachable_code)]
     0u64
   }

--- a/crates/rspack_fs/src/lib.rs
+++ b/crates/rspack_fs/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(windows, feature(windows_change_time))]
-
 mod read;
 pub use read::ReadableFileSystem;
 

--- a/crates/rspack_fs/src/lib.rs
+++ b/crates/rspack_fs/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(windows, feature(windows_change_time))]
+
 mod read;
 pub use read::ReadableFileSystem;
 

--- a/tests/e2e/cases/persistent-cache/rename-file/a.js
+++ b/tests/e2e/cases/persistent-cache/rename-file/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/tests/e2e/cases/persistent-cache/rename-file/b.js
+++ b/tests/e2e/cases/persistent-cache/rename-file/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/tests/e2e/cases/persistent-cache/rename-file/index.js
+++ b/tests/e2e/cases/persistent-cache/rename-file/index.js
@@ -1,0 +1,6 @@
+import a from "./a";
+import b from "./b";
+
+const div = document.createElement("div");
+div.innerText = a + b;
+document.body.appendChild(div);

--- a/tests/e2e/cases/persistent-cache/rename-file/index.test.ts
+++ b/tests/e2e/cases/persistent-cache/rename-file/index.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@/fixtures";
+
+async function expect_content(page: any, data: string) {
+	await expect(async () => {
+		await page.reload();
+		expect(await page.locator("div").innerText()).toBe(data);
+	}).toPass();
+}
+
+test("should compile", async ({ page, fileAction, rspack }) => {
+	await expect_content(page, "ab");
+	await rspack.stop();
+	await new Promise(res => {
+		setTimeout(res, 500);
+	});
+	// switch a, b
+	fileAction.renameFile("a.js", "temp.js");
+	fileAction.renameFile("b.js", "a.js");
+	fileAction.renameFile("temp.js", "b.js");
+
+	await rspack.start();
+	await expect_content(page, "ba");
+});

--- a/tests/e2e/cases/persistent-cache/rename-file/index.test.ts
+++ b/tests/e2e/cases/persistent-cache/rename-file/index.test.ts
@@ -7,9 +7,15 @@ async function expect_content(page: any, data: string) {
 	}).toPass();
 }
 
-test("should compile", async ({ page, fileAction, rspack }) => {
+test("should compile", async ({
+	page,
+	fileAction,
+	rspack,
+	rspackIncremental
+}) => {
 	await expect_content(page, "ab");
 	await rspack.stop();
+	await rspackIncremental.stop();
 	await new Promise(res => {
 		setTimeout(res, 500);
 	});
@@ -19,5 +25,6 @@ test("should compile", async ({ page, fileAction, rspack }) => {
 	fileAction.renameFile("temp.js", "b.js");
 
 	await rspack.start();
+	await rspackIncremental.start();
 	await expect_content(page, "ba");
 });

--- a/tests/e2e/cases/persistent-cache/rename-file/rspack.config.js
+++ b/tests/e2e/cases/persistent-cache/rename-file/rspack.config.js
@@ -1,0 +1,17 @@
+const rspack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	context: __dirname,
+	// use production mod to make sure
+	// the persistent cache will write to disk
+	mode: "production",
+	plugins: [new rspack.HtmlRspackPlugin()],
+	cache: true,
+	experiments: {
+		cache: {
+			type: "persistent"
+		}
+	}
+};

--- a/tests/e2e/fixtures/fileAction.ts
+++ b/tests/e2e/fixtures/fileAction.ts
@@ -4,6 +4,7 @@ import type { Fixtures } from "@playwright/test";
 import type { RspackFixtures } from "./rspack";
 
 type FileAction = {
+	renameFile(oldPath: string, newPath: string): void;
 	updateFile(relativePath: string, fn: (content: string) => string): void;
 	deleteFile(relativePath: string): void;
 };
@@ -22,6 +23,11 @@ export const fileActionFixtures: Fixtures<
 		const fileOriginContent: Record<string, string | null> = {};
 
 		await use({
+			renameFile(oldPath, newPath) {
+				const oldFilePath = path.resolve(rspack.projectDir, oldPath);
+				const newFilePath = path.resolve(rspack.projectDir, newPath);
+				fs.renameSync(oldFilePath, newFilePath);
+			},
 			updateFile(relativePath, fn) {
 				const filePath = path.resolve(rspack.projectDir, relativePath);
 				const fileExists = fs.existsSync(filePath);

--- a/tests/e2e/fixtures/rspack.ts
+++ b/tests/e2e/fixtures/rspack.ts
@@ -120,6 +120,15 @@ export const rspackFixtures = (): RspackFixtures => {
 				if (incremental) {
 					config.experiments ??= {};
 					config.experiments.incremental = true;
+					const cache = config.experiments.cache;
+					if (typeof cache === "object" && cache.type === "persistent") {
+						cache.storage = {
+							type: "filesystem",
+							...cache.storage,
+							//rewrite directory
+							directory: "node_modules/.cache/incremental"
+						};
+					}
 				}
 
 				return defaultRspackConfig.handleConfig(config);


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

The persistent cache snapshot will first calculate the modified file based on the modification time of the file, but after the file is renamed, the modification time will not be updated, so the larger of ctime and mtime should be used as the modification time.


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
