### PR TITLE
fix: should return full path in `resolver.resolveSync`

### DIFF
--- a/crates/rspack_binding_api/src/resolver.rs
+++ b/crates/rspack_binding_api/src/resolver.rs
@@ -67,9 +67,7 @@ impl JsResolver {
   pub fn resolve_sync(&self, path: String, request: String) -> napi::Result<Either<String, ()>> {
     block_on(async {
       match self.resolver.resolve(Path::new(&path), &request).await {
-        Ok(rspack_core::ResolveResult::Resource(resource)) => {
-          Ok(Either::A(resource.path.to_string()))
-        }
+        Ok(rspack_core::ResolveResult::Resource(resource)) => Ok(Either::A(resource.full_path())),
         Ok(rspack_core::ResolveResult::Ignored) => Ok(Either::B(())),
         Err(err) => Err(napi::Error::from_reason(format!("{err:?}"))),
       }

--- a/packages/rspack-test-tools/tests/configCases/resolver/resolve/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolver/resolve/rspack.config.js
@@ -16,6 +16,10 @@ class Plugin {
 						"./index.js",
 						{},
 						(error, res, req) => {
+							expect(
+								normalResolver.resolveSync({}, __dirname, "./index.js")
+							).toBe(res);
+
 							expect(error).toBeNull();
 							expect(res).toBe(path.join(__dirname, "/index.js"));
 							// Webpack does not have resource field

--- a/packages/rspack-test-tools/tests/configCases/resolver/with-fragment/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolver/with-fragment/rspack.config.js
@@ -17,6 +17,10 @@ class Plugin {
 						"./index.js#fragment",
 						{},
 						(error, res, req) => {
+							expect(
+								normalResolver.resolveSync({}, __dirname, "./index.js#fragment")
+							).toBe(res);
+
 							expect(error).toBeNull();
 							expect(res).toBe(path.join(__dirname, "/index.js#fragment"));
 							// Webpack does not have resource field

--- a/packages/rspack-test-tools/tests/configCases/resolver/with-query/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolver/with-query/rspack.config.js
@@ -17,6 +17,10 @@ class Plugin {
 						"./index.js?query",
 						{},
 						(error, res, req) => {
+							expect(
+								normalResolver.resolveSync({}, __dirname, "./index.js?query")
+							).toBe(res);
+
 							expect(error).toBeNull();
 							expect(res).toBe(path.join(__dirname, "/index.js?query"));
 							// Webpack does not have resource field


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Should return same result in `resolver.resolve` and `resolver.resolveSync`.

## Related links

<!-- Related issues or discussions. -->

Following up #11194

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
