### PR TITLE
fix: persistent cache lose module build error

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -61,7 +61,7 @@ impl MakeOccasion {
     artifact.state = MakeArtifactState::Uninitialized(force_build_dependencies, isolated_modules);
 
     // regenerate statistical data
-    // TODO remove set make_failed_module after all of module are cacheable
+    // TODO set make_failed_module after module.diagnostic are cacheable
     // make failed module include diagnostic that do not support cache, so recovery will not include failed module
     artifact.make_failed_module = Default::default();
     // recovery *_dep

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -62,6 +62,10 @@ pub fn save_module_graph(
       let module = mg
         .module_by_identifier(identifier)
         .expect("should have module");
+      // TODO remove after diagnostic cacheable
+      if !module.diagnostics().is_empty() {
+        return None;
+      }
       let blocks = module
         .get_blocks()
         .par_iter()

--- a/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
+++ b/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
@@ -71,7 +71,7 @@ export class HotUpdatePlugin {
 					filePath,
 					this.updateIndex - 1
 				);
-				if (content === oldContent) {
+				if (this.updateIndex !== 0 && content === oldContent) {
 					return;
 				}
 				await fs.writeFile(filePath, content);

--- a/packages/rspack-test-tools/src/processor/cache.ts
+++ b/packages/rspack-test-tools/src/processor/cache.ts
@@ -108,7 +108,8 @@ export class CacheProcessor<T extends ECompilerType> extends BasicProcessor<T> {
 				library: { type: "commonjs2" }
 			},
 			optimization: {
-				moduleIds: "named"
+				moduleIds: "named",
+				emitOnErrors: true
 			},
 			target: this._cacheOptions.target,
 			experiments: {

--- a/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/errors.js
+++ b/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/errors.js
@@ -1,0 +1,1 @@
+module.exports = [[/LoaderError/]];

--- a/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/file.js
+++ b/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/file.js
@@ -1,0 +1,3 @@
+export default 1;
+---
+export default 1;

--- a/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/index.js
@@ -1,0 +1,11 @@
+import value from "./loader.js!./file";
+
+it("should module error exist", async () => {
+	if (COMPILER_INDEX == 0) {
+		expect(value).toBe(1);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(value).toBe(1);
+	}
+});

--- a/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/index.js
+++ b/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/index.js
@@ -1,11 +1,11 @@
 import value from "./loader.js!./file";
 
 it("should module error exist", async () => {
-	if (COMPILER_INDEX == 0) {
+	if (COMPILER_INDEX === 0) {
 		expect(value).toBe(1);
 		await NEXT_START();
 	}
-	if (COMPILER_INDEX == 1) {
+	if (COMPILER_INDEX === 1) {
 		expect(value).toBe(1);
 	}
 });

--- a/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/loader.js
+++ b/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/loader.js
@@ -1,0 +1,4 @@
+module.exports = function (code) {
+	this.emitError(new Error("LoaderError"));
+	return code;
+};

--- a/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/rspack.config.js
@@ -1,0 +1,34 @@
+const rspack = require("@rspack/core");
+
+let index = 0;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	optimization: {
+		minimize: false
+	},
+	experiments: {
+		cache: {
+			type: "persistent"
+		}
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.done.tapPromise("PLUGIN", async stats => {
+					const { errors } = stats.toJson({ errors: true });
+					if (index == 0) {
+						expect(errors.length).toBe(1);
+						expect(errors[0].message).toMatch("LoaderError");
+					} else {
+						// TODO should be same as index 0, change it after
+						// write error to module.diagnostic
+						expect(errors.length).toBe(0);
+					}
+					index++;
+				});
+			}
+		}
+	]
+};

--- a/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/cacheCases/make/keep_module_error/rspack.config.js
@@ -18,7 +18,7 @@ module.exports = {
 			apply(compiler) {
 				compiler.hooks.done.tapPromise("PLUGIN", async stats => {
 					const { errors } = stats.toJson({ errors: true });
-					if (index == 0) {
+					if (index === 0) {
 						expect(errors.length).toBe(1);
 						expect(errors[0].message).toMatch("LoaderError");
 					} else {


### PR DESCRIPTION
## Summary

The persistent cache will not restore module.diagnostics because it does not support serialization, we should skip the module contains diagnostics to make sure these module force build when hot start.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
