### PR TITLE
refactor: move builtin virtual module plugin to experiments

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-base/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-base/rspack.config.js
@@ -1,4 +1,6 @@
-const { VirtualModulesPlugin } = require("@rspack/core");
+const {
+	experiments: { VirtualModulesPlugin }
+} = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {

--- a/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-context/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-context/rspack.config.js
@@ -1,4 +1,6 @@
-const { VirtualModulesPlugin } = require("@rspack/core");
+const {
+	experiments: { VirtualModulesPlugin }
+} = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {

--- a/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-dynamic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-dynamic/rspack.config.js
@@ -1,4 +1,6 @@
-const { VirtualModulesPlugin } = require("@rspack/core");
+const {
+	experiments: { VirtualModulesPlugin }
+} = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {

--- a/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-no-conflicts/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-no-conflicts/rspack.config.js
@@ -1,4 +1,6 @@
-const { VirtualModulesPlugin } = require("@rspack/core");
+const {
+	experiments: { VirtualModulesPlugin }
+} = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {

--- a/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-parent-dir/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/virtual-modules-parent-dir/rspack.config.js
@@ -1,4 +1,6 @@
-const { VirtualModulesPlugin } = require("@rspack/core");
+const {
+	experiments: { VirtualModulesPlugin }
+} = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {

--- a/packages/rspack-test-tools/tests/watchCases/virtual-modules/base/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/virtual-modules/base/rspack.config.js
@@ -1,4 +1,6 @@
-const { VirtualModulesPlugin } = require("@rspack/core");
+const {
+	experiments: { VirtualModulesPlugin }
+} = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2434,6 +2434,8 @@ interface Experiments_2 {
         transformSync: typeof transformSync;
         minifySync: typeof minifySync;
     };
+    // (undocumented)
+    VirtualModulesPlugin: typeof VirtualModulesPlugin;
 }
 
 // @public (undocumented)
@@ -6397,7 +6399,6 @@ declare namespace rspackExports {
         SourceMapDevToolPlugin,
         SwcJsMinimizerRspackPlugin,
         experiments,
-        VirtualModulesPlugin,
         getRawResolve,
         LoaderContext,
         LoaderDefinition,
@@ -8894,7 +8895,7 @@ interface VariableDeclarator extends Node_4, HasSpan {
 export const version: string;
 
 // @public (undocumented)
-export class VirtualModulesPlugin {
+class VirtualModulesPlugin {
     constructor(modules?: Record<string, string>);
     // (undocumented)
     static __internal__take_virtual_files(compiler: Compiler): {

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -356,6 +356,7 @@ import { createNativePlugin } from "./builtin-plugin";
 ///// Experiments SWC /////
 import { minify, minifySync, transform, transformSync } from "./swc";
 import { JavaScriptTracer } from "./trace";
+import { VirtualModulesPlugin } from "./VirtualModulesPlugin";
 
 interface Experiments {
 	globalTrace: {
@@ -386,6 +387,7 @@ interface Experiments {
 	};
 	CssChunkingPlugin: typeof CssChunkingPlugin;
 	createNativePlugin: typeof createNativePlugin;
+	VirtualModulesPlugin: typeof VirtualModulesPlugin;
 }
 
 export const experiments: Experiments = {
@@ -436,7 +438,6 @@ export const experiments: Experiments = {
 		sync: resolveSync
 	},
 	CssChunkingPlugin,
-	createNativePlugin
+	createNativePlugin,
+	VirtualModulesPlugin
 };
-
-export { VirtualModulesPlugin } from "./VirtualModulesPlugin";

--- a/website/docs/en/plugins/rspack/virtual-modules-plugin.mdx
+++ b/website/docs/en/plugins/rspack/virtual-modules-plugin.mdx
@@ -4,7 +4,7 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 
 <ApiMeta specific={['Rspack']} />
 
-The `rspack.VirtualModulesPlugin` is a Rust port of the [`webpack-virtual-modules`](https://github.com/sysgears/webpack-virtual-modules) plugin. It's deeply integrated with Rspack to deliver the same functionality with enhanced performance.
+The `rspack.experiments.VirtualModulesPlugin` is a Rust port of the [`webpack-virtual-modules`](https://github.com/sysgears/webpack-virtual-modules) plugin. It's deeply integrated with Rspack to deliver the same functionality with enhanced performance.
 
 ## Usage
 
@@ -13,7 +13,7 @@ The `rspack.VirtualModulesPlugin` is a Rust port of the [`webpack-virtual-module
 You can pass virtual modules to the constructor when creating a new VirtualModulesPlugin instance:
 
 ```ts
-new rspack.VirtualModulesPlugin(modules?: Record<string, string>)
+new rspack.experiments.VirtualModulesPlugin(modules?: Record<string, string>)
 ```
 
 **Parameters:**
@@ -25,7 +25,7 @@ const rspack = require('@rspack/core');
 
 module.exports = {
   plugins: [
-    new rspack.VirtualModulesPlugin({
+    new rspack.experiments.VirtualModulesPlugin({
       'src/generated/config.js': 'export default { version: "1.0.0" };',
       'src/generated/constants.js': `
         export const API_URL = "${process.env.API_URL || 'http://localhost:3000'}";
@@ -52,7 +52,7 @@ writeModule(filePath: string, contents: string): void
 ```js title="rspack.config.js"
 const rspack = require('@rspack/core');
 
-const virtualModulesPlugin = new rspack.VirtualModulesPlugin();
+const virtualModulesPlugin = new rspack.experiments.VirtualModulesPlugin();
 
 module.exports = {
   plugins: [

--- a/website/docs/zh/plugins/rspack/virtual-modules-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/virtual-modules-plugin.mdx
@@ -4,7 +4,7 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 
 <ApiMeta specific={['Rspack']} />
 
-`rspack.VirtualModulesPlugin` 是 Rust 实现的 [`webpack-virtual-modules`](https://github.com/sysgears/webpack-virtual-modules) 插件，它与 Rspack 深度集成，在提供相同功能的同时拥有更好的性能。
+`rspack.experiments.VirtualModulesPlugin` 是 Rust 实现的 [`webpack-virtual-modules`](https://github.com/sysgears/webpack-virtual-modules) 插件，它与 Rspack 深度集成，在提供相同功能的同时拥有更好的性能。
 
 ## 使用方法
 
@@ -13,7 +13,7 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 创建一个新的 VirtualModulesPlugin 实例，可以在构造函数中传入虚拟模块：
 
 ```ts
-new rspack.VirtualModulesPlugin(modules?: Record<string, string>)
+new rspack.experiments.VirtualModulesPlugin(modules?: Record<string, string>)
 ```
 
 **参数：**
@@ -25,7 +25,7 @@ const rspack = require('@rspack/core');
 
 module.exports = {
   plugins: [
-    new rspack.VirtualModulesPlugin({
+    new rspack.experiments.VirtualModulesPlugin({
       'src/generated/config.js': 'export default { version: "1.0.0" };',
       'src/generated/constants.js': `
         export const API_URL = "${process.env.API_URL || 'http://localhost:3000'}";
@@ -52,7 +52,7 @@ writeModule(filePath: string, contents: string): void
 ```js title="rspack.config.js"
 const rspack = require('@rspack/core');
 
-const virtualModulesPlugin = new rspack.VirtualModulesPlugin();
+const virtualModulesPlugin = new rspack.experiments.VirtualModulesPlugin();
 
 module.exports = {
   plugins: [


### PR DESCRIPTION
## Summary
After calling for testing, then put that to `rspack.VirualMoudlesPlugin` in next minor or major.
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
