### PR TITLE
docs: update ts config guide

### DIFF
--- a/website/docs/en/config/index.mdx
+++ b/website/docs/en/config/index.mdx
@@ -80,22 +80,12 @@ If your JavaScript runtime already natively supports TypeScript, you can use the
 
 For example, Node.js already natively supports TypeScript, you can use the following command to use the Node.js native loader to load the configuration file:
 
-- For Node.js v22.7.0 to v23.5.0, you need to enable the `--experimental-transform-types` flag:
+- For Node.js v22.18+ and v24.3+ which support native TypeScript by default, you can run the following command to load the TS config:
 
 ```json title="package.json"
 {
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-transform-types' rspack build"
-  }
-}
-```
-
-- For Node.js v23.6.0+, the `--experimental-transform-types` flag is no longer required:
-
-```json title="package.json"
-{
-  "scripts": {
-    "build": "rspack build"
+    "build": "rspack build --configLoader=native"
   }
 }
 ```

--- a/website/docs/zh/config/index.mdx
+++ b/website/docs/zh/config/index.mdx
@@ -80,7 +80,7 @@ Rspack 支持以下配置文件格式：
 
 例如，Node.js 已经原生支持 TypeScript，你可以使用以下命令来使用 Node.js 原生加载器来加载配置文件：
 
-- 对于 Node.js v22.18+ 到 v24.3+ 已经默认开启 TS 支持，你可以通过如下命令使用 Node.js 内置的TS支持来加载配置文件：
+- 对于原生支持 TypeScript 的 Node.js v22.18+ 和 v24.3+，你可以运行以下命令来加载 TS 配置：
 
 ```json title="package.json"
 {

--- a/website/docs/zh/config/index.mdx
+++ b/website/docs/zh/config/index.mdx
@@ -80,22 +80,12 @@ Rspack 支持以下配置文件格式：
 
 例如，Node.js 已经原生支持 TypeScript，你可以使用以下命令来使用 Node.js 原生加载器来加载配置文件：
 
-- 对于 Node.js v22.7.0 到 v23.5.0，你需要启用 `--experimental-transform-types` 选项：
+- 对于 Node.js v22.18+ 到 v24.3+ 已经默认开启 TS 支持，你可以通过如下命令使用 Node.js 内置的TS支持来加载配置文件：
 
 ```json title="package.json"
 {
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-transform-types' rspack build"
-  }
-}
-```
-
-- 对于 Node.js v23.6.0+，不再需要 `--experimental-transform-types` 选项：
-
-```json title="package.json"
-{
-  "scripts": {
-    "build": "rspack build"
+    "build": "rspack build --configLoader=native"
   }
 }
 ```


### PR DESCRIPTION
## Summary
Node.js already support enable typescript by default, so update the guide and remove experimental options

<!-- Describe what this PR does and why. -->

## Related links

- https://nodejs.org/en/blog/release/v22.18.0
- https://github.com/web-infra-dev/rspack/issues/11236#issuecomment-3199006061

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
