### PR TITLE
feat!: update minimum Node.js version to 18.12.0

### DIFF
--- a/packages/create-rspack/rslib.config.ts
+++ b/packages/create-rspack/rslib.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "@rslib/core";
 
 export default defineConfig({
-	lib: [{ format: "esm", syntax: ["node 18"] }]
+	lib: [{ format: "esm", syntax: ["node 18.12"] }]
 });

--- a/packages/create-rspack/rslib.config.ts
+++ b/packages/create-rspack/rslib.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "@rslib/core";
 
 export default defineConfig({
-	lib: [{ format: "esm", syntax: "es2021" }]
+	lib: [{ format: "esm", syntax: ["node 18"] }]
 });

--- a/packages/rspack-cli/rslib.config.ts
+++ b/packages/rspack-cli/rslib.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from "@rslib/core";
 
 export default defineConfig({
 	lib: [
-		{ format: "cjs", syntax: "es2021", dts: { bundle: false } },
-		{ format: "esm", syntax: "es2021" }
+		{ format: "cjs", syntax: ["node 18"], dts: { bundle: false } },
+		{ format: "esm", syntax: ["node 18"] }
 	],
 	source: {
 		tsconfigPath: "./tsconfig.build.json"

--- a/packages/rspack-cli/rslib.config.ts
+++ b/packages/rspack-cli/rslib.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from "@rslib/core";
 
 export default defineConfig({
 	lib: [
-		{ format: "cjs", syntax: ["node 18"], dts: { bundle: false } },
-		{ format: "esm", syntax: ["node 18"] }
+		{ format: "cjs", syntax: ["node 18.12"], dts: { bundle: false } },
+		{ format: "esm", syntax: ["node 18.12"] }
 	],
 	source: {
 		tsconfigPath: "./tsconfig.build.json"

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -31,7 +31,7 @@
   },
   "files": ["dist", "hot", "compiled", "module.d.ts"],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.12.0"
   },
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -26,7 +26,7 @@ const externalAlias = ({ request }: { request?: string }, callback) => {
 
 const commonLibConfig: LibConfig = {
 	format: "cjs",
-	syntax: ["node 16"],
+	syntax: ["node 18"],
 	source: {
 		define: {
 			WEBPACK_VERSION: JSON.stringify(require("./package.json").webpackVersion),

--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -26,7 +26,7 @@ const externalAlias = ({ request }: { request?: string }, callback) => {
 
 const commonLibConfig: LibConfig = {
 	format: "cjs",
-	syntax: ["node 18"],
+	syntax: ["node 18.12"],
 	source: {
 		define: {
 			WEBPACK_VERSION: JSON.stringify(require("./package.json").webpackVersion),


### PR DESCRIPTION
## Summary

`@rspack/core` v1.5 will no longer support Node 16, as Node.js reached end-of-life on September 11th, 2023, and many npm packages in the ecosystem have also dropped support for Node 16 (such as `webpack-dev-server`, `css-loader`, `sass-loader`, ...)

This PR updates the engines field in package.json to require Node.js >= 18.12.0 and updates build configs to target `node 18.12`.

## Related Links

- https://github.com/web-infra-dev/rspack/discussions/10867

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
