### PR TITLE
refactor: move builtin loader registration to plugin

### DIFF
--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -179,6 +179,18 @@ impl JsCompiler {
       let js_hooks_plugin = JsHooksAdapterPlugin::from_js_hooks(env, register_js_taps)?;
       plugins.push(js_hooks_plugin.clone().boxed());
 
+      // Register builtin loader plugins
+      plugins.push(Box::new(
+        rspack_loader_lightningcss::LightningcssLoaderPlugin::new(),
+      ));
+      plugins.push(Box::new(rspack_loader_swc::SwcLoaderPlugin::new()));
+      plugins.push(Box::new(
+        rspack_loader_react_refresh::ReactRefreshLoaderPlugin::new(),
+      ));
+      plugins.push(Box::new(
+        rspack_loader_preact_refresh::PreactRefreshLoaderPlugin::new(),
+      ));
+
       let tsfn = env
         .create_function("cleanup_revoked_modules", cleanup_revoked_modules)?
         .build_threadsafe_function::<External<(CompilerId, Vec<ModuleIdentifier>)>>()

--- a/crates/rspack_binding_api/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/resolver.rs
@@ -26,23 +26,23 @@ impl Identifiable for JsLoader {
 }
 
 // TODO: should be compiled with a different cfg
-pub fn get_builtin_test_loader(builtin: &str) -> Result<BoxLoader> {
+pub fn get_builtin_test_loader(builtin: &str) -> Option<BoxLoader> {
   if builtin.starts_with(rspack_loader_testing::SIMPLE_ASYNC_LOADER_IDENTIFIER) {
-    return Ok(Arc::new(rspack_loader_testing::SimpleAsyncLoader));
+    return Some(Arc::new(rspack_loader_testing::SimpleAsyncLoader));
   }
   if builtin.starts_with(rspack_loader_testing::SIMPLE_LOADER_IDENTIFIER) {
-    return Ok(Arc::new(rspack_loader_testing::SimpleLoader));
+    return Some(Arc::new(rspack_loader_testing::SimpleLoader));
   }
   if builtin.starts_with(rspack_loader_testing::PITCHING_LOADER_IDENTIFIER) {
-    return Ok(Arc::new(rspack_loader_testing::PitchingLoader));
+    return Some(Arc::new(rspack_loader_testing::PitchingLoader));
   }
   if builtin.starts_with(rspack_loader_testing::PASS_THROUGH_LOADER_IDENTIFIER) {
-    return Ok(Arc::new(rspack_loader_testing::PassthroughLoader));
+    return Some(Arc::new(rspack_loader_testing::PassthroughLoader));
   }
   if builtin.starts_with(rspack_loader_testing::NO_PASS_THROUGH_LOADER_IDENTIFIER) {
-    return Ok(Arc::new(rspack_loader_testing::NoPassthroughLoader));
+    return Some(Arc::new(rspack_loader_testing::NoPassthroughLoader));
   }
-  unreachable!("Unexpected builtin test loader: {builtin}")
+  None
 }
 
 #[plugin_hook(NormalModuleFactoryResolveLoader for JsLoaderRspackPlugin,tracing=false)]
@@ -63,7 +63,7 @@ pub(crate) async fn resolve_loader(
   };
 
   if loader_request.starts_with("builtin:test") {
-    return Ok(get_builtin_test_loader(loader_request).ok());
+    return Ok(get_builtin_test_loader(loader_request));
   }
 
   let Some(resolve_result) = resolver


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Move builtin loader registration to plugin. This adds support for custom loader in custom bindings.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
