### PR TITLE
feat: should rebuild all entries if there are entry removals

### DIFF
--- a/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/0/index0.js
+++ b/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/0/index0.js
@@ -1,13 +1,19 @@
-it("should have correct entrypoints", function() {
-  expect(Object.keys(__STATS__.entrypoints)).toEqual(["bundle0", "bundle1"]);
+import {value} from './shared'
 
-  const index0 = __STATS__.modules.find(m => m.name === "./index0.js");
-  expect(index0.built).toBe(true);
-  expect(index0.reasons.length).toBe(1);
-  expect(index0.reasons[0].type).toBe("entry");
+expect(Object.keys(__STATS__.entrypoints)).toEqual(["bundle0", "bundle1"]);
 
-  const index1 = __STATS__.modules.find(m => m.name === "./index1.js");
-  expect(index1.built).toBe(true);
-  expect(index1.reasons.length).toBe(1);
-  expect(index1.reasons[0].type).toBe("entry");
-})
+const index0 = __STATS__.modules.find(m => m.name === "./index0.js");
+expect(index0.built).toBe(true);
+expect(index0.reasons.length).toBe(1);
+expect(index0.reasons[0].type).toBe("entry");
+
+const index1 = __STATS__.modules.find(m => m.name === "./index1.js");
+expect(index1.built).toBe(true);
+expect(index1.reasons.length).toBe(1);
+expect(index1.reasons[0].type).toBe("entry");
+
+const shared = __STATS__.modules.find(m => m.name === "./shared.js");
+expect(value).toBe(42)
+expect(shared.built).toBe(true);
+
+expect(shared.reasons.length).toBe(4);

--- a/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/0/index1.js
+++ b/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/0/index1.js
@@ -1,1 +1,2 @@
-console.log.bind(console, 1);
+import {value} from './shared'
+console.log.bind(console, value);

--- a/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/0/shared.js
+++ b/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/0/shared.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/1/index0.js
+++ b/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/1/index0.js
@@ -1,3 +1,4 @@
+import {value} from './shared'
 it("should have correct entrypoints", function() {
   expect(Object.keys(__STATS__.entrypoints)).toEqual(["bundle0"]);
 
@@ -5,4 +6,9 @@ it("should have correct entrypoints", function() {
   expect(index0.built).toBe(true);
   expect(index0.reasons.length).toBe(1);
   expect(index0.reasons[0].type).toBe("entry");
+
+  const shared = __STATS__.modules.find(m => m.name === "./shared.js");
+	expect(value).toBe(42)
+	expect(shared.built).toBe(false);
+  expect(shared.reasons.length).toBe(2);
 })

--- a/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/entries/dynamic-entries-remove/rspack.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const fs = require("fs");
+const rspack = require("@rspack/core");
 
 let compiler;
 let step = 0;
@@ -27,6 +28,7 @@ module.exports = {
 		filename: "[name].js"
 	},
 	plugins: [
+		new rspack.experiments.RemoveDuplicateModulesPlugin(),
 		function (c) {
 			compiler = c;
 			c.hooks.done.tap("test", () => {


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

close #11247 

Rebuild all entries if there are entry removals.

When we deal with dynamic chunk removals, we rebuild them from affected modules. However entry is a little bit different, entry removal may have different available modules, and can affect other entry.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
