### PR TITLE
perf: cache concatenated imports

### DIFF
--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -244,7 +244,7 @@ pub(super) mod get_side_effects_connection_state {
     }
 
     pub fn get(&self, key: &ModuleIdentifier) -> Option<ConnectionState> {
-      self.cache.get(key).map(|v| v.value().clone())
+      self.cache.get(key).map(|v| *v.value())
     }
 
     pub fn set(&self, key: ModuleIdentifier, value: ConnectionState) {

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -15,9 +15,9 @@ use serde::{Serialize, Serializer};
 
 use crate::{
   AsyncDependenciesBlockIdentifier, ChunkByUkey, ChunkGraph, ChunkGroup, ChunkGroupByUkey,
-  ChunkGroupUkey, ChunkUkey, Compilation, Module, ModuleGraph, ModuleIdentifier, ModuleIdsArtifact,
-  PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, RuntimeSpecMap, RuntimeSpecSet,
-  for_each_runtime,
+  ChunkGroupUkey, ChunkUkey, Compilation, ExportsInfoGetter, Module, ModuleGraph, ModuleIdentifier,
+  ModuleIdsArtifact, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, RuntimeSpecMap,
+  RuntimeSpecSet, for_each_runtime,
 };
 
 #[cacheable]
@@ -312,53 +312,52 @@ impl ChunkGraph {
     runtime: Option<&RuntimeSpec>,
   ) -> u64 {
     let mut hasher = FxHasher::default();
-    self
-      .get_module_graph_hash_without_connections(module, compilation, runtime)
-      .hash(&mut hasher);
     let strict = module.get_strict_esm_module();
     let mg = compilation.get_module_graph();
     let mg_cache = &compilation.module_graph_cache_artifact;
+    self
+      .get_module_graph_hash_without_connections(module, compilation, runtime, strict)
+      .hash(&mut hasher);
+
     let mut visited_modules = IdentifierSet::default();
     visited_modules.insert(module.identifier());
-    let mut hash_modules = vec![];
-    for connection in mg
+
+    let hash_modules = mg
       .get_outgoing_deps_in_order(&module.identifier())
-      .filter_map(|c| mg.connection_by_dependency_id(c))
-    {
-      let module_identifier = connection.module_identifier();
-      if visited_modules.contains(module_identifier) {
-        continue;
-      }
-      let active_state = connection.active_state(&mg, runtime, mg_cache);
-      if active_state.is_false() {
-        continue;
-      }
-      visited_modules.insert(*module_identifier);
-      for_each_runtime(
-        runtime,
-        |runtime| {
-          let runtime = runtime.map(|r| RuntimeSpec::from_iter([r.as_str().into()]));
-          let active_state = connection.active_state(&mg, runtime.as_ref(), mg_cache);
-          active_state.hash(&mut hasher);
-        },
-        true,
-      );
+      .filter_map(|c| {
+        let connection = mg.connection_by_dependency_id(c)?;
+        let module_identifier = connection.module_identifier();
+        if visited_modules.contains(module_identifier) {
+          return None;
+        }
+        let active_state = connection.active_state(&mg, runtime, mg_cache);
+        if active_state.is_false() {
+          return None;
+        }
+        visited_modules.insert(*module_identifier);
+        for_each_runtime(
+          runtime,
+          |runtime| {
+            let runtime = runtime.map(|r| RuntimeSpec::from_iter([r.as_str().into()]));
+            let active_state = connection.active_state(&mg, runtime.as_ref(), mg_cache);
+            active_state.hash(&mut hasher);
+          },
+          true,
+        );
+        Some(module_identifier)
+      })
+      .collect::<Vec<_>>();
+
+    for module_identifier in hash_modules {
       let module = mg
         .module_by_identifier(module_identifier)
         .expect("should have module")
         .as_ref();
-      module
-        .get_exports_type(&mg, &compilation.module_graph_cache_artifact, strict)
+      self
+        .get_module_graph_hash_without_connections(module, compilation, runtime, strict)
         .hash(&mut hasher);
-      hash_modules.push(module);
     }
-    let hash_results = hash_modules
-      .into_iter()
-      .map(|module| self.get_module_graph_hash_without_connections(module, compilation, runtime))
-      .collect::<Vec<_>>();
-    for hash_result in hash_results {
-      hash_result.hash(&mut hasher);
-    }
+
     hasher.finish()
   }
 
@@ -367,16 +366,33 @@ impl ChunkGraph {
     module: &dyn Module,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
+    strict: bool,
   ) -> u64 {
-    let mut hasher = FxHasher::default();
     let mg = compilation.get_module_graph();
-    let module_identifier = module.identifier();
-    let module_graph = compilation.get_module_graph();
-    Self::get_module_id(&compilation.module_ids_artifact, module_identifier).dyn_hash(&mut hasher);
-    module.source_types(&module_graph).dyn_hash(&mut hasher);
-    ModuleGraph::is_async(compilation, &module_identifier).dyn_hash(&mut hasher);
+    let mut hasher = FxHasher::default();
+
+    let (hash, exports_info_entry, exports_info_exports) = compilation
+      .module_graph_cache_artifact
+      .cached_module_graph_hash(module.identifier(), || {
+        let mut hasher = FxHasher::default();
+        let module_identifier = module.identifier();
+        Self::get_module_id(&compilation.module_ids_artifact, module_identifier)
+          .dyn_hash(&mut hasher);
+        module
+          .get_exports_type(&mg, &compilation.module_graph_cache_artifact, strict)
+          .hash(&mut hasher);
+        module.source_types(&mg).dyn_hash(&mut hasher);
+
+        ModuleGraph::is_async(compilation, &module_identifier).dyn_hash(&mut hasher);
+        let exports_info =
+          mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Full);
+        let (entry, exports) = exports_info.meta();
+        (hasher.finish(), entry, exports)
+      });
+
+    hasher.write_u64(hash);
     let exports_info =
-      mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Full);
+      ExportsInfoGetter::from_meta((exports_info_entry, exports_info_exports), &mg);
     exports_info.update_hash(&mut hasher, runtime);
     hasher.finish()
   }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -225,7 +225,7 @@ pub struct ExternalModuleInfo {
 
 #[derive(Debug, Clone)]
 pub struct ConnectionWithRuntimeCondition {
-  pub connection: ModuleGraphConnection,
+  pub connection: Arc<ModuleGraphConnection>,
   pub runtime_condition: RuntimeCondition,
 }
 
@@ -1927,7 +1927,7 @@ impl ConcatenatedModule {
         }
         indexmap::map::Entry::Vacant(vac) => {
           vac.insert(ConnectionWithRuntimeCondition {
-            connection: reference.connection.clone(),
+            connection: Arc::new(reference.connection.clone()),
             runtime_condition,
           });
         }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -223,8 +223,9 @@ pub struct ExternalModuleInfo {
   pub name: Option<Atom>,
 }
 
-pub struct ConnectionWithRuntimeCondition<'a> {
-  pub connection: &'a ModuleGraphConnection,
+#[derive(Debug, Clone)]
+pub struct ConnectionWithRuntimeCondition {
+  pub connection: ModuleGraphConnection,
   pub runtime_condition: RuntimeCondition,
 }
 
@@ -1554,8 +1555,6 @@ impl Module for ConcatenatedModule {
     };
     let runtime = runtime.as_deref();
     let concatenation_entries = self.create_concatenation_list(
-      self.root_module_ctxt.id,
-      self.modules.iter().map(|item| item.id).collect(),
       runtime,
       &compilation.get_module_graph(),
       &compilation.module_graph_cache_artifact,
@@ -1676,13 +1675,7 @@ impl ConcatenatedModule {
     Vec<(ModuleIdentifier, Option<RuntimeCondition>)>,
     IdentifierIndexMap<ModuleInfo>,
   ) {
-    let ordered_concatenation_list = self.create_concatenation_list(
-      self.root_module_ctxt.id,
-      self.modules.iter().map(|item| item.id).collect(),
-      runtime,
-      mg,
-      mg_cache,
-    );
+    let ordered_concatenation_list = self.create_concatenation_list(runtime, mg, mg_cache);
     let mut list = vec![];
     let mut map = IdentifierIndexMap::default();
     for (i, concatenation_entry) in ordered_concatenation_list.into_iter().enumerate() {
@@ -1737,23 +1730,26 @@ impl ConcatenatedModule {
 
   fn create_concatenation_list(
     &self,
-    root_module: ModuleIdentifier,
-    module_set: IdentifierIndexSet,
     runtime: Option<&RuntimeSpec>,
     mg: &ModuleGraph,
     mg_cache: &ModuleGraphCacheArtifact,
   ) -> Vec<ConcatenationEntry> {
+    let root_module = self.root_module_ctxt.id;
+    let module_set: IdentifierIndexSet = self.modules.iter().map(|item| item.id).collect();
+
     let mut list = vec![];
     let mut exists_entries = IdentifierMap::default();
     exists_entries.insert(root_module, RuntimeCondition::Boolean(true));
 
-    let imports_map = module_set
-      .par_iter()
-      .map(|module| {
-        let imports = self.get_concatenated_imports(module, &root_module, runtime, mg, mg_cache);
-        (*module, imports)
-      })
-      .collect::<IdentifierMap<_>>();
+    let imports_map = mg_cache.cached_concatenated_module_imports(self.id(), || {
+      module_set
+        .par_iter()
+        .map(|module| {
+          let imports = self.get_concatenated_imports(module, &root_module, runtime, mg, mg_cache);
+          (*module, imports)
+        })
+        .collect::<IdentifierMap<_>>()
+    });
 
     let imports = imports_map.get(&root_module).expect("should have imports");
     for i in imports {
@@ -1761,7 +1757,7 @@ impl ConcatenatedModule {
         &module_set,
         runtime,
         mg,
-        i.connection,
+        &i.connection,
         i.runtime_condition.clone(),
         &mut exists_entries,
         &mut list,
@@ -1808,7 +1804,7 @@ impl ConcatenatedModule {
           module_set,
           runtime,
           mg,
-          import.connection,
+          &import.connection,
           import.runtime_condition.clone(),
           exists_entry,
           list,
@@ -1851,14 +1847,14 @@ impl ConcatenatedModule {
     }
   }
 
-  fn get_concatenated_imports<'a>(
+  fn get_concatenated_imports(
     &self,
     module_id: &ModuleIdentifier,
     root_module_id: &ModuleIdentifier,
     runtime: Option<&RuntimeSpec>,
-    mg: &'a ModuleGraph,
-    mg_cache: &'a ModuleGraphCacheArtifact,
-  ) -> Vec<ConnectionWithRuntimeCondition<'a>> {
+    mg: &ModuleGraph,
+    mg_cache: &ModuleGraphCacheArtifact,
+  ) -> Vec<ConnectionWithRuntimeCondition> {
     let mut connections: Vec<&ModuleGraphConnection> =
       mg.get_ordered_outgoing_connections(module_id).collect();
     if module_id == root_module_id {
@@ -1931,7 +1927,7 @@ impl ConcatenatedModule {
         }
         indexmap::map::Entry::Vacant(vac) => {
           vac.insert(ConnectionWithRuntimeCondition {
-            connection: reference.connection,
+            connection: reference.connection.clone(),
             runtime_condition,
           });
         }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -72,6 +72,10 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
       .expect("should have nested exports info")
   }
 
+  pub fn meta(&self) -> (ExportsInfo, Vec<ExportsInfo>) {
+    (self.entry, self.exports.keys().copied().collect())
+  }
+
   pub fn other_exports_info(&self) -> &ExportInfoData {
     if let Some(redirect) = self.get_redirect_to_in_exports_info(&self.entry) {
       return self.get_other_in_exports_info(&redirect);
@@ -741,6 +745,23 @@ impl ExportsInfoGetter {
         arr.extend(names.iter().skip(1).cloned());
         Some(UsedName::Normal(arr))
       }
+    }
+  }
+
+  pub fn from_meta<'a>(
+    meta: (ExportsInfo, Vec<ExportsInfo>),
+    mg: &'a ModuleGraph,
+  ) -> PrefetchedExportsInfoWrapper<'a> {
+    let (entry, exports) = meta;
+    let exports = exports
+      .into_iter()
+      .map(|e| (e, mg.get_exports_info_by_id(&e)))
+      .collect::<HashMap<_, _>>();
+
+    PrefetchedExportsInfoWrapper {
+      exports: Arc::new(exports),
+      entry,
+      mode: PrefetchExportsInfoMode::Full,
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add cache of concatenated imports to prevent getting concatenated import multiple times during generating module hash every runtime and the code generation.
- Add cache of module hash because it will be generated every runtime of module runtime spec and also every active connection.

Before:
<img width="542" height="54" alt="image" src="https://github.com/user-attachments/assets/9666470f-058e-4602-a77c-8d6288ae76fc" />
<img width="492" height="46" alt="image" src="https://github.com/user-attachments/assets/33662e6f-aac4-461e-8cf9-c3dad12ef7b7" />

After:
<img width="522" height="44" alt="image" src="https://github.com/user-attachments/assets/6f867f6f-0046-42fc-89dc-71898b8b2218" />
<img width="470" height="64" alt="image" src="https://github.com/user-attachments/assets/f574c96c-8215-4be1-94e0-db8d17d96a9a" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
