### PR TITLE
fix: cache concatenated module imports is not safe

### DIFF
--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -132,7 +132,7 @@ impl ModuleGraphCacheArtifactInner {
     F: FnOnce() -> IdentifierMap<Vec<ConnectionWithRuntimeCondition>>,
   >(
     &self,
-    key: ModuleIdentifier,
+    key: ConcatenatedModuleImportsKey,
     f: F,
   ) -> IdentifierMap<Vec<ConnectionWithRuntimeCondition>> {
     if !self.freezed.load(Ordering::Acquire) {
@@ -196,14 +196,17 @@ pub(super) mod module_graph_hash {
   }
 }
 pub(super) mod concatenated_module_imports {
-  use rspack_collections::IdentifierDashMap;
-
   use super::*;
   use crate::{ConnectionWithRuntimeCondition, ModuleIdentifier};
 
+  pub type ConcatenatedModuleImportsKey = (ModuleIdentifier, String);
+
   #[derive(Debug, Default)]
   pub struct ConcatenatedModuleImportsCache {
-    cache: IdentifierDashMap<IdentifierMap<Vec<ConnectionWithRuntimeCondition>>>,
+    cache: dashmap::DashMap<
+      ConcatenatedModuleImportsKey,
+      IdentifierMap<Vec<ConnectionWithRuntimeCondition>>,
+    >,
   }
 
   impl ConcatenatedModuleImportsCache {
@@ -213,14 +216,14 @@ pub(super) mod concatenated_module_imports {
 
     pub fn get(
       &self,
-      key: &ModuleIdentifier,
+      key: &ConcatenatedModuleImportsKey,
     ) -> Option<IdentifierMap<Vec<ConnectionWithRuntimeCondition>>> {
       self.cache.get(key).map(|v| v.value().clone())
     }
 
     pub fn set(
       &self,
-      key: ModuleIdentifier,
+      key: ConcatenatedModuleImportsKey,
       value: IdentifierMap<Vec<ConnectionWithRuntimeCondition>>,
     ) {
       self.cache.insert(key, value);


### PR DESCRIPTION
## Summary

concatenated module imports are related to runtime, should add it to cache key

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
