### PR TITLE
perf: use new swc lexer for asi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,7 +4451,6 @@ dependencies = [
  "serde_json",
  "sugar_path",
  "swc_core",
- "swc_ecma_lexer",
  "swc_node_comments",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ jsonc-parser        = { version = "0.26.2", default-features = false, features =
 lightningcss        = { version = "1.0.0-alpha.64", default-features = false, features = ["grid", "serde"] }
 linked_hash_set     = { version = "0.1.5", default-features = false }
 md4                 = { version = "0.10.2", default-features = false }
+memchr              = { version = "2.7.5", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
 miette              = { version = "7.5.0", default-features = false }
 mimalloc            = { version = "0.2.4", package = "mimalloc-rspack", default-features = false }
@@ -111,9 +112,8 @@ url                 = { version = "2.5.4", default-features = false }
 urlencoding         = { version = "2.1.3", default-features = false }
 ustr                = { package = "ustr-fxhash", version = "1.0.1", default-features = false }
 wasmparser          = { version = "0.222.0", default-features = false }
-xxhash-rust         = { version = "0.8.14", default-features = false }
 winnow              = { version = "0.7.12", default-features = false, features = ["std", "simd"] }
-memchr              = { version = "2.7.5", default-features = false }
+xxhash-rust         = { version = "0.8.14", default-features = false }
 
 # Pinned
 napi        = { version = "3.1.6", default-features = false }
@@ -129,7 +129,6 @@ pnp                 = { version = "0.12.1", default-features = false }
 swc                 = { version = "34.0.0", default-features = false }
 swc_config          = { version = "3.1.1", default-features = false }
 swc_core            = { version = "35.0.0", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_lexer      = { version = "22.0.0", default-features = false }
 swc_ecma_minifier   = { version = "29.0.0", default-features = false }
 swc_error_reporters = { version = "16.0.1", default-features = false }
 swc_html            = { version = "25.0.0", default-features = false }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -41,6 +41,7 @@ swc_core = { workspace = true, features = [
   "__parser",
   "__utils",
   "common_sourcemap",
+  "ecma_parser_unstable",
   "ecma_preset_env",
   "ecma_transforms_optimization",
   "ecma_transforms_module",
@@ -49,7 +50,6 @@ swc_core = { workspace = true, features = [
   "base",
   "ecma_quote",
 ] }
-swc_ecma_lexer = { workspace = true }
 swc_node_comments = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -195,7 +195,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       Some(&comments),
     );
 
-    let lexer = swc_ecma_lexer::Lexer::new(
+    let lexer = swc_core::ecma::parser::Lexer::new(
       Syntax::Es(EsSyntax {
         allow_return_outside_function: matches!(
           module_type,

--- a/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
@@ -1,9 +1,9 @@
 use rustc_hash::FxHashSet;
 use swc_core::{
-  common::{BytePos, Span, Spanned},
+  common::{BytePos, Span},
   ecma::{
     ast::ClassMember,
-    parser::token::{Token, TokenAndSpan},
+    parser::unstable::{Token, TokenAndSpan},
     visit::{Visit, VisitWith},
   },
 };
@@ -57,7 +57,7 @@ impl InsertedSemicolons<'_> {
     if index > 0 {
       let prev = &self.tokens[index - 1];
       if !matches!(prev.token, Token::Semi) && self.can_insert_semi(index) {
-        self.semicolons.insert(prev.span_hi());
+        self.semicolons.insert(prev.span.hi);
       }
     }
   }
@@ -70,7 +70,7 @@ impl InsertedSemicolons<'_> {
     if index > 0 {
       let prev = &self.tokens[index - 1];
       if !matches!(prev.token, Token::Semi) && self.can_insert_semi(index) {
-        self.semicolons.insert(prev.span_hi());
+        self.semicolons.insert(prev.span.hi);
       }
     }
   }


### PR DESCRIPTION
## Summary

As is said in the swc docs:
```rs
#[cfg(feature = "unstable")]
pub mod unstable {
    //! This module expose tokens related to the `swc_ecma_parser::lexer`.
    //!
    //! Unlike the tokens re-exported from `swc_ecma_lexer`, the token kinds
    //! defined in the `swc_ecma_parser` here are non-strict for higher
    //! performance.
    //!
    //! Although it's marked as unstable, we can ensure that we will not
    //! introduce too many breaking changes. And we also encourage the
    //! applications to migrate to the lexer and tokens in terms of
    //! the performance.
    //!
    //! Also see the dicussion https://github.com/swc-project/swc/discussions/10683
    pub use swc_ecma_lexer::common::lexer::token::TokenFactory;

    pub use crate::lexer::{
        capturing::Capturing,
        token::{NextTokenAndSpan, Token, TokenAndSpan, TokenValue},
    };
}
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
