### PR TITLE
perf: napi communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,6 +3944,7 @@ dependencies = [
  "napi-derive",
  "once_cell",
  "parking_lot",
+ "rayon",
  "ropey",
  "rspack_allocator",
  "rspack_browserslist",

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -615,17 +615,6 @@ export interface JsAfterEmitData {
   uid?: number
 }
 
-export interface JsAfterResolveData {
-  request: string
-  context: string
-  issuer: string
-  issuerLayer?: string
-  fileDependencies: Array<string>
-  contextDependencies: Array<string>
-  missingDependencies: Array<string>
-  createData?: JsCreateData
-}
-
 export interface JsAfterTemplateExecutionData {
   html: string
   headTags: Array<JsHtmlPluginTag>
@@ -2734,7 +2723,7 @@ export interface RegisterJsTaps {
   registerNormalModuleFactoryFactorizeTaps: (stages: Array<number>) => Array<{ function: ((arg: JsFactorizeArgs) => Promise<JsFactorizeArgs>); stage: number; }>
   registerNormalModuleFactoryResolveTaps: (stages: Array<number>) => Array<{ function: ((arg: JsResolveArgs) => Promise<JsResolveArgs>); stage: number; }>
   registerNormalModuleFactoryResolveForSchemeTaps: (stages: Array<number>) => Array<{ function: ((arg: JsResolveForSchemeArgs) => Promise<[boolean | undefined, JsResolveForSchemeArgs]>); stage: number; }>
-  registerNormalModuleFactoryAfterResolveTaps: (stages: Array<number>) => Array<{ function: ((arg: JsAfterResolveData) => Promise<[boolean | undefined, JsCreateData | undefined]>); stage: number; }>
+  registerNormalModuleFactoryAfterResolveTaps: (stages: Array<number>) => Array<{ function: ((arg: string) => Promise<[boolean | undefined, JsCreateData | undefined]>); stage: number; }>
   registerNormalModuleFactoryCreateModuleTaps: (stages: Array<number>) => Array<{ function: ((arg: JsNormalModuleFactoryCreateModuleArgs) => Promise<void>); stage: number; }>
   registerContextModuleFactoryBeforeResolveTaps: (stages: Array<number>) => Array<{ function: ((arg: false | JsContextModuleFactoryBeforeResolveData) => Promise<false | JsContextModuleFactoryBeforeResolveData>); stage: number; }>
   registerContextModuleFactoryAfterResolveTaps: (stages: Array<number>) => Array<{ function: ((arg: false | JsContextModuleFactoryAfterResolveData) => Promise<false | JsContextModuleFactoryAfterResolveData>); stage: number; }>

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -57,6 +57,7 @@ futures                                = { workspace = true }
 glob                                   = { workspace = true }
 heck                                   = { workspace = true }
 once_cell                              = { workspace = true }
+rayon                                  = { workspace = true }
 rspack_cacheable                       = { workspace = true }
 rspack_ids                             = { workspace = true }
 rspack_javascript_compiler             = { workspace = true }

--- a/crates/rspack_binding_api/src/build_info.rs
+++ b/crates/rspack_binding_api/src/build_info.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use std::{cell::RefCell, sync::LazyLock};
 
 use napi::{
   bindgen_prelude::{
@@ -150,9 +150,7 @@ impl BuildInfo {
   }
 }
 
-fn create_known_private_properties(env: &Env) -> napi::Result<Vec<Property>> {
-  let mut properties = vec![];
-
+fn create_known_private_properties(env: &Env, properties: &mut Vec<Property>) -> napi::Result<()> {
   BUILD_INFO_ASSETS_SYMBOL.with(|once_cell| {
     #[allow(clippy::unwrap_used)]
     let symbol = once_cell.get().unwrap();
@@ -264,7 +262,11 @@ fn create_known_private_properties(env: &Env) -> napi::Result<Vec<Property>> {
     Ok::<(), napi::Error>(())
   })?;
 
-  Ok(properties)
+  Ok(())
+}
+
+thread_local! {
+  static BUILD_INFO_PROPERTIES_BUFFER: RefCell<Vec<Property>> = RefCell::new(Vec::new());
 }
 
 impl ToNapiValue for BuildInfo {
@@ -278,59 +280,64 @@ impl ToNapiValue for BuildInfo {
     let napi_val = ToNapiValue::to_napi_value(env, known)?;
     let mut object = Object::from_raw(env, napi_val);
 
-    let mut properties = create_known_private_properties(&env_wrapper)?;
+    BUILD_INFO_PROPERTIES_BUFFER.with(|ref_cell| {
+      let mut properties = ref_cell.borrow_mut();
+      properties.clear();
+      create_known_private_properties(&env_wrapper, &mut *properties)?;
 
-    let commit_custom_fields_fn: napi::bindgen_prelude::Function<'_, (), ()> = env_wrapper
-      .create_function_from_closure("commitCustomFieldsToRust", |ctx| {
-        let object = ctx.this::<Object>()?;
-        let env = ctx.env;
-        let this: &mut KnownBuildInfo = FromNapiMutRef::from_napi_mut_ref(env.raw(), object.raw())?;
+      let commit_custom_fields_fn: napi::bindgen_prelude::Function<'_, (), ()> = env_wrapper
+        .create_function_from_closure("commitCustomFieldsToRust", |ctx| {
+          let object = ctx.this::<Object>()?;
+          let env = ctx.env;
+          let this: &mut KnownBuildInfo =
+            FromNapiMutRef::from_napi_mut_ref(env.raw(), object.raw())?;
 
-        this.with_mut(|module| {
-          let mut extras = serde_json::Map::new();
-          let names = Array::from_unknown(object.get_property_names()?.to_unknown())?;
-          for index in 0..names.len() {
-            if let Some(name) = names.get::<String>(index)? {
-              if !KNOWN_BUILD_INFO_FIELD_NAMES.contains(name.as_str()) {
-                let value = object.get_named_property::<Unknown>(&name)?;
-                if let Some(json_value) = unknown_to_json_value(value)? {
-                  extras.insert(name, json_value);
+          this.with_mut(|module| {
+            let mut extras = serde_json::Map::new();
+            let names = Array::from_unknown(object.get_property_names()?.to_unknown())?;
+            for index in 0..names.len() {
+              if let Some(name) = names.get::<String>(index)? {
+                if !KNOWN_BUILD_INFO_FIELD_NAMES.contains(name.as_str()) {
+                  let value = object.get_named_property::<Unknown>(&name)?;
+                  if let Some(json_value) = unknown_to_json_value(value)? {
+                    extras.insert(name, json_value);
+                  }
                 }
               }
             }
-          }
 
-          module.build_info_mut().extras = extras;
+            module.build_info_mut().extras = extras;
 
-          Ok(())
-        })
+            Ok(())
+          })
+        })?;
+
+      val.with_ref(|module| {
+        let extras = &module.build_info().extras;
+        properties.reserve(extras.len() + 1);
+        for (key, value) in extras {
+          let napi_val = ToNapiValue::to_napi_value(env, value)?;
+          properties.push(
+            Property::new()
+              .with_utf8_name(key)?
+              .with_value(&Object::from_raw(env, napi_val)),
+          );
+        }
+        Ok(())
       })?;
-
-    val.with_ref(|module| {
-      let extras = &module.build_info().extras;
-      properties.reserve(extras.len() + 1);
-      for (key, value) in extras {
-        let napi_val = ToNapiValue::to_napi_value(env, value)?;
+      COMMIT_CUSTOM_FIELDS_SYMBOL.with(|once_cell| {
+        #[allow(clippy::unwrap_used)]
+        let symbol = once_cell.get().unwrap();
         properties.push(
           Property::new()
-            .with_utf8_name(key)?
-            .with_value(&Object::from_raw(env, napi_val)),
+            .with_name(&env_wrapper, symbol)?
+            .with_value(&commit_custom_fields_fn)
+            .with_property_attributes(PropertyAttributes::Configurable),
         );
-      }
-      Ok(())
+        Ok::<(), napi::Error>(())
+      })?;
+      object.define_properties(&properties)
     })?;
-    COMMIT_CUSTOM_FIELDS_SYMBOL.with(|once_cell| {
-      #[allow(clippy::unwrap_used)]
-      let symbol = once_cell.get().unwrap();
-      properties.push(
-        Property::new()
-          .with_name(&env_wrapper, symbol)?
-          .with_value(&commit_custom_fields_fn)
-          .with_property_attributes(PropertyAttributes::Configurable),
-      );
-      Ok::<(), napi::Error>(())
-    })?;
-    object.define_properties(&properties)?;
 
     Ok(napi_val)
   }

--- a/crates/rspack_binding_api/src/build_info.rs
+++ b/crates/rspack_binding_api/src/build_info.rs
@@ -266,7 +266,7 @@ fn create_known_private_properties(env: &Env, properties: &mut Vec<Property>) ->
 }
 
 thread_local! {
-  static BUILD_INFO_PROPERTIES_BUFFER: RefCell<Vec<Property>> = RefCell::new(Vec::new());
+  static BUILD_INFO_PROPERTIES_BUFFER: RefCell<Vec<Property>> = const { RefCell::new(Vec::new()) };
 }
 
 impl ToNapiValue for BuildInfo {
@@ -283,7 +283,7 @@ impl ToNapiValue for BuildInfo {
     BUILD_INFO_PROPERTIES_BUFFER.with(|ref_cell| {
       let mut properties = ref_cell.borrow_mut();
       properties.clear();
-      create_known_private_properties(&env_wrapper, &mut *properties)?;
+      create_known_private_properties(&env_wrapper, &mut properties)?;
 
       let commit_custom_fields_fn: napi::bindgen_prelude::Function<'_, (), ()> = env_wrapper
         .create_function_from_closure("commitCustomFieldsToRust", |ctx| {

--- a/crates/rspack_binding_api/src/dependency.rs
+++ b/crates/rspack_binding_api/src/dependency.rs
@@ -136,7 +136,7 @@ impl Dependency {
         if let Some(dependency) = dependency.downcast_ref::<CommonJsExportRequireDependency>() {
           let ids = dependency.get_ids(&module_graph);
           let mut arr = env.create_array(ids.len() as u32)?;
-          for (i, v) in ids.into_iter().enumerate() {
+          for (i, v) in ids.iter().enumerate() {
             arr.set(i as u32, v.as_str())?;
           }
           Either::A(arr)
@@ -145,14 +145,14 @@ impl Dependency {
         {
           let ids = dependency.get_ids(&module_graph);
           let mut arr = env.create_array(ids.len() as u32)?;
-          for (i, v) in ids.into_iter().enumerate() {
+          for (i, v) in ids.iter().enumerate() {
             arr.set(i as u32, v.as_str())?;
           }
           Either::A(arr)
         } else if let Some(dependency) = dependency.downcast_ref::<ESMImportSpecifierDependency>() {
           let ids = dependency.get_ids(&module_graph);
           let mut arr = env.create_array(ids.len() as u32)?;
-          for (i, v) in ids.into_iter().enumerate() {
+          for (i, v) in ids.iter().enumerate() {
             arr.set(i as u32, v.as_str())?;
           }
           Either::A(arr)

--- a/crates/rspack_binding_api/src/dependency.rs
+++ b/crates/rspack_binding_api/src/dependency.rs
@@ -126,7 +126,7 @@ impl Dependency {
     Ok(())
   }
 
-  #[napi(getter)]
+  #[napi(getter, ts_return_type = "Array<string> | undefined")]
   pub fn ids<'a>(&mut self, env: &'a Env) -> napi::Result<Either<Array<'a>, ()>> {
     let (dependency, compilation) = self.as_ref()?;
 

--- a/crates/rspack_binding_api/src/dependency.rs
+++ b/crates/rspack_binding_api/src/dependency.rs
@@ -1,6 +1,9 @@
 use std::{cell::RefCell, ptr::NonNull};
 
-use napi::{bindgen_prelude::ToNapiValue, Either, Env, JsString};
+use napi::{
+  bindgen_prelude::{Array, ToNapiValue},
+  Either, Env,
+};
 use napi_derive::napi;
 use rspack_core::{Compilation, CompilationId, DependencyId};
 use rspack_napi::OneShotInstanceRef;
@@ -124,35 +127,35 @@ impl Dependency {
   }
 
   #[napi(getter)]
-  pub fn ids<'a>(&mut self, env: &'a Env) -> napi::Result<Either<Vec<JsString<'a>>, ()>> {
+  pub fn ids<'a>(&mut self, env: &'a Env) -> napi::Result<Either<Array<'a>, ()>> {
     let (dependency, compilation) = self.as_ref()?;
 
     Ok(match compilation {
       Some(compilation) => {
         let module_graph = compilation.get_module_graph();
         if let Some(dependency) = dependency.downcast_ref::<CommonJsExportRequireDependency>() {
-          let ids = dependency
-            .get_ids(&module_graph)
-            .iter()
-            .map(|atom| env.create_string(atom.as_str()))
-            .collect::<napi::Result<Vec<_>>>()?;
-          Either::A(ids)
+          let ids = dependency.get_ids(&module_graph);
+          let mut arr = env.create_array(ids.len() as u32)?;
+          for (i, v) in ids.into_iter().enumerate() {
+            arr.set(i as u32, v.as_str())?;
+          }
+          Either::A(arr)
         } else if let Some(dependency) =
           dependency.downcast_ref::<ESMExportImportedSpecifierDependency>()
         {
-          let ids = dependency
-            .get_ids(&module_graph)
-            .iter()
-            .map(|atom| env.create_string(atom.as_str()))
-            .collect::<napi::Result<Vec<_>>>()?;
-          Either::A(ids)
+          let ids = dependency.get_ids(&module_graph);
+          let mut arr = env.create_array(ids.len() as u32)?;
+          for (i, v) in ids.into_iter().enumerate() {
+            arr.set(i as u32, v.as_str())?;
+          }
+          Either::A(arr)
         } else if let Some(dependency) = dependency.downcast_ref::<ESMImportSpecifierDependency>() {
-          let ids = dependency
-            .get_ids(&module_graph)
-            .iter()
-            .map(|atom| env.create_string(atom.as_str()))
-            .collect::<napi::Result<Vec<_>>>()?;
-          Either::A(ids)
+          let ids = dependency.get_ids(&module_graph);
+          let mut arr = env.create_array(ids.len() as u32)?;
+          for (i, v) in ids.into_iter().enumerate() {
+            arr.set(i as u32, v.as_str())?;
+          }
+          Either::A(arr)
         } else {
           Either::B(())
         }

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -47,6 +47,10 @@ impl From<JsFactoryMeta> for FactoryMeta {
   }
 }
 
+thread_local! {
+  pub(crate) static MODULE_PROPERTIES_BUFFER: RefCell<Vec<Property>> = RefCell::new(Vec::with_capacity(4));
+}
+
 // ## Clarify Access Methods for napi Module to Rust Module
 // Primary access: Query compilation.module_graph using module_identifier
 // Fallback for unregistered modules: Access via raw pointer when modules aren't yet stored in compilation.module_graph (e.g., during loader execution phase)
@@ -212,49 +216,66 @@ impl Module {
       Ok(())
     }
 
-    let mut properties = vec![
-      Property::new()
-        .with_utf8_name("type")?
-        .with_value(&env.create_string(module.module_type().as_str())?),
-      Property::new()
-        .with_utf8_name("context")?
-        .with_getter(context_getter),
-      Property::new()
-        .with_utf8_name("layer")?
-        .with_getter(layer_getter),
-      Property::new()
-        .with_utf8_name("useSourceMap")?
-        .with_getter(use_source_map_getter),
-      Property::new()
-        .with_utf8_name("useSimpleSourceMap")?
-        .with_getter(use_simple_source_map_getter),
-      Property::new()
-        .with_utf8_name("factoryMeta")?
-        .with_getter(factory_meta_getter)
-        .with_setter(factory_meta_setter),
-      Property::new()
-        .with_utf8_name("buildInfo")?
-        .with_getter(build_info_getter)
-        .with_setter(build_info_setter),
-      Property::new()
-        .with_utf8_name("buildMeta")?
-        .with_value(&Object::new(env)?),
-    ];
-
-    MODULE_IDENTIFIER_SYMBOL.with(|once_cell| {
-      let identifier = env.create_string(module.identifier().as_str())?;
-      #[allow(clippy::unwrap_used)]
-      let symbol = once_cell.get().unwrap();
+    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
+      let mut properties = ref_cell.borrow_mut();
+      properties.clear();
       properties.push(
         Property::new()
-          .with_name(env, symbol)?
-          .with_value(&identifier)
-          .with_property_attributes(PropertyAttributes::Configurable),
+          .with_utf8_name("type")?
+          .with_value(&env.create_string(module.module_type().as_str())?),
       );
-      Ok::<(), napi::Error>(())
-    })?;
+      properties.push(
+        Property::new()
+          .with_utf8_name("context")?
+          .with_getter(context_getter),
+      );
+      properties.push(
+        Property::new()
+          .with_utf8_name("layer")?
+          .with_getter(layer_getter),
+      );
+      properties.push(
+        Property::new()
+          .with_utf8_name("useSourceMap")?
+          .with_getter(use_source_map_getter),
+      );
+      properties.push(
+        Property::new()
+          .with_utf8_name("useSimpleSourceMap")?
+          .with_getter(use_simple_source_map_getter),
+      );
+      properties.push(
+        Property::new()
+          .with_utf8_name("factoryMeta")?
+          .with_getter(factory_meta_getter)
+          .with_setter(factory_meta_setter),
+      );
+      properties.push(
+        Property::new()
+          .with_utf8_name("buildInfo")?
+          .with_getter(build_info_getter)
+          .with_setter(build_info_setter),
+      );
+      properties.push(
+        Property::new()
+          .with_utf8_name("buildMeta")?
+          .with_value(&Object::new(env)?),
+      );
+      MODULE_IDENTIFIER_SYMBOL.with(|once_cell| {
+        let identifier = env.create_string(module.identifier().as_str())?;
+        #[allow(clippy::unwrap_used)]
+        let symbol = once_cell.get().unwrap();
+        properties.push(
+          Property::new()
+            .with_name(env, symbol)?
+            .with_value(&identifier)
+            .with_property_attributes(PropertyAttributes::Configurable),
+        );
+        Ok::<(), napi::Error>(())
+      })?;
 
-    object.define_properties(&properties)?;
+      object.define_properties(&properties)
+    })?;
 
     Ok(instance)
   }

--- a/crates/rspack_binding_api/src/module_graph.rs
+++ b/crates/rspack_binding_api/src/module_graph.rs
@@ -1,6 +1,6 @@
 use std::ptr::NonNull;
 
-use napi::{Either, Env, JsString};
+use napi::{bindgen_prelude::Array, Either, Env, JsString};
 use napi_derive::napi;
 use rspack_core::{Compilation, ModuleGraph, PrefetchExportsInfoMode, RuntimeSpec};
 
@@ -11,6 +11,7 @@ use crate::{
 #[napi]
 pub struct JsModuleGraph {
   compilation: NonNull<Compilation>,
+  connection_vec_buffer: Vec<ModuleGraphConnectionWrapper>,
 }
 
 impl JsModuleGraph {
@@ -18,6 +19,7 @@ impl JsModuleGraph {
     #[allow(clippy::unwrap_used)]
     Self {
       compilation: NonNull::new(compilation as *const Compilation as *mut Compilation).unwrap(),
+      connection_vec_buffer: Vec::new(),
     }
   }
 
@@ -143,51 +145,74 @@ impl JsModuleGraph {
     ts_args_type = "module: Module",
     ts_return_type = "ModuleGraphConnection[]"
   )]
-  pub fn get_outgoing_connections(
-    &self,
+  pub fn get_outgoing_connections<'a>(
+    &'a mut self,
+    env: &'a Env,
     module: ModuleObjectRef,
-  ) -> napi::Result<Vec<ModuleGraphConnectionWrapper>> {
+  ) -> napi::Result<Array<'a>> {
     let (compilation, module_graph) = self.as_ref()?;
-    Ok(
-      module_graph
-        .get_outgoing_connections(&module.identifier)
-        .map(|connection| ModuleGraphConnectionWrapper::new(connection.dependency_id, compilation))
-        .collect::<Vec<_>>(),
-    )
+    let vec = &mut self.connection_vec_buffer;
+    for connection in module_graph.get_outgoing_connections(&module.identifier) {
+      vec.push(ModuleGraphConnectionWrapper::new(
+        connection.dependency_id,
+        compilation,
+      ));
+    }
+    let mut arr = env.create_array(vec.len() as u32)?;
+    for (i, v) in vec.drain(..).enumerate() {
+      arr.set(i as u32, v)?;
+    }
+    Ok(arr)
   }
 
   #[napi(
     ts_args_type = "module: Module",
     ts_return_type = "ModuleGraphConnection[]"
   )]
-  pub fn get_outgoing_connections_in_order(
-    &self,
+  pub fn get_outgoing_connections_in_order<'a>(
+    &'a mut self,
+    env: &'a Env,
     module: ModuleObjectRef,
-  ) -> napi::Result<Vec<ModuleGraphConnectionWrapper>> {
+  ) -> napi::Result<Array<'a>> {
     let (compilation, module_graph) = self.as_ref()?;
-    Ok(
-      module_graph
-        .get_outgoing_deps_in_order(&module.identifier)
-        .map(|dependency_id| ModuleGraphConnectionWrapper::new(*dependency_id, compilation))
-        .collect::<Vec<_>>(),
-    )
+
+    let vec = &mut self.connection_vec_buffer;
+    for dependency_id in module_graph.get_outgoing_deps_in_order(&module.identifier) {
+      vec.push(ModuleGraphConnectionWrapper::new(
+        *dependency_id,
+        compilation,
+      ));
+    }
+    let mut arr = env.create_array(vec.len() as u32)?;
+    for (i, v) in vec.drain(..).enumerate() {
+      arr.set(i as u32, v)?;
+    }
+    Ok(arr)
   }
 
   #[napi(
     ts_args_type = "module: Module",
     ts_return_type = "ModuleGraphConnection[]"
   )]
-  pub fn get_incoming_connections(
-    &self,
+  pub fn get_incoming_connections<'a>(
+    &'a mut self,
+    env: &'a Env,
     module: ModuleObjectRef,
-  ) -> napi::Result<Vec<ModuleGraphConnectionWrapper>> {
+  ) -> napi::Result<Array<'a>> {
     let (compilation, module_graph) = self.as_ref()?;
-    Ok(
-      module_graph
-        .get_incoming_connections(&module.identifier)
-        .map(|connection| ModuleGraphConnectionWrapper::new(connection.dependency_id, compilation))
-        .collect::<Vec<_>>(),
-    )
+
+    let vec = &mut self.connection_vec_buffer;
+    for connection in module_graph.get_incoming_connections(&module.identifier) {
+      vec.push(ModuleGraphConnectionWrapper::new(
+        connection.dependency_id,
+        compilation,
+      ));
+    }
+    let mut arr = env.create_array(vec.len() as u32)?;
+    for (i, v) in vec.drain(..).enumerate() {
+      arr.set(i as u32, v)?;
+    }
+    Ok(arr)
   }
 
   #[napi(

--- a/crates/rspack_binding_api/src/modules/concatenated_module.rs
+++ b/crates/rspack_binding_api/src/modules/concatenated_module.rs
@@ -1,4 +1,4 @@
-use crate::{impl_module_methods, Module, ModuleObject};
+use crate::{impl_module_methods, Module, ModuleObject, MODULE_PROPERTIES_BUFFER};
 
 #[napi]
 #[repr(C)]
@@ -11,7 +11,12 @@ impl ConcatenatedModule {
     self,
     env: &napi::Env,
   ) -> napi::Result<napi::bindgen_prelude::ClassInstance<Self>> {
-    Self::new_inherited(self, env, vec![])
+    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
+      let mut properties = ref_cell.borrow_mut();
+      properties.clear();
+
+      Self::new_inherited(self, env, &mut *properties)
+    })
   }
 
   fn as_ref(

--- a/crates/rspack_binding_api/src/modules/concatenated_module.rs
+++ b/crates/rspack_binding_api/src/modules/concatenated_module.rs
@@ -15,7 +15,7 @@ impl ConcatenatedModule {
       let mut properties = ref_cell.borrow_mut();
       properties.clear();
 
-      Self::new_inherited(self, env, &mut *properties)
+      Self::new_inherited(self, env, &mut properties)
     })
   }
 

--- a/crates/rspack_binding_api/src/modules/context_module.rs
+++ b/crates/rspack_binding_api/src/modules/context_module.rs
@@ -15,7 +15,7 @@ impl ContextModule {
       let mut properties = ref_cell.borrow_mut();
       properties.clear();
 
-      Self::new_inherited(self, env, &mut *properties)
+      Self::new_inherited(self, env, &mut properties)
     })
   }
 }

--- a/crates/rspack_binding_api/src/modules/context_module.rs
+++ b/crates/rspack_binding_api/src/modules/context_module.rs
@@ -1,4 +1,4 @@
-use crate::{impl_module_methods, Module};
+use crate::{impl_module_methods, Module, MODULE_PROPERTIES_BUFFER};
 
 #[napi]
 #[repr(C)]
@@ -11,7 +11,12 @@ impl ContextModule {
     self,
     env: &napi::Env,
   ) -> napi::Result<napi::bindgen_prelude::ClassInstance<Self>> {
-    Self::new_inherited(self, env, vec![])
+    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
+      let mut properties = ref_cell.borrow_mut();
+      properties.clear();
+
+      Self::new_inherited(self, env, &mut *properties)
+    })
   }
 }
 

--- a/crates/rspack_binding_api/src/modules/external_module.rs
+++ b/crates/rspack_binding_api/src/modules/external_module.rs
@@ -23,7 +23,7 @@ impl ExternalModule {
           .with_utf8_name("userRequest")?
           .with_value(&user_request),
       );
-      Self::new_inherited(self, env, &mut *properties)
+      Self::new_inherited(self, env, &mut properties)
     })
   }
 

--- a/crates/rspack_binding_api/src/modules/external_module.rs
+++ b/crates/rspack_binding_api/src/modules/external_module.rs
@@ -1,4 +1,4 @@
-use crate::{impl_module_methods, Module};
+use crate::{impl_module_methods, Module, MODULE_PROPERTIES_BUFFER};
 
 #[napi]
 #[repr(C)]
@@ -14,10 +14,17 @@ impl ExternalModule {
     let (_, module) = self.as_ref()?;
     let user_request = env.create_string(module.user_request())?;
 
-    let properties = vec![napi::Property::new()
-      .with_utf8_name("userRequest")?
-      .with_value(&user_request)];
-    Self::new_inherited(self, env, properties)
+    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
+      let mut properties = ref_cell.borrow_mut();
+      properties.clear();
+
+      properties.push(
+        napi::Property::new()
+          .with_utf8_name("userRequest")?
+          .with_value(&user_request),
+      );
+      Self::new_inherited(self, env, &mut *properties)
+    })
   }
 
   fn as_ref(&mut self) -> napi::Result<(&rspack_core::Compilation, &rspack_core::ExternalModule)> {

--- a/crates/rspack_binding_api/src/modules/macros.rs
+++ b/crates/rspack_binding_api/src/modules/macros.rs
@@ -5,7 +5,7 @@ macro_rules! impl_module_methods {
       fn new_inherited<'a>(
         self,
         env: &'a napi::Env,
-        mut properties: Vec<napi::Property>,
+        properties: &mut Vec<napi::Property>,
       ) -> napi::Result<napi::bindgen_prelude::ClassInstance<'a, Self>> {
         use napi::bindgen_prelude::{JavaScriptClassExt, JsObjectValue, JsValue};
 
@@ -238,7 +238,7 @@ macro_rules! impl_module_methods {
           );
           Ok::<(), napi::Error>(())
         })?;
-        object.define_properties(&properties)?;
+        object.define_properties(properties)?;
 
         Ok(instance)
       }

--- a/crates/rspack_binding_api/src/modules/normal_module.rs
+++ b/crates/rspack_binding_api/src/modules/normal_module.rs
@@ -128,7 +128,7 @@ impl NormalModule {
           .with_getter(match_resource_getter)
           .with_setter(match_resource_setter),
       );
-      Self::new_inherited(self, env, &mut *properties)
+      Self::new_inherited(self, env, &mut properties)
     })
   }
 

--- a/crates/rspack_binding_api/src/modules/normal_module.rs
+++ b/crates/rspack_binding_api/src/modules/normal_module.rs
@@ -4,7 +4,10 @@ use napi::{
 };
 use rspack_core::{parse_resource, ResourceData, ResourceParsedData};
 
-use crate::{impl_module_methods, plugins::JsLoaderItem, Module, ReadonlyResourceDataWrapper};
+use crate::{
+  impl_module_methods, plugins::JsLoaderItem, Module, ReadonlyResourceDataWrapper,
+  MODULE_PROPERTIES_BUFFER,
+};
 
 #[napi]
 #[repr(C)]
@@ -85,31 +88,48 @@ impl NormalModule {
       Ok(())
     }
 
-    let properties = vec![
-      napi::Property::new()
-        .with_utf8_name("resource")?
-        .with_value(&resource),
-      napi::Property::new()
-        .with_utf8_name("request")?
-        .with_value(&request),
-      napi::Property::new()
-        .with_utf8_name("userRequest")?
-        .with_value(&user_request),
-      napi::Property::new()
-        .with_utf8_name("rawRequest")?
-        .with_value(&raw_request),
-      napi::Property::new()
-        .with_utf8_name("resourceResolveData")?
-        .with_value(&resource_resolve_data),
-      napi::Property::new()
-        .with_utf8_name("loaders")?
-        .with_value(&loaders),
-      napi::Property::new()
-        .with_utf8_name("matchResource")?
-        .with_getter(match_resource_getter)
-        .with_setter(match_resource_setter),
-    ];
-    Self::new_inherited(self, env, properties)
+    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
+      let mut properties = ref_cell.borrow_mut();
+      properties.clear();
+
+      properties.push(
+        napi::Property::new()
+          .with_utf8_name("resource")?
+          .with_value(&resource),
+      );
+      properties.push(
+        napi::Property::new()
+          .with_utf8_name("request")?
+          .with_value(&request),
+      );
+      properties.push(
+        napi::Property::new()
+          .with_utf8_name("userRequest")?
+          .with_value(&user_request),
+      );
+      properties.push(
+        napi::Property::new()
+          .with_utf8_name("rawRequest")?
+          .with_value(&raw_request),
+      );
+      properties.push(
+        napi::Property::new()
+          .with_utf8_name("resourceResolveData")?
+          .with_value(&resource_resolve_data),
+      );
+      properties.push(
+        napi::Property::new()
+          .with_utf8_name("loaders")?
+          .with_value(&loaders),
+      );
+      properties.push(
+        napi::Property::new()
+          .with_utf8_name("matchResource")?
+          .with_getter(match_resource_getter)
+          .with_setter(match_resource_setter),
+      );
+      Self::new_inherited(self, env, &mut *properties)
+    })
   }
 
   fn as_ref(&mut self) -> napi::Result<(&rspack_core::Compilation, &rspack_core::NormalModule)> {

--- a/crates/rspack_binding_api/src/normal_module_factory.rs
+++ b/crates/rspack_binding_api/src/normal_module_factory.rs
@@ -1,5 +1,6 @@
 use napi_derive::napi;
 use rspack_core::NormalModuleCreateData;
+use serde::Serialize;
 
 use crate::JsResourceData;
 
@@ -41,6 +42,8 @@ pub struct JsResolveArgs {
 
 pub type JsResolveOutput = JsResolveArgs;
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 #[napi(object)]
 pub struct JsCreateData {
   pub request: String,
@@ -48,7 +51,8 @@ pub struct JsCreateData {
   pub resource: String,
 }
 
-#[napi(object)]
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct JsAfterResolveData {
   pub request: String,
   pub context: String,

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -502,10 +502,10 @@ pub struct RegisterJsTaps {
   pub register_normal_module_factory_resolve_for_scheme_taps:
     RegisterFunction<JsResolveForSchemeArgs, Promise<JsResolveForSchemeOutput>>,
   #[napi(
-    ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsAfterResolveData) => Promise<[boolean | undefined, JsCreateData | undefined]>); stage: number; }>"
+    ts_type = "(stages: Array<number>) => Array<{ function: ((arg: string) => Promise<[boolean | undefined, JsCreateData | undefined]>); stage: number; }>"
   )]
   pub register_normal_module_factory_after_resolve_taps:
-    RegisterFunction<JsAfterResolveData, Promise<JsAfterResolveOutput>>,
+    RegisterFunction<String, Promise<JsAfterResolveOutput>>,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsNormalModuleFactoryCreateModuleArgs) => Promise<void>); stage: number; }>"
   )]
@@ -821,7 +821,7 @@ define_register!(
 );
 define_register!(
   RegisterNormalModuleFactoryAfterResolveTaps,
-  tap = NormalModuleFactoryAfterResolveTap<JsAfterResolveData, Promise<JsAfterResolveOutput>> @ NormalModuleFactoryAfterResolveHook,
+  tap = NormalModuleFactoryAfterResolveTap<String, Promise<JsAfterResolveOutput>> @ NormalModuleFactoryAfterResolveHook,
   cache = true,
   kind = RegisterJsTapKind::NormalModuleFactoryAfterResolve,
   skip = true,
@@ -1570,43 +1570,42 @@ impl NormalModuleFactoryAfterResolve for NormalModuleFactoryAfterResolveTap {
     data: &mut ModuleFactoryCreateData,
     create_data: &mut NormalModuleCreateData,
   ) -> rspack_error::Result<Option<bool>> {
-    match self
-      .function
-      .call_with_promise(JsAfterResolveData {
-        request: create_data.raw_request.to_string(),
-        context: data.context.to_string(),
-        issuer: data
-          .issuer
-          .as_ref()
-          .map(|issuer| issuer.to_string())
-          .unwrap_or_default(),
-        issuer_layer: data.issuer_layer.clone(),
-        file_dependencies: data
-          .file_dependencies
-          .clone()
-          .into_iter()
-          .map(|item| item.to_string_lossy().to_string())
-          .collect::<Vec<_>>(),
-        context_dependencies: data
-          .context_dependencies
-          .clone()
-          .into_iter()
-          .map(|item| item.to_string_lossy().to_string())
-          .collect::<Vec<_>>(),
-        missing_dependencies: data
-          .missing_dependencies
-          .clone()
-          .into_iter()
-          .map(|item| item.to_string_lossy().to_string())
-          .collect::<Vec<_>>(),
-        create_data: Some(JsCreateData {
-          request: create_data.request.to_owned(),
-          user_request: create_data.user_request.to_owned(),
-          resource: create_data.resource_resolve_data.resource.to_owned(),
-        }),
-      })
-      .await
-    {
+    let data = JsAfterResolveData {
+      request: create_data.raw_request.to_string(),
+      context: data.context.to_string(),
+      issuer: data
+        .issuer
+        .as_ref()
+        .map(|issuer| issuer.to_string())
+        .unwrap_or_default(),
+      issuer_layer: data.issuer_layer.clone(),
+      file_dependencies: data
+        .file_dependencies
+        .clone()
+        .into_iter()
+        .map(|item| item.to_string_lossy().to_string())
+        .collect::<Vec<_>>(),
+      context_dependencies: data
+        .context_dependencies
+        .clone()
+        .into_iter()
+        .map(|item| item.to_string_lossy().to_string())
+        .collect::<Vec<_>>(),
+      missing_dependencies: data
+        .missing_dependencies
+        .clone()
+        .into_iter()
+        .map(|item| item.to_string_lossy().to_string())
+        .collect::<Vec<_>>(),
+      create_data: Some(JsCreateData {
+        request: create_data.request.to_owned(),
+        user_request: create_data.user_request.to_owned(),
+        resource: create_data.resource_resolve_data.resource.to_owned(),
+      }),
+    };
+    let json = serde_json::to_string(&data).map_err(|e| rspack_error::error!(e.to_string()))?;
+
+    match self.function.call_with_promise(json).await {
       Ok((ret, resolve_data)) => {
         if let Some(resolve_data) = resolve_data {
           fn update_resource_data(old_resource_data: &mut ResourceData, new_resource: String) {

--- a/crates/rspack_binding_api/src/raw_options/raw_external.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_external.rs
@@ -203,8 +203,8 @@ impl RawExternalItemFnCtx {
 
             let merged_resolve_options = match second.resolve_options.as_ref() {
               Some(second_resolve_options) => match first.resolve_options.as_ref() {
-                Some(resolve_options) => Some(Box::new(
-                  resolve_options
+                Some(first_resolve_options) => Some(Box::new(
+                  first_resolve_options
                     .clone()
                     .merge(*second_resolve_options.clone()),
                 )),
@@ -215,8 +215,8 @@ impl RawExternalItemFnCtx {
 
             let merged_options = ResolveOptionsWithDependencyType {
               resolve_options: merged_resolve_options,
-              resolve_to_context: second.resolve_to_context,
-              dependency_category: second.dependency_category,
+              resolve_to_context: first.resolve_to_context,
+              dependency_category: first.dependency_category,
             };
             let resolver = resolver_factory.get(merged_options);
 

--- a/crates/rspack_binding_api/src/raw_options/raw_external.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_external.rs
@@ -90,7 +90,7 @@ impl ToNapiValue for &ContextInfo {
     if let Some(issuer_layer) = &val.issuer_layer {
       obj.set("issuerLayer", issuer_layer)?;
     }
-    napi::bindgen_prelude::Object::to_napi_value(env, obj)
+    ToNapiValue::to_napi_value(env, obj)
   }
 }
 
@@ -118,7 +118,7 @@ struct ResolveClosureContext {
 impl Drop for ResolveClosureContext {
   fn drop(&mut self) {
     let inner = self.i.take();
-    napi::bindgen_prelude::spawn_blocking(|| drop(inner));
+    rayon::spawn(move || drop(inner));
   }
 }
 
@@ -141,7 +141,7 @@ pub struct RawExternalItemFnCtx {
 impl Drop for RawExternalItemFnCtx {
   fn drop(&mut self) {
     let inner = self.i.take();
-    napi::bindgen_prelude::spawn_blocking(|| drop(inner));
+    rayon::spawn(move || drop(inner));
   }
 }
 

--- a/crates/rspack_binding_api/src/raw_options/raw_external.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_external.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, path::Path, sync::Arc};
 
 use napi::{
-  bindgen_prelude::{Either4, Function, FunctionCallContext, Promise},
+  bindgen_prelude::{Either4, Function, FunctionCallContext, Object, Promise, ToNapiValue},
   Either, Env,
 };
 use napi_derive::napi;
@@ -79,35 +79,83 @@ pub struct ContextInfo {
   pub issuer_layer: Option<String>,
 }
 
+impl ToNapiValue for &ContextInfo {
+  unsafe fn to_napi_value(
+    env: napi::sys::napi_env,
+    val: Self,
+  ) -> napi::Result<napi::sys::napi_value> {
+    let env_wrapper = Env::from(env);
+    let mut obj = Object::new(&env_wrapper)?;
+    obj.set("issuer", &val.issuer)?;
+    if let Some(issuer_layer) = &val.issuer_layer {
+      obj.set("issuerLayer", issuer_layer)?;
+    }
+    napi::bindgen_prelude::Object::to_napi_value(env, obj)
+  }
+}
+
 #[derive(Debug)]
-#[napi]
-pub struct RawExternalItemFnCtx {
+#[napi(object, object_from_js = false)]
+pub struct RawExternalItemFnCtxData<'a> {
+  pub request: &'a str,
+  pub context: &'a str,
+  pub dependency_type: &'a str,
+  pub context_info: &'a ContextInfo,
+}
+
+#[derive(Debug, Clone)]
+struct ResolveClosureContextInner {
+  first: Arc<ResolveOptionsWithDependencyType>,
+  second: Arc<ResolveOptionsWithDependencyType>,
+  resolver_factory: Arc<ResolverFactory>,
+}
+
+#[derive(Debug, Clone)]
+struct ResolveClosureContext {
+  i: Option<ResolveClosureContextInner>,
+}
+
+impl Drop for ResolveClosureContext {
+  fn drop(&mut self) {
+    let inner = self.i.take();
+    napi::bindgen_prelude::spawn_blocking(|| drop(inner));
+  }
+}
+
+#[derive(Debug)]
+struct RawExternalItemFnCtxInner {
   request: String,
   context: String,
   dependency_type: String,
   context_info: ContextInfo,
-  resolve_options_with_dependency_type: ResolveOptionsWithDependencyType,
+  resolve_options_with_dependency_type: Arc<ResolveOptionsWithDependencyType>,
   resolver_factory: Arc<ResolverFactory>,
 }
 
 #[derive(Debug)]
-#[napi(object)]
-pub struct RawExternalItemFnCtxData {
-  pub request: String,
-  pub context: String,
-  pub dependency_type: String,
-  pub context_info: ContextInfo,
+#[napi]
+pub struct RawExternalItemFnCtx {
+  i: Option<RawExternalItemFnCtxInner>,
+}
+
+impl Drop for RawExternalItemFnCtx {
+  fn drop(&mut self) {
+    let inner = self.i.take();
+    napi::bindgen_prelude::spawn_blocking(|| drop(inner));
+  }
 }
 
 #[napi]
 impl RawExternalItemFnCtx {
   #[napi]
   pub fn data(&self) -> RawExternalItemFnCtxData {
+    #[allow(clippy::unwrap_used)]
+    let inner = self.i.as_ref().unwrap();
     RawExternalItemFnCtxData {
-      request: self.request.clone(),
-      context: self.context.clone(),
-      dependency_type: self.dependency_type.clone(),
-      context_info: self.context_info.clone(),
+      request: inner.request.as_str(),
+      context: inner.context.as_str(),
+      dependency_type: inner.dependency_type.as_str(),
+      context_info: &inner.context_info,
     }
   }
 
@@ -119,12 +167,21 @@ impl RawExternalItemFnCtx {
     env: &'a Env,
     options: Option<RawResolveOptionsWithDependencyType>,
   ) -> napi::Result<Function<'a, (String, String, Function<'static>), ()>> {
-    let first = Arc::new(self.resolve_options_with_dependency_type.clone());
+    #[allow(clippy::unwrap_used)]
+    let inner = self.i.as_ref().unwrap();
+    let first = inner.resolve_options_with_dependency_type.clone();
     let second = Arc::new(
       normalize_raw_resolve_options_with_dependency_type(options, first.resolve_to_context)
         .map_err(|e| napi::Error::from_reason(e.to_string()))?,
     );
-    let resolver_factory = self.resolver_factory.clone();
+    let resolver_factory = inner.resolver_factory.clone();
+    let resolve_closure_context = ResolveClosureContext {
+      i: Some(ResolveClosureContextInner {
+        first,
+        second,
+        resolver_factory,
+      }),
+    };
 
     let f: Function<(String, String, Function<'static>), ()> =
       env.create_function_from_closure("resolve", move |ctx: FunctionCallContext| {
@@ -132,15 +189,20 @@ impl RawExternalItemFnCtx {
         let request = ctx.get::<String>(1)?;
         let callback = ctx.get::<Function<'static>>(2)?;
 
-        let first_clone = first.clone();
-        let second_clone = second.clone();
-        let resolver_factory = resolver_factory.clone();
+        let resolve_closure_context = resolve_closure_context.clone();
 
         callbackify(
           callback,
           async move {
-            let merged_resolve_options = match second_clone.resolve_options.as_ref() {
-              Some(second_resolve_options) => match first_clone.resolve_options.as_ref() {
+            #[allow(clippy::unwrap_used)]
+            let ResolveClosureContextInner {
+              first,
+              second,
+              resolver_factory,
+            } = resolve_closure_context.i.as_ref().unwrap();
+
+            let merged_resolve_options = match second.resolve_options.as_ref() {
+              Some(second_resolve_options) => match first.resolve_options.as_ref() {
                 Some(resolve_options) => Some(Box::new(
                   resolve_options
                     .clone()
@@ -148,13 +210,13 @@ impl RawExternalItemFnCtx {
                 )),
                 None => Some(second_resolve_options.clone()),
               },
-              None => first_clone.resolve_options.clone(),
+              None => first.as_ref().resolve_options.clone(),
             };
 
             let merged_options = ResolveOptionsWithDependencyType {
               resolve_options: merged_resolve_options,
-              resolve_to_context: second_clone.resolve_to_context,
-              dependency_category: second_clone.dependency_category,
+              resolve_to_context: second.resolve_to_context,
+              dependency_category: second.dependency_category,
             };
             let resolver = resolver_factory.get(merged_options);
 
@@ -185,15 +247,17 @@ impl RawExternalItemFnCtx {
 impl From<ExternalItemFnCtx> for RawExternalItemFnCtx {
   fn from(value: ExternalItemFnCtx) -> Self {
     Self {
-      request: value.request,
-      dependency_type: value.dependency_type,
-      context: value.context,
-      context_info: ContextInfo {
-        issuer: value.context_info.issuer,
-        issuer_layer: value.context_info.issuer_layer,
-      },
-      resolve_options_with_dependency_type: value.resolve_options_with_dependency_type,
-      resolver_factory: value.resolver_factory,
+      i: Some(RawExternalItemFnCtxInner {
+        request: value.request,
+        dependency_type: value.dependency_type,
+        context: value.context,
+        context_info: ContextInfo {
+          issuer: value.context_info.issuer,
+          issuer_layer: value.context_info.issuer_layer,
+        },
+        resolve_options_with_dependency_type: Arc::new(value.resolve_options_with_dependency_type),
+        resolver_factory: value.resolver_factory,
+      }),
     }
   }
 }

--- a/crates/rspack_binding_api/src/resource_data.rs
+++ b/crates/rspack_binding_api/src/resource_data.rs
@@ -63,7 +63,7 @@ pub struct ReadonlyResourceDataWrapper {
 }
 
 thread_local! {
-  static RESOURCE_DATA_PROPERTIES_BUFFER: RefCell<Vec<Property>> = RefCell::new(Vec::new());
+  static RESOURCE_DATA_PROPERTIES_BUFFER: RefCell<Vec<Property>> = const { RefCell::new(Vec::new()) };
 }
 
 impl ToNapiValue for ReadonlyResourceDataWrapper {

--- a/crates/rspack_binding_api/src/resource_data.rs
+++ b/crates/rspack_binding_api/src/resource_data.rs
@@ -58,12 +58,12 @@ impl ReadonlyResourceData {
   }
 }
 
-thread_local! {
-  static RESOURCE_DATA_PROPERTIES: RefCell<Vec<Property>> = RefCell::new(Vec::with_capacity(4));
-}
-
 pub struct ReadonlyResourceDataWrapper {
   i: Arc<rspack_core::ResourceData>,
+}
+
+thread_local! {
+  static RESOURCE_DATA_PROPERTIES_BUFFER: RefCell<Vec<Property>> = RefCell::new(Vec::new());
 }
 
 impl ToNapiValue for ReadonlyResourceDataWrapper {
@@ -80,7 +80,7 @@ impl ToNapiValue for ReadonlyResourceDataWrapper {
     let instance = template.into_instance(&env_wrapper)?;
     let mut object = instance.as_object(&env_wrapper);
 
-    RESOURCE_DATA_PROPERTIES.with(|ref_cell| {
+    RESOURCE_DATA_PROPERTIES_BUFFER.with(|ref_cell| {
       let mut properties = ref_cell.borrow_mut();
       properties.clear();
       properties.push(

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -52,7 +52,7 @@ pub struct ModuleGraphPartial {
   pub(crate) modules: IdentifierMap<Option<BoxModule>>,
 
   /// Dependencies indexed by `DependencyId`.
-  dependencies: HashMap<DependencyId, Option<BoxDependency>>,
+  dependencies: UkeyMap<DependencyId, Option<BoxDependency>>,
 
   /// AsyncDependenciesBlocks indexed by `AsyncDependenciesBlockIdentifier`.
   blocks: HashMap<AsyncDependenciesBlockIdentifier, Option<Box<AsyncDependenciesBlock>>>,
@@ -61,7 +61,7 @@ pub struct ModuleGraphPartial {
   module_graph_modules: IdentifierMap<Option<ModuleGraphModule>>,
 
   /// ModuleGraphConnection indexed by `DependencyId`.
-  connections: HashMap<DependencyId, Option<ModuleGraphConnection>>,
+  connections: UkeyMap<DependencyId, Option<ModuleGraphConnection>>,
 
   /// Dependency_id to parent module identifier and parent block
   ///

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -81,13 +81,13 @@ pub struct ModuleGraphPartial {
   ///     assert_eq!(parents_info, parent_module_id);
   ///   })
   /// ```
-  dependency_id_to_parents: HashMap<DependencyId, Option<DependencyParents>>,
+  dependency_id_to_parents: UkeyMap<DependencyId, Option<DependencyParents>>,
 
   // Module's ExportsInfo is also a part of ModuleGraph
   exports_info_map: UkeyMap<ExportsInfo, ExportsInfoData>,
   // TODO try move condition as connection field
-  connection_to_condition: HashMap<DependencyId, DependencyCondition>,
-  dep_meta_map: HashMap<DependencyId, DependencyExtraMeta>,
+  connection_to_condition: UkeyMap<DependencyId, DependencyCondition>,
+  dep_meta_map: UkeyMap<DependencyId, DependencyExtraMeta>,
 }
 
 #[derive(Debug, Default)]

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2630,7 +2630,7 @@ export class ExternalsPlugin extends RspackBuiltinPlugin {
     // (undocumented)
     name: BuiltinPluginName;
     // (undocumented)
-    raw(compiler: Compiler): BuiltinPlugin | undefined;
+    raw(): BuiltinPlugin | undefined;
 }
 
 // @public

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -5,7 +5,7 @@ import {
 	type RawExternalsPluginOptions
 } from "@rspack/binding";
 
-import type { Compiler, ExternalItem, ExternalItemValue, Externals } from "..";
+import type { ExternalItem, ExternalItemValue, Externals } from "..";
 import { getRawResolve } from "../config/adapter";
 import type { ResolveCallback } from "../config/adapterRuleUse";
 import type { ResolveRequest } from "../Resolver";
@@ -13,6 +13,7 @@ import { createBuiltinPlugin, RspackBuiltinPlugin } from "./base";
 
 export class ExternalsPlugin extends RspackBuiltinPlugin {
 	name = BuiltinPluginName.ExternalsPlugin;
+	resolveRequestCache = new Map<string, ResolveRequest>();
 
 	constructor(
 		private type: string,
@@ -21,117 +22,125 @@ export class ExternalsPlugin extends RspackBuiltinPlugin {
 		super();
 	}
 
-	raw(compiler: Compiler): BuiltinPlugin | undefined {
+	raw(): BuiltinPlugin | undefined {
 		const { type, externals } = this;
 		const raw: RawExternalsPluginOptions = {
 			type,
 			externals: (Array.isArray(externals) ? externals : [externals])
 				.filter(Boolean)
-				.map(item => getRawExternalItem(compiler, item))
+				.map(item => this.getRawExternalItem(item))
 		};
 		return createBuiltinPlugin(this.name, raw);
 	}
+
+	processResolveResult = (
+		text: string | undefined
+	): ResolveRequest | undefined => {
+		if (!text) return undefined;
+
+		let resolveRequest = this.resolveRequestCache.get(text);
+		if (!resolveRequest) {
+			resolveRequest = JSON.parse(text) as ResolveRequest;
+			this.resolveRequestCache.set(text, resolveRequest);
+		}
+		return Object.assign({}, resolveRequest);
+	};
+
+	getRawExternalItem = (item: ExternalItem | undefined): RawExternalItem => {
+		if (typeof item === "string" || item instanceof RegExp) {
+			return item;
+		}
+
+		if (typeof item === "function") {
+			const processResolveResult = this.processResolveResult;
+
+			return async (ctx: RawExternalItemFnCtx) => {
+				return await new Promise((resolve, reject) => {
+					const data = ctx.data();
+					const promise = item(
+						{
+							request: data.request,
+							dependencyType: data.dependencyType,
+							context: data.context,
+							contextInfo: {
+								issuer: data.contextInfo.issuer,
+								issuerLayer: data.contextInfo.issuerLayer ?? null
+							},
+							getResolve(options) {
+								const rawResolve = options ? getRawResolve(options) : undefined;
+								const resolve = ctx.getResolve(rawResolve);
+
+								return (
+									context: string,
+									request: string,
+									callback?: ResolveCallback
+								) => {
+									if (callback) {
+										resolve(context, request, (error, text) => {
+											if (error) {
+												callback(error);
+											} else {
+												const req = processResolveResult(text);
+												callback(null, req?.path ?? false, req);
+											}
+										});
+									} else {
+										return new Promise((promiseResolve, promiseReject) => {
+											resolve(context, request, (error, text) => {
+												if (error) {
+													promiseReject(error);
+												} else {
+													const req = processResolveResult(text);
+													promiseResolve(req?.path);
+												}
+											});
+										});
+									}
+								};
+							}
+						},
+						(err, result, type) => {
+							if (err) reject(err);
+							resolve({
+								result: getRawExternalItemValueFormFnResult(result),
+								externalType: type
+							});
+						}
+					) as Promise<ExternalItemValue> | ExternalItemValue | undefined;
+					if ((promise as Promise<ExternalItemValue>)?.then) {
+						(promise as Promise<ExternalItemValue>).then(
+							result =>
+								resolve({
+									result: getRawExternalItemValueFormFnResult(result),
+									externalType: undefined
+								}),
+							e => reject(e)
+						);
+					} else if (item.length === 1) {
+						// No callback and no promise returned, regarded as a synchronous function
+						resolve({
+							result: getRawExternalItemValueFormFnResult(
+								promise as ExternalItemValue | undefined
+							),
+							externalType: undefined
+						});
+					}
+				});
+			};
+		}
+		if (typeof item === "object") {
+			return Object.fromEntries(
+				Object.entries(item).map(([k, v]) => [k, getRawExternalItemValue(v)])
+			);
+		}
+		throw new TypeError(`Unexpected type of external item: ${typeof item}`);
+	};
 }
 
 type ArrayType<T> = T extends (infer R)[] ? R : never;
 type RecordValue<T> = T extends Record<any, infer R> ? R : never;
 type RawExternalItem = ArrayType<RawExternalsPluginOptions["externals"]>;
 type RawExternalItemValue = RecordValue<RawExternalItem>;
-
-function getRawExternalItem(
-	compiler: Compiler,
-	item: ExternalItem | undefined
-): RawExternalItem {
-	if (typeof item === "string" || item instanceof RegExp) {
-		return item;
-	}
-
-	if (typeof item === "function") {
-		return async (ctx: RawExternalItemFnCtx) => {
-			return await new Promise((resolve, reject) => {
-				const data = ctx.data();
-				const promise = item(
-					{
-						request: data.request,
-						dependencyType: data.dependencyType,
-						context: data.context,
-						contextInfo: {
-							issuer: data.contextInfo.issuer,
-							issuerLayer: data.contextInfo.issuerLayer ?? null
-						},
-						getResolve(options) {
-							const rawResolve = options ? getRawResolve(options) : undefined;
-							const resolve = ctx.getResolve(rawResolve);
-
-							return (
-								context: string,
-								request: string,
-								callback?: ResolveCallback
-							) => {
-								if (callback) {
-									resolve(context, request, (error, text) => {
-										if (error) {
-											callback(error);
-										} else {
-											const req = text
-												? (JSON.parse(text) as ResolveRequest)
-												: undefined;
-											callback(null, req?.path ?? false, req);
-										}
-									});
-								} else {
-									return new Promise((res, rej) => {
-										resolve(context, request, (error, text) => {
-											if (error) {
-												rej(error);
-											} else {
-												const req = text
-													? (JSON.parse(text) as ResolveRequest)
-													: undefined;
-												res(req?.path);
-											}
-										});
-									});
-								}
-							};
-						}
-					},
-					(err, result, type) => {
-						if (err) reject(err);
-						resolve({
-							result: getRawExternalItemValueFormFnResult(result),
-							externalType: type
-						});
-					}
-				) as Promise<ExternalItemValue> | ExternalItemValue | undefined;
-				if ((promise as Promise<ExternalItemValue>)?.then) {
-					(promise as Promise<ExternalItemValue>).then(
-						result =>
-							resolve({
-								result: getRawExternalItemValueFormFnResult(result),
-								externalType: undefined
-							}),
-						e => reject(e)
-					);
-				} else if (item.length === 1) {
-					// No callback and no promise returned, regarded as a synchronous function
-					resolve({
-						result: getRawExternalItemValueFormFnResult(
-							promise as ExternalItemValue | undefined
-						),
-						externalType: undefined
-					});
-				}
-			});
-		};
-	}
-	if (typeof item === "object") {
-		return Object.fromEntries(
-			Object.entries(item).map(([k, v]) => [k, getRawExternalItemValue(v)])
-		);
-	}
-	throw new TypeError(`Unexpected type of external item: ${typeof item}`);
-}
 
 function getRawExternalItemValueFormFnResult(result?: ExternalItemValue) {
 	return result === undefined ? result : getRawExternalItemValue(result);

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -13,7 +13,8 @@ import { createBuiltinPlugin, RspackBuiltinPlugin } from "./base";
 
 export class ExternalsPlugin extends RspackBuiltinPlugin {
 	name = BuiltinPluginName.ExternalsPlugin;
-	resolveRequestCache = new Map<string, ResolveRequest>();
+
+	#resolveRequestCache = new Map<string, ResolveRequest>();
 
 	constructor(
 		private type: string,
@@ -28,31 +29,31 @@ export class ExternalsPlugin extends RspackBuiltinPlugin {
 			type,
 			externals: (Array.isArray(externals) ? externals : [externals])
 				.filter(Boolean)
-				.map(item => this.getRawExternalItem(item))
+				.map(item => this.#getRawExternalItem(item))
 		};
 		return createBuiltinPlugin(this.name, raw);
 	}
 
-	processResolveResult = (
+	#processResolveResult = (
 		text: string | undefined
 	): ResolveRequest | undefined => {
 		if (!text) return undefined;
 
-		let resolveRequest = this.resolveRequestCache.get(text);
+		let resolveRequest = this.#resolveRequestCache.get(text);
 		if (!resolveRequest) {
 			resolveRequest = JSON.parse(text) as ResolveRequest;
-			this.resolveRequestCache.set(text, resolveRequest);
+			this.#resolveRequestCache.set(text, resolveRequest);
 		}
 		return Object.assign({}, resolveRequest);
 	};
 
-	getRawExternalItem = (item: ExternalItem | undefined): RawExternalItem => {
+	#getRawExternalItem = (item: ExternalItem | undefined): RawExternalItem => {
 		if (typeof item === "string" || item instanceof RegExp) {
 			return item;
 		}
 
 		if (typeof item === "function") {
-			const processResolveResult = this.processResolveResult;
+			const processResolveResult = this.#processResolveResult;
 
 			return async (ctx: RawExternalItemFnCtx) => {
 				return await new Promise((resolve, reject) => {

--- a/packages/rspack/src/taps/normalModuleFactory.ts
+++ b/packages/rspack/src/taps/normalModuleFactory.ts
@@ -115,19 +115,8 @@ export const createNormalModuleFactoryHooksRegisters: CreatePartialRegisters<
 			},
 
 			function (queried) {
-				return async function (arg: binding.JsAfterResolveData) {
-					const data: ResolveData = {
-						contextInfo: {
-							issuer: arg.issuer,
-							issuerLayer: arg.issuerLayer ?? null
-						},
-						request: arg.request,
-						context: arg.context,
-						fileDependencies: arg.fileDependencies,
-						missingDependencies: arg.missingDependencies,
-						contextDependencies: arg.contextDependencies,
-						createData: arg.createData
-					};
+				return async function (arg: string) {
+					const data = JSON.parse(arg) as ResolveData;
 					const ret = await queried.promise(data);
 					return [ret, data.createData];
 				};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Enhance NAPI communication performance through the following optimizations:

1. **Reduce memory allocation in JavaScript thread**: Use thread-local variables to store temporary data, avoiding frequent allocation/deallocation cycles
2. **Direct NAPI Array usage**: Replace Vec with direct NAPI Array operations to eliminate unnecessary Vec memory allocations
3. **Non-blocking Arc<T> cleanup**: Use rayon::spawn for dropping Arc<T> to prevent blocking the JavaScript thread
4. **RequestResult caching**: Cache RequestResult objects to avoid repeated JSON.parse operations

In this Next.js benchmark case https://github.com/SyMind/shadcn-ui/tree/next-rspack, build performance improved from 16s to 15s.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
