### PR TITLE
chore(wasm): bump @napi-rs/cli and @napi-rs/wasm-runtime

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -29,11 +29,10 @@
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": "web-infra-dev/rspack",
   "devDependencies": {
-    "@napi-rs/cli": "3.0.0-alpha.99",
-    "@napi-rs/wasm-runtime": "^0.2.12",
-    "emnapi": "^1.4.4",
-    "typescript": "^5.8.3",
-    "@emnapi/core": "^1.4.4"
+    "@napi-rs/cli": "3.0.1",
+    "@napi-rs/wasm-runtime": "^1.0.1",
+    "emnapi": "^1.4.5",
+    "typescript": "^5.8.3"
   },
   "napi": {
     "binaryName": "rspack",

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -48,12 +48,15 @@
       "aarch64-unknown-linux-gnu",
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-musl",
-      "aarch64-pc-windows-msvc"
+      "aarch64-pc-windows-msvc",
+      "wasm32-wasip1-threads"
     ],
     "wasm": {
       "initialMemory": 16384,
       "browser": {
-        "fs": true
+        "fs": true,
+        "asyncInit": true,
+        "buffer": true
       }
     }
   },

--- a/crates/node_binding/rspack.wasi-browser.js
+++ b/crates/node_binding/rspack.wasi-browser.js
@@ -1,11 +1,11 @@
 import {
-  getDefaultContext as __emnapiGetDefaultContext,
-  instantiateNapiModuleSync as __emnapiInstantiateNapiModuleSync,
-  WASI as __WASI,
   createOnMessage as __wasmCreateOnMessageForFsProxy,
+  getDefaultContext as __emnapiGetDefaultContext,
+  instantiateNapiModule as __emnapiInstantiateNapiModule,
+  WASI as __WASI,
 } from '@napi-rs/wasm-runtime'
-import { memfs } from '@napi-rs/wasm-runtime/fs'
-import __wasmUrl from './rspack.wasm32-wasi.wasm?url'
+import { memfs, Buffer } from '@napi-rs/wasm-runtime/fs'
+
 
 export const { fs: __fs, vol: __volume } = memfs()
 
@@ -17,7 +17,9 @@ const __wasi = new __WASI({
   },
 })
 
+const __wasmUrl = new URL('./rspack.wasm32-wasi.wasm', import.meta.url).href
 const __emnapiContext = __emnapiGetDefaultContext()
+__emnapiContext.feature.Buffer = Buffer
 
 const __sharedMemory = new WebAssembly.Memory({
   initial: 16384,
@@ -31,7 +33,7 @@ const {
   instance: __napiInstance,
   module: __wasiModule,
   napiModule: __napiModule,
-} = __emnapiInstantiateNapiModuleSync(__wasmFile, {
+} = await __emnapiInstantiateNapiModule(__wasmFile, {
   context: __emnapiContext,
   asyncWorkPoolSize: 4,
   wasi: __wasi,
@@ -61,3 +63,57 @@ const {
   },
 })
 export default __napiModule.exports
+export const Assets = __napiModule.exports.Assets
+export const AsyncDependenciesBlock = __napiModule.exports.AsyncDependenciesBlock
+export const Chunk = __napiModule.exports.Chunk
+export const ChunkGraph = __napiModule.exports.ChunkGraph
+export const ChunkGroup = __napiModule.exports.ChunkGroup
+export const Chunks = __napiModule.exports.Chunks
+export const CodeGenerationResult = __napiModule.exports.CodeGenerationResult
+export const CodeGenerationResults = __napiModule.exports.CodeGenerationResults
+export const ConcatenatedModule = __napiModule.exports.ConcatenatedModule
+export const ContextModule = __napiModule.exports.ContextModule
+export const Dependency = __napiModule.exports.Dependency
+export const Diagnostics = __napiModule.exports.Diagnostics
+export const EntryDataDto = __napiModule.exports.EntryDataDto
+export const EntryDataDTO = __napiModule.exports.EntryDataDTO
+export const EntryDependency = __napiModule.exports.EntryDependency
+export const EntryOptionsDto = __napiModule.exports.EntryOptionsDto
+export const EntryOptionsDTO = __napiModule.exports.EntryOptionsDTO
+export const ExternalModule = __napiModule.exports.ExternalModule
+export const JsCompilation = __napiModule.exports.JsCompilation
+export const JsCompiler = __napiModule.exports.JsCompiler
+export const JsContextModuleFactoryAfterResolveData = __napiModule.exports.JsContextModuleFactoryAfterResolveData
+export const JsContextModuleFactoryBeforeResolveData = __napiModule.exports.JsContextModuleFactoryBeforeResolveData
+export const JsDependencies = __napiModule.exports.JsDependencies
+export const JsEntries = __napiModule.exports.JsEntries
+export const JsExportsInfo = __napiModule.exports.JsExportsInfo
+export const JsModuleGraph = __napiModule.exports.JsModuleGraph
+export const JsResolver = __napiModule.exports.JsResolver
+export const JsResolverFactory = __napiModule.exports.JsResolverFactory
+export const JsStats = __napiModule.exports.JsStats
+export const KnownBuildInfo = __napiModule.exports.KnownBuildInfo
+export const Module = __napiModule.exports.Module
+export const ModuleGraphConnection = __napiModule.exports.ModuleGraphConnection
+export const NativeWatcher = __napiModule.exports.NativeWatcher
+export const NativeWatchResult = __napiModule.exports.NativeWatchResult
+export const NormalModule = __napiModule.exports.NormalModule
+export const RawExternalItemFnCtx = __napiModule.exports.RawExternalItemFnCtx
+export const ReadonlyResourceData = __napiModule.exports.ReadonlyResourceData
+export const Sources = __napiModule.exports.Sources
+export const BuiltinPluginName = __napiModule.exports.BuiltinPluginName
+export const cleanupGlobalTrace = __napiModule.exports.cleanupGlobalTrace
+export const EXPECTED_RSPACK_CORE_VERSION = __napiModule.exports.EXPECTED_RSPACK_CORE_VERSION
+export const formatDiagnostic = __napiModule.exports.formatDiagnostic
+export const JsLoaderState = __napiModule.exports.JsLoaderState
+export const JsRspackSeverity = __napiModule.exports.JsRspackSeverity
+export const loadBrowserslist = __napiModule.exports.loadBrowserslist
+export const minify = __napiModule.exports.minify
+export const minifySync = __napiModule.exports.minifySync
+export const RawRuleSetConditionType = __napiModule.exports.RawRuleSetConditionType
+export const registerGlobalTrace = __napiModule.exports.registerGlobalTrace
+export const RegisterJsTapKind = __napiModule.exports.RegisterJsTapKind
+export const syncTraceEvent = __napiModule.exports.syncTraceEvent
+export const transform = __napiModule.exports.transform
+export const transformSync = __napiModule.exports.transformSync
+

--- a/crates/node_binding/rspack.wasi-browser.js
+++ b/crates/node_binding/rspack.wasi-browser.js
@@ -116,4 +116,3 @@ export const RegisterJsTapKind = __napiModule.exports.RegisterJsTapKind
 export const syncTraceEvent = __napiModule.exports.syncTraceEvent
 export const transform = __napiModule.exports.transform
 export const transformSync = __napiModule.exports.transformSync
-

--- a/crates/node_binding/rspack.wasi.cjs
+++ b/crates/node_binding/rspack.wasi.cjs
@@ -66,18 +66,6 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
       __wasmCreateOnMessageForFsProxy(__nodeFs)(data)
     }
 
-    // We have enabled `reuseWorker` so normally the workers never exit, unless there's any exception. 
-    // For Rust threads, aborting one thread means aborting the process, but actually aborting Node.js workers doesn't abort the main thread.
-    // I'm not sure whether it's the expected behavior of Node.js workers, or the behavior has been controlled by emnapi.
-    // Anyway, this code is used for fix the bug: 
-    // When the main thread holds a strong tsfn that prevents the Node.js event loop exiting,
-    // if the worker responsible for unref the tsfn terminates, then the main thread will never exits.
-    worker.on('exit', (code) => {
-      if (code !== 0) {
-        process.exit(code);
-      }
-    });
-
     // The main thread of Node.js waits for all the active handles before exiting.
     // But Rust threads are never waited without `thread::join`.
     // So here we hack the code of Node.js to prevent the workers from being referenced (active).
@@ -94,7 +82,7 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
       const kHandle = Object.getOwnPropertySymbols(worker).find(s =>
         s.toString().includes("kHandle")
       );
-      if (kPublicPort) {
+      if (kHandle) {
         worker[kHandle].ref = () => {};
       }
 
@@ -120,3 +108,56 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
   },
 })
 module.exports = __napiModule.exports
+module.exports.Assets = __napiModule.exports.Assets
+module.exports.AsyncDependenciesBlock = __napiModule.exports.AsyncDependenciesBlock
+module.exports.Chunk = __napiModule.exports.Chunk
+module.exports.ChunkGraph = __napiModule.exports.ChunkGraph
+module.exports.ChunkGroup = __napiModule.exports.ChunkGroup
+module.exports.Chunks = __napiModule.exports.Chunks
+module.exports.CodeGenerationResult = __napiModule.exports.CodeGenerationResult
+module.exports.CodeGenerationResults = __napiModule.exports.CodeGenerationResults
+module.exports.ConcatenatedModule = __napiModule.exports.ConcatenatedModule
+module.exports.ContextModule = __napiModule.exports.ContextModule
+module.exports.Dependency = __napiModule.exports.Dependency
+module.exports.Diagnostics = __napiModule.exports.Diagnostics
+module.exports.EntryDataDto = __napiModule.exports.EntryDataDto
+module.exports.EntryDataDTO = __napiModule.exports.EntryDataDTO
+module.exports.EntryDependency = __napiModule.exports.EntryDependency
+module.exports.EntryOptionsDto = __napiModule.exports.EntryOptionsDto
+module.exports.EntryOptionsDTO = __napiModule.exports.EntryOptionsDTO
+module.exports.ExternalModule = __napiModule.exports.ExternalModule
+module.exports.JsCompilation = __napiModule.exports.JsCompilation
+module.exports.JsCompiler = __napiModule.exports.JsCompiler
+module.exports.JsContextModuleFactoryAfterResolveData = __napiModule.exports.JsContextModuleFactoryAfterResolveData
+module.exports.JsContextModuleFactoryBeforeResolveData = __napiModule.exports.JsContextModuleFactoryBeforeResolveData
+module.exports.JsDependencies = __napiModule.exports.JsDependencies
+module.exports.JsEntries = __napiModule.exports.JsEntries
+module.exports.JsExportsInfo = __napiModule.exports.JsExportsInfo
+module.exports.JsModuleGraph = __napiModule.exports.JsModuleGraph
+module.exports.JsResolver = __napiModule.exports.JsResolver
+module.exports.JsResolverFactory = __napiModule.exports.JsResolverFactory
+module.exports.JsStats = __napiModule.exports.JsStats
+module.exports.KnownBuildInfo = __napiModule.exports.KnownBuildInfo
+module.exports.Module = __napiModule.exports.Module
+module.exports.ModuleGraphConnection = __napiModule.exports.ModuleGraphConnection
+module.exports.NativeWatcher = __napiModule.exports.NativeWatcher
+module.exports.NativeWatchResult = __napiModule.exports.NativeWatchResult
+module.exports.NormalModule = __napiModule.exports.NormalModule
+module.exports.RawExternalItemFnCtx = __napiModule.exports.RawExternalItemFnCtx
+module.exports.ReadonlyResourceData = __napiModule.exports.ReadonlyResourceData
+module.exports.Sources = __napiModule.exports.Sources
+module.exports.BuiltinPluginName = __napiModule.exports.BuiltinPluginName
+module.exports.cleanupGlobalTrace = __napiModule.exports.cleanupGlobalTrace
+module.exports.EXPECTED_RSPACK_CORE_VERSION = __napiModule.exports.EXPECTED_RSPACK_CORE_VERSION
+module.exports.formatDiagnostic = __napiModule.exports.formatDiagnostic
+module.exports.JsLoaderState = __napiModule.exports.JsLoaderState
+module.exports.JsRspackSeverity = __napiModule.exports.JsRspackSeverity
+module.exports.loadBrowserslist = __napiModule.exports.loadBrowserslist
+module.exports.minify = __napiModule.exports.minify
+module.exports.minifySync = __napiModule.exports.minifySync
+module.exports.RawRuleSetConditionType = __napiModule.exports.RawRuleSetConditionType
+module.exports.registerGlobalTrace = __napiModule.exports.registerGlobalTrace
+module.exports.RegisterJsTapKind = __napiModule.exports.RegisterJsTapKind
+module.exports.syncTraceEvent = __napiModule.exports.syncTraceEvent
+module.exports.transform = __napiModule.exports.transform
+module.exports.transformSync = __napiModule.exports.transformSync

--- a/crates/node_binding/wasi-worker-browser.mjs
+++ b/crates/node_binding/wasi-worker-browser.mjs
@@ -1,4 +1,4 @@
-import { createFsProxy, instantiateNapiModuleSync, MessageHandler, WASI } from '@napi-rs/wasm-runtime'
+import { instantiateNapiModuleSync, MessageHandler, WASI, createFsProxy } from '@napi-rs/wasm-runtime'
 import { memfsExported as __memfsExported } from '@napi-rs/wasm-runtime/fs'
 
 const fs = createFsProxy(__memfsExported)

--- a/crates/rspack_binding_builder_testing/package.json
+++ b/crates/rspack_binding_builder_testing/package.json
@@ -22,11 +22,10 @@
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": "web-infra-dev/rspack",
   "devDependencies": {
-    "@napi-rs/cli": "3.0.0-alpha.99",
-    "@napi-rs/wasm-runtime": "^0.2.12",
-    "emnapi": "^1.4.4",
-    "typescript": "^5.8.3",
-    "@emnapi/core": "^1.4.4"
+    "@napi-rs/cli": "3.0.1",
+    "@napi-rs/wasm-runtime": "^1.0.1",
+    "emnapi": "^1.4.5",
+    "typescript": "^5.8.3"
   },
   "napi": {
     "binaryName": "rspack",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -26,6 +26,6 @@
     "wasi-worker-browser.mjs"
   ],
   "dependencies": {
-    "@napi-rs/wasm-runtime": "^0.2.12"
+    "@napi-rs/wasm-runtime": "^1.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,18 +94,15 @@ importers:
 
   crates/node_binding:
     devDependencies:
-      '@emnapi/core':
-        specifier: ^1.4.4
-        version: 1.4.4
       '@napi-rs/cli':
-        specifier: 3.0.0-alpha.99
-        version: 3.0.0-alpha.99(@emnapi/runtime@1.4.3)(@types/node@20.19.8)(emnapi@1.4.4)
+        specifier: 3.0.1
+        version: 3.0.1(@emnapi/runtime@1.4.5)(@types/node@20.19.8)(emnapi@1.4.5)
       '@napi-rs/wasm-runtime':
-        specifier: ^0.2.12
-        version: 0.2.12
+        specifier: ^1.0.1
+        version: 1.0.1
       emnapi:
-        specifier: ^1.4.4
-        version: 1.4.4
+        specifier: ^1.4.5
+        version: 1.4.5
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -128,18 +125,15 @@ importers:
 
   crates/rspack_binding_builder_testing:
     devDependencies:
-      '@emnapi/core':
-        specifier: ^1.4.4
-        version: 1.4.4
       '@napi-rs/cli':
-        specifier: 3.0.0-alpha.99
-        version: 3.0.0-alpha.99(@emnapi/runtime@1.4.3)(@types/node@20.19.8)(emnapi@1.4.4)
+        specifier: 3.0.1
+        version: 3.0.1(@emnapi/runtime@1.4.5)(@types/node@20.19.8)(emnapi@1.4.5)
       '@napi-rs/wasm-runtime':
-        specifier: ^0.2.12
-        version: 0.2.12
+        specifier: ^1.0.1
+        version: 1.0.1
       emnapi:
-        specifier: ^1.4.4
-        version: 1.4.4
+        specifier: ^1.4.5
+        version: 1.4.5
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -153,8 +147,8 @@ importers:
   npm/wasm32-wasi:
     dependencies:
       '@napi-rs/wasm-runtime':
-        specifier: ^0.2.12
-        version: 0.2.12
+        specifier: ^1.0.1
+        version: 1.0.1
 
   npm/win32-x64-msvc: {}
 
@@ -1604,11 +1598,20 @@ packages:
   '@emnapi/core@1.4.4':
     resolution: {integrity: sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==}
 
+  '@emnapi/core@1.4.5':
+    resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
+
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
 
+  '@emnapi/runtime@1.4.5':
+    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
+
   '@emnapi/wasi-threads@1.0.3':
     resolution: {integrity: sha512-8K5IFFsQqF9wQNJptGbS6FNKgUTsSRYnTqNCG1vPP8jFdjSv18n2mQfJpkt2Oibo9iBEzcDnDxNwKTzC7svlJw==}
+
+  '@emnapi/wasi-threads@1.0.4':
+    resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
 
   '@esbuild/aix-ppc64@0.25.5':
     resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
@@ -2123,8 +2126,8 @@ packages:
   '@module-federation/webpack-bundler-runtime@0.17.0':
     resolution: {integrity: sha512-o8XtXwqTDlqLgcALOfObcCbqXvUcSDHIEXrkcb4W+I8GJY7IqV0+x6rX4mJ3f59tca9qOF8zsZsOA6BU93Pvgw==}
 
-  '@napi-rs/cli@3.0.0-alpha.99':
-    resolution: {integrity: sha512-g+a+r+7wbK3f7jKWGPEpjTxClFYJfAsUfhaW06AoqnhUidrMOEwbPLKqYg+kApYfhR2+PRiV5mImZNFBTLx3uQ==}
+  '@napi-rs/cli@3.0.1':
+    resolution: {integrity: sha512-rO2aDZRzqs0bCPUpfaExKjK0L999FvT3iQK3f1NfnKa1njlaHqO7XK/mUzxn9pnrTglfyFixU4+S3SzzTaaKNA==}
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
@@ -2365,6 +2368,9 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@napi-rs/wasm-runtime@1.0.1':
+    resolution: {integrity: sha512-KVlQ/jgywZpixGCKMNwxStmmbYEMyokZpCf2YuIChhfJA2uqfAKNEM8INz7zzTo55iEXfBhIIs3VqYyqzDLj8g==}
 
   '@napi-rs/wasm-tools-android-arm-eabi@0.0.3':
     resolution: {integrity: sha512-T2tme8w5jZ/ZCjJurqNtKCxYtGoDjW9v2rn1bfI60ewCfkYXNpxrTURdkOib85sz+BcwmOfXn0enbg5W9KohoQ==}
@@ -4476,8 +4482,8 @@ packages:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
 
-  emnapi@1.4.4:
-    resolution: {integrity: sha512-cq7665hIGMLliYusV9SV9JMDuIZ9iVBUcs/OhqawSqrEO/0gB1L5O80PLaEXauCnag4c1tPimCaBwKUYITeZLA==}
+  emnapi@1.4.5:
+    resolution: {integrity: sha512-qYEfWKYngSahxc6Y+zajiiwzhhn5TkRci3BLQFKHVqT3vxj061IWCgaESZ9921OsbPiyetX43kckXw80dj9d6g==}
     peerDependencies:
       node-addon-api: '>= 6.1.0'
     peerDependenciesMeta:
@@ -8724,12 +8730,28 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.0.3
       tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.4.5':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.4
+      tslib: 2.8.1
 
   '@emnapi/runtime@1.4.3':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.4.5':
+    dependencies:
+      tslib: 2.8.1
 
   '@emnapi/wasi-threads@1.0.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
 
@@ -9357,7 +9379,7 @@ snapshots:
       '@module-federation/runtime': 0.17.0
       '@module-federation/sdk': 0.17.0
 
-  '@napi-rs/cli@3.0.0-alpha.99(@emnapi/runtime@1.4.3)(@types/node@20.19.8)(emnapi@1.4.4)':
+  '@napi-rs/cli@3.0.1(@emnapi/runtime@1.4.5)(@types/node@20.19.8)(emnapi@1.4.5)':
     dependencies:
       '@inquirer/prompts': 7.5.3(@types/node@20.19.8)
       '@napi-rs/cross-toolchain': 0.0.19
@@ -9373,8 +9395,8 @@ snapshots:
       typanion: 3.14.0
       wasm-sjlj: 1.0.6
     optionalDependencies:
-      '@emnapi/runtime': 1.4.3
-      emnapi: 1.4.4
+      '@emnapi/runtime': 1.4.5
+      emnapi: 1.4.5
     transitivePeerDependencies:
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'
@@ -9539,6 +9561,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.4.4
       '@emnapi/runtime': 1.4.3
+      '@tybys/wasm-util': 0.10.0
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.0.1':
+    dependencies:
+      '@emnapi/core': 1.4.5
+      '@emnapi/runtime': 1.4.5
       '@tybys/wasm-util': 0.10.0
 
   '@napi-rs/wasm-tools-android-arm-eabi@0.0.3':
@@ -11844,7 +11873,7 @@ snapshots:
 
   emittery@0.13.1: {}
 
-  emnapi@1.4.4: {}
+  emnapi@1.4.5: {}
 
   emoji-regex@10.4.0: {}
 


### PR DESCRIPTION
## Summary

This pr is necessary for @rspack/browser

1. Sync the hacky code to upstream so we can always generate template code
2. Remove some hacky code replaced with https://github.com/toyobayashi/emnapi/pull/156
3. Buffer injection https://github.com/napi-rs/napi-rs/pull/2777

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
