### PR TITLE
feat: rspack_storage support reset

### DIFF
--- a/crates/rspack_core/src/cache/persistent/storage/memory.rs
+++ b/crates/rspack_core/src/cache/persistent/storage/memory.rs
@@ -42,6 +42,9 @@ impl Storage for MemoryStorage {
     let _ = rs.send(Ok(()));
     Ok(rx)
   }
+  async fn reset(&self) {
+    self.inner.lock().expect("should get lock").clear();
+  }
 }
 
 #[cfg(test)]
@@ -70,5 +73,8 @@ mod tests {
     storage.remove(scope, "b".as_bytes());
     let arr = storage.load(scope).await.unwrap();
     assert_eq!(arr.len(), 1);
+    storage.reset().await;
+    let arr = storage.load(scope).await.unwrap();
+    assert_eq!(arr.len(), 0);
   }
 }

--- a/crates/rspack_storage/src/lib.rs
+++ b/crates/rspack_storage/src/lib.rs
@@ -19,6 +19,7 @@ pub trait Storage: std::fmt::Debug + Sync + Send {
   fn set(&self, scope: &'static str, key: Vec<u8>, value: Vec<u8>);
   fn remove(&self, scope: &'static str, key: &[u8]);
   fn trigger_save(&self) -> Result<Receiver<Result<()>>>;
+  async fn reset(&self);
 }
 
 pub type ArcStorage = Arc<dyn Storage>;

--- a/crates/rspack_storage/src/pack/mod.rs
+++ b/crates/rspack_storage/src/pack/mod.rs
@@ -82,4 +82,7 @@ impl Storage for PackStorage {
       &mut *self.updates.lock().expect("should get lock"),
     ))
   }
+  async fn reset(&self) {
+    self.manager.reset().await;
+  }
 }

--- a/crates/rspack_storage/src/pack/strategy/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/mod.rs
@@ -44,6 +44,7 @@ pub trait RootStrategy {
     scopes: &HashMap<String, PackScope>,
     root_options: &RootOptions,
   ) -> Result<()>;
+  async fn reset(&self);
 }
 
 #[derive(Debug, Default)]

--- a/crates/rspack_storage/src/pack/strategy/split/mod.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/mod.rs
@@ -156,6 +156,10 @@ impl RootStrategy for SplitPackStrategy {
 
     Ok(())
   }
+
+  async fn reset(&self) {
+    let _ = self.fs.remove_dir(&self.root).await;
+  }
 }
 
 impl ScopeStrategy for SplitPackStrategy {}


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
Add a reset method for storage to clean current scopes and files, it will be used by build dependencies when file change. 

``` rust
trait Storage {
  fn reset(&self);
}

// example for use
for item in modified_files {
  if build_dependencies.contains(item) {
    self.storage.reset();
  }
}
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
