### PR TITLE
docs: update examples and terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Come chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! Rspack team and R
 | [rspack-dev-server](https://github.com/web-infra-dev/rspack-dev-server)              | Dev server for Rspack                                                         |
 | [rstack-examples](https://github.com/rspack-contrib/rstack-examples)                 | Examples showcasing Rstack                                                    |
 | [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust port of [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
-| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Design resources for Rspack Stack                                             |
+| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Design resources for Rstack                                                   |
 
 ## Contributors
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,7 @@ Rstack 是一个围绕 Rspack 打造的 JavaScript 统一工具链，具有优�
 | [rspack-dev-server](https://github.com/web-infra-dev/rspack-dev-server)              | Rspack 的开发服务器                                                          |
 | [rstack-examples](https://github.com/rspack-contrib/rstack-examples)                 | Rstack 的示例项目                                                            |
 | [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust 版本的 [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
-| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Rspack Stack 的设计资源                                                      |
+| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Rstack 的设计资源                                                            |
 
 ## 致谢
 

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -66,7 +66,7 @@ The following code will add a new asset named `asset-name.js` and will not be co
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { RawSource } = compiler.webpack.sources;
+  const { RawSource } = compiler.rspack.sources;
   compilation.hooks.processAssets.tap('MyPlugin', () => {
     const buffer = Buffer.from(
       'i am content of emit asset, do not minimize me',
@@ -114,7 +114,7 @@ The following code replaces the content of `main.js` and not to minimize it:
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { RawSource } = compiler.webpack.sources;
+  const { RawSource } = compiler.rspack.sources;
   compilation.hooks.processAssets.tap('MyPlugin', () => {
     const updatedSource = new RawSource(
       `module.exports = "This is the updated"`,
@@ -415,7 +415,7 @@ compiler.hooks.make.tap('MyPlugin', compilation => {
     {
       path: 'dist/child',
     },
-    [new compiler.webpack.EntryPlugin(compiler.context, './child-entry.js')],
+    [new compiler.rspack.EntryPlugin(compiler.context, './child-entry.js')],
   );
   childCompiler.compile((err, childCompilation) => {});
 });
@@ -452,7 +452,7 @@ export default {
   plugins: [
     {
       apply(compiler) {
-        const { RuntimeModule } = compiler.webpack;
+        const { RuntimeModule } = compiler.rspack;
 
         class CustomRuntimeModule extends RuntimeModule {
           constructor() {

--- a/website/docs/en/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compilation-hooks.mdx
@@ -578,7 +578,7 @@ export default {
   plugins: [
     {
       apply(compiler) {
-        const { RuntimeGlobals } = compiler.webpack;
+        const { RuntimeGlobals } = compiler.rspack;
         compiler.hooks.thisCompilation.tap('CustomPlugin', compilation => {
           compilation.hooks.additionalTreeRuntimeRequirements.tap(
             'CustomPlugin',
@@ -618,7 +618,7 @@ export default {
   plugins: [
     {
       apply(compiler) {
-        const { RuntimeGlobals, RuntimeModule } = compiler.webpack;
+        const { RuntimeGlobals, RuntimeModule } = compiler.rspack;
         class CustomRuntimeModule extends RuntimeModule {
           constructor() {
             super('custom');
@@ -670,7 +670,7 @@ export default {
   plugins: [
     {
       apply(compiler) {
-        const { RuntimeGlobals } = compiler.webpack;
+        const { RuntimeGlobals } = compiler.rspack;
         compiler.hooks.compilation.tap('CustomPlugin', compilation => {
           compilation.hooks.runtimeModule.tap(
             'CustomPlugin',
@@ -733,14 +733,14 @@ Process the assets before emit.
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { Compilation } = compiler.webpack;
+  const { Compilation } = compiler.rspack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
       stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
     },
     assets => {
-      const { RawSource } = compiler.webpack.sources;
+      const { RawSource } = compiler.rspack.sources;
       const source = new RawSource('This is a new asset!');
       compilation.emitAsset('new-asset.txt', source);
     },
@@ -752,7 +752,7 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { Compilation } = compiler.webpack;
+  const { Compilation } = compiler.rspack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
@@ -764,7 +764,7 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
         return;
       }
 
-      const { RawSource } = compiler.webpack.sources;
+      const { RawSource } = compiler.rspack.sources;
       const oldContent = asset.source();
       const newContent = oldContent + '\nconsole.log("hello world!")';
       const source = new RawSource(newContent);
@@ -779,7 +779,7 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { Compilation } = compiler.webpack;
+  const { Compilation } = compiler.rspack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',

--- a/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
@@ -13,7 +13,7 @@ export default {
   plugins: [
     {
       apply: compiler => {
-        const { RuntimePlugin } = compiler.webpack;
+        const { RuntimePlugin } = compiler.rspack;
         compiler.hooks.compilation.tap('MyPlugin', compilation => {
           const hooks = RuntimePlugin.getCompilationHooks(compilation);
           //...

--- a/website/docs/en/blog/announcing-0-5.mdx
+++ b/website/docs/en/blog/announcing-0-5.mdx
@@ -233,7 +233,7 @@ class CustomDevServer {
   enableHMR(compiler) {
 -   compiler.options.devServer ??= {};
 -   compiler.options.devServer.hot = true;
-+   new compiler.webpack.HotModuleReplacementPlugin().apply(compiler);
++   new compiler.rspack.HotModuleReplacementPlugin().apply(compiler);
   }
 }
 ```
@@ -255,7 +255,7 @@ function prependEntry(compiler, additionalEntry) {
 -      ...(compiler.options.entry[key].import || []),
 -    ];
 -  }
-+  new compiler.webpack.EntryPlugin(compiler.context, additionalEntry, {
++  new compiler.rspack.EntryPlugin(compiler.context, additionalEntry, {
 +    name: undefined, // `name: undefined` to prepend the it to every entry, or add it to a specified entry with specified entry name
 +  }).apply(compiler);
 }

--- a/website/docs/en/blog/announcing-1-0.mdx
+++ b/website/docs/en/blog/announcing-1-0.mdx
@@ -89,9 +89,9 @@ The current goals of Rspack are:
 - Rspack is not just suitable for environments like browser and Node.js that we are familiar with; its goal is to cover all environments where JavaScript runs. This means that Rspack can easily support Deno, Electron, cross-platform applications, MiniApps, and any other JavaScript runtime.
 - We found that balancing "flexibility" and "out-of-the-box" in a single tool was a challenging task. Therefore, after open-sourcing Rspack, we developed a set of Rstack toolchains, including projects such as Rsbuild, Rspress, Rsdoctor, and Rslib, each targeting different use cases. For example, to reduce the complexity and high barriers to configuring Rspack, we provide Rsbuild for an out-of-the-box development experience.
 
-### Rspack stack
+### Rstack
 
-![Rspack Stack](https://assets.rspack.rs/rspack/assets/rspack-v1-0-rstack.png)
+![Rstack](https://assets.rspack.rs/rspack/assets/rspack-v1-0-rstack.png)
 
 Rstack is short for "Rspack Stack" and stands for the tech stack built around Rspack. It consists of the following tools:
 

--- a/website/docs/en/config/lazy-compilation.mdx
+++ b/website/docs/en/config/lazy-compilation.mdx
@@ -1,8 +1,11 @@
 import WebpackLicense from '@components/WebpackLicense';
+import { ApiMeta } from '@components/ApiMeta';
 
 <WebpackLicense from="https://webpack.js.org/configuration/experiments/#experimentslazycompilation" />
 
 # LazyCompilation
+
+<ApiMeta addedVersion="1.5.0" />
 
 Lazy Compilation is an optimization technique that delays the compilation of modules until they are actually requested. **Modules are only built when they are actually accessed.**
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -111,7 +111,7 @@ Next, see [Configure Rspack](/config/index) to learn about how to configure Rspa
 
 ## Migrating from existing projects
 
-If you need to migrate from an existing project to Rspack stack, you can refer to the following guides:
+If you need to migrate from an existing project to Rspack, you can refer to the following guides:
 
 - [Migrating from webpack to Rspack](/guide/migration/webpack)
 - [Migrating from webpack to Rsbuild](https://rsbuild.rs/guide/migration/webpack)

--- a/website/docs/en/misc/team/core-team.mdx
+++ b/website/docs/en/misc/team/core-team.mdx
@@ -2,9 +2,9 @@ import { RandomMemberList } from '@components/RandomMemberList.tsx';
 
 # Core team
 
-The development of Rspack stack is led by ByteDance's web infra team and driven together with community contributors on several core projects, including [Rspack](https://github.com/web-infra-dev/rspack), [Rsbuild](https://github.com/web-infra-dev/rsbuild), [Rspress](https://github.com/web-infra-dev/rspress), [Rsdoctor](https://github.com/web-infra-dev/rsdoctor), [Rslib](https://github.com/web-infra-dev/rslib), [Rstest](https://github.com/web-infra-dev/rstest) and [Rslint](https://github.com/web-infra-dev/rslint).
+The development of Rstack is led by ByteDance's web infra team and driven together with community contributors on several core projects, including [Rspack](https://github.com/web-infra-dev/rspack), [Rsbuild](https://github.com/web-infra-dev/rsbuild), [Rspress](https://github.com/web-infra-dev/rspress), [Rsdoctor](https://github.com/web-infra-dev/rsdoctor), [Rslib](https://github.com/web-infra-dev/rslib), [Rstest](https://github.com/web-infra-dev/rstest) and [Rslint](https://github.com/web-infra-dev/rslint).
 
-Current members of the Rspack team are listed in random order below.
+Current members of the Rstack team are listed in random order below.
 
 ## Members
 

--- a/website/docs/en/plugins/webpack/javascript-modules-plugin.mdx
+++ b/website/docs/en/plugins/webpack/javascript-modules-plugin.mdx
@@ -12,7 +12,7 @@ class MyJsMinimizerPlugin {
     compiler.hooks.compilation.tap(MyJsMinimizerPlugin.name, compilation => {
       // Access the chunkHash hooks of JavascriptModulesPlugin
       const hooks =
-        compiler.webpack.javascript.JavascriptModulesPlugin.getCompilationHooks(
+        compiler.rspack.javascript.JavascriptModulesPlugin.getCompilationHooks(
           compilation,
         );
       // Since the JS chunk has been optimized and its content has changed, the chunk hash for the JS chunk needs to be updated

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -66,7 +66,7 @@ emitAsset(
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { RawSource } = compiler.webpack.sources;
+  const { RawSource } = compiler.rspack.sources;
   compilation.hooks.processAssets.tap('MyPlugin', () => {
     const buffer = Buffer.from(
       'i am content of emit asset, do not minimize me',
@@ -114,7 +114,7 @@ updateAsset(
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { RawSource } = compiler.webpack.sources;
+  const { RawSource } = compiler.rspack.sources;
   compilation.hooks.processAssets.tap('MyPlugin', () => {
     const updatedSource = new RawSource(
       `module.exports = "This is the updated"`,
@@ -415,7 +415,7 @@ compiler.hooks.make.tap('MyPlugin', compilation => {
     {
       path: 'dist/child',
     },
-    [new compiler.webpack.EntryPlugin(compiler.context, './child-entry.js')],
+    [new compiler.rspack.EntryPlugin(compiler.context, './child-entry.js')],
   );
   childCompiler.compile((err, childCompilation) => {});
 });
@@ -452,7 +452,7 @@ export default {
   plugins: [
     {
       apply(compiler) {
-        const { RuntimeModule } = compiler.webpack;
+        const { RuntimeModule } = compiler.rspack;
 
         class CustomRuntimeModule extends RuntimeModule {
           constructor() {

--- a/website/docs/zh/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compilation-hooks.mdx
@@ -579,7 +579,7 @@ export default {
   plugins: [
     {
       apply(compiler) {
-        const { RuntimeGlobals } = compiler.webpack;
+        const { RuntimeGlobals } = compiler.rspack;
         compiler.hooks.thisCompilation.tap('CustomPlugin', compilation => {
           compilation.hooks.additionalTreeRuntimeRequirements.tap(
             'CustomPlugin',
@@ -619,7 +619,7 @@ export default {
   plugins: [
     {
       apply(compiler) {
-        const { RuntimeGlobals, RuntimeModule } = compiler.webpack;
+        const { RuntimeGlobals, RuntimeModule } = compiler.rspack;
         class CustomRuntimeModule extends RuntimeModule {
           constructor() {
             super('custom');
@@ -672,7 +672,7 @@ export default {
   plugins: [
     {
       apply(compiler) {
-        const { RuntimeGlobals } = compiler.webpack;
+        const { RuntimeGlobals } = compiler.rspack;
         compiler.hooks.compilation.tap('CustomPlugin', compilation => {
           compilation.hooks.runtimeModule.tap(
             'CustomPlugin',
@@ -735,14 +735,14 @@ console.log(__webpack_require__.p);
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { Compilation } = compiler.webpack;
+  const { Compilation } = compiler.rspack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
       stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
     },
     assets => {
-      const { RawSource } = compiler.webpack.sources;
+      const { RawSource } = compiler.rspack.sources;
       const source = new RawSource('This is a new asset!');
       compilation.emitAsset('new-asset.txt', source);
     },
@@ -754,7 +754,7 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { Compilation } = compiler.webpack;
+  const { Compilation } = compiler.rspack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',
@@ -766,7 +766,7 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
         return;
       }
 
-      const { RawSource } = compiler.webpack.sources;
+      const { RawSource } = compiler.rspack.sources;
       const oldContent = asset.source();
       const newContent = oldContent + '\nconsole.log("hello world!")';
       const source = new RawSource(newContent);
@@ -781,7 +781,7 @@ compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
 
 ```js
 compiler.hooks.thisCompilation.tap('MyPlugin', compilation => {
-  const { Compilation } = compiler.webpack;
+  const { Compilation } = compiler.rspack;
   compilation.hooks.processAssets.tap(
     {
       name: 'MyPlugin',

--- a/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
@@ -13,7 +13,7 @@ export default {
   plugins: [
     {
       apply: compiler => {
-        const { RuntimePlugin } = compiler.webpack;
+        const { RuntimePlugin } = compiler.rspack;
         compiler.hooks.compilation.tap('MyPlugin', compilation => {
           const hooks = RuntimePlugin.getCompilationHooks(compilation);
           // ...

--- a/website/docs/zh/blog/announcing-0-5.mdx
+++ b/website/docs/zh/blog/announcing-0-5.mdx
@@ -233,7 +233,7 @@ class CustomDevServer {
   enableHMR(compiler) {
 -   compiler.options.devServer ??= {};
 -   compiler.options.devServer.hot = true;
-+   new compiler.webpack.HotModuleReplacementPlugin().apply(compiler);
++   new compiler.rspack.HotModuleReplacementPlugin().apply(compiler);
   }
 }
 ```
@@ -255,7 +255,7 @@ function prependEntry(compiler, additionalEntry) {
 -      ...(compiler.options.entry[key].import || []),
 -    ];
 -  }
-+  new compiler.webpack.EntryPlugin(compiler.context, additionalEntry, {
++  new compiler.rspack.EntryPlugin(compiler.context, additionalEntry, {
 +    name: undefined, // `name: undefined` to prepend the it to every entry, or add it to a specified entry with specified entry name
 +  }).apply(compiler);
 }

--- a/website/docs/zh/blog/announcing-1-0.mdx
+++ b/website/docs/zh/blog/announcing-1-0.mdx
@@ -89,9 +89,9 @@ Rspack 当前的目标是：
 - Rspack 不仅仅适用于浏览器和 Node.js 这种我们熟悉的环境中，它的目标是覆盖所有运行 JavaScript 的场景，这意味着 Rspack 也可以很方便地支持 Deno、Electron、跨平台、小程序等一切 JavaScript 可以运行的环境。
 - 我们发现在单一的工具上兼顾「灵活性」和「开箱即用」是非常困难的事情。因此，在开源 Rspack 之后，我们开发了一套完整的 Rstack 工具链，包含 Rsbuild、Rspress、Rsdoctor 和 Rslib，它们分别面向不同的使用场景。例如，为了解决 Rspack 配置复杂、上手成本高的问题，我们通过 Rsbuild 来提供开箱即用的开发体验。
 
-### Rspack Stack
+### Rstack
 
-![Rspack Stack](https://assets.rspack.rs/rspack/assets/rspack-v1-0-rstack.png)
+![Rstack](https://assets.rspack.rs/rspack/assets/rspack-v1-0-rstack.png)
 
 Rstack 是 "Rspack Stack" 的缩写，代表以 Rspack 为核心的一整套技术栈，包含以下工具：
 

--- a/website/docs/zh/config/lazy-compilation.mdx
+++ b/website/docs/zh/config/lazy-compilation.mdx
@@ -1,8 +1,11 @@
 import WebpackLicense from '@components/WebpackLicense';
+import { ApiMeta } from '@components/ApiMeta';
 
 <WebpackLicense from="https://webpack.docschina.org/configuration/experiments/#experimentslazycompilation" />
 
 # LazyCompilation
+
+<ApiMeta addedVersion="1.5.0" />
 
 懒编译（Lazy Compilation）是一种优化技术，可以延迟模块的编译，直到它们被实际请求时才进行构建。**只有在真正访问到某个入口或模块时，才进行构建。**
 

--- a/website/docs/zh/misc/team/core-team.mdx
+++ b/website/docs/zh/misc/team/core-team.mdx
@@ -2,9 +2,9 @@ import { RandomMemberList } from '@components/RandomMemberList.tsx';
 
 # 核心团队
 
-Rspack stack 的开发由字节跳动的 web infra 团队主导，并与社区贡献者共同驱动多个核心项目的开发，包括 [Rspack](https://github.com/web-infra-dev/rspack)、[Rsbuild](https://github.com/web-infra-dev/rsbuild)、[Rspress](https://github.com/web-infra-dev/rspress)、[Rsdoctor](https://github.com/web-infra-dev/rsdoctor)、[Rslib](https://github.com/web-infra-dev/rslib)、[Rstest](https://github.com/web-infra-dev/rstest) 和 [Rslint](https://github.com/web-infra-dev/rslint)。
+Rstack 的开发由字节跳动的 web infra 团队主导，并与社区贡献者共同驱动多个核心项目的开发，包括 [Rspack](https://github.com/web-infra-dev/rspack)、[Rsbuild](https://github.com/web-infra-dev/rsbuild)、[Rspress](https://github.com/web-infra-dev/rspress)、[Rsdoctor](https://github.com/web-infra-dev/rsdoctor)、[Rslib](https://github.com/web-infra-dev/rslib)、[Rstest](https://github.com/web-infra-dev/rstest) 和 [Rslint](https://github.com/web-infra-dev/rslint)。
 
-目前工作团队成员如下，按照随机顺序排序。
+目前 Rstack 团队成员如下，按照随机顺序排序。
 
 ## 成员
 

--- a/website/docs/zh/plugins/webpack/javascript-modules-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/javascript-modules-plugin.mdx
@@ -12,7 +12,7 @@ class MyJsMinimizerPlugin {
     compiler.hooks.compilation.tap(MyJsMinimizerPlugin.name, compilation => {
       // 用来获取 JavascriptModulesPlugin 的 chunkHash 钩子
       const hooks =
-        compiler.webpack.javascript.JavascriptModulesPlugin.getCompilationHooks(
+        compiler.rspack.javascript.JavascriptModulesPlugin.getCompilationHooks(
           compilation,
         );
       // 由于 JS chunk 被优化，内容改变，所以要更新 JS chunk 的 chunk hash


### PR DESCRIPTION
## Summary

Update examples and terminology:

- replace `compiler.webpack` with `compiler.rspack` in examples
- update `Rspack Stack` references to `Rstack`
- add version metadata for the new lazy compilation option

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
