### PR TITLE
fix: don't test `JAVASCRIPT_ASSET_REGEXP` if `test` is provided

### DIFF
--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -179,10 +179,6 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     .par_iter_mut()
     .filter(|(filename, original)| {
       // propagate span in rayon to keep parent relation
-      if !JAVASCRIPT_ASSET_REGEXP.is_match(filename) {
-        return false
-      }
-
       let is_matched = match_object(options, filename);
 
       if !is_matched || original.get_info().minimized.unwrap_or(false) {
@@ -378,6 +374,8 @@ pub fn match_object(obj: &PluginOptions, str: &str) -> bool {
     if !condition.try_match(str) {
       return false;
     }
+  } else if !JAVASCRIPT_ASSET_REGEXP.is_match(str) {
+    return false;
   }
   if let Some(condition) = &obj.include {
     if !condition.try_match(str) {
@@ -389,6 +387,7 @@ pub fn match_object(obj: &PluginOptions, str: &str) -> bool {
       return false;
     }
   }
+
   true
 }
 

--- a/website/docs/en/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
@@ -35,7 +35,7 @@ When `optimization.minimizer` is set, the default minimizers are disabled, so we
 ### test
 
 - **Type:** `string | RegExp | Array<string | RegExp>`
-- **Default:** `undefined`
+- **Default:** `\.[cm]?js(\?.*)?$`
 
 Specify the files to be minimized. You can use regular expressions or file path strings, and only the files that match will be minimized.
 

--- a/website/docs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
@@ -35,7 +35,7 @@ export default {
 ### test
 
 - **类型：** `string | RegExp | Array<string | RegExp>`
-- **默认值：** `undefined`
+- **默认值：** `\.[cm]?js(\?.*)?$`
 
 指定需要被压缩的产物文件。可以使用正则表达式或者文件路径字符串，只有匹配的文件会被压缩。
 


### PR DESCRIPTION
## Summary

Currently we test the JAVASCRIPT_ASSET_REGEXP whether the `test` is provided or not.
 
In this pr, we only test the JAVASCRIPT_ASSET_REGEXP when the `test` is not provided, which is equivalent that `test` has a same default value as [terser-webpack-plugin](https://www.npmjs.com/package/terser-webpack-plugin#test). So I also update the docs.

## Related links

fixes https://github.com/web-infra-dev/rspack/issues/11183

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
