### PR TITLE
chore(ci): prevent prerelease published to lastest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
           - latest
           - beta
           - alpha
+          - rc
       test:
         type: boolean
         description: "Run tests before release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
         type: choice
         description: "Release Npm Tag"
         required: true
-        default: "latest"
         options:
           - canary
           - nightly
@@ -15,6 +14,16 @@ on:
           - beta
           - alpha
           - rc
+      tag_confirm:
+        type: choice
+        description: "Release Npm Tag Double Check"
+        required: true
+        options:
+          - canary
+          - nightly
+          - latest
+          - beta
+          - alpha
       test:
         type: boolean
         description: "Run tests before release"

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -19,7 +19,7 @@ export async function publish_handler(mode, options) {
 	const parsedVersion = parse(version);
 
 	if (npmTag === "latest" && parsedVersion.prerelease.length > 0) {
-		throw Error("Latest tag can not be prerelease version");
+		throw Error("Latest tag cannot be prerelease version");
 	}
 
 	if (fs.existsSync(npmrcPath)) {


### PR DESCRIPTION
## Summary
Add fool-proofings to prevent prerelease version published to npm latest tag.
1. Add double check to release workflow to confirm which tag is going to release.
2. Prevent prerelease version publishing to latest npm tag.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
