### PR TITLE
perf: get resolve in external plugin

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -463,7 +463,7 @@ export declare class NativeWatchResult {
 
 export declare class RawExternalItemFnCtx {
   data(): RawExternalItemFnCtxData
-  getResolver(): JsResolver
+  getResolve(options?: RawResolveOptionsWithDependencyType | undefined | null): (context: string, path: string, callback: (error?: Error, text?: string) => void) => void
 }
 
 export declare class ReadonlyResourceData {

--- a/crates/rspack_binding_api/src/raw_options/raw_external.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_external.rs
@@ -1,6 +1,9 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, path::Path, sync::Arc};
 
-use napi::bindgen_prelude::{Either4, Promise};
+use napi::{
+  bindgen_prelude::{Either4, Function, FunctionCallContext, Promise},
+  Either, Env,
+};
 use napi_derive::napi;
 use rspack_core::{
   ExternalItem, ExternalItemFnCtx, ExternalItemFnResult, ExternalItemValue,
@@ -10,7 +13,10 @@ use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_regex::RspackRegex;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::JsResolver;
+use crate::{
+  callbackify, normalize_raw_resolve_options_with_dependency_type, ErrorCode,
+  RawResolveOptionsWithDependencyType, ResolveRequest,
+};
 
 #[napi(object)]
 pub struct RawHttpExternalsRspackPluginOptions {
@@ -105,12 +111,69 @@ impl RawExternalItemFnCtx {
     }
   }
 
-  #[napi]
-  pub fn get_resolver(&self) -> JsResolver {
-    JsResolver::new(
-      self.resolver_factory.clone(),
-      self.resolve_options_with_dependency_type.clone(),
-    )
+  #[napi(
+    ts_return_type = "(context: string, path: string, callback: (error?: Error, text?: string) => void) => void"
+  )]
+  pub fn get_resolve<'a>(
+    &self,
+    env: &'a Env,
+    options: Option<RawResolveOptionsWithDependencyType>,
+  ) -> napi::Result<Function<'a, (String, String, Function<'static>), ()>> {
+    let first = self.resolve_options_with_dependency_type.clone();
+    let second =
+      normalize_raw_resolve_options_with_dependency_type(options, first.resolve_to_context)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+    let resolver_factory = self.resolver_factory.clone();
+
+    let f: Function<(String, String, Function<'static>), ()> =
+      env.create_function_from_closure("resolve", move |ctx: FunctionCallContext| {
+        let context = ctx.get::<String>(0)?;
+        let request = ctx.get::<String>(1)?;
+        let callback = ctx.get::<Function<'static>>(2)?;
+
+        let merged_resolve_options = match &second.resolve_options {
+          Some(second_resolve_options) => match &first.resolve_options {
+            Some(resolve_options) => Some(Box::new(
+              resolve_options
+                .clone()
+                .merge(*second_resolve_options.clone()),
+            )),
+            None => Some(second_resolve_options.clone()),
+          },
+          None => first.resolve_options.clone(),
+        };
+
+        let merged_options = ResolveOptionsWithDependencyType {
+          resolve_options: merged_resolve_options,
+          resolve_to_context: second.resolve_to_context,
+          dependency_category: second.dependency_category,
+        };
+        let resolver = resolver_factory.get(merged_options);
+
+        callbackify(
+          callback,
+          async move {
+            match resolver.resolve(Path::new(&context), &request).await {
+              Ok(rspack_core::ResolveResult::Resource(resource)) => {
+                let resolve_request = ResolveRequest::from(resource);
+                Ok(match serde_json::to_string(&resolve_request) {
+                  Ok(json) => Either::<String, ()>::A(json),
+                  Err(_) => Either::B(()),
+                })
+              }
+              Ok(rspack_core::ResolveResult::Ignored) => Ok(Either::B(())),
+              Err(err) => Err(napi::Error::new(
+                ErrorCode::Napi(napi::Status::GenericFailure),
+                format!("{err:?}"),
+              )),
+            }
+          },
+          None::<fn()>,
+        )
+        .map_err(|e| napi::Error::from_reason(e.reason.to_string()))
+      })?;
+
+    Ok(f)
   }
 }
 

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -5,16 +5,16 @@ import {
 	type RawExternalsPluginOptions
 } from "@rspack/binding";
 
-import {
-	type Compiler,
-	type ExternalItem,
-	type ExternalItemValue,
-	type Externals
+import type {
+	Compiler,
+	ExternalItem,
+	ExternalItemValue,
+	Externals
 } from "..";
 import { getRawResolve } from "../config/adapter";
+import type { ResolveCallback } from "../config/adapterRuleUse";
+import type { ResolveRequest } from "../Resolver";
 import { createBuiltinPlugin, RspackBuiltinPlugin } from "./base";
-import { ResolveCallback } from "../config/adapterRuleUse";
-import { ResolveRequest } from "../Resolver";
 
 export class ExternalsPlugin extends RspackBuiltinPlugin {
 	name = BuiltinPluginName.ExternalsPlugin;

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -5,12 +5,7 @@ import {
 	type RawExternalsPluginOptions
 } from "@rspack/binding";
 
-import type {
-	Compiler,
-	ExternalItem,
-	ExternalItemValue,
-	Externals
-} from "..";
+import type { Compiler, ExternalItem, ExternalItemValue, Externals } from "..";
 import { getRawResolve } from "../config/adapter";
 import type { ResolveCallback } from "../config/adapterRuleUse";
 import type { ResolveRequest } from "../Resolver";

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -71,12 +71,12 @@ function getRawExternalItem(
 								if (callback) {
 									resolve(context, request, (error, text) => {
 										if (error) {
-											callback?.(error);
+											callback(error);
 										} else {
 											const req = text
 												? (JSON.parse(text) as ResolveRequest)
 												: undefined;
-											callback?.(null, req?.path ?? false, req);
+											callback(null, req?.path ?? false, req);
 										}
 									});
 								} else {

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -73,20 +73,31 @@ function getRawExternalItem(
 								request: string,
 								callback?: ResolveCallback
 							) => {
-								return new Promise((res, rej) => {
+								if (callback) {
 									resolve(context, request, (error, text) => {
 										if (error) {
-											rej(error);
 											callback?.(error);
 										} else {
 											const req = text
 												? (JSON.parse(text) as ResolveRequest)
 												: undefined;
 											callback?.(null, req?.path ?? false, req);
-											res(req?.path);
 										}
 									});
-								});
+								} else {
+									return new Promise((res, rej) => {
+										resolve(context, request, (error, text) => {
+											if (error) {
+												rej(error);
+											} else {
+												const req = text
+													? (JSON.parse(text) as ResolveRequest)
+													: undefined;
+												res(req?.path);
+											}
+										});
+									});
+								}
 							};
 						}
 					},


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Directly implement the getResolve method through NAPI to avoid the overhead of constructing `JsResolver` multiple times.

In this Next.js benchmark case https://github.com/SyMind/shadcn-ui/tree/next-rspack, build performance improved from 17s to 16s.

## Before

<img width="1956" height="1628" alt="image" src="https://github.com/user-attachments/assets/f76171d2-7691-4ca6-8b49-bf00e6c969d4" />

## After

<img width="3454" height="1888" alt="image" src="https://github.com/user-attachments/assets/bffffa6a-fdad-4ce4-8bd3-0a7393ebac14" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
