### PR TITLE
fix(wasm): remove cjs loader support

### DIFF
--- a/packages/rspack/src/util/require.ts
+++ b/packages/rspack/src/util/require.ts
@@ -24,7 +24,7 @@ export function nonWebpackRequire(): RequireFn {
 							}
 
 							const loaderCode = data?.toString() || "";
-							// Only customn esm loader is supported.
+							// Only custom esm loader is supported.
 							// Use `import(base64code)` to load ESM
 							const dataUrl = `data:text/javascript;base64,${btoa(loaderCode)}`;
 							try {

--- a/packages/rspack/src/util/require.ts
+++ b/packages/rspack/src/util/require.ts
@@ -24,39 +24,15 @@ export function nonWebpackRequire(): RequireFn {
 							}
 
 							const loaderCode = data?.toString() || "";
-
-							// 1. Assume it's a cjs
+							// Only customn esm loader is supported.
+							// Use `import(base64code)` to load ESM
+							const dataUrl = `data:text/javascript;base64,${btoa(loaderCode)}`;
 							try {
-								// Use `new Function` to emulate CJS
-								const module = { exports: {} };
-								const exports = module.exports;
-								const createRequire = () => {
-									throw new Error(
-										"@rspack/browser doesn't support `require` in loaders yet"
-									);
-								};
-
-								// rslint-disable no-implied-eval
-								const wrapper = new Function(
-									"module",
-									"exports",
-									"require",
-									loaderCode
-								);
-
-								wrapper(module, exports, createRequire);
-								resolve(module.exports);
-							} catch {
-								// 2. Assume it's an esm
-								// Use `import(base64code)` to load ESM
-								const dataUrl = `data:text/javascript;base64,${btoa(loaderCode)}`;
-								try {
-									// biome-ignore lint/security/noGlobalEval: use `eval("import")` rather than `import` to suppress the warning in @rspack/browser
-									const modulePromise = eval(`import("${dataUrl}")`);
-									modulePromise.then(resolve);
-								} catch (e) {
-									reject(e);
-								}
+								// biome-ignore lint/security/noGlobalEval: use `eval("import")` rather than `import` to suppress the warning in @rspack/browser
+								const modulePromise = eval(`import("${dataUrl}")`);
+								modulePromise.then(resolve);
+							} catch (e) {
+								reject(e);
 							}
 						});
 					})

--- a/packages/rspack/src/util/require.ts
+++ b/packages/rspack/src/util/require.ts
@@ -29,6 +29,9 @@ export function nonWebpackRequire(): RequireFn {
 								new Blob([loaderCode], { type: "text/javascript" })
 							);
 							try {
+								// We have to use `eval` to prevent this dynamic import being handled by any bundler.
+								// Applications should config their CSP to allow `unsafe-eval`.
+								// In the future, we may find a better way to handle this, such as user-injected module executor.
 								// biome-ignore lint/security/noGlobalEval: use `eval("import")` rather than `import` to suppress the warning in @rspack/browser
 								const modulePromise = eval(
 									`import("${codeUrl}")`


### PR DESCRIPTION
## Summary

There could be security problems with `new Function` so we'd better not use it in rspack since it is a library.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
