### PR TITLE
fix: do not use user_request to match external module

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/bar.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/bar.js
@@ -1,0 +1,6 @@
+import { useless } from '../modern-module-reexport-star/value'
+
+(function() {
+	// side effect access
+	console.bind(useless)
+})()

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/foo.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/foo.js
@@ -1,0 +1,1 @@
+export * from './value'

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/rspack.config.js
@@ -1,0 +1,53 @@
+const path = require("path");
+
+/**@type {import('@rspack/core').Configuration} */
+const config = {
+	experiments: {
+		outputModule: true
+	},
+	context: __dirname,
+	mode: "development",
+	output: {
+		library: {
+			type: "modern-module"
+		},
+		filename: "[name].js"
+	},
+	entry: {
+		foo: "./foo.js",
+		bar: "./bar.js"
+	},
+	externalsType: "module",
+	externals: function ({ request }) {
+		if (request.includes("value")) {
+			// make '../modern-module-reexport-star/value' and './value'
+			// the same request
+			return path.resolve(__dirname, "./value.js");
+		}
+	},
+	optimization: {
+		concatenateModules: false,
+		avoidEntryIife: true,
+		concatenateModules: true,
+		minimize: false
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("MyPlugin", compilation => {
+					compilation.hooks.processAssets.tap("MyPlugin", assets => {
+						let list = Object.keys(assets);
+						const js = list.find(item => item.includes("foo.js"));
+						const jsContent = assets[js].source().toString();
+						expect(
+							// should make sure no default property access for default ExportsType
+							jsContent
+						).toContain("export * from");
+					});
+				});
+			}
+		}
+	]
+};
+
+module.exports = config;

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/rspack.config.js
@@ -26,7 +26,6 @@ const config = {
 		}
 	},
 	optimization: {
-		concatenateModules: false,
 		avoidEntryIife: true,
 		concatenateModules: true,
 		minimize: false

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-reexport-star/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return [];
+	}
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
fix #8557

use user_request to test if external module comes from a reexport dependency isn't necessary, and user_request is unstable if 2 external dependency has the same external config



## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
