### PR TITLE
feat(cli): use SWC to do TS config transformamation

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -9,7 +9,13 @@
 			"allowTrailingCommas": true
 		}
 	},
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {
@@ -42,7 +48,8 @@
 				"noPrototypeBuiltins": "off",
 				"noAssignInExpressions": "off",
 				"noControlCharactersInRegex": "off",
-				"noExplicitAny": "off"
+				"noExplicitAny": "off",
+				"noImplicitAnyLet": "off"
 			}
 		}
 	},

--- a/crates/rspack_binding_api/src/swc.rs
+++ b/crates/rspack_binding_api/src/swc.rs
@@ -57,7 +57,9 @@ fn _transform(source: String, options: String) -> napi::Result<TransformOutput> 
   compiler
     .transform(
       source,
-      Some(swc_core::common::FileName::Anon),
+      Some(swc_core::common::FileName::Real(
+        options.filename.clone().into(),
+      )),
       options,
       Some(module_source_map_kind),
       |_| {},

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -38,7 +38,8 @@
     "colorette": "2.0.20",
     "exit-hook": "^4.0.0",
     "webpack-bundle-analyzer": "4.10.2",
-    "yargs": "17.7.2"
+    "yargs": "17.7.2",
+    "pirates": "^4.0.7"
   },
   "devDependencies": {
     "@rslib/core": "0.12.1",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -37,8 +37,6 @@
     "@rspack/dev-server": "~1.1.3",
     "colorette": "2.0.20",
     "exit-hook": "^4.0.0",
-    "interpret": "^3.1.1",
-    "rechoir": "^0.8.0",
     "webpack-bundle-analyzer": "4.10.2",
     "yargs": "17.7.2"
   },

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -44,8 +44,6 @@
   "devDependencies": {
     "@rslib/core": "0.12.1",
     "@rspack/core": "workspace:*",
-    "@types/interpret": "^1.1.3",
-    "@types/rechoir": "^0.6.4",
     "@types/webpack-bundle-analyzer": "^4.7.0",
     "@types/yargs": "17.0.33",
     "concat-stream": "^2.0.0",

--- a/packages/rspack-cli/src/utils/isTsFile.ts
+++ b/packages/rspack-cli/src/utils/isTsFile.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
-
+export const TS_EXTENSION = [".ts", ".cts", ".mts"];
 const isTsFile = (configPath: string) => {
 	const ext = path.extname(configPath);
-	return /\.(c|m)?ts$/.test(ext);
+	return TS_EXTENSION.includes(ext);
 };
 
 export default isTsFile;

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -54,7 +54,26 @@ const registerLoader = (configPath: string) => {
 				module: { type: "commonjs" },
 				sourceMaps: false,
 				isModule: true
-			});
+			let result;
+			try {
+				result = experiments.swc.transform(source, {
+					jsc: {
+						parser: {
+							syntax: "typescript",
+							tsx: false,
+							decorators: true,
+							dynamicImport: true
+						}
+					},
+					module: { type: "commonjs" },
+					sourceMaps: false,
+					isModule: true
+				});
+			} catch (err) {
+				throw new Error(
+					`Failed to transform TypeScript config file "${filename}" with SWC: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
 			(mod as any)._compile(result.code, filename);
 		};
 	}

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
-	experiments, 
+	experiments,
 	type MultiRspackOptions,
 	type RspackOptions,
 	util
@@ -42,21 +42,10 @@ const registerLoader = (configPath: string) => {
 			filename: string
 		) {
 			const source = fs.readFileSync(filename, "utf-8");
-			const result = experiments.swc.transformSync(source, {
-				jsc: {
-					parser: {
-						syntax: "typescript",
-						tsx: false,
-						decorators: true,
-						dynamicImport: true
-					}
-				},
-				module: { type: "commonjs" },
-				sourceMaps: false,
-				isModule: true
+
 			let result;
 			try {
-				result = experiments.swc.transform(source, {
+				result = experiments.swc.transformSync(source, {
 					jsc: {
 						parser: {
 							syntax: "typescript",
@@ -71,7 +60,7 @@ const registerLoader = (configPath: string) => {
 				});
 			} catch (err) {
 				throw new Error(
-					`Failed to transform TypeScript config file "${filename}" with SWC: ${err instanceof Error ? err.message : String(err)}`
+					`Failed to transform TypeScript config file "${filename}" with rspack's builtin register: ${err instanceof Error ? err.message : String(err)}`
 				);
 			}
 			(mod as any)._compile(result.code, filename);

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
+	experiments, 
 	type MultiRspackOptions,
 	type RspackOptions,
-	util,
-	experiments
+	util
 } from "@rspack/core";
 import type { RspackCLIOptions } from "../types";
 import { crossImport } from "./crossImport";
@@ -26,8 +26,15 @@ const registerLoader = (configPath: string) => {
 	if (!isTsFile(configPath)) {
 		throw new Error(`config file "${configPath}" is not supported.`);
 	}
+	// this is a hack to workaround the issue that require.extensions is compiled to void(0) by rslib
+	// do not change it to require.extensions
+	function unsafeGetRequireExtension() {
+		// @ts-ignore
+		return require["extension" + "s"];
+	}
 
-	const nodeRequireExtensions: NodeJS.RequireExtensions = require.extensions;
+	const nodeRequireExtensions: NodeJS.RequireExtensions =
+		unsafeGetRequireExtension();
 
 	if (!nodeRequireExtensions[ext]) {
 		nodeRequireExtensions[ext] = function (

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -39,8 +39,9 @@ export function compile(sourcecode: string, filename: string) {
 				dynamicImport: true
 			}
 		},
+		filename: filename,
 		module: { type: "commonjs" },
-		sourceMaps: false,
+		sourceMaps: true,
 		isModule: true
 	});
 	return injectInlineSourceMap({ filename, code, map });

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -49,7 +49,6 @@ export function compile(sourcecode: string, filename: string) {
 const DEFAULT_CONFIG_NAME = "rspack.config" as const;
 // modified based on https://github.com/swc-project/swc-node/blob/master/packages/register/register.ts#L117
 const registerLoader = (configPath: string) => {
-	// TODO implement good `.mts` support after https://github.com/gulpjs/rechoir/issues/43
 	// For ESM and `.mts` you need to use: 'NODE_OPTIONS="--loader ts-node/esm" rspack build --config ./rspack.config.mts'
 	if (isEsmFile(configPath) && isTsFile(configPath)) {
 		return;

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -60,7 +60,13 @@ const registerLoader = (configPath: string) => {
 	}
 	addHook(
 		(code, filename) => {
-			return compile(code, filename);
+			try {
+				return compile(code, filename);
+			} catch (err) {
+				throw new Error(
+					`Failed to transform file "${filename}" when loading TypeScript config file:\n ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
 		},
 		{
 			exts: TS_EXTENSION

--- a/packages/rspack-cli/tests/build/config/config.test.ts
+++ b/packages/rspack-cli/tests/build/config/config.test.ts
@@ -260,6 +260,39 @@ describe("rspack cli", () => {
 			).resolves.toMatch(/Main monorepo file/);
 		});
 	});
+	describe("should support loader ts-node register", () => {
+		const cwd = resolve(__dirname, "./ts-node-register");
+		it("should load ts-node-register to support declare const enum", async () => {
+			const { exitCode, stdout, stderr } = await run(
+				cwd,
+				["-c", "rspack.config.ts"],
+				{
+					nodeOptions: ["--require", "ts-node/register"]
+				}
+			);
+			expect(stdout).toBeTruthy();
+			expect(stderr).toBeFalsy();
+			expect(exitCode).toBe(0);
+			expect(
+				readFile(resolve(cwd, `./dist/node-register.bundle.js`), {
+					encoding: "utf-8"
+				})
+			).resolves.toMatch(/Main ts-node-register file: 42/);
+		});
+		it("builtin swc-register can't handle declare const enum", async () => {
+			const { exitCode, stdout, stderr } = await run(
+				cwd,
+				["-c", "rspack.config.ts"],
+				{
+					nodeOptions: []
+				}
+			);
+			expect(stdout).toBeFalsy();
+			expect(stderr).toBeTruthy();
+			expect(stderr).toMatch(/ReferenceError: JSB is not defined/);
+			expect(exitCode).toBe(1);
+		});
+	});
 
 	// describe("loose-unrecognized-keys (default)", () => {
 	// 	const cwd = resolve(__dirname, "./loose-unrecognized-keys");

--- a/packages/rspack-cli/tests/build/config/ts-node-register/main.ts
+++ b/packages/rspack-cli/tests/build/config/ts-node-register/main.ts
@@ -1,0 +1,1 @@
+console.log(`Main ts-node-register file: ${ANSWER}`);

--- a/packages/rspack-cli/tests/build/config/ts-node-register/rspack.config.ts
+++ b/packages/rspack-cli/tests/build/config/ts-node-register/rspack.config.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import rspack from "@rspack/core";
+declare const enum JSB {
+	SECRET = 42
+}
+export default {
+	mode: "production",
+	entry: path.resolve(__dirname, "main.ts"),
+
+	output: {
+		path: path.resolve(__dirname, "dist"),
+		filename: "node-register.bundle.js"
+	},
+	plugins: [
+		new rspack.DefinePlugin({
+			ANSWER: JSB.SECRET
+		})
+	]
+};

--- a/packages/rspack-cli/tests/build/config/ts-node-register/tsconfig.json
+++ b/packages/rspack-cli/tests/build/config/ts-node-register/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": ".",
+    "target": "ESNext",
+    "module": "commonjs",
+    "noEmit": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "types": [
+      "./namespace.d.ts"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.js"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,9 @@ importers:
       exit-hook:
         specifier: ^4.0.0
         version: 4.0.0
+      pirates:
+        specifier: ^4.0.7
+        version: 4.0.7
       webpack-bundle-analyzer:
         specifier: 4.10.2
         version: 4.10.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,12 +419,6 @@ importers:
       '@rspack/core':
         specifier: workspace:*
         version: link:../rspack
-      '@types/interpret':
-        specifier: ^1.1.3
-        version: 1.1.3
-      '@types/rechoir':
-        specifier: ^0.6.4
-        version: 0.6.4
       '@types/webpack-bundle-analyzer':
         specifier: ^4.7.0
         version: 4.7.0(@swc/core@1.12.0(@swc/helpers@0.5.17))
@@ -3403,9 +3397,6 @@ packages:
   '@types/http-proxy@1.17.16':
     resolution: {integrity: sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==}
 
-  '@types/interpret@1.1.3':
-    resolution: {integrity: sha512-uBaBhj/BhilG58r64mtDb/BEdH51HIQLgP5bmWzc5qCtFMja8dCk/IOJmk36j0lbi9QHwI6sbtUNGuqXdKCAtQ==}
-
   '@types/is-ci@3.0.4':
     resolution: {integrity: sha512-AkCYCmwlXeuH89DagDCzvCAyltI2v9lh3U3DqSg/GrBYoReAaWwxfXCqMx9UV5MajLZ4ZFwZzV4cABGIxk2XRw==}
 
@@ -3470,9 +3461,6 @@ packages:
 
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
-
-  '@types/rechoir@0.6.4':
-    resolution: {integrity: sha512-qpb56wvjUSuJQwZzDcmQEFudUsolIabyOE9aP9Wr5s1EYlWQ/4Zz7XSjr69gDhWY5PBX/+M62ZLQgQyUzTiPAA==}
 
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
@@ -11142,10 +11130,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.9
 
-  '@types/interpret@1.1.3':
-    dependencies:
-      '@types/node': 20.17.55
-
   '@types/is-ci@3.0.4':
     dependencies:
       ci-info: 3.9.0
@@ -11220,10 +11204,6 @@ snapshots:
   '@types/react@19.1.8':
     dependencies:
       csstype: 3.1.3
-
-  '@types/rechoir@0.6.4':
-    dependencies:
-      '@types/interpret': 1.1.3
 
   '@types/retry@0.12.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,12 +403,6 @@ importers:
       exit-hook:
         specifier: ^4.0.0
         version: 4.0.0
-      interpret:
-        specifier: ^3.1.1
-        version: 3.1.1
-      rechoir:
-        specifier: ^0.8.0
-        version: 0.8.0
       webpack-bundle-analyzer:
         specifier: 4.10.2
         version: 4.10.2
@@ -5521,10 +5515,6 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  interpret@3.1.1:
-    resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
-    engines: {node: '>=10.13.0'}
-
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -7030,10 +7020,6 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-
-  rechoir@0.8.0:
-    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
-    engines: {node: '>= 10.13.0'}
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -13652,8 +13638,6 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  interpret@3.1.1: {}
-
   ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.2.0: {}
@@ -15777,10 +15761,6 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
-
-  rechoir@0.8.0:
-    dependencies:
-      resolve: 1.22.10
 
   recma-build-jsx@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Use  `experiments.swc` to transform TypeScript Rspack config files (CJS) at runtime and no need to install ts-node for most cases.

### Motivation

Provide out of box support of TypeScript config(CJS) support, TypeScript ESM is not covered and may be implemented in future PR.

### Breaking Change

@rspack/cli will not automatically try to load `ts-node/register` and `esbuild-resgister` to load TypeScript config, It will use builtin swc-register(based on rspack.experiments.transform) to load TypeScript config, It covers most cases of `ts-node` but if you still need more complex features(like declare const enum support), you can still use `ts-node/register` to  load typescript config by running following commands:

```
"build": "NODE_OPTIONS='--require ts-node/register' rspack build"
```

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).