### PR TITLE
perf: Replace hot regex with parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memfd"
@@ -3798,6 +3798,7 @@ dependencies = [
  "tokio",
  "tracing",
  "ustr-fxhash",
+ "winnow",
 ]
 
 [[package]]
@@ -3978,7 +3979,6 @@ dependencies = [
  "async-trait",
  "derive_more",
  "once_cell",
- "regex",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_error",
@@ -3990,6 +3990,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "winnow",
 ]
 
 [[package]]
@@ -4241,6 +4242,7 @@ dependencies = [
  "derive_more",
  "futures",
  "itertools 0.14.0",
+ "memchr",
  "rayon",
  "regex",
  "rspack_base64",
@@ -4454,6 +4456,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "winnow",
 ]
 
 [[package]]
@@ -5211,9 +5214,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -6837,9 +6840,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -6849,25 +6852,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -7749,9 +7759,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,8 @@ urlencoding         = { version = "2.1.3", default-features = false }
 ustr                = { package = "ustr-fxhash", version = "1.0.1", default-features = false }
 wasmparser          = { version = "0.222.0", default-features = false }
 xxhash-rust         = { version = "0.8.14", default-features = false }
+winnow              = { version = "0.7.12", default-features = false, features = ["std", "simd"] }
+memchr              = { version = "2.7.5", default-features = false }
 
 # Pinned
 napi        = { version = "3.1.6", default-features = false }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -79,6 +79,7 @@ swc_node_comments = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing = { workspace = true }
 ustr = { workspace = true }
+winnow = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2753,7 +2753,7 @@ pub fn split_readable_identifier(extra_info: &str) -> Vec<String> {
   let extra_info = REGEX.replace_all(extra_info, "");
   let mut splitted_info: Vec<String> = extra_info
     .split('/')
-    .map(|s| escape_identifier(s).to_string())
+    .map(|s| escape_identifier(s).into_owned())
     .collect();
   splitted_info.reverse();
   splitted_info
@@ -2767,5 +2767,5 @@ pub fn escape_name(name: &str) -> String {
     return "namespaceObject".to_string();
   }
 
-  escape_identifier(name).to_string()
+  escape_identifier(name).into_owned()
 }

--- a/crates/rspack_core/src/utils/comment.rs
+++ b/crates/rspack_core/src/utils/comment.rs
@@ -1,9 +1,4 @@
-use std::sync::LazyLock;
-
-use regex::Regex;
-
-static COMMENT_END_REGEX: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"\*\/").expect("should init regex"));
+use cow_utils::CowUtils;
 
 #[inline]
 pub fn to_comment(str: &str) -> String {
@@ -11,8 +6,7 @@ pub fn to_comment(str: &str) -> String {
     return String::new();
   }
 
-  let result = COMMENT_END_REGEX.replace_all(str, "* /");
-
+  let result = str.cow_replace("*/", "* /");
   format!("/*! {result} */")
 }
 
@@ -22,7 +16,6 @@ pub fn to_comment_with_nl(str: &str) -> String {
     return String::new();
   }
 
-  let result = COMMENT_END_REGEX.replace_all(str, "* /");
-
+  let result = str.cow_replace("*/", "* /");
   format!("/*! {result} */\n")
 }

--- a/crates/rspack_core/src/utils/identifier.rs
+++ b/crates/rspack_core/src/utils/identifier.rs
@@ -1,6 +1,5 @@
-use std::{borrow::Cow, sync::LazyLock};
+use std::borrow::Cow;
 
-use regex::Regex;
 use rspack_paths::Utf8Path;
 use rspack_util::identifier::absolute_to_request;
 
@@ -15,20 +14,65 @@ pub fn contextify(context: impl AsRef<Utf8Path>, request: &str) -> String {
     .join("!")
 }
 
-static IDENTIFIER_NAME_REPLACE_REGEX: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"^([^a-zA-Z$_])").expect("should init regex"));
-static IDENTIFIER_REGEXP: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"[^a-zA-Z0-9$]+").expect("should init regex"));
+fn is_ident_first_safe(b: u8) -> bool {
+  // TODO const
+  fn tablef() -> u128 {
+    (b'A'..=b'Z')
+      .chain(b'a'..=b'z')
+      .chain(Some(b'$'))
+      .chain(Some(b'_'))
+      .fold(0, |mut sum, next| {
+        sum |= 1 << next;
+        sum
+      })
+  }
+
+  #[allow(clippy::unreadable_literal)]
+  let table: u128 = 10633823849912963253511222563025453056;
+  debug_assert_eq!(table, tablef());
+  b < 128 && (table & (1 << b)) != 0
+}
+
+fn is_ident_safe(b: u8) -> bool {
+  // TODO const
+  fn tablef() -> u128 {
+    (b'0'..=b'9')
+      .chain(b'A'..=b'Z')
+      .chain(b'a'..=b'z')
+      .chain(Some(b'$'))
+      .fold(0, |mut sum, next| {
+        sum |= 1 << next;
+        sum
+      })
+  }
+
+  #[allow(clippy::unreadable_literal)]
+  let table: u128 = 10633823810298881996667002667428478976;
+  debug_assert_eq!(table, tablef());
+  b < 128 && (table & (1 << b)) != 0
+}
 
 #[inline]
 pub fn to_identifier(v: &str) -> Cow<'_, str> {
-  // Avoid any unnecessary cost
-  match IDENTIFIER_NAME_REPLACE_REGEX.replace_all(v, "_$1") {
-    Cow::Borrowed(_) => escape_identifier(v),
-    Cow::Owned(id) => match escape_identifier(&id) {
-      Cow::Borrowed(_unchanged) => Cow::Owned(id),
-      Cow::Owned(id) => Cow::Owned(id),
-    },
+  let mut buf = if v
+    .as_bytes()
+    .first()
+    .is_none_or(|&b| is_ident_first_safe(b) || !is_ident_safe(b))
+  {
+    String::new()
+  } else {
+    "_".into()
+  };
+
+  if escape_identifier_impl(v, &mut buf) {
+    if buf.is_empty() {
+      Cow::Borrowed(v)
+    } else {
+      buf.push_str(v);
+      Cow::Owned(buf)
+    }
+  } else {
+    Cow::Owned(buf)
   }
 }
 
@@ -48,7 +92,52 @@ pub fn to_identifier_with_escaped(v: String) -> String {
 }
 
 pub fn escape_identifier(v: &str) -> Cow<'_, str> {
-  IDENTIFIER_REGEXP.replace_all(v, "_")
+  let mut buf = String::new();
+  if escape_identifier_impl(v, &mut buf) {
+    Cow::Borrowed(v)
+  } else {
+    Cow::Owned(buf)
+  }
+}
+
+fn escape_identifier_impl(v: &str, out: &mut String) -> bool {
+  let vstr = v;
+  let v = v.as_bytes();
+  let mut pos = 0;
+  let mut is_safe = true;
+
+  // hot path
+  if v.iter().all(|&b| is_ident_safe(b)) {
+    return true;
+  }
+
+  for i in 0..v.len() {
+    match (is_ident_safe(v[i]), is_safe) {
+      (true, true) => (),
+      (false, true) => {
+        // # Safety
+        //
+        // always ascii
+        let s = &vstr[pos..i];
+        out.push_str(s);
+        out.push('_');
+        pos = i + 1;
+        is_safe = false;
+      }
+      (false, false) => pos = i + 1,
+      (true, false) => is_safe = true,
+    }
+  }
+
+  if pos != 0 {
+    // # Safety
+    //
+    // always ascii
+    let s = &vstr[pos..];
+    out.push_str(s);
+  }
+
+  pos == 0
 }
 
 pub fn stringify_loaders_and_resource<'a>(
@@ -71,4 +160,19 @@ pub fn stringify_loaders_and_resource<'a>(
   } else {
     Cow::Borrowed(resource)
   }
+}
+
+#[test]
+fn test_to_identifier() {
+  assert_eq!(to_identifier("ident0"), "ident0");
+  assert_eq!(to_identifier("0ident"), "_0ident");
+  assert_eq!(to_identifier("/ident"), "_ident");
+  assert_eq!(
+    to_identifier("ident0_stable/src/core/iter//range.rs"),
+    "ident0_stable_src_core_iter_range_rs"
+  );
+  assert_eq!(
+    to_identifier("ident0_stable/src/core/iter//range.rs?"),
+    "ident0_stable_src_core_iter_range_rs_"
+  );
 }

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -13,7 +13,6 @@ rustc-hash  = { workspace = true }
 tokio       = { workspace = true, features = ["test-util"] }
 
 once_cell          = { workspace = true }
-regex              = { workspace = true }
 rspack_cacheable   = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_error       = { workspace = true }
@@ -23,3 +22,4 @@ rspack_sources     = { workspace = true }
 rspack_util        = { workspace = true }
 serde_json         = { workspace = true }
 tracing            = { workspace = true }
+winnow             = { workspace = true }

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -28,6 +28,7 @@ rustc-hash               = { workspace = true }
 simd-json                = { workspace = true }
 sugar_path               = { workspace = true }
 tracing                  = { workspace = true }
+memchr                   = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_externals/src/http_externals_plugin.rs
+++ b/crates/rspack_plugin_externals/src/http_externals_plugin.rs
@@ -1,18 +1,8 @@
-use std::sync::LazyLock;
-
-use regex::Regex;
 use rspack_core::{
   BoxPlugin, ExternalItem, ExternalItemFnCtx, ExternalItemFnResult, ExternalItemValue, PluginExt,
 };
 
 use crate::ExternalsPlugin;
-
-static EXTERNAL_HTTP_REQUEST: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"^(//|https?://|#)").expect("Invalid regex"));
-static EXTERNAL_HTTP_STD_REQUEST: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"^(//|https?://|std:)").expect("Invalid regex"));
-static EXTERNAL_CSS_REQUEST: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"^\.css(\?|$)").expect("Invalid regex"));
 
 pub fn http_externals_rspack_plugin(css: bool, web_async: bool) -> BoxPlugin {
   if web_async {
@@ -26,21 +16,21 @@ fn http_external_item_web(css: bool) -> ExternalItem {
   ExternalItem::Fn(Box::new(move |ctx: ExternalItemFnCtx| {
     Box::pin(async move {
       if ctx.dependency_type == "url" {
-        if EXTERNAL_HTTP_REQUEST.is_match(&ctx.request) {
+        if is_external_http_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("asset".to_owned()),
             result: Some(ExternalItemValue::String(ctx.request)),
           });
         }
       } else if css && ctx.dependency_type == "css-import" {
-        if EXTERNAL_HTTP_REQUEST.is_match(&ctx.request) {
+        if is_external_http_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("css-import".to_owned()),
             result: Some(ExternalItemValue::String(ctx.request)),
           });
         }
-      } else if EXTERNAL_HTTP_STD_REQUEST.is_match(&ctx.request) {
-        if css && EXTERNAL_CSS_REQUEST.is_match(&ctx.request) {
+      } else if is_external_http_std_request(&ctx.request) {
+        if css && is_external_css_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("css-import".to_owned()),
             result: Some(ExternalItemValue::String(ctx.request)),
@@ -64,21 +54,21 @@ fn http_external_item_web_async(css: bool) -> ExternalItem {
   ExternalItem::Fn(Box::new(move |ctx: ExternalItemFnCtx| {
     Box::pin(async move {
       if ctx.dependency_type == "url" {
-        if EXTERNAL_HTTP_REQUEST.is_match(&ctx.request) {
+        if is_external_http_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("asset".to_owned()),
             result: Some(ExternalItemValue::String(ctx.request)),
           });
         }
       } else if css && ctx.dependency_type == "css-import" {
-        if EXTERNAL_HTTP_REQUEST.is_match(&ctx.request) {
+        if is_external_http_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("css-import".to_owned()),
             result: Some(ExternalItemValue::String(ctx.request)),
           });
         }
-      } else if EXTERNAL_HTTP_STD_REQUEST.is_match(&ctx.request) {
-        if css && EXTERNAL_CSS_REQUEST.is_match(&ctx.request) {
+      } else if is_external_http_std_request(&ctx.request) {
+        if css && is_external_css_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("css-import".to_owned()),
             result: Some(ExternalItemValue::String(ctx.request)),
@@ -96,4 +86,22 @@ fn http_external_item_web_async(css: bool) -> ExternalItem {
       })
     })
   }))
+}
+
+fn is_external_http_request(input: &str) -> bool {
+  input.starts_with("//")
+    || input.starts_with("https://")
+    || input.starts_with("http://")
+    || input.starts_with('#')
+}
+
+fn is_external_http_std_request(input: &str) -> bool {
+  input.starts_with("//")
+    || input.starts_with("https://")
+    || input.starts_with("http://")
+    || input.starts_with("std:")
+}
+
+fn is_external_css_request(input: &str) -> bool {
+  input == ".css" || input.starts_with(".css?")
 }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -54,7 +54,7 @@ swc_node_comments = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 url = { workspace = true }
-
+winnow = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -1,7 +1,6 @@
-use std::{hash::Hash, sync::LazyLock};
+use std::hash::Hash;
 
 use itertools::Itertools;
-use regex::Regex;
 use rspack_core::{
   AsyncDependenciesBlock, ConstDependency, DependencyRange, EntryOptions, GroupOptions,
   SharedSourceMap, SpanExt,
@@ -206,9 +205,6 @@ pub struct WorkerPlugin {
   pattern_syntax: FxHashMap<String, FxHashSet<String>>,
 }
 
-static WORKER_FROM_REGEX: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"^(.+?)(\(\))?\s+from\s+(.+)$").expect("invalid regex"));
-
 const WORKER_SPECIFIER_TAG: &str = "_identifier__worker_specifier_tag__";
 const DEFAULT_SYNTAX: [&str; 4] = [
   "Worker",
@@ -260,11 +256,8 @@ impl WorkerPlugin {
       }
     } else if let Some(syntax) = syntax.strip_suffix("()") {
       self.call_syntax.insert(syntax.to_string());
-    } else if let Some(captures) = WORKER_FROM_REGEX.captures(syntax) {
-      let ids = &captures[1];
-      let is_call = &captures.get(2).is_some();
-      let source = &captures[3];
-      if *is_call {
+    } else if let Ok(((ids, is_call), source)) = worker_from(syntax) {
+      if is_call {
         self
           .from_call_syntax
           .insert((ids.to_string(), source.to_string()));
@@ -479,4 +472,41 @@ impl JavascriptParserPlugin for WorkerPlugin {
         true
       })
   }
+}
+
+fn worker_from(mut input: &str) -> winnow::ModalResult<((&str, bool), &str)> {
+  use winnow::{ascii, combinator::separated_pair, prelude::*, stream::AsChar, token};
+
+  let ident_and_call = token::take_while(1.., |c: char| !c.is_space()).map(|ident: &str| {
+    ident
+      .strip_suffix("()")
+      .map(|ident| (ident, true))
+      .unwrap_or((ident, false))
+  });
+
+  let mut parser = separated_pair(
+    ident_and_call,
+    (ascii::multispace1, "from", ascii::multispace1),
+    token::take_while(1.., |_| true),
+  );
+
+  parser.parse_next(&mut input)
+}
+
+#[test]
+fn test_worker_from() {
+  assert_eq!(
+    worker_from("Worker from worker_threads").ok(),
+    Some((("Worker", false), "worker_threads"))
+  );
+
+  assert_eq!(
+    worker_from("worker() from worker_threads").ok(),
+    Some((("worker", true), "worker_threads"))
+  );
+
+  assert_eq!(
+    worker_from("()() from worker_threads").ok(),
+    Some((("()", true), "worker_threads"))
+  );
 }

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -111,15 +111,11 @@ pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
   SEGMENTS_SPLIT_REGEXP
     .split(identifier)
     .map(|str| request_to_absolute(context, str))
-    .collect::<Vec<String>>()
-    .join("")
+    .collect()
 }
 
-static ZERO_WIDTH_SPACE: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new("\u{200b}(.)").expect("invalid regex"));
-
 pub fn strip_zero_width_space_for_fragment(s: &str) -> Cow<'_, str> {
-  ZERO_WIDTH_SPACE.replace_all(s, "$1")
+  s.cow_replace("\u{200b}#", "#")
 }
 
 pub fn insert_zero_width_space_for_fragment(s: &str) -> Cow<'_, str> {

--- a/deny.toml
+++ b/deny.toml
@@ -249,7 +249,8 @@ skip = [
     { crate = "zerocopy", reason = "external dependency"},
     { crate = "linux-raw-sys", reason = "external dependency"},
     { crate = "rustix", reason = "external dependency"},
-    
+
+    { crate = "winnow", reason = "external dependency"},
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This eliminates most of the regex block in small benchmark.

<img width="2966" height="929" alt="sftrace image" src="https://github.com/user-attachments/assets/00229338-7ae4-4539-8d16-a4e49a368757" />

Partially solved https://github.com/web-infra-dev/rspack/issues/11319, but there are still many regex not replaced

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
