### PR TITLE
chore: ignore moduleFederationDefaultRuntime.js in rslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:js": "pnpm run lint-ci:js --write",
     "lint-ci:js": "biome check --diagnostic-level=warn --no-errors-on-unmatched --max-diagnostics=none --error-on-warnings",
     "lint:rs": "node ./scripts/check_rust_dependency.cjs",
-    "lint:type": "rslint --config rslint.json --max-warnings=1995",
+    "lint:type": "rslint --config rslint.json --max-warnings=1705",
     "build:binding:dev": "pnpm --filter @rspack/binding run build:dev",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",
     "build:binding:ci": "pnpm --filter @rspack/binding run build:ci",

--- a/rslint.json
+++ b/rslint.json
@@ -2,6 +2,9 @@
   {
     "language": "javascript",
     "files": [],
+    "ignores": [
+      "packages/rspack/src/runtime/moduleFederationDefaultRuntime.js"
+    ],
     "languageOptions": {
       "parserOptions": {
         "projectService": false,


### PR DESCRIPTION
## Summary
ignore 290 errors in `moduleFederationDefaultRuntime.js`.
it's a runtimejs file, ignore this temporally to reduce lint type errors
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
