### PR TITLE
refactor: remove redundant `PluginContext` and `async_trait` from trait `Plugin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,6 @@ dependencies = [
 name = "rspack_plugin_dynamic_entry"
 version = "0.4.11"
 dependencies = [
- "async-trait",
  "derive_more 2.0.1",
  "futures",
  "rspack_core",
@@ -4662,7 +4661,6 @@ dependencies = [
 name = "rspack_plugin_entry"
 version = "0.4.11"
 dependencies = [
- "async-trait",
  "rspack_core",
  "rspack_error",
  "rspack_hook",
@@ -4965,7 +4963,6 @@ dependencies = [
 name = "rspack_plugin_progress"
 version = "0.4.11"
 dependencies = [
- "async-trait",
  "futures",
  "indicatif",
  "rspack_collections",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4591,7 +4591,6 @@ dependencies = [
 name = "rspack_plugin_devtool"
 version = "0.4.11"
 dependencies = [
- "async-trait",
  "cow-utils",
  "dashmap 6.1.0",
  "derive_more 2.0.1",
@@ -4851,7 +4850,6 @@ dependencies = [
 name = "rspack_plugin_library"
 version = "0.4.11"
 dependencies = [
- "async-trait",
  "futures",
  "regex",
  "rspack_cacheable",
@@ -4940,7 +4938,6 @@ dependencies = [
 name = "rspack_plugin_module_info_header"
 version = "0.4.11"
 dependencies = [
- "async-trait",
  "regex",
  "rspack_cacheable",
  "rspack_collections",
@@ -5026,7 +5023,6 @@ dependencies = [
 name = "rspack_plugin_rsdoctor"
 version = "0.4.11"
 dependencies = [
- "async-trait",
  "atomic_refcell",
  "futures",
  "indexmap",
@@ -5047,7 +5043,6 @@ dependencies = [
 name = "rspack_plugin_rslib"
 version = "0.4.11"
 dependencies = [
- "async-trait",
  "rspack_core",
  "rspack_error",
  "rspack_hook",
@@ -5060,7 +5055,6 @@ dependencies = [
 name = "rspack_plugin_rstest"
 version = "0.4.11"
 dependencies = [
- "async-trait",
  "camino",
  "regex",
  "rspack_cacheable",

--- a/crates/rspack_binding_api/src/plugins/js_cleanup_plugin.rs
+++ b/crates/rspack_binding_api/src/plugins/js_cleanup_plugin.rs
@@ -3,8 +3,7 @@ use derive_more::Debug;
 use napi::{Status, bindgen_prelude::External, threadsafe_function::ThreadsafeFunction};
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  ApplyContext, CompilationRevokedModules, CompilerId, CompilerOptions, ModuleIdentifier,
-  PluginContext,
+  ApplyContext, CompilationRevokedModules, CompilerId, CompilerOptions, ModuleIdentifier, Plugin,
 };
 use rspack_error::ToStringResultToRspackResultExt;
 use rspack_hook::{plugin, plugin_hook};
@@ -32,19 +31,13 @@ impl JsCleanupPlugin {
   }
 }
 
-#[async_trait]
-impl rspack_core::Plugin for JsCleanupPlugin {
+impl Plugin for JsCleanupPlugin {
   fn name(&self) -> &'static str {
     "rspack.JsCleanupPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut ApplyContext>,
-    _options: &CompilerOptions,
-  ) -> rspack_error::Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> rspack_error::Result<()> {
     ctx
-      .context
       .compilation_hooks
       .revoked_modules
       .tap(revoked_modules::new(self));

--- a/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
+++ b/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use napi::{Env, Result};
 use rspack_core::{
   ApplyContext, Compilation, CompilationId, CompilationParams, CompilerCompilation,
-  CompilerOptions, PluginContext,
+  CompilerOptions, Plugin,
 };
 use rspack_hook::{Hook as _, plugin, plugin_hook};
 use rspack_plugin_html::HtmlRspackPlugin;
@@ -80,113 +80,84 @@ impl fmt::Debug for JsHooksAdapterPlugin {
   }
 }
 
-#[async_trait]
-impl rspack_core::Plugin for JsHooksAdapterPlugin {
+impl Plugin for JsHooksAdapterPlugin {
   fn name(&self) -> &'static str {
     "rspack.JsHooksAdapterPlugin"
   }
 
   // #[tracing::instrument("js_hooks_adapter::apply", skip_all)]
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut ApplyContext>,
-    _options: &CompilerOptions,
-  ) -> rspack_error::Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> rspack_error::Result<()> {
     ctx
-      .context
       .compiler_hooks
       .this_compilation
       .intercept(self.register_compiler_this_compilation_taps.clone());
     ctx
-      .context
       .compiler_hooks
       .compilation
       .intercept(self.register_compiler_compilation_taps.clone());
     ctx
-      .context
       .compiler_hooks
       .make
       .intercept(self.register_compiler_make_taps.clone());
     ctx
-      .context
       .compiler_hooks
       .finish_make
       .intercept(self.register_compiler_finish_make_taps.clone());
     ctx
-      .context
       .compiler_hooks
       .should_emit
       .intercept(self.register_compiler_should_emit_taps.clone());
     ctx
-      .context
       .compiler_hooks
       .emit
       .intercept(self.register_compiler_emit_taps.clone());
     ctx
-      .context
       .compiler_hooks
       .after_emit
       .intercept(self.register_compiler_after_emit_taps.clone());
     ctx
-      .context
       .compiler_hooks
       .asset_emitted
       .intercept(self.register_compiler_asset_emitted_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .build_module
       .intercept(self.register_compilation_build_module_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .still_valid_module
       .intercept(self.register_compilation_still_valid_module_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .succeed_module
       .intercept(self.register_compilation_succeed_module_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .execute_module
       .intercept(self.register_compilation_execute_module_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .finish_modules
       .intercept(self.register_compilation_finish_modules_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .optimize_modules
       .intercept(self.register_compilation_optimize_modules_taps.clone());
+    ctx.compilation_hooks.after_optimize_modules.intercept(
+      self
+        .register_compilation_after_optimize_modules_taps
+        .clone(),
+    );
     ctx
-      .context
-      .compilation_hooks
-      .after_optimize_modules
-      .intercept(
-        self
-          .register_compilation_after_optimize_modules_taps
-          .clone(),
-      );
-    ctx
-      .context
       .compilation_hooks
       .optimize_tree
       .intercept(self.register_compilation_optimize_tree_taps.clone());
+    ctx.compilation_hooks.optimize_chunk_modules.intercept(
+      self
+        .register_compilation_optimize_chunk_modules_taps
+        .clone(),
+    );
     ctx
-      .context
-      .compilation_hooks
-      .optimize_chunk_modules
-      .intercept(
-        self
-          .register_compilation_optimize_chunk_modules_taps
-          .clone(),
-      );
-    ctx
-      .context
       .compilation_hooks
       .additional_tree_runtime_requirements
       .intercept(
@@ -194,72 +165,54 @@ impl rspack_core::Plugin for JsHooksAdapterPlugin {
           .register_compilation_additional_tree_runtime_requirements_taps
           .clone(),
       );
+    ctx.compilation_hooks.runtime_requirement_in_tree.intercept(
+      self
+        .register_compilation_runtime_requirement_in_tree_taps
+        .clone(),
+    );
     ctx
-      .context
-      .compilation_hooks
-      .runtime_requirement_in_tree
-      .intercept(
-        self
-          .register_compilation_runtime_requirement_in_tree_taps
-          .clone(),
-      );
-    ctx
-      .context
       .compilation_hooks
       .runtime_module
       .intercept(self.register_compilation_runtime_module_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .chunk_hash
       .intercept(self.register_compilation_chunk_hash_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .chunk_asset
       .intercept(self.register_compilation_chunk_asset_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .process_assets
       .intercept(self.register_compilation_process_assets_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .after_process_assets
       .intercept(self.register_compilation_after_process_assets_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .seal
       .intercept(self.register_compilation_seal_taps.clone());
     ctx
-      .context
       .compilation_hooks
       .after_seal
       .intercept(self.register_compilation_after_seal_taps.clone());
 
+    ctx.normal_module_factory_hooks.before_resolve.intercept(
+      self
+        .register_normal_module_factory_before_resolve_taps
+        .clone(),
+    );
     ctx
-      .context
-      .normal_module_factory_hooks
-      .before_resolve
-      .intercept(
-        self
-          .register_normal_module_factory_before_resolve_taps
-          .clone(),
-      );
-    ctx
-      .context
       .normal_module_factory_hooks
       .factorize
       .intercept(self.register_normal_module_factory_factorize_taps.clone());
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve
       .intercept(self.register_normal_module_factory_resolve_taps.clone());
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_for_scheme
       .intercept(
@@ -267,63 +220,43 @@ impl rspack_core::Plugin for JsHooksAdapterPlugin {
           .register_normal_module_factory_resolve_for_scheme_taps
           .clone(),
       );
-    ctx
-      .context
-      .normal_module_factory_hooks
-      .after_resolve
-      .intercept(
-        self
-          .register_normal_module_factory_after_resolve_taps
-          .clone(),
-      );
-    ctx
-      .context
-      .normal_module_factory_hooks
-      .create_module
-      .intercept(
-        self
-          .register_normal_module_factory_create_module_taps
-          .clone(),
-      );
-    ctx
-      .context
-      .context_module_factory_hooks
-      .before_resolve
-      .intercept(
-        self
-          .register_context_module_factory_before_resolve_taps
-          .clone(),
-      );
-    ctx
-      .context
-      .context_module_factory_hooks
-      .after_resolve
-      .intercept(
-        self
-          .register_context_module_factory_after_resolve_taps
-          .clone(),
-      );
+    ctx.normal_module_factory_hooks.after_resolve.intercept(
+      self
+        .register_normal_module_factory_after_resolve_taps
+        .clone(),
+    );
+    ctx.normal_module_factory_hooks.create_module.intercept(
+      self
+        .register_normal_module_factory_create_module_taps
+        .clone(),
+    );
+    ctx.context_module_factory_hooks.before_resolve.intercept(
+      self
+        .register_context_module_factory_before_resolve_taps
+        .clone(),
+    );
+    ctx.context_module_factory_hooks.after_resolve.intercept(
+      self
+        .register_context_module_factory_after_resolve_taps
+        .clone(),
+    );
 
     ctx
-      .context
       .compiler_hooks
       .compilation
       .tap(js_hooks_adapter_compilation::new(self));
 
     ctx
-      .context
       .compiler_hooks
       .compilation
       .tap(html_hooks_adapter_compilation::new(self));
 
     ctx
-      .context
       .compiler_hooks
       .compilation
       .tap(runtime_hooks_adapter_compilation::new(self));
 
     ctx
-      .context
       .compiler_hooks
       .compilation
       .tap(rsdoctor_hooks_adapter_compilation::new(self));

--- a/crates/rspack_binding_api/src/plugins/js_loader/mod.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/mod.rs
@@ -17,7 +17,7 @@ use napi::{
 };
 use rspack_core::{
   ApplyContext, Compilation, CompilationParams, CompilerEmit, CompilerId, CompilerOptions,
-  CompilerThisCompilation, Plugin, PluginContext,
+  CompilerThisCompilation, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -195,33 +195,29 @@ impl Plugin for JsLoaderRspackPlugin {
     "rspack.JsLoaderRspackPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compiler_hooks
       .this_compilation
       .tap(this_compilation::new(self));
 
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_loader
       .tap(resolver::resolve_loader::new(self));
 
     ctx
-      .context
       .normal_module_hooks
       .loader_should_yield
       .tap(scheduler::loader_should_yield::new(self));
 
     ctx
-      .context
       .normal_module_hooks
       .loader_yield
       .tap(scheduler::loader_yield::new(self));
 
     // TODO: tap compiler done hook will be better.
-    ctx.context.compiler_hooks.emit.tap(done::new(self));
+    ctx.compiler_hooks.emit.tap(done::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_binding_builder_testing/src/lib.rs
+++ b/crates/rspack_binding_builder_testing/src/lib.rs
@@ -3,7 +3,7 @@ extern crate napi_derive;
 extern crate rspack_binding_builder;
 
 use rspack_binding_builder_macros::register_plugin;
-use rspack_core::{ApplyContext, BoxPlugin, CompilerOptions, Plugin, PluginContext};
+use rspack_core::{BoxPlugin, Plugin};
 use rspack_napi::{napi, napi::bindgen_prelude::*};
 
 #[derive(Debug)]
@@ -11,11 +11,7 @@ use rspack_napi::{napi, napi::bindgen_prelude::*};
 struct BindingBuilderTestingPlugin;
 
 impl Plugin for BindingBuilderTestingPlugin {
-  fn apply(
-    &self,
-    _ctx: PluginContext<&mut ApplyContext>,
-    _options: &CompilerOptions,
-  ) -> rspack_error::Result<()> {
+  fn apply(&self, _ctx: &mut rspack_core::ApplyContext<'_>) -> rspack_error::Result<()> {
     Ok(())
   }
 }

--- a/crates/rspack_core/src/plugin/context.rs
+++ b/crates/rspack_core/src/plugin/context.rs
@@ -1,33 +1,11 @@
 use rspack_util::fx_hash::FxDashMap;
 
 use crate::{
-  CompilationHooks, CompilerHooks, ConcatenatedModuleHooks, ContextModuleFactoryHooks,
-  GeneratorOptions, ModuleType, NormalModuleFactoryHooks, NormalModuleHooks, ParserAndGenerator,
-  ParserOptions,
+  CompilationHooks, CompilerHooks, CompilerOptions, ConcatenatedModuleHooks,
+  ContextModuleFactoryHooks, GeneratorOptions, ModuleType, NormalModuleFactoryHooks,
+  NormalModuleHooks, ParserAndGenerator, ParserOptions,
 };
 
-#[derive(Debug, Default)]
-pub struct PluginContext<T = ()> {
-  pub context: T,
-}
-
-impl PluginContext {
-  pub fn new() -> Self {
-    Self::with_context(())
-  }
-}
-
-impl<T> PluginContext<T> {
-  pub fn with_context(context: T) -> Self {
-    Self { context }
-  }
-
-  pub fn into_context(self) -> T {
-    self.context
-  }
-}
-
-// pub type BoxedParser = Box<dyn Parser>;
 pub type BoxedParserAndGenerator = Box<dyn ParserAndGenerator>;
 pub type BoxedParserAndGeneratorBuilder = Box<
   dyn 'static
@@ -36,6 +14,7 @@ pub type BoxedParserAndGeneratorBuilder = Box<
     + Fn(Option<&ParserOptions>, Option<&GeneratorOptions>) -> BoxedParserAndGenerator,
 >;
 
+#[non_exhaustive]
 pub struct ApplyContext<'c> {
   pub(crate) registered_parser_and_generator_builder:
     &'c mut FxDashMap<ModuleType, BoxedParserAndGeneratorBuilder>,
@@ -45,6 +24,8 @@ pub struct ApplyContext<'c> {
   pub context_module_factory_hooks: &'c mut ContextModuleFactoryHooks,
   pub normal_module_hooks: &'c mut NormalModuleHooks,
   pub concatenated_module_hooks: &'c mut ConcatenatedModuleHooks,
+
+  pub compiler_options: &'c CompilerOptions,
 }
 
 impl ApplyContext<'_> {

--- a/crates/rspack_core/src/plugin/mod.rs
+++ b/crates/rspack_core/src/plugin/mod.rs
@@ -7,19 +7,14 @@ pub use context::*;
 pub use plugin_driver::*;
 use rspack_error::Result;
 
-use crate::{CompilerOptions, compiler::CompilationId};
+use crate::compiler::CompilationId;
 
-#[async_trait::async_trait]
 pub trait Plugin: fmt::Debug + Send + Sync {
   fn name(&self) -> &'static str {
     "unknown"
   }
 
-  fn apply(
-    &self,
-    _ctx: PluginContext<&mut ApplyContext>,
-    _options: &CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: &mut ApplyContext) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -7,7 +7,7 @@ use rspack_util::fx_hash::FxDashMap;
 use crate::{
   ApplyContext, BoxedParserAndGeneratorBuilder, CompilationHooks, CompilationId, CompilerHooks,
   CompilerOptions, ConcatenatedModuleHooks, ContextModuleFactoryHooks, ModuleType,
-  NormalModuleFactoryHooks, NormalModuleHooks, Plugin, PluginContext, ResolverFactory,
+  NormalModuleFactoryHooks, NormalModuleHooks, Plugin, ResolverFactory,
 };
 
 #[derive(Debug)]
@@ -49,11 +49,10 @@ impl PluginDriver {
       context_module_factory_hooks: &mut context_module_factory_hooks,
       normal_module_hooks: &mut normal_module_hooks,
       concatenated_module_hooks: &mut concatenated_module_hooks,
+      compiler_options: &options,
     };
     for plugin in &plugins {
-      plugin
-        .apply(PluginContext::with_context(&mut apply_context), &options)
-        .expect("TODO:");
+      plugin.apply(&mut apply_context).expect("TODO:");
     }
 
     Arc::new(Self {

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -1,9 +1,6 @@
 use rayon::prelude::*;
 use rspack_collections::{DatabaseItem, UkeyMap};
-use rspack_core::{
-  ApplyContext, CompilationChunkIds, CompilerOptions, Plugin, PluginContext,
-  incremental::IncrementalPasses,
-};
+use rspack_core::{CompilationChunkIds, Plugin, incremental::IncrementalPasses};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -123,12 +120,8 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
 }
 
 impl Plugin for DeterministicChunkIdsPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compilation_hooks
-      .chunk_ids
-      .tap(chunk_ids::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compilation_hooks.chunk_ids.tap(chunk_ids::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -1,8 +1,7 @@
 use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
-  ApplyContext, ChunkGraph, Compilation, CompilationModuleIds, CompilerOptions, Plugin,
-  PluginContext, incremental::IncrementalPasses,
+  ChunkGraph, Compilation, CompilationModuleIds, Plugin, incremental::IncrementalPasses,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -82,12 +81,8 @@ async fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
 }
 
 impl Plugin for DeterministicModuleIdsPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compilation_hooks
-      .module_ids
-      .tap(module_ids::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compilation_hooks.module_ids.tap(module_ids::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -1,8 +1,7 @@
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 use rspack_collections::{DatabaseItem, UkeyIndexSet, UkeySet};
 use rspack_core::{
-  ApplyContext, ChunkGraph, ChunkIdsArtifact, ChunkUkey, Compilation, CompilationChunkIds,
-  CompilerOptions, Logger, Plugin, PluginContext,
+  ChunkGraph, ChunkIdsArtifact, ChunkUkey, Compilation, CompilationChunkIds, Logger, Plugin,
   chunk_graph_chunk::ChunkId,
   incremental::{self, IncrementalPasses, Mutation, Mutations},
 };
@@ -305,16 +304,8 @@ impl Plugin for NamedChunkIdsPlugin {
     "rspack.NamedChunkIdsPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut ApplyContext>,
-    _options: &CompilerOptions,
-  ) -> rspack_error::Result<()> {
-    ctx
-      .context
-      .compilation_hooks
-      .chunk_ids
-      .tap(chunk_ids::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> rspack_error::Result<()> {
+    ctx.compilation_hooks.chunk_ids.tap(chunk_ids::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -1,8 +1,8 @@
 use rayon::prelude::*;
 use rspack_collections::{IdentifierIndexSet, IdentifierSet};
 use rspack_core::{
-  ApplyContext, ChunkGraph, CompilationModuleIds, CompilerOptions, Logger, ModuleGraph, ModuleId,
-  ModuleIdentifier, ModuleIdsArtifact, Plugin, PluginContext,
+  ChunkGraph, CompilationModuleIds, Logger, ModuleGraph, ModuleId, ModuleIdentifier,
+  ModuleIdsArtifact, Plugin,
   incremental::{self, IncrementalPasses, Mutation, Mutations},
 };
 use rspack_error::Result;
@@ -243,12 +243,8 @@ impl Plugin for NamedModuleIdsPlugin {
     "NamedModuleIdsPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compilation_hooks
-      .module_ids
-      .tap(module_ids::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compilation_hooks.module_ids.tap(module_ids::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
@@ -1,9 +1,6 @@
 use itertools::Itertools;
 use rspack_collections::DatabaseItem;
-use rspack_core::{
-  ApplyContext, Chunk, CompilationChunkIds, CompilerOptions, Plugin, PluginContext,
-  incremental::IncrementalPasses,
-};
+use rspack_core::{Chunk, CompilationChunkIds, Plugin, incremental::IncrementalPasses};
 use rspack_hook::{plugin, plugin_hook};
 
 use crate::id_helpers::{assign_ascending_chunk_ids, compare_chunks_natural};
@@ -56,16 +53,8 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
 }
 
 impl Plugin for NaturalChunkIdsPlugin {
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut ApplyContext>,
-    _options: &CompilerOptions,
-  ) -> rspack_error::Result<()> {
-    ctx
-      .context
-      .compilation_hooks
-      .chunk_ids
-      .tap(chunk_ids::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> rspack_error::Result<()> {
+    ctx.compilation_hooks.chunk_ids.tap(chunk_ids::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_ids/src/natural_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_module_ids_plugin.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  ApplyContext, CompilationModuleIds, CompilerOptions, Plugin, PluginContext,
-  compare_modules_by_pre_order_index_or_identifier, incremental::IncrementalPasses,
+  CompilationModuleIds, Plugin, compare_modules_by_pre_order_index_or_identifier,
+  incremental::IncrementalPasses,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -49,12 +49,8 @@ impl Plugin for NaturalModuleIdsPlugin {
     "NaturalModuleIdsPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compilation_hooks
-      .module_ids
-      .tap(module_ids::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compilation_hooks.module_ids.tap(module_ids::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
@@ -2,10 +2,7 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 use rspack_collections::DatabaseItem;
-use rspack_core::{
-  ApplyContext, Chunk, CompilationChunkIds, CompilerOptions, Plugin, PluginContext,
-  incremental::IncrementalPasses,
-};
+use rspack_core::{Chunk, CompilationChunkIds, Plugin, incremental::IncrementalPasses};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 
@@ -105,12 +102,8 @@ impl Plugin for OccurrenceChunkIdsPlugin {
     "rspack.OccurrenceChunkIdsPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compilation_hooks
-      .chunk_ids
-      .tap(chunk_ids::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compilation_hooks.chunk_ids.tap(chunk_ids::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_loader_lightningcss/src/plugin.rs
+++ b/crates/rspack_loader_lightningcss/src/plugin.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use rspack_core::{
-  ApplyContext, BoxLoader, CompilerOptions, Context, ModuleRuleUseLoader,
-  NormalModuleFactoryResolveLoader, Plugin, PluginContext, Resolver,
+  BoxLoader, Context, ModuleRuleUseLoader, NormalModuleFactoryResolveLoader, Plugin, Resolver,
 };
 use rspack_error::{Result, SerdeResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
@@ -30,9 +29,8 @@ impl Plugin for LightningcssLoaderPlugin {
     "LightningcssLoaderPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_loader
       .tap(resolve_loader::new(self));

--- a/crates/rspack_loader_preact_refresh/src/plugin.rs
+++ b/crates/rspack_loader_preact_refresh/src/plugin.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use rspack_core::{
-  ApplyContext, BoxLoader, CompilerOptions, Context, ModuleRuleUseLoader,
-  NormalModuleFactoryResolveLoader, Plugin, PluginContext, Resolver,
+  BoxLoader, Context, ModuleRuleUseLoader, NormalModuleFactoryResolveLoader, Plugin, Resolver,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -30,9 +29,8 @@ impl Plugin for PreactRefreshLoaderPlugin {
     "PreactRefreshLoaderPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_loader
       .tap(resolve_loader::new(self));

--- a/crates/rspack_loader_react_refresh/src/plugin.rs
+++ b/crates/rspack_loader_react_refresh/src/plugin.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use rspack_core::{
-  ApplyContext, BoxLoader, CompilerOptions, Context, ModuleRuleUseLoader,
-  NormalModuleFactoryResolveLoader, Plugin, PluginContext, Resolver,
+  BoxLoader, Context, ModuleRuleUseLoader, NormalModuleFactoryResolveLoader, Plugin, Resolver,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -30,9 +29,8 @@ impl Plugin for ReactRefreshLoaderPlugin {
     "ReactRefreshLoaderPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_loader
       .tap(resolve_loader::new(self));

--- a/crates/rspack_loader_swc/src/plugin.rs
+++ b/crates/rspack_loader_swc/src/plugin.rs
@@ -4,8 +4,7 @@ use std::{
 };
 
 use rspack_core::{
-  ApplyContext, BoxLoader, CompilerOptions, Context, ModuleRuleUseLoader,
-  NormalModuleFactoryResolveLoader, Plugin, PluginContext, Resolver,
+  BoxLoader, Context, ModuleRuleUseLoader, NormalModuleFactoryResolveLoader, Plugin, Resolver,
 };
 use rspack_error::{Result, SerdeResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
@@ -35,9 +34,8 @@ impl Plugin for SwcLoaderPlugin {
     "SwcLoaderPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_loader
       .tap(resolve_loader::new(self));

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{borrow::Cow, collections::HashSet, hash::Hasher, path::PathBuf};
 
 use asset_exports_dependency::AssetExportsDependency;
-use async_trait::async_trait;
 use rayon::prelude::*;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
@@ -809,24 +808,18 @@ async fn render_manifest(
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for AssetPlugin {
   fn name(&self) -> &'static str {
     "asset"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .render_manifest
       .tap(render_manifest::new(self));
 
-    ctx.context.register_parser_and_generator_builder(
+    ctx.register_parser_and_generator_builder(
       rspack_core::ModuleType::Asset,
       Box::new(move |parser_options, generator_options| {
         let data_url_condition = parser_options
@@ -844,12 +837,12 @@ impl Plugin for AssetPlugin {
       }),
     );
 
-    ctx.context.register_parser_and_generator_builder(
+    ctx.register_parser_and_generator_builder(
       rspack_core::ModuleType::AssetInline,
       Box::new(|_, _| Box::new(AssetParserAndGenerator::with_inline())),
     );
 
-    ctx.context.register_parser_and_generator_builder(
+    ctx.register_parser_and_generator_builder(
       rspack_core::ModuleType::AssetResource,
       Box::new(move |_, generator_options| {
         let emit = generator_options
@@ -860,7 +853,7 @@ impl Plugin for AssetPlugin {
       }),
     );
 
-    ctx.context.register_parser_and_generator_builder(
+    ctx.register_parser_and_generator_builder(
       rspack_core::ModuleType::AssetSource,
       Box::new(move |_, _| Box::new(AssetParserAndGenerator::with_source())),
     );

--- a/crates/rspack_plugin_banner/src/lib.rs
+++ b/crates/rspack_plugin_banner/src/lib.rs
@@ -222,13 +222,8 @@ impl Plugin for BannerPlugin {
     "rspack.BannerPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(process_assets::new(self));

--- a/crates/rspack_plugin_circular_dependencies/src/lib.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/lib.rs
@@ -4,8 +4,7 @@ use futures::future::BoxFuture;
 use itertools::Itertools;
 use rspack_collections::{Identifier, IdentifierMap};
 use rspack_core::{
-  ApplyContext, Compilation, CompilationOptimizeModules, CompilerOptions, DependencyType,
-  ModuleIdentifier, Plugin, PluginContext,
+  Compilation, CompilationOptimizeModules, DependencyType, ModuleIdentifier, Plugin,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
@@ -404,9 +403,8 @@ async fn optimize_modules(&self, compilation: &mut Compilation) -> Result<Option
 
 // implement apply method for the plugin
 impl Plugin for CircularDependencyRspackPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_modules
       .tap(optimize_modules::new(self));

--- a/crates/rspack_plugin_context_replacement/src/lib.rs
+++ b/crates/rspack_plugin_context_replacement/src/lib.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use rspack_core::{
-  AfterResolveResult, ApplyContext, BeforeResolveResult, CompilerOptions, ContextElementDependency,
+  AfterResolveResult, BeforeResolveResult, ContextElementDependency,
   ContextModuleFactoryAfterResolve, ContextModuleFactoryBeforeResolve, DependencyId,
-  DependencyType, Plugin, PluginContext,
+  DependencyType, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -140,14 +140,12 @@ impl Plugin for ContextReplacementPlugin {
     "rspack.ContextReplacementPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .context_module_factory_hooks
       .before_resolve
       .tap(cmf_before_resolve::new(self));
     ctx
-      .context
       .context_module_factory_hooks
       .after_resolve
       .tap(cmf_after_resolve::new(self));

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -706,13 +706,8 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 }
 
 impl Plugin for CopyRspackPlugin {
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(process_assets::new(self));

--- a/crates/rspack_plugin_css_chunking/src/lib.rs
+++ b/crates/rspack_plugin_css_chunking/src/lib.rs
@@ -8,8 +8,8 @@ use rspack_collections::{
   UkeySet,
 };
 use rspack_core::{
-  ApplyContext, ChunkUkey, Compilation, CompilationOptimizeChunks, CompilationParams,
-  CompilerCompilation, Logger, Module, ModuleIdentifier, Plugin, PluginContext, SourceType,
+  ChunkUkey, Compilation, CompilationOptimizeChunks, CompilationParams, CompilerCompilation,
+  Logger, Module, ModuleIdentifier, Plugin, SourceType,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -417,19 +417,10 @@ impl Plugin for CssChunkingPlugin {
     "rspack.CssChunkingPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
 
     ctx
-      .context
       .compilation_hooks
       .optimize_chunks
       .tap(optimize_chunks::new(self));

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait              = { workspace = true }
 cow-utils                = { workspace = true }
 dashmap                  = { workspace = true }
 derive_more              = { workspace = true, features = ["debug"] }

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -4,9 +4,9 @@ use cow_utils::CowUtils;
 use dashmap::DashMap;
 use derive_more::Debug;
 use rspack_core::{
-  ApplyContext, BoxModule, ChunkInitFragments, ChunkUkey, Compilation,
-  CompilationAdditionalModuleRuntimeRequirements, CompilationParams, CompilerCompilation,
-  CompilerOptions, Filename, ModuleIdentifier, PathData, Plugin, PluginContext, RuntimeGlobals,
+  BoxModule, ChunkInitFragments, ChunkUkey, Compilation,
+  CompilationAdditionalModuleRuntimeRequirements, CompilationParams, CompilerCompilation, Filename,
+  ModuleIdentifier, PathData, Plugin, RuntimeGlobals,
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
@@ -196,14 +196,12 @@ impl Plugin for EvalDevToolModulePlugin {
     EVAL_DEV_TOOL_MODULE_PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compiler_hooks
       .compilation
       .tap(eval_devtool_plugin_compilation::new(self));
     ctx
-      .context
       .compilation_hooks
       .additional_module_runtime_requirements
       .tap(eval_devtool_plugin_additional_module_runtime_requirements::new(self));

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -4,9 +4,9 @@ use dashmap::DashMap;
 use derive_more::Debug;
 use futures::future::join_all;
 use rspack_core::{
-  ApplyContext, BoxModule, ChunkGraph, ChunkInitFragments, ChunkUkey, Compilation,
-  CompilationAdditionalModuleRuntimeRequirements, CompilationParams, CompilerCompilation,
-  CompilerOptions, Filename, ModuleIdentifier, PathData, Plugin, PluginContext, RuntimeGlobals,
+  BoxModule, ChunkGraph, ChunkInitFragments, ChunkUkey, Compilation,
+  CompilationAdditionalModuleRuntimeRequirements, CompilationParams, CompilerCompilation, Filename,
+  ModuleIdentifier, PathData, Plugin, RuntimeGlobals,
   rspack_sources::{BoxSource, MapOptions, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
@@ -258,20 +258,17 @@ async fn eval_source_map_devtool_plugin_additional_module_runtime_requirements(
   Ok(())
 }
 
-#[async_trait::async_trait]
 impl Plugin for EvalSourceMapDevToolPlugin {
   fn name(&self) -> &'static str {
     EVAL_SOURCE_MAP_DEV_TOOL_PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compiler_hooks
       .compilation
       .tap(eval_source_map_devtool_plugin_compilation::new(self));
     ctx
-      .context
       .compilation_hooks
       .additional_module_runtime_requirements
       .tap(eval_source_map_devtool_plugin_additional_module_runtime_requirements::new(self));

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_module_options_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_module_options_plugin.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  ApplyContext, BoxModule, ChunkUkey, Compilation, CompilationBuildModule, CompilationId,
-  CompilationRuntimeModule, CompilerId, CompilerOptions, ModuleIdentifier, Plugin, PluginContext,
+  BoxModule, ChunkUkey, Compilation, CompilationBuildModule, CompilationId,
+  CompilationRuntimeModule, CompilerId, ModuleIdentifier, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -68,14 +68,12 @@ impl Plugin for SourceMapDevToolModuleOptionsPlugin {
     "SourceMapDevToolModuleOptionsPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .build_module
       .tap(build_module::new(self));
     ctx
-      .context
       .compilation_hooks
       .runtime_module
       .tap(runtime_module::new(self));

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -14,7 +14,7 @@ use regex::Regex;
 use rspack_collections::DatabaseItem;
 use rspack_core::{
   AssetInfo, Chunk, ChunkUkey, Compilation, CompilationAsset, CompilationProcessAssets, Filename,
-  Logger, ModuleIdentifier, PathData, Plugin, PluginContext,
+  Logger, ModuleIdentifier, PathData, Plugin,
   rspack_sources::{ConcatSource, MapOptions, RawStringSource, Source, SourceExt},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error, miette::IntoDiagnostic};
@@ -714,13 +714,8 @@ impl Plugin for SourceMapDevToolPlugin {
     "rspack.SourceMapDevToolPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(process_assets::new(self));

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_entry_plugin.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_entry_plugin.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use rspack_core::{
-  ApplyContext, Compilation, CompilationParams, CompilerCompilation, CompilerMake, CompilerOptions,
-  Context, DependencyType, EntryOptions, Plugin, PluginContext,
+  Compilation, CompilationParams, CompilerCompilation, CompilerMake, Context, DependencyType,
+  EntryOptions, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -30,20 +30,15 @@ impl DllEntryPlugin {
   }
 }
 
-#[async_trait::async_trait]
 impl Plugin for DllEntryPlugin {
   fn name(&self) -> &'static str {
     "rspack.DllEntryPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
 
-    ctx.context.compiler_hooks.make.tap(make::new(self));
+    ctx.compiler_hooks.make.tap(make::new(self));
 
     Ok(())
   }

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_plugin.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_plugin.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  ApplyContext, BoxModule, Compilation, CompilationParams, CompilerCompilation, CompilerOptions,
-  Context, DependencyType, LibIdentOptions, ModuleFactoryCreateData, NormalModuleCreateData,
-  NormalModuleFactoryFactorize, NormalModuleFactoryModule, Plugin, PluginContext,
+  BoxModule, Compilation, CompilationParams, CompilerCompilation, Context, DependencyType,
+  LibIdentOptions, ModuleFactoryCreateData, NormalModuleCreateData, NormalModuleFactoryFactorize,
+  NormalModuleFactoryModule, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -43,21 +43,15 @@ impl Plugin for DelegatedPlugin {
     "rspack.DelegatedPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
 
     ctx
-      .context
       .normal_module_factory_hooks
       .factorize
       .tap(factorize::new(self));
 
     ctx
-      .context
       .normal_module_factory_hooks
       .module
       .tap(nmf_module::new(self));

--- a/crates/rspack_plugin_dll/src/dll_reference/dll_reference_agency_plugin.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/dll_reference_agency_plugin.rs
@@ -1,7 +1,4 @@
-use rspack_core::{
-  ApplyContext, CompilerOptions, Context, ExternalItem, ExternalItemValue, LibraryType, Plugin,
-  PluginContext,
-};
+use rspack_core::{Context, ExternalItem, ExternalItemValue, LibraryType, Plugin};
 use rspack_error::Result;
 use rspack_hook::plugin;
 use rspack_plugin_externals::ExternalsPlugin;
@@ -39,7 +36,7 @@ impl Plugin for DllReferenceAgencyPlugin {
     "rspack.DllReferenceAgencyPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     let mut name = self.options.name.clone();
     let mut source_type = self.options.source_type.clone();
     let mut resolved_content = self.options.content.clone();
@@ -70,8 +67,7 @@ impl Plugin for DllReferenceAgencyPlugin {
 
     let external = ExternalItem::Object(external_item_object);
 
-    ExternalsPlugin::new(source_type.unwrap_or("var".into()), vec![external])
-      .apply(PluginContext::with_context(ctx.context), options)?;
+    ExternalsPlugin::new(source_type.unwrap_or("var".into()), vec![external]).apply(ctx)?;
 
     DelegatedPlugin::new(DelegatedPluginOptions {
       source: source.clone(),
@@ -80,9 +76,9 @@ impl Plugin for DllReferenceAgencyPlugin {
       content: resolved_content,
       extensions: self.options.extensions.clone(),
       context: self.options.context.clone(),
-      compilation_context: options.context.clone(),
+      compilation_context: ctx.compiler_options.context.clone(),
     })
-    .apply(PluginContext::with_context(ctx.context), options)?;
+    .apply(ctx)?;
 
     Ok(())
   }

--- a/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
+++ b/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
@@ -1,8 +1,7 @@
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  ApplyContext, BoxModule, Compilation, CompilationBuildModule, CompilationId,
-  CompilationOptimizeDependencies, CompilerId, CompilerOptions, FactoryMeta, Plugin, PluginContext,
-  RuntimeSpec, get_entry_runtime,
+  BoxModule, Compilation, CompilationBuildModule, CompilationId, CompilationOptimizeDependencies,
+  CompilerId, FactoryMeta, Plugin, RuntimeSpec, get_entry_runtime,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -24,15 +23,13 @@ impl Plugin for FlagAllModulesAsUsedPlugin {
     "rspack:FlagAllModulesAsUsedPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_dependencies
       .tap(optimize_dependencies::new(self));
 
     ctx
-      .context
       .compilation_hooks
       .build_module
       .tap(build_module::new(self));

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -1,8 +1,7 @@
 use rspack_collections::DatabaseItem;
 use rspack_core::{
-  ApplyContext, ChunkGraph, Compilation, CompilerEmit, CompilerOptions, Context, EntryDependency,
-  Filename, LibIdentOptions, PathData, Plugin, PluginContext, PrefetchExportsInfoMode,
-  ProvidedExports, SourceType,
+  ChunkGraph, Compilation, CompilerEmit, Context, EntryDependency, Filename, LibIdentOptions,
+  PathData, Plugin, PrefetchExportsInfoMode, ProvidedExports, SourceType,
 };
 use rspack_error::{Error, Result, ToStringResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
@@ -45,8 +44,8 @@ impl Plugin for LibManifestPlugin {
     "rspack.LibManifestPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx.context.compiler_hooks.emit.tap(emit::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.emit.tap(emit::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_dynamic_entry/Cargo.toml
+++ b/crates/rspack_plugin_dynamic_entry/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait  = { workspace = true }
 derive_more  = { workspace = true, features = ["debug"] }
 futures      = { workspace = true }
 rspack_core  = { workspace = true }

--- a/crates/rspack_plugin_dynamic_entry/src/lib.rs
+++ b/crates/rspack_plugin_dynamic_entry/src/lib.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use derive_more::Debug;
 use futures::future::BoxFuture;
 use rspack_core::{
-  ApplyContext, BoxDependency, Compilation, CompilationParams, CompilerCompilation, CompilerMake,
-  CompilerOptions, Context, DependencyType, EntryDependency, EntryOptions, Plugin, PluginContext,
+  BoxDependency, Compilation, CompilationParams, CompilerCompilation, CompilerMake, Context,
+  DependencyType, EntryDependency, EntryOptions, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -83,15 +82,10 @@ async fn make(&self, compilation: &mut Compilation) -> Result<()> {
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for DynamicEntryPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx.context.compiler_hooks.make.tap(make::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
+    ctx.compiler_hooks.make.tap(make::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
+++ b/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
@@ -1,4 +1,4 @@
-use rspack_core::{Compilation, CompilationOptimizeChunks, Logger, Plugin, PluginContext};
+use rspack_core::{Compilation, CompilationOptimizeChunks, Logger, Plugin};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -123,13 +123,8 @@ impl Plugin for EnsureChunkConditionsPlugin {
     "rspack.EnsureChunkConditionsPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_chunks
       .tap(optimize_chunks::new(self));

--- a/crates/rspack_plugin_entry/Cargo.toml
+++ b/crates/rspack_plugin_entry/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait  = { workspace = true }
 rspack_core  = { workspace = true }
 rspack_error = { workspace = true }
 rspack_hook  = { workspace = true }

--- a/crates/rspack_plugin_entry/src/lib.rs
+++ b/crates/rspack_plugin_entry/src/lib.rs
@@ -1,9 +1,8 @@
 use std::sync::LazyLock;
 
-use async_trait::async_trait;
 use rspack_core::{
-  ApplyContext, BoxDependency, Compilation, CompilationParams, CompilerCompilation, CompilerMake,
-  CompilerOptions, Context, DependencyType, EntryDependency, EntryOptions, Plugin, PluginContext,
+  BoxDependency, Compilation, CompilationParams, CompilerCompilation, CompilerMake, Context,
+  DependencyType, EntryDependency, EntryOptions, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -50,15 +49,10 @@ async fn make(&self, compilation: &mut Compilation) -> Result<()> {
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for EntryPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx.context.compiler_hooks.make.tap(make::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
+    ctx.compiler_hooks.make.tap(make::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -5,11 +5,10 @@ use std::{
 
 use regex::Regex;
 use rspack_core::{
-  ApplyContext, BoxModule, CompilerOptions, ContextInfo, DependencyMeta, DependencyType,
-  ExternalItem, ExternalItemFnCtx, ExternalItemValue, ExternalModule, ExternalRequest,
-  ExternalRequestValue, ExternalType, ExternalTypeEnum, ModuleDependency, ModuleExt,
-  ModuleFactoryCreateData, NormalModuleFactoryFactorize, Plugin, PluginContext,
-  ResolveOptionsWithDependencyType, SourceType,
+  BoxModule, ContextInfo, DependencyMeta, DependencyType, ExternalItem, ExternalItemFnCtx,
+  ExternalItemValue, ExternalModule, ExternalRequest, ExternalRequestValue, ExternalType,
+  ExternalTypeEnum, ModuleDependency, ModuleExt, ModuleFactoryCreateData,
+  NormalModuleFactoryFactorize, Plugin, ResolveOptionsWithDependencyType, SourceType,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -224,9 +223,8 @@ impl Plugin for ExternalsPlugin {
     "rspack.ExternalsPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .factorize
       .tap(factorize::new(self));

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -9,12 +9,11 @@ use regex::Regex;
 use rspack_cacheable::cacheable;
 use rspack_collections::{DatabaseItem, IdentifierMap, IdentifierSet, UkeySet};
 use rspack_core::{
-  ApplyContext, AssetInfo, Chunk, ChunkGraph, ChunkGroupUkey, ChunkKind, ChunkUkey, Compilation,
+  AssetInfo, Chunk, ChunkGraph, ChunkGroupUkey, ChunkKind, ChunkUkey, Compilation,
   CompilationContentHash, CompilationParams, CompilationRenderManifest,
-  CompilationRuntimeRequirementInTree, CompilerCompilation, CompilerOptions, DependencyType,
-  Filename, Module, ModuleGraph, ModuleIdentifier, ModuleType, NormalModuleFactoryParser,
-  ParserAndGenerator, ParserOptions, PathData, Plugin, PluginContext, RenderManifestEntry,
-  RuntimeGlobals, SourceType, get_undo_path,
+  CompilationRuntimeRequirementInTree, CompilerCompilation, DependencyType, Filename, Module,
+  ModuleGraph, ModuleIdentifier, ModuleType, NormalModuleFactoryParser, ParserAndGenerator,
+  ParserOptions, PathData, Plugin, RenderManifestEntry, RuntimeGlobals, SourceType, get_undo_path,
   rspack_sources::{
     BoxSource, CachedSource, ConcatSource, RawStringSource, SourceExt, SourceMap, SourceMapSource,
     WithoutOriginalOptions,
@@ -702,32 +701,23 @@ async fn nmf_parser(
   Ok(())
 }
 
-#[async_trait::async_trait]
 impl Plugin for PluginCssExtract {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirement_in_tree::new(self));
     ctx
-      .context
       .compilation_hooks
       .content_hash
       .tap(content_hash::new(self));
     ctx
-      .context
       .compilation_hooks
       .render_manifest
       .tap(render_manifest::new(self));
 
     ctx
-      .context
       .normal_module_factory_hooks
       .parser
       .tap(nmf_parser::new(self));

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -2,16 +2,15 @@ mod hot_module_replacement;
 
 use std::collections::hash_map;
 
-use async_trait::async_trait;
 use hot_module_replacement::HotModuleReplacementRuntimeModule;
 use rspack_collections::{DatabaseItem, IdentifierSet, UkeyMap};
 use rspack_core::{
-  ApplyContext, AssetInfo, Chunk, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
+  AssetInfo, Chunk, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationAsset, CompilationParams,
-  CompilationProcessAssets, CompilationRecords, CompilerCompilation, CompilerOptions,
-  DependencyType, LoaderContext, ModuleId, ModuleIdentifier, ModuleType, NormalModuleFactoryParser,
-  NormalModuleLoader, ParserAndGenerator, ParserOptions, PathData, Plugin, PluginContext,
-  RunnerContext, RuntimeGlobals, RuntimeModuleExt, RuntimeSpec,
+  CompilationProcessAssets, CompilationRecords, CompilerCompilation, DependencyType, LoaderContext,
+  ModuleId, ModuleIdentifier, ModuleType, NormalModuleFactoryParser, NormalModuleLoader,
+  ParserAndGenerator, ParserOptions, PathData, Plugin, RunnerContext, RuntimeGlobals,
+  RuntimeModuleExt, RuntimeSpec,
   chunk_graph_chunk::ChunkId,
   rspack_sources::{RawStringSource, SourceExt},
 };
@@ -461,35 +460,26 @@ async fn additional_tree_runtime_requirements(
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for HotModuleReplacementPlugin {
   fn name(&self) -> &'static str {
     "rspack.HotModuleReplacementPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(process_assets::new(self));
     ctx
-      .context
       .normal_module_hooks
       .loader
       .tap(normal_module_loader::new(self));
     ctx
-      .context
       .normal_module_factory_hooks
       .parser
       .tap(normal_module_factory_parser::new(self));
     ctx
-      .context
       .compilation_hooks
       .additional_tree_runtime_requirements
       .tap(additional_tree_runtime_requirements::new(self));

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -293,13 +293,8 @@ impl Plugin for HtmlRspackPlugin {
     "rspack.HtmlRspackPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(process_assets::new(self));

--- a/crates/rspack_plugin_ignore/src/lib.rs
+++ b/crates/rspack_plugin_ignore/src/lib.rs
@@ -1,8 +1,8 @@
 use derive_more::Debug;
 use futures::future::BoxFuture;
 use rspack_core::{
-  ApplyContext, BeforeResolveResult, CompilerOptions, ContextModuleFactoryBeforeResolve,
-  ModuleFactoryCreateData, NormalModuleFactoryBeforeResolve, Plugin, PluginContext,
+  BeforeResolveResult, ContextModuleFactoryBeforeResolve, ModuleFactoryCreateData,
+  NormalModuleFactoryBeforeResolve, Plugin,
 };
 use rspack_error::{Result, miette::Context};
 use rspack_hook::{plugin, plugin_hook};
@@ -88,15 +88,13 @@ impl Plugin for IgnorePlugin {
     "IgnorePlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .before_resolve
       .tap(nmf_before_resolve::new(self));
 
     ctx
-      .context
       .context_module_factory_hooks
       .before_resolve
       .tap(cmf_before_resolve::new(self));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/mod.rs
@@ -5,8 +5,8 @@ use std::{borrow::Cow, collections::HashMap};
 use itertools::Itertools;
 use parser::{DefineParserPlugin, walk_definitions};
 use rspack_core::{
-  ApplyContext, Compilation, CompilationParams, CompilerCompilation, CompilerOptions, ModuleType,
-  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, PluginContext,
+  Compilation, CompilationParams, CompilerCompilation, ModuleType, NormalModuleFactoryParser,
+  ParserAndGenerator, ParserOptions, Plugin,
 };
 use rspack_error::{
   DiagnosticExt, Result,
@@ -108,14 +108,9 @@ impl Plugin for DefinePlugin {
     "rspack.DefinePlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .normal_module_factory_hooks
       .parser
       .tap(nmf_parser::new(self));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin.rs
@@ -2,8 +2,8 @@ use cow_utils::CowUtils;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use rspack_core::{
-  ApplyContext, CompilerOptions, DependencyRange, ModuleType, NormalModuleFactoryParser,
-  ParserAndGenerator, ParserOptions, Plugin, PluginContext, SharedSourceMap,
+  DependencyRange, ModuleType, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions,
+  Plugin, SharedSourceMap,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -163,9 +163,8 @@ impl Plugin for ProvidePlugin {
     "rspack.ProvidePlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .parser
       .tap(nmf_parser::new(self));

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -1,7 +1,6 @@
 use rspack_core::{
-  ApplyContext, BoxModule, ChunkInitFragments, ChunkUkey, Compilation, CompilationParams,
-  CompilerCompilation, CompilerOptions, InitFragmentExt, InitFragmentKey, InitFragmentStage,
-  NormalInitFragment, Plugin, PluginContext,
+  BoxModule, ChunkInitFragments, ChunkUkey, Compilation, CompilationParams, CompilerCompilation,
+  InitFragmentExt, InitFragmentKey, InitFragmentStage, NormalInitFragment, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -65,12 +64,8 @@ impl Plugin for APIPlugin {
     "rspack.APIPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -1,11 +1,11 @@
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  ApplyContext, BuildMetaExportsType, Compilation, CompilationFinishModules, CompilerOptions,
-  DependenciesBlock, DependencyId, EvaluatedInlinableValue, ExportInfo, ExportInfoData,
-  ExportNameOrSpec, ExportProvided, ExportsInfo, ExportsInfoData, ExportsOfExportsSpec,
-  ExportsSpec, Inlinable, Logger, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
-  ModuleIdentifier, Nullable, Plugin, PluginContext, PrefetchExportsInfoMode, get_target,
+  BuildMetaExportsType, Compilation, CompilationFinishModules, DependenciesBlock, DependencyId,
+  EvaluatedInlinableValue, ExportInfo, ExportInfoData, ExportNameOrSpec, ExportProvided,
+  ExportsInfo, ExportsInfoData, ExportsOfExportsSpec, ExportsSpec, Inlinable, Logger, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, Nullable, Plugin,
+  PrefetchExportsInfoMode, get_target,
   incremental::{self, IncrementalPasses},
 };
 use rspack_error::Result;
@@ -217,9 +217,8 @@ impl Plugin for FlagDependencyExportsPlugin {
     "FlagDependencyExportsPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .finish_modules
       .tap(finish_modules::new(self));

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -489,13 +489,8 @@ async fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<O
 }
 
 impl Plugin for FlagDependencyUsagePlugin {
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_dependencies
       .tap(optimize_dependencies::new(self));

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -2,8 +2,8 @@ use linked_hash_set::LinkedHashSet;
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  ApplyContext, Compilation, CompilationFinishModules, CompilerOptions, DependencyType, Logger,
-  ModuleGraph, ModuleIdentifier, Plugin, PluginContext,
+  Compilation, CompilationFinishModules, DependencyType, Logger, ModuleGraph, ModuleIdentifier,
+  Plugin,
   incremental::{IncrementalPasses, Mutation, Mutations},
 };
 use rspack_error::Result;
@@ -189,9 +189,8 @@ impl Plugin for InferAsyncModulesPlugin {
     "InferAsyncModulesPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .finish_modules
       .tap(finish_modules::new(self));

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -4,10 +4,9 @@ use itertools::Itertools;
 use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
-  ApplyContext, BuildMetaExportsType, Compilation, CompilationOptimizeCodeGeneration,
-  CompilerOptions, ExportInfo, ExportProvided, ExportsInfo, ExportsInfoGetter, ModuleGraph, Plugin,
-  PluginContext, PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper, UsageState,
-  incremental::IncrementalPasses,
+  BuildMetaExportsType, Compilation, CompilationOptimizeCodeGeneration, ExportInfo, ExportProvided,
+  ExportsInfo, ExportsInfoGetter, ModuleGraph, Plugin, PrefetchExportsInfoMode,
+  PrefetchedExportsInfoWrapper, UsageState, incremental::IncrementalPasses,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -204,9 +203,8 @@ async fn optimize_code_generation(&self, compilation: &mut Compilation) -> Resul
 }
 
 impl Plugin for MangleExportsPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_code_generation
       .tap(optimize_code_generation::new(self));

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -4,11 +4,11 @@ use std::{borrow::Cow, collections::VecDeque, sync::Arc};
 use rayon::prelude::*;
 use rspack_collections::{IdentifierDashMap, IdentifierIndexSet, IdentifierMap, IdentifierSet};
 use rspack_core::{
-  ApplyContext, BoxDependency, Compilation, CompilationOptimizeChunkModules, CompilerOptions,
-  DependencyId, ExportProvided, ExportsInfoGetter, ExtendedReferencedExport, LibIdentOptions,
-  Logger, Module, ModuleExt, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
-  ModuleGraphModule, ModuleIdentifier, Plugin, PluginContext, PrefetchExportsInfoMode,
-  ProvidedExports, RuntimeCondition, RuntimeSpec, SourceType,
+  BoxDependency, Compilation, CompilationOptimizeChunkModules, DependencyId, ExportProvided,
+  ExportsInfoGetter, ExtendedReferencedExport, LibIdentOptions, Logger, Module, ModuleExt,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleGraphModule,
+  ModuleIdentifier, Plugin, PrefetchExportsInfoMode, ProvidedExports, RuntimeCondition,
+  RuntimeSpec, SourceType,
   concatenated_module::{
     ConcatenatedInnerModule, ConcatenatedModule, RootModuleContext, is_esm_dep_like,
   },
@@ -1313,9 +1313,8 @@ async fn optimize_chunk_modules(&self, compilation: &mut Compilation) -> Result<
 }
 
 impl Plugin for ModuleConcatenationPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_chunk_modules
       .tap(optimize_chunk_modules::new(self));

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -938,18 +938,12 @@ impl Plugin for SideEffectsFlagPlugin {
     "SideEffectsFlagPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .module
       .tap(nmf_module::new(self));
     ctx
-      .context
       .compilation_hooks
       .optimize_dependencies
       .tap(optimize_dependencies::new(self));

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -12,10 +12,10 @@ use json::{
 };
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, CompilerOptions, ExportsInfoGetter,
-  GenerateContext, Module, ModuleGraph, NAMESPACE_OBJECT_EXPORT, ParseOption, ParserAndGenerator,
-  Plugin, PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper, RuntimeGlobals, RuntimeSpec,
-  SourceType, UsageState, UsedNameItem,
+  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ExportsInfoGetter, GenerateContext,
+  Module, ModuleGraph, NAMESPACE_OBJECT_EXPORT, ParseOption, ParserAndGenerator, Plugin,
+  PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper, RuntimeGlobals, RuntimeSpec, SourceType,
+  UsageState, UsedNameItem,
   diagnostics::ModuleParseError,
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
 };
@@ -246,12 +246,8 @@ impl Plugin for JsonPlugin {
     "json"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &CompilerOptions,
-  ) -> Result<()> {
-    ctx.context.register_parser_and_generator_builder(
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.register_parser_and_generator_builder(
       rspack_core::ModuleType::Json,
       Box::new(|p, g| {
         let p = p

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -4,10 +4,9 @@ use std::{
 };
 
 use rspack_core::{
-  ApplyContext, BoxModule, Compilation, CompilationId, CompilationParams, CompilerCompilation,
-  CompilerId, CompilerOptions, DependencyType, EntryDependency, LibIdentOptions, Module,
-  ModuleFactory, ModuleFactoryCreateData, NormalModuleCreateData, NormalModuleFactoryModule,
-  Plugin, PluginContext,
+  BoxModule, Compilation, CompilationId, CompilationParams, CompilerCompilation, CompilerId,
+  DependencyType, EntryDependency, LibIdentOptions, Module, ModuleFactory, ModuleFactoryCreateData,
+  NormalModuleCreateData, NormalModuleFactoryModule, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -212,15 +211,10 @@ async fn normal_module_factory_module(
 impl<T: Backend + 'static, F: LazyCompilationTestCheck + 'static> Plugin
   for LazyCompilationPlugin<T, F>
 {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
 
     ctx
-      .context
       .normal_module_factory_hooks
       .module
       .tap(normal_module_factory_module::new(self));

--- a/crates/rspack_plugin_library/Cargo.toml
+++ b/crates/rspack_plugin_library/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace       = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait              = { workspace = true }
 futures                  = { workspace = true }
 regex                    = { workspace = true }
 rspack_cacheable         = { workspace = true }

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -1,10 +1,9 @@
 use std::hash::Hash;
 
 use rspack_core::{
-  ApplyContext, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
-  CompilationParams, CompilerCompilation, CompilerOptions, ExternalModule, Filename, LibraryName,
-  LibraryNonUmdObject, LibraryOptions, LibraryType, PathData, Plugin, PluginContext,
-  RuntimeGlobals, SourceType,
+  ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationParams,
+  CompilerCompilation, ExternalModule, Filename, LibraryName, LibraryNonUmdObject, LibraryOptions,
+  LibraryType, PathData, Plugin, RuntimeGlobals, SourceType,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error_bail};
@@ -213,14 +212,9 @@ impl Plugin for AmdLibraryPlugin {
     PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .additional_chunk_runtime_requirements
       .tap(additional_chunk_runtime_requirements::new(self));

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -4,12 +4,11 @@ use futures::future::join_all;
 use regex::Regex;
 use rspack_collections::DatabaseItem;
 use rspack_core::{
-  ApplyContext, BoxModule, Chunk, ChunkUkey, CodeGenerationDataTopLevelDeclarations, Compilation,
+  BoxModule, Chunk, ChunkUkey, CodeGenerationDataTopLevelDeclarations, Compilation,
   CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules, CompilationParams,
-  CompilerCompilation, CompilerOptions, EntryData, ExportProvided, Filename, LibraryExport,
-  LibraryName, LibraryNonUmdObject, LibraryOptions, ModuleIdentifier, PathData, Plugin,
-  PluginContext, PrefetchExportsInfoMode, RuntimeGlobals, SourceType, UsageState,
-  get_entry_runtime, property_access,
+  CompilerCompilation, EntryData, ExportProvided, Filename, LibraryExport, LibraryName,
+  LibraryNonUmdObject, LibraryOptions, ModuleIdentifier, PathData, Plugin, PrefetchExportsInfoMode,
+  RuntimeGlobals, SourceType, UsageState, get_entry_runtime, property_access,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -484,25 +483,18 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
   Ok(())
 }
 
-#[async_trait::async_trait]
 impl Plugin for AssignLibraryPlugin {
   fn name(&self) -> &'static str {
     PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .finish_modules
       .tap(finish_modules::new(self));
     ctx
-      .context
       .compilation_hooks
       .additional_chunk_runtime_requirements
       .tap(additional_chunk_runtime_requirements::new(self));

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -1,10 +1,9 @@
 use std::hash::Hash;
 
 use rspack_core::{
-  ApplyContext, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
-  CompilationFinishModules, CompilationParams, CompilerCompilation, CompilerOptions, EntryData,
-  LibraryExport, LibraryOptions, LibraryType, ModuleIdentifier, Plugin, PluginContext,
-  RuntimeGlobals, UsageState, get_entry_runtime, property_access,
+  ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules,
+  CompilationParams, CompilerCompilation, EntryData, LibraryExport, LibraryOptions, LibraryType,
+  ModuleIdentifier, Plugin, RuntimeGlobals, UsageState, get_entry_runtime, property_access,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
@@ -172,25 +171,18 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
   Ok(())
 }
 
-#[async_trait::async_trait]
 impl Plugin for ExportPropertyLibraryPlugin {
   fn name(&self) -> &'static str {
     "rspack.ExportPropertyLibraryPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .finish_modules
       .tap(finish_modules::new(self));
     ctx
-      .context
       .compilation_hooks
       .additional_chunk_runtime_requirements
       .tap(additional_chunk_runtime_requirements::new(self));

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -2,11 +2,11 @@ use std::{hash::Hash, sync::Arc};
 
 use rspack_collections::IdentifierMap;
 use rspack_core::{
-  ApplyContext, BoxDependency, ChunkUkey, CodeGenerationExportsFinalNames, Compilation,
+  BoxDependency, ChunkUkey, CodeGenerationExportsFinalNames, Compilation,
   CompilationOptimizeChunkModules, CompilationParams, CompilerCompilation, CompilerFinishMake,
-  CompilerOptions, ConcatenatedModule, ConcatenatedModuleExportsDefinitions, DependenciesBlock,
-  Dependency, DependencyId, LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, PluginContext,
-  PrefetchExportsInfoMode, RuntimeSpec, UsedNameItem,
+  ConcatenatedModule, ConcatenatedModuleExportsDefinitions, DependenciesBlock, Dependency,
+  DependencyId, LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, PrefetchExportsInfoMode,
+  RuntimeSpec, UsedNameItem,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -449,29 +449,19 @@ impl Plugin for ModernModuleLibraryPlugin {
     PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
 
     ctx
-      .context
       .concatenated_module_hooks
       .exports_definitions
       .tap(exports_definitions::new(self));
 
     ctx
-      .context
       .compilation_hooks
       .optimize_chunk_modules
       .tap(optimize_chunk_modules::new(self));
-    ctx
-      .context
-      .compiler_hooks
-      .finish_make
-      .tap(finish_make::new(self));
+    ctx.compiler_hooks.finish_make.tap(finish_make::new(self));
 
     Ok(())
   }

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -1,9 +1,9 @@
 use std::hash::Hash;
 
 use rspack_core::{
-  ApplyContext, ChunkUkey, Compilation, CompilationParams, CompilerCompilation, CompilerOptions,
-  ExportProvided, ExportsType, LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin,
-  PluginContext, PrefetchExportsInfoMode, UsedNameItem, property_access,
+  ChunkUkey, Compilation, CompilationParams, CompilerCompilation, ExportProvided, ExportsType,
+  LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, PrefetchExportsInfoMode, UsedNameItem,
+  property_access,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -148,12 +148,8 @@ impl Plugin for ModuleLibraryPlugin {
     PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -1,9 +1,9 @@
 use std::hash::Hash;
 
 use rspack_core::{
-  ApplyContext, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
-  CompilationParams, CompilerCompilation, CompilerOptions, ExternalModule, ExternalRequest,
-  LibraryName, LibraryNonUmdObject, LibraryOptions, Plugin, PluginContext, RuntimeGlobals,
+  ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationParams,
+  CompilerCompilation, ExternalModule, ExternalRequest, LibraryName, LibraryNonUmdObject,
+  LibraryOptions, Plugin, RuntimeGlobals,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error_bail};
@@ -201,14 +201,9 @@ impl Plugin for SystemLibraryPlugin {
     PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .additional_chunk_runtime_requirements
       .tap(additional_chunk_runtime_requirements::new(self));

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -1,11 +1,10 @@
 use std::{borrow::Cow, hash::Hash};
 
 use rspack_core::{
-  ApplyContext, Chunk, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
-  CompilationParams, CompilerCompilation, CompilerOptions, ExternalModule, ExternalRequest,
-  Filename, LibraryAuxiliaryComment, LibraryCustomUmdObject, LibraryName, LibraryNonUmdObject,
-  LibraryOptions, LibraryType, ModuleGraph, ModuleGraphCacheArtifact, PathData, Plugin,
-  PluginContext, RuntimeGlobals, SourceType,
+  Chunk, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationParams,
+  CompilerCompilation, ExternalModule, ExternalRequest, Filename, LibraryAuxiliaryComment,
+  LibraryCustomUmdObject, LibraryName, LibraryNonUmdObject, LibraryOptions, LibraryType,
+  ModuleGraph, ModuleGraphCacheArtifact, PathData, Plugin, RuntimeGlobals, SourceType,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error};
@@ -301,20 +300,14 @@ async fn additional_chunk_runtime_requirements(
   Ok(())
 }
 
-#[async_trait::async_trait]
 impl Plugin for UmdLibraryPlugin {
   fn name(&self) -> &'static str {
     PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .additional_chunk_runtime_requirements
       .tap(additional_chunk_runtime_requirements::new(self));

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -305,18 +305,9 @@ impl Plugin for LightningCssMinimizerRspackPlugin {
     "rspack.LightningCssMinimizerRspackPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compilation_hooks.chunk_hash.tap(chunk_hash::new(self));
     ctx
-      .context
-      .compilation_hooks
-      .chunk_hash
-      .tap(chunk_hash::new(self));
-    ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(process_assets::new(self));

--- a/crates/rspack_plugin_limit_chunk_count/src/lib.rs
+++ b/crates/rspack_plugin_limit_chunk_count/src/lib.rs
@@ -316,13 +316,8 @@ impl Plugin for LimitChunkCountPlugin {
     "LimitChunkCountPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_chunks
       .tap(optimize_chunks::new(self));

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -1,8 +1,8 @@
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rspack_collections::UkeySet;
 use rspack_core::{
-  ChunkUkey, Compilation, CompilationOptimizeChunks, ExportsInfo, ModuleGraph, Plugin,
-  PluginContext, RuntimeSpec, incremental::Mutation, is_runtime_equal,
+  ChunkUkey, Compilation, CompilationOptimizeChunks, ExportsInfo, ModuleGraph, Plugin, RuntimeSpec,
+  incremental::Mutation, is_runtime_equal,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -142,13 +142,8 @@ impl Plugin for MergeDuplicateChunksPlugin {
     "rspack.MergeDuplicateChunksPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_chunks
       .tap(optimize_chunks::new(self));

--- a/crates/rspack_plugin_mf/src/container/container_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/container_plugin.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use rspack_core::{
-  ApplyContext, ChunkUkey, Compilation, CompilationParams, CompilationRuntimeRequirementInTree,
-  CompilerCompilation, CompilerMake, CompilerOptions, DependencyType, EntryOptions, EntryRuntime,
-  Filename, LibraryOptions, Plugin, PluginContext, RuntimeGlobals,
+  ChunkUkey, Compilation, CompilationParams, CompilationRuntimeRequirementInTree,
+  CompilerCompilation, CompilerMake, DependencyType, EntryOptions, EntryRuntime, Filename,
+  LibraryOptions, Plugin, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -114,21 +113,15 @@ async fn runtime_requirements_in_tree(
   Ok(None)
 }
 
-#[async_trait]
 impl Plugin for ContainerPlugin {
   fn name(&self) -> &'static str {
     "rspack.ContainerPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
+    ctx.compiler_hooks.make.tap(make::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx.context.compiler_hooks.make.tap(make::new(self));
-    ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use rspack_core::{
-  ApplyContext, BoxModule, ChunkUkey, Compilation, CompilationParams,
-  CompilationRuntimeRequirementInTree, CompilerCompilation, CompilerOptions, DependencyType,
-  ExternalType, ModuleExt, ModuleFactoryCreateData, NormalModuleFactoryFactorize, Plugin,
-  PluginContext, RuntimeGlobals,
+  BoxModule, ChunkUkey, Compilation, CompilationParams, CompilationRuntimeRequirementInTree,
+  CompilerCompilation, DependencyType, ExternalType, ModuleExt, ModuleFactoryCreateData,
+  NormalModuleFactoryFactorize, Plugin, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -129,25 +127,18 @@ async fn runtime_requirements_in_tree(
   Ok(None)
 }
 
-#[async_trait]
 impl Plugin for ContainerReferencePlugin {
   fn name(&self) -> &'static str {
     "rspack.ContainerReferencePlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .normal_module_factory_hooks
       .factorize
       .tap(factorize::new(self));
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_plugin.rs
@@ -7,9 +7,9 @@
 use std::sync::{Arc, Mutex};
 
 use rspack_core::{
-  ApplyContext, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
-  CompilationParams, CompilationRuntimeRequirementInTree, CompilerCompilation, CompilerOptions,
-  DependencyId, ModuleIdentifier, Plugin, PluginContext, RuntimeGlobals,
+  ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationParams,
+  CompilationRuntimeRequirementInTree, CompilerCompilation, DependencyId, ModuleIdentifier, Plugin,
+  RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -219,19 +219,13 @@ impl Plugin for EmbedFederationRuntimePlugin {
     "EmbedFederationRuntimePlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .additional_chunk_runtime_requirements
       .tap(additional_chunk_runtime_requirements_tree::new(self));
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirement_in_tree::new(self));

--- a/crates/rspack_plugin_mf/src/container/federation_modules_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/federation_modules_plugin.rs
@@ -10,8 +10,7 @@ use std::{
 };
 
 use rspack_core::{
-  ApplyContext, Compilation, CompilationId, CompilationParams, CompilerCompilation,
-  CompilerOptions, Dependency, Plugin, PluginContext,
+  Compilation, CompilationId, CompilationParams, CompilerCompilation, Dependency, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{define_hook, plugin, plugin_hook};
@@ -96,18 +95,13 @@ async fn compilation(
   Ok(())
 }
 
-#[async_trait::async_trait]
 impl Plugin for FederationModulesPlugin {
   fn name(&self) -> &'static str {
     "rspack.container.FederationModulesPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_mf/src/container/hoist_container_references_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/hoist_container_references_plugin.rs
@@ -19,8 +19,8 @@ use std::{
 
 use async_trait::async_trait;
 use rspack_core::{
-  ApplyContext, Compilation, CompilationOptimizeChunks, CompilerCompilation, CompilerOptions,
-  Dependency, DependencyId, Module, ModuleIdentifier, Plugin, PluginContext,
+  Compilation, CompilationOptimizeChunks, CompilerCompilation, Dependency, DependencyId, Module,
+  ModuleIdentifier, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -303,14 +303,9 @@ impl Plugin for HoistContainerReferencesPlugin {
     "HoistContainerReferencesPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .optimize_chunks
       .tap(optimize_chunks::new(self));

--- a/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
@@ -3,11 +3,9 @@
 //! Main orchestration plugin for Module Federation runtime functionality.
 //! Coordinates federation plugins, manages runtime dependencies, and adds the base FederationRuntimeModule.
 
-use async_trait::async_trait;
 use rspack_core::{
-  ApplyContext, BoxDependency, ChunkUkey, Compilation,
-  CompilationAdditionalTreeRuntimeRequirements, CompilerFinishMake, CompilerOptions, EntryOptions,
-  Plugin, PluginContext, RuntimeGlobals,
+  BoxDependency, ChunkUkey, Compilation, CompilationAdditionalTreeRuntimeRequirements,
+  CompilerFinishMake, EntryOptions, Plugin, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -75,30 +73,22 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for ModuleFederationRuntimePlugin {
   fn name(&self) -> &'static str {
     "rspack.container.ModuleFederationRuntimePlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .additional_tree_runtime_requirements
       .tap(additional_tree_runtime_requirements::new(self));
 
-    ctx
-      .context
-      .compiler_hooks
-      .finish_make
-      .tap(finish_make::new(self));
+    ctx.compiler_hooks.finish_make.tap(finish_make::new(self));
 
     // Apply supporting plugins
-    EmbedFederationRuntimePlugin::default()
-      .apply(PluginContext::with_context(ctx.context), options)?;
-    HoistContainerReferencesPlugin::default()
-      .apply(PluginContext::with_context(ctx.context), options)?;
+    EmbedFederationRuntimePlugin::default().apply(ctx)?;
+    HoistContainerReferencesPlugin::default().apply(ctx)?;
 
     Ok(())
   }

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -4,16 +4,15 @@ use std::{
   sync::{Arc, LazyLock, Mutex, RwLock},
 };
 
-use async_trait::async_trait;
 use camino::Utf8Path;
 use regex::Regex;
 use rspack_cacheable::cacheable;
 use rspack_core::{
-  ApplyContext, BoxModule, ChunkUkey, Compilation, CompilationAdditionalTreeRuntimeRequirements,
-  CompilationParams, CompilerOptions, CompilerThisCompilation, Context, DependencyCategory,
-  DependencyType, ModuleExt, ModuleFactoryCreateData, NormalModuleCreateData,
-  NormalModuleFactoryCreateModule, NormalModuleFactoryFactorize, Plugin, PluginContext,
-  ResolveOptionsWithDependencyType, ResolveResult, Resolver, RuntimeGlobals,
+  BoxModule, ChunkUkey, Compilation, CompilationAdditionalTreeRuntimeRequirements,
+  CompilationParams, CompilerThisCompilation, Context, DependencyCategory, DependencyType,
+  ModuleExt, ModuleFactoryCreateData, NormalModuleCreateData, NormalModuleFactoryCreateModule,
+  NormalModuleFactoryFactorize, Plugin, ResolveOptionsWithDependencyType, ResolveResult, Resolver,
+  RuntimeGlobals,
 };
 use rspack_error::{Diagnostic, Result, error};
 use rspack_fs::ReadableFileSystem;
@@ -475,30 +474,25 @@ async fn additional_tree_runtime_requirements(
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for ConsumeSharedPlugin {
   fn name(&self) -> &'static str {
     "rspack.ConsumeSharedPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compiler_hooks
       .this_compilation
       .tap(this_compilation::new(self));
     ctx
-      .context
       .normal_module_factory_hooks
       .factorize
       .tap(factorize::new(self));
     ctx
-      .context
       .normal_module_factory_hooks
       .create_module
       .tap(create_module::new(self));
     ctx
-      .context
       .compilation_hooks
       .additional_tree_runtime_requirements
       .tap(additional_tree_runtime_requirements::new(self));

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_plugin.rs
@@ -3,12 +3,11 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use async_trait::async_trait;
 use regex::Regex;
 use rspack_core::{
-  ApplyContext, BoxDependency, BoxModule, Compilation, CompilationParams, CompilerCompilation,
-  CompilerFinishMake, CompilerOptions, DependencyType, EntryOptions, ModuleFactoryCreateData,
-  NormalModuleCreateData, NormalModuleFactoryModule, Plugin, PluginContext,
+  BoxDependency, BoxModule, Compilation, CompilationParams, CompilerCompilation,
+  CompilerFinishMake, DependencyType, EntryOptions, ModuleFactoryCreateData,
+  NormalModuleCreateData, NormalModuleFactoryModule, Plugin,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
@@ -287,25 +286,15 @@ async fn normal_module_factory_module(
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for ProvideSharedPlugin {
   fn name(&self) -> &'static str {
     "rspack.ProvideSharedPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
+    ctx.compiler_hooks.finish_make.tap(finish_make::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
-      .compiler_hooks
-      .finish_make
-      .tap(finish_make::new(self));
-    ctx
-      .context
       .normal_module_factory_hooks
       .module
       .tap(normal_module_factory_module::new(self));

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_plugin.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  ChunkUkey, Compilation, CompilationRuntimeRequirementInTree, Plugin, PluginContext,
-  RuntimeGlobals, RuntimeModuleExt,
+  ChunkUkey, Compilation, CompilationRuntimeRequirementInTree, Plugin, RuntimeGlobals,
+  RuntimeModuleExt,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -39,13 +39,8 @@ impl Plugin for ShareRuntimePlugin {
     "rspack.ShareRuntimePlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_module_info_header/Cargo.toml
+++ b/crates/rspack_plugin_module_info_header/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait              = { workspace = true }
 regex                    = { workspace = true }
 rspack_cacheable         = { workspace = true }
 rspack_collections       = { workspace = true }

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -1,14 +1,13 @@
 use std::{hash::Hash, sync::LazyLock};
 
-use async_trait::async_trait;
 use regex::Regex;
 use rspack_cacheable::with::AsVecConverter;
 use rspack_collections::Identifiable;
 use rspack_core::{
-  ApplyContext, BoxModule, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkUkey,
-  Compilation, CompilationParams, CompilerCompilation, CompilerOptions, ExportInfo, ExportProvided,
-  ExportsInfoGetter, Module, ModuleGraph, ModuleIdentifier, Plugin, PluginContext,
-  PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper, UsageState, get_target,
+  BoxModule, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkUkey, Compilation,
+  CompilationParams, CompilerCompilation, ExportInfo, ExportProvided, ExportsInfoGetter, Module,
+  ModuleGraph, ModuleIdentifier, Plugin, PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper,
+  UsageState, get_target,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_comment_with_nl,
 };
@@ -301,18 +300,13 @@ async fn render_js_module_package(
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for ModuleInfoHeaderPlugin {
   fn name(&self) -> &'static str {
     "rspack.ModuleInfoHeaderPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_no_emit_on_errors/src/lib.rs
+++ b/crates/rspack_plugin_no_emit_on_errors/src/lib.rs
@@ -1,8 +1,6 @@
 use std::fmt::Debug;
 
-use rspack_core::{
-  ApplyContext, Compilation, CompilerOptions, CompilerShouldEmit, Plugin, PluginContext,
-};
+use rspack_core::{Compilation, CompilerShouldEmit, Plugin};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 
@@ -30,12 +28,8 @@ impl Plugin for NoEmitOnErrorsPlugin {
     "NoEmitOnErrorsPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .should_emit
-      .tap(should_emit::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.should_emit.tap(should_emit::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_progress/Cargo.toml
+++ b/crates/rspack_plugin_progress/Cargo.toml
@@ -8,8 +8,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = { workspace = true }
-futures     = { workspace = true }
+futures = { workspace = true }
 # unicode-width feature related to https://github.com/web-infra-dev/rspack/issues/10988
 indicatif          = { workspace = true, features = ["default"] }
 rspack_collections = { workspace = true }

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -8,19 +8,17 @@ use std::{
   time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use async_trait::async_trait;
 use futures::future::BoxFuture;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rspack_collections::IdentifierMap;
 use rspack_core::{
-  ApplyContext, BoxModule, Compilation, CompilationAfterOptimizeModules,
-  CompilationAfterProcessAssets, CompilationBuildModule, CompilationChunkIds,
-  CompilationFinishModules, CompilationId, CompilationModuleIds, CompilationOptimizeChunkModules,
-  CompilationOptimizeChunks, CompilationOptimizeDependencies, CompilationOptimizeModules,
-  CompilationOptimizeTree, CompilationParams, CompilationProcessAssets, CompilationSeal,
-  CompilationSucceedModule, CompilerAfterEmit, CompilerClose, CompilerCompilation, CompilerEmit,
-  CompilerFinishMake, CompilerId, CompilerMake, CompilerOptions, CompilerThisCompilation,
-  ModuleIdentifier, Plugin, PluginContext,
+  BoxModule, Compilation, CompilationAfterOptimizeModules, CompilationAfterProcessAssets,
+  CompilationBuildModule, CompilationChunkIds, CompilationFinishModules, CompilationId,
+  CompilationModuleIds, CompilationOptimizeChunkModules, CompilationOptimizeChunks,
+  CompilationOptimizeDependencies, CompilationOptimizeModules, CompilationOptimizeTree,
+  CompilationParams, CompilationProcessAssets, CompilationSeal, CompilationSucceedModule,
+  CompilerAfterEmit, CompilerClose, CompilerCompilation, CompilerEmit, CompilerFinishMake,
+  CompilerId, CompilerMake, CompilerThisCompilation, ModuleIdentifier, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -522,102 +520,69 @@ async fn close(&self, _compilation: &Compilation) -> Result<()> {
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for ProgressPlugin {
   fn name(&self) -> &'static str {
     "progress"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compiler_hooks
       .this_compilation
       .tap(this_compilation::new(self));
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
+    ctx.compiler_hooks.make.tap(make::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx.context.compiler_hooks.make.tap(make::new(self));
-    ctx
-      .context
       .compilation_hooks
       .build_module
       .tap(build_module::new(self));
     ctx
-      .context
       .compilation_hooks
       .succeed_module
       .tap(succeed_module::new(self));
+    ctx.compiler_hooks.finish_make.tap(finish_make::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .finish_make
-      .tap(finish_make::new(self));
-    ctx
-      .context
       .compilation_hooks
       .finish_modules
       .tap(finish_modules::new(self));
-    ctx.context.compilation_hooks.seal.tap(seal::new(self));
+    ctx.compilation_hooks.seal.tap(seal::new(self));
     ctx
-      .context
       .compilation_hooks
       .optimize_dependencies
       .tap(optimize_dependencies::new(self));
     ctx
-      .context
       .compilation_hooks
       .optimize_modules
       .tap(optimize_modules::new(self));
     ctx
-      .context
       .compilation_hooks
       .after_optimize_modules
       .tap(after_optimize_modules::new(self));
     ctx
-      .context
       .compilation_hooks
       .optimize_chunks
       .tap(optimize_chunks::new(self));
     ctx
-      .context
       .compilation_hooks
       .optimize_tree
       .tap(optimize_tree::new(self));
     ctx
-      .context
       .compilation_hooks
       .optimize_chunk_modules
       .tap(optimize_chunk_modules::new(self));
+    ctx.compilation_hooks.module_ids.tap(module_ids::new(self));
+    ctx.compilation_hooks.chunk_ids.tap(chunk_ids::new(self));
     ctx
-      .context
-      .compilation_hooks
-      .module_ids
-      .tap(module_ids::new(self));
-    ctx
-      .context
-      .compilation_hooks
-      .chunk_ids
-      .tap(chunk_ids::new(self));
-    ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(process_assets::new(self));
     ctx
-      .context
       .compilation_hooks
       .after_process_assets
       .tap(after_process_assets::new(self));
-    ctx.context.compiler_hooks.emit.tap(emit::new(self));
-    ctx
-      .context
-      .compiler_hooks
-      .after_emit
-      .tap(after_emit::new(self));
-    ctx.context.compiler_hooks.close.tap(close::new(self));
+    ctx.compiler_hooks.emit.tap(emit::new(self));
+    ctx.compiler_hooks.after_emit.tap(after_emit::new(self));
+    ctx.compiler_hooks.close.tap(close::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -14,7 +14,6 @@ use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
   AssetInfo, BindingCell, Compilation, CompilationId, CompilationProcessAssets, Logger, Plugin,
-  PluginContext,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
@@ -66,13 +65,8 @@ impl Plugin for RealContentHashPlugin {
     "rspack.RealContentHashPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(process_assets::new(self));

--- a/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
+++ b/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
@@ -86,13 +86,8 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
 }
 
 impl Plugin for RemoveDuplicateModulesPlugin {
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> rspack_error::Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> rspack_error::Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_chunks
       .tap(optimize_chunks::new(self));

--- a/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
+++ b/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
@@ -50,13 +50,8 @@ impl Plugin for RemoveEmptyChunksPlugin {
     "rspack.RemoveEmptyChunksPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_chunks
       .tap(optimize_chunks::new(self));

--- a/crates/rspack_plugin_rsdoctor/Cargo.toml
+++ b/crates/rspack_plugin_rsdoctor/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait           = { workspace = true }
 atomic_refcell        = { workspace = true }
 futures               = { workspace = true }
 indexmap              = { workspace = true }

--- a/crates/rspack_plugin_rslib/Cargo.toml
+++ b/crates/rspack_plugin_rslib/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait              = { workspace = true }
 rspack_core              = { workspace = true }
 rspack_error             = { workspace = true }
 rspack_hook              = { workspace = true }

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -1,9 +1,7 @@
 use std::time::{Duration, Instant};
 
-use async_trait::async_trait;
 use rspack_core::{
-  ApplyContext, CompilerOptions, ModuleType, NormalModuleFactoryParser, ParserAndGenerator,
-  ParserOptions, Plugin, PluginContext,
+  ModuleType, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -56,15 +54,13 @@ async fn nmf_parser(
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for RslibPlugin {
   fn name(&self) -> &'static str {
     "rslib"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .parser
       .tap(nmf_parser::new(self));

--- a/crates/rspack_plugin_rstest/Cargo.toml
+++ b/crates/rspack_plugin_rstest/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait              = { workspace = true }
 camino                   = { workspace = true }
 regex                    = { workspace = true }
 rspack_cacheable         = { workspace = true }

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -3,11 +3,9 @@ use std::{
   time::{Duration, Instant},
 };
 
-use async_trait::async_trait;
 use rspack_core::{
-  ApplyContext, Compilation, CompilationParams, CompilationProcessAssets, CompilerCompilation,
-  CompilerOptions, ModuleType, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions,
-  Plugin, PluginContext,
+  Compilation, CompilationParams, CompilationProcessAssets, CompilerCompilation, ModuleType,
+  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin,
   rspack_sources::{BoxSource, ReplaceSource, SourceExt},
 };
 use rspack_error::Result;
@@ -223,28 +221,21 @@ async fn mock_hoist_process_assets(&self, compilation: &mut Compilation) -> Resu
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for RstestPlugin {
   fn name(&self) -> &'static str {
     "rstest"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
 
     ctx
-      .context
       .compiler_hooks
       .compilation
       .tap(compilation_stage_9999::new(self));
 
     if self.options.module_path_name {
       ctx
-        .context
         .normal_module_factory_hooks
         .parser
         .tap(nmf_parser::new(self));
@@ -252,7 +243,6 @@ impl Plugin for RstestPlugin {
 
     if self.options.hoist_mock_module {
       ctx
-        .context
         .compilation_hooks
         .process_assets
         .tap(mock_hoist_process_assets::new(self));

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -1,9 +1,8 @@
 use std::hash::Hash;
 
 use rspack_core::{
-  ApplyContext, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
-  CompilationAdditionalChunkRuntimeRequirements, CompilationParams, CompilerCompilation,
-  CompilerOptions, Plugin, PluginContext, RuntimeGlobals,
+  ChunkGraph, ChunkKind, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
+  CompilationParams, CompilerCompilation, Plugin, RuntimeGlobals,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
@@ -190,14 +189,9 @@ impl Plugin for ArrayPushCallbackChunkFormatPlugin {
     PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .additional_chunk_runtime_requirements
       .tap(additional_chunk_runtime_requirements::new(self));

--- a/crates/rspack_plugin_runtime/src/bundler_info.rs
+++ b/crates/rspack_plugin_runtime/src/bundler_info.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   ChunkUkey, Compilation, CompilationAdditionalTreeRuntimeRequirements,
-  CompilationRuntimeRequirementInTree, Plugin, PluginContext, RuntimeGlobals,
+  CompilationRuntimeRequirementInTree, Plugin, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -89,18 +89,12 @@ impl Plugin for BundlerInfoPlugin {
     "BundlerInfoPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .additional_tree_runtime_requirements
       .tap(additional_tree_runtime_requirements::new(self));
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_runtime/src/chunk_prefetch_preload.rs
+++ b/crates/rspack_plugin_runtime/src/chunk_prefetch_preload.rs
@@ -62,13 +62,8 @@ impl Plugin for ChunkPrefetchPreloadPlugin {
     "ChunkPrefetchPreloadPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .additional_tree_runtime_requirements
       .tap(additional_tree_runtime_requirements::new(self));

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -1,9 +1,8 @@
 use std::hash::Hash;
 
 use rspack_core::{
-  ApplyContext, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
-  CompilationDependentFullHash, CompilationParams, CompilerCompilation, CompilerOptions, Plugin,
-  PluginContext, RuntimeGlobals,
+  ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
+  CompilationDependentFullHash, CompilationParams, CompilerCompilation, Plugin, RuntimeGlobals,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
@@ -190,19 +189,13 @@ impl Plugin for CommonJsChunkFormatPlugin {
     PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .additional_chunk_runtime_requirements
       .tap(additional_chunk_runtime_requirements::new(self));
     ctx
-      .context
       .compilation_hooks
       .dependent_full_hash
       .tap(compilation_dependent_full_hash::new(self));

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   ChunkLoading, ChunkLoadingType, ChunkUkey, Compilation, CompilationRuntimeRequirementInTree,
-  Plugin, PluginContext, RuntimeGlobals,
+  Plugin, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -90,13 +90,8 @@ impl Plugin for CommonJsChunkLoadingPlugin {
     "CommonJsChunkLoadingPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   ChunkLoading, ChunkLoadingType, ChunkUkey, Compilation, CompilationRuntimeRequirementInTree,
-  Plugin, PluginContext, RuntimeGlobals, RuntimeModuleExt,
+  Plugin, RuntimeGlobals, RuntimeModuleExt,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -71,13 +71,8 @@ impl Plugin for ImportScriptsChunkLoadingPlugin {
     "ImportScriptsChunkLoadingPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_runtime/src/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/jsonp_chunk_loading.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   ChunkLoading, ChunkLoadingType, ChunkUkey, Compilation, CompilationRuntimeRequirementInTree,
-  Plugin, PluginContext, RuntimeGlobals,
+  Plugin, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -67,13 +67,8 @@ impl Plugin for JsonpChunkLoadingPlugin {
     "JsonpChunkLoadingPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -1,10 +1,8 @@
 use std::hash::Hash;
 
-use async_trait::async_trait;
 use rspack_core::{
-  ApplyContext, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
-  CompilationAdditionalChunkRuntimeRequirements, CompilationDependentFullHash, CompilationParams,
-  CompilerCompilation, CompilerOptions, Plugin, PluginContext, RuntimeGlobals,
+  ChunkGraph, ChunkKind, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
+  CompilationDependentFullHash, CompilationParams, CompilerCompilation, Plugin, RuntimeGlobals,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, miette};
@@ -262,25 +260,18 @@ async fn render_chunk(
   Ok(())
 }
 
-#[async_trait]
 impl Plugin for ModuleChunkFormatPlugin {
   fn name(&self) -> &'static str {
     PLUGIN_NAME
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .additional_chunk_runtime_requirements
       .tap(additional_chunk_runtime_requirements::new(self));
     ctx
-      .context
       .compilation_hooks
       .dependent_full_hash
       .tap(compilation_dependent_full_hash::new(self));

--- a/crates/rspack_plugin_runtime/src/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_loading.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   ChunkLoading, ChunkLoadingType, ChunkUkey, Compilation, CompilationRuntimeRequirementInTree,
-  Plugin, PluginContext, RuntimeGlobals, RuntimeModuleExt,
+  Plugin, RuntimeGlobals, RuntimeModuleExt,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -61,13 +61,8 @@ impl Plugin for ModuleChunkLoadingPlugin {
     "ModuleChunkLoadingPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -3,15 +3,13 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use async_trait::async_trait;
 use atomic_refcell::AtomicRefCell;
 use rspack_collections::DatabaseItem;
 use rspack_core::{
-  ApplyContext, ChunkLoading, ChunkUkey, Compilation, CompilationId, CompilationParams,
+  ChunkLoading, ChunkUkey, Compilation, CompilationId, CompilationParams,
   CompilationRuntimeRequirementInModule, CompilationRuntimeRequirementInTree, CompilerCompilation,
-  CompilerOptions, ModuleIdentifier, Plugin, PluginContext, PublicPath, RuntimeGlobals,
-  RuntimeModuleExt, SourceType, get_css_chunk_filename_template, get_js_chunk_filename_template,
-  has_hash_placeholder,
+  ModuleIdentifier, Plugin, PublicPath, RuntimeGlobals, RuntimeModuleExt, SourceType,
+  get_css_chunk_filename_template, get_js_chunk_filename_template, has_hash_placeholder,
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
@@ -535,25 +533,18 @@ async fn runtime_requirements_in_tree(
   Ok(None)
 }
 
-#[async_trait]
 impl Plugin for RuntimePlugin {
   fn name(&self) -> &'static str {
     "rspack.RuntimePlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_module
       .tap(runtime_requirements_in_module::new(self));
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_runtime/src/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/startup_chunk_dependencies.rs
@@ -1,8 +1,6 @@
-use async_trait::async_trait;
 use rspack_core::{
-  ApplyContext, ChunkLoading, ChunkUkey, Compilation, CompilationAdditionalTreeRuntimeRequirements,
-  CompilationRuntimeRequirementInTree, CompilerOptions, Plugin, PluginContext, RuntimeGlobals,
-  RuntimeModuleExt,
+  ChunkLoading, ChunkUkey, Compilation, CompilationAdditionalTreeRuntimeRequirements,
+  CompilationRuntimeRequirementInTree, Plugin, RuntimeGlobals, RuntimeModuleExt,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -72,20 +70,17 @@ async fn runtime_requirements_in_tree(
   Ok(None)
 }
 
-#[async_trait]
 impl Plugin for StartupChunkDependenciesPlugin {
   fn name(&self) -> &'static str {
     "StartupChunkDependenciesPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .additional_tree_runtime_requirements
       .tap(additional_tree_runtime_requirements::new(self));
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_runtime_chunk/src/lib.rs
+++ b/crates/rspack_plugin_runtime_chunk/src/lib.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use futures::future::BoxFuture;
-use rspack_core::{ApplyContext, Compilation, CompilationAddEntry, CompilerOptions, PluginContext};
+use rspack_core::{Compilation, CompilationAddEntry};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 
@@ -64,12 +64,8 @@ async fn add_entry(&self, compilation: &mut Compilation, entry_name: Option<&str
 }
 
 impl rspack_core::Plugin for RuntimeChunkPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compilation_hooks
-      .add_entry
-      .tap(add_entry::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compilation_hooks.add_entry.tap(add_entry::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_schemes/src/data_uri.rs
+++ b/crates/rspack_plugin_schemes/src/data_uri.rs
@@ -2,9 +2,8 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 use rspack_core::{
-  ApplyContext, CompilerOptions, Content, ModuleFactoryCreateData,
-  NormalModuleFactoryResolveForScheme, NormalModuleReadResource, Plugin, PluginContext,
-  ResourceData, Scheme,
+  Content, ModuleFactoryCreateData, NormalModuleFactoryResolveForScheme, NormalModuleReadResource,
+  Plugin, ResourceData, Scheme,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -78,20 +77,17 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
   Ok(None)
 }
 
-#[async_trait::async_trait]
 impl Plugin for DataUriPlugin {
   fn name(&self) -> &'static str {
     "rspack.DataUriPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_for_scheme
       .tap(resolve_for_scheme::new(self));
     ctx
-      .context
       .normal_module_hooks
       .read_resource
       .tap(read_resource::new(self));

--- a/crates/rspack_plugin_schemes/src/file_uri.rs
+++ b/crates/rspack_plugin_schemes/src/file_uri.rs
@@ -1,6 +1,5 @@
 use rspack_core::{
-  ApplyContext, CompilerOptions, ModuleFactoryCreateData, NormalModuleFactoryResolveForScheme,
-  Plugin, PluginContext, ResourceData, Scheme,
+  ModuleFactoryCreateData, NormalModuleFactoryResolveForScheme, Plugin, ResourceData, Scheme,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error};
 use rspack_hook::{plugin, plugin_hook};
@@ -41,15 +40,13 @@ async fn normal_module_factory_resolve_for_scheme(
   Ok(None)
 }
 
-#[async_trait::async_trait]
 impl Plugin for FileUriPlugin {
   fn name(&self) -> &'static str {
     "rspack.FileUriPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_for_scheme
       .tap(normal_module_factory_resolve_for_scheme::new(self));

--- a/crates/rspack_plugin_schemes/src/http_uri/mod.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/mod.rs
@@ -3,15 +3,13 @@ mod lockfile;
 
 use std::{fmt::Debug, sync::Arc};
 
-use async_trait::async_trait;
 use http_cache::{ContentFetchResult, FetchResultType, fetch_content};
 pub use http_cache::{HttpClient, HttpResponse};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rspack_core::{
-  ApplyContext, CompilerOptions, Content, ModuleFactoryCreateData,
-  NormalModuleFactoryResolveForScheme, NormalModuleFactoryResolveInScheme,
-  NormalModuleReadResource, Plugin, PluginContext, ResourceData, Scheme,
+  Content, ModuleFactoryCreateData, NormalModuleFactoryResolveForScheme,
+  NormalModuleFactoryResolveInScheme, NormalModuleReadResource, Plugin, ResourceData, Scheme,
 };
 use rspack_error::{
   AnyhowResultToRspackResultExt, Result,
@@ -180,25 +178,21 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
   Ok(None)
 }
 
-#[async_trait]
 impl Plugin for HttpUriPlugin {
   fn name(&self) -> &'static str {
     "rspack.HttpUriPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_for_scheme
       .tap(resolve_for_scheme::new(self));
     ctx
-      .context
       .normal_module_factory_hooks
       .resolve_in_scheme
       .tap(resolve_in_scheme::new(self));
     ctx
-      .context
       .normal_module_hooks
       .read_resource
       .tap(read_resource::new(self));

--- a/crates/rspack_plugin_size_limits/src/lib.rs
+++ b/crates/rspack_plugin_size_limits/src/lib.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 use derive_more::Debug;
 use futures::future::BoxFuture;
 use rspack_core::{
-  ApplyContext, ChunkGroup, ChunkGroupUkey, Compilation, CompilationAsset, CompilerAfterEmit,
-  CompilerOptions, Plugin, PluginContext,
+  ChunkGroup, ChunkGroupUkey, Compilation, CompilationAsset, CompilerAfterEmit, Plugin,
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
@@ -260,12 +259,8 @@ impl Plugin for SizeLimitsPlugin {
     "SizeLimitsPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .after_emit
-      .tap(after_emit::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.after_emit.tap(after_emit::new(self));
 
     Ok(())
   }

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -200,13 +200,8 @@ impl Plugin for SplitChunksPlugin {
     "rspack.SplitChunksPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .optimize_chunks
       .tap(optimize_chunks::new(self));

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -17,7 +17,7 @@ use html::{alter_asset_tag_groups, before_asset_tag_generation};
 pub use integrity::SubresourceIntegrityHashFunction;
 use rspack_core::{
   ChunkLoading, ChunkLoadingType, Compilation, CompilationId, CompilationParams,
-  CompilerThisCompilation, CrossOriginLoading, Plugin, PluginContext,
+  CompilerThisCompilation, CrossOriginLoading, Plugin,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
@@ -150,19 +150,14 @@ impl Plugin for SubresourceIntegrityPlugin {
     "rspack.SubresourceIntegrityPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
-    if let ChunkLoading::Enable(chunk_loading) = &options.output.chunk_loading
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    if let ChunkLoading::Enable(chunk_loading) = &ctx.compiler_options.output.chunk_loading
       && matches!(
         chunk_loading,
         ChunkLoadingType::Require | ChunkLoadingType::AsyncNode
       )
     {
       ctx
-        .context
         .compiler_hooks
         .this_compilation
         .tap(warn_non_web::new(self));
@@ -171,25 +166,21 @@ impl Plugin for SubresourceIntegrityPlugin {
     }
 
     ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(handle_assets::new(self));
 
     ctx
-      .context
       .compilation_hooks
       .after_process_assets
       .tap(detect_unresolved_integrity::new(self));
 
     ctx
-      .context
       .compiler_hooks
       .this_compilation
       .tap(handle_compilation::new(self));
 
     ctx
-      .context
       .compilation_hooks
       .additional_tree_runtime_requirements
       .tap(handle_runtime::new(self));

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -11,7 +11,7 @@ use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
   AssetInfo, ChunkUkey, Compilation, CompilationAsset, CompilationParams, CompilationProcessAssets,
-  CompilerCompilation, Plugin, PluginContext,
+  CompilerCompilation, Plugin,
   diagnostics::MinifyError,
   rspack_sources::{
     ConcatSource, MapOptions, RawStringSource, Source, SourceExt, SourceMapSource,
@@ -394,18 +394,9 @@ impl Plugin for SwcJsMinimizerRspackPlugin {
     PLUGIN_NAME
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
-    ctx
-      .context
       .compilation_hooks
       .process_assets
       .tap(process_assets::new(self));

--- a/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
+++ b/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
@@ -4,10 +4,7 @@ use std::collections::HashMap;
 
 use cow_utils::CowUtils;
 use rspack_collections::{Identifier, IdentifierSet};
-use rspack_core::{
-  ApplyContext, Compilation, CompilationSeal, CompilerOptions, Logger, ModuleGraph, Plugin,
-  PluginContext,
-};
+use rspack_core::{Compilation, CompilationSeal, Logger, ModuleGraph, Plugin};
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -107,8 +104,8 @@ impl Plugin for WarnCaseSensitiveModulesPlugin {
     "rspack.WarnCaseSensitiveModulesPlugin"
   }
 
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx.context.compilation_hooks.seal.tap(seal::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compilation_hooks.seal.tap(seal::new(self));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_wasm/src/loading_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/loading_plugin.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  BoxPlugin, ChunkUkey, Compilation, CompilationRuntimeRequirementInTree, Plugin, PluginContext,
-  PluginExt, RuntimeGlobals, RuntimeModuleExt, WasmLoadingType,
+  BoxPlugin, ChunkUkey, Compilation, CompilationRuntimeRequirementInTree, Plugin, PluginExt,
+  RuntimeGlobals, RuntimeModuleExt, WasmLoadingType,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -48,13 +48,8 @@ impl Plugin for FetchCompileAsyncWasmPlugin {
     "FetchCompileAsyncWasmPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(fetch_compile_async_wasm_plugin_runtime_requirements_in_tree::new(self));
@@ -115,13 +110,8 @@ impl Plugin for ReadFileCompileAsyncWasmPlugin {
     "ReadFileCompileAsyncWasmPlugin"
   }
 
-  fn apply(
-    &self,
-    ctx: PluginContext<&mut rspack_core::ApplyContext>,
-    _options: &rspack_core::CompilerOptions,
-  ) -> Result<()> {
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
     ctx
-      .context
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(read_file_compile_async_wasm_plugin_runtime_requirements_in_tree::new(self));

--- a/crates/rspack_plugin_worker/src/lib.rs
+++ b/crates/rspack_plugin_worker/src/lib.rs
@@ -1,7 +1,4 @@
-use rspack_core::{
-  ApplyContext, Compilation, CompilationParams, CompilerCompilation, CompilerOptions,
-  DependencyType, PluginContext,
-};
+use rspack_core::{Compilation, CompilationParams, CompilerCompilation, DependencyType};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 
@@ -23,12 +20,8 @@ async fn compilation(
 }
 
 impl rspack_core::Plugin for WorkerPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &CompilerOptions) -> Result<()> {
-    ctx
-      .context
-      .compiler_hooks
-      .compilation
-      .tap(compilation::new(self));
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
     Ok(())
   }
 }

--- a/website/docs/en/contribute/architecture/builtin-plugin.md
+++ b/website/docs/en/contribute/architecture/builtin-plugin.md
@@ -6,7 +6,7 @@ A simple example:
 
 ```rust
 use rspack_hook::{plugin, plugin_hook};
-use rspack_core::{Plugin, PluginContext, ApplyContext, CompilerOptions};
+use rspack_core::{Plugin,  ApplyContext, CompilerOptions};
 use rspack_core::CompilerCompilation;
 use rspack_error::Result;
 
@@ -24,8 +24,8 @@ async fn compilation(&self, compilation: &mut Compilation) -> Result<()> {
 
 // implement apply method for the plugin
 impl Plugin for MyPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &mut CompilerOptions) -> Result<()> {
-    ctx.context.compiler_hooks.tap(compilation::new(self))
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.tap(compilation::new(self))
     Ok(())
   }
 }

--- a/website/docs/en/contribute/architecture/builtin-plugin.md
+++ b/website/docs/en/contribute/architecture/builtin-plugin.md
@@ -6,7 +6,7 @@ A simple example:
 
 ```rust
 use rspack_hook::{plugin, plugin_hook};
-use rspack_core::{Plugin,  ApplyContext, CompilerOptions};
+use rspack_core::{Plugin, ApplyContext, CompilerOptions};
 use rspack_core::CompilerCompilation;
 use rspack_error::Result;
 

--- a/website/docs/zh/contribute/architecture/builtin-plugin.md
+++ b/website/docs/zh/contribute/architecture/builtin-plugin.md
@@ -6,7 +6,7 @@ Builtin 插件使用 [rspack_macros](https://github.com/web-infra-dev/rspack/tre
 
 ```rust
 use rspack_hook::{plugin, plugin_hook};
-use rspack_core::{Plugin, PluginContext, ApplyContext, CompilerOptions};
+use rspack_core::{Plugin,  ApplyContext, CompilerOptions};
 use rspack_core::CompilerCompilation;
 use rspack_error::Result;
 
@@ -24,8 +24,8 @@ async fn compilation(&self, compilation: &mut Compilation) -> Result<()> {
 
 // implement apply method for the plugin
 impl Plugin for MyPlugin {
-  fn apply(&self, ctx: PluginContext<&mut ApplyContext>, _options: &mut CompilerOptions) -> Result<()> {
-    ctx.context.compiler_hooks.tap(compilation::new(self))
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.tap(compilation::new(self))
     Ok(())
   }
 }

--- a/website/docs/zh/contribute/architecture/builtin-plugin.md
+++ b/website/docs/zh/contribute/architecture/builtin-plugin.md
@@ -6,7 +6,7 @@ Builtin 插件使用 [rspack_macros](https://github.com/web-infra-dev/rspack/tre
 
 ```rust
 use rspack_hook::{plugin, plugin_hook};
-use rspack_core::{Plugin,  ApplyContext, CompilerOptions};
+use rspack_core::{Plugin, ApplyContext, CompilerOptions};
 use rspack_core::CompilerCompilation;
 use rspack_error::Result;
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

remove redundant `PluginContext` and `async_trait` from trait `Plugin`

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
