### PR TITLE
perf: improve code splitting

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -983,7 +983,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       return;
     }
     let block_modules =
-      self.get_block_modules(module_identifier.into(), Some(runtime), compilation);
+      self.get_block_modules(module_identifier.into(), Some(runtime.clone()), compilation);
 
     let indices = ctx.2.entry(module_identifier).or_default();
 

--- a/crates/rspack_core/src/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/build_chunk_graph/incremental.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, hash::BuildHasherDefault};
+use std::{collections::HashSet, hash::BuildHasherDefault, sync::Arc};
 
 use num_bigint::BigUint;
 use rspack_collections::{
@@ -607,7 +607,7 @@ impl CodeSplitter {
     &self,
     cache: &ChunkCreateData,
     runtime: &RuntimeSpec,
-    new_available_modules: BigUint,
+    new_available_modules: Arc<BigUint>,
     options: Option<&GroupOptions>,
   ) -> bool {
     cache.can_rebuild
@@ -619,7 +619,7 @@ impl CodeSplitter {
   pub fn available_modules_affected(
     &self,
     cache: &ChunkCreateData,
-    new_available_modules: BigUint,
+    new_available_modules: Arc<BigUint>,
   ) -> bool {
     if new_available_modules == cache.available_modules {
       return false;
@@ -629,7 +629,7 @@ impl CodeSplitter {
     // 0010
     // 0100
     // diff: 0110
-    let diff = &cache.available_modules ^ new_available_modules;
+    let diff = cache.available_modules.as_ref() ^ new_available_modules.as_ref();
 
     let cache_result = cache
       .cache_result
@@ -666,7 +666,7 @@ struct CacheResult {
 #[derive(Debug, Clone)]
 pub struct ChunkCreateData {
   // input
-  available_modules: BigUint,
+  available_modules: Arc<BigUint>,
   options: Option<GroupOptions>,
   runtime: RuntimeSpec,
   pub module: ModuleIdentifier,

--- a/crates/rspack_core/src/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/build_chunk_graph/mod.rs
@@ -21,6 +21,8 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
     Default::default()
   };
 
+  splitter.prepare(compilation)?;
+
   splitter.update_with_compilation(compilation)?;
 
   if !enable_incremental || splitter.chunk_group_infos.is_empty() {

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -54,6 +54,14 @@ pub struct ChunkGroup {
   pub(crate) is_over_size_limit: Option<bool>,
 }
 
+impl Default for ChunkGroup {
+  fn default() -> Self {
+    Self::new(ChunkGroupKind::Normal {
+      options: Default::default(),
+    })
+  }
+}
+
 impl ChunkGroup {
   pub fn new(kind: ChunkGroupKind) -> Self {
     Self {


### PR DESCRIPTION
## Summary

- Use Arc to prevent cloning of `BigUint` multiple times
- Parallelize preparing dependencies and outgoing connections of modules before calling `split()`

Before:
<img width="1268" height="268" alt="image" src="https://github.com/user-attachments/assets/e6a7b070-4b32-4e04-a25d-1ac3be8c00b7" />


After:
<img width="1268" height="290" alt="image" src="https://github.com/user-attachments/assets/5c8c7f5d-02c9-4351-96cb-f6790c9630a1" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
