### PR TITLE
docs: add Rslint to the list of Rstack tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ Come chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! Rspack team and R
 
 ## Links
 
-| Name                                                                                 | Description                                                                     |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
-| [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)                    | A curated list of awesome things related to Rspack                              |
-| [Rspack 1.x documentation](https://rspack.rs/)                                       | Documentation for Rspack 1.x (latest)                                           |
-| [Rspack 0.x documentation](https://v0.rspack.rs/)                                    | Documentation for Rspack 0.x version                                            |
-| [rspack-dev-server](https://github.com/web-infra-dev/rspack-dev-server)              | Dev server for Rspack                                                           |
-| [rstack-examples](https://github.com/rspack-contrib/rstack-examples)                 | Examples showcasing Rstack ecosystem tools (Rspack, Rsbuild, Rspress, Rsdoctor) |
-| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust port of [webpack-sources](https://www.npmjs.com/package/webpack-sources)   |
-| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Design resources for Rspack Stack                                               |
+| Name                                                                                 | Description                                                                   |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)                    | A curated list of awesome things related to Rspack                            |
+| [Rspack 1.x documentation](https://rspack.rs/)                                       | Documentation for Rspack 1.x (latest)                                         |
+| [Rspack 0.x documentation](https://v0.rspack.rs/)                                    | Documentation for Rspack 0.x version                                          |
+| [rspack-dev-server](https://github.com/web-infra-dev/rspack-dev-server)              | Dev server for Rspack                                                         |
+| [rstack-examples](https://github.com/rspack-contrib/rstack-examples)                 | Examples showcasing Rstack                                                    |
+| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust port of [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
+| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Design resources for Rspack Stack                                             |
 
 ## Contributors
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,7 +71,7 @@ Rstack 是一个围绕 Rspack 打造的 JavaScript 统一工具链，具有优�
 | [Rspack 1.x 文档](https://rspack.rs/zh/)                                             | Rspack 1.x 版本的文档（最新）                                                |
 | [Rspack 0.x 文档](https://v0.rspack.rs/zh/)                                          | Rspack 0.x 版本的文档                                                        |
 | [rspack-dev-server](https://github.com/web-infra-dev/rspack-dev-server)              | Rspack 的开发服务器                                                          |
-| [rstack-examples](https://github.com/rspack-contrib/rstack-examples)                 | Rstack 生态（Rspack、Rsbuild、Rspress、Rsdoctor）的示例                      |
+| [rstack-examples](https://github.com/rspack-contrib/rstack-examples)                 | Rstack 的示例项目                                                            |
 | [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust 版本的 [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
 | [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Rspack Stack 的设计资源                                                      |
 


### PR DESCRIPTION
## Summary

Add Rslint to the list of Rstack tools.

## Related links

https://github.com/web-infra-dev/rslint

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
