### PR TITLE
fix: export the missing `PathData` type

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -656,6 +656,14 @@ export type ChunkLoadingGlobal = string;
 export type ChunkLoadingType = string | "jsonp" | "import-scripts" | "require" | "async-node" | "import";
 
 // @public (undocumented)
+export type ChunkPathData = {
+    id?: string;
+    name?: string;
+    hash?: string;
+    contentHash?: Record<string, string>;
+};
+
+// @public (undocumented)
 export class CircularDependencyRspackPlugin extends RspackBuiltinPlugin {
     constructor(options: CircularDependencyRspackPluginOptions);
     // (undocumented)
@@ -5528,16 +5536,8 @@ export type PathData = {
     runtime?: string;
     url?: string;
     id?: string;
-    chunk?: Chunk | PathDataChunkLike;
+    chunk?: Chunk | ChunkPathData;
     contentHashType?: string;
-};
-
-// @public (undocumented)
-export type PathDataChunkLike = {
-    id?: string;
-    name?: string;
-    hash?: string;
-    contentHash?: Record<string, string>;
 };
 
 // @public
@@ -6247,10 +6247,10 @@ declare namespace rspackExports {
         Asset,
         AssetInfo,
         Assets,
+        ChunkPathData,
         CompilationParams,
         LogEntry,
         PathData,
-        PathDataChunkLike,
         Compilation,
         Compiler,
         MultiCompilerOptions,

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -79,7 +79,7 @@ export interface Asset {
 	info: AssetInfo;
 }
 
-export type PathDataChunkLike = {
+export type ChunkPathData = {
 	id?: string;
 	name?: string;
 	hash?: string;
@@ -93,7 +93,7 @@ export type PathData = {
 	runtime?: string;
 	url?: string;
 	id?: string;
-	chunk?: Chunk | PathDataChunkLike;
+	chunk?: Chunk | ChunkPathData;
 	contentHashType?: string;
 };
 

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -8,10 +8,10 @@ export type {
 	Asset,
 	AssetInfo,
 	Assets,
+	ChunkPathData,
 	CompilationParams,
 	LogEntry,
-	PathData,
-	PathDataChunkLike
+	PathData
 } from "./Compilation";
 export { Compilation } from "./Compilation";
 export { Compiler } from "./Compiler";


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This type can be used when using function in `output.filename`. It would be great to have type exported.

## Related links

<!-- Related issues or discussions. -->

https://rsbuild.rs/config/output/filename#using-function

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
