### PR TITLE
fix(incremental): LimitChunkCountPlugin panic with incremental turned on

### DIFF
--- a/crates/rspack_plugin_limit_chunk_count/src/lib.rs
+++ b/crates/rspack_plugin_limit_chunk_count/src/lib.rs
@@ -300,11 +300,13 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
   compilation.chunk_graph = new_chunk_graph;
 
   if let Some(mutations) = compilation.incremental.mutations_write() {
-    for chunk in removed_chunks {
-      mutations.add(Mutation::ChunkRemove { chunk });
-    }
+    // ChunkRemove mutations must be added last because a chunk can be removed after another chunk
+    // has been integrated into it
     for chunk in integrated_chunks {
       mutations.add(Mutation::ChunksIntegrate { to: chunk });
+    }
+    for chunk in removed_chunks {
+      mutations.add(Mutation::ChunkRemove { chunk });
     }
   }
 

--- a/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/0/index.js
@@ -1,0 +1,12 @@
+async function main() {
+	const { utilA } = await import(/*webpackChunkName:"utilA"*/ "./utilA.js");
+	const { utilB } = await import(/*webpackChunkName:"utilB"*/ "./utilB.js");
+	expect(utilA()).toBe("a");
+	expect(utilB()).toBe("b");
+}
+
+main();
+
+it("should compile and only contain one chunk", () => {
+	expect(__STATS__.chunks.length).toBe(1);
+});

--- a/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/0/utilA.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/0/utilA.js
@@ -1,0 +1,3 @@
+export function utilA() {
+	return "a";
+}

--- a/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/0/utilB.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/0/utilB.js
@@ -1,0 +1,3 @@
+export function utilB() {
+	return "b";
+}

--- a/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/1/utilA.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/1/utilA.js
@@ -1,0 +1,4 @@
+export function utilA() {
+	console.log("debug");
+	return "a";
+}

--- a/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/rspack.config.js
@@ -1,0 +1,5 @@
+var rspack = require("@rspack/core");
+/** @type {import("webpack").Configuration} */
+module.exports = {
+	plugins: [new rspack.optimize.LimitChunkCountPlugin({ maxChunks: 1 })]
+};

--- a/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/test.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	writeStatsOuptut: true,
+	validate(stats) {
+		console.log(JSON.stringify(stats));
+	}
+};

--- a/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/limit-chunk-count-plugin/test.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-	writeStatsOuptut: true,
-	validate(stats) {
-		console.log(JSON.stringify(stats));
-	}
+	writeStatsOuptut: true
 };


### PR DESCRIPTION
## Summary

This fixes https://github.com/web-infra-dev/rspack/issues/11232.

This bug only happens with `experiments.incremental` set to `advance` (or `advance-slient`), and it happens because of the order in which we add mutations. Here's an example failure scenario with 3 chunks, `a`, `b`, and `c`, with the `LimitChunkCountPlugin` configured to 1 `maxChunks`:

1. `c` gets integrated into `b`, `integrated_chunks.insert(b)` and `removed_chunks.insert(c)`
1. `b` gets integrated into `a`, `integrated_chunks.insert(a)` and `removed_chunks.insert(b)`

https://github.com/web-infra-dev/rspack/blob/c40ac65cf85f423ea3eb7ddbf61ac82a2fe542f8/crates/rspack_plugin_limit_chunk_count/src/lib.rs#L210-L212

So now, we have:
`removed_chunks` contains `c` and `b`
`integrated_chunks` contains `b` and `a`

So we add these mutations (in this order):
`Mutation::ChunkRemove { chunk: c }`
`Mutation::ChunkRemove { chunk: b }`
`Mutation::ChunksIntegrate { to: b }`
`Mutation::ChunksIntegrate { to: a }`

https://github.com/web-infra-dev/rspack/blob/c40ac65cf85f423ea3eb7ddbf61ac82a2fe542f8/crates/rspack_plugin_limit_chunk_count/src/lib.rs#L302-L309

Later down the line when a file changes and we do an incremental rebuild, we get the affected chunks:
https://github.com/web-infra-dev/rspack/blob/973bd5cdd76730bcec047db9a04a8f488e9627fa/crates/rspack_core/src/compiler/compilation.rs#L1908

https://github.com/web-infra-dev/rspack/blob/81908623f3bba84ee1d76c2fca59e4906132b227/crates/rspack_core/src/incremental/mutations.rs#L146-L170

Because the `ChunkRemove` mutations come first, we end up with `b` and `a` as our affected chunks, even though we removed chunk `b`. That causes a panic at runtime when one of the taps of `additional_chunk_runtime_requirements` tries to get the non-existent chunk:
https://github.com/web-infra-dev/rspack/blob/973bd5cdd76730bcec047db9a04a8f488e9627fa/crates/rspack_core/src/compiler/compilation.rs#L2143-L2150

https://github.com/web-infra-dev/rspack/blob/8029c1dbc23a71a482fc5a869fd5feed598a5ff3/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs#L39-L46

This PR does the simpler thing of adding the `ChunkRemove` mutations after the `ChunksIntegrate` mutations, but we could instead keep track of mutations when integrating and removing chunks and add them in the order in which the mutations happen. I chose to do the most minimal change, but happy to do it the other way (or another way entirely) if that's preferred.

## Related links

https://github.com/web-infra-dev/rspack/issues/11232

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
