### PR TITLE
fix: fix_issuers not clean cycled modules children

### DIFF
--- a/crates/rspack_core/src/compiler/make/cutout/fix_issuers.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/fix_issuers.rs
@@ -359,6 +359,7 @@ impl FixIssuers {
   }
 
   /// The 4th step of self.fix_artifact, clean cycled modules.
+  /// return the modules and their parents whose issuer has been removed.
   ///
   /// This function will traverse the `clean_modules` returned in previous step,
   /// recursively check whether the incoming_connections of all parent modules of the current module can be used as the issuer,
@@ -369,7 +370,7 @@ impl FixIssuers {
     artifact: &mut MakeArtifact,
     helper: &mut IssuerHelper,
     clean_modules: IdentifierMap<IdentifierSet>,
-  ) {
+  ) -> IdentifierMap<Vec<Option<ModuleIdentifier>>> {
     let mut revoke_module = IdentifierSet::default();
     let mut module_graph = artifact.get_module_graph_mut();
     for (mid, paths) in clean_modules {
@@ -435,31 +436,71 @@ impl FixIssuers {
       revoke_module.extend(useless_module);
     }
 
+    // calculate need_update_issuer_modules by revoke module
+    let mut need_update_issuer_modules = IdentifierMap::default();
+    for mid in &revoke_module {
+      for child_con in module_graph.get_outgoing_connections(mid) {
+        let child_mid = child_con.module_identifier();
+        if need_update_issuer_modules.contains_key(child_mid) {
+          continue;
+        }
+        if revoke_module.contains(child_mid) {
+          continue;
+        }
+        let child_mgm = module_graph
+          .module_graph_module_by_identifier(child_mid)
+          .expect("should mgm exist");
+        if matches!(child_mgm.issuer(), ModuleIssuer::Some(x) if x == mid) {
+          let child_module_parents = child_mgm
+            .incoming_connections()
+            .iter()
+            .filter_map(|dep_id| {
+              let origin_module_identifier = module_graph
+                .connection_by_dependency_id(dep_id)
+                .expect("should have connection")
+                .original_module_identifier;
+              if let Some(mid) = origin_module_identifier
+                && revoke_module.contains(&mid)
+              {
+                return None;
+              }
+              Some(origin_module_identifier)
+            })
+            .collect();
+          need_update_issuer_modules.insert(*child_mid, child_module_parents);
+        }
+      }
+    }
     for mid in revoke_module {
       artifact.revoke_module(&mid);
     }
+
+    need_update_issuer_modules
   }
 
   /// fix artifact module graph issuers
   pub fn fix_artifact(self, artifact: &mut MakeArtifact) {
-    let need_update_issuer_modules = self.apply_force_build_module_issuer(artifact);
-    if need_update_issuer_modules.is_empty() {
-      return;
-    }
+    let mut need_update_issuer_modules = self.apply_force_build_module_issuer(artifact);
 
-    let need_check_available_modules =
-      Self::try_set_first_incoming(artifact, need_update_issuer_modules);
-    if need_check_available_modules.is_empty() {
-      return;
-    }
+    loop {
+      if need_update_issuer_modules.is_empty() {
+        return;
+      }
+      let need_check_available_modules =
+        Self::try_set_first_incoming(artifact, need_update_issuer_modules);
+      if need_check_available_modules.is_empty() {
+        return;
+      }
 
-    let mut helper = IssuerHelper::default();
-    let need_clean_cycle_modules =
-      Self::set_available_issuer(artifact, &mut helper, need_check_available_modules);
-    if need_clean_cycle_modules.is_empty() {
-      return;
-    }
+      let mut helper = IssuerHelper::default();
+      let need_clean_cycle_modules =
+        Self::set_available_issuer(artifact, &mut helper, need_check_available_modules);
+      if need_clean_cycle_modules.is_empty() {
+        return;
+      }
 
-    Self::clean_cycle_module(artifact, &mut helper, need_clean_cycle_modules);
+      need_update_issuer_modules =
+        Self::clean_cycle_module(artifact, &mut helper, need_clean_cycle_modules);
+    }
   }
 }

--- a/crates/rspack_core/src/compiler/make/cutout/fix_issuers.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/fix_issuers.rs
@@ -157,8 +157,8 @@ impl FixIssuers {
     self.need_check_modules.insert(module_identifier);
   }
 
-  /// The 1st step of self.fix_artifact, apply `self.force_build_module_issuers` to module graph, and
-  /// return the modules and their parents whose issuer not in the incoming connections.
+  /// The 1st step of self.fix_artifact, apply `self.force_build_module_issuers` to module graph.
+  /// Returns the modules and their parents whose issuer not in the incoming connections.
   ///
   /// This function will traverse the `self.need_check_modules`
   /// 1. remove not exist module.
@@ -204,7 +204,7 @@ impl FixIssuers {
   }
 
   /// The 2nd step of self.fix_artifact, try to set first mgm.incoming_connection as issuer.
-  /// return the modules and their parents whose issuer has been set.
+  /// Returns the modules and their parents whose issuer has been set.
   ///
   /// This function will traverse the `need_update_issuer_modules` returned in previous step
   /// 1. if a module has no parent module, revoke the module and add its child modules
@@ -300,7 +300,7 @@ impl FixIssuers {
   }
 
   /// The 3rd step of self.fix_artifact, set available issuer from parents.
-  /// return the modules and their parents whose parents are cycled.
+  /// Returns the modules and their parents whose parents are cycled.
   ///
   /// This function will traverse the `need_check_available_modules` returned in previous step
   /// 1. call IssuerHelper.calc_issuer to get a issuer
@@ -359,7 +359,7 @@ impl FixIssuers {
   }
 
   /// The 4th step of self.fix_artifact, clean cycled modules.
-  /// return the modules and their parents whose issuer has been removed.
+  /// Returns the modules and their parents whose issuer has been removed.
   ///
   /// This function will traverse the `clean_modules` returned in previous step,
   /// recursively check whether the incoming_connections of all parent modules of the current module can be used as the issuer,

--- a/packages/rspack-test-tools/tests/hotCases/make/issue-10915/__snapshots__/web/0.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/make/issue-10915/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case issue-10915: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: bundle.js
+
+## Manifest
+
+
+## Update

--- a/packages/rspack-test-tools/tests/hotCases/make/issue-10915/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/make/issue-10915/__snapshots__/web/1.snap.txt
@@ -1,0 +1,57 @@
+# Case issue-10915: Step 1
+
+## Changed Files
+- file.js
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 63
+- Update: main.LAST_HASH.hot-update.js, size: 563
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":["./a.js","./b.js","./c.js","./d.js"]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./file.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["webpackHotUpdate"]("main", {
+"./file.js": 
+/*!*****************!*\
+  !*** ./file.js ***!
+  \*****************/
+(function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+});
+/* ESM default export */ const __WEBPACK_DEFAULT_EXPORT__ = ("file");
+
+
+}),
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/packages/rspack-test-tools/tests/hotCases/make/issue-10915/a.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/issue-10915/a.js
@@ -1,0 +1,5 @@
+import b from "./b";
+// self ref
+import "./a";
+
+export default "a" + b;

--- a/packages/rspack-test-tools/tests/hotCases/make/issue-10915/b.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/issue-10915/b.js
@@ -1,0 +1,3 @@
+import c from "./c";
+
+export default "b" + c;

--- a/packages/rspack-test-tools/tests/hotCases/make/issue-10915/c.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/issue-10915/c.js
@@ -1,0 +1,5 @@
+import d from "./d";
+// self ref
+import "./c";
+
+export default "c" + d;

--- a/packages/rspack-test-tools/tests/hotCases/make/issue-10915/d.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/issue-10915/d.js
@@ -1,0 +1,1 @@
+export default "d";

--- a/packages/rspack-test-tools/tests/hotCases/make/issue-10915/file.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/issue-10915/file.js
@@ -1,0 +1,5 @@
+import a from './a'
+
+export default "file-" + a;
+---
+export default "file";

--- a/packages/rspack-test-tools/tests/hotCases/make/issue-10915/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/issue-10915/index.js
@@ -1,0 +1,7 @@
+import value from "./file";
+
+it("should fix issue 10915", async () => {
+	expect(value).toBe("file-abcd");
+	await NEXT_HMR();
+	expect(value).toBe("file");
+});

--- a/packages/rspack-test-tools/tests/hotCases/make/issue-10915/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/issue-10915/rspack.config.js
@@ -1,0 +1,44 @@
+const plugin = {
+	name: "PLUGIN",
+	apply(compiler) {
+		let isFirst = true;
+		compiler.hooks.compilation.tap("PLUGIN", compilation => {
+			compilation.hooks.finishModules.tap("PLUGIN", modules => {
+				let hasModuleA = false;
+				let hasModuleB = false;
+				let hasModuleC = false;
+				let hasModuleD = false;
+				for (const m of modules) {
+					if (m.identifier().endsWith("a.js")) {
+						hasModuleA = true;
+					}
+					if (m.identifier().endsWith("b.js")) {
+						hasModuleB = true;
+					}
+					if (m.identifier().endsWith("c.js")) {
+						hasModuleC = true;
+					}
+					if (m.identifier().endsWith("d.js")) {
+						hasModuleD = true;
+					}
+				}
+				if (isFirst) {
+					isFirst = false;
+					expect(hasModuleA && hasModuleB && hasModuleC && hasModuleD).toBe(
+						true
+					);
+				} else {
+					expect(hasModuleA || hasModuleB || hasModuleC || hasModuleD).toBe(
+						false
+					);
+				}
+			});
+		});
+	}
+};
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	plugins: [plugin]
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
When fix_issuers cleans up cycled modules in step4, it will revoke many modules, and these modules may be issuer of other modules. lets look at a simple example for this problem:

<img width="2519" height="692" alt="image" src="https://github.com/user-attachments/assets/f4bef5f2-1c93-4add-91d5-8d7516f50d73" />

This PR will remove ModuleC to make the module graph work properly.


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
