### PR TITLE
feat: propagate const for inline const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5404,6 +5404,7 @@ dependencies = [
  "rspack_paths",
  "rspack_regex",
  "rustc-hash 2.1.1",
+ "ryu-js",
  "serde",
  "serde_json",
  "signal-hook",
@@ -5486,9 +5487,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "ryu-js"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "saffron"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ ropey               = { version = "1.6.1", default-features = false }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.2", default-features = false }
 rspack_sources      = { version = "0.4.8", default-features = false }
 rustc-hash          = { version = "2.1.0", default-features = false }
+ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }
 serde               = { version = "1.0.217", default-features = false, features = ["derive"] }
 serde_json          = { version = "1.0.134", default-features = false, features = ["std"] }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -401,7 +401,11 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
       export_info.get_used(runtime).dyn_hash(hasher);
       export_info.provided().dyn_hash(hasher);
       export_info.terminal_binding().dyn_hash(hasher);
-      export_info.inlinable().dyn_hash(hasher);
+      export_info
+        .inlinable()
+        .as_inline()
+        .map(|v| v.render())
+        .dyn_hash(hasher);
     }
 
     let mut exports = self.exports.values().collect_vec();

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -401,11 +401,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
       export_info.get_used(runtime).dyn_hash(hasher);
       export_info.provided().dyn_hash(hasher);
       export_info.terminal_binding().dyn_hash(hasher);
-      export_info
-        .inlinable()
-        .as_inline()
-        .map(|v| v.render())
-        .dyn_hash(hasher);
+      export_info.inlinable().dyn_hash(hasher);
     }
 
     let mut exports = self.exports.values().collect_vec();

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsPreset, AsVec},
 };
-use rspack_util::{atom::Atom, json_stringify};
+use rspack_util::{atom::Atom, json_stringify, ryu_js};
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::DependencyId;
@@ -33,55 +33,76 @@ pub enum UsedExports {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-enum EvaluatedInlinableValueInner {
+#[derive(Debug, Clone)]
+pub enum EvaluatedInlinableValue {
   Null,
   Undefined,
   Boolean(bool),
-  Number(#[cacheable(with=AsPreset)] Atom),
+  Number(f64),
   String(#[cacheable(with=AsPreset)] Atom),
 }
 
-#[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct EvaluatedInlinableValue(EvaluatedInlinableValueInner);
+impl Hash for EvaluatedInlinableValue {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    match self {
+      EvaluatedInlinableValue::Null => 0.hash(state),
+      EvaluatedInlinableValue::Undefined => 1.hash(state),
+      EvaluatedInlinableValue::Boolean(v) => {
+        2.hash(state);
+        v.hash(state);
+      }
+      EvaluatedInlinableValue::Number(v) => {
+        3.hash(state);
+        let mut buf = ryu_js::Buffer::new();
+        buf.format(*v).hash(state);
+      }
+      EvaluatedInlinableValue::String(atom) => {
+        4.hash(state);
+        atom.hash(state);
+      }
+    }
+  }
+}
 
 impl EvaluatedInlinableValue {
   pub const SHORT_SIZE: usize = 6;
 
   pub fn new_null() -> Self {
-    Self(EvaluatedInlinableValueInner::Null)
+    Self::Null
   }
 
   pub fn new_undefined() -> Self {
-    Self(EvaluatedInlinableValueInner::Undefined)
+    Self::Undefined
   }
 
   pub fn new_boolean(v: bool) -> Self {
-    Self(EvaluatedInlinableValueInner::Boolean(v))
+    Self::Boolean(v)
   }
 
-  pub fn new_number(v: Atom) -> Self {
-    Self(EvaluatedInlinableValueInner::Number(v))
+  pub fn new_number(v: f64) -> Self {
+    Self::Number(v)
   }
 
   pub fn new_string(v: Atom) -> Self {
-    Self(EvaluatedInlinableValueInner::String(v))
+    Self::String(v)
   }
 
   pub fn render(&self) -> Cow<'_, str> {
-    match &self.0 {
-      EvaluatedInlinableValueInner::Null => "null".into(),
-      EvaluatedInlinableValueInner::Undefined => "undefined".into(),
-      EvaluatedInlinableValueInner::Boolean(v) => if *v { "true" } else { "false" }.into(),
-      EvaluatedInlinableValueInner::Number(v) => v.as_str().into(),
-      EvaluatedInlinableValueInner::String(v) => json_stringify(v.as_str()).into(),
+    match self {
+      Self::Null => "null".into(),
+      Self::Undefined => "undefined".into(),
+      Self::Boolean(v) => if *v { "true" } else { "false" }.into(),
+      Self::Number(v) => {
+        let mut buf = ryu_js::Buffer::new();
+        buf.format(*v).to_string().into()
+      }
+      Self::String(v) => json_stringify(v.as_str()).into(),
     }
   }
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum Inlinable {
   NoByProvide,
   NoByUse,
@@ -91,6 +112,13 @@ pub enum Inlinable {
 impl Inlinable {
   pub fn can_inline(&self) -> bool {
     matches!(self, Inlinable::Inlined(_))
+  }
+
+  pub fn as_inline(&self) -> Option<&EvaluatedInlinableValue> {
+    match self {
+      Inlinable::Inlined(value) => Some(value),
+      _ => None,
+    }
   }
 }
 

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -102,7 +102,7 @@ impl EvaluatedInlinableValue {
 }
 
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub enum Inlinable {
   NoByProvide,
   NoByUse,
@@ -112,13 +112,6 @@ pub enum Inlinable {
 impl Inlinable {
   pub fn can_inline(&self) -> bool {
     matches!(self, Inlinable::Inlined(_))
-  }
-
-  pub fn as_inline(&self) -> Option<&EvaluatedInlinableValue> {
-    match self {
-      Inlinable::Inlined(value) => Some(value),
-      _ => None,
-    }
   }
 }
 

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -44,22 +44,18 @@ pub enum EvaluatedInlinableValue {
 
 impl Hash for EvaluatedInlinableValue {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    std::mem::discriminant(self).hash(state);
     match self {
-      EvaluatedInlinableValue::Null => 0.hash(state),
-      EvaluatedInlinableValue::Undefined => 1.hash(state),
       EvaluatedInlinableValue::Boolean(v) => {
-        2.hash(state);
         v.hash(state);
       }
       EvaluatedInlinableValue::Number(v) => {
-        3.hash(state);
-        let mut buf = ryu_js::Buffer::new();
-        buf.format(*v).hash(state);
+        v.to_bits().hash(state);
       }
       EvaluatedInlinableValue::String(atom) => {
-        4.hash(state);
         atom.hash(state);
       }
+      _ => {}
     }
   }
 }

--- a/crates/rspack_loader_swc/src/collect_ts_info.rs
+++ b/crates/rspack_loader_swc/src/collect_ts_info.rs
@@ -4,7 +4,7 @@ use rspack_swc_plugin_ts_collector::{
 };
 use rustc_hash::FxHashMap;
 use swc::atoms::Atom;
-use swc_core::ecma::{ast::Program, utils::number::ToJsString, visit::VisitWith};
+use swc_core::ecma::{ast::Program, visit::VisitWith};
 
 use crate::options::{CollectTypeScriptInfoOptions, CollectingEnumKind};
 
@@ -33,9 +33,7 @@ pub fn collect_typescript_info(
             .into_iter()
             .map(|(id, v)| {
               let value = match v {
-                EnumMemberValue::Number(n) => {
-                  Some(EvaluatedInlinableValue::new_number(n.to_js_string().into()))
-                }
+                EnumMemberValue::Number(n) => Some(EvaluatedInlinableValue::new_number(n)),
                 EnumMemberValue::String(s) => Some(EvaluatedInlinableValue::new_string(s)),
                 EnumMemberValue::Unknown => None,
               };

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -3,16 +3,17 @@ use rspack_core::{
   GetUsedNameParam, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
   PrefetchExportsInfoMode, RuntimeSpec, UsedName,
 };
-use swc_core::ecma::{
-  ast::{ModuleDecl, ModuleItem, Program, VarDeclKind},
-  utils::number::ToJsString,
-};
+use rspack_util::ryu_js;
+use swc_core::ecma::ast::{ModuleDecl, ModuleItem, Program, VarDeclKind};
 
 use super::JavascriptParserPlugin;
 use crate::{
   dependency::ESMImportSpecifierDependency,
-  utils::eval::BasicEvaluatedExpression,
-  visitors::{JavascriptParser, Statement, TopLevelScope},
+  utils::eval::{
+    BasicEvaluatedExpression, evaluate_to_boolean, evaluate_to_null, evaluate_to_number,
+    evaluate_to_string, evaluate_to_undefined,
+  },
+  visitors::{JavascriptParser, Statement, TagInfoData, TopLevelScope},
 };
 
 pub const INLINABLE_CONST_TAG: &str = "inlinable const";
@@ -49,7 +50,32 @@ impl JavascriptParserPlugin for InlineConstPlugin {
     None
   }
 
-  fn pre_statement(&self, parser: &mut JavascriptParser, stmt: Statement) -> Option<bool> {
+  fn evaluate_identifier(
+    &self,
+    parser: &mut JavascriptParser,
+    ident: &str,
+    start: u32,
+    end: u32,
+  ) -> Option<BasicEvaluatedExpression<'static>> {
+    if !parser.has_inlinable_const_decls || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+      return None;
+    }
+    // Propagate inlinable constants. Help the rest const variable declarations that referencing the
+    // inlinable constants to evaluate to an inlinable constants.
+    let inlinable = parser
+      .get_tag_data(ident, INLINABLE_CONST_TAG)
+      .map(InlinableConstData::downcast)
+      .map(|data| data.value)?;
+    Some(match inlinable {
+      EvaluatedInlinableValue::Null => evaluate_to_null(start, end),
+      EvaluatedInlinableValue::Undefined => evaluate_to_undefined(start, end),
+      EvaluatedInlinableValue::Boolean(v) => evaluate_to_boolean(v, start, end),
+      EvaluatedInlinableValue::Number(v) => evaluate_to_number(v, start, end),
+      EvaluatedInlinableValue::String(v) => evaluate_to_string(v.to_string(), start, end),
+    })
+  }
+
+  fn block_pre_statement(&self, parser: &mut JavascriptParser, stmt: Statement) -> Option<bool> {
     if !parser.has_inlinable_const_decls || !matches!(parser.top_level_scope, TopLevelScope::Top) {
       return None;
     }
@@ -86,8 +112,7 @@ fn to_evaluated_inlinable_value(
     Some(EvaluatedInlinableValue::new_boolean(evaluated.bool()))
   } else if evaluated.is_number()
     && let num = evaluated.number()
-    && let num = num.to_js_string()
-    && num.len() <= EvaluatedInlinableValue::SHORT_SIZE
+    && ryu_js::Buffer::new().format(num).len() <= EvaluatedInlinableValue::SHORT_SIZE
   {
     Some(EvaluatedInlinableValue::new_number(num.into()))
   } else if evaluated.is_string()

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -114,7 +114,7 @@ fn to_evaluated_inlinable_value(
     && let num = evaluated.number()
     && ryu_js::Buffer::new().format(num).len() <= EvaluatedInlinableValue::SHORT_SIZE
   {
-    Some(EvaluatedInlinableValue::new_number(num.into()))
+    Some(EvaluatedInlinableValue::new_number(num))
   } else if evaluated.is_string()
     && let str = evaluated.string()
     && str.len() <= EvaluatedInlinableValue::SHORT_SIZE

--- a/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
@@ -644,9 +644,21 @@ pub fn evaluate_to_number<'a>(value: f64, start: u32, end: u32) -> BasicEvaluate
   eval
 }
 
+pub fn evaluate_to_boolean<'a>(value: bool, start: u32, end: u32) -> BasicEvaluatedExpression<'a> {
+  let mut eval = BasicEvaluatedExpression::with_range(start, end);
+  eval.set_bool(value);
+  eval
+}
+
 pub fn evaluate_to_null<'a>(start: u32, end: u32) -> BasicEvaluatedExpression<'a> {
   let mut eval = BasicEvaluatedExpression::with_range(start, end);
   eval.set_null();
+  eval
+}
+
+pub fn evaluate_to_undefined<'a>(start: u32, end: u32) -> BasicEvaluatedExpression<'a> {
+  let mut eval = BasicEvaluatedExpression::with_range(start, end);
+  eval.set_undefined();
   eval
 }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -494,7 +494,7 @@ impl<'parser> JavascriptParser<'parser> {
     Some(self.definitions_db.expect_get_variable(id))
   }
 
-  pub fn get_tag_data(&mut self, name: &Atom, tag: &str) -> Option<Box<dyn anymap::CloneAny>> {
+  pub fn get_tag_data(&mut self, name: &str, tag: &str) -> Option<Box<dyn anymap::CloneAny>> {
     self
       .get_variable_info(name)
       .and_then(|variable_info| variable_info.tag_info)

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -515,7 +515,7 @@ impl JavascriptParserPlugin for RstestParserPlugin {
     let first_arg = self.handle_mock_first_arg(parser, call_expr);
     if first_arg.is_some() {
       let tag_data = parser.get_tag_data(
-        &Atom::from(self.compose_rstest_import_call_key(call_expr).as_str()),
+        &self.compose_rstest_import_call_key(call_expr),
         RSTEST_MOCK_FIRST_ARG_TAG,
       );
 

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -20,6 +20,7 @@ ropey            = { workspace = true }
 rspack_cacheable = { workspace = true }
 rspack_paths     = { workspace = true }
 rustc-hash       = { workspace = true }
+ryu-js           = { workspace = true }
 serde            = { workspace = true }
 serde_json       = { workspace = true }
 sugar_path       = { workspace = true }

--- a/crates/rspack_util/src/itoa.rs
+++ b/crates/rspack_util/src/itoa.rs
@@ -1,6 +1,1 @@
 pub use itoa::Buffer;
-
-#[macro_export]
-macro_rules! itoa {
-  ($i:expr) => {{ $crate::itoa::Buffer::new().format($i) }};
-}

--- a/crates/rspack_util/src/lib.rs
+++ b/crates/rspack_util/src/lib.rs
@@ -15,6 +15,7 @@ pub mod location;
 pub mod node_path;
 pub mod number_hash;
 pub mod queue;
+pub mod ryu_js;
 pub mod size;
 pub mod source_map;
 pub mod swc;

--- a/crates/rspack_util/src/ryu_js.rs
+++ b/crates/rspack_util/src/ryu_js.rs
@@ -1,0 +1,1 @@
+pub use ryu_js::Buffer;

--- a/packages/rspack-test-tools/tests/configCases/inline-const/basic/constants.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-const/basic/constants.js
@@ -4,3 +4,8 @@ export const REMOVE_b = true
 export const REMOVE_i = 123456
 export const REMOVE_f = 123.45
 export const REMOVE_s = "remove"
+
+const a = 1 << 0;
+const b = 2 << 1;
+const c = 3 << 2;
+export const REMOVE_m = a | b | c;

--- a/packages/rspack-test-tools/tests/configCases/inline-const/basic/index.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-const/basic/index.js
@@ -15,6 +15,7 @@ it("should inline constants", () => {
   expect(constants.REMOVE_i).toBe(123456);
   expect(constants.REMOVE_f).toBe(123.45);
   expect(constants.REMOVE_s).toBe("remove");
+  expect(constants.REMOVE_m).toBe(13);
   // END:A
   const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
   expect(block.includes(`(/* inlined export .REMOVE_n */ null).toBe(null)`)).toBe(true);
@@ -23,6 +24,7 @@ it("should inline constants", () => {
   expect(block.includes(`(/* inlined export .REMOVE_i */ 123456).toBe(123456)`)).toBe(true);
   expect(block.includes(`(/* inlined export .REMOVE_f */ 123.45).toBe(123.45)`)).toBe(true);
   expect(block.includes(`(/* inlined export .REMOVE_s */ "remove").toBe("remove")`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_m */ 13).toBe(13)`)).toBe(true);
 })
 
 it("should inline constants with re-export", () => {

--- a/packages/rspack-test-tools/tests/configCases/inline-const/basic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-const/basic/rspack.config.js
@@ -7,13 +7,6 @@ function config(index, { concatenateModules } = {}) {
 		output: {
 			filename: `bundle.${index}.js`
 		},
-		module: {
-			parser: {
-				javascript: {
-					inlineConst: true
-				}
-			}
-		},
 		plugins: [
 			function (compiler) {
 				new compiler.webpack.DefinePlugin({

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -104,7 +104,8 @@ export const applyRspackOptionsDefaults = (
 		css: options.experiments.css,
 		targetProperties,
 		mode: options.mode,
-		uniqueName: options.output.uniqueName
+		uniqueName: options.output.uniqueName,
+		inlineConst: options.experiments.inlineConst
 	});
 
 	applyOutputDefaults(options.output, {
@@ -291,7 +292,8 @@ const applySnapshotDefaults = (
 ) => {};
 
 const applyJavascriptParserOptionsDefaults = (
-	parserOptions: JavascriptParserOptions
+	parserOptions: JavascriptParserOptions,
+	{ inlineConst }: { inlineConst?: boolean }
 ) => {
 	D(parserOptions, "dynamicImportMode", "lazy");
 	D(parserOptions, "dynamicImportPrefetch", false);
@@ -307,7 +309,7 @@ const applyJavascriptParserOptionsDefaults = (
 	D(parserOptions, "importDynamic", true);
 	D(parserOptions, "worker", ["..."]);
 	D(parserOptions, "importMeta", true);
-	D(parserOptions, "inlineConst", false);
+	D(parserOptions, "inlineConst", inlineConst);
 	D(parserOptions, "typeReexportsPresence", "no-tolerant");
 };
 
@@ -324,13 +326,15 @@ const applyModuleDefaults = (
 		css,
 		targetProperties,
 		mode,
-		uniqueName
+		uniqueName,
+		inlineConst
 	}: {
 		asyncWebAssembly: boolean;
 		css?: boolean;
 		targetProperties: any;
 		mode?: Mode;
 		uniqueName?: string;
+		inlineConst?: boolean;
 	}
 ) => {
 	assertNotNill(module.parser);
@@ -346,7 +350,9 @@ const applyModuleDefaults = (
 
 	F(module.parser, "javascript", () => ({}));
 	assertNotNill(module.parser.javascript);
-	applyJavascriptParserOptionsDefaults(module.parser.javascript);
+	applyJavascriptParserOptionsDefaults(module.parser.javascript, {
+		inlineConst
+	});
 
 	F(module.parser, JSON_MODULE_TYPE, () => ({}));
 	assertNotNill(module.parser[JSON_MODULE_TYPE]);

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -940,7 +940,7 @@ const __webpack_modules__ = {
 
 The switch for the experimental feature [`builtin:swc-loader rspackExperiments.collectTypeScriptInfo.exportedEnum`](/guide/features/builtin-swc-loader#rspackexperimentscollecttypescriptinfoexportedenum). Must be enabled to use the feature.
 
-Please refer to this [example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info) for more details.
+Please refer to [collect typescript info example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info) for more details.
 
 ## experiments.typeReexportsPresence
 
@@ -951,7 +951,7 @@ Please refer to this [example](https://github.com/rspack-contrib/rstack-examples
 
 The switch for the experimental feature [`module.parser.javascript.typeReexportsPresence`](/config/module#moduleparserjavascripttypereexportspresence). Must be enabled to use the feature.
 
-Please refer to this [example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info) for more details.
+Please refer to [collect typescript info example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info) for more details.
 
 ## experiments.nativeWatcher
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -910,7 +910,26 @@ Rspack will use the input file system wrapped by `VirtualModulesPlugin`; other t
 - **Type:** `boolean`
 - **Default:** `false`
 
-The switch for the experimental feature [`module.parser.javascript.inlineConst`](/config/module#moduleparserjavascriptinlineconst). Must be enabled to use the feature.
+Whether to enable the experimental feature [`module.parser.javascript.inlineConst`](/config/module#moduleparserjavascriptinlineconst), which will perform cross-module inline optimization for constant exports in leaf modules of the module graph.
+
+A common optimization case is `constants.js`, for example:
+
+```js
+// constants.js
+export const IS_A = true;
+// index.js
+import { IS_A } from './constants';
+console.log(IS_A ? 1 : 2);
+
+// Bundled by Rspack: output.js
+const __webpack_modules__ = {
+  './index.js': __webpack_require__ => {
+    // 1. IS_A will be inlined at the usage sites.
+    // 2. If all exports from constants.js are inlined, the constants.js module will be optimized away and won't appear in the final output.
+    console.log(true ? 1 : 2);
+  },
+};
+```
 
 ## experiments.inlineEnum
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -916,15 +916,15 @@ A common optimization case is `constants.js`, for example:
 
 ```js
 // constants.js
-export const IS_A = true;
+export const A = true;
 // index.js
-import { IS_A } from './constants';
-console.log(IS_A ? 1 : 2);
+import { A } from './constants';
+console.log(A ? 1 : 2);
 
 // Bundled by Rspack: output.js
 const __webpack_modules__ = {
   './index.js': __webpack_require__ => {
-    // 1. IS_A will be inlined at the usage sites.
+    // 1. A will be inlined at the usage sites.
     // 2. If all exports from constants.js are inlined, the constants.js module will be optimized away and won't appear in the final output.
     console.log(true ? 1 : 2);
   },

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -931,6 +931,8 @@ const __webpack_modules__ = {
 };
 ```
 
+Please refer to [inline const example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/inline-const)
+
 ## experiments.inlineEnum
 
 <ApiMeta addedVersion="1.4.1" />

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -633,7 +633,7 @@ export default {
 ```
 
 :::warning
-This is currently an experimental feature. You must enable [experiments.inlineConst](/config/experiments#experimentstypereexportspresence) for this configuration to take effect.
+This is currently an experimental feature, so you also need to enable [experiments.inlineConst](/config/experiments#experimentstypereexportspresence).
 :::
 
 ### module.parser["javascript/auto"]

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -589,7 +589,26 @@ export default {
 - **Type:** `boolean`
 - **Default:** `false`
 
-Performs cross-module inline optimization for constant exports in leaf modules of the module graph, commonly seen in scenarios like `constants.js`.
+Performs cross-module inline optimization for constant exports in leaf modules of the module graph.
+
+A common optimization case is `constants.js`, for example:
+
+```js
+// constants.js
+export const IS_A = true;
+// index.js
+import { IS_A } from './constants';
+console.log(IS_A ? 1 : 2);
+
+// 经过打包后的结果 output.js
+const __webpack_modules__ = {
+  './index.js': __webpack_require__ => {
+    // 1. IS_A 会被内联到使用的地方。
+    // 2. 如果 constants.js 的所有导出都被内联，则会把 constants.js 模块优化掉，constants.js 模块不会出现在产物中。
+    console.log(true ? 1 : 2);
+  },
+};
+```
 
 Inline optimization is applied when the constant value is:
 

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -595,15 +595,15 @@ A common optimization case is `constants.js`, for example:
 
 ```js
 // constants.js
-export const IS_A = true;
+export const A = true;
 // index.js
-import { IS_A } from './constants';
-console.log(IS_A ? 1 : 2);
+import { A } from './constants';
+console.log(A ? 1 : 2);
 
 // 经过打包后的结果 output.js
 const __webpack_modules__ = {
   './index.js': __webpack_require__ => {
-    // 1. IS_A 会被内联到使用的地方。
+    // 1. A 会被内联到使用的地方。
     // 2. 如果 constants.js 的所有导出都被内联，则会把 constants.js 模块优化掉，constants.js 模块不会出现在产物中。
     console.log(true ? 1 : 2);
   },

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -525,7 +525,7 @@ export default {
 };
 ```
 
-Please refer to this [example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info) for more details.
+Please refer to [collect typescript info example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info) for more details.
 
 :::warning
 This is currently an experimental feature. You must enable [experiments.typeReexportsPresence](/config/experiments#experimentstypereexportspresence) for this configuration to take effect.
@@ -600,11 +600,11 @@ export const A = true;
 import { A } from './constants';
 console.log(A ? 1 : 2);
 
-// 经过打包后的结果 output.js
+// Bundled by Rspack: output.js
 const __webpack_modules__ = {
   './index.js': __webpack_require__ => {
-    // 1. A 会被内联到使用的地方。
-    // 2. 如果 constants.js 的所有导出都被内联，则会把 constants.js 模块优化掉，constants.js 模块不会出现在产物中。
+    // 1. A will be inlined at the usage sites.
+    // 2. If all exports from constants.js are inlined, the constants.js module will be optimized away and won't appear in the final output.
     console.log(true ? 1 : 2);
   },
 };
@@ -631,6 +631,8 @@ export default {
   },
 };
 ```
+
+Please refer to [inline const example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/inline-const)
 
 :::warning
 This is currently an experimental feature, so you also need to enable [experiments.inlineConst](/config/experiments#experimentstypereexportspresence).

--- a/website/docs/en/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/features/builtin-swc-loader.mdx
@@ -461,7 +461,7 @@ Collects information from TypeScript's AST for consumption by subsequent Rspack 
 
 To ensure the accuracy of the collected information, users must ensure that subsequent Normal Loaders after `builtin:swc-loader` do not modify the Abstract Syntax Tree (AST) corresponding to the collected information. This precaution is necessary to prevent discrepancies between the collected information and the actual code.
 
-Please refer to this [example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info) for more details.
+Please refer to [collect typescript info example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info) for more details.
 
 #### rspackExperiments.collectTypeScriptInfo.typeExports
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -911,7 +911,26 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `false`
 
-实验性功能 [`module.parser.javascript.inlineConst`](/config/module#moduleparserjavascriptinlineconst) 的开关，开启后才能使用。
+实验性功能 [`module.parser.javascript.inlineConst`](/config/module#moduleparserjavascriptinlineconst) 的开关，开启后会将位于模块图叶子节点的模块中的常量导出进行跨模块的 inline 优化。
+
+常见的优化场景为 `constants.js`，比如：
+
+```js
+// constants.js
+export const IS_A = true;
+// index.js
+import { IS_A } from './constants';
+console.log(IS_A ? 1 : 2);
+
+// 经过打包后的结果 output.js
+const __webpack_modules__ = {
+  './index.js': __webpack_require__ => {
+    // 1. IS_A 会被内联到使用的地方。
+    // 2. 如果 constants.js 的所有导出都被内联，则会把 constants.js 模块优化掉，constants.js 模块不会出现在产物中。
+    console.log(true ? 1 : 2);
+  },
+};
+```
 
 ## experiments.inlineEnum
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -932,6 +932,8 @@ const __webpack_modules__ = {
 };
 ```
 
+详细示例可参考：[inline const example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/inline-const)
+
 ## experiments.inlineEnum
 
 <ApiMeta addedVersion="1.4.1" />
@@ -941,7 +943,7 @@ const __webpack_modules__ = {
 
 实验性功能 [`builtin:swc-loader rspackExperiments.collectTypeScriptInfo.exportedEnum`](/guide/features/builtin-swc-loader#rspackexperimentscollecttypescriptinfoexportedenum) 的开关，开启后才能使用。
 
-详细示例可参考：[example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info)
+详细示例可参考：[collect typescript info example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info)
 
 ## experiments.typeReexportsPresence
 
@@ -952,7 +954,7 @@ const __webpack_modules__ = {
 
 实验性功能 [`module.parser.javascript.typeReexportsPresence`](/config/module#moduleparserjavascripttypereexportspresence) 的开关，开启后才能使用。
 
-详细示例可参考：[example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info)
+详细示例可参考：[collect typescript info example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info)
 
 ## experiments.nativeWatcher
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -917,15 +917,15 @@ export default {
 
 ```js
 // constants.js
-export const IS_A = true;
+export const A = true;
 // index.js
-import { IS_A } from './constants';
-console.log(IS_A ? 1 : 2);
+import { A } from './constants';
+console.log(A ? 1 : 2);
 
 // 经过打包后的结果 output.js
 const __webpack_modules__ = {
   './index.js': __webpack_require__ => {
-    // 1. IS_A 会被内联到使用的地方。
+    // 1. A 会被内联到使用的地方。
     // 2. 如果 constants.js 的所有导出都被内联，则会把 constants.js 模块优化掉，constants.js 模块不会出现在产物中。
     console.log(true ? 1 : 2);
   },

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -595,15 +595,15 @@ export default {
 
 ```js
 // constants.js
-export const IS_A = true;
+export const A = true;
 // index.js
-import { IS_A } from './constants';
-console.log(IS_A ? 1 : 2);
+import { A } from './constants';
+console.log(A ? 1 : 2);
 
 // 经过打包后的结果 output.js
 const __webpack_modules__ = {
   './index.js': __webpack_require__ => {
-    // IS_A 会被内联到使用的地方，且 constants.js 所有导出都被内联，
+    // A 会被内联到使用的地方，且 constants.js 所有导出都被内联，
     // 会把 constants.js 模块优化掉，constants.js 模块不会出现在产物中。
     console.log(true ? 1 : 2);
   },

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -589,7 +589,26 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `false`
 
-对位于模块图叶子节点的模块中的常量导出进行跨模块的 inline 优化，常见场景为 `constants.js`。
+对位于模块图叶子节点的模块中的常量导出进行跨模块的 inline 优化。
+
+常见的优化场景为 `constants.js`，比如：
+
+```js
+// constants.js
+export const IS_A = true;
+// index.js
+import { IS_A } from './constants';
+console.log(IS_A ? 1 : 2);
+
+// 经过打包后的结果 output.js
+const __webpack_modules__ = {
+  './index.js': __webpack_require__ => {
+    // IS_A 会被内联到使用的地方，且 constants.js 所有导出都被内联，
+    // 会把 constants.js 模块优化掉，constants.js 模块不会出现在产物中。
+    console.log(true ? 1 : 2);
+  },
+};
+```
 
 inline 优化的条件是常量值为：
 
@@ -614,7 +633,7 @@ export default {
 ```
 
 :::warning
-目前仍为实验性功能，需要开启 [experiments.inlineConst](/config/experiments#experimentstypereexportspresence) 该配置才会生效。
+目前仍为实验性功能，需要开启 [experiments.inlineConst](/config/experiments#experimentstypereexportspresence)。
 :::
 
 ### module.parser["javascript/auto"]

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -525,7 +525,7 @@ export default {
 };
 ```
 
-详细示例可参考：[example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info)
+详细示例可参考：[collect typescript info example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info)
 
 :::warning
 目前仍为实验性功能，需要开启 [experiments.typeReexportsPresence](/config/experiments#experimentstypereexportspresence) 该配置才会生效。
@@ -603,8 +603,8 @@ console.log(A ? 1 : 2);
 // 经过打包后的结果 output.js
 const __webpack_modules__ = {
   './index.js': __webpack_require__ => {
-    // A 会被内联到使用的地方，且 constants.js 所有导出都被内联，
-    // 会把 constants.js 模块优化掉，constants.js 模块不会出现在产物中。
+    // 1. A 会被内联到使用的地方。
+    // 2. 如果 constants.js 的所有导出都被内联，则会把 constants.js 模块优化掉，constants.js 模块不会出现在产物中。
     console.log(true ? 1 : 2);
   },
 };
@@ -631,6 +631,8 @@ export default {
   },
 };
 ```
+
+详细示例可参考：[inline const example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/inline-const)
 
 :::warning
 目前仍为实验性功能，需要开启 [experiments.inlineConst](/config/experiments#experimentstypereexportspresence)。

--- a/website/docs/zh/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-swc-loader.mdx
@@ -463,7 +463,7 @@ import 'antd/es/button/style';
 
 为了保证收集到的信息的准确性，用户需要确保 `builtin:swc-loader` 后续的 Normal Loader 不会去修改这些已经被收集到的相关信息对应的 AST，以免导致收集到的信息和实际的代码不一致的情况。
 
-详细示例可参考：[example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info)
+详细示例可参考：[collect typescript info example](https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/collect-typescript-info)
 
 #### rspackExperiments.collectTypeScriptInfo.typeExports
 


### PR DESCRIPTION
## Summary

Propagate const:

```js
const a = 1;
const b = 2;
export const value = a + b // before this won't inline, this PR will inline it
```


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
