### PR TITLE
perf: improve calculate order index of code splitting

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -893,7 +893,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         continue;
       };
 
-      let mut visited = IdentifierIndexSet::default();
+      let mut visited = IdentifierSet::default();
 
       let mut ctx = (0, 0, Default::default());
       for root in roots {
@@ -968,16 +968,15 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     &mut self,
     module_identifier: ModuleIdentifier,
     runtime: &RuntimeSpec,
-    visited: &mut IdentifierIndexSet,
+    visited: &mut IdentifierSet,
     ctx: &mut (usize, usize, IndexMap<ModuleIdentifier, (usize, usize)>),
     compilation: &mut Compilation,
   ) {
-    let block_modules =
-      self.get_block_modules(module_identifier.into(), Some(runtime), compilation);
-    if visited.contains(&module_identifier) {
+    if !visited.insert(module_identifier) {
       return;
     }
-    visited.insert(module_identifier);
+    let block_modules =
+      self.get_block_modules(module_identifier.into(), Some(runtime), compilation);
 
     let indices = ctx.2.entry(module_identifier).or_default();
 


### PR DESCRIPTION
## Summary

- no need to use `IdentifierIndexSet`, use `IdentifierSet` instead
- no need to get module blocks if the module has been visited


Before:


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
