### PR TITLE
fix: pass actual root context to parallel loader context

### DIFF
--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -759,7 +759,7 @@ export async function runLoaders(
 			resource: loaderContext.resource,
 			mode: loaderContext.mode,
 			sourceMap: loaderContext.sourceMap,
-			rootContext: loaderContext.context!,
+			rootContext: loaderContext.rootContext,
 			loaderIndex: loaderContext.loaderIndex,
 			loaders: loaderContext.loaders.map(item => {
 				let options = item.options;


### PR DESCRIPTION
## Summary

This PR fixes the `rootContext` in parallel loaders - currently it is the same as `context` which is different depending on the processed file, but it should be equal to `compiler.context`

related API reference: https://rspack.rs/api/loader-api/context#thisrootcontext

## Related links

n/a

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
