### PR TITLE
perf(browser): remove tracing

### DIFF
--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -564,10 +564,8 @@ fn register_global_trace(
   output: String,
 ) -> anyhow::Result<()> {
   #[cfg(not(feature = "browser"))]
-  let res = trace_event::register_global_trace(filter, layer, output);
-  #[cfg(feature = "browser")]
-  let res = Ok(());
-  res
+  trace_event::register_global_trace(filter, layer, output)?;
+  Ok(())
 }
 
 #[napi]

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -113,16 +113,8 @@ use rspack_core::{
 use rspack_error::Diagnostic;
 use rspack_fs::{IntermediateFileSystem, NativeFileSystem, ReadableFileSystem};
 use rspack_tasks::{CURRENT_COMPILER_CONTEXT, CompilerContext, within_compiler_context_sync};
-use rspack_tracing::{PerfettoTracer, StdoutTracer, TraceEvent, Tracer};
-use rspack_util::tracing_preset::{
-  TRACING_ALL_PRESET, TRACING_BENCH_TARGET, TRACING_OVERVIEW_PRESET,
-};
 use rustc_hash::FxHashMap;
 use swc_core::common::util::take::Take;
-use tracing::level_filters::LevelFilter;
-use tracing_subscriber::{
-  EnvFilter, Layer, Registry, layer::SubscriberExt, reload, util::SubscriberInitExt,
-};
 
 use crate::{
   async_dependency_block::AsyncDependenciesBlockWrapper,
@@ -488,14 +480,6 @@ fn concurrent_compiler_error() -> Error<ErrorCode> {
   )
 }
 
-#[derive(Default)]
-enum TraceState {
-  Uninitialized,                                            // uninitialized
-  On(Box<dyn Tracer>, reload::Handle<EnvFilter, Registry>), // initialized and turned on
-  #[default]
-  Off,                                          // initialized but turned off
-}
-
 #[cfg(target_family = "wasm")]
 const _: () = {
   #[used]
@@ -564,9 +548,6 @@ fn print_error_diagnostic(e: rspack_error::Error, colored: bool) -> String {
     .expect("should print diagnostics")
 }
 
-thread_local! {
-  static GLOBAL_TRACE_STATE: RefCell<TraceState> = const { RefCell::new(TraceState::Uninitialized) };
-}
 /**
  * this is a process level tracing, which means it would be shared by all compilers in the same process
  * only the first call would take effect, the following calls would be ignored
@@ -582,91 +563,25 @@ fn register_global_trace(
   #[napi(ts_arg_type = " \"logger\" | \"perfetto\" ")] layer: String,
   output: String,
 ) -> anyhow::Result<()> {
-  let filter = match filter.as_str() {
-    "OVERVIEW" => TRACING_OVERVIEW_PRESET,
-    "ALL" => TRACING_ALL_PRESET,
-    "BENCH" => TRACING_BENCH_TARGET,
-    _ => filter.as_str(),
-  };
-  GLOBAL_TRACE_STATE.with(|state| {
-    let mut state = state.borrow_mut();
-    if let TraceState::Uninitialized = *state {
-      let mut tracer: Box<dyn Tracer> = match layer.as_str() {
-        "logger" => Box::new(StdoutTracer),
-        "perfetto"=> Box::new(PerfettoTracer::default()),
-        _ => anyhow::bail!(
-          "Unexpected layer: {}, supported layers:'logger', 'perfetto' ",
-          layer
-        ),
-      };
-      if let Some(layer) = tracer.setup(&output) {
-        // SAFETY: we know that trace_var is `Ok(String)` now,
-        // for the second unwrap, if we can't parse the directive, then the tracing result would be
-        // unexpected, then panic is reasonable
-        let (filter,reload_handle) = reload::Layer::new(EnvFilter::builder()
-          .with_default_directive(LevelFilter::INFO.into())
-          .with_regex(true)
-          .parse(filter)
-          .expect("Parse tracing directive syntax failed, for details about the directive syntax you could refer https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives")
-      );
-        tracing_subscriber::registry()
-          .with(<_ as Layer<Registry>>::with_filter(layer, filter))
-          .init();
-        let new_state = TraceState::On(tracer, reload_handle);
-        *state = new_state;
-      };
-    }
-    Ok(())
-  })
+  #[cfg(not(feature = "browser"))]
+  let res = trace_event::register_global_trace(filter, layer, output);
+  #[cfg(feature = "browser")]
+  let res = Ok(());
+  res
 }
 
 #[napi]
 // only the first call would take effect, the following calls would be ignored
 pub fn cleanup_global_trace() {
-  GLOBAL_TRACE_STATE.with(|state| {
-    let mut state = state.borrow_mut();
-    match *state {
-      TraceState::Uninitialized => {
-        panic!("Global trace is not initialized, please call register_global_trace first");
-      }
-      TraceState::Off => {
-        // do nothing, already cleaned up
-      }
-      TraceState::On(ref mut tracer, ref mut reload_handle) => {
-        tracer.teardown();
-        // turn off the tracing event
-        let _ = reload_handle.modify(|filter| *filter = EnvFilter::new("off"));
-        *state = TraceState::Off;
-      }
-    }
-  });
+  #[cfg(not(feature = "browser"))]
+  trace_event::cleanup_global_trace();
 }
+
 // sync Node.js event to Rust side
 #[napi]
 fn sync_trace_event(events: Vec<RawTraceEvent>) {
-  use std::borrow::BorrowMut;
-  GLOBAL_TRACE_STATE.with(|state| {
-    let mut state = state.borrow_mut();
-    if let TraceState::On(tracer, _) = &mut **state.borrow_mut() {
-      tracer.sync_trace(
-        events
-          .into_iter()
-          .map(|event| TraceEvent {
-            name: event.name,
-            track_name: event.track_name,
-            process_name: event.process_name,
-            args: event
-              .args
-              .map(|args| args.into_iter().map(|(k, v)| (k, v.to_string())).collect()),
-            uuid: event.uuid,
-            ts: event.ts.get_u64().1,
-            ph: event.ph,
-            categories: event.categories,
-          })
-          .collect(),
-      );
-    }
-  });
+  #[cfg(not(feature = "browser"))]
+  trace_event::sync_trace_event(events);
 }
 
 fn node_init(mut _exports: Object, env: Env) -> Result<()> {

--- a/crates/rspack_binding_api/src/trace_event.rs
+++ b/crates/rspack_binding_api/src/trace_event.rs
@@ -1,6 +1,20 @@
+use std::cell::RefCell;
+
 use napi::bindgen_prelude::BigInt;
 use napi_derive::napi;
+use rspack_tracing::{PerfettoTracer, StdoutTracer, TraceEvent, Tracer};
+use rspack_util::tracing_preset::{
+  TRACING_ALL_PRESET, TRACING_BENCH_TARGET, TRACING_OVERVIEW_PRESET,
+};
 use rustc_hash::FxHashMap as HashMap;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{
+  EnvFilter, Layer, Registry, layer::SubscriberExt, reload, util::SubscriberInitExt,
+};
+
+thread_local! {
+  static GLOBAL_TRACE_STATE: RefCell<TraceState> = const { RefCell::new(TraceState::Uninitialized) };
+}
 
 #[napi(object)]
 #[derive(Debug)]
@@ -21,4 +35,106 @@ pub struct RawTraceEvent {
   pub ph: String,
   // category
   pub categories: Option<Vec<String>>,
+}
+
+#[derive(Default)]
+enum TraceState {
+  /// uninitialized
+  Uninitialized,
+  /// initialized and turned on
+  On(Box<dyn Tracer>, reload::Handle<EnvFilter, Registry>),
+  /// initialized but turned off
+  #[default]
+  Off,
+}
+
+pub(super) fn register_global_trace(
+  filter: String,
+  layer: String,
+  output: String,
+) -> anyhow::Result<()> {
+  let filter = match filter.as_str() {
+    "OVERVIEW" => TRACING_OVERVIEW_PRESET,
+    "ALL" => TRACING_ALL_PRESET,
+    "BENCH" => TRACING_BENCH_TARGET,
+    _ => filter.as_str(),
+  };
+  GLOBAL_TRACE_STATE.with(|state| {
+    let mut state = state.borrow_mut();
+    if let TraceState::Uninitialized = *state {
+      let mut tracer: Box<dyn Tracer> = match layer.as_str() {
+        "logger" => Box::new(StdoutTracer),
+        "perfetto"=> Box::new(PerfettoTracer::default()),
+        _ => anyhow::bail!(
+          "Unexpected layer: {}, supported layers:'logger', 'perfetto' ",
+          layer
+        ),
+      };
+      if let Some(layer) = tracer.setup(&output) {
+        // SAFETY: we know that trace_var is `Ok(String)` now,
+        // for the second unwrap, if we can't parse the directive, then the tracing result would be
+        // unexpected, then panic is reasonable
+        let (filter,reload_handle) = reload::Layer::new(EnvFilter::builder()
+          .with_default_directive(LevelFilter::INFO.into())
+          .with_regex(true)
+          .parse(filter)
+          .expect("Parse tracing directive syntax failed, for details about the directive syntax you could refer https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives")
+      );
+        tracing_subscriber::registry()
+          .with(<_ as Layer<Registry>>::with_filter(layer, filter))
+          .init();
+        let new_state = TraceState::On(tracer, reload_handle);
+        *state = new_state;
+      };
+    }
+    Ok(())
+  })
+}
+
+/// only the first call would take effect, the following calls would be ignored
+pub(super) fn cleanup_global_trace() {
+  GLOBAL_TRACE_STATE.with(|state| {
+    let mut state = state.borrow_mut();
+    match *state {
+      TraceState::Uninitialized => {
+        panic!("Global trace is not initialized, please call register_global_trace first");
+      }
+      TraceState::Off => {
+        // do nothing, already cleaned up
+      }
+      TraceState::On(ref mut tracer, ref mut reload_handle) => {
+        tracer.teardown();
+        // turn off the tracing event
+        let _ = reload_handle.modify(|filter| *filter = EnvFilter::new("off"));
+        *state = TraceState::Off;
+      }
+    }
+  });
+}
+
+/// sync Node.js event to Rust side
+pub(super) fn sync_trace_event(events: Vec<RawTraceEvent>) {
+  use std::borrow::BorrowMut;
+  GLOBAL_TRACE_STATE.with(|state| {
+    let mut state = state.borrow_mut();
+    if let TraceState::On(tracer, _) = &mut **state.borrow_mut() {
+      tracer.sync_trace(
+        events
+          .into_iter()
+          .map(|event| TraceEvent {
+            name: event.name,
+            track_name: event.track_name,
+            process_name: event.process_name,
+            args: event
+              .args
+              .map(|args| args.into_iter().map(|(k, v)| (k, v.to_string())).collect()),
+            uuid: event.uuid,
+            ts: event.ts.get_u64().1,
+            ph: event.ph,
+            categories: event.categories,
+          })
+          .collect(),
+      );
+    }
+  });
 }

--- a/crates/rspack_binding_api/src/trace_event.rs
+++ b/crates/rspack_binding_api/src/trace_event.rs
@@ -64,7 +64,7 @@ pub(super) fn register_global_trace(
     if let TraceState::Uninitialized = *state {
       let mut tracer: Box<dyn Tracer> = match layer.as_str() {
         "logger" => Box::new(StdoutTracer),
-        "perfetto"=> Box::new(PerfettoTracer::default()),
+        "perfetto" => Box::new(PerfettoTracer::default()),
         _ => anyhow::bail!(
           "Unexpected layer: {}, supported layers:'logger', 'perfetto' ",
           layer


### PR DESCRIPTION
## Summary

Generally I think nobody will use tracing in browser.

Before: 28.48MB
After: 27.50MB

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
