### PR TITLE
chore: supporting  linux cache compressing with zstd

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -41,7 +41,7 @@ runs:
       uses: ./.github/actions/cache/restore
       with:
         path: ~/.rustup/toolchains
-        key: rustup-cache-v2-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
+        key: rustup-cache-v3-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
 
     # install components for nightly toolchain
     - name: Install
@@ -61,7 +61,7 @@ runs:
       if: ${{ inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       with:
         path: ~/.rustup/toolchains
-        key: rustup-cache-v2-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
+        key: rustup-cache-v3-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
 
     - name: Cargo cache
       if: ${{ runner.environment != 'self-hosted' || runner.os != 'Windows' }}

--- a/.github/actions/rustup/cargo/action.yml
+++ b/.github/actions/rustup/cargo/action.yml
@@ -13,13 +13,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install zstd
-      if: ${{ runner.environment == 'self-hosted' && runner.os == 'Linux' }}
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y zstd
-
     - name: Cache to github
       if: ${{ runner.environment == 'github-hosted' }}
       uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
@@ -32,7 +25,7 @@ runs:
       uses: stormslowly/rust-cache@8269079380bc35105b3ed8b0f1f7c9557c6dec93 # v0.0.2
       if: ${{ runner.environment == 'self-hosted' }}
       with:
-        prefix-key: "RCache-L-4"
+        prefix-key: "RCache-L-5"
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         fullmatch-only: "true"


### PR DESCRIPTION
## Summary

After self-hosted runner upgrade, zstd is default supported. So bumping cache version to adapt new cache version

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
