### PR TITLE
fix: should match `resource` instead of `identifier`

### DIFF
--- a/crates/rspack_plugin_circular_dependencies/src/lib.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/lib.rs
@@ -284,20 +284,10 @@ impl CircularDependencyRspackPlugin {
         continue;
       };
 
-      let Some(target_module) = compilation
-        .module_by_identifier(target_id)
-        .and_then(|m| m.as_normal_module())
-      else {
-        continue;
-      };
-
       // Not all cycles are errors, so filter out any cycles containing
       // explicitly-ignored modules.
       if self.is_ignored_module(module.resource_resolved_data().resource.as_str())
-        || self.is_ignored_connection(
-          module.resource_resolved_data().resource.as_str(),
-          target_module.resource_resolved_data().resource.as_str(),
-        )
+        || self.is_ignored_connection(module_id, target_id)
       {
         return true;
       }

--- a/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
@@ -28,7 +28,7 @@ module.exports = {
 	plugins: [
 		new CircularDependencyRspackPlugin({
 			failOnError: false,
-			exclude: /ignore-circular/,
+			exclude: /(ignore-circular|loader)/,
 			onStart(_compilation) {
 				expect(typeof _compilation.errors === "object").toBeTruthy();
 				expect(typeof _compilation.errors.push === "function").toBeTruthy();

--- a/website/docs/en/plugins/rspack/circular-dependency-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/circular-dependency-rspack-plugin.mdx
@@ -127,7 +127,7 @@ export default {
 - **Type:** `RegExp`
 - **Default:** `undefined`
 
-Similar to `exclude` from the original [`circular-dependency-plugin`](https://github.com/aackerman/circular-dependency-plugin), detected cycles containing any module identifier that matches this pattern will be ignored.
+Similar to `exclude` from the original [`circular-dependency-plugin`](https://github.com/aackerman/circular-dependency-plugin), detected cycles containing any module resource path that matches this pattern will be ignored.
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';

--- a/website/docs/zh/plugins/rspack/circular-dependency-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/circular-dependency-rspack-plugin.mdx
@@ -131,7 +131,7 @@ export default {
 - **类型:** `RegExp`
 - **默认值:** `undefined`
 
-和 webpack 插件 [`circular-dependency-plugin`](https://github.com/aackerman/circular-dependency-plugin) 里的 `exclude` 配置类似，检测到的任何包含该模式匹配的模块标识符的循环依赖都会被忽略。
+和 webpack 插件 [`circular-dependency-plugin`](https://github.com/aackerman/circular-dependency-plugin) 里的 `exclude` 配置类似，检测到的任何包含该模式匹配的模块路径的循环依赖都会被忽略。
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';


### PR DESCRIPTION
## Summary

close: #11085

## Related links

<!-- Related issues or discussions. -->
https://github.com/aackerman/circular-dependency-plugin/blob/21777bf980e78cb55bff0c91e43a03bbfb37f762/index.js#L28-L32

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
