### PR TITLE
docs: remove outdated Node version requirements from quick start

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -49,8 +49,6 @@ We recommend using [Rsbuild](https://rsbuild.rs/) to create new projects, simply
 
 Rspack CLI is a tool comparable to webpack CLI, offering the basic `serve` and `build` commands.
 
-Rsbuild supports Node.js >= 16, but Rspack CLI requires Node.js version >= 18.12.0.
-
 Run the following command to create an Rspack CLI project:
 
 <PackageManagerTabs command="create rspack@latest" />

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -49,8 +49,6 @@ Rsbuild 是由 Rspack 驱动的高性能构建工具，由 Rspack 团队开发�
 
 Rspack CLI 是对标 webpack CLI 的工具，提供基础的 `serve` 和 `build` 构建命令。
 
-Rsbuild 支持 Node.js >= 16，但是 Rspack CLI 要求 Node.js 版本 >= 18.12.0
-
 执行如下命令即可创建基于 Rspack CLI 的项目：
 
 <PackageManagerTabs command="create rspack@latest" />


### PR DESCRIPTION
## Summary

Remove outdated Node version requirements from quick start.

Rsbuild v1.5 no longer support Node 16, see: https://github.com/web-infra-dev/rsbuild/releases/tag/v1.5.0-beta.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
