### PR TITLE
fix: use parse meta to collect ts info

### DIFF
--- a/crates/rspack_binding_api/src/plugins/js_loader/context.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/context.rs
@@ -140,7 +140,9 @@ impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
         Some(c) => Either::B(c.to_owned().into_bytes().into()),
         None => Either::A(Null),
       },
-      parse_meta: cx.parse_meta.clone().into_iter().collect(),
+      // Since js side only set parse meta, and can't read it, so we can use Default here to only bring the
+      // set values from js side to rust side.
+      parse_meta: Default::default(),
       additional_data: cx
         .additional_data()
         .and_then(|data| data.get::<ThreadsafeJsValueRef<Unknown>>())

--- a/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
@@ -180,7 +180,9 @@ pub(crate) fn merge_loader_context(
     })
     .collect();
   to.loader_index = from.loader_index;
-  to.parse_meta = from.parse_meta.into_iter().collect();
+  for (key, value) in from.parse_meta {
+    to.parse_meta.insert(key, Box::new(value));
+  }
 
   Ok(())
 }

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -102,7 +102,7 @@ pub mod reserved_names;
 
 use rspack_cacheable::{cacheable, with::AsPreset};
 pub use rspack_loader_runner::{
-  get_scheme, parse_resource, AdditionalData, ResourceData, ResourceParsedData, Scheme,
+  get_scheme, parse_resource, AdditionalData, ParseMeta, ResourceData, ResourceParsedData, Scheme,
   BUILTIN_LOADER_PREFIX,
 };
 pub use rspack_macros::{impl_runtime_module, impl_source_map_config};

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -7,7 +7,7 @@ use rspack_cacheable::{
 };
 use rspack_error::{Result, TWithDiagnosticArray};
 use rspack_hash::RspackHashDigest;
-use rspack_loader_runner::{AdditionalData, ResourceData};
+use rspack_loader_runner::{AdditionalData, ParseMeta, ResourceData};
 use rspack_sources::BoxSource;
 use rspack_util::{ext::AsAny, source_map::SourceMapKind};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -35,7 +35,7 @@ pub struct ParseContext<'a> {
   pub resource_data: &'a ResourceData,
   pub compiler_options: &'a CompilerOptions,
   pub additional_data: Option<AdditionalData>,
-  pub parse_meta: FxHashMap<String, String>,
+  pub parse_meta: ParseMeta,
   pub build_info: &'a mut BuildInfo,
   pub build_meta: &'a mut BuildMeta,
 }
@@ -48,6 +48,8 @@ pub struct CollectedTypeScriptInfo {
   #[cacheable(with=AsMap<AsPreset>)]
   pub exported_enums: FxHashMap<Atom, TSEnumValue>,
 }
+
+pub const COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY: &str = "rspack-collected-ts-info";
 
 #[cacheable]
 #[derive(Debug, Default, Clone)]

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -12,6 +12,7 @@ use rspack_cacheable::{
 };
 use rspack_error::{Error, Result, ToStringResultToRspackResultExt};
 use rspack_paths::Utf8PathBuf;
+use rustc_hash::FxHashMap;
 
 use crate::{get_scheme, Scheme};
 
@@ -290,3 +291,4 @@ impl DescriptionData {
 }
 
 pub type AdditionalData = anymap::Map<dyn CloneAny + Send + Sync>;
+pub type ParseMeta = FxHashMap<String, Box<dyn CloneAny + Send + Sync>>;

--- a/crates/rspack_loader_runner/src/context.rs
+++ b/crates/rspack_loader_runner/src/context.rs
@@ -4,10 +4,11 @@ use derive_more::Debug;
 use rspack_error::Diagnostic;
 use rspack_paths::Utf8Path;
 use rspack_sources::SourceMap;
-use rustc_hash::{FxHashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  loader::LoaderItemList, AdditionalData, Content, LoaderItem, LoaderRunnerPlugin, ResourceData,
+  loader::LoaderItemList, AdditionalData, Content, LoaderItem, LoaderRunnerPlugin, ParseMeta,
+  ResourceData,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -38,7 +39,7 @@ pub struct LoaderContext<Context> {
   pub resource_data: Arc<ResourceData>,
   #[debug(skip)]
   pub context: Context,
-  pub parse_meta: FxHashMap<String, String>,
+  pub parse_meta: ParseMeta,
 
   pub(crate) content: Option<Content>,
   pub(crate) source_map: Option<SourceMap>,

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -8,7 +8,7 @@ mod plugin;
 mod runner;
 mod scheme;
 
-pub use content::{AdditionalData, Content, DescriptionData, ResourceData};
+pub use content::{AdditionalData, Content, DescriptionData, ParseMeta, ResourceData};
 pub use context::{LoaderContext, State};
 pub use loader::{parse_resource, DisplayWithSuffix, Loader, LoaderItem, ResourceParsedData};
 pub use plugin::LoaderRunnerPlugin;

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, path::PathBuf, sync::Arc};
 use rspack_error::{error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_fs::ReadableFileSystem;
 use rspack_sources::SourceMap;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashSet as HashSet;
 use tokio::task::spawn_blocking;
 use tracing::{info_span, Instrument};
 
@@ -12,6 +12,7 @@ use crate::{
   context::{LoaderContext, State},
   loader::{Loader, LoaderItem},
   plugin::LoaderRunnerPlugin,
+  ParseMeta,
 };
 
 impl<Context> LoaderContext<Context> {
@@ -215,7 +216,7 @@ pub struct LoaderResult {
   pub content: Content,
   pub source_map: Option<SourceMap>,
   pub additional_data: Option<AdditionalData>,
-  pub parse_meta: HashMap<String, String>,
+  pub parse_meta: ParseMeta,
 }
 
 impl<Context> TryFrom<LoaderContext<Context>> for TWithDiagnosticArray<LoaderResult> {

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -11,7 +11,7 @@ use options::SwcCompilerOptionsWithAdditional;
 pub use options::SwcLoaderJsOptions;
 pub use plugin::SwcLoaderPlugin;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_core::{AdditionalData, Mode, RunnerContext};
+use rspack_core::{Mode, RunnerContext, COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY};
 use rspack_error::{miette, Diagnostic, Result};
 use rspack_javascript_compiler::{JavaScriptCompiler, TransformOutput};
 use rspack_loader_runner::{Identifiable, Identifier, Loader, LoaderContext};
@@ -124,14 +124,14 @@ impl SwcLoader {
       );
     }
 
-    let mut finish = (code, map, None);
     if let Some(collected_ts_info) = collected_ts_info {
-      let mut additional_data = AdditionalData::new();
-      additional_data.insert(collected_ts_info);
-      finish.2 = Some(additional_data);
+      loader_context.parse_meta.insert(
+        COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY.to_string(),
+        Box::new(collected_ts_info),
+      );
     }
 
-    loader_context.finish_with(finish);
+    loader_context.finish_with((code, map));
 
     Ok(())
   }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, ChunkGraph, CollectedTypeScriptInfo,
   Compilation, DependenciesBlock, DependencyId, DependencyRange, GenerateContext, Module,
   ModuleGraph, ModuleType, ParseContext, ParseResult, ParserAndGenerator, SideEffectsBailoutItem,
-  SourceType, TemplateContext, TemplateReplaceSource,
+  SourceType, TemplateContext, TemplateReplaceSource, COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY,
 };
 use rspack_error::{miette::Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_javascript_compiler::JavaScriptCompiler;
@@ -144,16 +144,17 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       module_identifier,
       loaders,
       module_parser_options,
-      mut additional_data,
-      parse_meta,
+      additional_data,
+      mut parse_meta,
       ..
     } = parse_context;
     let mut diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>> = vec![];
 
-    if let Some(additional_data) = &mut additional_data
-      && let Some(collected_ts_info) = additional_data.remove::<CollectedTypeScriptInfo>()
+    if let Some(collected_ts_info) = parse_meta.remove(COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY)
+      && let Ok(collected_ts_info) =
+        (collected_ts_info as Box<dyn std::any::Any>).downcast::<CollectedTypeScriptInfo>()
     {
-      build_info.collected_typescript_info = Some(collected_ts_info);
+      build_info.collected_typescript_info = Some(*collected_ts_info);
     }
 
     let default_with_diagnostics =

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -6,12 +6,12 @@ use std::sync::Arc;
 
 use rspack_core::{
   AdditionalData, AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo,
-  BuildMeta, CompilerOptions, ModuleIdentifier, ModuleLayer, ModuleType, ParserOptions,
+  BuildMeta, CompilerOptions, ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta, ParserOptions,
   ResourceData,
 };
 use rspack_error::miette::Diagnostic;
 use rspack_javascript_compiler::ast::Program;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use swc_core::{
   common::{comments::Comments, BytePos, Mark, SourceFile, SourceMap},
   ecma::atoms::Atom,
@@ -62,7 +62,7 @@ pub fn scan_dependencies(
   parser_plugins: &mut Vec<BoxJavascriptParserPlugin>,
   parser_pre_plugins: &mut Vec<BoxJavascriptParserPlugin>,
   additional_data: Option<AdditionalData>,
-  parse_meta: FxHashMap<String, String>,
+  parse_meta: ParseMeta,
 ) -> Result<ScanDependenciesResult, Vec<Box<dyn Diagnostic + Send + Sync>>> {
   let mut parser = JavascriptParser::new(
     source_map,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -12,7 +12,8 @@ use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_core::{
   AdditionalData, AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo,
   BuildMeta, CompilerOptions, DependencyRange, JavascriptParserOptions, JavascriptParserUrl,
-  ModuleIdentifier, ModuleLayer, ModuleType, ResourceData, SpanExt, TypeReexportPresenceMode,
+  ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta, ResourceData, SpanExt,
+  TypeReexportPresenceMode,
 };
 use rspack_error::miette::Diagnostic;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -226,7 +227,7 @@ pub struct JavascriptParser<'parser> {
   pub blocks: Vec<Box<AsyncDependenciesBlock>>,
   // TODO: remove `additional_data` once we have builtin:css-extract-loader
   pub additional_data: Option<AdditionalData>,
-  pub parse_meta: FxHashMap<String, String>,
+  pub parse_meta: ParseMeta,
   pub(crate) comments: Option<&'parser dyn Comments>,
   pub(crate) build_meta: &'parser mut BuildMeta,
   pub build_info: &'parser mut BuildInfo,
@@ -283,7 +284,7 @@ impl<'parser> JavascriptParser<'parser> {
     parser_plugins: &'parser mut Vec<BoxJavascriptParserPlugin>,
     parser_pre_plugins: &'parser mut Vec<BoxJavascriptParserPlugin>,
     additional_data: Option<AdditionalData>,
-    parse_meta: FxHashMap<String, String>,
+    parse_meta: ParseMeta,
   ) -> Self {
     let warning_diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>> = Vec::with_capacity(4);
     let mut errors = Vec::with_capacity(4);

--- a/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/enum.ts
+++ b/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/enum.ts
@@ -1,0 +1,4 @@
+export enum E {
+  A,
+  B,
+}

--- a/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/index.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/index.js
@@ -1,0 +1,13 @@
+import { E } from "./enum";
+
+const generated = /** @type {string} */ (__non_webpack_require__("fs").readFileSync(__filename, "utf-8"));
+
+it("should inline for enum when builtin:swc-loader is not the last loader", () => {
+  // START:A
+  expect(E.A).toBe(0);
+  expect(E.B).toBe(1);
+  // END:A
+  const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
+  expect(block.includes(`(/* inlined export .E.A */ 0).toBe(0)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.B */ 1).toBe(1)`)).toBe(true);
+})

--- a/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/loader.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/loader.js
@@ -1,0 +1,3 @@
+module.exports = function (content) {
+  return content;
+}

--- a/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/rspack.config.js
@@ -1,0 +1,38 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	resolve: {
+		extensions: [".ts", "..."]
+	},
+	module: {
+		rules: [
+			{
+				test: /\.ts$/,
+				use: [
+					"./loader.js",
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								parser: {
+									syntax: "typescript"
+								}
+							},
+							rspackExperiments: {
+								collectTypeScriptInfo: {
+									exportedEnum: true
+								}
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	optimization: {
+		moduleIds: "named",
+		concatenateModules: false
+	},
+	experiments: {
+		inlineEnum: true
+	}
+};

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4237,7 +4237,7 @@ export type Loader = Record<string, any>;
 // @public (undocumented)
 export interface LoaderContext<OptionsType = {}> {
     // @internal
-    __internal__parseMeta: Record<string, string>;
+    __internal__setParseMeta: (key: string, value: string) => void;
     // (undocumented)
     addBuildDependency(file: string): void;
     addContextDependency(context: string): void;

--- a/packages/rspack/src/builtin-plugin/css-extract/loader.ts
+++ b/packages/rspack/src/builtin-plugin/css-extract/loader.ts
@@ -102,7 +102,7 @@ export const pitch: LoaderDefinition["pitch"] = function (request, _, data) {
 	const emit = typeof options.emit !== "undefined" ? options.emit : true;
 	const callback = this.async();
 	const filepath = this.resourcePath;
-	const parseMeta = this.__internal__parseMeta;
+
 	this.addDependency(filepath);
 
 	let { publicPath } = this._compilation!.outputOptions;
@@ -260,7 +260,7 @@ export const pitch: LoaderDefinition["pitch"] = function (request, _, data) {
 				: result;
 
 		if (dependencies.length > 0) {
-			parseMeta[PLUGIN_NAME] = JSON.stringify(dependencies);
+			this.__internal__setParseMeta(PLUGIN_NAME, JSON.stringify(dependencies));
 		}
 
 		callback(null, resultSource, undefined, data);

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -383,7 +383,7 @@ export interface LoaderContext<OptionsType = {}> {
 	 *
 	 * @internal
 	 */
-	__internal__parseMeta: Record<string, string>;
+	__internal__setParseMeta: (key: string, value: string) => void;
 }
 
 export type LoaderDefinitionFunction<

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -739,10 +739,11 @@ export async function runLoaders(
 		set: data =>
 			(loaderContext.loaders[loaderContext.loaderIndex].loaderItem.data = data)
 	});
-	Object.defineProperty(loaderContext, "__internal__parseMeta", {
-		enumerable: true,
-		get: () => context.__internal__parseMeta
-	});
+
+	/// Rspack private
+	loaderContext.__internal__setParseMeta = (key: string, value: string) => {
+		context.__internal__parseMeta[key] = value;
+	};
 
 	const getWorkerLoaderContext = () => {
 		const normalModule =


### PR DESCRIPTION
## Summary

AdditionalData will lose the stored info if there are loader after (see https://github.com/web-infra-dev/rspack/pull/7878), so use parseMeta to store the info. 
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
