### PR TITLE
chore: Use macro instead of runtime debug_assert

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -71,7 +71,7 @@ async function build() {
 			(!process.env.RUST_TARGET || process.env.RUST_TARGET.includes("linux") || process.env.RUST_TARGET.includes("darwin"))
 		) {
 			features.push("sftrace-setup");
-			envs.RUSTFLAGS = "-Zinstrument-xray=always";
+			envs.RUSTFLAGS = "-Zinstrument-xray=always -Csymbol-mangling-version=v0";
 		}
 		if (values.profile === "release") {
 			features.push("info-level");


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This uses a macro instead of `debug_assert!` to ensure the correctness of the const table. avoids slow running in debug profile.

By the way, it also enables `-Csymbol-mangling-version=v0` for debug profile to get better symbol name.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
