### PR TITLE
fix: native watcher fails to work correctly with persistent cache

### DIFF
--- a/packages/rspack/src/NativeWatchFileSystem.ts
+++ b/packages/rspack/src/NativeWatchFileSystem.ts
@@ -180,7 +180,7 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
 	): [binding.NativeWatcher, boolean] {
 		if (this.#inner) {
 			// Reuse existing watcher, no need to create a new one
-			// Returning [instance, false] indicates that the native watcher is uninitialized
+			// Returning [instance, false] indicates that the native watcher is being reused (already initialized)
 			return [this.#inner, false];
 		}
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the native file watcher doesn't work correctly with persistent cache. The main changes include:

1. Modified the getNativeWatcher method to return a tuple of [watcher, initialized], indicating whether the watcher is newly initialized or being reused.

2. Enhanced the watch method to handle file dependencies differently based on the watcher's initialization state:

- For newly initialized watchers: Pass all dependencies (files, directories, missing)
- For existing watchers: Only pass incremental changes (added/removed dependencies)

3. Improved code structure by extracting repeated logic into variables for better maintainability.

This fix ensures proper file watching behavior when persistent cache is enabled, preventing potential issues with file detection and updates.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
