### PR TITLE
fix: should add incoming blocks for async entrypoint

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -1587,6 +1587,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         .chunk_group_by_ukey
         .expect_get_mut(&item_chunk_group);
       item_chunk_group.add_async_entrypoint(entrypoint);
+      self.incoming_blocks_by_cgi.entry(cgi).or_default().insert(
+        DependenciesBlockIdentifier::AsyncDependenciesBlock(block_id),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Should add incoming blocks for async_entrypoints like normal chunks, so that they can be invalidated during incremental rebuild

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
