### PR TITLE
docs(quick-start): update runtime installation instructions

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -13,30 +13,25 @@ As a low-level bundler, Rspack has a rich ecosystem that includes various framew
 
 See the [Ecosystem](/guide/start/ecosystem) page to explore these ecosystem projects.
 
-## Setup environment
+## Environment preparation
 
-Rspack supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/), or [Bun](https://bun.sh/) as the runtime.
+Rspack supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/), or [Bun](https://bun.sh/) as the JavaScript runtime.
 
-### Node.js
+You can refer to the following installation guides and choose one runtime:
 
-For Node.js, please install Node.js >= 16, it is recommended to use the Node.js LTS version.
+- [Install Node.js](https://nodejs.org/en/download)
+- [Install Bun](https://bun.com/docs/installation)
+- [Install Deno](https://docs.deno.com/runtime/getting_started/installation/)
 
-Check the current Node.js version with the following command:
+:::tip Version requirements
 
-```bash
-node -v
-```
+Rspack has the following Node.js version requirements:
 
-If you do not have Node.js installed in current environment, or the installed version is too low, you can use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to install.
+- `@rspack/cli >= v1.0.0` requires Node.js 18.12.0 or higher.
+- `@rspack/core >= v1.5.0` requires Node.js 18.12.0 or higher.
+- `@rspack/core < v1.5.0` requires Node.js 16.0.0 or higher.
 
-Here is an example of how to install via nvm:
-
-```bash
-# Install Node.js LTS
-nvm install --lts
-# Switch to Node.js LTS
-nvm use --lts
-```
+:::
 
 ## Create a new project
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -15,28 +15,23 @@ import { PackageManagerTabs } from '@theme';
 
 ## 环境准备
 
-Rspack 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 或 [Bun](https://bun.sh/) 作为运行时。
+Rspack 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 或 [Bun](https://bun.sh/) 作为 JavaScript 运行时。
 
-### Node.js
+你可以参考以下安装指南，选择其中一种运行时：
 
-对于 Node.js，请安装 Node.js >= 16 版本，推荐使用 Node.js LTS 版本。
+- [安装 Node.js](https://nodejs.org/en/download)
+- [安装 Bun](https://bun.com/docs/installation)
+- [安装 Deno](https://docs.deno.com/runtime/getting_started/installation/)
 
-通过以下命令检查当前使用的 Node.js 版本：
+:::tip 版本要求
 
-```bash
-node -v
-```
+Rspack 对于 Node.js 的版本要求如下：
 
-如果你的环境中尚未安装 Node.js，或是版本过低，可以通过 [nvm](https://github.com/nvm-sh/nvm) 或 [fnm](https://github.com/Schniz/fnm) 安装。
+- `@rspack/cli >= v1.0.0` 要求 Node.js 至少为 18.12.0。
+- `@rspack/core >= v1.5.0` 要求 Node.js 至少为 18.12.0。
+- `@rspack/core < v1.5.0` 最低支持 Node.js 16.0.0。
 
-下面是通过 nvm 安装的例子：
-
-```bash
-# 安装 Node.js LTS
-nvm install --lts
-# 切换到 Node.js LTS
-nvm use --lts
-```
+:::
 
 ## 创建新项目
 


### PR DESCRIPTION
## Summary

As @rspack/core ≥ 1.5.0 no longer supports Node 16, the quick start guide should be updated to reflect this.

This PR also adds links to the installation guides for other JavaScript runtimes, such as Bun and Deno.

## Related links

- https://github.com/web-infra-dev/rspack/discussions/10867

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
