### PR TITLE
fix(parser): do not skip parsing expression inside require.resolve

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -129,10 +129,6 @@ pub struct CommonJsImportsParserPlugin;
 
 impl CommonJsImportsParserPlugin {
   fn process_resolve(&self, parser: &mut JavascriptParser, call_expr: &CallExpr, weak: bool) {
-    if matches!(parser.javascript_options.require_resolve, Some(false)) {
-      return;
-    }
-
     if call_expr.args.len() != 1 {
       return;
     }
@@ -514,6 +510,10 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     {
       Some(true)
     } else if for_name == expr_name::REQUIRE_RESOLVE {
+      if matches!(parser.javascript_options.require_resolve, Some(false)) {
+        return None;
+      }
+
       self.process_resolve(parser, call_expr, false);
       Some(true)
     } else if for_name == expr_name::REQUIRE_RESOLVE_WEAK {

--- a/packages/rspack-test-tools/tests/configCases/parsing/require-resolve/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/require-resolve/index.js
@@ -1,3 +1,5 @@
+import path from 'path'
+
 const dir = process.env.DIR_READ_FROM_RUNTIME
 
 const resolve1 = require.resolve(dir)
@@ -8,12 +10,15 @@ const resolve3 = require.resolve('./foo/' + dir + '.js')
 
 const resolve4 = require.resolve(process.env.RANDOM ? './foo/' + dir + '.js' : './bar/' + dir + 'js')
 
+const resolve5 = require.resolve(path.resolve(__dirname, './other.js'))
+
+const resolve6 = require.resolve('./a', { paths: [ cwd, path.resolve(cwd, 'node_modules') ] })
 
 // Can't handle, `require` will turn into expression
-// const resolve5 = require.resolve
-// resolve5('./other.js')
+// const resolve7 = require.resolve
+// resolve7('./other.js')
 
 // Can't handle, `require` will turn into `undefined`
 // const __require = require
-// const resolve6 = __require.resolve('./other.js')
+// const resolve8 = __require.resolve('./other.js')
 

--- a/packages/rspack-test-tools/tests/configCases/parsing/require-resolve/test.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/require-resolve/test.js
@@ -7,4 +7,6 @@ it("`require.resolve` should preserve as-is when `requireResolve` is disabled", 
   expect(code).toContain("require.resolve('./other.js')");
   expect(code).toContain("require.resolve('./foo/' + dir + '.js')");
   expect(code).toContain("require.resolve(process.env.RANDOM ? './foo/' + dir + '.js' : './bar/' + dir + 'js')");
+  expect(code).toContain("require.resolve(external_path_default().resolve(__dirname, './other.js'))");
+  expect(code).toContain("require.resolve('./a', { paths: [ cwd, external_path_default().resolve(cwd, 'node_modules') ] })");
 });


### PR DESCRIPTION
## Summary

when i was migrating Rsdoctor from Modern Module to Rslib, i found the following code and its wrong output due to the skip of expression in `require.resolve`

source:

```js
import path from 'path';

export function loadLoaderModule(loaderPath, cwd = process.cwd()) {
  const mod = require(process.env.A
    ? path.resolve(cwd, cleanLoaderPath)
    : require.resolve(cleanLoaderPath, {
        paths: [cwd, path.resolve(cwd, 'node_modules')],
      }));

  return 1;
}
```

output:

```js
// ...
const external_path_namespaceObject = require("path");
var external_path_default = /*#__PURE__*/ __webpack_require__.n(external_path_namespaceObject);
function loadLoaderModule(loaderPath, cwd = process.cwd()) {
    require(process.env.DOCTOR_TEST ? external_path_default().resolve(cwd, cleanLoaderPath) : require.resolve(cleanLoaderPath, {
        paths: [
            cwd,
            path.resolve(cwd, 'node_modules') // 🔴 path is bind to external_path_namespaceObject
        ]
    }));
    return external_path_default().resolve('q');
}
// ...
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
