### PR TITLE
feat: allow external modules placed in async chunks

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2144,6 +2144,7 @@ export interface RawExternalItemFnResult {
 export interface RawExternalsPluginOptions {
   type: string
   externals: (string | RegExp | Record<string, string | boolean | string[] | Record<string, string[]>> | ((...args: any[]) => any))[]
+  placeInInitial: boolean
 }
 
 export interface RawExternalsPresets {

--- a/crates/rspack/src/builder/builder_context.rs
+++ b/crates/rspack/src/builder/builder_context.rs
@@ -12,7 +12,7 @@ use rspack_core::{
 #[repr(u8)]
 pub(super) enum BuiltinPluginOptions {
   // External handling plugins
-  ExternalsPlugin((ExternalType, Vec<ExternalItem>)),
+  ExternalsPlugin((ExternalType, Vec<ExternalItem>, bool)),
   NodeTargetPlugin,
   ElectronTargetPlugin(rspack_plugin_externals::ElectronTargetContext),
   HttpExternalsRspackPlugin((bool /* css */, bool /* web_async */)),
@@ -111,9 +111,11 @@ impl BuilderContext {
     let mut plugins = Vec::new();
     self.plugins.drain(..).for_each(|plugin| match plugin {
       // External handling plugins
-      BuiltinPluginOptions::ExternalsPlugin((external_type, externals)) => {
-        plugins
-          .push(rspack_plugin_externals::ExternalsPlugin::new(external_type, externals).boxed());
+      BuiltinPluginOptions::ExternalsPlugin((external_type, externals, place_in_initial)) => {
+        plugins.push(
+          rspack_plugin_externals::ExternalsPlugin::new(external_type, externals, place_in_initial)
+            .boxed(),
+        );
       }
       BuiltinPluginOptions::NodeTargetPlugin => {
         plugins.push(rspack_plugin_externals::node_target_plugin())

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1084,6 +1084,7 @@ impl CompilerOptionsBuilder {
         .push(BuiltinPluginOptions::ExternalsPlugin((
           expect!(self.externals_type.clone()),
           externals,
+          false,
         )));
     }
 
@@ -1135,6 +1136,7 @@ impl CompilerOptionsBuilder {
         .push(BuiltinPluginOptions::ExternalsPlugin((
           "node-commonjs".to_string(),
           vec!["nw.gui".to_string().into()],
+          false,
         )));
     }
 

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -364,7 +364,12 @@ impl<'a> BuiltinPlugin<'a> {
           .map(|e| RawExternalItemWrapper(e).try_into())
           .collect::<Result<Vec<_>>>()
           .map_err(|report| napi::Error::from_reason(report.to_string()))?;
-        let plugin = ExternalsPlugin::new(plugin_options.r#type, externals).boxed();
+        let plugin = ExternalsPlugin::new(
+          plugin_options.r#type,
+          externals,
+          plugin_options.place_in_initial,
+        )
+        .boxed();
         plugins.push(plugin);
       }
       BuiltinPluginName::NodeTargetPlugin => plugins.push(node_target_plugin()),

--- a/crates/rspack_binding_api/src/raw_options/raw_external.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_external.rs
@@ -36,6 +36,7 @@ pub struct RawExternalsPluginOptions {
     ts_type = "(string | RegExp | Record<string, string | boolean | string[] | Record<string, string[]>> | ((...args: any[]) => any))[]"
   )]
   pub externals: Vec<RawExternalItem>,
+  pub place_in_initial: bool,
 }
 
 type RawExternalItem = Either4<

--- a/crates/rspack_plugin_dll/src/dll_reference/dll_reference_agency_plugin.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/dll_reference_agency_plugin.rs
@@ -67,7 +67,7 @@ impl Plugin for DllReferenceAgencyPlugin {
 
     let external = ExternalItem::Object(external_item_object);
 
-    ExternalsPlugin::new(source_type.unwrap_or("var".into()), vec![external]).apply(ctx)?;
+    ExternalsPlugin::new(source_type.unwrap_or("var".into()), vec![external], false).apply(ctx)?;
 
     DelegatedPlugin::new(DelegatedPluginOptions {
       source: source.clone(),

--- a/crates/rspack_plugin_externals/src/electron_target_plugin.rs
+++ b/crates/rspack_plugin_externals/src/electron_target_plugin.rs
@@ -41,6 +41,7 @@ pub fn electron_target_plugin(context: ElectronTargetContext, plugins: &mut Vec<
       .into_iter()
       .map(|i| ExternalItem::String(i.to_string()))
       .collect(),
+      false,
     )
     .boxed(),
   );
@@ -68,6 +69,7 @@ pub fn electron_target_plugin(context: ElectronTargetContext, plugins: &mut Vec<
         .into_iter()
         .map(|i| ExternalItem::String(i.to_string()))
         .collect(),
+        false,
       )
       .boxed(),
     ),
@@ -78,6 +80,7 @@ pub fn electron_target_plugin(context: ElectronTargetContext, plugins: &mut Vec<
           .into_iter()
           .map(|i| ExternalItem::String(i.to_string()))
           .collect(),
+        false,
       )
       .boxed(),
     ),

--- a/crates/rspack_plugin_externals/src/http_externals_plugin.rs
+++ b/crates/rspack_plugin_externals/src/http_externals_plugin.rs
@@ -6,9 +6,19 @@ use crate::ExternalsPlugin;
 
 pub fn http_externals_rspack_plugin(css: bool, web_async: bool) -> BoxPlugin {
   if web_async {
-    ExternalsPlugin::new("import".to_owned(), vec![http_external_item_web_async(css)]).boxed()
+    ExternalsPlugin::new(
+      "import".to_owned(),
+      vec![http_external_item_web_async(css)],
+      false,
+    )
+    .boxed()
   } else {
-    ExternalsPlugin::new("module".to_owned(), vec![http_external_item_web(css)]).boxed()
+    ExternalsPlugin::new(
+      "module".to_owned(),
+      vec![http_external_item_web(css)],
+      false,
+    )
+    .boxed()
   }
 }
 

--- a/crates/rspack_plugin_externals/src/node_target_plugin.rs
+++ b/crates/rspack_plugin_externals/src/node_target_plugin.rs
@@ -65,6 +65,7 @@ pub fn node_target_plugin() -> BoxPlugin {
       // Yarn PnP adds pnpapi as "builtin"
       ExternalItem::from("pnpapi".to_string()),
     ],
+    false,
   )
   .boxed()
 }

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -22,11 +22,12 @@ static UNSPECIFIED_EXTERNAL_TYPE_REGEXP: LazyLock<Regex> =
 pub struct ExternalsPlugin {
   externals: Vec<ExternalItem>,
   r#type: ExternalType,
+  place_in_initial: bool,
 }
 
 impl ExternalsPlugin {
-  pub fn new(r#type: ExternalType, externals: Vec<ExternalItem>) -> Self {
-    Self::new_inner(externals, r#type)
+  pub fn new(r#type: ExternalType, externals: Vec<ExternalItem>, place_in_initial: bool) -> Self {
+    Self::new_inner(externals, r#type, place_in_initial)
   }
 
   fn handle_external(
@@ -137,6 +138,7 @@ impl ExternalsPlugin {
       r#type.unwrap_or(external_module_type),
       dependency.request().to_owned(),
       dependency_meta,
+      self.place_in_initial,
     ))
   }
 }

--- a/packages/rspack-test-tools/tests/configCases/externals/in-async-chunks/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/in-async-chunks/index.js
@@ -1,0 +1,1 @@
+import('./module')

--- a/packages/rspack-test-tools/tests/configCases/externals/in-async-chunks/module.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/in-async-chunks/module.js
@@ -1,0 +1,6 @@
+import { resolve } from 'path'
+import { readFileSync } from 'fs'
+
+const file = readFileSync(resolve(__dirname, 'module.js'), 'utf-8')
+
+expect(file).toContain('import { resolve } from "path')

--- a/packages/rspack-test-tools/tests/configCases/externals/in-async-chunks/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/in-async-chunks/rspack.config.js
@@ -1,0 +1,16 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "async-node",
+	externals: ["path", "fs"],
+	externalsType: "module",
+	output: {
+		chunkFormat: "module",
+		filename: "[name].mjs",
+		library: {
+			type: "modern-module"
+		}
+	},
+	experiments: {
+		outputModule: true
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-dynamic-import-runtime/index.js
@@ -5,8 +5,7 @@ it("modern-module-dynamic-import-runtime", () => {
 	const initialChunk = fs.readFileSync(path.resolve(__dirname, "main.js"), "utf-8");
 	const asyncChunk = fs.readFileSync(path.resolve(__dirname, "async.js"), "utf-8");
 
-	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_lit_alias_9f8ad874__ from "lit-alias"');
-	expect(initialChunk).toContain('import * as __WEBPACK_EXTERNAL_MODULE_svelte_alias_b2b3c54d__ from "svelte-alias"');
+
 	expect(initialChunk).toContain('import { react } from "react-alias"');
 	expect(initialChunk).toContain('import { angular } from "angular-alias";');
 	expect(initialChunk).toContain('const reactNs = await import("react-alias")');
@@ -14,6 +13,9 @@ it("modern-module-dynamic-import-runtime", () => {
 	expect(initialChunk).toContain('const jqueryNs = await import("jquery-alias", { with: {"type":"url"} })');
 	expect(initialChunk).toContain(`const reactNs2 = await import(/* 123 */ // 456
 /*webpackChunkName: 'useless'*/ "react-alias")`)
+
+	expect(asyncChunk).toContain('import { lit } from "lit-alias"');
+	expect(asyncChunk).toContain('import { svelte } from "svelte-alias"');
 	expect(asyncChunk).toContain('const litNs = await import("lit-alias")');
 	expect(asyncChunk).toContain('const solidNs = await import("solid-alias")');
 

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2644,7 +2644,7 @@ export type Externals = ExternalItem | ExternalItem[];
 
 // @public (undocumented)
 export class ExternalsPlugin extends RspackBuiltinPlugin {
-    constructor(type: string, externals: Externals);
+    constructor(type: string, externals: Externals, placeInInitial?: boolean | undefined);
     // (undocumented)
     name: BuiltinPluginName;
     // (undocumented)

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -18,7 +18,8 @@ export class ExternalsPlugin extends RspackBuiltinPlugin {
 
 	constructor(
 		private type: string,
-		private externals: Externals
+		private externals: Externals,
+		private placeInInitial?: boolean
 	) {
 		super();
 	}
@@ -30,7 +31,8 @@ export class ExternalsPlugin extends RspackBuiltinPlugin {
 			type,
 			externals: (Array.isArray(externals) ? externals : [externals])
 				.filter(Boolean)
-				.map(item => this.#getRawExternalItem(item))
+				.map(item => this.#getRawExternalItem(item)),
+			placeInInitial: this.placeInInitial ?? false
 		};
 		return createBuiltinPlugin(this.name, raw);
 	}

--- a/packages/rspack/src/container/ContainerReferencePlugin.ts
+++ b/packages/rspack/src/container/ContainerReferencePlugin.ts
@@ -68,7 +68,7 @@ export class ContainerReferencePlugin extends RspackBuiltinPlugin {
 				i++;
 			}
 		}
-		new ExternalsPlugin(remoteType, remoteExternals).apply(compiler);
+		new ExternalsPlugin(remoteType, remoteExternals, true).apply(compiler);
 		new ShareRuntimePlugin(this._options.enhanced).apply(compiler);
 
 		const rawOptions: RawContainerReferencePluginOptions = {

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -90,9 +90,11 @@ export class RspackOptionsApply {
 				options.externalsType,
 				"options.externalsType should have value after `applyRspackOptionsDefaults`"
 			);
-			new ExternalsPlugin(options.externalsType, options.externals).apply(
-				compiler
-			);
+			new ExternalsPlugin(
+				options.externalsType,
+				options.externals,
+				false
+			).apply(compiler);
 		}
 
 		if (options.externalsPresets.node) {
@@ -116,7 +118,7 @@ export class RspackOptionsApply {
 			new ElectronTargetPlugin().apply(compiler);
 		}
 		if (options.externalsPresets.nwjs) {
-			new ExternalsPlugin("node-commonjs", "nw.gui").apply(compiler);
+			new ExternalsPlugin("node-commonjs", "nw.gui", false).apply(compiler);
 		}
 		if (
 			options.externalsPresets.web ||


### PR DESCRIPTION
## Summary

Allow normal external modules to be placed in async chunks.

Normally external modules are placed in initial chunks because they may access runtime, which only exist in entry chunks, however some externalType do not require it, they can be placed anywhere.

ModuleFederation implemented based on ExternalModule and it will load some container modules before chunk loading, which need external modules to be in initial chunks, so adding new configuration that forces external modules to be placed in initial chunks.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
