### PR TITLE
fix: should not render export in modern-module when iife enabled

### DIFF
--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -225,7 +225,7 @@ async fn render_startup(
     }
   }
 
-  if !exports.is_empty() {
+  if !exports.is_empty() && !compilation.options.output.iife {
     source.add(RawStringSource::from(format!(
       "export {{ {} }};\n",
       exports.join(", ")

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-iife/foo.mjs
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-iife/foo.mjs
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-iife/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-iife/index.js
@@ -1,0 +1,3 @@
+import { foo } from './foo.mjs';
+console.log('foo: ', foo);
+export { foo };

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-iife/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-iife/rspack.config.js
@@ -1,0 +1,35 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		index: "./index.js"
+	},
+	output: {
+		filename: `[name].js`,
+		iife: true,
+		asyncChunks: false,
+		library: {
+			type: "modern-module"
+		}
+	},
+	optimization: {
+		minimize: true,
+		moduleIds: "named"
+	},
+	plugins: [
+		function () {
+			/**
+			 * @param {import("@rspack/core").Compilation} compilation compilation
+			 * @returns {void}
+			 */
+			const handler = compilation => {
+				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
+					const bundle = Object.values(assets)[0]._value;
+					expect(bundle).toContain(
+						`(()=>{"use strict";console.log("foo: ","foo")})();`
+					);
+				});
+			};
+			this.hooks.compilation.tap("testcase", handler);
+		}
+	]
+};


### PR DESCRIPTION
## Summary

Should not render export in modern-module when iife enabled to avoid minfication error:

<img width="1492" height="340" alt="image" src="https://github.com/user-attachments/assets/411ae833-b94c-4bc1-bf7f-58f02eba1264" />

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
