### PR TITLE
chore(linker): remove flag `--warn-unresolved-symbols`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -43,10 +43,6 @@ rustflags = [
 [target.'cfg(target_vendor = "apple")']
 rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains,-all_load"]
 
-# To be able to run unit tests on Linux, support compilation to 'x86_64-unknown-linux-gnu'.
-[target.'cfg(target_os = "linux")']
-rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols"]
-
 # To be able to run unit tests on Windows, support compilation to 'x86_64-pc-windows-msvc'.
 # Use Hybrid CRT to reduce the size of the binary (Coming by default with Windows 10 and later versions).
 [target.'cfg(target_os = "windows")']


### PR DESCRIPTION
## Summary

Try to remove ld flag `--warn-unresolved-symbols` for linux.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
