### PR TITLE
perf: improve bundle splitting

### DIFF
--- a/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_split_chunks/raw_split_chunk_chunks.rs
@@ -2,23 +2,26 @@ use std::sync::Arc;
 
 use napi::{JsString, bindgen_prelude::Either3};
 use rspack_napi::{string::JsStringExt, threadsafe_function::ThreadsafeFunction};
+use rspack_plugin_split_chunks::{
+  ChunkFilter, create_chunk_filter_from_str, create_regex_chunk_filter_from_str,
+};
 use rspack_regex::RspackRegex;
 
 use crate::chunk::ChunkWrapper;
 
 pub type Chunks<'a> = Either3<RspackRegex, JsString<'a>, ThreadsafeFunction<ChunkWrapper, bool>>;
 
-pub fn create_chunks_filter(raw: Chunks) -> rspack_plugin_split_chunks::ChunkFilter {
+pub fn create_chunks_filter(raw: Chunks) -> ChunkFilter {
   match raw {
-    Either3::A(regex) => rspack_plugin_split_chunks::create_regex_chunk_filter_from_str(regex),
+    Either3::A(regex) => create_regex_chunk_filter_from_str(regex),
     Either3::B(js_str) => {
       let js_str = js_str.into_string();
-      rspack_plugin_split_chunks::create_chunk_filter_from_str(&js_str)
+      create_chunk_filter_from_str(&js_str)
     }
-    Either3::C(f) => Arc::new(move |chunk_ukey, compilation| {
+    Either3::C(f) => ChunkFilter::Func(Arc::new(move |chunk_ukey, compilation| {
       let f = f.clone();
       let chunk_wrapper = ChunkWrapper::new(*chunk_ukey, compilation);
       Box::pin(async move { f.call_with_sync(chunk_wrapper).await })
-    }),
+    })),
   }
 }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -353,6 +353,39 @@ impl ChunkGraph {
     }
   }
 
+  pub fn disconnect_chunks_and_modules(
+    &mut self,
+    chunks: &[ChunkUkey],
+    modules: &[ModuleIdentifier],
+  ) {
+    for chunk in chunks.iter() {
+      let cgc = self.expect_chunk_graph_chunk_mut(*chunk);
+      for module in modules.iter() {
+        cgc.modules.remove(module);
+        if let Some(source_types_by_module) = &mut cgc.source_types_by_module {
+          source_types_by_module.remove(module);
+        }
+      }
+    }
+    for module in modules.iter() {
+      let cgm = self.expect_chunk_graph_module_mut(*module);
+      for chunk in chunks.iter() {
+        cgm.chunks.remove(chunk);
+      }
+    }
+  }
+
+  pub fn connect_chunk_and_modules(&mut self, chunk: ChunkUkey, modules: &[ModuleIdentifier]) {
+    for module in modules.iter() {
+      let cgm = self.expect_chunk_graph_module_mut(*module);
+      cgm.chunks.insert(chunk);
+    }
+    let cgc = self.expect_chunk_graph_chunk_mut(chunk);
+    for module in modules.iter() {
+      cgc.modules.insert(*module);
+    }
+  }
+
   pub fn get_chunk_modules<'module>(
     &self,
     chunk: &ChunkUkey,

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -515,7 +515,11 @@ impl SplitChunksPlugin {
             );
 
             if max_size_setting.is_none()
-              && !(fallback_cache_group.chunks_filter)(&chunk.ukey(), compilation).await?
+              && !(if fallback_cache_group.chunks_filter.is_func() {
+              fallback_cache_group.chunks_filter.test_func(&chunk.ukey(), compilation).await?
+            } else {
+              fallback_cache_group.chunks_filter.test_internal(&chunk.ukey(), compilation)
+            })
             {
               tracing::debug!("Chunk({:?}) skips `maxSize` checking. Reason: max_size_setting.is_none() and chunks_filter is false", chunk.chunk_reason());
               return Ok(None);

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -4,7 +4,7 @@ mod max_size;
 mod min_size;
 mod module_group;
 
-use std::{borrow::Cow, fmt::Debug};
+use std::{borrow::Cow, collections::BinaryHeap, fmt::Debug};
 
 use rspack_collections::UkeyMap;
 use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -4,7 +4,7 @@ mod max_size;
 mod min_size;
 mod module_group;
 
-use std::{borrow::Cow, collections::BinaryHeap, fmt::Debug};
+use std::{borrow::Cow, fmt::Debug};
 
 use rspack_collections::UkeyMap;
 use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -54,9 +54,10 @@ impl SplitChunksPlugin {
       .collect::<Vec<_>>();
 
     let module_sizes = Self::get_module_sizes(&all_modules, compilation);
+    let module_chunks = Self::get_module_chunks(&all_modules, compilation);
 
     let mut module_group_map = self
-      .prepare_module_group_map(&all_modules, compilation, &module_sizes)
+      .prepare_module_group_map(&all_modules, compilation, &module_sizes, &module_chunks)
       .await?;
     tracing::trace!("prepared module_group_map {:#?}", module_group_map);
     logger.time_end(start);


### PR DESCRIPTION
## Summary

- If the chunk filter is not a JavaScript binding function, handle it synchronously to reduce the time consumption introduced by "join_all".
- Add `disconnect_chunks_and_modules` and `connect_chunk_and_modules` on chunk graph to reduce the number of times of obtaining chunk_graph_chunk and chunk_graph_module.
- Call `get_module_chunks` in parallel to reduce the number of calls in the subsequent `prepare_module_group_map`.
- Cache the results of `get_combs` based on `used_exports` to prevent repeated calculations for the same module.
- When removing duplicate modules, traverse the chunk group with a smaller number of modules to reduce the hashing cost.
- When the cache group name exists, it is quite likely that the same module will obtain the same cache group key under different chunk sets. In this case, there is no need to add the module again.


> Since the running time of bundle splitting is unstable, it is currently judged to be caused by a large number of invocations of rayon for concurrent module removal. There are approximately 5,000 invocations. At this time, if the CPU is busy, performance degradation may occur due to the invocations being blocked. Therefore, the following time consumption is for reference only.

Before:
<img width="586" height="56" alt="image" src="https://github.com/user-attachments/assets/ae385795-61c0-42b0-ab87-ca8207c226d9" />


After:
<img width="498" height="58" alt="image" src="https://github.com/user-attachments/assets/643a4d23-dda3-40fc-b64d-f91d3276e52d" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
