### PR TITLE
feat: rspack cli add config path to build dependencies

### DIFF
--- a/packages/rspack-cli/src/commands/preview.ts
+++ b/packages/rspack-cli/src/commands/preview.ts
@@ -54,7 +54,7 @@ export class PreviewCommand implements RspackCommand {
 				const rspackOptions = { ...options, argv: { ...options } };
 				const { RspackDevServer } = await import("@rspack/dev-server");
 
-				let config = await cli.loadConfig(rspackOptions);
+				let { config } = await cli.loadConfig(rspackOptions);
 				config = await getPreviewConfig(config, options);
 				if (!Array.isArray(config)) {
 					config = [config as RspackOptions];

--- a/packages/rspack-cli/tests/build/issue-11009/base.config.js
+++ b/packages/rspack-cli/tests/build/issue-11009/base.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	entry: "./entry.js"
+};

--- a/packages/rspack-cli/tests/build/issue-11009/entry.js
+++ b/packages/rspack-cli/tests/build/issue-11009/entry.js
@@ -1,0 +1,1 @@
+export default "entry-issue-11009";

--- a/packages/rspack-cli/tests/build/issue-11009/index.test.ts
+++ b/packages/rspack-cli/tests/build/issue-11009/index.test.ts
@@ -1,0 +1,13 @@
+import { resolve } from "path";
+import { readFile, run } from "../../utils/test-utils";
+
+it.concurrent(
+	"should set config path to persistent cache build dependencies",
+	async () => {
+		const { stdout } = await run(__dirname, []);
+		const mainJs = await readFile(resolve(__dirname, "dist/main.js"), "utf-8");
+		expect(mainJs).toContain("entry-issue-11009");
+		expect(stdout).toContain("issue-11009/rspack.config.js");
+		expect(stdout).toContain("issue-11009/base.config.js");
+	}
+);

--- a/packages/rspack-cli/tests/build/issue-11009/index.test.ts
+++ b/packages/rspack-cli/tests/build/issue-11009/index.test.ts
@@ -1,13 +1,21 @@
 import { resolve } from "path";
 import { readFile, run } from "../../utils/test-utils";
 
-it.concurrent(
-	"should set config path to persistent cache build dependencies",
-	async () => {
-		const { stdout } = await run(__dirname, []);
-		const mainJs = await readFile(resolve(__dirname, "dist/main.js"), "utf-8");
-		expect(mainJs).toContain("entry-issue-11009");
-		expect(stdout).toContain("issue-11009/rspack.config.js");
-		expect(stdout).toContain("issue-11009/base.config.js");
-	}
-);
+describe("issue-11009 build", () => {
+	it.concurrent(
+		"should set config path to persistent cache build dependencies",
+		async () => {
+			if (process.env.WASM) {
+				// skip when test wasm
+				return;
+			}
+			const { stdout } = await run(__dirname, []);
+			const mainJs = await readFile(
+				resolve(__dirname, "dist/main.js"),
+				"utf-8"
+			);
+			expect(mainJs).toContain("entry-issue-11009");
+			expect(stdout).toContain("===buildDependencies===");
+		}
+	);
+});

--- a/packages/rspack-cli/tests/build/issue-11009/rspack.config.js
+++ b/packages/rspack-cli/tests/build/issue-11009/rspack.config.js
@@ -16,10 +16,14 @@ module.exports = {
 	plugins: [
 		{
 			apply(compiler) {
-				console.log(
-					"buildDependencies is ",
-					compiler.options.experiments.cache.buildDependencies
-				);
+				const [dep1, dep2] =
+					compiler.options.experiments.cache.buildDependencies;
+				if (
+					dep1 === path.resolve(__dirname, "./rspack.config.js") &&
+					dep2 === path.resolve(__dirname, "./base.config.js")
+				) {
+					console.log("===buildDependencies===");
+				}
 			}
 		}
 	]

--- a/packages/rspack-cli/tests/build/issue-11009/rspack.config.js
+++ b/packages/rspack-cli/tests/build/issue-11009/rspack.config.js
@@ -1,0 +1,26 @@
+const path = require("path");
+
+/** @type {import('@rspack/cli').Configuration} */
+module.exports = {
+	mode: "development", // will be override to "production" by "--mode"
+	extends: ["./base.config.js"],
+	output: {
+		path: path.resolve(__dirname, "dist")
+	},
+	cache: true,
+	experiments: {
+		cache: {
+			type: "persistent"
+		}
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				console.log(
+					"buildDependencies is ",
+					compiler.options.experiments.cache.buildDependencies
+				);
+			}
+		}
+	]
+};

--- a/packages/rspack-cli/tests/build/plugin-apply-error/plugin-apply-error.test.ts
+++ b/packages/rspack-cli/tests/build/plugin-apply-error/plugin-apply-error.test.ts
@@ -3,7 +3,6 @@ import { run } from "../../utils/test-utils";
 describe("plugin apply throw error", () => {
 	it.concurrent("should report error", async () => {
 		const { stderr } = await run(__dirname);
-		console.log(stderr);
 		expect(stderr).toMatch(/error in plugin/);
 	});
 });

--- a/packages/rspack-cli/tests/serve/issue-11009/base.config.js
+++ b/packages/rspack-cli/tests/serve/issue-11009/base.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	entry: "./entry.js"
+};

--- a/packages/rspack-cli/tests/serve/issue-11009/entry.js
+++ b/packages/rspack-cli/tests/serve/issue-11009/entry.js
@@ -1,0 +1,1 @@
+export default "entry-issue-11009";

--- a/packages/rspack-cli/tests/serve/issue-11009/index.test.ts
+++ b/packages/rspack-cli/tests/serve/issue-11009/index.test.ts
@@ -1,0 +1,12 @@
+import { runWatch } from "../../utils/test-utils";
+
+describe("should set config path to persistent cache build dependencies", () => {
+	it.concurrent("should serve work", async () => {
+		const { stdout } = await runWatch(__dirname, ["serve"], {
+			killString: /localhost/
+		});
+
+		expect(stdout).toContain("issue-11009/rspack.config.js");
+		expect(stdout).toContain("issue-11009/base.config.js");
+	});
+});

--- a/packages/rspack-cli/tests/serve/issue-11009/index.test.ts
+++ b/packages/rspack-cli/tests/serve/issue-11009/index.test.ts
@@ -1,12 +1,19 @@
 import { runWatch } from "../../utils/test-utils";
 
-describe("should set config path to persistent cache build dependencies", () => {
-	it.concurrent("should serve work", async () => {
-		const { stdout } = await runWatch(__dirname, ["serve"], {
-			killString: /localhost/
-		});
+describe("issue-11009 serve", () => {
+	it.concurrent(
+		"should set config path to persistent cache build dependencies",
+		async () => {
+			if (process.env.WASM) {
+				// skip when test wasm
+				return;
+			}
 
-		expect(stdout).toContain("issue-11009/rspack.config.js");
-		expect(stdout).toContain("issue-11009/base.config.js");
-	});
+			const { stdout } = await runWatch(__dirname, ["serve"], {
+				killString: /localhost/
+			});
+
+			expect(stdout).toContain("===buildDependencies===");
+		}
+	);
 });

--- a/packages/rspack-cli/tests/serve/issue-11009/rspack.config.js
+++ b/packages/rspack-cli/tests/serve/issue-11009/rspack.config.js
@@ -13,10 +13,14 @@ module.exports = {
 	plugins: [
 		{
 			apply(compiler) {
-				console.log(
-					"buildDependencies is ",
-					compiler.options.experiments.cache.buildDependencies
-				);
+				const [dep1, dep2] =
+					compiler.options.experiments.cache.buildDependencies;
+				if (
+					dep1 === path.resolve(__dirname, "./rspack.config.js") &&
+					dep2 === path.resolve(__dirname, "./base.config.js")
+				) {
+					console.log("===buildDependencies===");
+				}
 			}
 		}
 	]

--- a/packages/rspack-cli/tests/serve/issue-11009/rspack.config.js
+++ b/packages/rspack-cli/tests/serve/issue-11009/rspack.config.js
@@ -1,0 +1,23 @@
+const path = require("path");
+
+/** @type {import('@rspack/cli').Configuration} */
+module.exports = {
+	mode: "development", // will be override to "production" by "--mode"
+	extends: ["./base.config.js"],
+	cache: true,
+	experiments: {
+		cache: {
+			type: "persistent"
+		}
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				console.log(
+					"buildDependencies is ",
+					compiler.options.experiments.cache.buildDependencies
+				);
+			}
+		}
+	]
+};


### PR DESCRIPTION
## Summary

Rspack cli will find and load config, this PR will set the config path to build dependencies if persistent cache is enabled.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
