### PR TITLE
perf: improve process concatenated configurations

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -126,7 +126,6 @@ pub enum BindingType {
 pub struct ConcatenatedInnerModule {
   pub id: ModuleIdentifier,
   pub size: f64,
-  pub original_source_hash: Option<u64>,
   pub shorten_id: String,
 }
 


### PR DESCRIPTION
## Summary

- Remove `original_source_hash` because it is never used 
- Parallelize creating concatenated modules
- Parallelize preparing outgoings and incoming connections of concatenated modules

> Can not remove `ModuleConcatenationPlugin::process_concatenated_configuration` and `ModuleGraph::copy_outgoing_module_connections` and `ModuleGraph::move_module_connections` because these methods are also used in `ModernModuleLibraryPlugin`. Should remove them in another pull request.

Before:
<img width="598" height="56" alt="image" src="https://github.com/user-attachments/assets/a1ffe52b-5874-4e48-9db0-29f28c9fb8a7" />


After:
<img width="670" height="62" alt="image" src="https://github.com/user-attachments/assets/c5ae27bf-2e23-45f0-8603-8844f9998650" />



## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
