### PR TITLE
fix: temporarily ignore NativeWatcher tests in CI due to instability

### DIFF
--- a/packages/rspack-test-tools/jest.config.js
+++ b/packages/rspack-test-tools/jest.config.js
@@ -25,8 +25,8 @@ const wasmConfig = process.env.WASM && {
 		"Incremental-watch-webpack.test.js",
 		"Incremental-watch.test.js",
 		"Incremental-web.test.js",
-		"Incremental-webworker.test.js",
-		"NativeWatcher.test.js"
+		"Incremental-webworker.test.js"
+		// "NativeWatcher.test.js"
 	],
 	maxWorkers: 1,
 	maxConcurrency: 1,
@@ -75,5 +75,11 @@ const config = {
 	},
 	...(wasmConfig || {})
 };
+
+config.testPathIgnorePatterns = config.testPathIgnorePatterns || [];
+config.testPathIgnorePatterns.push(
+	// Skip temporarily because native watcher is always timeout in CI
+	"NativeWatcher.test.js"
+);
 
 module.exports = config;


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
Native Watcher is always timeout, so we temporarily ignore NativeWatcher tests.

I will enable after refactor ignored tsfn in nativeWatcher

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
