### PR TITLE
perf: improve bundle splitting part 2

### DIFF
--- a/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use napi::{bindgen_prelude::Either3, JsString};
+use napi::{JsString, bindgen_prelude::Either3};
 use rspack_napi::{string::JsStringExt, threadsafe_function::ThreadsafeFunction};
 use rspack_regex::RspackRegex;
 

--- a/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use napi::{JsString, bindgen_prelude::Either3};
-use rspack_collections::DatabaseItem;
+use napi::{bindgen_prelude::Either3, JsString};
 use rspack_napi::{string::JsStringExt, threadsafe_function::ThreadsafeFunction};
 use rspack_regex::RspackRegex;
 
@@ -16,9 +15,9 @@ pub fn create_chunks_filter(raw: Chunks) -> rspack_plugin_split_chunks::ChunkFil
       let js_str = js_str.into_string();
       rspack_plugin_split_chunks::create_chunk_filter_from_str(&js_str)
     }
-    Either3::C(f) => Arc::new(move |chunk, compilation| {
+    Either3::C(f) => Arc::new(move |chunk_ukey, compilation| {
       let f = f.clone();
-      let chunk_wrapper = ChunkWrapper::new(chunk.ukey(), compilation);
+      let chunk_wrapper = ChunkWrapper::new(*chunk_ukey, compilation);
       Box::pin(async move { f.call_with_sync(chunk_wrapper).await })
     }),
   }

--- a/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_name.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_name.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use napi::bindgen_prelude::Either3;
 use napi_derive::napi;
-use rspack_collections::DatabaseItem;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_split_chunks::{ChunkNameGetter, ChunkNameGetterFnCtx};
 
@@ -32,7 +31,7 @@ impl<'a> From<ChunkNameGetterFnCtx<'a>> for JsChunkOptionNameCtx {
       chunks: value
         .chunks
         .iter()
-        .map(|chunk| ChunkWrapper::new(chunk.ukey(), value.compilation))
+        .map(|chunk| ChunkWrapper::new(*chunk, value.compilation))
         .collect(),
       cache_group_key: value.cache_group_key.to_string(),
     }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -127,6 +127,16 @@ impl ChunkGraph {
     chunk_graph_chunk.modules.contains(module_identifier)
   }
 
+  pub fn is_any_module_in_chunk(
+    &self,
+    mut module_identifiers: impl Iterator<Item = &ModuleIdentifier>,
+    chunk_ukey: ChunkUkey,
+  ) -> bool {
+    let chunk_graph_chunk = self.expect_chunk_graph_chunk(&chunk_ukey);
+    module_identifiers
+      .any(|module_identifier| chunk_graph_chunk.modules.contains(module_identifier))
+  }
+
   pub(crate) fn expect_chunk_graph_module_mut(
     &mut self,
     module_identifier: ModuleIdentifier,

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -1,6 +1,7 @@
 use derive_more::Debug;
 use rspack_collections::{IdentifierSet, UkeySet};
-use rspack_core::{ChunkUkey, ModuleIdentifier};
+use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
+use rustc_hash::FxHashMap;
 
 use crate::{
   CacheGroup,
@@ -28,6 +29,7 @@ pub(crate) struct ModuleGroup {
   /// A module
   pub chunk_name: Option<String>,
   pub sizes: SplitChunkSizes,
+  pub source_types_modules: FxHashMap<SourceType, IdentifierSet>,
   /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[debug(skip)]
   pub chunks: UkeySet<ChunkUkey>,
@@ -47,34 +49,68 @@ impl ModuleGroup {
       cache_group_priority: cache_group.priority,
       cache_group_reuse_existing_chunk: cache_group.reuse_existing_chunk,
       sizes: Default::default(),
+      source_types_modules: Default::default(),
       chunks: Default::default(),
       chunk_name,
     }
   }
 
-  pub fn add_module(&mut self, module: ModuleIdentifier, module_sizes: &ModuleSizes) {
-    let old_len = self.modules.len();
-    self.modules.insert(module);
+  pub fn get_source_types_modules(
+    &self,
+    ty: &[SourceType],
+    module_sizes: &ModuleSizes,
+  ) -> IdentifierSet {
+    // if there is only one source type, we can just use the `source_types_modules` directly
+    // instead of iterating over all modules
+    if ty.len() == 1 {
+      self
+        .source_types_modules
+        .get(ty.first().expect("should have at least one source type"))
+        .cloned()
+        .unwrap_or_default()
+    } else {
+      self
+        .modules
+        .iter()
+        .filter_map(|module| {
+          let sizes = module_sizes.get(module).expect("should have module size");
+          if ty.iter().any(|ty| sizes.contains_key(ty)) {
+            Some(*module)
+          } else {
+            None
+          }
+        })
+        .collect()
+    }
+  }
 
-    if self.modules.len() != old_len {
+  pub fn add_module(&mut self, module: ModuleIdentifier, module_sizes: &ModuleSizes) {
+    if self.modules.insert(module) {
       let module_sizes = module_sizes.get(&module).expect("should have module size");
       for (ty, s) in module_sizes.iter() {
         let size = self.sizes.entry(*ty).or_default();
         *size += s;
+        self
+          .source_types_modules
+          .entry(*ty)
+          .or_default()
+          .insert(module);
       }
     }
   }
 
   pub fn remove_module(&mut self, module: ModuleIdentifier, module_sizes: &ModuleSizes) {
-    let old_len = self.modules.len();
-    self.modules.remove(&module);
-
-    if self.modules.len() != old_len {
+    if self.modules.remove(&module) {
       let module_sizes = module_sizes.get(&module).expect("should have module size");
       for (ty, s) in module_sizes.iter() {
         let size = self.sizes.entry(*ty).or_default();
         *size -= s;
         *size = size.max(0.0);
+        self
+          .source_types_modules
+          .entry(*ty)
+          .or_default()
+          .remove(&module);
       }
     }
   }

--- a/crates/rspack_plugin_split_chunks/src/options/chunk_name.rs
+++ b/crates/rspack_plugin_split_chunks/src/options/chunk_name.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use rspack_core::{Chunk, Compilation, Module};
+use rspack_core::{ChunkUkey, Compilation, Module};
 use rspack_error::Result;
 
 pub struct ChunkNameGetterFnCtx<'a> {
   pub module: &'a dyn Module,
   pub compilation: &'a Compilation,
-  pub chunks: &'a Vec<&'a Chunk>,
+  pub chunks: &'a Vec<ChunkUkey>,
   pub cache_group_key: &'a str,
 }
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -515,7 +515,7 @@ impl SplitChunksPlugin {
             );
 
             if max_size_setting.is_none()
-              && !(fallback_cache_group.chunks_filter)(chunk, compilation).await?
+              && !(fallback_cache_group.chunks_filter)(&chunk.ukey(), compilation).await?
             {
               tracing::debug!("Chunk({:?}) skips `maxSize` checking. Reason: max_size_setting.is_none() and chunks_filter is false", chunk.chunk_reason());
               return Ok(None);

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -46,10 +46,17 @@ impl SplitChunksPlugin {
     let logger = compilation.get_logger(self.name());
     let start = logger.time("prepare module group map");
 
-    let module_sizes = Self::get_module_sizes(compilation);
+    let all_modules = compilation
+      .get_module_graph()
+      .modules()
+      .keys()
+      .copied()
+      .collect::<Vec<_>>();
+
+    let module_sizes = Self::get_module_sizes(&all_modules, compilation);
 
     let mut module_group_map = self
-      .prepare_module_group_map(compilation, &module_sizes)
+      .prepare_module_group_map(&all_modules, compilation, &module_sizes)
       .await?;
     tracing::trace!("prepared module_group_map {:#?}", module_group_map);
     logger.time_end(start);

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -6,14 +6,15 @@ use std::{
 use dashmap::{DashMap, mapref::entry::Entry};
 use futures::future::join_all;
 use rayon::prelude::*;
-use rspack_collections::{DatabaseItem, IdentifierMap, UkeyMap, UkeySet};
+use rspack_collections::{IdentifierMap, UkeyIndexMap, UkeySet};
 use rspack_core::{
-  Chunk, ChunkByUkey, ChunkGraph, ChunkUkey, Compilation, Module, ModuleGraph, ModuleIdentifier,
+  ChunkByUkey, ChunkGraph, ChunkUkey, Compilation, Module, ModuleGraph, ModuleIdentifier,
   PrefetchExportsInfoMode, UsageKey,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_util::fx_hash::FxDashMap;
+use rspack_util::{fx_hash::FxDashMap, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::{FxHashMap, FxHasher};
+use tracing::instrument;
 
 use super::ModuleGroupMap;
 use crate::{
@@ -36,7 +37,7 @@ struct MatchedItem<'a> {
   module: &'a dyn Module,
   cache_group_index: usize,
   cache_group: &'a CacheGroup,
-  selected_chunks: Vec<&'a Chunk>,
+  selected_chunks: Vec<ChunkUkey>,
   selected_chunks_key: ChunksKey,
 }
 
@@ -76,7 +77,7 @@ fn get_key<I: Iterator<Item = ChunkUkey>>(chunks: I) -> ChunksKey {
 
 type ChunkSetsInGraph<'a> = (
   &'a FxHashMap<ChunksKey, UkeySet<ChunkUkey>>,
-  &'a UkeyMap<u32, Vec<UkeySet<ChunkUkey>>>,
+  &'a UkeyIndexMap<u32, Vec<UkeySet<ChunkUkey>>>,
 );
 
 #[derive(Default)]
@@ -85,10 +86,10 @@ struct Combinator {
   used_exports_combinations_cache: FxDashMap<ChunksKey, Vec<UkeySet<ChunkUkey>>>,
 
   chunk_sets_in_graph: FxHashMap<ChunksKey, UkeySet<ChunkUkey>>,
-  chunk_sets_by_count: UkeyMap<u32, Vec<UkeySet<ChunkUkey>>>,
+  chunk_sets_by_count: UkeyIndexMap<u32, Vec<UkeySet<ChunkUkey>>>,
 
   used_exports_chunk_sets_in_graph: FxHashMap<ChunksKey, UkeySet<ChunkUkey>>,
-  used_exports_chunk_sets_by_count: UkeyMap<u32, Vec<UkeySet<ChunkUkey>>>,
+  used_exports_chunk_sets_by_count: UkeyIndexMap<u32, Vec<UkeySet<ChunkUkey>>>,
 
   grouped_by_exports: IdentifierMap<Vec<UkeySet<ChunkUkey>>>,
 }
@@ -121,7 +122,7 @@ impl Combinator {
     chunks_key: ChunksKey,
     combinations_cache: &FxDashMap<ChunksKey, Vec<UkeySet<ChunkUkey>>>,
     chunk_sets_in_graph: &FxHashMap<ChunksKey, UkeySet<ChunkUkey>>,
-    chunk_sets_by_count: &UkeyMap<u32, Vec<UkeySet<ChunkUkey>>>,
+    chunk_sets_by_count: &UkeyIndexMap<u32, Vec<UkeySet<ChunkUkey>>>,
   ) -> Vec<UkeySet<ChunkUkey>> {
     match combinations_cache.entry(chunks_key) {
       Entry::Occupied(entry) => entry.get().clone(),
@@ -139,6 +140,8 @@ impl Combinator {
                 result.push(set.clone());
               }
             }
+          } else {
+            break;
           }
         }
 
@@ -189,31 +192,32 @@ impl Combinator {
 
   fn prepare_group_by_chunks(
     &mut self,
-    module_graph: &ModuleGraph,
+    all_modules: &[ModuleIdentifier],
     chunk_graph: &ChunkGraph,
-  ) -> ChunkSetsInGraph<'_> {
-    let chunk_sets_in_graph = &mut self.chunk_sets_in_graph;
-    let chunk_sets_by_count = &mut self.chunk_sets_by_count;
+  ) {
+    self.chunk_sets_in_graph = all_modules
+      .par_iter()
+      .filter_map(|module| {
+        let chunks = chunk_graph.get_module_chunks(*module);
+        if chunks.is_empty() {
+          return None;
+        }
+        let chunk_key = get_key(chunks.iter().copied());
+        Some((chunk_key, chunks.clone()))
+      })
+      .collect::<FxHashMap<_, _>>();
 
-    for module in module_graph.modules().keys() {
-      let chunks = chunk_graph.get_module_chunks(*module);
-      if chunks.is_empty() {
-        continue;
-      }
-      let chunk_key = get_key(chunks.iter().copied());
-      chunk_sets_in_graph.insert(chunk_key, chunks.clone());
-    }
-
-    for chunks in chunk_sets_in_graph.values() {
+    for chunks in self.chunk_sets_in_graph.values() {
       let count = chunks.len();
 
-      chunk_sets_by_count
+      self
+        .chunk_sets_by_count
         .entry(count as u32)
         .and_modify(|set| set.push(chunks.clone()))
         .or_insert(vec![chunks.clone()]);
     }
 
-    (&self.chunk_sets_in_graph, &self.chunk_sets_by_count)
+    self.chunk_sets_by_count.sort_keys();
   }
 
   fn group_by_chunks(&self) -> ChunkSetsInGraph<'_> {
@@ -222,58 +226,53 @@ impl Combinator {
 
   fn prepare_group_by_used_exports(
     &mut self,
+    all_modules: &[ModuleIdentifier],
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     chunk_by_ukey: &ChunkByUkey,
-  ) -> ChunkSetsInGraph<'_> {
-    let grouped_by_exports = &mut self.grouped_by_exports;
-    let used_exports_chunk_sets_in_graph = &mut self.used_exports_chunk_sets_in_graph;
-    let used_exports_chunk_sets_by_count = &mut self.used_exports_chunk_sets_by_count;
-
-    let modules = module_graph.modules().keys().copied().collect::<Vec<_>>();
-
-    let mut module_grouped_chunks = modules
+  ) {
+    let (module_grouped_chunks, used_exports_chunks): (Vec<_>, Vec<_>) = all_modules
       .par_iter()
-      .map(|module| {
-        (
-          *module,
-          Self::group_chunks_by_exports(
-            module,
-            chunk_graph.get_module_chunks(*module).iter().cloned(),
-            module_graph,
-            chunk_by_ukey,
-          ),
-        )
+      .filter_map(|module| {
+        let grouped_chunks = Self::group_chunks_by_exports(
+          module,
+          chunk_graph.get_module_chunks(*module).iter().cloned(),
+          module_graph,
+          chunk_by_ukey,
+        );
+        let mut used_exports_chunks = FxHashMap::default();
+        for chunks in &grouped_chunks {
+          if chunks.is_empty() {
+            continue;
+          }
+          let chunk_key = get_key(chunks.iter().copied());
+          used_exports_chunks.insert(chunk_key, chunks.clone());
+        }
+        Some(((*module, grouped_chunks), used_exports_chunks))
       })
-      .collect::<IdentifierMap<_>>();
+      .unzip();
 
-    for module in modules {
-      let grouped_chunks = module_grouped_chunks
-        .remove(&module)
-        .expect("should have grouped chunks");
-      for chunks in &grouped_chunks {
-        if chunks.is_empty() {
+    self.grouped_by_exports = module_grouped_chunks.into_iter().collect();
+
+    for used_exports_chunks in used_exports_chunks {
+      for (chunk_key, chunks) in used_exports_chunks {
+        if self
+          .used_exports_chunk_sets_in_graph
+          .insert(chunk_key, chunks.clone())
+          .is_some()
+        {
           continue;
         }
-        let chunk_key = get_key(chunks.iter().copied());
-        used_exports_chunk_sets_in_graph.insert(chunk_key, chunks.clone());
+        let count = chunks.len();
+        self
+          .used_exports_chunk_sets_by_count
+          .entry(count as u32)
+          .or_default()
+          .push(chunks);
       }
-
-      grouped_by_exports.insert(module, grouped_chunks);
     }
 
-    for chunks in used_exports_chunk_sets_in_graph.values() {
-      let count = chunks.len();
-      used_exports_chunk_sets_by_count
-        .entry(count as u32)
-        .and_modify(|set| set.push(chunks.clone()))
-        .or_insert(vec![chunks.clone()]);
-    }
-
-    (
-      used_exports_chunk_sets_in_graph,
-      used_exports_chunk_sets_by_count,
-    )
+    self.used_exports_chunk_sets_by_count.sort_keys();
   }
 
   fn group_by_used_exports(&self) -> ChunkSetsInGraph<'_> {
@@ -310,9 +309,10 @@ impl SplitChunksPlugin {
     (best_entry_key, best_module_group)
   }
 
-  // #[tracing::instrument(skip_all)]
+  #[instrument(name = "Compilation:SplitChunks:prepare_module_group_map",target=TRACING_BENCH_TARGET, skip_all)]
   pub(crate) async fn prepare_module_group_map(
     &self,
+    all_modules: &[ModuleIdentifier],
     compilation: &Compilation,
     module_sizes: &ModuleSizes,
   ) -> Result<ModuleGroupMap> {
@@ -322,7 +322,7 @@ impl SplitChunksPlugin {
 
     let mut combinator = Combinator::default();
 
-    combinator.prepare_group_by_chunks(&module_graph, &compilation.chunk_graph);
+    combinator.prepare_group_by_chunks(all_modules, &compilation.chunk_graph);
 
     if self
       .cache_groups
@@ -330,19 +330,18 @@ impl SplitChunksPlugin {
       .any(|cache_group| cache_group.used_exports)
     {
       combinator.prepare_group_by_used_exports(
+        all_modules,
         &module_graph,
         &compilation.chunk_graph,
         &compilation.chunk_by_ukey,
       );
     }
 
-    let modules = module_graph.modules();
-
     let module_group_results = rspack_futures::scope::<_, Result<_>>(|token| {
-      modules.values().for_each(|module| {
-        let s = unsafe { token.used((&self, module, compilation, &module_group_map, &combinator, &module_sizes)) };
-        s.spawn(|(plugin, module, compilation, module_group_map, combinator, module_sizes)| async move {
-          let module = &***module;
+      all_modules.iter().for_each(|module| {
+        let s = unsafe { token.used((&self, module, &module_graph, compilation, &module_group_map, &combinator, &module_sizes)) };
+        s.spawn(|(plugin, module, module_graph, compilation, module_group_map, combinator, module_sizes)| async move {
+          let module = module_graph.module_by_identifier(module).expect("should have module").as_ref();
           let belong_to_chunks = compilation
               .chunk_graph
               .get_module_chunks(module.identifier());
@@ -355,8 +354,15 @@ impl SplitChunksPlugin {
 
           for idx in 0..plugin.cache_groups.len() {
             let cache_group = &plugin.cache_groups[idx];
+
+            let mut is_match = true;
+            // Filter by `splitChunks.cacheGroups.{cacheGroup}.type`
+            is_match &= (cache_group.r#type)(module);
+            // Filter by `splitChunks.cacheGroups.{cacheGroup}.layer`
+            is_match &= (cache_group.layer)(module.get_layer().map(ToString::to_string)).await?;
+
             // Filter by `splitChunks.cacheGroups.{cacheGroup}.test`
-            let is_match_the_test = match &cache_group.test {
+            is_match &= match &cache_group.test {
               CacheGroupTest::String(str) => module
                 .name_for_condition().is_some_and(|name| name.starts_with(str)),
               CacheGroupTest::RegExp(regexp) => module
@@ -367,19 +373,6 @@ impl SplitChunksPlugin {
               }
               CacheGroupTest::Enabled => true,
             };
-            let is_match_the_type: bool = (cache_group.r#type)(module);
-            let is_match_the_layer = (cache_group.layer)(module.get_layer().map(ToString::to_string)).await?;
-            let is_match = is_match_the_test && is_match_the_type && is_match_the_layer;
-            if !is_match {
-              tracing::trace!(
-                "Module({:?}) is ignored by CacheGroup({:?}). Reason: !(is_match_the_test({:?}) && is_match_the_type({:?}) && is_match_the_layer({:?}))",
-                module.identifier(),
-                cache_group.key,
-                is_match_the_test,
-                is_match_the_type,
-                is_match_the_layer
-              );
-            }
 
             temp.push(is_match);
           }
@@ -417,19 +410,18 @@ impl SplitChunksPlugin {
 
               let selected_chunks = join_all(chunk_combination.iter().map(|c|
                 async move {
-                  let c = compilation.chunk_by_ukey.expect_get(c);
                   // Filter by `splitChunks.cacheGroups.{cacheGroup}.chunks`
                   (cache_group.chunk_filter)(c, compilation).await.map(|filtered|  (c, filtered))
                 }
               )).await.into_iter().collect::<Result<Vec<_>>>()?.into_iter().filter_map(
-                    |(chunk, filtered)| {
-                      if filtered {
-                        Some(chunk)
-                      } else {
-                        None
-                      }
-                    }
-                  ).collect::<Vec<_>>();
+                |(chunk, filtered)| {
+                  if filtered {
+                    Some(chunk)
+                  } else {
+                    None
+                  }
+                }
+              ).copied().collect::<Vec<_>>();
 
               // Filter by `splitChunks.cacheGroups.{cacheGroup}.minChunks`
               if selected_chunks.len() < cache_group.min_chunks as usize {
@@ -444,7 +436,7 @@ impl SplitChunksPlugin {
               }
 
               let selected_chunks_key =
-                { get_key(selected_chunks.iter().map(|chunk| chunk.ukey())) };
+                get_key(selected_chunks.iter().copied());
 
               merge_matched_item_into_module_group_map(
                 MatchedItem {
@@ -490,20 +482,15 @@ impl SplitChunksPlugin {
     let keys_of_invalid_group = module_group_map
       .iter_mut()
       .par_bridge()
-      .filter(|(_key, each_module_group)| {
-        // Fast path: check whether has overlap on chunks
-        each_module_group
+      .filter_map(|(key, other_module_group)| {
+        other_module_group
           .chunks
           .intersection(used_chunks)
-          .next()
-          .is_some()
-      })
-      .filter_map(|(key, other_module_group)| {
+          .next()?;
+
         current_module_group.modules.iter().for_each(|module| {
-          if other_module_group.modules.contains(module) {
-            tracing::trace!("remove module({module}) from {key}");
-            other_module_group.remove_module(*module, module_sizes);
-          }
+          tracing::trace!("remove module({module}) from {key}");
+          other_module_group.remove_module(*module, module_sizes);
         });
 
         if other_module_group.modules.is_empty() {
@@ -518,10 +505,9 @@ impl SplitChunksPlugin {
 
         // Since there are modules removed, make sure the rest of chunks are all used.
         other_module_group.chunks.retain(|c| {
-          other_module_group
-            .modules
-            .iter()
-            .any(|m| compilation.chunk_graph.is_module_in_chunk(m, *c))
+          compilation
+            .chunk_graph
+            .is_any_module_in_chunk(other_module_group.modules.iter(), *c)
         });
 
         let cache_group = other_module_group.get_cache_group(&self.cache_groups);
@@ -677,8 +663,6 @@ async fn merge_matched_item_into_module_group_map(
   };
 
   module_group.add_module(module.identifier(), module_sizes);
-  module_group
-    .chunks
-    .extend(selected_chunks.iter().map(|c| c.ukey()));
+  module_group.chunks.extend(selected_chunks.iter().copied());
   Ok(())
 }


### PR DESCRIPTION
## Summary

- Add `is_any_module_in_chunk ` to prevent getting same chunk for every module
- No need to get `Chunk` for every calling of `chunk_filter` because the default filter function will not using it
- Add `source_types_modules` on `ModuleGroup` to save the source types to modules mapping. No need to visit all modules when some source types violate size limits that have only a few modules like `css`. This may make time cost of  bundle splitting much more stable.
- Get all modules only once during the whole bundle splitting phase.
- Parallelize preparing groups by chunks and sort the `chunk_sets_by_count` to prevent visiting all lengths

Before:
<img width="590" height="92" alt="image" src="https://github.com/user-attachments/assets/ff622394-8410-4bc3-b62d-94bfcb094e5f" />


After:
<img width="604" height="60" alt="image" src="https://github.com/user-attachments/assets/4fccd3a3-cd28-4526-a595-189d34f3f801" />



## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
