### PR TITLE
perf(wasm): use build-std for release-wasi

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -79,6 +79,7 @@ async function build() {
 		if (positionals.length > 0
 			|| values.profile === "release"
 			|| values.profile === "release-debug"
+			|| values.profile === "release-wasi"
 			|| values.profile === "profiling"
 		) {
 			// napi need `--` to separate options and positional arguments.
@@ -86,6 +87,7 @@ async function build() {
 
 			if (values.profile === "release"
 				|| values.profile === "release-debug"
+				|| values.profile === "release-wasi"
 				|| values.profile === "profiling"
 			) {
 				// allows to optimize std with current compile arguments


### PR DESCRIPTION
## Summary

This is the missing part of https://github.com/web-infra-dev/rspack/pull/11077

In my mac:
Before: 28.86M
After: 28.39M

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
