### PR TITLE
chore: build http test case avoid send http request

### DIFF
--- a/tests/webpack-examples/build-http/example.js
+++ b/tests/webpack-examples/build-http/example.js
@@ -1,7 +1,7 @@
 import pMap1 from "https://cdn.skypack.dev/p-map";
 import pMap2 from "https://cdn.esm.sh/p-map";
 import pMap3 from "https://jspm.dev/p-map";
-import pMap4 from "https://unpkg.com/p-map-series?module"; // unpkg doesn't support p-map :(
+import pMap4 from "https://unpkg.com/p-map-series@3.0.0/index.js?module"; // unpkg doesn't support p-map :(
 console.log(pMap1);
 console.log(pMap2);
 console.log(pMap3);


### PR DESCRIPTION
## Summary

Requesting `https://unpkg.com/p-map-series?module` will return 302 and redirect to the real resource link, but the request will not be cached. This PR removes such requests to ensure that the test is independent of network conditions.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
