### PR TITLE
feat(binding-builder): use full path to `napi` bindgen preludes

### DIFF
--- a/crates/rspack_binding_builder_macros/src/register_plugin.rs
+++ b/crates/rspack_binding_builder_macros/src/register_plugin.rs
@@ -28,11 +28,11 @@ impl RegisterPluginInput {
 
     let expanded = quote! {
         #[napi]
-        fn #plugin_register_ident() -> napi::Result<()> {
+        pub fn #plugin_register_ident() -> napi::bindgen_prelude::Result<()> {
             fn register<'a>(
-                env: Env,
-                options: Unknown<'a>,
-            ) -> Result<rspack_core::BoxPlugin> {
+                env: napi::bindgen_prelude::Env,
+                options: napi::bindgen_prelude::Unknown<'a>,
+            ) -> napi::bindgen_prelude::Result<rspack_core::BoxPlugin> {
               (#plugin)(env, options)
             }
             let name = #name.to_string();


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Use `pub` and full path to `napi` bindgen preludes

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
