### PR TITLE
fix: change request at before resolve for mf

### DIFF
--- a/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
@@ -65,10 +65,7 @@ async fn compilation(
 
 #[plugin_hook(NormalModuleFactoryFactorize for ContainerReferencePlugin)]
 async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<BoxModule>> {
-  let dependency = data.dependencies[0]
-    .as_module_dependency()
-    .expect("should be module dependency");
-  let request = dependency.request();
+  let request = &data.request;
   if !request.contains('!') {
     for (key, config) in &self.options.remotes {
       let key_len = key.len();

--- a/packages/rspack-test-tools/tests/configCases/container-1-0/change-data-request/a.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-0/change-data-request/a.js
@@ -1,0 +1,1 @@
+export default 'a'

--- a/packages/rspack-test-tools/tests/configCases/container-1-0/change-data-request/bootstrap.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-0/change-data-request/bootstrap.js
@@ -1,0 +1,7 @@
+import a from "myA";
+
+export function test(it) {
+	it("should have correct value for remote module", () => {
+		expect(a).toBe("a");
+	});
+}

--- a/packages/rspack-test-tools/tests/configCases/container-1-0/change-data-request/index.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-0/change-data-request/index.js
@@ -1,0 +1,3 @@
+it("should import the correct modules", () => {
+	return import("./bootstrap").then(({ test }) => test(it))
+});

--- a/packages/rspack-test-tools/tests/configCases/container-1-0/change-data-request/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-0/change-data-request/rspack.config.js
@@ -1,0 +1,38 @@
+const { ModuleFederationPluginV1: ModuleFederationPlugin } =
+	require("@rspack/core").container;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	plugins: [
+		new ModuleFederationPlugin({
+			name: "A",
+			filename: "container-a.js",
+			library: {
+				type: "commonjs-module"
+			},
+			exposes: {
+				".": "./a"
+			},
+			remoteType: "commonjs-module",
+			remotes: {
+				A: "./container-a.js"
+			}
+		}),
+		function (compiler) {
+			compiler.hooks.thisCompilation.tap(
+				"ChangeDataRequest",
+				(compilation, { normalModuleFactory }) => {
+					normalModuleFactory.hooks.beforeResolve.tap(
+						"ChangeDataRequest",
+						data => {
+							if (data.request === "myA") {
+								data.request = "A";
+							}
+						}
+					);
+				}
+			);
+		}
+	]
+};


### PR DESCRIPTION
## Summary

After https://github.com/web-infra-dev/rspack/pull/10999 modify data.request at beforeResolve won't change the dependency, so use data.request to get the request for mf remotes, this is also align with webpack

<!-- Describe what this PR does and why. -->

## Related links

fix #11088

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
