### PR TITLE
ci(bench): run codspeed bench as soon as build finishes

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -66,7 +66,7 @@ jobs:
   bench:
     uses: ./.github/workflows/reusable-build-bench.yml
     if: inputs.bench
-    needs: [build, codspeed]
+    needs: codspeed
     with:
       target: ${{ inputs.target }}
       runner: ${{ inputs.runner }}


### PR DESCRIPTION
## Summary

run codspeed bench as soon as build finishes

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
