### PR TITLE
fix(browser): fix @rspack/browser building

### DIFF
--- a/packages/rspack-browser/package.json
+++ b/packages/rspack-browser/package.json
@@ -19,11 +19,9 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "pnpm run --fail-if-no-match --filter @rspack/core build:browser || pnpm --filter @rspack-canary/core build:browser"
+    "build": "pnpm run --fail-if-no-match --filter @rspack/core build:browser || pnpm --fail-if-no-match --filter @rspack-canary/core build:browser"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack/src/browser/service.ts
+++ b/packages/rspack/src/browser/service.ts
@@ -1,4 +1,27 @@
-export enum RequestType {}
+export enum RequestType {
+	AddDependency = "AddDependency",
+	AddContextDependency = "AddContextDependency",
+	AddMissingDependency = "AddMissingDependency",
+	AddBuildDependency = "AddBuildDependency",
+	GetDependencies = "GetDependencies",
+	GetContextDependencies = "GetContextDependencies",
+	GetMissingDependencies = "GetMissingDependencies",
+	ClearDependencies = "ClearDependencies",
+	Resolve = "Resolve",
+	GetResolve = "GetResolve",
+	GetLogger = "GetLogger",
+	EmitError = "EmitError",
+	EmitWarning = "EmitWarning",
+	EmitFile = "EmitFile",
+	EmitDiagnostic = "EmitDiagnostic",
+	SetCacheable = "SetCacheable",
+	ImportModule = "ImportModule",
+	UpdateLoaderObjects = "UpdateLoaderObjects",
+	CompilationGetPath = "CompilationGetPath",
+	CompilationGetPathWithInfo = "CompilationGetPathWithInfo",
+	CompilationGetAssetPath = "CompilationGetAssetPath",
+	CompilationGetAssetPathWithInfo = "CompilationGetAssetPathWithInfo"
+}
 
 export async function run() {
 	throw new Error("Not support browser");


### PR DESCRIPTION
## Summary

1. Rsbuild enables `inlineEnum` by default so we have to add all enums to our browser shim.
2. Add `--fail-if-no-match` to build script. This makes ci fails if the build script fails.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
