### PR TITLE
fix: bailout optimize if there are external modules in other concate scope

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -674,7 +674,8 @@ impl Module for ConcatenatedModule {
     let tmp = rspack_futures::scope::<_, Result<_>>(|token| {
       arc_map.iter().for_each(|(id, info)| {
         let concatenation_scope = if let ModuleInfo::Concatenated(info) = &info {
-          let concatenation_scope = ConcatenationScope::new(arc_map.clone(), info.as_ref().clone());
+          let concatenation_scope =
+            ConcatenationScope::new(self.id, arc_map.clone(), info.as_ref().clone());
 
           Some(concatenation_scope)
         } else {

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -441,6 +441,69 @@ impl ExternalModule {
                 serde_json::to_string(meta).expect("json stringify failed"),
               )
             });
+
+            #[derive(Clone, Copy)]
+            struct ExternalImportOptimize(pub bool);
+
+            let safe_to_optimize =
+              if let Some(optimize) = concatenation_scope.data.get::<ExternalImportOptimize>() {
+                optimize.0
+              } else {
+                let chunk = compilation
+                  .chunk_graph
+                  .get_module_chunks(concatenation_scope.concat_module_id);
+
+                let safe_to_optimize = if chunk.is_empty() {
+                  false
+                } else {
+                  let chunk = chunk
+                    .iter()
+                    .next()
+                    .expect("concate module have only 1 chunk");
+
+                  // chunk: [extern_1, extern_2],
+                  // they are placed in 2 different concate modules
+                  // They may have conflict symbols, but we can't know during codegen,
+                  // and even if we know we can't determine which one to rename, as they
+                  // render in parallel.
+                  // This will be improved in incoming esm format.
+                  //
+                  // We must ensure that there is no other external modules in different
+                  // concate modules of the same chunk
+                  let module_graph = compilation.get_module_graph();
+                  let mut safe_to_optimize = true;
+                  'outer: for m in compilation
+                    .chunk_graph
+                    .get_chunk_modules(chunk, &module_graph)
+                  {
+                    if m.identifier() == concatenation_scope.concat_module_id {
+                      // skip self
+                      continue;
+                    }
+
+                    if let Some(m) = m.as_concatenated_module() {
+                      for m in m.get_modules() {
+                        if let Some(external_module) = module_graph
+                          .module_by_identifier(&m.id)
+                          .expect("should have module")
+                          .as_external_module()
+                          && external_module.resolve_external_type() == "module"
+                        {
+                          safe_to_optimize = false;
+                          break 'outer;
+                        }
+                      }
+                    }
+                  }
+                  safe_to_optimize
+                };
+
+                concatenation_scope
+                  .data
+                  .insert(ExternalImportOptimize(safe_to_optimize));
+                safe_to_optimize
+              };
+
             match used_exports {
               UsedExports::UsedNamespace(true) | UsedExports::Unknown => {
                 chunk_init_fragments.push(
@@ -489,18 +552,46 @@ impl ExternalModule {
                 );
               }
               UsedExports::UsedNames(atoms) => {
-                concatenation_scope.register_import(
-                  request.primary().to_string(),
-                  attributes.clone(),
-                  None,
-                );
-                for atom in &atoms {
+                if !safe_to_optimize {
+                  chunk_init_fragments.push(
+                    NormalInitFragment::new(
+                      format!(
+                        "import * as __WEBPACK_EXTERNAL_MODULE_{}__ from {}{};\n",
+                        id.clone(),
+                        json_stringify(request.primary()),
+                        attributes.clone().unwrap_or_default()
+                      ),
+                      InitFragmentStage::StageESMImports,
+                      module_graph
+                        .get_pre_order_index(&self.identifier())
+                        .map_or(0, |num| num as i32),
+                      InitFragmentKey::ModuleExternal(request.primary().into()),
+                      None,
+                    )
+                    .boxed(),
+                  );
+                  let external_module_id = format!("__WEBPACK_EXTERNAL_MODULE_{id}__");
+                  let namespace_export_with_name = format!(
+                    "{}{}{}",
+                    NAMESPACE_OBJECT_EXPORT,
+                    &external_module_id,
+                    &property_access(request.iter(), 1)
+                  );
+                  concatenation_scope.register_namespace_export(&namespace_export_with_name);
+                } else {
                   concatenation_scope.register_import(
                     request.primary().to_string(),
                     attributes.clone(),
-                    Some(atom.clone()),
+                    None,
                   );
-                  concatenation_scope.register_raw_export(atom.clone(), atom.to_string());
+                  for atom in &atoms {
+                    concatenation_scope.register_import(
+                      request.primary().to_string(),
+                      attributes.clone(),
+                      Some(atom.clone()),
+                    );
+                    concatenation_scope.register_raw_export(atom.clone(), atom.to_string());
+                  }
                 }
               }
             }

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -3,6 +3,7 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
+use anymap::CloneAny;
 use regex::Regex;
 use rspack_collections::IdentifierIndexMap;
 use rspack_util::itoa;
@@ -34,19 +35,24 @@ pub struct ModuleReferenceOptions {
 
 #[derive(Debug, Clone)]
 pub struct ConcatenationScope {
+  pub concat_module_id: ModuleIdentifier,
   pub current_module: ConcatenatedModuleInfo,
   pub modules_map: Arc<IdentifierIndexMap<ModuleInfo>>,
+  pub data: anymap::Map<dyn CloneAny + Send + Sync>,
 }
 
 #[allow(unused)]
 impl ConcatenationScope {
   pub fn new(
+    concat_module_id: ModuleIdentifier,
     modules_map: Arc<IdentifierIndexMap<ModuleInfo>>,
     current_module: ConcatenatedModuleInfo,
   ) -> Self {
     ConcatenationScope {
+      concat_module_id,
       current_module,
       modules_map,
+      data: Default::default(),
     }
   }
 

--- a/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/cjs.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/cjs.js
@@ -1,0 +1,1 @@
+require('./other-entry.js')

--- a/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/index.js
@@ -1,0 +1,6 @@
+import { readFile } from 'externals-1/foo'
+import './cjs'
+
+it('should not optimize external modules in different concatenation scope', () => {
+	expect(readFile).toBeDefined()
+})

--- a/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/other-entry.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/other-entry.js
@@ -1,0 +1,5 @@
+import { readFile } from 'externals-2/foo'
+
+it('should not optimize external modules in different concatenation scope', () => {
+	expect(readFile).toBeDefined()
+})

--- a/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/rspack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "node",
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "[name].mjs"
+	},
+	optimization: {
+		concatenateModules: true
+	},
+	externals: {
+		"externals-1/foo": "fs",
+		"externals-2/foo": "fs?1"
+	},
+	externalsType: "module",
+	experiments: {
+		outputModule: true
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/multi-concat-modules/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["main.mjs"];
+	}
+};


### PR DESCRIPTION
## Summary

Concate render in parallel, and each cannot have information of others. Thus when register global import, it must ensure that there is no other external modules in other concate scope.

eg.

```js
// foo.js in concate module 1
import {v} from 'externals1'

// bar.js in concate module 2
import {v} from 'externals2'
```

Result:

```js
import {v} from 'externals1'
import {v} from 'externals2' // <- duplicated imported specifier

__webpack_modules__ = {
  "concate1": function() { ... }
  "concate2": function() { ... }
}
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
