### PR TITLE
perf: enhance native watcher with customizable ignore patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,6 +4231,7 @@ dependencies = [
  "fast-glob",
  "notify",
  "pnp",
+ "rayon",
  "rspack_error",
  "rspack_paths",
  "rspack_regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4225,8 +4225,10 @@ version = "0.4.9"
 dependencies = [
  "async-trait",
  "cfg-if",
+ "cow-utils",
  "dashmap 6.1.0",
  "dunce",
+ "fast-glob",
  "notify",
  "pnp",
  "rspack_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,6 +4233,7 @@ dependencies = [
  "pnp",
  "rspack_error",
  "rspack_paths",
+ "rspack_regex",
  "rspack_util",
  "tokio",
  "tracing",

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1511,7 +1511,7 @@ export interface NativeWatcherOptions {
   pollInterval?: number
   aggregateTimeout?: number
   /** Ignored paths or a function to determine if a path should be ignored. */
-  ignored?: string | string[] | ((path: string) => boolean)
+  ignored?: string | string[] | RegExp | ((path: string) => boolean)
 }
 
 export interface NodeFsStats {

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1510,8 +1510,11 @@ export interface NativeWatcherOptions {
   followSymlinks?: boolean
   pollInterval?: number
   aggregateTimeout?: number
-  /** Ignored paths or a function to determine if a path should be ignored. */
-  ignored?: string | string[] | RegExp | ((path: string) => boolean)
+  /**
+   * The ignored paths for the watcher.
+   * It can be a single path, an array of paths, or a regular expression.
+   */
+  ignored?: string | string[] | RegExp
 }
 
 export interface NodeFsStats {

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1510,7 +1510,7 @@ export interface NativeWatcherOptions {
   followSymlinks?: boolean
   pollInterval?: number
   aggregateTimeout?: number
-  /** A function that will be called with the path of a file or directory that is ignored. */
+  /** Ignored paths or a function to determine if a path should be ignored. */
   ignored?: string | ((path: string) => boolean)
 }
 

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1511,7 +1511,7 @@ export interface NativeWatcherOptions {
   pollInterval?: number
   aggregateTimeout?: number
   /** A function that will be called with the path of a file or directory that is ignored. */
-  ignored?: (path: string) => boolean
+  ignored?: string | ((path: string) => boolean)
 }
 
 export interface NodeFsStats {

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1511,7 +1511,7 @@ export interface NativeWatcherOptions {
   pollInterval?: number
   aggregateTimeout?: number
   /** Ignored paths or a function to determine if a path should be ignored. */
-  ignored?: string | ((path: string) => boolean)
+  ignored?: string | string[] | ((path: string) => boolean)
 }
 
 export interface NodeFsStats {

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -39,7 +39,7 @@ pub struct NativeWatcherOptions {
   pub aggregate_timeout: Option<u32>,
 
   #[napi(ts_type = "string | ((path: string) => boolean)")]
-  /// A function that will be called with the path of a file or directory that is ignored.
+  /// Ignored paths or a function to determine if a path should be ignored.
   pub ignored: Option<JsWatcherIgnored>,
 }
 

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -17,13 +17,14 @@ impl Ignored for SafetyIgnored {
   }
 }
 
-type JsWatcherIgnored = Either<String, ThreadsafeFunction<String, bool>>;
+type JsWatcherIgnored = Either3<String, Vec<String>, ThreadsafeFunction<String, bool>>;
 
 fn to_fs_watcher_ignored(ignored: Option<JsWatcherIgnored>) -> FsWatcherIgnored {
   if let Some(ignored) = ignored {
     match ignored {
-      Either::A(path) => FsWatcherIgnored::Path(path),
-      Either::B(func) => FsWatcherIgnored::Fn(Box::new(SafetyIgnored { f: func })),
+      Either3::A(path) => FsWatcherIgnored::Path(path),
+      Either3::B(paths) => FsWatcherIgnored::Paths(paths),
+      Either3::C(func) => FsWatcherIgnored::Fn(Box::new(SafetyIgnored { f: func })),
     }
   } else {
     FsWatcherIgnored::None
@@ -38,7 +39,7 @@ pub struct NativeWatcherOptions {
 
   pub aggregate_timeout: Option<u32>,
 
-  #[napi(ts_type = "string | ((path: string) => boolean)")]
+  #[napi(ts_type = "string | string[] | ((path: string) => boolean)")]
   /// Ignored paths or a function to determine if a path should be ignored.
   pub ignored: Option<JsWatcherIgnored>,
 }

--- a/crates/rspack_fs/Cargo.toml
+++ b/crates/rspack_fs/Cargo.toml
@@ -15,6 +15,7 @@ dunce        = { workspace = true }
 fast-glob    = { workspace = true }
 notify       = { workspace = true, features = ["macos_fsevent"] }
 pnp          = { workspace = true }
+rayon        = { workspace = true }
 rspack_error = { workspace = true }
 rspack_paths = { workspace = true }
 rspack_regex = { workspace = true }

--- a/crates/rspack_fs/Cargo.toml
+++ b/crates/rspack_fs/Cargo.toml
@@ -9,8 +9,10 @@ version.workspace = true
 [dependencies]
 async-trait  = { workspace = true }
 cfg-if       = { workspace = true }
+cow-utils    = { workspace = true }
 dashmap      = { workspace = true }
 dunce        = { workspace = true }
+fast-glob    = { workspace = true }
 notify       = { workspace = true, features = ["macos_fsevent"] }
 pnp          = { workspace = true }
 rspack_error = { workspace = true }

--- a/crates/rspack_fs/Cargo.toml
+++ b/crates/rspack_fs/Cargo.toml
@@ -17,6 +17,7 @@ notify       = { workspace = true, features = ["macos_fsevent"] }
 pnp          = { workspace = true }
 rspack_error = { workspace = true }
 rspack_paths = { workspace = true }
+rspack_regex = { workspace = true }
 rspack_util  = { workspace = true }
 tokio        = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing      = { workspace = true }

--- a/crates/rspack_fs/src/lib.rs
+++ b/crates/rspack_fs/src/lib.rs
@@ -3,8 +3,7 @@ pub use read::ReadableFileSystem;
 
 mod watcher;
 pub use watcher::{
-  EventAggregateHandler, EventHandler, FsWatcher, FsWatcherIgnored, FsWatcherOptions, Ignored,
-  PathUpdater,
+  EventAggregateHandler, EventHandler, FsWatcher, FsWatcherIgnored, FsWatcherOptions, PathUpdater,
 };
 
 mod write;

--- a/crates/rspack_fs/src/lib.rs
+++ b/crates/rspack_fs/src/lib.rs
@@ -3,7 +3,8 @@ pub use read::ReadableFileSystem;
 
 mod watcher;
 pub use watcher::{
-  EventAggregateHandler, EventHandler, FsWatcher, FsWatcherOptions, Ignored, PathUpdater,
+  EventAggregateHandler, EventHandler, FsWatcher, FsWatcherIgnored, FsWatcherOptions, Ignored,
+  PathUpdater,
 };
 
 mod write;

--- a/crates/rspack_fs/src/watcher/analyzer/directories.rs
+++ b/crates/rspack_fs/src/watcher/analyzer/directories.rs
@@ -114,7 +114,7 @@ mod tests {
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
     let dir_0 = ArcPath::from(current_dir.join("src"));
 
-    let path_manager = PathManager::new(None);
+    let path_manager = PathManager::default();
     let file_updater = PathUpdater {
       added: vec![
         current_dir.join("Cargo.toml").to_string_lossy().to_string(),

--- a/crates/rspack_fs/src/watcher/analyzer/directories.rs
+++ b/crates/rspack_fs/src/watcher/analyzer/directories.rs
@@ -67,8 +67,8 @@ mod tests {
   use super::*;
   use crate::watcher::path_manager::{PathManager, PathUpdater};
 
-  #[tokio::test]
-  async fn test_find_watch_directories() {
+  #[test]
+  fn test_find_watch_directories() {
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
     let path_manager = PathManager::default();
     let file_updater = PathUpdater {
@@ -91,7 +91,6 @@ mod tests {
 
     path_manager
       .update_paths(file_updater, directory_updater, missing_updater)
-      .await
       .unwrap();
     let analyzer = WatcherDirectoriesAnalyzer::default();
     let watch_patterns = analyzer.analyze(path_manager.access());
@@ -109,8 +108,8 @@ mod tests {
     }));
   }
 
-  #[tokio::test]
-  async fn test_find_non_exists_watcher_directories() {
+  #[test]
+  fn test_find_non_exists_watcher_directories() {
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
     let dir_0 = ArcPath::from(current_dir.join("src"));
 
@@ -141,7 +140,6 @@ mod tests {
     };
     path_manager
       .update_paths(file_updater, directory_updater, missing_updater)
-      .await
       .unwrap();
 
     let analyzer = WatcherDirectoriesAnalyzer::default();

--- a/crates/rspack_fs/src/watcher/analyzer/root.rs
+++ b/crates/rspack_fs/src/watcher/analyzer/root.rs
@@ -161,7 +161,7 @@ mod tests {
     let file_1 = ArcPath::from(current_dir.join("src/lib.rs"));
     let dir_0 = ArcPath::from(current_dir.clone());
     let dir_1 = ArcPath::from(current_dir.join("src"));
-    let path_manager = PathManager::new(None);
+    let path_manager = PathManager::default();
     let file_updater = PathUpdater {
       added: vec![
         file_0.to_string_lossy().to_string(),
@@ -197,7 +197,7 @@ mod tests {
   async fn test_find_with_missing() {
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
 
-    let path_manager = PathManager::new(None);
+    let path_manager = PathManager::default();
     let file_updater = PathUpdater {
       added: vec![],
       removed: vec![],

--- a/crates/rspack_fs/src/watcher/analyzer/root.rs
+++ b/crates/rspack_fs/src/watcher/analyzer/root.rs
@@ -154,8 +154,8 @@ mod tests {
   use super::*;
   use crate::watcher::path_manager::{PathManager, PathUpdater};
 
-  #[tokio::test]
-  async fn test_find_watch_root() {
+  #[test]
+  fn test_find_watch_root() {
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
     let file_0 = ArcPath::from(current_dir.join("Cargo.toml"));
     let file_1 = ArcPath::from(current_dir.join("src/lib.rs"));
@@ -182,7 +182,6 @@ mod tests {
     };
     path_manager
       .update_paths(file_updater, directory_updater, missing_updater)
-      .await
       .unwrap();
 
     let analyzer = WatcherRootAnalyzer::default();
@@ -193,8 +192,8 @@ mod tests {
     assert_eq!(watch_patterns[0].mode, notify::RecursiveMode::Recursive);
   }
 
-  #[tokio::test]
-  async fn test_find_with_missing() {
+  #[test]
+  fn test_find_with_missing() {
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
 
     let path_manager = PathManager::default();
@@ -229,7 +228,6 @@ mod tests {
 
     path_manager
       .update_paths(file_updater, directory_updater, missing_updater)
-      .await
       .unwrap();
 
     let analyzer = WatcherRootAnalyzer::default();

--- a/crates/rspack_fs/src/watcher/executor.rs
+++ b/crates/rspack_fs/src/watcher/executor.rs
@@ -11,8 +11,7 @@ use tokio::sync::{
   Mutex,
 };
 
-use super::{EventAggregateHandler, FsEventKind};
-use crate::watcher::{EventHandler, FsEvent};
+use super::{EventAggregateHandler, EventHandler, FsEvent, FsEventKind};
 
 type ThreadSafetyReceiver<T> = ThreadSafety<UnboundedReceiver<T>>;
 type ThreadSafety<T> = Arc<Mutex<T>>;

--- a/crates/rspack_fs/src/watcher/ignored.rs
+++ b/crates/rspack_fs/src/watcher/ignored.rs
@@ -1,9 +1,10 @@
-use std::fmt::Debug;
+use std::{borrow::Cow, fmt::Debug};
 
 use async_trait::async_trait;
 use cow_utils::CowUtils;
 use fast_glob::glob_match;
 use rspack_error::Result;
+use rspack_regex::RspackRegex;
 
 #[async_trait]
 pub trait Ignored: Send + Sync {
@@ -16,6 +17,7 @@ pub enum FsWatcherIgnored {
   None,
   Path(String),
   Paths(Vec<String>),
+  Regex(RspackRegex),
   Fn(Box<dyn Ignored>),
 }
 
@@ -25,21 +27,29 @@ impl Debug for FsWatcherIgnored {
       FsWatcherIgnored::None => write!(f, "FsWatcherIgnored::None"),
       FsWatcherIgnored::Path(s) => write!(f, "FsWatcherIgnored::Pattern({s})"),
       FsWatcherIgnored::Paths(s) => write!(f, "FsWatcherIgnored::Patterns({s:?})"),
+      FsWatcherIgnored::Regex(reg) => write!(f, "FsWatcherIgnored::Reg({reg:?})"),
       FsWatcherIgnored::Fn(_) => write!(f, "FsWatcherIgnored::Fn(...)"),
     }
   }
+}
+
+/// Normalize the path by replacing backslashes with forward slashes.
+/// Smooth out the differences in the system, specifically for Windows
+fn normalize_path<'a>(path: &'a str) -> Cow<'a, str> {
+  path.cow_replace("\\", "/")
 }
 
 impl FsWatcherIgnored {
   pub async fn should_be_ignored(&self, p: &str) -> Result<bool> {
     match self {
       FsWatcherIgnored::None => Ok(false),
-      FsWatcherIgnored::Path(path) => Ok(glob_match(path, p.cow_replace("\\", "/").as_bytes())), // Smooth out the differences in the system, specifically for Windows
+      FsWatcherIgnored::Path(path) => Ok(glob_match(path, normalize_path(p).as_bytes())),
       FsWatcherIgnored::Paths(paths) => Ok(
         paths
           .iter()
-          .any(|path| glob_match(path, p.cow_replace("\\", "/").as_bytes())),
+          .any(|path| glob_match(path, normalize_path(p).as_bytes())),
       ),
+      FsWatcherIgnored::Regex(reg) => Ok(reg.test(&normalize_path(p))),
       FsWatcherIgnored::Fn(ignored) => ignored.ignore(p).await, // Function-based ignored cannot be empty
     }
   }

--- a/crates/rspack_fs/src/watcher/ignored.rs
+++ b/crates/rspack_fs/src/watcher/ignored.rs
@@ -1,0 +1,39 @@
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use cow_utils::CowUtils;
+use fast_glob::glob_match;
+use rspack_error::Result;
+
+#[async_trait]
+pub trait Ignored: Send + Sync {
+  async fn ignore(&self, path: &str) -> Result<bool>;
+}
+
+#[derive(Default)]
+pub enum FsWatcherIgnored {
+  #[default]
+  None,
+  Path(String),
+  Fn(Box<dyn Ignored>),
+}
+
+impl Debug for FsWatcherIgnored {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      FsWatcherIgnored::None => write!(f, "FsWatcherIgnored::None"),
+      FsWatcherIgnored::Path(s) => write!(f, "FsWatcherIgnored::Pattern({s})"),
+      FsWatcherIgnored::Fn(_) => write!(f, "FsWatcherIgnored::Fn(...)"),
+    }
+  }
+}
+
+impl FsWatcherIgnored {
+  pub async fn should_be_ignored(&self, path: &str) -> Result<bool> {
+    match self {
+      FsWatcherIgnored::None => Ok(false),
+      FsWatcherIgnored::Path(s) => Ok(glob_match(s, path.cow_replace("\\", "/").as_bytes())), // Smooth out the differences in the system, specifically for Windows
+      FsWatcherIgnored::Fn(ignored) => ignored.ignore(path).await, // Function-based ignored cannot be empty
+    }
+  }
+}

--- a/crates/rspack_fs/src/watcher/ignored.rs
+++ b/crates/rspack_fs/src/watcher/ignored.rs
@@ -1,15 +1,8 @@
 use std::{borrow::Cow, fmt::Debug};
 
-use async_trait::async_trait;
 use cow_utils::CowUtils;
 use fast_glob::glob_match;
-use rspack_error::Result;
 use rspack_regex::RspackRegex;
-
-#[async_trait]
-pub trait Ignored: Send + Sync {
-  async fn ignore(&self, path: &str) -> Result<bool>;
-}
 
 #[derive(Default)]
 pub enum FsWatcherIgnored {
@@ -18,17 +11,15 @@ pub enum FsWatcherIgnored {
   Path(String),
   Paths(Vec<String>),
   Regex(RspackRegex),
-  Fn(Box<dyn Ignored>),
 }
 
 impl Debug for FsWatcherIgnored {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       FsWatcherIgnored::None => write!(f, "FsWatcherIgnored::None"),
-      FsWatcherIgnored::Path(s) => write!(f, "FsWatcherIgnored::Pattern({s})"),
-      FsWatcherIgnored::Paths(s) => write!(f, "FsWatcherIgnored::Patterns({s:?})"),
-      FsWatcherIgnored::Regex(reg) => write!(f, "FsWatcherIgnored::Reg({reg:?})"),
-      FsWatcherIgnored::Fn(_) => write!(f, "FsWatcherIgnored::Fn(...)"),
+      FsWatcherIgnored::Path(s) => write!(f, "FsWatcherIgnored::Path({s})"),
+      FsWatcherIgnored::Paths(s) => write!(f, "FsWatcherIgnored::Paths({s:?})"),
+      FsWatcherIgnored::Regex(reg) => write!(f, "FsWatcherIgnored::Regex({reg:?})"),
     }
   }
 }
@@ -40,17 +31,15 @@ fn normalize_path<'a>(path: &'a str) -> Cow<'a, str> {
 }
 
 impl FsWatcherIgnored {
-  pub async fn should_be_ignored(&self, p: &str) -> Result<bool> {
+  pub fn should_be_ignored(&self, p: &str) -> bool {
     match self {
-      FsWatcherIgnored::None => Ok(false),
-      FsWatcherIgnored::Path(path) => Ok(glob_match(path, normalize_path(p).as_bytes())),
-      FsWatcherIgnored::Paths(paths) => Ok(
-        paths
-          .iter()
-          .any(|path| glob_match(path, normalize_path(p).as_bytes())),
-      ),
-      FsWatcherIgnored::Regex(reg) => Ok(reg.test(&normalize_path(p))),
-      FsWatcherIgnored::Fn(ignored) => ignored.ignore(p).await, // Function-based ignored cannot be empty
+      FsWatcherIgnored::None => false,
+      FsWatcherIgnored::Path(path) => glob_match(path, normalize_path(p).as_bytes()),
+      FsWatcherIgnored::Paths(paths) => paths
+        .iter()
+        .any(|path| glob_match(path, normalize_path(p).as_bytes())),
+
+      FsWatcherIgnored::Regex(reg) => reg.test(&normalize_path(p)),
     }
   }
 }

--- a/crates/rspack_fs/src/watcher/mod.rs
+++ b/crates/rspack_fs/src/watcher/mod.rs
@@ -11,7 +11,7 @@ use std::{collections::HashSet, sync::Arc};
 use analyzer::{Analyzer, RecommendedAnalyzer};
 use disk_watcher::DiskWatcher;
 use executor::Executor;
-pub use ignored::{FsWatcherIgnored, Ignored};
+pub use ignored::FsWatcherIgnored;
 use path_manager::PathManager;
 pub use path_manager::PathUpdater;
 use rspack_error::Result;
@@ -133,8 +133,7 @@ impl FsWatcher {
   ) -> Result<()> {
     self
       .path_manager
-      .update_paths(files, directories, missing)
-      .await?;
+      .update_paths(files, directories, missing)?;
 
     let watch_patterns = self.analyzer.analyze(self.path_manager.access());
     self.disk_watcher.watch(watch_patterns.into_iter())?;

--- a/crates/rspack_fs/src/watcher/mod.rs
+++ b/crates/rspack_fs/src/watcher/mod.rs
@@ -100,7 +100,7 @@ impl FsWatcher {
   ) {
     self.path_manager.reset();
     self.scanner.scan();
-    if let Err(e) = self.wait_for_event(files, directories, missing).await {
+    if let Err(e) = self.wait_for_event(files, directories, missing) {
       event_aggregate_handler.on_error(e);
       return;
     };
@@ -125,7 +125,7 @@ impl FsWatcher {
     Ok(())
   }
 
-  async fn wait_for_event(
+  fn wait_for_event(
     &mut self,
     files: PathUpdater,
     directories: PathUpdater,

--- a/crates/rspack_fs/src/watcher/mod.rs
+++ b/crates/rspack_fs/src/watcher/mod.rs
@@ -1,6 +1,7 @@
 mod analyzer;
 mod disk_watcher;
 mod executor;
+mod ignored;
 mod path_manager;
 mod scanner;
 mod trigger;
@@ -10,8 +11,9 @@ use std::{collections::HashSet, sync::Arc};
 use analyzer::{Analyzer, RecommendedAnalyzer};
 use disk_watcher::DiskWatcher;
 use executor::Executor;
+pub use ignored::{FsWatcherIgnored, Ignored};
 use path_manager::PathManager;
-pub use path_manager::{Ignored, PathUpdater};
+pub use path_manager::PathUpdater;
 use rspack_error::Result;
 use rspack_paths::ArcPath;
 use scanner::Scanner;
@@ -70,7 +72,7 @@ pub struct FsWatcher {
 }
 
 impl FsWatcher {
-  pub fn new(options: FsWatcherOptions, ignored: Option<Arc<dyn Ignored>>) -> Self {
+  pub fn new(options: FsWatcherOptions, ignored: FsWatcherIgnored) -> Self {
     let (tx, rx) = mpsc::unbounded_channel();
 
     let path_manager = Arc::new(PathManager::new(ignored));

--- a/crates/rspack_fs/src/watcher/path_manager.rs
+++ b/crates/rspack_fs/src/watcher/path_manager.rs
@@ -269,7 +269,7 @@ mod tests {
   use rspack_error::Result;
 
   use super::*;
-  use crate::{FsWatcherIgnored, Ignored};
+  use crate::Ignored;
 
   struct TestIgnored {
     pub ignored: Vec<String>,

--- a/crates/rspack_fs/src/watcher/path_manager.rs
+++ b/crates/rspack_fs/src/watcher/path_manager.rs
@@ -344,6 +344,6 @@ mod tests {
 
     all_paths.sort();
 
-    assert_eq!(all_paths, vec!["src", "src/index.js", "src/page/index.ts"]);
+    assert_eq!(all_paths, vec!["src/", "src/index.js", "src/page/index.ts"]);
   }
 }

--- a/crates/rspack_fs/src/watcher/path_manager.rs
+++ b/crates/rspack_fs/src/watcher/path_manager.rs
@@ -264,7 +264,10 @@ mod tests {
       removed: vec![],
     };
     let paths: HashSet<ArcPath> = HashSet::new();
-    let ignored = FsWatcherIgnored::Paths(vec![".git".to_owned(), "node_modules".to_owned()]);
+    let ignored = FsWatcherIgnored::Paths(vec![
+      "**/.git/**".to_owned(),
+      "**/node_modules/**".to_owned(),
+    ]);
     let incremental_manager = IncrementalManager::default();
 
     updater
@@ -312,14 +315,17 @@ mod tests {
 
   #[test]
   fn test_manager() {
-    let ignored = FsWatcherIgnored::Paths(vec!["node_modules".to_string(), ".git".to_string()]);
+    let ignored = FsWatcherIgnored::Paths(vec![
+      "**/node_modules/**".to_string(),
+      "**/.git/**".to_string(),
+    ]);
     let path_manager = PathManager::new(ignored);
     let files = PathUpdater {
       added: vec!["src/index.js".to_string()],
       removed: vec![],
     };
     let directories = PathUpdater {
-      added: vec!["src".to_string(), "node_modules".to_string()],
+      added: vec!["src/".to_string(), "node_modules/".to_string()],
       removed: vec![],
     };
     let missing = PathUpdater {

--- a/crates/rspack_fs/src/watcher/scanner.rs
+++ b/crates/rspack_fs/src/watcher/scanner.rs
@@ -84,7 +84,7 @@ mod tests {
     let missing = HashSet::new();
     missing.insert(ArcPath::from(current_dir.join("___missing_file.txt")));
 
-    let mut path_manager = PathManager::new(None);
+    let mut path_manager = PathManager::default();
     path_manager.files.extend(files);
     path_manager.directories.extend(directories);
     path_manager.missing.extend(missing);

--- a/packages/rspack-test-tools/jest.config.js
+++ b/packages/rspack-test-tools/jest.config.js
@@ -25,8 +25,8 @@ const wasmConfig = process.env.WASM && {
 		"Incremental-watch-webpack.test.js",
 		"Incremental-watch.test.js",
 		"Incremental-web.test.js",
-		"Incremental-webworker.test.js"
-		// "NativeWatcher.test.js"
+		"Incremental-webworker.test.js",
+		"NativeWatcher.test.js"
 	],
 	maxWorkers: 1,
 	maxConcurrency: 1,
@@ -75,11 +75,5 @@ const config = {
 	},
 	...(wasmConfig || {})
 };
-
-config.testPathIgnorePatterns = config.testPathIgnorePatterns || [];
-config.testPathIgnorePatterns.push(
-	// Skip temporarily because native watcher is always timeout in CI
-	"NativeWatcher.test.js"
-);
 
 module.exports = config;

--- a/packages/rspack-test-tools/src/case/nativeWatcher.ts
+++ b/packages/rspack-test-tools/src/case/nativeWatcher.ts
@@ -52,8 +52,7 @@ const creator = new BasicCaseCreator({
 					)
 		);
 	},
-	// TODO: support more concurrency
-	concurrent: 4
+	concurrent: true
 });
 
 export function createNativeWatcher(

--- a/packages/rspack-test-tools/src/processor/watch.ts
+++ b/packages/rspack-test-tools/src/processor/watch.ts
@@ -348,11 +348,7 @@ export class WatchStepProcessor<
 			});
 		});
 		// wait compiler to ready watch the files and diretories
-		// TODO: native watcher will call ignored js function in rust
-		// but it will block the watch step processor. Then, native watcher maybe spend more time.
-		// So we need to wait a while to ensure the files and directories are ready.
-		const timeout = this._watchOptions.nativeWatcher ? 500 : 100;
-		await new Promise(resolve => setTimeout(resolve, timeout));
+		await new Promise(resolve => setTimeout(resolve, 100));
 		copyDiff(
 			path.join(context.getSource(), this._watchOptions.stepName),
 			this._watchOptions.tempDir,

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -62,7 +62,6 @@
     "webpack-sources": "3.3.3",
     "glob-to-regexp": "^0.4.1",
     "zod": "^3.25.76",
-    "@types/glob-to-regexp": "^0.4.4",
     "zod-validation-error": "3.5.3"
   },
   "dependencies": {

--- a/packages/rspack/prebundle.config.mjs
+++ b/packages/rspack/prebundle.config.mjs
@@ -8,7 +8,6 @@ export default {
 		"@swc/types",
 		"graceful-fs",
 		"browserslist-load-config",
-		"glob-to-regexp",
 		{
 			name: "webpack-sources",
 			copyDts: true
@@ -16,8 +15,7 @@ export default {
 		{
 			name: "watchpack",
 			externals: {
-				"graceful-fs": "../graceful-fs/index.js",
-				"glob-to-regexp": "../glob-to-regexp/index.js"
+				"graceful-fs": "../graceful-fs/index.js"
 			},
 			afterBundle(task) {
 				const importStatement = "import fs from 'graceful-fs';";

--- a/packages/rspack/src/NativeWatchFileSystem.ts
+++ b/packages/rspack/src/NativeWatchFileSystem.ts
@@ -14,17 +14,19 @@ import type { FileSystemInfoEntry, Watcher, WatchFileSystem } from "./util/fs";
 type JsWatcherIgnored =
 	| string
 	| string[]
+	| RegExp
 	| ((item: string) => boolean)
 	| undefined;
 
 const toJsWatcherIgnored = (
 	ignored: Watchpack.WatchOptions["ignored"]
 ): JsWatcherIgnored => {
-	if (Array.isArray(ignored) || typeof ignored === "string") {
+	if (
+		Array.isArray(ignored) ||
+		typeof ignored === "string" ||
+		ignored instanceof RegExp
+	) {
 		return ignored;
-	}
-	if (ignored instanceof RegExp) {
-		return (item: string) => ignored.test(item.replace(/\\/g, "/"));
 	}
 	if (typeof ignored === "function") {
 		return (item: string) => ignored(item);

--- a/packages/rspack/src/NativeWatchFileSystem.ts
+++ b/packages/rspack/src/NativeWatchFileSystem.ts
@@ -11,33 +11,17 @@ import type { FileSystemInfoEntry, Watcher, WatchFileSystem } from "./util/fs";
  * Copyright (c) JS Foundation and other contributors
  * https://github.com/webpack/watchpack/blob/main/LICENSE
  */
-const stringToRegexp = (ignored: string) => {
-	if (ignored.length === 0) {
-		return;
-	}
-	const globToRegExp: typeof import("glob-to-regexp") = require("glob-to-regexp");
-	const { source } = globToRegExp(ignored, { globstar: true, extended: true });
-	return `${source.slice(0, -1)}(?:$|\\/)`;
-};
-
-type JsWatcherIgnored = string | ((item: string) => boolean) | undefined;
+type JsWatcherIgnored =
+	| string
+	| string[]
+	| ((item: string) => boolean)
+	| undefined;
 
 const toJsWatcherIgnored = (
 	ignored: Watchpack.WatchOptions["ignored"]
 ): JsWatcherIgnored => {
-	if (Array.isArray(ignored)) {
-		const stringRegexps = ignored.map(i => stringToRegexp(i)).filter(Boolean);
-		if (stringRegexps.length === 0) {
-			return undefined;
-		}
-		return stringRegexps.join("|");
-	}
-	if (typeof ignored === "string") {
-		const stringRegexp = stringToRegexp(ignored);
-		if (!stringRegexp) {
-			return undefined;
-		}
-		return stringRegexp;
+	if (Array.isArray(ignored) || typeof ignored === "string") {
+		return ignored;
 	}
 	if (ignored instanceof RegExp) {
 		return (item: string) => ignored.test(item.replace(/\\/g, "/"));

--- a/packages/rspack/src/NativeWatchFileSystem.ts
+++ b/packages/rspack/src/NativeWatchFileSystem.ts
@@ -11,12 +11,7 @@ import type { FileSystemInfoEntry, Watcher, WatchFileSystem } from "./util/fs";
  * Copyright (c) JS Foundation and other contributors
  * https://github.com/webpack/watchpack/blob/main/LICENSE
  */
-type JsWatcherIgnored =
-	| string
-	| string[]
-	| RegExp
-	| ((item: string) => boolean)
-	| undefined;
+type JsWatcherIgnored = string | string[] | RegExp | undefined;
 
 const toJsWatcherIgnored = (
 	ignored: Watchpack.WatchOptions["ignored"]
@@ -29,7 +24,9 @@ const toJsWatcherIgnored = (
 		return ignored;
 	}
 	if (typeof ignored === "function") {
-		return (item: string) => ignored(item);
+		throw new Error(
+			"NativeWatcher does not support using a function for the 'ignored' option"
+		);
 	}
 	if (ignored) {
 		throw new Error(`Invalid option for 'ignored': ${ignored}`);

--- a/packages/rspack/src/Watching.ts
+++ b/packages/rspack/src/Watching.ts
@@ -66,7 +66,10 @@ export class Watching {
 		}
 		// Ignore watching files in node_modules to reduce memory usage and make startup faster
 		if (this.watchOptions.ignored === undefined) {
-			this.watchOptions.ignored = /[\\/](?:\.git|node_modules)[\\/]/;
+			// We're using string patterns instead of RegExp objects for the watcher configuration
+			// as passing RegExp through NAPI would invoke tsfn (Thread-safe Function) calls,
+			// which have shown significant performance overhead in testing.
+			this.watchOptions.ignored = ["**/node_modules/**", "**/.git/**"];
 		}
 
 		process.nextTick(() => {

--- a/packages/rspack/src/Watching.ts
+++ b/packages/rspack/src/Watching.ts
@@ -66,10 +66,7 @@ export class Watching {
 		}
 		// Ignore watching files in node_modules to reduce memory usage and make startup faster
 		if (this.watchOptions.ignored === undefined) {
-			// We're using string patterns instead of RegExp objects for the watcher configuration
-			// as passing RegExp through NAPI would invoke tsfn (Thread-safe Function) calls,
-			// which have shown significant performance overhead in testing.
-			this.watchOptions.ignored = ["**/node_modules/**", "**/.git/**"];
+			this.watchOptions.ignored = /[\\/](?:\.git|node_modules)[\\/]/;
 		}
 
 		process.nextTick(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,9 +316,6 @@ importers:
       '@swc/types':
         specifier: 0.1.23
         version: 0.1.23
-      '@types/glob-to-regexp':
-        specifier: ^0.4.4
-        version: 0.4.4
       '@types/graceful-fs':
         specifier: 4.1.9
         version: 4.1.9
@@ -3212,9 +3209,6 @@ packages:
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
-
-  '@types/glob-to-regexp@0.4.4':
-    resolution: {integrity: sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -10449,8 +10443,6 @@ snapshots:
       '@types/node': 20.17.55
 
   '@types/geojson@7946.0.16': {}
-
-  '@types/glob-to-regexp@0.4.4': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:


### PR DESCRIPTION
## Summary

### What This PR Does
This PR significantly enhances Rspack's native watcher by introducing support for both glob pattern-based and function-based ignore patterns, while delivering substantial performance improvements over the previous implementation.
### Performance Optimizations
- Reduced NAPI Overhead: Replaced RegExp objects with string patterns to avoid expensive Thread-safe Function (tsfn) calls across the Rust-JavaScript boundary
- Native Glob Matching: Implemented fast, native glob pattern matching using the fast-glob crate instead of JavaScript regex operations
- Cross-Platform Path Handling: Added automatic path normalization for Windows compatibility (\ → /)
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
