### PR TITLE
fix: update node inspector import and remove workaround

### DIFF
--- a/packages/rspack/src/trace/index.ts
+++ b/packages/rspack/src/trace/index.ts
@@ -30,14 +30,14 @@ export class JavaScriptTracer {
 	// plugin counter for different channel in trace viewer, choose 100 to avoid conflict with known tracks
 	// biome-ignore lint/correctness/noUnusedPrivateClassMembers: this is a bug of biome which can't analyze cross module usage
 	private static counter = 10000;
+
 	/**
 	 * only first call take effects, subsequent calls will be ignored
 	 * @param layer tracing layer
 	 * @param output tracing output file path
 	 */
 	static async initJavaScriptTrace(layer: string, output: string) {
-		//FIXME:  workaround for Node.js 16 crash bug, remove it when drop support for Node.js 16
-		const { Session } = require("node:inspector");
+		const { Session } = await import("node:inspector");
 		this.session = new Session();
 		this.layer = layer;
 		this.output = output;
@@ -45,6 +45,7 @@ export class JavaScriptTracer {
 		this.state = "on";
 		this.startTime = process.hrtime.bigint(); // use microseconds
 	}
+
 	static uuid() {
 		return this.counter++;
 	}


### PR DESCRIPTION
## Summary

This PR updates the node inspector import and removed workaround since Rspack now require Node.js 18.12+.

## Related links

- reverts https://github.com/web-infra-dev/rspack/pull/10861

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
