### PR TITLE
perf: parallel process exports spec

### DIFF
--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -110,6 +110,19 @@ pub struct ExportsSpec {
   pub exclude_exports: Option<FxHashSet<Atom>>,
 }
 
+impl ExportsSpec {
+  pub fn has_nested_exports(&self) -> bool {
+    match &self.exports {
+      ExportsOfExportsSpec::UnknownExports => false,
+      ExportsOfExportsSpec::NoExports => false,
+      ExportsOfExportsSpec::Names(names) => names.iter().any(|name| match name {
+        ExportNameOrSpec::String(_) => false,
+        ExportNameOrSpec::ExportSpec(spec) => spec.exports.is_some(),
+      }),
+    }
+  }
+}
+
 pub trait DependencyConditionFn: Sync + Send {
   fn get_connection_state(
     &self,

--- a/crates/rspack_core/src/exports/export_info_setter.rs
+++ b/crates/rspack_core/src/exports/export_info_setter.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 use rspack_util::atom::Atom;
 
 use super::{ExportInfoData, ExportInfoTargetValue, Inlinable, UsageFilterFnTy, UsageState};
-use crate::{DependencyId, ExportsInfo, ExportsInfoData, ModuleGraph, Nullable, RuntimeSpec};
+use crate::{DependencyId, ExportsInfo, Nullable, RuntimeSpec};
 
 impl ExportInfoData {
   pub fn reset_provide_info(&mut self) {
@@ -210,31 +210,6 @@ impl ExportInfoData {
       changed = true;
     }
     changed
-  }
-
-  pub fn create_nested_exports_info(&mut self, mg: &mut ModuleGraph) -> ExportsInfo {
-    if self.exports_info_owned() {
-      return self
-        .exports_info()
-        .expect("should have exports_info when exports_info is true");
-    }
-
-    self.set_exports_info_owned(true);
-    let new_exports_info = ExportsInfoData::default();
-    let new_exports_info_id = new_exports_info.id();
-
-    self.set_exports_info_owned(true);
-    self.set_exports_info(Some(new_exports_info_id));
-
-    mg.set_exports_info(new_exports_info_id, new_exports_info);
-    new_exports_info_id.set_has_provide_info(mg);
-    let old_exports_info = self.exports_info();
-    if let Some(exports_info) = old_exports_info {
-      exports_info
-        .as_data_mut(mg)
-        .set_redirect_name_to(Some(new_exports_info_id));
-    }
-    new_exports_info_id
   }
 
   pub fn set_has_use_info(&mut self, nested_exports_info: &mut Vec<ExportsInfo>) {

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -210,22 +210,6 @@ impl ExportsInfo {
     changed
   }
 
-  pub fn set_all_known_exports_used(
-    &self,
-    mg: &mut ModuleGraph,
-    runtime: Option<&RuntimeSpec>,
-  ) -> bool {
-    let mut changed = false;
-    let exports_info = self.as_data_mut(mg);
-    for export_info in exports_info.exports_mut().values_mut() {
-      if !matches!(export_info.provided(), Some(ExportProvided::Provided)) {
-        continue;
-      }
-      changed |= export_info.set_used(UsageState::Used, runtime);
-    }
-    changed
-  }
-
   pub fn set_used_in_unknown_way(
     &self,
     mg: &mut ModuleGraph,

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -34,7 +34,7 @@ impl ExportsInfoData {
     changed
   }
 
-  pub fn ensure_export_info(&mut self, name: &Atom) -> &mut ExportInfoData {
+  pub fn ensure_owned_export_info(&mut self, name: &Atom) -> &mut ExportInfoData {
     if self.named_exports(name).is_none() {
       let new_info = ExportInfoData::new(
         self.id(),
@@ -48,7 +48,11 @@ impl ExportsInfoData {
       .expect("should have export info")
   }
 
-  pub fn set_unknown_exports_provided(
+  // TODO: remove this method
+  // This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`
+  // So this method should only be used when you actually known the `redirect_to` is not exist
+  // and you need to modify exports info datas parallelly
+  pub fn set_owned_unknown_exports_provided(
     &mut self,
     can_mangle: bool,
     exclude_exports: Option<&FxHashSet<Atom>>,
@@ -60,7 +64,7 @@ impl ExportsInfoData {
 
     if let Some(exclude_exports) = &exclude_exports {
       for name in exclude_exports.iter() {
-        self.ensure_export_info(name);
+        self.ensure_owned_export_info(name);
       }
     }
 

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -48,10 +48,10 @@ impl ExportsInfoData {
       .expect("should have export info")
   }
 
-  // TODO: remove this method
-  // This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`.
-  // It should only be used when you know the `redirect_to` does not exist and you need to modify
-  // exports info data in parallel. Remove this method after refactoring `set_unknown_exports_provided`.
+  /// TODO: remove this method
+  /// This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`.
+  /// It should only be used when you know the `redirect_to` does not exist and you need to modify
+  /// exports info data in parallel. Remove this method after refactoring `set_unknown_exports_provided`.
   pub fn set_owned_unknown_exports_provided(
     &mut self,
     can_mangle: bool,

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -48,10 +48,12 @@ impl ExportsInfoData {
       .expect("should have export info")
   }
 
-  // TODO: remove this method (See issue #123 for details)
-  // This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`.
-  // It should only be used when you know the `redirect_to` does not exist and you need to modify
-  // exports info data in parallel. Remove this method after refactoring `set_unknown_exports_provided`.
+  /**
+   * TODO: remove this method
+   * This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`.
+   * It should only be used when you know the `redirect_to` does not exist and you need to modify
+   * exports info data in parallel. Remove this method after refactoring `set_unknown_exports_provided`.
+   */
   pub fn set_owned_unknown_exports_provided(
     &mut self,
     can_mangle: bool,

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -51,7 +51,7 @@ impl ExportsInfoData {
   // TODO: remove this method
   // This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`
   // So this method should only be used when you actually known the `redirect_to` is not exist
-  // and you need to modify exports info datas parallelly
+  // and you need to modify exports info data parallelly
   pub fn set_owned_unknown_exports_provided(
     &mut self,
     can_mangle: bool,

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -48,12 +48,10 @@ impl ExportsInfoData {
       .expect("should have export info")
   }
 
-  /**
-   * TODO: remove this method
-   * This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`.
-   * It should only be used when you know the `redirect_to` does not exist and you need to modify
-   * exports info data in parallel. Remove this method after refactoring `set_unknown_exports_provided`.
-   */
+  // TODO: remove this method
+  // This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`.
+  // It should only be used when you know the `redirect_to` does not exist and you need to modify
+  // exports info data in parallel. Remove this method after refactoring `set_unknown_exports_provided`.
   pub fn set_owned_unknown_exports_provided(
     &mut self,
     can_mangle: bool,

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -48,10 +48,10 @@ impl ExportsInfoData {
       .expect("should have export info")
   }
 
-  // TODO: remove this method
-  // This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`
-  // So this method should only be used when you actually known the `redirect_to` is not exist
-  // and you need to modify exports info data parallelly
+  // TODO: remove this method (See issue #123 for details)
+  // This method is a copy of `set_unknown_exports_provided` and not considered the `redirect_to`.
+  // It should only be used when you know the `redirect_to` does not exist and you need to modify
+  // exports info data in parallel. Remove this method after refactoring `set_unknown_exports_provided`.
   pub fn set_owned_unknown_exports_provided(
     &mut self,
     can_mangle: bool,

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -271,11 +271,9 @@ fn collect_module_exports_specs(
   Some((res, has_nested_exports))
 }
 
-///
 /// Merge exports specs to exports info data
 /// and also collect the dependencies
 /// which will be used to backtrack when target exports info is changed
-///
 pub fn process_exports_spec(
   mg: &mut ModuleGraph,
   module_id: &ModuleIdentifier,
@@ -339,14 +337,11 @@ pub fn process_exports_spec(
   (changed, dependencies)
 }
 
-///
 /// Merge exports specs to exports info data
 /// and also collect the dependencies
 /// which will be used to backtrack when target exports info is changed
-///
 /// This method is used for the case that the exports info data will not be nested modified
 /// that means this exports info can be modified parallelly
-///
 pub fn process_exports_spec_without_nested(
   mg: &ModuleGraph,
   module_id: &ModuleIdentifier,
@@ -507,12 +502,9 @@ pub fn merge_exports_without_nested(
   (changed, dependencies)
 }
 
-///
 /// Do merging of exports info and create export infos from export specs
-///
 /// This method is used for the case that the exports info data will be nested modified
 /// that means this exports info can not be modified parallelly
-///
 pub fn merge_exports(
   mg: &mut ModuleGraph,
   module_id: &ModuleIdentifier,

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -81,7 +81,7 @@ impl<'a> FlagDependencyExportsState<'a> {
       // and this merging can not be done parallelly
       //
       // There are two cases that the `redirect_to` or nested `exports` exist:
-      // 1. exports from json dependecy which has nested json object data
+      // 1. exports from json dependency which has nested json object data
       // 2. exports from an esm reexport and the target is a commonjs module which should create a interop `default` export
       let (non_nested_specs, has_nested_specs): (Vec<_>, Vec<_>) = module_exports_specs
         .into_iter()

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -339,14 +339,14 @@ pub fn process_exports_spec(
   (changed, dependencies)
 }
 
-/**
- * Merge exports specs to exports info data
- * and also collect the dependencies
- * which will be used to backtrack when target exports info is changed
- *
- * This method is used for the case that the exports info data will not be nested modified
- * that means this exports info can be modified parallelly
- */
+///
+/// Merge exports specs to exports info data
+/// and also collect the dependencies
+/// which will be used to backtrack when target exports info is changed
+///
+/// This method is used for the case that the exports info data will not be nested modified
+/// that means this exports info can be modified parallelly
+///
 pub fn process_exports_spec_without_nested(
   mg: &ModuleGraph,
   module_id: &ModuleIdentifier,

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
@@ -59,13 +57,13 @@ impl<'a> FlagDependencyExportsState<'a> {
     while !batch.is_empty() {
       let modules = std::mem::take(&mut batch);
       let module_exports_specs = modules
-        .into_iter()
+        .into_par_iter()
         .map(|module_id| {
           let exports_specs =
             collect_module_exports_specs(&module_id, self.mg, self.mg_cache).unwrap_or_default();
           (module_id, exports_specs)
         })
-        .collect::<VecDeque<_>>();
+        .collect::<Vec<_>>();
 
       let mut changed_modules = FxHashSet::default();
 

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -271,11 +271,11 @@ fn collect_module_exports_specs(
   Some((res, has_nested_exports))
 }
 
-/**
- * Merge exports specs to exports info data
- * and also collect the dependencies
- * which will be used to backtrack when target exports info is changed
- */
+///
+/// Merge exports specs to exports info data
+/// and also collect the dependencies
+/// which will be used to backtrack when target exports info is changed
+///
 pub fn process_exports_spec(
   mg: &mut ModuleGraph,
   module_id: &ModuleIdentifier,

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -455,12 +455,10 @@ impl<'a> ParsedExportSpec<'a> {
   }
 }
 
-/**
- * Do merging of exports info and create export infos from export specs
- *
- * This method is used for the case that the exports info data will not be nested modified
- * that means this exports info can be modified parallelly
- */
+/// Do merging of exports info and create export infos from export specs
+///
+/// This method is used for the case that the exports info data will not be nested modified
+/// that means this exports info can be modified parallelly
 pub fn merge_exports_without_nested(
   mg: &ModuleGraph,
   module_id: &ModuleIdentifier,

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -509,12 +509,12 @@ pub fn merge_exports_without_nested(
   (changed, dependencies)
 }
 
-/**
- * Do merging of exports info and create export infos from export specs
- *
- * This method is used for the case that the exports info data will be nested modified
- * that means this exports info can not be modified parallelly
- */
+///
+/// Do merging of exports info and create export infos from export specs
+///
+/// This method is used for the case that the exports info data will be nested modified
+/// that means this exports info can not be modified parallelly
+///
 pub fn merge_exports(
   mg: &mut ModuleGraph,
   module_id: &ModuleIdentifier,

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -163,7 +163,9 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
       if self.ns_object_used {
         exports_info.set_used_in_unknown_way(&mut module_graph, Some(&runtime));
       } else {
-        exports_info.set_all_known_exports_used(&mut module_graph, Some(&runtime));
+        exports_info
+          .as_data_mut(&mut module_graph)
+          .set_all_known_exports_used(Some(&runtime));
       }
     }
   }


### PR DESCRIPTION
## Summary

Parallelize process exports specs when:
- the exports info data does not have `redirect_to`
- the exports specs do not have nested `exports` which will only be used in cjs interop and json nested objects

This means only the module's direct exports info data will be modified and the modules can be distinct by module_ids, so they can be modified parallelly. 

Before：
<img width="1330" height="346" alt="image" src="https://github.com/user-attachments/assets/db1bf983-87c6-4573-a70c-d59746772734" />


After：
<img width="1326" height="314" alt="image" src="https://github.com/user-attachments/assets/4ee37f6d-c7e3-4257-9ac9-1ddc0bb8b5ab" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
