### PR TITLE
refactor: remove features that are not supported in stable Rust

### DIFF
--- a/crates/rspack_binding_api/src/compilation/mod.rs
+++ b/crates/rspack_binding_api/src/compilation/mod.rs
@@ -74,7 +74,7 @@ impl JsCompilation {
 
     compilation
       .update_asset(&filename, |original_source, mut original_info| {
-        let new_source: napi::Result<BoxSource> = try {
+        let new_source: napi::Result<BoxSource> = (|| -> napi::Result<BoxSource> {
           let new_source = match new_source_or_function {
             Either::A(new_source) => new_source.into(),
             Either::B(new_source_fn) => {
@@ -83,8 +83,8 @@ impl JsCompilation {
               js_compat_source.into()
             }
           };
-          new_source
-        };
+          Ok(new_source)
+        })();
         let new_source = new_source.to_rspack_result()?;
 
         let new_info: Option<rspack_core::AssetInfo> = match asset_info_update_or_function {

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "256"]
-#![feature(try_blocks)]
 #![allow(deprecated)]
 
 #[macro_use]

--- a/crates/rspack_collections/src/lib.rs
+++ b/crates/rspack_collections/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(const_type_name)]
-
 mod identifier;
 mod ukey;
 

--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -1159,7 +1159,7 @@ impl CodeSplitter {
 
       match chunk_desc {
         ChunkDesc::Entry(entry_desc) => {
-          let box EntryChunkDesc {
+          let EntryChunkDesc {
             entry,
             entry_modules,
             chunk_modules,
@@ -1171,7 +1171,7 @@ impl CodeSplitter {
             post_order_indices,
             runtime,
             ..
-          } = entry_desc;
+          } = *entry_desc;
 
           let entry_chunk_ukey =
             if reuse && let Some(chunk) = self.cache_chunks.remove(&cache.cache_ukey) {
@@ -1378,7 +1378,7 @@ Or do you want to use the entrypoints '{name}' and '{entry_runtime}' independent
           }
         }
         ChunkDesc::Chunk(chunk_desc) => {
-          let box NormalChunkDesc {
+          let NormalChunkDesc {
             options,
             chunk_modules,
             pre_order_indices,
@@ -1386,7 +1386,7 @@ Or do you want to use the entrypoints '{name}' and '{entry_runtime}' independent
             incoming_blocks,
             runtime,
             ..
-          } = chunk_desc;
+          } = *chunk_desc;
 
           let modules = chunk_modules;
 

--- a/crates/rspack_core/src/cache/persistent/build_dependencies/helper/visitor.rs
+++ b/crates/rspack_core/src/cache/persistent/build_dependencies/helper/visitor.rs
@@ -19,12 +19,14 @@ impl Visit for DependencyVisitor {
   fn visit_call_expr(&mut self, node: &CallExpr) {
     let is_match_ident = match &node.callee {
       Callee::Import(_) => true,
-      Callee::Expr(box Expr::Ident(ident)) => ident.sym == "require",
+      Callee::Expr(expr) if matches!(expr.as_ref(), Expr::Ident(ident) if ident.sym == "require") => {
+        true
+      }
       _ => false,
     };
     if is_match_ident
       && let Some(args) = node.args.first()
-      && let box Expr::Lit(Lit::Str(s)) = &args.expr
+      && let Expr::Lit(Lit::Str(s)) = args.expr.as_ref()
     {
       self.requests.push(s.value.to_string());
     }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1948,7 +1948,8 @@ impl ConcatenatedModule {
     runtime: Option<&RuntimeSpec>,
     concatenation_scope: Option<ConcatenationScope>,
   ) -> Result<ModuleInfo> {
-    if let ModuleInfo::Concatenated(box info) = info {
+    if let ModuleInfo::Concatenated(boxed_info) = info {
+      let info = boxed_info.as_ref();
       let module_id = info.module;
       let concatenation_scope =
         concatenation_scope.expect("should have concatenation scope for concatenated module");

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -208,9 +208,9 @@ impl ContextModule {
     &self.options.context_options
   }
 
-  fn get_fake_map(
+  fn get_fake_map<'a>(
     &self,
-    dependencies: impl IntoIterator<Item = &DependencyId>,
+    dependencies: impl IntoIterator<Item = &'a DependencyId>,
     compilation: &Compilation,
   ) -> FakeMapValue {
     let dependencies = dependencies.into_iter();
@@ -306,9 +306,9 @@ impl ContextModule {
     )
   }
 
-  fn get_user_request_map(
+  fn get_user_request_map<'a>(
     &self,
-    dependencies: impl IntoIterator<Item = &DependencyId>,
+    dependencies: impl IntoIterator<Item = &'a DependencyId>,
     compilation: &Compilation,
   ) -> FxIndexMap<String, Option<String>> {
     let module_graph = compilation.get_module_graph();

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -179,7 +179,8 @@ impl DependencyCondition {
     match self {
       Self::False => ConnectionState::Active(false),
       Self::Fn(f) => f.get_connection_state(connection, runtime, mg, module_graph_cache),
-      Self::Composed(box (primary, rest)) => {
+      Self::Composed(boxed) => {
+        let (primary, rest) = boxed.as_ref();
         let primary_state =
           primary.get_connection_state(connection, runtime, mg, module_graph_cache);
         let rest_state = rest.get_connection_state(connection, runtime, mg, module_graph_cache);

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -768,32 +768,30 @@ impl Module for ExternalModule {
     let mut cgr = CodeGenerationResult::default();
     let (request, external_type) = self.get_request_and_external_type();
     match self.external_type.as_str() {
-      "asset" => {
-        if let Some(request) = request {
-          cgr.add(
-            SourceType::JavaScript,
-            RawStringSource::from(format!(
-              "module.exports = {};",
-              serde_json::to_string(request.primary()).to_rspack_result()?
-            ))
-            .boxed(),
-          );
-          cgr
-            .data
-            .insert(CodeGenerationDataUrl::new(request.primary().to_string()));
-        }
+      "asset" if request.is_some() => {
+        let request = request.expect("request should be some");
+        cgr.add(
+          SourceType::JavaScript,
+          RawStringSource::from(format!(
+            "module.exports = {};",
+            serde_json::to_string(request.primary()).to_rspack_result()?
+          ))
+          .boxed(),
+        );
+        cgr
+          .data
+          .insert(CodeGenerationDataUrl::new(request.primary().to_string()));
       }
-      "css-import" => {
-        if let Some(request) = request {
-          cgr.add(
-            SourceType::Css,
-            RawStringSource::from(format!(
-              "@import url({});",
-              serde_json::to_string(request.primary()).to_rspack_result()?
-            ))
-            .boxed(),
-          );
-        }
+      "css-import" if request.is_some() => {
+        let request = request.expect("request should be some");
+        cgr.add(
+          SourceType::Css,
+          RawStringSource::from(format!(
+            "@import url({});",
+            serde_json::to_string(request.primary()).to_rspack_result()?
+          ))
+          .boxed(),
+        );
       }
       _ => {
         let (source, chunk_init_fragments, runtime_requirements) = self.get_source(

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -1,9 +1,3 @@
-#![feature(if_let_guard)]
-#![feature(iter_intersperse)]
-#![feature(box_patterns)]
-#![feature(anonymous_lifetime_in_impl_trait)]
-#![feature(async_trait_bounds)]
-#![feature(ptr_as_ref_unchecked)]
 use std::{fmt, sync::Arc};
 mod artifacts;
 mod binding;

--- a/crates/rspack_error/src/emitter.rs
+++ b/crates/rspack_error/src/emitter.rs
@@ -21,9 +21,9 @@ impl FlushDiagnostic for StringDiagnosticDisplay {
 impl FlushDiagnostic for StandardStreamLock<'_> {}
 pub trait DiagnosticDisplay {
   type Output;
-  fn emit_batch_diagnostic(
+  fn emit_batch_diagnostic<'a>(
     &mut self,
-    diagnostics: impl Iterator<Item = &Diagnostic>,
+    diagnostics: impl Iterator<Item = &'a Diagnostic>,
   ) -> Self::Output;
   fn emit_diagnostic(&mut self, diagnostic: &Diagnostic) -> Self::Output;
 }
@@ -34,9 +34,9 @@ pub struct StdioDiagnosticDisplay;
 impl DiagnosticDisplay for StdioDiagnosticDisplay {
   type Output = crate::Result<()>;
 
-  fn emit_batch_diagnostic(
+  fn emit_batch_diagnostic<'a>(
     &mut self,
-    diagnostics: impl Iterator<Item = &Diagnostic>,
+    diagnostics: impl Iterator<Item = &'a Diagnostic>,
   ) -> Self::Output {
     let writer = StandardStream::stderr(ColorChoice::Always);
     let mut lock_writer = writer.lock();
@@ -93,9 +93,9 @@ impl WriteColor for StringDiagnosticDisplay {
 impl DiagnosticDisplay for StringDiagnosticDisplay {
   type Output = crate::Result<String>;
 
-  fn emit_batch_diagnostic(
+  fn emit_batch_diagnostic<'a>(
     &mut self,
-    diagnostics: impl Iterator<Item = &Diagnostic>,
+    diagnostics: impl Iterator<Item = &'a Diagnostic>,
   ) -> Self::Output {
     emit_batch_diagnostic(diagnostics, self)?;
     if self.sorted {
@@ -121,9 +121,9 @@ pub struct ColoredStringDiagnosticDisplay;
 impl DiagnosticDisplay for ColoredStringDiagnosticDisplay {
   type Output = crate::Result<String>;
 
-  fn emit_batch_diagnostic(
+  fn emit_batch_diagnostic<'a>(
     &mut self,
-    diagnostics: impl Iterator<Item = &Diagnostic>,
+    diagnostics: impl Iterator<Item = &'a Diagnostic>,
   ) -> Self::Output {
     let mut buf = Buffer::ansi();
     for d in diagnostics {
@@ -139,8 +139,8 @@ impl DiagnosticDisplay for ColoredStringDiagnosticDisplay {
   }
 }
 
-fn emit_batch_diagnostic<T: Write + WriteColor + FlushDiagnostic>(
-  diagnostics: impl Iterator<Item = &Diagnostic>,
+fn emit_batch_diagnostic<'a, T: Write + WriteColor + FlushDiagnostic>(
+  diagnostics: impl Iterator<Item = &'a Diagnostic>,
   writer: &mut T,
 ) -> crate::Result<()> {
   for diagnostic in diagnostics {
@@ -182,9 +182,9 @@ impl DiagnosticDisplayer {
 impl DiagnosticDisplay for DiagnosticDisplayer {
   type Output = crate::Result<String>;
 
-  fn emit_batch_diagnostic(
+  fn emit_batch_diagnostic<'a>(
     &mut self,
-    diagnostics: impl Iterator<Item = &Diagnostic>,
+    diagnostics: impl Iterator<Item = &'a Diagnostic>,
   ) -> Self::Output {
     match self {
       Self::Colored(d) => d.emit_batch_diagnostic(diagnostics),

--- a/crates/rspack_error/src/lib.rs
+++ b/crates/rspack_error/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(anonymous_lifetime_in_impl_trait)]
-
 mod catch_unwind;
 mod convert;
 mod diagnostic;

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -414,13 +414,15 @@ fn compare_chunks_by_groups(
   a: &Chunk,
   b: &Chunk,
 ) -> Ordering {
-  let a_groups = a
+  let a_groups: Vec<_> = a
     .get_sorted_groups_iter(chunk_group_by_ukey)
-    .map(|group| chunk_group_by_ukey.expect_get(group).index);
-  let b_groups = b
+    .map(|group| chunk_group_by_ukey.expect_get(group).index)
+    .collect();
+  let b_groups: Vec<_> = b
     .get_sorted_groups_iter(chunk_group_by_ukey)
-    .map(|group| chunk_group_by_ukey.expect_get(group).index);
-  a_groups.cmp_by(b_groups, |a, b| a.cmp(&b))
+    .map(|group| chunk_group_by_ukey.expect_get(group).index)
+    .collect();
+  a_groups.cmp(&b_groups)
 }
 
 pub fn compare_chunks_natural<'a>(

--- a/crates/rspack_ids/src/lib.rs
+++ b/crates/rspack_ids/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(iter_intersperse)]
-#![feature(iter_order_by)]
-
 mod deterministic_module_ids_plugin;
 pub use deterministic_module_ids_plugin::*;
 mod named_module_ids_plugin;

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -100,12 +100,19 @@ impl Debug for Content {
       Self::Buffer(_) => "Buffer",
     };
 
-    content
-      .field(
-        ty,
-        &s[0..usize::min(s.len(), s.ceil_char_boundary(20))].to_owned(),
-      )
-      .finish()
+    // Safe string truncation to approximately 20 characters
+    let truncated = if s.len() <= 20 {
+      s.as_str()
+    } else {
+      // Find the last character boundary at or before position 20
+      let mut end = 20;
+      while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+      }
+      &s[0..end]
+    };
+
+    content.field(ty, &truncated.to_owned()).finish()
   }
 }
 

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(round_char_boundary)]
-
 mod content;
 mod context;
 mod loader;

--- a/crates/rspack_macros/src/lib.rs
+++ b/crates/rspack_macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(try_find)]
-
 mod cacheable;
 mod cacheable_dyn;
 mod hook;

--- a/crates/rspack_macros/src/merge.rs
+++ b/crates/rspack_macros/src/merge.rs
@@ -8,22 +8,28 @@ use syn::{
 pub fn expand_merge_from_derive(input: DeriveInput) -> Result<TokenStream> {
   let name = input.ident;
   let generics = add_trait_bounds(input.generics);
-  let chose_base = input.attrs.iter().try_find(|a| -> Result<bool> {
-    match &a.meta {
+  let mut chose_base = None;
+  for a in &input.attrs {
+    let is_match = match &a.meta {
       Meta::List(list) => {
         if !list.path.is_ident("merge_from") {
-          return Ok(false);
+          false
+        } else {
+          let mut has_enum_base = false;
+          list.parse_nested_meta(|meta| {
+            has_enum_base = meta.path.is_ident("enum_base");
+            Ok(())
+          })?;
+          has_enum_base
         }
-        let mut chose_base = false;
-        list.parse_nested_meta(|meta| {
-          chose_base = meta.path.is_ident("enum_base");
-          Ok(())
-        })?;
-        Ok(chose_base)
       }
-      _ => Ok(false),
+      _ => false,
+    };
+    if is_match {
+      chose_base = Some(a);
+      break;
     }
-  })?;
+  }
   let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
   let body = body(input.data, chose_base)?;
   Ok(quote! {

--- a/crates/rspack_napi/src/lib.rs
+++ b/crates/rspack_napi/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(try_blocks)]
 #![forbid(unsafe_op_in_unsafe_fn)]
 
 mod ext;

--- a/crates/rspack_napi_macros/src/lib.rs
+++ b/crates/rspack_napi_macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(try_find)]
-
 mod field_names;
 mod tagged_union;
 

--- a/crates/rspack_plugin_circular_dependencies/src/lib.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(array_windows)]
-
 use cow_utils::CowUtils;
 use derive_more::Debug;
 use futures::future::BoxFuture;
@@ -270,7 +268,8 @@ impl CircularDependencyRspackPlugin {
     cycle: &[ModuleIdentifier],
     compilation: &Compilation,
   ) -> bool {
-    for [module_id, target_id] in cycle.array_windows::<2>() {
+    for window in cycle.windows(2) {
+      let [module_id, target_id] = [&window[0], &window[1]];
       // If any dependency in the cycle is purely asynchronous, then it does not count as a runtime
       // circular dependency, since execution order will be guaranteed.
       if module_map[module_id].dependencies[target_id].is_asynchronous_only() {

--- a/crates/rspack_plugin_css/src/lib.rs
+++ b/crates/rspack_plugin_css/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(if_let_guard)]
-#![feature(box_patterns)]
-
 pub mod dependency;
 pub mod parser_and_generator;
 pub mod plugin;

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -146,8 +146,13 @@ impl ParserAndGenerator for CssParserAndGenerator {
     let mode = match module_type {
       ModuleType::CssModule => css_module_lexer::Mode::Local,
       ModuleType::CssAuto
-        if let Some(resource_path) = resource_path
-          && REGEX_IS_MODULES.is_match(resource_path.as_str()) =>
+        if resource_path.is_some()
+          && REGEX_IS_MODULES.is_match(
+            resource_path
+              .as_ref()
+              .expect("should have resource_path for module_type css/auto")
+              .as_str(),
+          ) =>
       {
         css_module_lexer::Mode::Local
       }

--- a/crates/rspack_plugin_html/src/lib.rs
+++ b/crates/rspack_plugin_html/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(box_patterns)]
-
 pub mod asset;
 pub mod config;
 pub mod injector;

--- a/crates/rspack_plugin_javascript/src/lib.rs
+++ b/crates/rspack_plugin_javascript/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(if_let_guard)]
-#![feature(box_patterns)]
 #![recursion_limit = "256"]
 
 pub mod dependency;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -397,7 +397,8 @@ impl JavascriptParserPlugin for APIPlugin {
   fn call(&self, parser: &mut JavascriptParser, call_expr: &CallExpr, _name: &str) -> Option<bool> {
     macro_rules! not_supported_call {
       ($check: ident, $name: literal) => {
-        if let Callee::Expr(box Expr::Member(expr)) = &call_expr.callee
+        if let Callee::Expr(expr_box) = &call_expr.callee
+          && let Expr::Member(expr) = &**expr_box
           && expr_matcher::$check(&Expr::Member(expr.to_owned()))
         {
           let (warning, dep) = expression_not_supported(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
@@ -112,16 +112,19 @@ fn get_hoisted_declarations<'a>(
           collect_from_block_stm(finalizer, &mut stmt_stack);
         }
       }
-      Stmt::Decl(decl)
-        if let Some(r#fn) = decl.as_fn_decl()
-          && include_function_declarations =>
-      {
+      Stmt::Decl(decl) if decl.as_fn_decl().is_some() && include_function_declarations => {
+        let r#fn = decl
+          .as_fn_decl()
+          .expect("decl is `FunctionDeclaration` in `if_guard`");
         collect_declaration_from_ident(&r#fn.ident, &mut declarations);
       }
-      Stmt::Decl(decl)
-        if let Some(var) = decl.as_var()
-          && let Some(decls) = get_var_kind_decls(var) =>
-      {
+      Stmt::Decl(decl) if decl.as_var().is_some() => {
+        let Some(var) = decl.as_var() else {
+          continue;
+        };
+        let Some(decls) = get_var_kind_decls(var) else {
+          continue;
+        };
         for decl in decls {
           collect_declaration_from_pat(&decl.name, &mut declarations);
         }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -32,7 +32,13 @@ fn get_non_optional_member_chain_from_expr(mut expr: &Expr, mut count: i32) -> &
     } else if let Expr::OptChain(opt_chain) = expr {
       expr = match &*opt_chain.base {
         OptChainBase::Member(member) => &*member.obj,
-        OptChainBase::Call(call) if let Some(member) = call.callee.as_member() => &*member.obj,
+        OptChainBase::Call(call) if call.callee.as_member().is_some() => {
+          let member = call
+            .callee
+            .as_member()
+            .expect("`call.callee` is `MemberExpr` in `if_guard`");
+          &*member.obj
+        }
         _ => unreachable!(),
       };
       count -= 1;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -30,8 +30,9 @@ pub fn get_url_request(
     }) = args.first()
     && let Some(ExprOrSpread {
       spread: None,
-      expr: box Expr::Member(arg2),
+      expr: arg2_expr,
     }) = args.get(1)
+    && let Expr::Member(arg2) = &**arg2_expr
     && is_meta_url(parser, arg2)
   {
     return parser
@@ -80,8 +81,9 @@ impl JavascriptParserPlugin for URLPlugin {
       let arg2 = args.get(1)?;
       if let ExprOrSpread {
         spread: None,
-        expr: box Expr::Member(arg2),
+        expr: arg2_expr,
       } = arg2
+        && let Expr::Member(arg2) = &**arg2_expr
         && !is_meta_url(parser, arg2)
       {
         return None;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -165,8 +165,9 @@ fn handle_worker<'a>(
   if let Some(expr_or_spread) = args.first()
     && let ExprOrSpread {
       spread: None,
-      expr: box Expr::New(new_url_expr),
+      expr: expr_box,
     } = expr_or_spread
+    && let Expr::New(new_url_expr) = &**expr_box
     && let Some((request, start, end)) = get_url_request(parser, new_url_expr)
   {
     let path = ParsedNewWorkerPath {

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -265,8 +265,8 @@ impl SideEffectsFlagPluginVisitor<'_> {
           return;
         }
 
-        let pure_test = match stmt.test {
-          Some(box ref test) => is_pure_expression(test, self.unresolved_ctxt, self.comments),
+        let pure_test = match &stmt.test {
+          Some(test) => is_pure_expression(test, self.unresolved_ctxt, self.comments),
           None => true,
         };
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -40,16 +40,18 @@ pub(crate) mod expr_like {
   impl ExprLikeEqIgnoreSpan for dyn ExprLike {
     fn expr_like_eq_ignore_span(&self, other: &dyn ExprLike) -> bool {
       match (self, other) {
-        (left, right)
-          if let Some(left) = left.as_member()
-            && let Some(right) = right.as_member() =>
-        {
+        (left, right) if left.as_member().is_some() && right.as_member().is_some() => {
+          let left = left
+            .as_member()
+            .expect("`left` is `MemberExpr` in `if_guard`");
+          let right = right
+            .as_member()
+            .expect("`right` is `MemberExpr` in `if_guard`");
           left.dyn_eq_ignore_span(right)
         }
-        (left, right)
-          if let Some(left) = left.as_ident()
-            && let Some(right) = right.as_ident() =>
-        {
+        (left, right) if left.as_ident().is_some() && right.as_ident().is_some() => {
+          let left = left.as_ident().expect("`left` is `Ident` in `if_guard`");
+          let right = right.as_ident().expect("`right` is `Ident` in `if_guard`");
           left.dyn_eq_ignore_span(right)
         }
         _ => false,

--- a/crates/rspack_plugin_runtime/src/lib.rs
+++ b/crates/rspack_plugin_runtime/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(get_mut_unchecked)]
 mod helpers;
 pub use helpers::*;
 mod common_js_chunk_format;

--- a/crates/rspack_regex/tests/main.rs
+++ b/crates/rspack_regex/tests/main.rs
@@ -1,5 +1,3 @@
-#![feature(box_patterns)]
-
 macro_rules! regex {
   // `()` indicates that the macro takes no argument.
   ($pat:literal) => {

--- a/crates/rspack_util/src/lib.rs
+++ b/crates/rspack_util/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(int_roundings)]
-
 mod merge;
 
 pub mod asset_condition;


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Part of https://github.com/web-infra-dev/rspack/issues/4285

Will remove `abi_custom` feature after we move from `wasmer` to `wasmtime`.
See https://github.com/web-infra-dev/rspack/pull/11217

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
