### PR TITLE
chore: upgrade rspack_resolver to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -351,6 +360,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1543,7 +1558,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set 0.8.0",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
@@ -3328,7 +3354,7 @@ dependencies = [
  "byteorder",
  "clean-path",
  "concurrent_lru",
- "fancy-regex",
+ "fancy-regex 0.13.0",
  "indexmap 2.7.1",
  "lazy_static",
  "miniz_oxide 0.7.4",
@@ -3339,6 +3365,26 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "thiserror 2.0.9",
+]
+
+[[package]]
+name = "pnp"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3167cbab15e437e9c7db8a4cf613eb4a77583d4327a8964d50fedd6cf364bd"
+dependencies = [
+ "byteorder",
+ "clean-path",
+ "concurrent_lru",
+ "fancy-regex 0.14.0",
+ "miniz_oxide 0.8.2",
+ "path-slash",
+ "pathdiff",
+ "radix_trie",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
  "thiserror 2.0.9",
 ]
 
@@ -4231,7 +4277,7 @@ dependencies = [
  "dunce",
  "fast-glob",
  "notify",
- "pnp",
+ "pnp 0.9.4",
  "rayon",
  "rspack_error",
  "rspack_paths",
@@ -5321,9 +5367,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3bb6b0edc681de93831f8f3e531b9338afbea4ef6f49534ac025d11d1bca2d"
+checksum = "134749bd1a1bfa618ee0ced72b689dee1fd04304d3442358085bf0115404b230"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -5332,7 +5378,7 @@ dependencies = [
  "futures",
  "indexmap 2.7.1",
  "json-strip-comments",
- "pnp",
+ "pnp 0.12.1",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,12 +22,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,17 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
-name = "arca"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f915ddd863ef73f11c10c75170e86db1d4f539689bc6bfb9ce25d6528d6fe83"
-dependencies = [
- "clean-path",
- "path-slash",
- "radix_trie",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,7 +242,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.2",
+ "miniz_oxide",
  "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -339,27 +322,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -646,7 +614,6 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "serde",
  "windows-targets 0.52.6",
 ]
 
@@ -1270,7 +1237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -1554,22 +1520,11 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fancy-regex"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
-dependencies = [
- "bit-set 0.5.3",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
@@ -1614,7 +1569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1809,7 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.7.1",
+ "indexmap",
  "stable_deref_trait",
 ]
 
@@ -2199,17 +2154,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
@@ -2500,7 +2444,7 @@ dependencies = [
  "cssparser-color",
  "data-encoding",
  "getrandom 0.2.15",
- "indexmap 2.7.1",
+ "indexmap",
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
@@ -2738,15 +2682,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -3035,7 +2970,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
+ "indexmap",
  "memchr",
  "ruzstd",
 ]
@@ -3257,7 +3192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "indexmap",
 ]
 
 [[package]]
@@ -3346,30 +3281,6 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pnp"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6add7fe3063e1c9b9a2b9780fba7047187617a37823a6541a62160f4e972cc91"
-dependencies = [
- "arca",
- "byteorder",
- "clean-path",
- "concurrent_lru",
- "fancy-regex 0.13.0",
- "indexmap 2.7.1",
- "lazy_static",
- "miniz_oxide 0.7.4",
- "path-slash",
- "pathdiff",
- "radix_trie",
- "regex",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.9",
-]
-
-[[package]]
-name = "pnp"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3167cbab15e437e9c7db8a4cf613eb4a77583d4327a8964d50fedd6cf364bd"
@@ -3377,8 +3288,8 @@ dependencies = [
  "byteorder",
  "clean-path",
  "concurrent_lru",
- "fancy-regex 0.14.0",
- "miniz_oxide 0.8.2",
+ "fancy-regex",
+ "miniz_oxide",
  "path-slash",
  "pathdiff",
  "radix_trie",
@@ -3838,7 +3749,7 @@ dependencies = [
  "bytecheck 0.8.0",
  "bytes",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
+ "indexmap",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
@@ -3886,7 +3797,7 @@ version = "0.4.10"
 dependencies = [
  "bitflags 2.9.1",
  "enum-tag",
- "indexmap 2.7.1",
+ "indexmap",
  "insta",
  "regex",
  "rspack_browserslist",
@@ -4121,7 +4032,7 @@ dependencies = [
  "camino",
  "dashmap 6.1.0",
  "hashlink",
- "indexmap 2.7.1",
+ "indexmap",
  "inventory",
  "json",
  "lightningcss",
@@ -4162,7 +4073,7 @@ version = "0.4.10"
 dependencies = [
  "dashmap 6.1.0",
  "hashlink",
- "indexmap 2.7.1",
+ "indexmap",
  "rayon",
  "rspack_cacheable",
  "serde",
@@ -4185,7 +4096,7 @@ dependencies = [
  "futures",
  "hashlink",
  "hex",
- "indexmap 2.7.1",
+ "indexmap",
  "indoc",
  "itertools 0.14.0",
  "json",
@@ -4277,7 +4188,7 @@ dependencies = [
  "dunce",
  "fast-glob",
  "notify",
- "pnp 0.9.4",
+ "pnp",
  "rayon",
  "rspack_error",
  "rspack_paths",
@@ -4629,7 +4540,7 @@ dependencies = [
  "cow-utils",
  "css-module-lexer",
  "heck 0.5.0",
- "indexmap 2.7.1",
+ "indexmap",
  "once_cell",
  "regex",
  "rspack_cacheable",
@@ -4652,7 +4563,7 @@ dependencies = [
 name = "rspack_plugin_css_chunking"
 version = "0.4.10"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "rspack_collections",
  "rspack_core",
  "rspack_error",
@@ -4857,7 +4768,7 @@ dependencies = [
  "cow-utils",
  "either",
  "fast-glob",
- "indexmap 2.7.1",
+ "indexmap",
  "indoc",
  "itertools 0.14.0",
  "linked_hash_set",
@@ -5061,7 +4972,7 @@ version = "0.4.10"
 dependencies = [
  "aho-corasick",
  "derive_more 2.0.1",
- "indexmap 2.7.1",
+ "indexmap",
  "once_cell",
  "rayon",
  "regex",
@@ -5104,7 +5015,7 @@ version = "0.4.10"
 dependencies = [
  "async-trait",
  "futures",
- "indexmap 2.7.1",
+ "indexmap",
  "rayon",
  "rspack_collections",
  "rspack_core",
@@ -5155,7 +5066,7 @@ dependencies = [
  "cow-utils",
  "derive_more 2.0.1",
  "futures",
- "indexmap 2.7.1",
+ "indexmap",
  "itertools 0.14.0",
  "rspack_cacheable",
  "rspack_collections",
@@ -5250,7 +5161,7 @@ dependencies = [
  "cow-utils",
  "derive_more 2.0.1",
  "futures",
- "indexmap 2.7.1",
+ "indexmap",
  "pathdiff",
  "rayon",
  "regex",
@@ -5318,7 +5229,7 @@ dependencies = [
  "async-trait",
  "cow-utils",
  "dashmap 6.1.0",
- "indexmap 2.7.1",
+ "indexmap",
  "rayon",
  "rspack_cacheable",
  "rspack_collections",
@@ -5376,9 +5287,9 @@ dependencies = [
  "dashmap 6.1.0",
  "dunce",
  "futures",
- "indexmap 2.7.1",
+ "indexmap",
  "json-strip-comments",
- "pnp 0.12.1",
+ "pnp",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -5478,7 +5389,7 @@ dependencies = [
  "concat-string",
  "cow-utils",
  "dashmap 6.1.0",
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "regex",
  "ropey",
@@ -5598,7 +5509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
- "indexmap 2.7.1",
+ "indexmap",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -5704,7 +5615,7 @@ version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -5721,42 +5632,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.7.1",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
-dependencies = [
- "darling 0.20.10",
- "proc-macro2",
- "quote",
- "syn 2.0.95",
-]
-
-[[package]]
 name = "serde_yml"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "libyml",
  "memchr",
@@ -5977,7 +5858,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6635404b73efc136af3a7956e53c53d4f34b2f16c95a15c438929add0f69412"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "smallvec",
  "static-self-derive",
 ]
@@ -6066,7 +5947,7 @@ dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
  "either",
- "indexmap 2.7.1",
+ "indexmap",
  "jsonc-parser",
  "once_cell",
  "par-core",
@@ -6199,7 +6080,7 @@ dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
  "globset",
- "indexmap 2.7.1",
+ "indexmap",
  "once_cell",
  "regex",
  "regress",
@@ -6346,7 +6227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "821b58933011407cbc401ff065d1d834cefee9080a2ea4ae0197acac837d8f4f"
 dependencies = [
  "arrayvec",
- "indexmap 2.7.1",
+ "indexmap",
  "is-macro",
  "rustc-hash 2.1.1",
  "serde",
@@ -6564,7 +6445,7 @@ checksum = "b04fc032c6daffe598a1c2233e04c0581a202518c6a8653df70eeb755ce941d0"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
- "indexmap 2.7.1",
+ "indexmap",
  "num-bigint",
  "num_cpus",
  "once_cell",
@@ -6616,7 +6497,7 @@ checksum = "994b30cf27c462a26f3a4876cc586aac0d304ea0c6d77e7d28eecf2c1d7b5b10"
 dependencies = [
  "anyhow",
  "foldhash",
- "indexmap 2.7.1",
+ "indexmap",
  "once_cell",
  "precomputed-map",
  "preset_env_base",
@@ -6676,7 +6557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70af89987ce2d0c05d031a014608cd1e9af3bd18292453c659ae27b6fb19f8f8"
 dependencies = [
  "better_scoped_tls",
- "indexmap 2.7.1",
+ "indexmap",
  "once_cell",
  "par-core",
  "par-iter",
@@ -6711,7 +6592,7 @@ version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3863a98e3b91419fe5b17beb14cd5673b2cc9024a4f14a8b833f5dd30239630f"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "par-core",
  "serde",
  "swc_atoms",
@@ -6755,7 +6636,7 @@ dependencies = [
  "Inflector",
  "anyhow",
  "bitflags 2.9.1",
- "indexmap 2.7.1",
+ "indexmap",
  "is-macro",
  "path-clean 1.0.1",
  "pathdiff",
@@ -6782,7 +6663,7 @@ checksum = "da7d21c354b7e67589915c35774a3ef147fd22ecf43a876940032a05afb387cb"
 dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
- "indexmap 2.7.1",
+ "indexmap",
  "once_cell",
  "par-core",
  "petgraph",
@@ -6824,7 +6705,7 @@ checksum = "23b7c2d9188eaeac8a15f338faafa9e3aeba2ee96749d626d9316c97e45046bb"
 dependencies = [
  "base64",
  "bytes-str",
- "indexmap 2.7.1",
+ "indexmap",
  "once_cell",
  "rustc-hash 2.1.1",
  "serde",
@@ -6865,7 +6746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7437f5e07a880092bd50a599faa15f7f4a28cc017d7702dea46eb60d321430ad"
 dependencies = [
  "bitflags 2.9.1",
- "indexmap 2.7.1",
+ "indexmap",
  "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
@@ -6882,7 +6763,7 @@ version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b34cc429270ae5d908574f3cf531fcb9dc52d43f689c5e8ca9598ebc117a32"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "num_cpus",
  "once_cell",
  "par-core",
@@ -7463,7 +7344,7 @@ version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7485,7 +7366,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -7496,7 +7377,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7795,7 +7676,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "getrandom 0.2.15",
- "indexmap 2.7.1",
+ "indexmap",
  "libc",
  "pin-project-lite",
  "replace_with",
@@ -8045,7 +7926,7 @@ dependencies = [
  "cfg-if",
  "cmake",
  "derive_more 2.0.1",
- "indexmap 2.7.1",
+ "indexmap",
  "js-sys",
  "more-asserts",
  "paste",
@@ -8142,7 +8023,7 @@ dependencies = [
  "ciborium",
  "derive_builder 0.12.0",
  "hex",
- "indexmap 2.7.1",
+ "indexmap",
  "saffron",
  "schemars",
  "semver",
@@ -8233,7 +8114,7 @@ dependencies = [
  "enumset",
  "getrandom 0.2.15",
  "hex",
- "indexmap 2.7.1",
+ "indexmap",
  "more-asserts",
  "rkyv 0.8.8",
  "serde",
@@ -8258,7 +8139,7 @@ dependencies = [
  "dashmap 6.1.0",
  "enum-iterator",
  "fnv",
- "indexmap 2.7.1",
+ "indexmap",
  "libc",
  "libunwind",
  "mach2",
@@ -8390,7 +8271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags 2.9.1",
- "indexmap 2.7.1",
+ "indexmap",
 ]
 
 [[package]]
@@ -8438,7 +8319,7 @@ dependencies = [
  "ciborium",
  "document-features",
  "ignore",
- "indexmap 2.7.1",
+ "indexmap",
  "leb128",
  "lexical-sort",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ inventory = { version = "0.3.17", default-features = false }
 rkyv      = { version = "=0.8.8", default-features = false, features = ["std", "bytecheck"] }
 
 # Must be pinned with the same swc versions
-pnp                 = { version = "0.9.0", default-features = false }
+pnp                 = { version = "0.12.1", default-features = false }
 swc                 = { version = "32.0.0", default-features = false }
 swc_config          = { version = "3.1.1", default-features = false }
 swc_core            = { version = "33.0.0", default-features = false, features = ["parallel_rayon"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ regex               = { version = "1.11.1", default-features = false }
 regex-syntax        = { version = "0.8.5", default-features = false, features = ["std"] }
 regress             = { version = "0.10.4", default-features = false, features = ["pattern"] }
 ropey               = { version = "1.6.1", default-features = false }
-rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.0", default-features = false }
+rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.1", default-features = false }
 rspack_sources      = { version = "0.4.8", default-features = false }
 rustc-hash          = { version = "2.1.0", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }


### PR DESCRIPTION
## Summary
Update rspack resolver to 0.6.1
Benefits:
yarn projects with PnP feature enabled will get some resolve performance improvement.
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
