### PR TITLE
fix: should return `resource` instead of `path` in resolve

### DIFF
--- a/crates/rspack_binding_api/src/resolver.rs
+++ b/crates/rspack_binding_api/src/resolver.rs
@@ -19,7 +19,6 @@ use crate::{
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveRequest {
-  pub resource: String,
   pub path: String,
   pub query: String,
   pub fragment: String,
@@ -29,11 +28,9 @@ pub struct ResolveRequest {
 
 impl From<rspack_core::Resource> for ResolveRequest {
   fn from(value: rspack_core::Resource) -> Self {
-    let resource = value.full_path();
     let (description_file_path, description_file_data) =
       value.description_data.map(|data| data.into_parts()).unzip();
     Self {
-      resource,
       path: value.path.to_string(),
       query: value.query,
       fragment: value.fragment,

--- a/crates/rspack_binding_api/src/resolver.rs
+++ b/crates/rspack_binding_api/src/resolver.rs
@@ -19,6 +19,7 @@ use crate::{
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveRequest {
+  pub resource: String,
   pub path: String,
   pub query: String,
   pub fragment: String,
@@ -28,9 +29,11 @@ pub struct ResolveRequest {
 
 impl From<rspack_core::Resource> for ResolveRequest {
   fn from(value: rspack_core::Resource) -> Self {
+    let resource = value.full_path();
     let (description_file_path, description_file_data) =
       value.description_data.map(|data| data.into_parts()).unzip();
     Self {
+      resource,
       path: value.path.to_string(),
       query: value.query,
       fragment: value.fragment,

--- a/packages/rspack-test-tools/tests/configCases/resolver/resolve/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolver/resolve/rspack.config.js
@@ -18,8 +18,25 @@ class Plugin {
 						(error, res, req) => {
 							expect(error).toBeNull();
 							expect(res).toBe(path.join(__dirname, "/index.js"));
-							expect(req.path).toBe(path.join(__dirname, "/index.js"));
-							callback();
+							expect(req.resource).toBe(path.join(__dirname, "/index.js"));
+
+							// With query
+							normalResolver.resolve(
+								{},
+								__dirname,
+								"./index.js?query",
+								{},
+								(error, res, req) => {
+									expect(error).toBeNull();
+									expect(res).toBe(path.join(__dirname, "/index.js?query"));
+									expect(req.resource).toBe(
+										path.join(__dirname, "/index.js?query")
+									);
+									expect(req.path).toBe(path.join(__dirname, "/index.js"));
+									expect(req.query).toBe("?query");
+									callback();
+								}
+							);
 						}
 					);
 				}

--- a/packages/rspack-test-tools/tests/configCases/resolver/with-fragment/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolver/with-fragment/rspack.config.js
@@ -10,17 +10,19 @@ class Plugin {
 				"PLUGIN",
 				(modules, callback) => {
 					const normalResolver = compiler.resolverFactory.get("normal");
+					// With fragment
 					normalResolver.resolve(
 						{},
 						__dirname,
-						"./index.js",
+						"./index.js#fragment",
 						{},
 						(error, res, req) => {
 							expect(error).toBeNull();
-							expect(res).toBe(path.join(__dirname, "/index.js"));
+							expect(res).toBe(path.join(__dirname, "/index.js#fragment"));
 							// Webpack does not have resource field
 							expect(req.resource).toBe(undefined);
 							expect(req.path).toBe(path.join(__dirname, "/index.js"));
+							expect(req.fragment).toBe("#fragment");
 							callback();
 						}
 					);

--- a/packages/rspack-test-tools/tests/configCases/resolver/with-query/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolver/with-query/rspack.config.js
@@ -10,17 +10,19 @@ class Plugin {
 				"PLUGIN",
 				(modules, callback) => {
 					const normalResolver = compiler.resolverFactory.get("normal");
+					// With query
 					normalResolver.resolve(
 						{},
 						__dirname,
-						"./index.js",
+						"./index.js?query",
 						{},
 						(error, res, req) => {
 							expect(error).toBeNull();
-							expect(res).toBe(path.join(__dirname, "/index.js"));
+							expect(res).toBe(path.join(__dirname, "/index.js?query"));
 							// Webpack does not have resource field
 							expect(req.resource).toBe(undefined);
 							expect(req.path).toBe(path.join(__dirname, "/index.js"));
+							expect(req.query).toBe("?query");
 							callback();
 						}
 					);

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -6064,8 +6064,6 @@ interface ResolveRequest {
     path: string;
     // (undocumented)
     query: string;
-    // (undocumented)
-    resource: string;
 }
 
 // @public (undocumented)

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -6064,6 +6064,8 @@ interface ResolveRequest {
     path: string;
     // (undocumented)
     query: string;
+    // (undocumented)
+    resource: string;
 }
 
 // @public (undocumented)

--- a/packages/rspack/src/Resolver.ts
+++ b/packages/rspack/src/Resolver.ts
@@ -31,6 +31,7 @@ type JsonObjectTypes = { [index: string]: JsonValueTypes } & {
 };
 
 export interface ResolveRequest {
+	resource: string;
 	path: string;
 	query: string;
 	fragment: string;
@@ -64,7 +65,7 @@ export class Resolver {
 				return;
 			}
 			const req = text ? (JSON.parse(text) as ResolveRequest) : undefined;
-			callback(error, req ? req.path : false, req);
+			callback(error, req ? req.resource : false, req);
 		});
 	}
 

--- a/packages/rspack/src/Resolver.ts
+++ b/packages/rspack/src/Resolver.ts
@@ -31,7 +31,6 @@ type JsonObjectTypes = { [index: string]: JsonValueTypes } & {
 };
 
 export interface ResolveRequest {
-	resource: string;
 	path: string;
 	query: string;
 	fragment: string;
@@ -65,7 +64,13 @@ export class Resolver {
 				return;
 			}
 			const req = text ? (JSON.parse(text) as ResolveRequest) : undefined;
-			callback(error, req ? req.resource : false, req);
+			callback(
+				error,
+				req
+					? `${req.path.replace(/#/g, "\u200b#")}${req.query.replace(/#/g, "\u200b#")}${req.fragment}`
+					: false,
+				req
+			);
 		});
 	}
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Return `resource` instead of `path` in `resolver.resolve`.

## Related links

<!-- Related issues or discussions. -->

close: #11191

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
