### PR TITLE
chore: upgrade rslint to v0.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "^5.8.3",
     "webpack": "5.99.9",
     "zx": "8.7.1",
-    "@rslint/core": "0.0.9"
+    "@rslint/core": "0.0.15"
   },
   "packageManager": "pnpm@10.10.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: 7.30.7
         version: 7.30.7(@types/node@20.19.9)
       '@rslint/core':
-        specifier: 0.0.9
-        version: 0.0.9
+        specifier: 0.0.15
+        version: 0.0.15
       '@rspack/cli':
         specifier: workspace:*
         version: link:packages/rspack-cli
@@ -581,10 +581,10 @@ importers:
         version: 4.17.21
       postcss-loader:
         specifier: ^8.1.1
-        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.5.6)(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17)))
+        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.5.4)(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17)))
       postcss-pxtorem:
         specifier: ^6.1.0
-        version: 6.1.0(postcss@8.5.6)
+        version: 6.1.0(postcss@8.5.4)
       raw-loader:
         specifier: ^4.0.2
         version: 4.0.2(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17)))
@@ -2665,9 +2665,39 @@ packages:
       typescript:
         optional: true
 
-  '@rslint/core@0.0.9':
-    resolution: {integrity: sha512-rhH24Bzotq/b+PPYI/jZsm77uKsAA+/uD/hqDd9UxwpwnqdPNG3IG4UbqN476Zem21WX+HV+fuHmYgwMys1oIw==}
+  '@rslint/core@0.0.15':
+    resolution: {integrity: sha512-U6NBznW5Ycy8Q9zzzdj+DZW+gXiZ7BLtYwzzYybgchn5xIV7JcKC/wVHmE64mXAq5AdcN9NYcLBK6mkb8bXHCQ==}
     hasBin: true
+
+  '@rslint/darwin-arm64@0.0.15':
+    resolution: {integrity: sha512-eBn9Fi52YHYyaTGwxN+CS+vX4K5CzoMRFeXCz/xplV67/k9s1QPtlWPJh9hK9Zu3/ijqMC7c5oE0/mhJn965ig==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rslint/darwin-x64@0.0.15':
+    resolution: {integrity: sha512-PxRu09Q3b3iyTLa47bMsixp5ms3KGRzRfjezeCx/LgWWBYXoNCJmUcDRpuDzAhVf3huxe1f2haVuYkkLYsTm/Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rslint/linux-arm64@0.0.15':
+    resolution: {integrity: sha512-GiEaFJInBvm6KPDZaXBmYbQ9qkbW6Yrwj8/5lMus77Rav1uHvrF/aCK6DV6vOW3aoLyyNPutGgHy9dwKsNJmjQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rslint/linux-x64@0.0.15':
+    resolution: {integrity: sha512-NuSrJpyXkT/n+tL/jBcfvAgr3NmasGkLQfky2eECP9f6xPbMiyEbrJuKzecX8XaRpY1R/prW1sx1YXUMx6OKlg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rslint/win32-arm64@0.0.15':
+    resolution: {integrity: sha512-N63m6/R0Auaqkf0HUtNmIFL37eEi/PtAP7JqXjTGOJv/2/ChRcYvh+L5T2bzhnh8swBnFD5gNV9GtfbnADPw2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rslint/win32-x64@0.0.15':
+    resolution: {integrity: sha512-+gvPNDo6UgcMyP6R0+S7HhDdrSIVyUH4UgVGhqzgsJHJ9W9ubLHFupo77IpuF0Ke79Ak8MMOXKyk+0Mx6ambsQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@rspack/binding-darwin-arm64@1.4.10':
     resolution: {integrity: sha512-PraYGuVSzvEwdoYC8T70qI/8j1QeUe2sysiWmjSdxUpxJsDfw35hK9TfxULeAJULlAUAiiXs03hdZk29DBc3ow==}
@@ -9859,7 +9889,32 @@ snapshots:
       '@microsoft/api-extractor': 7.52.9(@types/node@24.1.0)
       typescript: 5.8.3
 
-  '@rslint/core@0.0.9': {}
+  '@rslint/core@0.0.15':
+    optionalDependencies:
+      '@rslint/darwin-arm64': 0.0.15
+      '@rslint/darwin-x64': 0.0.15
+      '@rslint/linux-arm64': 0.0.15
+      '@rslint/linux-x64': 0.0.15
+      '@rslint/win32-arm64': 0.0.15
+      '@rslint/win32-x64': 0.0.15
+
+  '@rslint/darwin-arm64@0.0.15':
+    optional: true
+
+  '@rslint/darwin-x64@0.0.15':
+    optional: true
+
+  '@rslint/linux-arm64@0.0.15':
+    optional: true
+
+  '@rslint/linux-x64@0.0.15':
+    optional: true
+
+  '@rslint/win32-arm64@0.0.15':
+    optional: true
+
+  '@rslint/win32-x64@0.0.15':
+    optional: true
 
   '@rspack/binding-darwin-arm64@1.4.10':
     optional: true
@@ -14583,6 +14638,18 @@ snapshots:
       postcss: 8.5.6
       ts-node: 10.9.2(@swc/core@1.12.0(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3)
 
+  postcss-loader@8.1.1(@rspack/core@packages+rspack)(postcss@8.5.4)(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17))):
+    dependencies:
+      cosmiconfig: 9.0.0(typescript@5.8.3)
+      jiti: 1.21.7
+      postcss: 8.5.4
+      semver: 7.7.2
+    optionalDependencies:
+      '@rspack/core': link:packages/rspack
+      webpack: 5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - typescript
+
   postcss-loader@8.1.1(@rspack/core@packages+rspack)(postcss@8.5.6)(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.12.0(@swc/helpers@0.5.17))):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
@@ -14621,9 +14688,9 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-pxtorem@6.1.0(postcss@8.5.6):
+  postcss-pxtorem@6.1.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.4
 
   postcss-selector-parser@6.1.2:
     dependencies:


### PR DESCRIPTION
## Summary
upgrade rslint to 0.0.15 which supports optionalDependencies
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
