### PR TITLE
perf: prepare module sizes for bundle splitting

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/common.rs
+++ b/crates/rspack_plugin_split_chunks/src/common.rs
@@ -5,6 +5,7 @@ use std::{
 
 use derive_more::Debug;
 use futures::future::BoxFuture;
+use rspack_collections::IdentifierMap;
 use rspack_core::{Chunk, Compilation, Module, SourceType};
 use rspack_error::Result;
 use rspack_regex::RspackRegex;
@@ -165,3 +166,5 @@ pub struct FallbackCacheGroup {
   pub max_initial_size: SplitChunkSizes,
   pub automatic_name_delimiter: String,
 }
+
+pub(crate) type ModuleSizes = IdentifierMap<FxHashMap<SourceType, f64>>;

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -1,10 +1,12 @@
-use std::ops::Deref;
-
 use rayon::prelude::*;
+use rspack_collections::IdentifierMap;
 use rspack_core::{Compilation, SourceType};
+use rustc_hash::FxHashMap;
 
 use super::ModuleGroupMap;
-use crate::{module_group::ModuleGroup, CacheGroup, SplitChunkSizes, SplitChunksPlugin};
+use crate::{
+  common::ModuleSizes, module_group::ModuleGroup, CacheGroup, SplitChunkSizes, SplitChunksPlugin,
+};
 
 impl SplitChunksPlugin {
   pub(crate) fn check_min_size_reduction(
@@ -34,9 +36,9 @@ impl SplitChunksPlugin {
   /// Return `true` if the `ModuleGroup` become empty.
   pub(crate) fn remove_min_size_violating_modules(
     module_group_key: &str,
-    compilation: &Compilation,
     module_group: &mut ModuleGroup,
     cache_group: &CacheGroup,
+    module_sizes: &ModuleSizes,
   ) -> bool {
     // Find out what `SourceType`'s size is not fit the min_size
     let violating_source_types: Box<[SourceType]> = module_group
@@ -65,20 +67,19 @@ impl SplitChunksPlugin {
     })
     .collect::<Box<[_]>>();
 
-    let module_graph = compilation.get_module_graph();
     // Remove modules having violating SourceType
     let violating_modules = module_group
       .modules
       .iter()
       .filter_map(|module_id| {
-        let module = module_graph
-          .module_by_identifier(module_id)
-          .expect("Should have a module");
+        let sizes = module_sizes
+          .get(module_id)
+          .expect("should have module size");
         let having_violating_source_type = violating_source_types
           .iter()
-          .any(|ty: &SourceType| module.source_types(&module_graph).contains(ty));
+          .any(|ty: &SourceType| sizes.contains_key(ty));
         if having_violating_source_type {
-          Some(module)
+          Some(*module_id)
         } else {
           None
         }
@@ -87,9 +88,9 @@ impl SplitChunksPlugin {
 
     // question: After removing violating modules, the size of other `SourceType`s of this `ModuleGroup`
     // may not fit again. But Webpack seems ignore this case. Not sure if it is on purpose.
-    violating_modules.into_iter().for_each(|violating_module| {
-      module_group.remove_module(violating_module.deref(), compilation)
-    });
+    violating_modules
+      .into_iter()
+      .for_each(|violating_module| module_group.remove_module(violating_module, module_sizes));
 
     module_group.modules.is_empty()
   }
@@ -98,8 +99,8 @@ impl SplitChunksPlugin {
   // #[tracing::instrument(skip_all)]
   pub(crate) fn ensure_min_size_fit(
     &self,
-    compilation: &Compilation,
     module_group_map: &mut ModuleGroupMap,
+    module_sizes: &ModuleSizes,
   ) {
     let invalidated_module_groups = module_group_map
       .par_iter_mut()
@@ -117,9 +118,9 @@ impl SplitChunksPlugin {
 
         if Self::remove_min_size_violating_modules(
           module_group_key,
-          compilation,
           module_group,
           cache_group,
+          module_sizes,
         ) || !Self::check_min_size_reduction(
           &module_group.sizes,
           &cache_group.min_size_reduction,
@@ -139,5 +140,22 @@ impl SplitChunksPlugin {
       );
       module_group_map.remove(&key);
     });
+  }
+
+  pub(crate) fn get_module_sizes(compilation: &Compilation) -> ModuleSizes {
+    let module_graph = compilation.get_module_graph();
+    module_graph
+      .modules()
+      .values()
+      .par_bridge()
+      .map(|module| {
+        let sizes = module
+          .source_types(&module_graph)
+          .iter()
+          .map(|ty| (*ty, module.size(Some(ty), Some(compilation))))
+          .collect::<FxHashMap<_, _>>();
+        (module.identifier(), sizes)
+      })
+      .collect::<IdentifierMap<_>>()
   }
 }

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -17,6 +17,7 @@ use rustc_hash::{FxHashMap, FxHasher};
 
 use super::ModuleGroupMap;
 use crate::{
+  common::ModuleSizes,
   module_group::{compare_entries, CacheGroupIdx, ModuleGroup},
   options::{
     cache_group::CacheGroup,
@@ -294,14 +295,15 @@ impl SplitChunksPlugin {
     let mut iter: std::collections::hash_map::Iter<String, ModuleGroup> = module_group_map.iter();
     let (key, mut best_module_group) = iter.next().expect("at least have one item");
 
-    let mut best_entry_key = key.clone();
+    let mut best_entry_key = key;
     for (key, each_module_group) in iter {
       if compare_entries(best_module_group, each_module_group) < 0f64 {
-        best_entry_key = key.clone();
+        best_entry_key = key;
         best_module_group = each_module_group;
       }
     }
 
+    let best_entry_key = best_entry_key.clone();
     let best_module_group = module_group_map
       .remove(&best_entry_key)
       .expect("This should never happen, please file an issue");
@@ -312,6 +314,7 @@ impl SplitChunksPlugin {
   pub(crate) async fn prepare_module_group_map(
     &self,
     compilation: &Compilation,
+    module_sizes: &ModuleSizes,
   ) -> Result<ModuleGroupMap> {
     let module_graph = compilation.get_module_graph();
 
@@ -337,8 +340,8 @@ impl SplitChunksPlugin {
 
     let module_group_results = rspack_futures::scope::<_, Result<_>>(|token| {
       modules.values().for_each(|module| {
-        let s = unsafe { token.used((&self, module, compilation, &module_group_map, &combinator)) };
-        s.spawn(|(plugin, module, compilation, module_group_map, combinator)| async move {
+        let s = unsafe { token.used((&self, module, compilation, &module_group_map, &combinator, &module_sizes)) };
+        s.spawn(|(plugin, module, compilation, module_group_map, combinator, module_sizes)| async move {
           let module = &***module;
           let belong_to_chunks = compilation
               .chunk_graph
@@ -454,7 +457,8 @@ impl SplitChunksPlugin {
                 },
                 module_group_map,
                 &mut chunk_key_to_string,
-                compilation
+                compilation,
+                module_sizes,
               ).await?;
             }
           }
@@ -480,9 +484,9 @@ impl SplitChunksPlugin {
     module_group_map: &mut ModuleGroupMap,
     used_chunks: &UkeySet<ChunkUkey>,
     compilation: &Compilation,
+    module_sizes: &ModuleSizes,
   ) {
     // remove all modules from other entries and update size
-    let module_graph = compilation.get_module_graph();
     let keys_of_invalid_group = module_group_map
       .iter_mut()
       .par_bridge()
@@ -498,10 +502,7 @@ impl SplitChunksPlugin {
         current_module_group.modules.iter().for_each(|module| {
           if other_module_group.modules.contains(module) {
             tracing::trace!("remove module({module}) from {key}");
-            let module = module_graph
-              .module_by_identifier(module)
-              .unwrap_or_else(|| panic!("Module({module}) not found"));
-            other_module_group.remove_module(&**module, compilation);
+            other_module_group.remove_module(*module, module_sizes);
           }
         });
 
@@ -540,7 +541,7 @@ impl SplitChunksPlugin {
         }
 
         // Validate `min_size` again
-        if Self::remove_min_size_violating_modules(key, compilation, other_module_group, cache_group)
+        if Self::remove_min_size_violating_modules(key, other_module_group, cache_group, module_sizes)
           || !Self::check_min_size_reduction(&other_module_group.sizes, &cache_group.min_size_reduction, other_module_group.chunks.len()) {
           tracing::trace!(
             "{key} is deleted for violating min_size {:#?}",
@@ -624,6 +625,7 @@ async fn merge_matched_item_into_module_group_map(
   module_group_map: &DashMap<String, ModuleGroup>,
   chunk_key_to_string: &mut HashMap<ChunksKey, String, ChunksKeyHashBuilder>,
   compilation: &Compilation,
+  module_sizes: &ModuleSizes,
 ) -> Result<()> {
   let MatchedItem {
     idx,
@@ -675,7 +677,7 @@ async fn merge_matched_item_into_module_group_map(
       .or_insert_with(|| ModuleGroup::new(idx, chunk_name, cache_group_index, cache_group))
   };
 
-  module_group.add_module(module, compilation);
+  module_group.add_module(module.identifier(), module_sizes);
   module_group
     .chunks
     .extend(selected_chunks.iter().map(|c| c.ukey()));


### PR DESCRIPTION
## Summary

Prepare module sizes for bundle splitting to prevent calling `module_by_identifier` too many times

Before:
<img width="1224" height="284" alt="image" src="https://github.com/user-attachments/assets/8e8d9dfa-0d22-4b99-83ac-0f784c41aa87" />

After:
<img width="1228" height="276" alt="image" src="https://github.com/user-attachments/assets/df2c4d8c-d227-4e75-932d-47aae6151e35" />

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
