### PR TITLE
chore: setup rpath for sftrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6181,9 +6181,9 @@ dependencies = [
 
 [[package]]
 name = "sftrace-setup"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3fd16d5db34706ab7200fb106bb1006f1801d1af9efabd65fb78ad8b9c8b0e"
+checksum = "98fb782409291a83a40a6d272876e7bbbfe226e095df441d6102ec0bd37d4922"
 
 [[package]]
 name = "sha1"

--- a/crates/node_binding/build.rs
+++ b/crates/node_binding/build.rs
@@ -1,3 +1,41 @@
 fn main() {
   rspack_binding_build::setup();
+
+  #[cfg(feature = "sftrace-setup")]
+  {
+    sftrace_setup();
+  }
+}
+
+#[cfg(feature = "sftrace-setup")]
+fn sftrace_setup() {
+  use std::path::PathBuf;
+
+  fn search_sftracelib() -> Option<PathBuf> {
+    use std::process::{Command, Stdio};
+
+    let result = Command::new("sftrace")
+      .stdin(Stdio::null())
+      .stdout(Stdio::piped())
+      .stderr(Stdio::inherit())
+      .arg("record")
+      .arg("--print-solib")
+      .output();
+
+    match result {
+      Ok(output) if output.status.success() => {
+        let out = String::from_utf8(output.stdout).ok()?;
+        let mut out = PathBuf::from(out);
+        out.pop();
+        Some(out)
+      }
+      _ => None,
+    }
+  }
+
+  if let Some(lib) = search_sftracelib() {
+    println!("cargo::rustc-link-arg=-Wl,-rpath,{}", lib.display());
+  } else {
+    println!("cargo::warning=not found sftrace");
+  }
 }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This allows the release-debug profile to be run without have to specify the sftrace so path using LD_LIBRARY_PATH.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
