### PR TITLE
fix: remove last builtin:swc-loader warning for collecting ts info

### DIFF
--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -113,18 +113,6 @@ impl SwcLoader {
         else {
           return;
         };
-        if loader_context.loader_index != 0 {
-          loader_context.emit_diagnostic(
-            miette::miette! {
-              severity = miette::Severity::Warning,
-              "To ensure the accuracy of the collected TypeScript information, `rspackExperiments.collectTypeScriptInfo` can only be used when `builtin:swc-loader` is employed as the last normal loader. For now `rspackExperiments.collectTypeScriptInfo` is overridden to disabled. If you want to suppress this warning, either turn off `rspackExperiments.collectTypeScriptInfo` in the configuration or place `builtin:swc-loader` as the first element in the `use` array.\nLoaders: {}\nLoader index: {}\nResource: {}",
-              loader_context.request().to_string(),
-              loader_context.loader_index,
-              loader_context.resource(),
-            }.into(),
-          );
-          return;
-        }
         collected_ts_info = Some(collect_typescript_info(program, options));
       },
       |_| transformer::transform(&self.options_with_additional.rspack_experiments),

--- a/website/docs/en/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/features/builtin-swc-loader.mdx
@@ -459,7 +459,7 @@ import 'antd/es/button/style';
 
 Collects information from TypeScript's AST for consumption by subsequent Rspack processes, providing better TypeScript development experience and smaller output bundle size.
 
-To ensure the accuracy of collected information, this configuration can only be used when `builtin:swc-loader` is the last normal loader.
+To ensure the accuracy of the collected information, users must ensure that subsequent Normal Loaders after `builtin:swc-loader` do not modify the Abstract Syntax Tree (AST) corresponding to the collected information. This precaution is necessary to prevent discrepancies between the collected information and the actual code.
 
 Please refer to this [example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info) for more details.
 

--- a/website/docs/zh/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-swc-loader.mdx
@@ -461,7 +461,7 @@ import 'antd/es/button/style';
 
 从 TypeScript 的 AST 中收集信息，以供 Rspack 后续过程进行消费，提供对 TypeScript 更好的开发体验和更小的产物体积。
 
-为了保证收集到的信息的准确性，该配置只能在 builtin:swc-loader 作为最后一个 normal loader 时使用。
+为了保证收集到的信息的准确性，用户需要确保 `builtin:swc-loader` 后续的 Normal Loader 不会去修改这些已经被收集到的相关信息对应的 AST，以免导致收集到的信息和实际的代码不一致的情况。
 
 详细示例可参考：[example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info)
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Remove the "last builtin:swc-loader" warning, duo to a very common use case: in rspack react-refresh-loader will use after the builtin:swc-loader.

And currently these two features based on collecting TypeScript information can be guaranteed by LSP (if the AST is modified by loader, the corresponding LSP also needs to modified; otherwise, the build results will be inconsistent with the feedback from LSP), and most of the loader won't change TypeScript information (at least the info that these two features needed)

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
