### PR TITLE
feat(rslib): intercept more APIPlugin expressions

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/rslib/plugin-api/index.js
+++ b/packages/rspack-test-tools/tests/configCases/rslib/plugin-api/index.js
@@ -1,1 +1,7 @@
 console.log(require.cache)
+console.log(require.extensions)
+console.log(require.config)
+console.log(require.version)
+console.log(require.include)
+console.log(require.onError)
+

--- a/packages/rspack-test-tools/tests/configCases/rslib/plugin-api/test.js
+++ b/packages/rspack-test-tools/tests/configCases/rslib/plugin-api/test.js
@@ -4,6 +4,11 @@ const fs = require('fs');
 const file = path.resolve(__dirname, 'bundle0.js')
 const content = fs.readFileSync(file, 'utf-8');
 
-it ('`require.cache` should be not handled by APIPlugin', () => {
+it ('some expressions should not be handled by APIPlugin', () => {
 	expect(content).toContain('console.log(require.cache)')
+	expect(content).toContain('console.log(require.extensions)')
+	expect(content).toContain('console.log(require.config)')
+	expect(content).toContain('console.log(require.version)')
+	expect(content).toContain('console.log(require.include)')
+	expect(content).toContain('console.log(require.onError)')
 })


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Intercept more expressions which are supposed to be handled by APIPlugin, this functionality should be enabled by default when targeting `node` in Rslib.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
