### PR TITLE
fix: batch rename_asset with parallel optimization

### DIFF
--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -260,6 +260,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   logger.time_end(start);
 
   let start = logger.time("update assets");
+  let mut asset_renames = Vec::with_capacity(updates.len());
   for (name, new_source, new_name) in updates {
     compilation.update_asset(&name, |_, old_info| {
       let new_hashes: HashSet<_> = old_info
@@ -279,9 +280,11 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
       ))
     })?;
     if let Some(new_name) = new_name {
-      compilation.rename_asset(&name, new_name);
+      asset_renames.push((name, new_name));
     }
   }
+
+  compilation.par_rename_assets(asset_renames);
 
   logger.time_end(start);
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Batch version of rename_asset with parallel optimization.
Multiple calls to rename_asset would cause performance degradation due to repeated full traversals of chunk_by_ukey. This method uses parallel iteration over chunk_by_ukey to reduce traversal frequency and improve performance.

Fix performance regression in https://github.com/web-infra-dev/rspack/pull/11293

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
