### PR TITLE
fix: should not enable `exportedEnum` by default

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/type-reexports-presence/tolerant/index.ts
+++ b/packages/rspack-test-tools/tests/configCases/type-reexports-presence/tolerant/index.ts
@@ -1,1 +1,7 @@
 import "../no-tolerant/index";
+
+// const enum should work as normal
+export const enum Foo {
+  Bar,
+  Baz,
+}

--- a/packages/rspack/src/builtin-loader/swc/collectTypeScriptInfo.ts
+++ b/packages/rspack/src/builtin-loader/swc/collectTypeScriptInfo.ts
@@ -1,5 +1,18 @@
 export type CollectTypeScriptInfoOptions = {
+	/**
+	 * Whether to collect type exports information for `typeReexportsPresence`.
+	 * This is used to check type exports of submodules when running in `'tolerant'` mode.
+	 * @default false
+	 */
 	typeExports?: boolean;
+	/**
+	 * Whether to collect information about exported `enum`s.
+	 * - `true` will collect all `enum` information, including `const enum`s and regular `enum`s.
+	 * - `false` will not collect any `enum` information.
+	 * - `'const-only'` will gather only `const enum`s, enabling Rspack to perform cross-module
+	 * inlining optimizations for them.
+	 * @default false
+	 */
 	exportedEnum?: boolean | "const-only";
 };
 
@@ -11,7 +24,7 @@ export function resolveCollectTypeScriptInfo(
 		exportedEnum:
 			options.exportedEnum === true
 				? "all"
-				: options.exportedEnum === false
+				: options.exportedEnum === false || options.exportedEnum === undefined
 					? "none"
 					: "const-only"
 	};

--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -26,6 +26,10 @@ export type SwcLoaderOptions = Config & {
 	 */
 	rspackExperiments?: {
 		import?: PluginImportOptions;
+		/**
+		 * Collects information from TypeScript's AST for consumption by subsequent Rspack processes,
+		 * providing better TypeScript development experience and smaller output bundle size.
+		 */
 		collectTypeScriptInfo?: CollectTypeScriptInfoOptions;
 	};
 };

--- a/website/docs/en/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/features/builtin-swc-loader.mdx
@@ -470,7 +470,7 @@ Please refer to this [example](https://github.com/rspack-contrib/rstack-examples
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether to collect type exports for [`typeReexportsPresence`](/config/module#moduleparserjavascripttypereexportspresence), used to check type exports of submodules in `'tolerant'` mode.
+Whether to collect type exports information for [`typeReexportsPresence`](/config/module#moduleparserjavascripttypereexportspresence). This is used to check type exports of submodules when running in `'tolerant'` mode.
 
 #### rspackExperiments.collectTypeScriptInfo.exportedEnum
 
@@ -479,7 +479,11 @@ Whether to collect type exports for [`typeReexportsPresence`](/config/module#mod
 - **Type:** `boolean | 'const-only'`
 - **Default:** `false`
 
-Whether to collect exported `enum`s. Using `'const-only'` will only collect exported `const enum`s, enabling Rspack to perform cross-module inline optimizations on the collected enums.
+Whether to collect information about exported `enum`s.
+
+- `true` will collect all `enum` information, including `const enum`s and regular `enum`s.
+- `false` will not collect any `enum` information.
+- `'const-only'` will gather only `const enum`s, enabling Rspack to perform cross-module inlining optimizations for them.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-swc-loader.mdx
@@ -472,7 +472,7 @@ import 'antd/es/button/style';
 - **类型：** `boolean`
 - **默认值：** `false`
 
-是否收集类型导出，提供给 [`typeReexportsPresence`](/config/module#moduleparserjavascripttypereexportspresence) 使用，用于 `'tolerant'` 模式下检查子模块的类型导出。
+是否收集类型导出信息，提供给 [`typeReexportsPresence`](/config/module#moduleparserjavascripttypereexportspresence) 使用，用于 `'tolerant'` 模式下检查子模块的类型导出。
 
 #### rspackExperiments.collectTypeScriptInfo.exportedEnum
 
@@ -481,7 +481,11 @@ import 'antd/es/button/style';
 - **类型：** `boolean | 'const-only'`
 - **默认值：** `false`
 
-是否收集导出的 `enum`，使用 `'const-only'` 则仅收集导出的 `const enum`，提供给 Rspack 对收集到的 enum 进行跨模块的 inline 优化。
+是否收集导出的 `enum` 信息。
+
+- `true` 将收集所有 `enum` 信息，包括 `const enum` 和普通 `enum`。
+- `false` 不收集任何 `enum` 信息。
+- `'const-only'` 仅收集 `const enum` 信息，使 Rspack 能够对其进行跨模块内联优化。
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

When `collectTypeScriptInfo.exportedEnum` is `undefined`, it should be resolved to `none` instead of `const-only`.

I meet this issue when I try to enable `typeExports` in Rsbuild: https://github.com/web-infra-dev/rsbuild/pull/5670

This PR also improved the JSDoc of `collectTypeScriptInfo` and its properties.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
