### PR TITLE
fix: sri plugin should process async chunk in async entrypoints

### DIFF
--- a/crates/rspack_plugin_sri/src/asset.rs
+++ b/crates/rspack_plugin_sri/src/asset.rs
@@ -208,6 +208,7 @@ fn digest_chunks(compilation: &Compilation) -> Vec<HashSet<ChunkUkey>> {
       visited_chunk_groups.insert(chunk_group);
       if let Some(chunk_group) = compilation.chunk_group_by_ukey.get(chunk_group) {
         batch_chunk_groups.extend(chunk_group.children.iter());
+        batch_chunk_groups.extend(chunk_group.async_entrypoints_iterable());
         for chunk in chunk_group.chunks.iter() {
           if visited_chunks.contains(chunk) {
             continue;

--- a/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/index.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/index.js
@@ -1,0 +1,16 @@
+const worker = new Worker(new URL('./my-worker.worker.js', import.meta.url));
+
+let rx;
+const promise = new Promise(resolve => {
+	rx = resolve;
+})
+
+it('should compile success', async () => {
+	const res = await promise;
+
+	expect(res).toBe('ok')
+})
+
+worker.onmessage = (e) => {
+  rx(e.data)
+}

--- a/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/index.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/index.js
@@ -3,7 +3,7 @@ const worker = new Worker(new URL('./my-worker.worker.js', import.meta.url));
 let rx;
 const promise = new Promise(resolve => {
 	rx = resolve;
-})
+});
 
 it('should compile success', async () => {
 	const res = await promise;

--- a/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/my-worker.worker.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/my-worker.worker.js
@@ -1,0 +1,3 @@
+import('./dyn.js').then(() => {
+	postMessage("ok");
+});

--- a/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/rspack.config.js
@@ -1,0 +1,16 @@
+const rspack = require("@rspack/core");
+
+module.exports = {
+	mode: "production",
+	target: "web",
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		crossOriginLoading: "anonymous"
+	},
+	plugins: [
+		new rspack.HtmlRspackPlugin(),
+		new rspack.experiments.SubresourceIntegrityPlugin()
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/test.filter.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/test.filter.js
@@ -1,0 +1,5 @@
+var supportsWorker = require("../../../../dist/helper/legacy/supportsWorker");
+
+module.exports = function (config) {
+	return supportsWorker();
+};

--- a/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/worker.js
+++ b/packages/rspack-test-tools/tests/configCases/sri/async-entrypoints/worker.js
@@ -1,0 +1,1 @@
+self.postMessage('ok')


### PR DESCRIPTION
## Summary

close #11201
close #11082

<!-- Describe what this PR does and why. -->

SRI plugin should also process chunks under async entrypoints, eg: Worker or MF

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
