### PR TITLE
perf: parallelize flag usage plugin

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -1,17 +1,20 @@
 use std::collections::{hash_map::Entry, VecDeque};
 
+use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, UkeyMap};
 use rspack_core::{
   get_entry_runtime, incremental::IncrementalPasses, is_exports_object_referenced,
   is_no_exports_referenced, AsyncDependenciesBlockIdentifier, BuildMetaExportsType, Compilation,
   CompilationOptimizeDependencies, ConnectionState, DependenciesBlock, DependencyId, ExportsInfo,
-  ExtendedReferencedExport, GroupOptions, Inlinable, ModuleIdentifier, Plugin, ReferencedExport,
-  RuntimeSpec, UsageState,
+  ExtendedReferencedExport, GroupOptions, Inlinable, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, Plugin, ReferencedExport, RuntimeSpec, UsageState,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::{queue::Queue, swc::join_atom};
 use rustc_hash::FxHashMap as HashMap;
+
+type ProcessBlockTask = (ModuleOrAsyncDependenciesBlock, Option<RuntimeSpec>, bool);
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 enum ModuleOrAsyncDependenciesBlock {
@@ -82,217 +85,125 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     }
     self.compilation.entries = entries;
 
-    while let Some((module_id, runtime)) = q.dequeue() {
+    loop {
+      let mut batch = vec![];
+      while let Some(task) = q.dequeue() {
+        batch.push(task);
+      }
+
       self.compilation.module_graph_cache_artifact.freeze();
-      self.process_module(
-        ModuleOrAsyncDependenciesBlock::Module(module_id),
-        runtime,
-        false,
-        &mut q,
-      );
+
+      let batch_res = batch
+        .into_par_iter()
+        .map(|(block_id, runtime, force_side_effects)| {
+          let (referenced_exports, module_tasks) =
+            self.process_module(block_id, runtime.as_ref(), force_side_effects, self.global);
+          (
+            runtime,
+            force_side_effects,
+            referenced_exports,
+            module_tasks,
+          )
+        })
+        .collect::<Vec<_>>();
+
+      for (runtime, force_side_effects, referenced_exports, module_tasks) in batch_res {
+        for i in module_tasks {
+          q.enqueue(i);
+        }
+        for (module_id, referenced_exports) in referenced_exports {
+          let res = self.process_referenced_module(
+            module_id,
+            referenced_exports,
+            runtime.clone(),
+            force_side_effects,
+          );
+          for i in res {
+            q.enqueue(i);
+          }
+        }
+      }
+
       self.compilation.module_graph_cache_artifact.unfreeze();
+
+      if q.is_empty() {
+        break;
+      }
     }
   }
 
   fn process_module(
-    &mut self,
+    &self,
     block_id: ModuleOrAsyncDependenciesBlock,
-    runtime: Option<RuntimeSpec>,
+    runtime: Option<&RuntimeSpec>,
     force_side_effects: bool,
-    q: &mut Queue<(ModuleIdentifier, Option<RuntimeSpec>)>,
+    global: bool,
+  ) -> (
+    IdentifierMap<Vec<ExtendedReferencedExport>>,
+    Vec<ProcessBlockTask>,
   ) {
+    let mut q = vec![];
     let mut map: IdentifierMap<ProcessModuleReferencedExports> = IdentifierMap::default();
-    let mut dependencies = vec![];
 
-    let mut queue = VecDeque::new();
-    queue.push_back(block_id);
-    while let Some(block_id) = queue.pop_front() {
-      let module_graph = self.compilation.get_module_graph();
-      let (blocks, block_dependencies) = match block_id {
-        ModuleOrAsyncDependenciesBlock::Module(module) => {
-          let block = module_graph
-            .module_by_identifier(&module)
-            .expect("should have module");
-          (
-            block.get_blocks().to_vec(),
-            block.get_dependencies().to_vec(),
-          )
-        }
-        ModuleOrAsyncDependenciesBlock::AsyncDependenciesBlock(async_dependencies_block_id) => {
-          let block = module_graph
-            .block_by_id(&async_dependencies_block_id)
-            .expect("should have module");
-          (
-            block.get_blocks().to_vec(),
-            block.get_dependencies().to_vec(),
-          )
-        }
-      };
-      dependencies.extend(block_dependencies);
-      for block_id in blocks {
-        let module_graph = self.compilation.get_module_graph();
-        let block = module_graph
-          .block_by_id(&block_id)
-          .expect("should have block");
-        if !self.global
-          && let Some(GroupOptions::Entrypoint(options)) = block.get_group_options()
-        {
-          let runtime = RuntimeSpec::from_entry_options(options);
-          self.process_module(
-            ModuleOrAsyncDependenciesBlock::AsyncDependenciesBlock(block_id),
-            runtime,
-            true,
-            q,
-          )
-        } else {
-          queue.push_back(ModuleOrAsyncDependenciesBlock::AsyncDependenciesBlock(
-            block_id,
-          ));
-        }
-      }
-    }
+    let (dependencies, async_blocks) = collect_active_dependencies(
+      block_id,
+      runtime,
+      &self.compilation.get_module_graph(),
+      &self.compilation.module_graph_cache_artifact,
+      global,
+    );
+    q.extend(async_blocks);
 
-    for dep_id in dependencies.into_iter() {
-      let module_graph = self.compilation.get_module_graph();
-      let module_graph_cache = &self.compilation.module_graph_cache_artifact;
-      let connection = module_graph.connection_by_dependency_id(&dep_id);
-
-      let connection = if let Some(connection) = connection {
-        connection
-      } else {
-        continue;
-      };
-      let active_state =
-        connection.active_state(&module_graph, runtime.as_ref(), module_graph_cache);
-
-      match active_state {
-        ConnectionState::Active(false) => {
-          continue;
-        }
-        ConnectionState::TransitiveOnly => {
-          self.process_module(
-            ModuleOrAsyncDependenciesBlock::Module(*connection.module_identifier()),
-            runtime.clone(),
-            false,
-            q,
-          );
-          continue;
-        }
-        _ => {}
-      }
-      let old_referenced_exports = map.remove(connection.module_identifier());
-      let dep = module_graph
-        .dependency_by_id(&dep_id)
-        .expect("should have dep");
-
-      let referenced_exports = if let Some(md) = dep.as_module_dependency() {
-        md.get_referenced_exports(&module_graph, module_graph_cache, runtime.as_ref())
-      } else if dep.as_context_dependency().is_some() {
-        vec![ExtendedReferencedExport::Array(vec![])]
-      } else {
+    for (dep_id, module_id) in dependencies.into_iter() {
+      let old_referenced_exports = map.remove(&module_id);
+      let Some(referenced_exports) = get_dependency_referenced_exports(
+        dep_id,
+        &self.compilation.get_module_graph(),
+        &self.compilation.module_graph_cache_artifact,
+        runtime,
+      ) else {
         continue;
       };
 
-      if old_referenced_exports.is_none()
-        || matches!(old_referenced_exports, Some(ProcessModuleReferencedExports::ExtendRef(ref v)) if is_no_exports_referenced(v))
-        || is_exports_object_referenced(&referenced_exports)
+      if let Some(new_referenced_exports) =
+        merge_referenced_exports(old_referenced_exports, referenced_exports)
       {
-        map.insert(
-          *connection.module_identifier(),
-          ProcessModuleReferencedExports::ExtendRef(referenced_exports),
-        );
-      } else if let Some(old_referenced_exports) = old_referenced_exports {
-        if is_no_exports_referenced(&referenced_exports) {
-          map.insert(
-            *connection.module_identifier(),
-            old_referenced_exports.clone(),
-          );
-          continue;
-        }
-
-        let mut exports_map = match old_referenced_exports {
-          ProcessModuleReferencedExports::Map(map) => map,
-          ProcessModuleReferencedExports::ExtendRef(ref_items) => {
-            let mut exports_map = HashMap::default();
-            for item in ref_items.iter() {
-              match item {
-                ExtendedReferencedExport::Array(arr) => {
-                  exports_map.insert(join_atom(arr.iter(), "\n"), item.clone());
-                }
-                ExtendedReferencedExport::Export(export) => {
-                  exports_map.insert(join_atom(export.name.iter(), "\n"), item.clone());
-                }
-              }
-            }
-            exports_map
-          }
-        };
-
-        for mut item in referenced_exports.into_iter() {
-          match item {
-            ExtendedReferencedExport::Array(ref arr) => {
-              let key = join_atom(arr.iter(), "\n");
-              exports_map.entry(key).or_insert(item);
-            }
-            ExtendedReferencedExport::Export(ref mut export) => {
-              let key = join_atom(export.name.iter(), "\n");
-              match exports_map.entry(key) {
-                Entry::Occupied(mut occ) => {
-                  let old_item = occ.get();
-                  match old_item {
-                    ExtendedReferencedExport::Array(_) => {
-                      occ.insert(item);
-                    }
-                    ExtendedReferencedExport::Export(old_item) => {
-                      occ.insert(ExtendedReferencedExport::Export(ReferencedExport {
-                        name: std::mem::take(&mut export.name),
-                        can_mangle: export.can_mangle && old_item.can_mangle,
-                        can_inline: export.can_inline && old_item.can_inline,
-                      }));
-                    }
-                  }
-                }
-                Entry::Vacant(vac) => {
-                  vac.insert(item);
-                }
-              }
-            }
-          }
-        }
-        map.insert(
-          *connection.module_identifier(),
-          ProcessModuleReferencedExports::Map(exports_map),
-        );
+        map.insert(module_id, new_referenced_exports);
       }
     }
 
-    for (module_id, referenced_exports) in map {
-      let normalized_refs = match referenced_exports {
-        ProcessModuleReferencedExports::Map(map) => map.into_values().collect::<Vec<_>>(),
-        ProcessModuleReferencedExports::ExtendRef(extend_ref) => extend_ref,
-      };
-      self.process_referenced_module(
-        module_id,
-        normalized_refs,
-        runtime.clone(),
-        force_side_effects,
-        q,
-      );
-    }
+    (
+      map
+        .into_iter()
+        .map(|(module_id, referenced_exports)| {
+          (
+            module_id,
+            match referenced_exports {
+              ProcessModuleReferencedExports::Map(map) => map.into_values().collect::<Vec<_>>(),
+              ProcessModuleReferencedExports::ExtendRef(extend_ref) => extend_ref,
+            },
+          )
+        })
+        .collect::<IdentifierMap<_>>(),
+      q,
+    )
   }
 
   fn process_entry_dependency(
     &mut self,
     dep: DependencyId,
     runtime: Option<RuntimeSpec>,
-    queue: &mut Queue<(ModuleIdentifier, Option<RuntimeSpec>)>,
+    queue: &mut Queue<ProcessBlockTask>,
   ) {
     if let Some(module) = self
       .compilation
       .get_module_graph()
       .module_graph_module_by_dependency_id(&dep)
     {
-      self.process_referenced_module(module.module_identifier, vec![], runtime, true, queue);
+      let res = self.process_referenced_module(module.module_identifier, vec![], runtime, true);
+      for i in res {
+        queue.enqueue(i);
+      }
     }
   }
 
@@ -302,8 +213,8 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     used_exports: Vec<ExtendedReferencedExport>,
     runtime: Option<RuntimeSpec>,
     force_side_effects: bool,
-    queue: &mut Queue<(ModuleIdentifier, Option<RuntimeSpec>)>,
-  ) {
+  ) -> Vec<ProcessBlockTask> {
+    let mut queue = vec![];
     let mut module_graph = self.compilation.get_module_graph_mut();
     let mgm = module_graph
       .module_graph_module_by_identifier(&module_id)
@@ -320,9 +231,13 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       if need_insert {
         let flag = mgm_exports_info.set_used_without_info(&mut module_graph, runtime.as_ref());
         if flag {
-          queue.enqueue((module_id, None));
+          queue.push((
+            ModuleOrAsyncDependenciesBlock::Module(module_id),
+            None,
+            false,
+          ));
         }
-        return;
+        return queue;
       }
 
       for used_export_info in used_exports {
@@ -336,34 +251,34 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
           let flag = mgm_exports_info.set_used_in_unknown_way(&mut module_graph, runtime.as_ref());
 
           if flag {
-            queue.enqueue((module_id, runtime.clone()));
+            queue.push((
+              ModuleOrAsyncDependenciesBlock::Module(module_id),
+              runtime.clone(),
+              false,
+            ));
           }
         } else {
           let mut current_exports_info = mgm_exports_info;
           let len = used_exports.len();
+
           for (i, used_export) in used_exports.into_iter().enumerate() {
-            let export_info = current_exports_info.get_export_info(&mut module_graph, &used_export);
+            let export_info = current_exports_info
+              .get_export_info(&mut module_graph, &used_export)
+              .as_data_mut(&mut module_graph);
             if !can_mangle {
-              export_info
-                .as_data_mut(&mut module_graph)
-                .set_can_mangle_use(Some(false));
+              export_info.set_can_mangle_use(Some(false));
             }
             if !can_inline {
-              export_info
-                .as_data_mut(&mut module_graph)
-                .set_inlinable(Inlinable::NoByUse);
+              export_info.set_inlinable(Inlinable::NoByUse);
             }
             let last_one = i == len - 1;
             if !last_one {
-              let nested_info = export_info.as_data(&module_graph).exports_info();
-              if let Some(nested_info) = nested_info {
-                let changed_flag = export_info
-                  .as_data_mut(&mut module_graph)
-                  .set_used_conditionally(
-                    Box::new(|used| used == &UsageState::Unused),
-                    UsageState::OnlyPropertiesUsed,
-                    runtime.as_ref(),
-                  );
+              if let Some(nested_info) = export_info.exports_info() {
+                let changed_flag = export_info.set_used_conditionally(
+                  Box::new(|used| used == &UsageState::Unused),
+                  UsageState::OnlyPropertiesUsed,
+                  runtime.as_ref(),
+                );
                 if changed_flag {
                   let current_module = if current_exports_info == mgm_exports_info {
                     Some(module_id)
@@ -371,10 +286,14 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
                     self
                       .exports_info_module_map
                       .get(&current_exports_info)
-                      .cloned()
+                      .copied()
                   };
                   if let Some(current_module) = current_module {
-                    queue.enqueue((current_module, runtime.clone()));
+                    queue.push((
+                      ModuleOrAsyncDependenciesBlock::Module(current_module),
+                      runtime.clone(),
+                      false,
+                    ));
                   }
                 }
                 current_exports_info = nested_info;
@@ -382,13 +301,11 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
               }
             }
 
-            let changed_flag = export_info
-              .as_data_mut(&mut module_graph)
-              .set_used_conditionally(
-                Box::new(|v| v != &UsageState::Used),
-                UsageState::Used,
-                runtime.as_ref(),
-              );
+            let changed_flag = export_info.set_used_conditionally(
+              Box::new(|v| v != &UsageState::Used),
+              UsageState::Used,
+              runtime.as_ref(),
+            );
             if changed_flag {
               let current_module = if current_exports_info == mgm_exports_info {
                 Some(module_id)
@@ -399,7 +316,11 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
                   .cloned()
               };
               if let Some(current_module) = current_module {
-                queue.enqueue((current_module, runtime.clone()));
+                queue.push((
+                  ModuleOrAsyncDependenciesBlock::Module(current_module),
+                  runtime.clone(),
+                  false,
+                ));
               }
             }
             break;
@@ -413,15 +334,20 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
           None => false,
         }
       {
-        return;
+        return queue;
       }
       let changed_flag = mgm_exports_info
         .as_data_mut(&mut module_graph)
         .set_used_for_side_effects_only(runtime.as_ref());
       if changed_flag {
-        queue.enqueue((module_id, runtime));
+        queue.push((
+          ModuleOrAsyncDependenciesBlock::Module(module_id),
+          runtime,
+          false,
+        ));
       }
     }
+    queue
   }
 }
 
@@ -467,5 +393,163 @@ impl Plugin for FlagDependencyUsagePlugin {
       .optimize_dependencies
       .tap(optimize_dependencies::new(self));
     Ok(())
+  }
+}
+
+fn merge_referenced_exports(
+  old_referenced_exports: Option<ProcessModuleReferencedExports>,
+  referenced_exports: Vec<ExtendedReferencedExport>,
+) -> Option<ProcessModuleReferencedExports> {
+  if old_referenced_exports.is_none()
+    || matches!(old_referenced_exports, Some(ProcessModuleReferencedExports::ExtendRef(ref v)) if is_no_exports_referenced(v))
+    || is_exports_object_referenced(&referenced_exports)
+  {
+    return Some(ProcessModuleReferencedExports::ExtendRef(
+      referenced_exports,
+    ));
+  } else if let Some(old_referenced_exports) = old_referenced_exports {
+    if is_no_exports_referenced(&referenced_exports) {
+      return Some(old_referenced_exports);
+    }
+
+    let mut exports_map = match old_referenced_exports {
+      ProcessModuleReferencedExports::Map(map) => map,
+      ProcessModuleReferencedExports::ExtendRef(ref_items) => ref_items
+        .into_iter()
+        .map(|item| {
+          let key = match &item {
+            ExtendedReferencedExport::Array(arr) => join_atom(arr.iter(), "\n"),
+            ExtendedReferencedExport::Export(export) => join_atom(export.name.iter(), "\n"),
+          };
+          (key, item)
+        })
+        .collect::<HashMap<_, _>>(),
+    };
+
+    for mut item in referenced_exports.into_iter() {
+      match item {
+        ExtendedReferencedExport::Array(ref arr) => {
+          let key = join_atom(arr.iter(), "\n");
+          exports_map.entry(key).or_insert(item);
+        }
+        ExtendedReferencedExport::Export(ref mut export) => {
+          let key = join_atom(export.name.iter(), "\n");
+          match exports_map.entry(key) {
+            Entry::Occupied(mut occ) => {
+              let old_item = occ.get();
+              match old_item {
+                ExtendedReferencedExport::Array(_) => {
+                  occ.insert(item);
+                }
+                ExtendedReferencedExport::Export(old_item) => {
+                  occ.insert(ExtendedReferencedExport::Export(ReferencedExport {
+                    name: std::mem::take(&mut export.name),
+                    can_mangle: export.can_mangle && old_item.can_mangle,
+                    can_inline: export.can_inline && old_item.can_inline,
+                  }));
+                }
+              }
+            }
+            Entry::Vacant(vac) => {
+              vac.insert(item);
+            }
+          }
+        }
+      }
+    }
+    return Some(ProcessModuleReferencedExports::Map(exports_map));
+  }
+  None
+}
+
+fn collect_active_dependencies(
+  block_id: ModuleOrAsyncDependenciesBlock,
+  runtime: Option<&RuntimeSpec>,
+  module_graph: &ModuleGraph,
+  module_graph_cache: &ModuleGraphCacheArtifact,
+  global: bool,
+) -> (Vec<(DependencyId, ModuleIdentifier)>, Vec<ProcessBlockTask>) {
+  let mut q = vec![];
+  let mut queue = VecDeque::new();
+  let mut dependencies = vec![];
+  queue.push_back(block_id);
+  while let Some(block_id) = queue.pop_front() {
+    let (blocks, block_dependencies) = match block_id {
+      ModuleOrAsyncDependenciesBlock::Module(module) => {
+        let block = module_graph
+          .module_by_identifier(&module)
+          .expect("should have module");
+        (block.get_blocks(), block.get_dependencies())
+      }
+      ModuleOrAsyncDependenciesBlock::AsyncDependenciesBlock(async_dependencies_block_id) => {
+        let block = module_graph
+          .block_by_id(&async_dependencies_block_id)
+          .expect("should have module");
+        (block.get_blocks(), block.get_dependencies())
+      }
+    };
+    dependencies.extend(block_dependencies);
+    for block_id in blocks {
+      let block = module_graph
+        .block_by_id(block_id)
+        .expect("should have block");
+      if !global && let Some(GroupOptions::Entrypoint(options)) = block.get_group_options() {
+        let runtime = RuntimeSpec::from_entry_options(options);
+        q.push((
+          ModuleOrAsyncDependenciesBlock::AsyncDependenciesBlock(*block_id),
+          runtime,
+          true,
+        ));
+      } else {
+        queue.push_back(ModuleOrAsyncDependenciesBlock::AsyncDependenciesBlock(
+          *block_id,
+        ));
+      }
+    }
+  }
+
+  let dependencies = dependencies
+    .into_iter()
+    .filter_map(|dep_id| {
+      let connection = module_graph.connection_by_dependency_id(&dep_id)?;
+      let active_state = connection.active_state(module_graph, runtime, module_graph_cache);
+
+      match active_state {
+        ConnectionState::Active(false) => {
+          return None;
+        }
+        ConnectionState::TransitiveOnly => {
+          q.push((
+            ModuleOrAsyncDependenciesBlock::Module(*connection.module_identifier()),
+            runtime.cloned(),
+            false,
+          ));
+          return None;
+        }
+        _ => {}
+      }
+      Some((dep_id, *connection.module_identifier()))
+    })
+    .collect::<Vec<_>>();
+
+  (dependencies, q)
+}
+
+fn get_dependency_referenced_exports(
+  dep_id: DependencyId,
+  module_graph: &ModuleGraph,
+  module_graph_cache: &ModuleGraphCacheArtifact,
+  runtime: Option<&RuntimeSpec>,
+) -> Option<Vec<ExtendedReferencedExport>> {
+  let dep = module_graph
+    .dependency_by_id(&dep_id)
+    .expect("should have dep");
+
+  if let Some(md) = dep.as_module_dependency() {
+    Some(md.get_referenced_exports(module_graph, module_graph_cache, runtime))
+  } else if dep.as_context_dependency().is_some() {
+    Some(vec![ExtendedReferencedExport::Array(vec![])])
+  } else {
+    None
   }
 }

--- a/crates/rspack_util/src/queue.rs
+++ b/crates/rspack_util/src/queue.rs
@@ -28,6 +28,10 @@ impl<T: Hash + PartialEq + Eq + Clone> Queue<T> {
     }
   }
 
+  pub fn is_empty(&self) -> bool {
+    self.q.is_empty()
+  }
+
   pub fn dequeue(&mut self) -> Option<T> {
     if let Some(item) = self.q.pop_front() {
       self.set.remove(&item);


### PR DESCRIPTION
## Summary

This is a new implement of flag dependency usage plugin strategy just like the part of https://github.com/web-infra-dev/rspack/pull/10712  but consider of the get mode cache and repeat modules. The same is process modules in batches but keep `Queue` and cache to avoid repeat computing.

And also this PR has been tested in rome case and will not lead to performance regression.

Before:
<img width="1352" height="294" alt="image" src="https://github.com/user-attachments/assets/00b8b7cd-4c1c-428d-b029-372d469730bb" />

After:
<img width="1358" height="326" alt="image" src="https://github.com/user-attachments/assets/d3221144-ff39-4a28-a3ba-4d2407902395" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
