### PR TITLE
refactor: remove cache from compilation and use mutable self in cache trait

### DIFF
--- a/crates/rspack_core/src/cache/disable.rs
+++ b/crates/rspack_core/src/cache/disable.rs
@@ -11,7 +11,7 @@ pub struct DisableCache;
 
 #[async_trait::async_trait]
 impl Cache for DisableCache {
-  async fn before_make(&self, make_artifact: &mut MakeArtifact) -> Result<()> {
+  async fn before_make(&mut self, make_artifact: &mut MakeArtifact) -> Result<()> {
     *make_artifact = Default::default();
     Ok(())
   }

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -25,17 +25,17 @@ use crate::{make::MakeArtifact, Compilation, CompilerOptions, ExperimentCacheOpt
 #[async_trait::async_trait]
 pub trait Cache: Debug + Send + Sync {
   /// before compile return is_hot_start
-  async fn before_compile(&self, _compilation: &mut Compilation) -> Result<bool> {
+  async fn before_compile(&mut self, _compilation: &mut Compilation) -> Result<bool> {
     Ok(false)
   }
-  async fn after_compile(&self, _compilation: &Compilation) -> Result<()> {
+  async fn after_compile(&mut self, _compilation: &Compilation) -> Result<()> {
     Ok(())
   }
 
-  async fn before_make(&self, _make_artifact: &mut MakeArtifact) -> Result<()> {
+  async fn before_make(&mut self, _make_artifact: &mut MakeArtifact) -> Result<()> {
     Ok(())
   }
-  async fn after_make(&self, _make_artifact: &MakeArtifact) -> Result<()> {
+  async fn after_make(&mut self, _make_artifact: &MakeArtifact) -> Result<()> {
     Ok(())
   }
 }

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -7,7 +7,7 @@ use std::{fmt::Debug, sync::Arc};
 use rspack_error::Result;
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem};
 
-pub use self::{disable::DisableCache, memory::MemoryCache, persistent::PersistentCache};
+use self::{disable::DisableCache, memory::MemoryCache, persistent::PersistentCache};
 use crate::{make::MakeArtifact, Compilation, CompilerOptions, ExperimentCacheOptions};
 
 /// Cache trait
@@ -45,11 +45,11 @@ pub fn new_cache(
   compiler_option: Arc<CompilerOptions>,
   input_filesystem: Arc<dyn ReadableFileSystem>,
   intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
-) -> Arc<dyn Cache> {
+) -> Box<dyn Cache> {
   match &compiler_option.experiments.cache {
-    ExperimentCacheOptions::Disabled => Arc::new(DisableCache),
-    ExperimentCacheOptions::Memory => Arc::new(MemoryCache),
-    ExperimentCacheOptions::Persistent(option) => Arc::new(PersistentCache::new(
+    ExperimentCacheOptions::Disabled => Box::new(DisableCache),
+    ExperimentCacheOptions::Memory => Box::new(MemoryCache),
+    ExperimentCacheOptions::Persistent(option) => Box::new(PersistentCache::new(
       compiler_path,
       option,
       compiler_option.clone(),

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -80,7 +80,7 @@ impl PersistentCache {
 
 #[async_trait::async_trait]
 impl Cache for PersistentCache {
-  async fn before_compile(&self, compilation: &mut Compilation) -> Result<bool> {
+  async fn before_compile(&mut self, compilation: &mut Compilation) -> Result<bool> {
     // TODO move meta_occasion.recovery to a init fn of Cache trait and call init after create cache.
     self.meta_occasion.recovery().await?;
 
@@ -97,7 +97,7 @@ impl Cache for PersistentCache {
     Ok(false)
   }
 
-  async fn after_compile(&self, compilation: &Compilation) -> Result<()> {
+  async fn after_compile(&mut self, compilation: &Compilation) -> Result<()> {
     // save meta
     self.meta_occasion.save();
 
@@ -143,7 +143,7 @@ impl Cache for PersistentCache {
     Ok(())
   }
 
-  async fn before_make(&self, make_artifact: &mut MakeArtifact) -> Result<()> {
+  async fn before_make(&mut self, make_artifact: &mut MakeArtifact) -> Result<()> {
     // TODO When does not need to pass variables through make_artifact.state, use compilation.is_rebuild to check
     if matches!(make_artifact.state, MakeArtifactState::Uninitialized(..)) {
       *make_artifact = self.make_occasion.recovery().await?;
@@ -151,7 +151,7 @@ impl Cache for PersistentCache {
     Ok(())
   }
 
-  async fn after_make(&self, make_artifact: &MakeArtifact) -> Result<()> {
+  async fn after_make(&mut self, make_artifact: &MakeArtifact) -> Result<()> {
     self.make_occasion.save(make_artifact);
     Ok(())
   }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -41,7 +41,6 @@ use super::{
 };
 use crate::{
   build_chunk_graph::{build_chunk_graph, build_chunk_graph_new},
-  cache::Cache,
   get_runtime_key,
   incremental::{self, Incremental, IncrementalPasses, Mutation},
   is_source_equal,
@@ -269,7 +268,6 @@ pub struct Compilation {
 
   pub code_generated_modules: IdentifierSet,
   pub build_time_executed_modules: IdentifierSet,
-  pub cache: Arc<dyn Cache>,
   pub old_cache: Arc<OldCache>,
   pub code_splitting_cache: CodeSplittingCache,
   pub incremental: Incremental,
@@ -333,7 +331,6 @@ impl Compilation {
     resolver_factory: Arc<ResolverFactory>,
     loader_resolver_factory: Arc<ResolverFactory>,
     records: Option<CompilationRecords>,
-    cache: Arc<dyn Cache>,
     old_cache: Arc<OldCache>,
     incremental: Incremental,
     module_executor: Option<ModuleExecutor>,
@@ -397,7 +394,6 @@ impl Compilation {
         },
       )),
       build_time_executed_modules: Default::default(),
-      cache,
       old_cache,
       incremental,
       code_splitting_cache: Default::default(),

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -12,7 +12,6 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::MakeArtifact;
 use crate::{
-  cache::Cache,
   incremental::Incremental,
   module_graph::{ModuleGraph, ModuleGraphPartial},
   old_cache::Cache as OldCache,
@@ -35,7 +34,6 @@ pub struct MakeTaskContext {
   pub compiler_options: Arc<CompilerOptions>,
   pub resolver_factory: Arc<ResolverFactory>,
   pub loader_resolver_factory: Arc<ResolverFactory>,
-  pub cache: Arc<dyn Cache>,
   pub old_cache: Arc<OldCache>,
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
   pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
@@ -44,7 +42,7 @@ pub struct MakeTaskContext {
 }
 
 impl MakeTaskContext {
-  pub fn new(compilation: &Compilation, artifact: MakeArtifact, cache: Arc<dyn Cache>) -> Self {
+  pub fn new(compilation: &Compilation, artifact: MakeArtifact) -> Self {
     Self {
       compiler_id: compilation.compiler_id(),
       compilation_id: compilation.id(),
@@ -53,7 +51,6 @@ impl MakeTaskContext {
       compiler_options: compilation.options.clone(),
       resolver_factory: compilation.resolver_factory.clone(),
       loader_resolver_factory: compilation.loader_resolver_factory.clone(),
-      cache,
       old_cache: compilation.old_cache.clone(),
       dependency_factories: compilation.dependency_factories.clone(),
       dependency_templates: compilation.dependency_templates.clone(),
@@ -80,7 +77,6 @@ impl MakeTaskContext {
       self.resolver_factory.clone(),
       self.loader_resolver_factory.clone(),
       None,
-      self.cache.clone(),
       self.old_cache.clone(),
       Incremental::new_cold(self.compiler_options.experiments.incremental),
       None,
@@ -157,7 +153,7 @@ pub async fn repair(
     })
     .collect::<Vec<_>>();
 
-  let mut ctx = MakeTaskContext::new(compilation, artifact, compilation.cache.clone());
+  let mut ctx = MakeTaskContext::new(compilation, artifact);
   run_task_loop(&mut ctx, init_tasks).await?;
   Ok(ctx.artifact)
 }

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -93,7 +93,7 @@ pub struct Compiler {
   pub buildtime_plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
   pub loader_resolver_factory: Arc<ResolverFactory>,
-  pub cache: Arc<dyn Cache>,
+  pub cache: Box<dyn Cache>,
   pub old_cache: Arc<OldCache>,
   /// emitted asset versions
   /// the key of HashMap is filename, the value of HashMap is version
@@ -173,7 +173,6 @@ impl Compiler {
         resolver_factory.clone(),
         loader_resolver_factory.clone(),
         None,
-        cache.clone(),
         old_cache.clone(),
         incremental,
         Some(module_executor),
@@ -231,7 +230,6 @@ impl Compiler {
         self.resolver_factory.clone(),
         self.loader_resolver_factory.clone(),
         None,
-        self.cache.clone(),
         self.old_cache.clone(),
         Incremental::new_cold(self.options.experiments.incremental),
         Some(Default::default()),

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -5,8 +5,6 @@ mod execute;
 mod module_tracker;
 mod overwrite;
 
-use std::sync::Arc;
-
 use context::{ExecutorTaskContext, ImportModuleMeta};
 use entry::EntryTask;
 use execute::ExecuteTask;
@@ -28,8 +26,7 @@ use self::{
 };
 use super::make::{repair::MakeTaskContext, update_module_graph, MakeArtifact, MakeParam};
 use crate::{
-  cache::MemoryCache, task_loop::run_task_loop, Compilation, CompilationAsset, Context,
-  DependencyId, PublicPath,
+  task_loop::run_task_loop, Compilation, CompilationAsset, Context, DependencyId, PublicPath,
 };
 
 #[derive(Debug, Default)]
@@ -63,7 +60,7 @@ impl ModuleExecutor {
     make_artifact = update_module_graph(compilation, make_artifact, params).await?;
 
     let mut ctx = ExecutorTaskContext {
-      origin_context: MakeTaskContext::new(compilation, make_artifact, Arc::new(MemoryCache)),
+      origin_context: MakeTaskContext::new(compilation, make_artifact),
       tracker: Default::default(),
       entries: std::mem::take(&mut self.entries),
       executed_entry_deps: Default::default(),

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -64,7 +64,6 @@ impl Compiler {
         self.resolver_factory.clone(),
         self.loader_resolver_factory.clone(),
         Some(records),
-        self.cache.clone(),
         self.old_cache.clone(),
         Incremental::new_hot(self.options.experiments.incremental),
         Some(ModuleExecutor::default()),

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -133,7 +133,6 @@ pub fn build_chunk_graph_benchmark_inner(c: &mut Criterion) {
       compiler.resolver_factory.clone(),
       compiler.loader_resolver_factory.clone(),
       None,
-      compiler.cache.clone(),
       compiler.old_cache.clone(),
       Incremental::new_cold(compiler.options.experiments.incremental),
       Some(Default::default()),


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
1. Delete all cache held elsewhere, leaving only compiler.cache
``` diff
struct Compiler {
-  cache: Arc<dyn Cache>
+  cache: Box<dyn Cache>
}
struct Compilation {
-  cache: Arc<dyn Cache>
}
```
2. Use mutable self in cache trait
``` diff
trait Cache {
-  fn before_make(&self, artifact: &MakeArtifact);
+  fn before_make(&mut self, artifact: &MakeArtifact);
...
}
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
