### PR TITLE
refactor: clean paren ast for analyzing dependencies

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -19,6 +19,7 @@ use swc_core::{
   ecma::{
     ast,
     parser::{EsSyntax, Syntax, lexer::Lexer},
+    transforms::base::fixer::paren_remover,
   },
 };
 use swc_node_comments::SwcComments;
@@ -227,6 +228,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
 
     let mut semicolons = Default::default();
     ast.transform(|program, context| {
+      program.visit_mut_with(&mut paren_remover(Some(&comments)));
       program.visit_mut_with(&mut resolver(
         context.unresolved_mark,
         context.top_level_mark,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -75,7 +75,7 @@ fn is_module_exports_member_expr_start<E: ExprLike>(expr: &E) -> bool {
 }
 
 fn get_value_of_property_description(expr_or_spread: &ExprOrSpread) -> Option<&Expr> {
-  if let Expr::Object(ObjectLit { props, .. }) = expr_or_spread.expr.unwrap_parens() {
+  if let Expr::Object(ObjectLit { props, .. }) = &*expr_or_spread.expr {
     for prop in props {
       if let PropOrSpread::Prop(prop) = prop
         && let Prop::KeyValue(key_value_prop) = &**prop

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -447,7 +447,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     if let ModuleDecl::ExportDefaultExpr(ExportDefaultExpr { expr, .. }) = export_decl
       && is_pure_expression(expr, self.unresolved_context, parser.comments)
     {
-      let export_part = expr.unwrap_parens();
+      let export_part = &**expr;
       let variable = Self::tag_top_level_symbol(parser, &DEFAULT_STAR_JS_WORD);
       let export_span = export_decl.span();
       parser
@@ -481,10 +481,9 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     {
       let name = &ident.id.sym;
 
-      let unwrapped_init = init.unwrap_parens();
-      if unwrapped_init.is_class()
+      if init.is_class()
         && is_pure_class(
-          &unwrapped_init.as_class().expect("should be class").class,
+          &init.as_class().expect("should be class").class,
           self.unresolved_context,
           parser.comments,
         )
@@ -502,7 +501,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
           .decl_with_top_level_symbol
           .insert(decl.span(), v);
 
-        if !unwrapped_init.is_fn_expr() && !unwrapped_init.is_arrow() && !unwrapped_init.is_lit() {
+        if !init.is_fn_expr() && !init.is_arrow() && !init.is_lit() {
           parser.inner_graph.pure_declarators.insert(decl.span());
         }
       }

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -16,7 +16,7 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{AssertUtf8, Utf8Path};
 use sugar_path::SugarPath;
 use swc_core::{
-  common::{GLOBALS, Span, Spanned, SyntaxContext, comments, comments::Comments},
+  common::{GLOBALS, Spanned, SyntaxContext, comments, comments::Comments},
   ecma::{
     ast::*,
     utils::{ExprCtx, ExprExt},
@@ -334,7 +334,6 @@ fn is_pure_call_expr(
   expr: &Expr,
   unresolved_ctxt: SyntaxContext,
   comments: Option<&dyn Comments>,
-  paren_spans: &mut Vec<Span>,
 ) -> bool {
   let Expr::Call(call_expr) = expr else {
     unreachable!();
@@ -342,17 +341,10 @@ fn is_pure_call_expr(
   let callee = &call_expr.callee;
   let pure_flag = comments
     .and_then(|comments| {
-      paren_spans.push(callee.span());
-      while let Some(span) = paren_spans.pop() {
-        if let Some(comment_list) = comments.get_leading(span.lo)
-          && let Some(last_comment) = comment_list.last()
-          && last_comment.kind == comments::CommentKind::Block
-        {
-          // iterate through the parens and check if it contains pure comment
-          if PURE_COMMENTS.is_match(&last_comment.text) {
-            return Some(true);
-          }
-        }
+      if let Some(comment_list) = comments.get_leading(callee.span().lo) {
+        return Some(comment_list.iter().any(|comment| {
+          comment.kind == comments::CommentKind::Block && PURE_COMMENTS.is_match(&comment.text)
+        }));
       }
       None
     })
@@ -420,20 +412,10 @@ pub fn is_pure_expression<'a>(
     expr: &'a Expr,
     unresolved_ctxt: SyntaxContext,
     comments: Option<&'a dyn Comments>,
-    paren_spans: &mut Vec<Span>,
   ) -> bool {
     match expr {
-      Expr::Call(_) => is_pure_call_expr(expr, unresolved_ctxt, comments, paren_spans),
-      Expr::Paren(par) => {
-        paren_spans.push(par.span());
-        let mut cur = par.expr.as_ref();
-        while let Expr::Paren(paren) = cur {
-          paren_spans.push(paren.span());
-          cur = paren.expr.as_ref();
-        }
-
-        _is_pure_expression(cur, unresolved_ctxt, comments, paren_spans)
-      }
+      Expr::Call(_) => is_pure_call_expr(expr, unresolved_ctxt, comments),
+      Expr::Paren(_) => unreachable!(),
       _ => !expr.may_have_side_effects(ExprCtx {
         unresolved_ctxt,
         is_unresolved_ref_safe: true,
@@ -442,7 +424,7 @@ pub fn is_pure_expression<'a>(
       }),
     }
   }
-  _is_pure_expression(expr, unresolved_ctxt, comments, &mut vec![])
+  _is_pure_expression(expr, unresolved_ctxt, comments)
 }
 
 pub fn is_pure_class_member<'a>(

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_source.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_source.rs
@@ -7,6 +7,8 @@ use swc_core::{
   ecma::{
     ast::EsVersion,
     parser::{EsSyntax, Syntax, parse_file_as_expr},
+    transforms::base::fixer::paren_remover,
+    visit::VisitMutWith,
   },
 };
 
@@ -44,8 +46,11 @@ pub fn eval_source<T: Display>(
       ));
       None
     }
-    Ok(expr) => BasicEvaluatedExpression::with_owned_expression(*expr, |expr| {
-      Some(parser.evaluate_expression(expr))
-    }),
+    Ok(mut expr) => {
+      expr.visit_mut_with(&mut paren_remover(None));
+      BasicEvaluatedExpression::with_owned_expression(*expr, |expr| {
+        Some(parser.evaluate_expression(expr))
+      })
+    }
   }
 }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
@@ -62,7 +62,7 @@ fn eval_typeof<'a>(
 
   let arg = parser.evaluate_expression(&expr.arg);
   if arg.is_unknown() {
-    let arg = expr.arg.unwrap_parens();
+    let arg = &*expr.arg;
     if arg.as_fn_expr().is_some() || arg.as_class().is_some() {
       let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
       res.set_string("function".to_string());

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -982,13 +982,11 @@ impl<'parser> JavascriptParser<'parser> {
     pattern: &ObjectPat,
     expr: &'a Expr,
   ) -> Option<&'a Expr> {
-    let expr = expr.unwrap_parens();
     let expr = if let Some(await_expr) = expr.as_await_expr() {
       &await_expr.arg
     } else {
       expr
     };
-    let expr = expr.unwrap_parens();
     let destructuring = if let Some(assign) = expr.as_assign()
       && let Some(pat) = assign.left.as_pat()
       && let Some(obj_pat) = pat.as_object()

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1114,7 +1114,6 @@ impl JavascriptParser<'_> {
       Expr::Array(array) => eval::eval_array_expression(self, array),
       Expr::New(new) => eval::eval_new_expression(self, new),
       Expr::Call(call) => eval::eval_call_expression(self, call),
-      Expr::Paren(paren) => self.evaluating(&paren.expr),
       Expr::OptChain(opt_chain) => self.enter_optional_chain(
         opt_chain,
         |parser, call| {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
@@ -95,11 +95,6 @@ impl JavascriptParser<'_> {
     if let Some(assign) = stmt.expr.as_assign() {
       self.pre_walk_assignment_expression(assign)
     }
-    if let Some(paren) = stmt.expr.as_paren()
-      && let Some(assign) = paren.expr.as_assign()
-    {
-      self.pre_walk_assignment_expression(assign)
-    }
   }
 
   pub(super) fn block_pre_walk_variable_declaration(&mut self, decl: VariableDeclaration<'_>) {


### PR DESCRIPTION
## Summary

use cleaner ast to analyze dependencies

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
