### PR TITLE
fix: update response headers in lazy compilation middleware

### DIFF
--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -177,8 +177,12 @@ const lazyCompilationMiddlewareInternal = (
 		const indices = req.url.slice(lazyCompilationPrefix.length).split("@");
 		req.socket.setNoDelay(true);
 
-		res.setHeader("content-type", "text/event-stream");
-		res.writeHead(200);
+		res.writeHead(200, {
+			"content-type": "text/event-stream",
+			"Access-Control-Allow-Origin": "*",
+			"Access-Control-Allow-Methods": "*",
+			"Access-Control-Allow-Headers": "*"
+		});
 		res.write("\n");
 
 		const moduleActivated = [];


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
Lazy compilation middleware should have `Access-Control-Allow-Origin`,  `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers` headers like [webpack.lazyCompilationBackend](https://github.com/webpack/webpack/blob/main/lib/hmr/lazyCompilationBackend.js#L78-L83) to avoid tigger CORS. 
## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
