### PR TITLE
fix: buildDependencies skip resolve nodejs builtin module

### DIFF
--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rspack/tests/defaults.rs
+assertion_line: 16
 expression: options
 ---
 CompilerOptions {
@@ -249,6 +250,7 @@ CompilerOptions {
                         description_files: None,
                         enforce_extension: None,
                         pnp: None,
+                        builtin_modules: false,
                     },
                     "esm": Resolve {
                         extensions: Some(
@@ -297,6 +299,7 @@ CompilerOptions {
                         description_files: None,
                         enforce_extension: None,
                         pnp: None,
+                        builtin_modules: false,
                     },
                     "loaderImport": Resolve {
                         extensions: Some(
@@ -345,6 +348,7 @@ CompilerOptions {
                         description_files: None,
                         enforce_extension: None,
                         pnp: None,
+                        builtin_modules: false,
                     },
                     "url": Resolve {
                         extensions: None,
@@ -371,6 +375,7 @@ CompilerOptions {
                         description_files: None,
                         enforce_extension: None,
                         pnp: None,
+                        builtin_modules: false,
                     },
                     "worker": Resolve {
                         extensions: Some(
@@ -421,6 +426,7 @@ CompilerOptions {
                         description_files: None,
                         enforce_extension: None,
                         pnp: None,
+                        builtin_modules: false,
                     },
                     "commonjs": Resolve {
                         extensions: Some(
@@ -469,6 +475,7 @@ CompilerOptions {
                         description_files: None,
                         enforce_extension: None,
                         pnp: None,
+                        builtin_modules: false,
                     },
                     "amd": Resolve {
                         extensions: Some(
@@ -517,6 +524,7 @@ CompilerOptions {
                         description_files: None,
                         enforce_extension: None,
                         pnp: None,
+                        builtin_modules: false,
                     },
                     "loader": Resolve {
                         extensions: Some(
@@ -565,6 +573,7 @@ CompilerOptions {
                         description_files: None,
                         enforce_extension: None,
                         pnp: None,
+                        builtin_modules: false,
                     },
                     "unknown": Resolve {
                         extensions: Some(
@@ -613,6 +622,7 @@ CompilerOptions {
                         description_files: None,
                         enforce_extension: None,
                         pnp: None,
+                        builtin_modules: false,
                     },
                 },
             ),
@@ -620,6 +630,7 @@ CompilerOptions {
         description_files: None,
         enforce_extension: None,
         pnp: None,
+        builtin_modules: false,
     },
     resolve_loader: Resolve {
         extensions: Some(
@@ -669,6 +680,7 @@ CompilerOptions {
         description_files: None,
         enforce_extension: None,
         pnp: None,
+        builtin_modules: false,
     },
     module: ModuleOptions {
         rules: [
@@ -872,6 +884,7 @@ CompilerOptions {
                                                         description_files: None,
                                                         enforce_extension: None,
                                                         pnp: None,
+                                                        builtin_modules: false,
                                                     },
                                                 },
                                             ),
@@ -879,6 +892,7 @@ CompilerOptions {
                                         description_files: None,
                                         enforce_extension: None,
                                         pnp: None,
+                                        builtin_modules: false,
                                     },
                                 ),
                                 enforce: Normal,
@@ -969,6 +983,7 @@ CompilerOptions {
                                                         description_files: None,
                                                         enforce_extension: None,
                                                         pnp: None,
+                                                        builtin_modules: false,
                                                     },
                                                 },
                                             ),
@@ -976,6 +991,7 @@ CompilerOptions {
                                         description_files: None,
                                         enforce_extension: None,
                                         pnp: None,
+                                        builtin_modules: false,
                                     },
                                 ),
                                 enforce: Normal,
@@ -1144,6 +1160,7 @@ CompilerOptions {
                                                         description_files: None,
                                                         enforce_extension: None,
                                                         pnp: None,
+                                                        builtin_modules: false,
                                                     },
                                                 },
                                             ),
@@ -1151,6 +1168,7 @@ CompilerOptions {
                                         description_files: None,
                                         enforce_extension: None,
                                         pnp: None,
+                                        builtin_modules: false,
                                     },
                                 ),
                                 enforce: Normal,

--- a/crates/rspack_binding_api/src/options/raw_resolve.rs
+++ b/crates/rspack_binding_api/src/options/raw_resolve.rs
@@ -174,6 +174,7 @@ impl TryFrom<RawResolveOptions> for Resolve {
       description_files,
       imports_fields,
       pnp,
+      builtin_modules: false,
     })
   }
 }
@@ -304,6 +305,7 @@ pub fn normalize_raw_resolve_options_with_dependency_type(
         by_dependency,
         description_files: raw.description_files,
         enforce_extension: raw.enforce_extension,
+        builtin_modules: false,
       };
       Ok(ResolveOptionsWithDependencyType {
         resolve_options: Some(Box::new(resolve_options)),

--- a/crates/rspack_core/src/options/resolve/clever_merge.rs
+++ b/crates/rspack_core/src/options/resolve/clever_merge.rs
@@ -460,6 +460,7 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
     restrictions: result_entry.restrictions.base,
     roots: result_entry.roots.base,
     pnp: result_entry.pnp.base,
+    builtin_modules: false,
   }
 }
 

--- a/crates/rspack_core/src/options/resolve/mod.rs
+++ b/crates/rspack_core/src/options/resolve/mod.rs
@@ -138,6 +138,8 @@ pub struct Resolve {
   pub enforce_extension: Option<EnforceExtension>,
   /// If set, Yarn PnP resolution will be supported.
   pub pnp: Option<bool>,
+  /// Whether to parse [module.builtinModules](https://nodejs.org/api/module.html#modulebuiltinmodules) or not.
+  pub builtin_modules: bool,
 }
 
 /// Tsconfig Options

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -19,7 +19,7 @@ use sugar_path::SugarPath;
 
 pub use self::{
   factory::{ResolveOptionsWithDependencyType, ResolverFactory},
-  resolver_impl::{ResolveInnerOptions, Resolver},
+  resolver_impl::{ResolveInnerError, ResolveInnerOptions, Resolver},
 };
 use crate::{
   Context, DependencyCategory, DependencyType, ErrorSpan, ModuleIdentifier, Resolve,

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -324,7 +324,7 @@ fn to_rspack_resolver_options(
     extension_alias,
     restrictions,
     roots,
-    builtin_modules: false,
+    builtin_modules: options.builtin_modules,
     imports_fields,
     enable_pnp: options.pnp.unwrap_or(false),
   }


### PR DESCRIPTION
## Summary

The persistent cache buildDependencies will recursively collect dependencies, and it should skip the nodejs builtin modules.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
