### PR TITLE
fix(rspack_plugin_wasm): fix wasm [name] placeholder in runtime

### DIFF
--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -2,6 +2,7 @@ use std::{
   borrow::Cow,
   collections::hash_map::DefaultHasher,
   hash::{Hash, Hasher},
+  path::Path,
 };
 
 use indexmap::IndexMap;
@@ -261,10 +262,16 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
           None
         };
 
+        let origin_filename = Path::new(&normal_module.resource_resolved_data().resource)
+          .file_stem()
+          .and_then(|s| s.to_str())
+          .unwrap_or("");
+
         let instantiate_call = format!(
-          "{}(exports, module.id, {} {})",
+          "{}(exports, module.id, {}, {} {})",
           RuntimeGlobals::INSTANTIATE_WASM,
           serde_json::to_string(&hash).expect("should be ok"),
+          serde_json::to_string(origin_filename).expect("should be ok"),
           imports_obj.unwrap_or_default()
         );
 

--- a/crates/rspack_plugin_wasm/src/runtime.rs
+++ b/crates/rspack_plugin_wasm/src/runtime.rs
@@ -60,6 +60,7 @@ impl RuntimeModule for AsyncWasmLoadingRuntimeModule {
           .hash(&hash)
           .content_hash(&hash)
           .id(&PathData::prepare_id("\" + wasmModuleId + \""))
+          .filename("\" + wasmModuleName + \"")
           .runtime(chunk.runtime().as_str()),
       )
       .await?;
@@ -109,7 +110,7 @@ fn get_async_wasm_loading(req: &str, supports_streaming: bool) -> String {
   if supports_streaming {
     format!(
       r#"
-    __webpack_require__.v = function(exports, wasmModuleId, wasmModuleHash, importsObj) {{
+    __webpack_require__.v = function(exports, wasmModuleId, wasmModuleHash, wasmModuleName, importsObj) {{
       var req = {req};
       var fallback = function() {{
         return req{fallback_code}
@@ -122,7 +123,7 @@ fn get_async_wasm_loading(req: &str, supports_streaming: bool) -> String {
     let req = req.trim_end_matches(';');
     format!(
       r#"
-    __webpack_require__.v = function(exports, wasmModuleId, wasmModuleHash, importsObj) {{
+    __webpack_require__.v = function(exports, wasmModuleId, wasmModuleHash, wasmModuleName, importsObj) {{
       return {req}{fallback_code}
     }};
       "#


### PR DESCRIPTION
## Summary
Because `[name]` replacement requires `filename` or `chunkname` in PathData, it is replaced at runtime by injecting placeholders (`wasmModuleName`)

## Related links
https://github.com/web-infra-dev/rspack/issues/11351

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
