### PR TITLE
refactor: limit exported symbols in `rspack_binding_api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,7 +3890,6 @@ version = "0.4.11"
 dependencies = [
  "anyhow",
  "async-trait",
- "browserslist-rs",
  "color-backtrace",
  "cow-utils",
  "derive_more 2.0.1",

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -19,7 +19,6 @@ sftrace-setup   = ["dep:sftrace-setup", "rspack_allocator/sftrace-setup"]
 
 [dependencies]
 anyhow                   = { workspace = true }
-browserslist-rs          = { workspace = true }
 ropey                    = { workspace = true }
 rspack_allocator         = { workspace = true }
 rspack_browserslist      = { workspace = true }

--- a/crates/rspack_binding_api/README.md
+++ b/crates/rspack_binding_api/README.md
@@ -23,7 +23,6 @@ Shared binding API for Rspack, providing bridge interfaces between Rspack core f
 - Any version update may contain breaking changes
 - It is recommended to lock specific version numbers in production environments
 - Please thoroughly test all functionality before upgrading
-- Check [CHANGELOG](../CHANGELOG.md) for specific changes
 
 ## API Usage Warning
 

--- a/crates/rspack_binding_api/README.md
+++ b/crates/rspack_binding_api/README.md
@@ -1,0 +1,48 @@
+# rspack_binding_api
+
+Shared binding API for Rspack, providing bridge interfaces between Rspack core functionality and Node.js/browser environments.
+
+## Overview
+
+`rspack_binding_api` is the core binding layer in the Rspack project, responsible for exposing Rspack core functionality written in Rust to JavaScript/TypeScript environments. It provides complete API interfaces for compilation, building, module processing, and other functionalities.
+
+## Features
+
+- `browser`: Enable browser environment support
+- `color-backtrace`: Enable colored error backtraces
+- `debug_tool`: Enable debug tools
+- `plugin`: Enable SWC plugin support
+- `sftrace-setup`: Enable performance tracing setup
+
+## Important Notice
+
+⚠️ **Version Compatibility Warning**
+
+**This repository does not follow Semantic Versioning (SemVer).**
+
+- Any version update may contain breaking changes
+- It is recommended to lock specific version numbers in production environments
+- Please thoroughly test all functionality before upgrading
+- Check [CHANGELOG](../CHANGELOG.md) for specific changes
+
+## API Usage Warning
+
+🚨 **This package's API should NOT be used as a public Rust API**
+
+This crate is designed to be linked as a **C dynamic library** during Rspack binding generation, not as a public Rust API for external consumption.
+
+### For Developers
+
+If you're working on Rspack itself:
+- This crate is safe to use within the Rspack project
+- Changes should be coordinated with the binding generation process
+- Test thoroughly when making changes
+
+If you're an external developer:
+- Do not depend on this crate directly
+- Use the official Rspack Node.js package instead
+- Report issues through the main Rspack repository
+
+If you're a user of Rspack custom binding:
+- Do not depend on this crate directly
+- Use [`rspack_binding_builder`](https://crates.io/crates/rspack_binding_builder) to build your own binding

--- a/crates/rspack_binding_api/src/allocator.rs
+++ b/crates/rspack_binding_api/src/allocator.rs
@@ -1,7 +1,11 @@
 use napi::{Env, bindgen_prelude::ToNapiValue, sys::napi_env};
 use rspack_core::BindingCell;
 
-use crate::{AssetInfo, Assets, CodeGenerationResult, CodeGenerationResults, Sources};
+use crate::{
+  asset::AssetInfo,
+  build_info::Assets,
+  compilation::{CodeGenerationResult, CodeGenerationResults, Sources},
+};
 
 pub(crate) struct NapiAllocatorImpl;
 

--- a/crates/rspack_binding_api/src/asset_condition.rs
+++ b/crates/rspack_binding_api/src/asset_condition.rs
@@ -30,10 +30,6 @@ impl From<RawAssetConditionsWrapper> for AssetConditions {
   }
 }
 
-pub fn into_asset_condition(r: RawAssetCondition) -> AssetCondition {
-  RawAssetConditionWrapper(r).into()
-}
-
 pub fn into_asset_conditions(r: RawAssetConditions) -> AssetConditions {
   RawAssetConditionsWrapper(r).into()
 }

--- a/crates/rspack_binding_api/src/async_dependency_block.rs
+++ b/crates/rspack_binding_api/src/async_dependency_block.rs
@@ -5,7 +5,7 @@ use rspack_core::DependenciesBlock as _;
 use rspack_napi::{OneShotRef, napi::bindgen_prelude::*};
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::DependencyWrapper;
+use crate::dependency::DependencyWrapper;
 
 #[napi]
 pub struct AsyncDependenciesBlock {

--- a/crates/rspack_binding_api/src/build_info.rs
+++ b/crates/rspack_binding_api/src/build_info.rs
@@ -10,7 +10,7 @@ use rspack_core::WeakBindingCell;
 use rspack_napi::unknown_to_json_value;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::{Module, define_symbols};
+use crate::{define_symbols, module::Module};
 
 define_symbols! {
   BUILD_INFO_ASSETS_SYMBOL => "BUILD_INFO_ASSETS_SYMBOL",

--- a/crates/rspack_binding_api/src/chunk.rs
+++ b/crates/rspack_binding_api/src/chunk.rs
@@ -9,7 +9,7 @@ use rspack_collections::UkeyMap;
 use rspack_core::{Compilation, CompilationId};
 use rspack_napi::OneShotRef;
 
-use crate::{ChunkGroupWrapper, compilation::entries::EntryOptionsDTO};
+use crate::{chunk_group::ChunkGroupWrapper, compilation::entries::EntryOptionsDTO};
 
 #[napi]
 pub struct Chunk {

--- a/crates/rspack_binding_api/src/chunk_graph.rs
+++ b/crates/rspack_binding_api/src/chunk_graph.rs
@@ -5,8 +5,11 @@ use napi_derive::napi;
 use rspack_core::{Compilation, ModuleId, SourceType};
 
 use crate::{
-  AsyncDependenciesBlock, Chunk, ChunkGroupWrapper, ChunkWrapper, JsRuntimeSpec, ModuleObject,
-  ModuleObjectRef,
+  async_dependency_block::AsyncDependenciesBlock,
+  chunk::{Chunk, ChunkWrapper},
+  chunk_group::ChunkGroupWrapper,
+  module::{ModuleObject, ModuleObjectRef},
+  runtime::JsRuntimeSpec,
 };
 
 pub type JsModuleId = Either<String, u32>;

--- a/crates/rspack_binding_api/src/chunk_group.rs
+++ b/crates/rspack_binding_api/src/chunk_group.rs
@@ -6,7 +6,11 @@ use rspack_collections::UkeyMap;
 use rspack_core::{Compilation, CompilationId};
 use rspack_napi::OneShotRef;
 
-use crate::{ChunkWrapper, ModuleObject, ModuleObjectRef, location::RealDependencyLocation};
+use crate::{
+  chunk::ChunkWrapper,
+  location::RealDependencyLocation,
+  module::{ModuleObject, ModuleObjectRef},
+};
 
 #[napi]
 pub struct ChunkGroup {

--- a/crates/rspack_binding_api/src/compilation/chunks.rs
+++ b/crates/rspack_binding_api/src/compilation/chunks.rs
@@ -4,7 +4,10 @@ use napi::{
 };
 use rspack_core::Compilation;
 
-use crate::{Chunk, ChunkWrapper, JsCompilation};
+use crate::{
+  chunk::{Chunk, ChunkWrapper},
+  compilation::JsCompilation,
+};
 
 #[napi]
 pub struct Chunks {

--- a/crates/rspack_binding_api/src/compilation/code_generation_results.rs
+++ b/crates/rspack_binding_api/src/compilation/code_generation_results.rs
@@ -2,7 +2,11 @@ use napi::Either;
 use rspack_core::{Reflector, WeakBindingCell};
 use rustc_hash::FxHashMap;
 
-use crate::{JsCompatSourceOwned, JsRuntimeSpec, ModuleObjectRef, ToJsCompatSourceOwned};
+use crate::{
+  module::ModuleObjectRef,
+  runtime::JsRuntimeSpec,
+  source::{JsCompatSourceOwned, ToJsCompatSourceOwned},
+};
 
 // Map<string, Source>
 #[napi]

--- a/crates/rspack_binding_api/src/compilation/diagnostics.rs
+++ b/crates/rspack_binding_api/src/compilation/diagnostics.rs
@@ -2,7 +2,7 @@ use napi::{Either, bindgen_prelude::WeakReference};
 use rspack_core::Compilation;
 use rspack_error::RspackSeverity;
 
-use crate::{JsCompilation, RspackError};
+use crate::{compilation::JsCompilation, error::RspackError};
 
 #[napi]
 pub struct Diagnostics {

--- a/crates/rspack_binding_api/src/compilation/entries.rs
+++ b/crates/rspack_binding_api/src/compilation/entries.rs
@@ -3,8 +3,9 @@ use rspack_core::{ChunkLoading, Compilation, EntryData, EntryOptions, EntryRunti
 use rspack_napi::napi::bindgen_prelude::*;
 
 use crate::{
-  DependencyWrapper, RawChunkLoading, WithFalse, dependency::Dependency, entry::JsEntryOptions,
-  library::JsLibraryOptions,
+  dependency::{Dependency, DependencyWrapper},
+  options::{entry::JsEntryOptions, library::JsLibraryOptions},
+  raw_options::{RawChunkLoading, WithFalse},
 };
 
 #[napi]

--- a/crates/rspack_binding_api/src/compilation/mod.rs
+++ b/crates/rspack_binding_api/src/compilation/mod.rs
@@ -23,13 +23,22 @@ use rspack_plugin_runtime::RuntimeModuleFromJs;
 use rspack_tasks::{within_compiler_context, within_compiler_context_sync};
 use rustc_hash::FxHashMap;
 
-use super::PathWithInfo;
 use crate::{
-  AssetInfo, COMPILER_REFERENCES, Chunk, ChunkGraph, ChunkGroupWrapper, ChunkWrapper,
-  EntryDependency, ErrorCode, JsAddingRuntimeModule, JsAsset, JsCompatSource, JsFilename,
-  JsModuleGraph, JsPathData, JsRspackDiagnostic, JsStats, JsStatsOptimizationBailout, ModuleObject,
-  RspackError, RspackResultToNapiResultExt, ToJsCompatSource, create_stats_warnings,
-  entry::JsEntryOptions, utils::callbackify,
+  COMPILER_REFERENCES,
+  asset::{AssetInfo, JsAsset},
+  chunk::{Chunk, ChunkWrapper},
+  chunk_graph::ChunkGraph,
+  chunk_group::ChunkGroupWrapper,
+  dependencies::EntryDependency,
+  error::{ErrorCode, JsRspackDiagnostic, RspackError, RspackResultToNapiResultExt},
+  filename::JsFilename,
+  module::{JsAddingRuntimeModule, ModuleObject},
+  module_graph::JsModuleGraph,
+  options::entry::JsEntryOptions,
+  path_data::{JsPathData, PathWithInfo},
+  source::{JsCompatSource, ToJsCompatSource},
+  stats::{JsStats, JsStatsOptimizationBailout, create_stats_warnings},
+  utils::callbackify,
 };
 
 #[napi]

--- a/crates/rspack_binding_api/src/context_module_factory.rs
+++ b/crates/rspack_binding_api/src/context_module_factory.rs
@@ -5,7 +5,7 @@ use napi_derive::napi;
 use rspack_core::{AfterResolveData, BeforeResolveData};
 use rspack_regex::RspackRegex;
 
-use crate::DependencyWrapper;
+use crate::dependency::DependencyWrapper;
 
 #[napi]
 pub struct JsContextModuleFactoryBeforeResolveData(Box<BeforeResolveData>);

--- a/crates/rspack_binding_api/src/dependencies/mod.rs
+++ b/crates/rspack_binding_api/src/dependencies/mod.rs
@@ -4,7 +4,7 @@ pub use entry_dependency::*;
 use napi::bindgen_prelude::{Either, FromNapiValue};
 use rspack_core::DependencyId;
 
-use crate::Dependency;
+use crate::dependency::Dependency;
 
 // DependencyObject is used to uniformly handle Dependency and EntryDependency.
 pub struct DependencyObject(Option<DependencyId>);

--- a/crates/rspack_binding_api/src/dependency.rs
+++ b/crates/rspack_binding_api/src/dependency.rs
@@ -13,7 +13,7 @@ use rspack_plugin_javascript::dependency::{
 };
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::ModuleObject;
+use crate::module::ModuleObject;
 
 // allows JS-side access to a Dependency instance that has already
 // been processed and stored in the Compilation.

--- a/crates/rspack_binding_api/src/error.rs
+++ b/crates/rspack_binding_api/src/error.rs
@@ -13,7 +13,7 @@ use rspack_error::{
 };
 use rspack_napi::napi::check_status;
 
-use crate::{DependencyLocation, ModuleObject, define_symbols};
+use crate::{define_symbols, location::DependencyLocation, module::ModuleObject};
 
 pub enum ErrorCode {
   Napi(napi::Status),

--- a/crates/rspack_binding_api/src/exports_info.rs
+++ b/crates/rspack_binding_api/src/exports_info.rs
@@ -7,7 +7,7 @@ use rspack_core::{
 };
 use rspack_util::atom::Atom;
 
-use crate::JsRuntimeSpec;
+use crate::runtime::JsRuntimeSpec;
 
 #[napi]
 pub struct JsExportsInfo {

--- a/crates/rspack_binding_api/src/filename.rs
+++ b/crates/rspack_binding_api/src/filename.rs
@@ -8,7 +8,7 @@ use napi::{
 use rspack_core::{Filename, FilenameFn, LocalFilenameFn, PathData, PublicPath};
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 
-use crate::{AssetInfo, JsPathData};
+use crate::{asset::AssetInfo, path_data::JsPathData};
 
 type FilenameValue =
   Either<String, ThreadsafeFunction<FnArgs<(JsPathData, Option<AssetInfo>)>, String>>;

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -1,9 +1,7 @@
-//! # rspack_binding_api
-//!
-//! Shared binding API for Rspack, providing bridge interfaces between Rspack core functionality and Node.js/browser environments.
-//!
-//! ## Overview
-//!
+#![recursion_limit = "256"]
+#![allow(deprecated)]
+#![allow(unused)]
+
 //! `rspack_binding_api` is the core binding layer in the Rspack project, responsible for exposing Rspack core functionality written in Rust to JavaScript/TypeScript environments. It provides complete API interfaces for compilation, building, module processing, and other functionalities.
 //!
 //! ## Features
@@ -45,10 +43,6 @@
 //! If you're a user of Rspack custom binding:
 //! - Do not depend on this crate directly
 //! - Use [`rspack_binding_builder`](https://crates.io/crates/rspack_binding_builder) to build your own binding
-
-#![recursion_limit = "256"]
-#![allow(deprecated)]
-#![allow(unused)]
 
 #[macro_use]
 extern crate napi_derive;

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -1,29 +1,10 @@
 #![recursion_limit = "256"]
 #![allow(deprecated)]
+#![allow(unused)]
 
 #[macro_use]
 extern crate napi_derive;
 extern crate rspack_allocator;
-use std::{cell::RefCell, sync::Arc};
-
-use compiler::{Compiler, CompilerState, CompilerStateGuard};
-use fs_node::HybridFileSystem;
-use napi::{CallContext, bindgen_prelude::*};
-use rspack_collections::UkeyMap;
-use rspack_core::{
-  BoxDependency, Compilation, CompilerId, EntryOptions, ModuleIdentifier, PluginExt,
-};
-use rspack_error::Diagnostic;
-use rspack_fs::{IntermediateFileSystem, NativeFileSystem, ReadableFileSystem};
-use rspack_tasks::{CURRENT_COMPILER_CONTEXT, CompilerContext, within_compiler_context_sync};
-use rspack_util::tracing_preset::{
-  TRACING_ALL_PRESET, TRACING_BENCH_TARGET, TRACING_OVERVIEW_PRESET,
-};
-
-use crate::{
-  fs_node::{NodeFileSystem, ThreadsafeNodeFS},
-  trace_event::RawTraceEvent,
-};
 
 mod allocator;
 mod asset;
@@ -75,56 +56,45 @@ mod swc;
 mod trace_event;
 mod utils;
 
-pub use asset::*;
-pub use asset_condition::*;
-pub use async_dependency_block::*;
-pub use browserslist::*;
-pub use build_info::*;
-pub use chunk::*;
-pub use chunk_graph::*;
-pub use chunk_group::*;
-pub use clean_options::*;
-pub use codegen_result::*;
-pub use compilation::*;
-pub use context_module_factory::*;
-pub use dependencies::*;
-pub use dependency::*;
-pub use diagnostic::*;
-pub use error::*;
-pub use exports_info::*;
-pub use filename::*;
-pub use html::*;
-pub use location::*;
-pub use module::*;
-pub use module_graph::*;
-pub use module_graph_connection::*;
-pub use modules::*;
-pub use native_watcher::*;
-pub use normal_module_factory::*;
-pub use options::*;
-pub use path_data::*;
-pub use plugins::buildtime_plugins;
-use plugins::*;
-pub use raw_options::*;
-pub use resolver::*;
-use resolver_factory::*;
-pub use resource_data::*;
-pub use rsdoctor::*;
-pub use rslib::*;
-pub use rspack_resolver::*;
+use std::{cell::RefCell, sync::Arc};
+
+use napi::{CallContext, bindgen_prelude::*};
+use rspack_collections::UkeyMap;
+use rspack_core::{
+  BoxDependency, Compilation, CompilerId, EntryOptions, ModuleIdentifier, PluginExt,
+};
+use rspack_error::Diagnostic;
+use rspack_fs::{IntermediateFileSystem, NativeFileSystem, ReadableFileSystem};
+use rspack_tasks::{CURRENT_COMPILER_CONTEXT, CompilerContext, within_compiler_context_sync};
 use rspack_tracing::{PerfettoTracer, StdoutTracer, TraceEvent, Tracer};
-pub use rstest::*;
-pub use runtime::*;
+use rspack_util::tracing_preset::{
+  TRACING_ALL_PRESET, TRACING_BENCH_TARGET, TRACING_OVERVIEW_PRESET,
+};
 use rustc_hash::FxHashMap;
-pub use source::*;
-pub use stats::*;
-pub use swc::*;
 use swc_core::common::util::take::Take;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
   EnvFilter, Layer, Registry, layer::SubscriberExt, reload, util::SubscriberInitExt,
 };
-pub use utils::*;
+
+use crate::{
+  async_dependency_block::AsyncDependenciesBlockWrapper,
+  chunk::ChunkWrapper,
+  chunk_group::ChunkGroupWrapper,
+  compilation::JsCompilationWrapper,
+  compiler::{Compiler, CompilerState, CompilerStateGuard},
+  dependency::DependencyWrapper,
+  error::{ErrorCode, RspackResultToNapiResultExt},
+  fs_node::{HybridFileSystem, NodeFileSystem, ThreadsafeNodeFS},
+  module::ModuleObject,
+  plugins::{
+    JsCleanupPlugin, JsHooksAdapterPlugin, RegisterJsTapKind, RegisterJsTaps, buildtime_plugins,
+  },
+  raw_options::{BuiltinPlugin, RawOptions, WithFalse},
+  resolver_factory::JsResolverFactory,
+  trace_event::RawTraceEvent,
+  utils::callbackify,
+};
 
 // Export expected @rspack/core version
 /// Expected version of @rspack/core to the current binding version
@@ -133,7 +103,7 @@ pub use utils::*;
 pub const EXPECTED_RSPACK_CORE_VERSION: &str = rspack_workspace::rspack_pkg_version!();
 
 thread_local! {
-  pub static COMPILER_REFERENCES: RefCell<UkeyMap<CompilerId, WeakReference<JsCompiler>>> = Default::default();
+  static COMPILER_REFERENCES: RefCell<UkeyMap<CompilerId, WeakReference<JsCompiler>>> = Default::default();
 }
 
 #[js_function(1)]
@@ -146,7 +116,7 @@ fn cleanup_revoked_modules(ctx: CallContext) -> Result<()> {
 }
 
 #[napi(custom_finalize)]
-pub struct JsCompiler {
+struct JsCompiler {
   js_hooks_plugin: JsHooksAdapterPlugin,
   compiler: Compiler,
   state: CompilerState,
@@ -520,7 +490,7 @@ thread_local! {
  * Copyright (c)
  */
 #[napi]
-pub fn register_global_trace(
+fn register_global_trace(
   filter: String,
   #[napi(ts_arg_type = " \"logger\" | \"perfetto\" ")] layer: String,
   output: String,
@@ -586,7 +556,7 @@ pub fn cleanup_global_trace() {
 }
 // sync Node.js event to Rust side
 #[napi]
-pub fn sync_trace_event(events: Vec<RawTraceEvent>) {
+fn sync_trace_event(events: Vec<RawTraceEvent>) {
   use std::borrow::BorrowMut;
   GLOBAL_TRACE_STATE.with(|state| {
     let mut state = state.borrow_mut();
@@ -618,7 +588,7 @@ fn node_init(mut _exports: Object, env: Env) -> Result<()> {
 }
 
 #[napi(module_exports)]
-pub fn rspack_module_exports(exports: Object, env: Env) -> Result<()> {
+fn rspack_module_exports(exports: Object, env: Env) -> Result<()> {
   node_init(exports, env)?;
   module::export_symbols(exports, env)?;
   build_info::export_symbols(exports, env)?;

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -1,3 +1,51 @@
+//! # rspack_binding_api
+//!
+//! Shared binding API for Rspack, providing bridge interfaces between Rspack core functionality and Node.js/browser environments.
+//!
+//! ## Overview
+//!
+//! `rspack_binding_api` is the core binding layer in the Rspack project, responsible for exposing Rspack core functionality written in Rust to JavaScript/TypeScript environments. It provides complete API interfaces for compilation, building, module processing, and other functionalities.
+//!
+//! ## Features
+//!
+//! - `browser`: Enable browser environment support
+//! - `color-backtrace`: Enable colored error backtraces
+//! - `debug_tool`: Enable debug tools
+//! - `plugin`: Enable SWC plugin support
+//! - `sftrace-setup`: Enable performance tracing setup
+//!
+//! ## Important Notice
+//!
+//! ⚠️ **Version Compatibility Warning**
+//!
+//! **This repository does not follow Semantic Versioning (SemVer).**
+//!
+//! - Any version update may contain breaking changes
+//! - It is recommended to lock specific version numbers in production environments
+//! - Please thoroughly test all functionality before upgrading
+//!
+//! ## API Usage Warning
+//!
+//! 🚨 **This package's API should NOT be used as a public Rust API**
+//!
+//! This crate is designed to be linked as a **C dynamic library** during Rspack binding generation, not as a public Rust API for external consumption.
+//!
+//! ### For Developers
+//!
+//! If you're working on Rspack itself:
+//! - This crate is safe to use within the Rspack project
+//! - Changes should be coordinated with the binding generation process
+//! - Test thoroughly when making changes
+//!
+//! If you're an external developer:
+//! - Do not depend on this crate directly
+//! - Use the official Rspack Node.js package instead
+//! - Report issues through the main Rspack repository
+//!
+//! If you're a user of Rspack custom binding:
+//! - Do not depend on this crate directly
+//! - Use [`rspack_binding_builder`](https://crates.io/crates/rspack_binding_builder) to build your own binding
+
 #![recursion_limit = "256"]
 #![allow(deprecated)]
 #![allow(unused)]
@@ -59,6 +107,7 @@ mod utils;
 use std::{cell::RefCell, sync::Arc};
 
 use napi::{CallContext, bindgen_prelude::*};
+pub use raw_options::{CustomPluginBuilder, register_custom_plugin};
 use rspack_collections::UkeyMap;
 use rspack_core::{
   BoxDependency, Compilation, CompilerId, EntryOptions, ModuleIdentifier, PluginExt,

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -15,11 +15,17 @@ use rspack_napi::{
 use rspack_plugin_runtime::RuntimeModuleFromJs;
 use rspack_util::source_map::SourceMapKind;
 
-use super::JsCompatSourceOwned;
 use crate::{
-  AssetInfo, AsyncDependenciesBlockWrapper, BuildInfo, COMPILER_REFERENCES, ChunkWrapper,
-  ConcatenatedModule, ContextModule, DependencyWrapper, ExternalModule, JsCodegenerationResults,
-  JsCompatSource, JsCompiler, NormalModule, ToJsCompatSource, define_symbols,
+  COMPILER_REFERENCES, JsCompiler,
+  asset::AssetInfo,
+  async_dependency_block::AsyncDependenciesBlockWrapper,
+  build_info::BuildInfo,
+  chunk::ChunkWrapper,
+  codegen_result::JsCodegenerationResults,
+  define_symbols,
+  dependency::DependencyWrapper,
+  modules::{ConcatenatedModule, ContextModule, ExternalModule, NormalModule},
+  source::{JsCompatSource, JsCompatSourceOwned, ToJsCompatSource},
 };
 
 define_symbols! {

--- a/crates/rspack_binding_api/src/module_graph.rs
+++ b/crates/rspack_binding_api/src/module_graph.rs
@@ -5,7 +5,10 @@ use napi_derive::napi;
 use rspack_core::{Compilation, ModuleGraph, PrefetchExportsInfoMode, RuntimeSpec};
 
 use crate::{
-  DependencyObject, JsExportsInfo, ModuleGraphConnectionWrapper, ModuleObject, ModuleObjectRef,
+  dependencies::DependencyObject,
+  exports_info::JsExportsInfo,
+  module::{ModuleObject, ModuleObjectRef},
+  module_graph_connection::ModuleGraphConnectionWrapper,
 };
 
 #[napi]

--- a/crates/rspack_binding_api/src/module_graph_connection.rs
+++ b/crates/rspack_binding_api/src/module_graph_connection.rs
@@ -6,7 +6,7 @@ use rspack_collections::UkeyMap;
 use rspack_core::{Compilation, CompilationId, DependencyId, ModuleGraph};
 use rspack_napi::OneShotRef;
 
-use crate::{DependencyWrapper, ModuleObject};
+use crate::{dependency::DependencyWrapper, module::ModuleObject};
 
 #[napi]
 pub struct ModuleGraphConnection {

--- a/crates/rspack_binding_api/src/modules/concatenated_module.rs
+++ b/crates/rspack_binding_api/src/modules/concatenated_module.rs
@@ -1,4 +1,7 @@
-use crate::{MODULE_PROPERTIES_BUFFER, Module, ModuleObject, impl_module_methods};
+use crate::{
+  impl_module_methods,
+  module::{MODULE_PROPERTIES_BUFFER, Module, ModuleObject},
+};
 
 #[napi]
 #[repr(C)]

--- a/crates/rspack_binding_api/src/modules/context_module.rs
+++ b/crates/rspack_binding_api/src/modules/context_module.rs
@@ -1,4 +1,7 @@
-use crate::{MODULE_PROPERTIES_BUFFER, Module, impl_module_methods};
+use crate::{
+  impl_module_methods,
+  module::{MODULE_PROPERTIES_BUFFER, Module},
+};
 
 #[napi]
 #[repr(C)]

--- a/crates/rspack_binding_api/src/modules/external_module.rs
+++ b/crates/rspack_binding_api/src/modules/external_module.rs
@@ -1,4 +1,7 @@
-use crate::{MODULE_PROPERTIES_BUFFER, Module, impl_module_methods};
+use crate::{
+  impl_module_methods,
+  module::{MODULE_PROPERTIES_BUFFER, Module},
+};
 
 #[napi]
 #[repr(C)]

--- a/crates/rspack_binding_api/src/modules/macros.rs
+++ b/crates/rspack_binding_api/src/modules/macros.rs
@@ -72,7 +72,7 @@ macro_rules! impl_module_methods {
         }
 
         #[js_function]
-        fn factory_meta_getter(ctx: napi::CallContext) -> napi::Result<$crate::JsFactoryMeta> {
+        fn factory_meta_getter(ctx: napi::CallContext) -> napi::Result<$crate::module::JsFactoryMeta> {
           use rspack_core::Module;
 
           let this = ctx.this_unchecked::<napi::JsObject>();
@@ -85,14 +85,14 @@ macro_rules! impl_module_methods {
           let (_, module) = wrapped_value.module.as_ref()?;
           Ok(match module.as_normal_module() {
             Some(normal_module) => match normal_module.factory_meta() {
-              Some(meta) => $crate::JsFactoryMeta {
+              Some(meta) => $crate::module::JsFactoryMeta {
                 side_effect_free: meta.side_effect_free,
               },
-              None => $crate::JsFactoryMeta {
+              None => $crate::module::JsFactoryMeta {
                 side_effect_free: None,
               },
             },
-            None => $crate::JsFactoryMeta {
+            None => $crate::module::JsFactoryMeta {
               side_effect_free: None,
             },
           })
@@ -108,7 +108,7 @@ macro_rules! impl_module_methods {
             )?
           };
           let module = wrapped_value.module.as_mut()?;
-          let factory_meta = ctx.get::<$crate::JsFactoryMeta>(0)?;
+          let factory_meta = ctx.get::<$crate::module::JsFactoryMeta>(0)?;
           module.set_factory_meta(factory_meta.into());
           Ok(())
         }
@@ -119,13 +119,13 @@ macro_rules! impl_module_methods {
           let mut this = ctx.this::<napi::JsObject>()?;
           let env = ctx.env;
           let raw_env = env.raw();
-          let mut reference: napi::bindgen_prelude::Reference<$crate::Module> =
+          let mut reference: napi::bindgen_prelude::Reference<$crate::module::Module> =
             unsafe { napi::bindgen_prelude::Reference::from_napi_value(raw_env, this.raw())? };
           if let Some(r) = &reference.build_info_ref {
             return r.as_object(env);
           }
-          let mut build_info = $crate::BuildInfo::new(reference.downgrade()).get_jsobject(env)?;
-          $crate::MODULE_BUILD_INFO_SYMBOL.with(|once_cell| {
+          let mut build_info = $crate::build_info::BuildInfo::new(reference.downgrade()).get_jsobject(env)?;
+          $crate::module::MODULE_BUILD_INFO_SYMBOL.with(|once_cell| {
             let sym = unsafe {
               #[allow(clippy::unwrap_used)]
               let napi_val = napi::bindgen_prelude::ToNapiValue::to_napi_value(env.raw(), once_cell.get().unwrap())?;
@@ -149,7 +149,7 @@ macro_rules! impl_module_methods {
           let raw_env = env.raw();
           let mut reference: napi::bindgen_prelude::Reference<Module> =
             unsafe { napi::bindgen_prelude::Reference::from_napi_value(raw_env, this.raw())? };
-          let new_build_info = $crate::BuildInfo::new(reference.downgrade());
+          let new_build_info = $crate::build_info::BuildInfo::new(reference.downgrade());
           let mut new_instrance = new_build_info.get_jsobject(env)?;
 
           let names = input_object.get_all_property_names(
@@ -173,7 +173,7 @@ macro_rules! impl_module_methods {
             }
           }
 
-          $crate::MODULE_BUILD_INFO_SYMBOL.with(|once_cell| {
+          $crate::module::MODULE_BUILD_INFO_SYMBOL.with(|once_cell| {
             let sym = unsafe {
               #[allow(clippy::unwrap_used)]
               let napi_val = napi::bindgen_prelude::ToNapiValue::to_napi_value(env.raw(), once_cell.get().unwrap())?;
@@ -227,7 +227,7 @@ macro_rules! impl_module_methods {
             .with_utf8_name("buildMeta")?
             .with_value(&napi::bindgen_prelude::Object::new(env)?)
         );
-        $crate:: MODULE_IDENTIFIER_SYMBOL.with(|once_cell| {
+        $crate::module::MODULE_IDENTIFIER_SYMBOL.with(|once_cell| {
           let identifier = env.create_string(module.identifier().as_str())?;
           let symbol = once_cell.get().unwrap();
           properties.push(
@@ -255,7 +255,7 @@ macro_rules! impl_module_methods {
       pub fn original_source(
         &mut self,
         env: &napi::Env,
-      ) -> napi::Result<napi::Either<$crate::JsCompatSource<'_>, ()>> {
+      ) -> napi::Result<napi::Either<$crate::source::JsCompatSource<'_>, ()>> {
         self.module.original_source(env)
       }
 
@@ -287,7 +287,7 @@ macro_rules! impl_module_methods {
       pub fn lib_ident<'a>(
         &mut self,
         env: &'a napi::Env,
-        options: $crate::JsLibIdentOptions,
+        options: $crate::module::JsLibIdentOptions,
       ) -> napi::Result<Option<napi::JsString<'a>>> {
         self.module.lib_ident(env, options)
       }
@@ -301,7 +301,7 @@ macro_rules! impl_module_methods {
         &mut self,
         env: &napi::Env,
         filename: String,
-        source: $crate::JsCompatSource,
+        source: $crate::source::JsCompatSource,
         asset_info: Option<napi::bindgen_prelude::Object>,
       ) -> napi::Result<()> {
         self

--- a/crates/rspack_binding_api/src/modules/normal_module.rs
+++ b/crates/rspack_binding_api/src/modules/normal_module.rs
@@ -5,8 +5,10 @@ use napi::{
 use rspack_core::{ResourceData, ResourceParsedData, parse_resource};
 
 use crate::{
-  MODULE_PROPERTIES_BUFFER, Module, ReadonlyResourceDataWrapper, impl_module_methods,
+  impl_module_methods,
+  module::{MODULE_PROPERTIES_BUFFER, Module},
   plugins::JsLoaderItem,
+  resource_data::ReadonlyResourceDataWrapper,
 };
 
 #[napi]

--- a/crates/rspack_binding_api/src/normal_module_factory.rs
+++ b/crates/rspack_binding_api/src/normal_module_factory.rs
@@ -2,7 +2,7 @@ use napi_derive::napi;
 use rspack_core::NormalModuleCreateData;
 use serde::Serialize;
 
-use crate::JsResourceData;
+use crate::resource_data::JsResourceData;
 
 #[napi(object)]
 pub struct JsResolveForSchemeArgs {

--- a/crates/rspack_binding_api/src/options/entry.rs
+++ b/crates/rspack_binding_api/src/options/entry.rs
@@ -3,7 +3,7 @@ use napi_derive::napi;
 use rspack_core::{EntryOptions, EntryRuntime};
 
 use super::library::JsLibraryOptions;
-use crate::{JsFilename, RawChunkLoading};
+use crate::{filename::JsFilename, raw_options::RawChunkLoading};
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]

--- a/crates/rspack_binding_api/src/path_data.rs
+++ b/crates/rspack_binding_api/src/path_data.rs
@@ -1,6 +1,6 @@
 use napi_derive::napi;
 
-use super::AssetInfo;
+use crate::asset::AssetInfo;
 
 #[napi(object)]
 pub struct JsPathData {

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -70,19 +70,33 @@ use rspack_plugin_runtime::{
 };
 
 use crate::{
-  ChunkWrapper, JsAdditionalTreeRuntimeRequirementsArg, JsAdditionalTreeRuntimeRequirementsResult,
-  JsAfterEmitData, JsAfterResolveData, JsAfterResolveOutput, JsAfterTemplateExecutionData,
-  JsAlterAssetTagGroupsData, JsAlterAssetTagsData, JsAssetEmittedArgs,
-  JsBeforeAssetTagGenerationData, JsBeforeEmitData, JsBeforeResolveArgs, JsBeforeResolveOutput,
-  JsChunkAssetArgs, JsCompilationWrapper, JsContextModuleFactoryAfterResolveDataWrapper,
-  JsContextModuleFactoryAfterResolveResult, JsContextModuleFactoryBeforeResolveDataWrapper,
-  JsContextModuleFactoryBeforeResolveResult, JsCreateData, JsCreateScriptData, JsExecuteModuleArg,
-  JsFactorizeArgs, JsFactorizeOutput, JsLinkPrefetchData, JsLinkPreloadData,
-  JsNormalModuleFactoryCreateModuleArgs, JsResolveArgs, JsResolveForSchemeArgs,
-  JsResolveForSchemeOutput, JsResolveOutput, JsRsdoctorAssetPatch, JsRsdoctorChunkGraph,
-  JsRsdoctorModuleGraph, JsRsdoctorModuleIdsPatch, JsRsdoctorModuleSourcesPatch, JsRuntimeGlobals,
-  JsRuntimeModule, JsRuntimeModuleArg, JsRuntimeRequirementInTreeArg,
-  JsRuntimeRequirementInTreeResult, ModuleObject, ToJsCompatSourceOwned,
+  asset::JsAssetEmittedArgs,
+  chunk::{ChunkWrapper, JsChunkAssetArgs},
+  compilation::JsCompilationWrapper,
+  context_module_factory::{
+    JsContextModuleFactoryAfterResolveDataWrapper, JsContextModuleFactoryAfterResolveResult,
+    JsContextModuleFactoryBeforeResolveDataWrapper, JsContextModuleFactoryBeforeResolveResult,
+  },
+  html::{
+    JsAfterEmitData, JsAfterTemplateExecutionData, JsAlterAssetTagGroupsData, JsAlterAssetTagsData,
+    JsBeforeAssetTagGenerationData, JsBeforeEmitData,
+  },
+  module::{JsExecuteModuleArg, JsRuntimeModule, JsRuntimeModuleArg, ModuleObject},
+  normal_module_factory::{
+    JsAfterResolveData, JsAfterResolveOutput, JsBeforeResolveArgs, JsBeforeResolveOutput,
+    JsCreateData, JsFactorizeArgs, JsFactorizeOutput, JsNormalModuleFactoryCreateModuleArgs,
+    JsResolveArgs, JsResolveForSchemeArgs, JsResolveForSchemeOutput, JsResolveOutput,
+  },
+  rsdoctor::{
+    JsRsdoctorAssetPatch, JsRsdoctorChunkGraph, JsRsdoctorModuleGraph, JsRsdoctorModuleIdsPatch,
+    JsRsdoctorModuleSourcesPatch,
+  },
+  runtime::{
+    JsAdditionalTreeRuntimeRequirementsArg, JsAdditionalTreeRuntimeRequirementsResult,
+    JsCreateScriptData, JsLinkPrefetchData, JsLinkPreloadData, JsRuntimeGlobals,
+    JsRuntimeRequirementInTreeArg, JsRuntimeRequirementInTreeResult,
+  },
+  source::ToJsCompatSourceOwned,
 };
 
 #[napi(object)]

--- a/crates/rspack_binding_api/src/plugins/js_loader/context.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/context.rs
@@ -8,7 +8,7 @@ use rspack_loader_runner::State as LoaderState;
 use rspack_napi::threadsafe_js_value_ref::ThreadsafeJsValueRef;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::{ModuleObject, RspackError};
+use crate::{error::RspackError, module::ModuleObject};
 
 #[napi(object)]
 #[derive(Hash)]

--- a/crates/rspack_binding_api/src/plugins/js_loader/mod.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/mod.rs
@@ -24,7 +24,7 @@ use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashSet;
 use tokio::sync::{OnceCell, RwLock};
 
-use crate::{COMPILER_REFERENCES, RspackResultToNapiResultExt};
+use crate::{COMPILER_REFERENCES, error::RspackResultToNapiResultExt};
 
 pub type JsLoaderRunner = ThreadsafeFunction<
   JsLoaderContext,

--- a/crates/rspack_binding_api/src/raw_options/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/mod.rs
@@ -38,7 +38,7 @@ pub use raw_output::*;
 pub use raw_split_chunks::*;
 pub use raw_stats::*;
 
-pub use crate::raw_resolve::*;
+pub use crate::options::raw_resolve::*;
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -122,11 +122,16 @@ use self::{
   raw_size_limits::RawSizeLimitsPluginOptions,
 };
 use crate::{
-  JsLoaderRunnerGetter, RawContextReplacementPluginOptions, RawDynamicEntryPluginOptions,
-  RawEvalDevToolModulePluginOptions, RawExternalItemWrapper, RawExternalsPluginOptions,
-  RawHttpExternalsRspackPluginOptions, RawRsdoctorPluginOptions, RawRslibPluginOptions,
-  RawRstestPluginOptions, RawSplitChunksOptions, SourceMapDevToolPluginOptions,
-  entry::JsEntryPluginOptions, plugins::JsLoaderRspackPlugin,
+  options::entry::JsEntryPluginOptions,
+  plugins::{JsLoaderRspackPlugin, JsLoaderRunnerGetter, RawContextReplacementPluginOptions},
+  raw_options::{
+    RawDynamicEntryPluginOptions, RawEvalDevToolModulePluginOptions, RawExternalItemWrapper,
+    RawExternalsPluginOptions, RawHttpExternalsRspackPluginOptions, RawSplitChunksOptions,
+    SourceMapDevToolPluginOptions,
+  },
+  rsdoctor::RawRsdoctorPluginOptions,
+  rslib::RawRslibPluginOptions,
+  rstest::RawRstestPluginOptions,
 };
 
 #[napi(string_enum)]

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -231,6 +231,7 @@ pub enum BuiltinPluginName {
   CssChunkingPlugin,
 }
 
+#[doc(hidden)]
 pub type CustomPluginBuilder =
   for<'a> fn(env: Env, options: Unknown<'a>) -> napi::Result<BoxPlugin>;
 

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -136,6 +136,7 @@ use crate::{
 
 #[napi(string_enum)]
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum BuiltinPluginName {
   // webpack also have these plugins
   DefinePlugin,

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_banner.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_banner.rs
@@ -6,7 +6,10 @@ use rspack_error::Result;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_banner::{BannerContent, BannerContentFnCtx, BannerPluginOptions};
 
-use crate::{ChunkWrapper, RawAssetConditions, into_asset_conditions};
+use crate::{
+  asset_condition::{RawAssetConditions, into_asset_conditions},
+  chunk::ChunkWrapper,
+};
 
 #[napi(object, object_from_js = false)]
 pub struct JsBannerContentFnCtx {

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_css_extract.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_css_extract.rs
@@ -2,7 +2,7 @@ use napi_derive::napi;
 use rspack_plugin_extract_css::plugin::{CssExtractOptions, InsertType};
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::JsFilename;
+use crate::filename::JsFilename;
 
 #[napi(object, object_to_js = false)]
 pub struct RawCssExtractPluginOption {

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_dll.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_dll.rs
@@ -8,7 +8,7 @@ use rspack_plugin_dll::{
 use rustc_hash::FxHashMap as HashMap;
 use swc_core::atoms::Atom;
 
-use crate::{JsBuildMeta, JsFilename};
+use crate::{filename::JsFilename, module::JsBuildMeta};
 
 #[derive(Debug)]
 #[napi(object)]

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_lazy_compilation.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_lazy_compilation.rs
@@ -13,7 +13,7 @@ use rspack_plugin_lazy_compilation::{
 };
 use rspack_regex::RspackRegex;
 
-use crate::ModuleObject;
+use crate::module::ModuleObject;
 
 #[derive(Debug)]
 pub struct RawLazyCompilationTest<F = ThreadsafeFunction<ModuleObject, Option<bool>>>(

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_lightning_css_minimizer.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_lightning_css_minimizer.rs
@@ -5,7 +5,7 @@ use rspack_plugin_lightning_css_minimizer::{
   Draft, MinimizerOptions, NonStandard, PluginOptions, PseudoClasses,
 };
 
-use crate::{RawAssetConditions, into_asset_conditions};
+use crate::asset_condition::{RawAssetConditions, into_asset_conditions};
 
 #[derive(Debug)]
 #[napi(object)]

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_mf.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_mf.rs
@@ -8,7 +8,7 @@ use rspack_plugin_mf::{
   ProvideOptions, ProvideVersion, RemoteOptions,
 };
 
-use crate::{
+use crate::options::{
   entry::{JsEntryRuntime, JsEntryRuntimeWrapper},
   library::JsLibraryOptions,
 };

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_swc_js_minimizer.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_swc_js_minimizer.rs
@@ -7,7 +7,7 @@ use rspack_plugin_swc_js_minimizer::{
 use serde::de::DeserializeOwned;
 use swc_core::base::BoolOrDataConfig;
 
-use crate::{RawAssetConditions, into_asset_conditions};
+use crate::asset_condition::{RawAssetConditions, into_asset_conditions};
 
 #[derive(Debug)]
 #[napi(object)]

--- a/crates/rspack_binding_api/src/raw_options/raw_devtool.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_devtool.rs
@@ -11,7 +11,7 @@ use rspack_plugin_devtool::{
   Append, EvalDevToolModulePluginOptions, ModuleFilenameTemplate, ModuleFilenameTemplateFnCtx,
 };
 
-use crate::{RawAssetConditions, into_asset_conditions};
+use crate::asset_condition::{RawAssetConditions, into_asset_conditions};
 
 type RawAppend = Either3<String, bool, ThreadsafeFunction<RawPathData, String>>;
 

--- a/crates/rspack_binding_api/src/raw_options/raw_dynamic_entry.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_dynamic_entry.rs
@@ -3,7 +3,7 @@ use napi_derive::napi;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_dynamic_entry::{DynamicEntryPluginOptions, EntryDynamicResult};
 
-use crate::entry::JsEntryOptions;
+use crate::options::entry::JsEntryOptions;
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]

--- a/crates/rspack_binding_api/src/raw_options/raw_external.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_external.rs
@@ -14,8 +14,12 @@ use rspack_regex::RspackRegex;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
-  ErrorCode, RawResolveOptionsWithDependencyType, ResolveRequest, callbackify,
-  normalize_raw_resolve_options_with_dependency_type,
+  error::ErrorCode,
+  options::raw_resolve::{
+    RawResolveOptionsWithDependencyType, normalize_raw_resolve_options_with_dependency_type,
+  },
+  resolver::ResolveRequest,
+  utils::callbackify,
 };
 
 #[napi(object)]

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -23,7 +23,7 @@ use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_regex::RspackRegex;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::{JsFilename, ModuleObject, RawResolveOptions};
+use crate::{filename::JsFilename, module::ModuleObject, options::raw_resolve::RawResolveOptions};
 
 /// `loader` is for both JS and Rust loaders.
 /// `options` is

--- a/crates/rspack_binding_api/src/raw_options/raw_output.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_output.rs
@@ -5,7 +5,10 @@ use rspack_core::{
   OutputOptions, PathInfo, TrustedTypes, WasmLoading,
 };
 
-use crate::{JsCleanOptions, JsFilename, WithFalse, library::JsLibraryOptions};
+use crate::{
+  clean_options::JsCleanOptions, filename::JsFilename, options::library::JsLibraryOptions,
+  raw_options::WithFalse,
+};
 
 #[derive(Debug)]
 #[napi(object)]

--- a/crates/rspack_binding_api/src/raw_options/raw_split_chunks/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_split_chunks/mod.rs
@@ -22,7 +22,7 @@ use self::{
   raw_split_chunk_name::default_chunk_option_name,
   raw_split_chunk_size::RawSplitChunkSizes,
 };
-use crate::JsFilename;
+use crate::filename::JsFilename;
 
 #[napi(object, object_to_js = false)]
 #[derive(Debug)]

--- a/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
@@ -6,7 +6,7 @@ use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_split_chunks::{CacheGroupTest, CacheGroupTestFnCtx};
 use rspack_regex::RspackRegex;
 
-use crate::ModuleObject;
+use crate::module::ModuleObject;
 
 pub(super) type RawCacheGroupTest =
   Either3<String, RspackRegex, ThreadsafeFunction<JsCacheGroupTestCtx, Option<bool>>>;

--- a/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
@@ -4,7 +4,7 @@ use napi::{JsString, bindgen_prelude::Either3};
 use rspack_napi::{string::JsStringExt, threadsafe_function::ThreadsafeFunction};
 use rspack_regex::RspackRegex;
 
-use crate::ChunkWrapper;
+use crate::chunk::ChunkWrapper;
 
 pub type Chunks<'a> = Either3<RspackRegex, JsString<'a>, ThreadsafeFunction<ChunkWrapper, bool>>;
 

--- a/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_name.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_name.rs
@@ -5,7 +5,7 @@ use napi_derive::napi;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_split_chunks::{ChunkNameGetter, ChunkNameGetterFnCtx};
 
-use crate::{ChunkWrapper, ModuleObject};
+use crate::{chunk::ChunkWrapper, module::ModuleObject};
 
 pub(super) type RawChunkOptionName =
   Either3<String, bool, ThreadsafeFunction<JsChunkOptionNameCtx, Option<String>>>;

--- a/crates/rspack_binding_api/src/resolver.rs
+++ b/crates/rspack_binding_api/src/resolver.rs
@@ -8,7 +8,7 @@ use napi_derive::napi;
 use rspack_core::Resolver;
 use serde::Serialize;
 
-use crate::{ErrorCode, callbackify};
+use crate::{error::ErrorCode, utils::callbackify};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/rspack_binding_api/src/resolver_factory.rs
+++ b/crates/rspack_binding_api/src/resolver_factory.rs
@@ -5,10 +5,12 @@ use rspack_core::{Resolve, ResolverFactory};
 use rspack_fs::{NativeFileSystem, ReadableFileSystem};
 
 use crate::{
-  JsResolver, RawResolveOptions, RspackResultToNapiResultExt,
-  raw_resolve::{
-    RawResolveOptionsWithDependencyType, normalize_raw_resolve_options_with_dependency_type,
+  error::RspackResultToNapiResultExt,
+  options::raw_resolve::{
+    RawResolveOptions, RawResolveOptionsWithDependencyType,
+    normalize_raw_resolve_options_with_dependency_type,
   },
+  resolver::JsResolver,
 };
 
 #[napi]

--- a/crates/rspack_binding_api/src/runtime.rs
+++ b/crates/rspack_binding_api/src/runtime.rs
@@ -10,7 +10,7 @@ use rspack_plugin_runtime::{
 };
 use rustc_hash::FxHashMap;
 
-use crate::ChunkWrapper;
+use crate::chunk::ChunkWrapper;
 
 type RuntimeGlobalMap = (
   FxHashMap<RuntimeGlobals, String>,

--- a/crates/rspack_binding_api/src/source.rs
+++ b/crates/rspack_binding_api/src/source.rs
@@ -8,7 +8,7 @@ use rspack_core::rspack_sources::{
 };
 use rspack_napi::napi::bindgen_prelude::*;
 
-use crate::RspackResultToNapiResultExt;
+use crate::error::RspackResultToNapiResultExt;
 
 /// Zero copy `JsCompatSource` slice shared between Rust and Node.js if buffer is used.
 ///

--- a/crates/rspack_binding_api/src/stats.rs
+++ b/crates/rspack_binding_api/src/stats.rs
@@ -20,8 +20,10 @@ use rspack_util::{atom::Atom, itoa};
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
-  JsCompilation, JsModuleId, RspackError, RspackResultToNapiResultExt, identifier::JsIdentifier,
-  to_js_module_id,
+  chunk_graph::{JsModuleId, to_js_module_id},
+  compilation::JsCompilation,
+  error::{RspackError, RspackResultToNapiResultExt},
+  identifier::JsIdentifier,
 };
 
 // These handles are only used during the `to_json` call,

--- a/crates/rspack_binding_api/src/utils.rs
+++ b/crates/rspack_binding_api/src/utils.rs
@@ -3,7 +3,7 @@ use rspack_napi::napi::{
   Result, bindgen_prelude::*, threadsafe_function::ThreadsafeFunctionCallMode,
 };
 
-use crate::ErrorCode;
+use crate::error::ErrorCode;
 /**
  *  execution workflow
  *  1. let future_result = fut.await; // get rust future result


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Limit exported symbols in `rspack_binding_api`. 

I also added some usage clarifications to the existing rustdoc.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
