### PR TITLE
feat: preserve all comments if user use externalize dynamic import

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -66,6 +66,7 @@ pub struct ImportDependency {
   #[cacheable(with=AsOption<AsVec<AsPreset>>)]
   pub referenced_exports: Option<Vec<Atom>>,
   pub attributes: Option<ImportAttributes>,
+  pub comments: Vec<(bool, String)>,
   pub resource_identifier: String,
   pub factorize_info: FactorizeInfo,
   pub optional: bool,
@@ -78,6 +79,7 @@ impl ImportDependency {
     referenced_exports: Option<Vec<Atom>>,
     attributes: Option<ImportAttributes>,
     optional: bool,
+    comments: Vec<(bool, String)>,
   ) -> Self {
     let resource_identifier =
       create_resource_identifier_for_esm_dependency(request.as_str(), attributes.as_ref());
@@ -90,6 +92,7 @@ impl ImportDependency {
       resource_identifier,
       factorize_info: Default::default(),
       optional,
+      comments,
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -5,6 +5,7 @@ use rspack_core::{
   DynamicImportMode, GroupOptions, ImportAttributes, SharedSourceMap, SpanExt,
 };
 use rspack_error::miette::Severity;
+use rspack_util::swc::get_swc_comments;
 use swc_core::{
   common::Spanned,
   ecma::{ast::CallExpr, atoms::Atom},
@@ -121,12 +122,18 @@ impl JavascriptParserPlugin for ImportParserPlugin {
         parser.dependencies.push(Box::new(dep));
         return Some(true);
       }
+
       let dep = Box::new(ImportDependency::new(
         param.string().as_str().into(),
         node.span.into(),
         exports,
         attributes,
         parser.in_try,
+        get_swc_comments(
+          parser.comments,
+          dyn_imported.span().lo,
+          dyn_imported.span().hi,
+        ),
       ));
       let source_map: SharedSourceMap = parser.source_map.clone();
       let mut block = AsyncDependenciesBlock::new(

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -227,7 +227,7 @@ pub struct JavascriptParser<'parser> {
   pub source_map: Arc<SourceMap>,
   pub(crate) source_file: &'parser SourceFile,
   pub parse_meta: ParseMeta,
-  pub(crate) comments: Option<&'parser dyn Comments>,
+  pub comments: Option<&'parser dyn Comments>,
   pub build_meta: &'parser mut BuildMeta,
   pub build_info: &'parser mut BuildInfo,
   pub resource_data: &'parser ResourceData,

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -271,6 +271,7 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
                   external_module.external_type.clone(),
                   import_dependency.range.clone(),
                   import_dependency.get_attributes().cloned(),
+                  import_dependency.comments.clone(),
                 );
 
                 deps_to_replace.push(Box::new(new_dep));

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/index.js
@@ -12,7 +12,8 @@ it("modern-module-dynamic-import-runtime", () => {
 	expect(initialChunk).toContain('const reactNs = await import("react-alias")');
 	expect(initialChunk).toContain('const vueNs = await import("vue-alias")');
 	expect(initialChunk).toContain('const jqueryNs = await import("jquery-alias", { with: {"type":"url"} })');
-
+	expect(initialChunk).toContain(`const reactNs2 = await import(/* 123 */ // 456
+/*webpackChunkName: 'useless'*/ "react-alias")`)
 	expect(asyncChunk).toContain('const litNs = await import("lit-alias")');
 	expect(asyncChunk).toContain('const solidNs = await import("solid-alias")');
 

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/main.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/main.js
@@ -4,7 +4,11 @@ import { angular } from 'angular' // 'module' externalized
 export const main = async () => {
 	const dyn = await import('./dyn.js') // lazy dynamic import
 	const reactNs = await import('react') // 'module' + 'import' externalized
+  const reactNs2 = await import(/* 123 */
+		// 456
+		/*webpackChunkName: 'useless'*/
+		 'react') // 'import' externalized + comment
   const vueNs = await import('vue') // 'import' externalized
   const jqueryNs = await import('jquery', { with: { type: 'url' } }) // import attributes should be preserved
-	console.log(angular, react, reactNs, vueNs, dyn, jqueryNs)
+	console.log(angular, react, reactNs, vueNs, dyn, jqueryNs, reactNs2)
 }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Should preserve user's raw comments if dynamic imports are externalized

eg.

```js
import(/*comments should be preserved*/ './foo')
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
