### PR TITLE
fix: should allow `externalHelpers: false`

### DIFF
--- a/crates/rspack_loader_swc/Cargo.toml
+++ b/crates/rspack_loader_swc/Cargo.toml
@@ -33,7 +33,7 @@ serde                          = { workspace = true, features = ["derive"] }
 serde_json                     = { workspace = true }
 swc                            = { workspace = true, features = ["manual-tokio-runtime"] }
 swc_config                     = { workspace = true }
-swc_core                       = { workspace = true, features = ["base", "ecma_ast", "common", "ecma_preset_env"] }
+swc_core                       = { workspace = true, features = ["base", "ecma_ast", "common", "ecma_preset_env", "ecma_helpers_inline"] }
 tokio                          = { workspace = true }
 tracing                        = { workspace = true }
 

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-default/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-default/index.js
@@ -1,0 +1,10 @@
+it("should convert TypeScript to JavaScript", () => {
+	const { Foo } = require("./lib");
+	expect(new Foo().foo()).toBe(42);
+});
+
+it("should not have swc/helpers", () => {
+	expect(
+		Object.keys(__webpack_modules__).some(name => name.includes("swc/helpers"))
+	).toBe(false);
+});

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-default/lib.ts
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-default/lib.ts
@@ -1,0 +1,5 @@
+export class Foo {
+	foo(): number {
+		return 42;
+	}
+}

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-default/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-default/rspack.config.js
@@ -1,0 +1,25 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	resolve: {
+		extensions: ["...", ".ts"]
+	},
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.ts$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								target: "es5"
+							}
+						}
+					}
+				],
+				type: "javascript/auto"
+			}
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-false/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-false/index.js
@@ -1,0 +1,10 @@
+it("should convert TypeScript to JavaScript", () => {
+	const { Foo } = require("./lib");
+	expect(new Foo().foo()).toBe(42);
+});
+
+it("should not have swc/helpers", () => {
+	expect(
+		Object.keys(__webpack_modules__).some(name => name.includes("swc/helpers"))
+	).toBe(false);
+});

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-false/lib.ts
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-false/lib.ts
@@ -1,0 +1,5 @@
+export class Foo {
+	foo(): number {
+		return 42;
+	}
+}

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-false/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-false/rspack.config.js
@@ -1,0 +1,26 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	resolve: {
+		extensions: ["...", ".ts"]
+	},
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.ts$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								externalHelpers: false,
+								target: "es5"
+							}
+						}
+					}
+				],
+				type: "javascript/auto"
+			}
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-true/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-true/index.js
@@ -1,0 +1,10 @@
+it("should convert TypeScript to JavaScript", () => {
+	const { Foo } = require("./lib");
+	expect(new Foo().foo()).toBe(42);
+});
+
+it("should have swc/helpers", () => {
+	expect(
+		Object.keys(__webpack_modules__).some(name => name.includes("swc/helpers"))
+	).toBe(true);
+});

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-true/lib.ts
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-true/lib.ts
@@ -1,0 +1,5 @@
+export class Foo {
+	foo(): number {
+		return 42;
+	}
+}

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-true/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/external-helpers-true/rspack.config.js
@@ -1,0 +1,26 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	resolve: {
+		extensions: ["...", ".ts"]
+	},
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.ts$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								externalHelpers: true,
+								target: "es5"
+							}
+						}
+					}
+				],
+				type: "javascript/auto"
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Enable the `ecma_helpers_inline` feature of `swc_core`.

Fix there regression where `externalHelpers: false` of `builtin:swc-loader` take no effect.

## Related links

<!-- Related issues or discussions. -->

Introduced in https://github.com/web-infra-dev/rspack/pull/11089

Related SWC change: https://github.com/swc-project/swc/pull/10808

We may also want to revert https://github.com/rspack-contrib/rspack-benchcases/pull/5 :)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
