### PR TITLE
chore(deps): update lightningcss crate to 1.0.0-alpha.67

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,9 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -2216,9 +2219,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.64"
+version = "1.0.0-alpha.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a296273515b1036d06fce6c1d6bfc11347083458e1765ae4a70d6288cdb15521"
+checksum = "798fba4e1205eed356b8ed7754cc3f7f04914e27855ca641409f4a532e992149"
 dependencies = [
  "ahash 0.8.12",
  "bitflags 2.9.1",
@@ -2753,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "parcel_selectors"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccbc6fb560df303a44e511618256029410efbc87779018f751ef12c488271fe"
+checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.14", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 jsonc-parser        = { version = "0.26.2", default-features = false, features = ["serde"] }
-lightningcss        = { version = "1.0.0-alpha.64", default-features = false, features = ["grid", "serde"] }
+lightningcss        = { version = "1.0.0-alpha.67", default-features = false, features = ["serde"] }
 linked_hash_set     = { version = "0.1.5", default-features = false }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.7.5", default-features = false }

--- a/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/prefixes-with-targets-array/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-lightningcss-loader/prefixes-with-targets-array/index.js
@@ -12,7 +12,7 @@ it("should transform CSS and add prefixes correctly", () => {
 	expect(css.includes('-webkit-user-select: none;')).toBeTruthy();
 	expect(css.includes('-ms-user-select: none;')).toBeTruthy();
 	expect(css.includes('user-select: none;')).toBeTruthy();
-	expect(css.includes('background: -webkit-linear-gradient(#fff, #000);')).toBeTruthy();
+	expect(css.includes('background: -webkit-linear-gradient(top, #fff, #000);')).toBeTruthy();
 	expect(css.includes('background: linear-gradient(#fff, #000);')).toBeTruthy();
 	expect(css.includes('-webkit-transition: all .5s;')).toBeTruthy();
 	expect(css.includes('transition: all .5s;')).toBeTruthy();


### PR DESCRIPTION
## Summary

- Update lightningcss crate to 1.0.0-alpha.67, see https://github.com/parcel-bundler/lightningcss/commits/master/
- The `grid` feature has been removed, see: https://github.com/parcel-bundler/lightningcss/pull/972

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
