### PR TITLE
feat(rstest): strip import_call as first arg in mock function

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/mockFirstArgIsImport.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/mockFirstArgIsImport.js
@@ -1,0 +1,18 @@
+import { foo, baz } from './src/barrel'
+
+rs.mock(import('./src/foo'), () => {
+  return { value: 'mockedFoo' }
+})
+
+rs.mock(import('./src/baz'))
+
+it('should mock modules', async () => {
+	rs.doMock(import('./src/bar'), () => {
+  	return { value: 'mockedBar' }
+	})
+
+	const { bar } = await import('./src/barrel')
+	expect(foo).toBe('mockedFoo')
+	expect(bar).toBe('mockedBar')
+	expect(baz).toBe('mockedBaz')
+})

--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/rspack.config.js
@@ -176,5 +176,6 @@ module.exports = [
 		optimization: {
 			mangleExports: false
 		}
-	}
+	},
+	rstestEntry("./mockFirstArgIsImport.js")
 ];

--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/src/__mocks__/baz.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/src/__mocks__/baz.js
@@ -1,0 +1,1 @@
+export const value = 'mockedBaz';

--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/src/barrel.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/src/barrel.js
@@ -1,2 +1,3 @@
 export { value as foo } from './foo.js';
 export { value as bar } from './bar.js';
+export { value as baz } from './baz.js';

--- a/packages/rspack-test-tools/tests/configCases/rstest/mock/src/baz.js
+++ b/packages/rspack-test-tools/tests/configCases/rstest/mock/src/baz.js
@@ -1,0 +1,1 @@
+export const value = 'baz';


### PR DESCRIPTION
## Summary

strip the import call in the first arg of `mock` and `doMock` and other mock functions.

```ts
rs.mock(import('./src/a'))
// will be parsed as
rs.mock('./src/a')
```

To allow using then stripping the import call is to gain better IDE type inferring support. No other differences.

There's something I'm not very sure in https://github.com/web-infra-dev/rspack/pull/11099/files#diff-40c0d32c43ce5b65da53481dcdff3dd9226e0e5565549315f49a120afe5c8525R203. I use a manual made UUID (by using expr loc) as the name of tagged import call to avoid confusion with other non-target import calls and support multiple target import calls with same request. But this kind of UUID is not seen elsewhere.

GitHub diff is terrible, here's the diff on VS Code on my machine.

<img width="1074" height="1916" alt="Code 2025-07-21 14 32 19" src="https://github.com/user-attachments/assets/8a44d3c4-dfd6-43e5-87a8-8d7899f943d6" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
