### PR TITLE
fix: external resolve esm module

### DIFF
--- a/crates/rspack_binding_api/src/raw_options/raw_external.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_external.rs
@@ -153,8 +153,8 @@ impl RawExternalItemFnCtx {
 
             let merged_options = ResolveOptionsWithDependencyType {
               resolve_options: merged_resolve_options,
-              resolve_to_context: second_clone.resolve_to_context,
-              dependency_category: second_clone.dependency_category,
+              resolve_to_context: first_clone.resolve_to_context,
+              dependency_category: first_clone.dependency_category,
             };
             let resolver = resolver_factory.get(merged_options);
 

--- a/packages/rspack-test-tools/tests/configCases/externals/get-resolve/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/get-resolve/index.js
@@ -1,0 +1,8 @@
+global.cjs = "cjs";
+global.esm = "esm";
+
+it("should resolve right file", async () => {
+    expect(require("foo")).toBe("cjs");
+    expect((await import("foo")).default).toBe("esm");
+})
+

--- a/packages/rspack-test-tools/tests/configCases/externals/get-resolve/node_modules/foo/index.cjs
+++ b/packages/rspack-test-tools/tests/configCases/externals/get-resolve/node_modules/foo/index.cjs
@@ -1,0 +1,1 @@
+throw new Error("Should not be executed directly.");

--- a/packages/rspack-test-tools/tests/configCases/externals/get-resolve/node_modules/foo/index.mjs
+++ b/packages/rspack-test-tools/tests/configCases/externals/get-resolve/node_modules/foo/index.mjs
@@ -1,0 +1,1 @@
+throw new Error("Should not be executed directly.");

--- a/packages/rspack-test-tools/tests/configCases/externals/get-resolve/node_modules/foo/package.json
+++ b/packages/rspack-test-tools/tests/configCases/externals/get-resolve/node_modules/foo/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "foo",
+    "main": "./index.cjs",
+    "exports": {
+        ".": {
+            "import": "./index.mjs",
+            "default": "./index.cjs"
+        }
+    }
+}

--- a/packages/rspack-test-tools/tests/configCases/externals/get-resolve/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/get-resolve/rspack.config.js
@@ -1,0 +1,22 @@
+const path = require("path");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+    externals: [
+        ({ context, request, getResolve }, callback) => {
+            const resolveFunction = getResolve();
+            resolveFunction(context, request, (err, resource) => {
+                if (err) {
+                    return callback(err);
+                }
+                if (resource === path.resolve(__dirname, "node_modules/foo/index.mjs")) {
+                    callback(null, "global esm");
+                } else if (resource === path.resolve(__dirname, "node_modules/foo/index.cjs")) {
+                    callback(null, "global cjs");
+                } else {
+                    callback(null, false);
+                }
+            });
+        }
+    ]
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR fixes an issue with external module resolution in Rspack, specifically addressing how ESM modules are resolved during the external resolution process. The fix corrects the dependency category and resolve context being passed to the resolver.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
