### PR TITLE
feat(parser): add new JavaScript parser options `importMagicComments`

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2144,6 +2144,11 @@ export interface RawJavascriptParserOptions {
    * @experimental
    */
   typeReexportsPresence?: string
+  /**
+   * This option is experimental in Rspack only and subject to change or be removed anytime.
+   * @experimental
+   */
+  importMagicComments?: boolean
 }
 
 export interface RawJsonGeneratorOptions {

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1421,6 +1421,7 @@ CompilerOptions {
                             inline_const: Some(
                                 false,
                             ),
+                            import_magic_comments: None,
                         },
                     ),
                 },

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -296,6 +296,9 @@ pub struct RawJavascriptParserOptions {
   /// This option is experimental in Rspack only and subject to change or be removed anytime.
   /// @experimental
   pub type_reexports_presence: Option<String>,
+  /// This option is experimental in Rspack only and subject to change or be removed anytime.
+  /// @experimental
+  pub import_magic_comments: Option<bool>,
 }
 
 impl From<RawJavascriptParserOptions> for JavascriptParserOptions {
@@ -340,6 +343,7 @@ impl From<RawJavascriptParserOptions> for JavascriptParserOptions {
       require_resolve: value.require_resolve,
       import_dynamic: value.import_dynamic,
       inline_const: value.inline_const,
+      import_magic_comments: value.import_magic_comments,
     }
   }
 }

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -282,6 +282,7 @@ pub struct JavascriptParserOptions {
   pub require_resolve: Option<bool>,
   pub import_dynamic: Option<bool>,
   pub inline_const: Option<bool>,
+  pub import_magic_comments: Option<bool>,
 }
 
 #[cacheable]

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -42,13 +42,21 @@ impl JavascriptParserPlugin for ImportParserPlugin {
       .get_order();
     let dynamic_import_fetch_priority = parser.javascript_options.dynamic_import_fetch_priority;
 
-    let magic_comment_options = try_extract_webpack_magic_comment(
-      parser.source_file,
-      &parser.comments,
-      node.span,
-      dyn_imported.span(),
-      &mut parser.warning_diagnostics,
-    );
+    let magic_comment_options = match parser
+      .javascript_options
+      .import_magic_comments
+      .unwrap_or(true)
+    {
+      true => try_extract_webpack_magic_comment(
+        parser.source_file,
+        &parser.comments,
+        node.span,
+        dyn_imported.span(),
+        &mut parser.warning_diagnostics,
+      ),
+      false => return None,
+    };
+
     if magic_comment_options
       .get_webpack_ignore()
       .unwrap_or_default()

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -42,19 +42,21 @@ impl JavascriptParserPlugin for ImportParserPlugin {
       .get_order();
     let dynamic_import_fetch_priority = parser.javascript_options.dynamic_import_fetch_priority;
 
-    let magic_comment_options = match parser
+    let magic_comment_options = if parser
       .javascript_options
       .import_magic_comments
       .unwrap_or(true)
     {
-      true => try_extract_webpack_magic_comment(
+      try_extract_webpack_magic_comment(
         parser.source_file,
         &parser.comments,
         node.span,
         dyn_imported.span(),
         &mut parser.warning_diagnostics,
-      ),
-      false => return None,
+      )
+    } else {
+      // TODO: need to add a field to store the original comments and render them in the template
+      Default::default()
     };
 
     if magic_comment_options

--- a/crates/rspack_plugin_javascript/src/webpack_comment.rs
+++ b/crates/rspack_plugin_javascript/src/webpack_comment.rs
@@ -28,7 +28,7 @@ pub enum WebpackComment {
   Exports,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct WebpackCommentMap(FxHashMap<WebpackComment, String>);
 
 impl WebpackCommentMap {

--- a/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
@@ -193,6 +193,7 @@ Object {
         dynamicImportPreload: false,
         exprContextCritical: true,
         importDynamic: true,
+        importMagicComments: true,
         importMeta: true,
         inlineConst: false,
         requireAsExpression: true,

--- a/packages/rspack-test-tools/tests/configCases/parsing/import-magic-comments/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/import-magic-comments/index.js
@@ -1,0 +1,7 @@
+export function foo(
+) {
+  import(
+    /* webpackChunkName: "my-chunk-name" */
+    'module'
+  );
+}

--- a/packages/rspack-test-tools/tests/configCases/parsing/import-magic-comments/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/import-magic-comments/rspack.config.js
@@ -1,0 +1,17 @@
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	entry: {
+		index: "./index.js",
+		test: "./test.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	module: {
+		parser: {
+			javascript: {
+				importMagicComments: false
+			}
+		}
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/parsing/import-magic-comments/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/import-magic-comments/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["test.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/parsing/import-magic-comments/test.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/import-magic-comments/test.js
@@ -1,0 +1,7 @@
+const fs = require("fs");
+const path  = require("path");
+
+it("magic comments should preserve as-is when `magicComments` is disabled", () => {
+  const code = fs.readFileSync(path.join(__dirname, "./index.js"), 'utf-8');
+  expect(code).toContain(`/* webpackChunkName: "my-chunk-name" */`);
+});

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3366,6 +3366,7 @@ export type JavascriptParserOptions = {
     importDynamic?: boolean;
     inlineConst?: boolean;
     typeReexportsPresence?: "no-tolerant" | "tolerant" | "tolerant-no-check";
+    importMagicComments?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -581,7 +581,8 @@ function getRawJavascriptParserOptions(
 		requireResolve: parser.requireResolve,
 		importDynamic: parser.importDynamic,
 		inlineConst: parser.inlineConst,
-		typeReexportsPresence: parser.typeReexportsPresence
+		typeReexportsPresence: parser.typeReexportsPresence,
+		importMagicComments: parser.importMagicComments
 	};
 }
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -306,6 +306,7 @@ const applyJavascriptParserOptionsDefaults = (
 	D(parserOptions, "importMeta", true);
 	D(parserOptions, "inlineConst", false);
 	D(parserOptions, "typeReexportsPresence", "no-tolerant");
+	D(parserOptions, "importMagicComments", true);
 };
 
 const applyJsonGeneratorOptionsDefaults = (

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1104,6 +1104,12 @@ export type JavascriptParserOptions = {
 
 	/** Whether to tolerant exportsPresence for type reexport */
 	typeReexportsPresence?: "no-tolerant" | "tolerant" | "tolerant-no-check";
+
+	/**
+	 * Enable or disable parsing magic comments in import() statements.
+	 * @default true
+	 */
+	importMagicComments?: boolean;
 };
 
 export type JsonParserOptions = {

--- a/packages/rspack/src/schema/config.ts
+++ b/packages/rspack/src/schema/config.ts
@@ -656,6 +656,7 @@ export const getRspackOptionsSchema = memoize(() => {
 		"tolerant",
 		"tolerant-no-check"
 	]);
+	const importMagicComments = z.boolean();
 
 	const javascriptParserOptions = z
 		.strictObject({
@@ -680,7 +681,8 @@ export const getRspackOptionsSchema = memoize(() => {
 			requireResolve: requireResolve,
 			importDynamic: importDynamic,
 			inlineConst: inlineConst,
-			typeReexportsPresence: typeReexportsPresence
+			typeReexportsPresence: typeReexportsPresence,
+			importMagicComments: importMagicComments
 			// #endregion
 		})
 		.partial() satisfies z.ZodType<t.JavascriptParserOptions>;


### PR DESCRIPTION
## Summary

When emitting library outputs, magic comments need to be preserved for upstream.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
