### PR TITLE
feat: expose `experiments.swc` in parallel loader context

### DIFF
--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -246,6 +246,12 @@ async function loaderImpl(
 
 	loaderContext._compiler = {
 		...loaderContext._compiler,
+		rspack: {
+			// @ts-expect-error: some properties are missing.
+			experiments: {
+				swc: require("../swc")
+			}
+		},
 		// @ts-expect-error: some properties are missing.
 		webpack: {
 			util: {


### PR DESCRIPTION
## Summary

This PR enhances the loader context in parallel loader by exposing `rspack.experiments.swc` API . This removes a need for importing `rspack` directly in the loader (or loader module) and instead makes it possible to access the `swc` API just like in non parallel loaders

## Related links

n/a

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
