### PR TITLE
fix: CssGetFilenameRuntime should detect runtime requirements correctly

### DIFF
--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -538,7 +538,9 @@ async fn runtime_requirement_in_tree(
         "mini-css",
         SOURCE_TYPE[0],
         "__webpack_require__.miniCssF".into(),
-        move |_| has_hot_update,
+        move |runtime_requirements| {
+          runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS)
+        },
         move |chunk, compilation| {
           chunk
             .content_hash(&compilation.chunk_hashes_artifact)?


### PR DESCRIPTION
## Summary

`CssGetFilenameRuntime` can be registered multiple times, each time with different name (maybe), this is caused by `runtime_requirements_in_tree` can be invoke multiple times.

I cannot find a minimum way to repro the failed cases tho

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
