### PR TITLE
perf: reuse plugin hooks

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -523,7 +523,8 @@ impl JsPlugin {
     chunk_ukey: &ChunkUkey,
     output_path: &str,
   ) -> Result<BoxSource> {
-    let hooks = Self::get_compilation_hooks(compilation.id());
+    let js_plugin_hooks = Self::get_compilation_hooks(compilation.id());
+    let hooks = js_plugin_hooks.read().await;
     let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
     let supports_arrow_function = compilation
       .options
@@ -565,8 +566,6 @@ impl JsPlugin {
     }
     if !all_strict && all_modules.iter().all(|m| m.build_info().strict) {
       if let Some(strict_bailout) = hooks
-        .read()
-        .await
         .strict_runtime_bailout
         .call(compilation, chunk_ukey)
         .await?
@@ -596,6 +595,7 @@ impl JsPlugin {
       &chunk_modules,
       all_strict,
       output_path,
+      &hooks,
     )
     .await?;
     let has_chunk_modules_result = chunk_modules_result.is_some();
@@ -660,6 +660,7 @@ impl JsPlugin {
             all_strict,
             has_chunk_modules_result,
             output_path,
+            &hooks,
           )
           .await?
       } else {
@@ -670,8 +671,16 @@ impl JsPlugin {
         let m = module_graph
           .module_by_identifier(m_identifier)
           .expect("should have module");
-        let Some((mut rendered_module, fragments, additional_fragments)) =
-          render_module(compilation, chunk_ukey, m, all_strict, false, output_path).await?
+        let Some((mut rendered_module, fragments, additional_fragments)) = render_module(
+          compilation,
+          chunk_ukey,
+          m,
+          all_strict,
+          false,
+          output_path,
+          &hooks,
+        )
+        .await?
         else {
           continue;
         };
@@ -704,8 +713,6 @@ impl JsPlugin {
           Some(format!("it uses a non-standard name for the exports ({exports_argument}).").into())
         } else {
           hooks
-            .read()
-            .await
             .embed_in_runtime_bailout
             .call(compilation, m, chunk)
             .await?
@@ -756,8 +763,6 @@ impl JsPlugin {
         source: startup_sources.boxed(),
       };
       hooks
-        .read()
-        .await
         .render_startup
         .call(
           compilation,
@@ -777,8 +782,6 @@ impl JsPlugin {
         source: RawStringSource::from(startup.join("\n") + "\n").boxed(),
       };
       hooks
-        .read()
-        .await
         .render_startup
         .call(
           compilation,
@@ -808,8 +811,6 @@ impl JsPlugin {
       source: final_source,
     };
     hooks
-      .read()
-      .await
       .render
       .call(compilation, chunk_ukey, &mut render_source)
       .await?;
@@ -834,6 +835,7 @@ impl JsPlugin {
     all_strict: bool,
     has_chunk_modules_result: bool,
     output_path: &str,
+    hooks: &JavascriptModulesPluginHooks,
   ) -> Result<Option<IdentifierMap<Arc<dyn Source>>>> {
     let inner_strict = !all_strict && all_modules.iter().all(|m| m.build_info().strict);
     let is_multiple_entries = inlined_modules.len() > 1;
@@ -854,9 +856,18 @@ impl JsPlugin {
 
     let render_module_results = rspack_futures::scope::<_, _>(|token| {
       all_modules.iter().for_each(|module| {
-        let s = unsafe { token.used((compilation, chunk_ukey, module, all_strict, output_path)) };
+        let s = unsafe {
+          token.used((
+            compilation,
+            chunk_ukey,
+            module,
+            all_strict,
+            output_path,
+            &hooks,
+          ))
+        };
         s.spawn(
-          move |(compilation, chunk_ukey, module, all_strict, output_path)| async move {
+          move |(compilation, chunk_ukey, module, all_strict, output_path, hooks)| async move {
             render_module(
               compilation,
               chunk_ukey,
@@ -864,6 +875,7 @@ impl JsPlugin {
               all_strict,
               false,
               output_path,
+              hooks,
             )
             .await
           },
@@ -1162,7 +1174,8 @@ impl JsPlugin {
     chunk_ukey: &ChunkUkey,
     output_path: &str,
   ) -> Result<BoxSource> {
-    let hooks = Self::get_compilation_hooks(compilation.id());
+    let js_plugin_hooks = Self::get_compilation_hooks(compilation.id());
+    let hooks = js_plugin_hooks.read().await;
     let module_graph = &compilation.get_module_graph();
     let is_module = compilation.options.output.module;
     let mut all_strict = compilation.options.output.module;
@@ -1174,8 +1187,6 @@ impl JsPlugin {
     let mut sources = ConcatSource::default();
     if !all_strict && chunk_modules.iter().all(|m| m.build_info().strict) {
       if let Some(strict_bailout) = hooks
-        .read()
-        .await
         .strict_runtime_bailout
         .call(compilation, chunk_ukey)
         .await?
@@ -1194,6 +1205,7 @@ impl JsPlugin {
       &chunk_modules,
       all_strict,
       output_path,
+      &hooks,
     )
     .await?
     .unwrap_or_else(|| (RawStringSource::from_static("{}").boxed(), Vec::new()));
@@ -1201,8 +1213,6 @@ impl JsPlugin {
       source: chunk_modules_source,
     };
     hooks
-      .read()
-      .await
       .render_chunk
       .call(compilation, chunk_ukey, &mut render_source)
       .await?;
@@ -1215,8 +1225,6 @@ impl JsPlugin {
       source: source_with_fragments,
     };
     hooks
-      .read()
-      .await
       .render
       .call(compilation, chunk_ukey, &mut render_source)
       .await?;

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -180,7 +180,8 @@ async fn compilation(
 
   let css_hooks = CssPlugin::get_compilation_hooks_mut(compilation.id());
   css_hooks
-    .borrow_mut()
+    .write()
+    .await
     .render_module_package
     .tap(render_css_module_package::new(self));
 

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -180,8 +180,7 @@ async fn compilation(
 
   let css_hooks = CssPlugin::get_compilation_hooks_mut(compilation.id());
   css_hooks
-    .write()
-    .await
+    .borrow_mut()
     .render_module_package
     .tap(render_css_module_package::new(self));
 


### PR DESCRIPTION
## Summary

Plugin compilation hooks maps are dashmap. Should not get the hook to render every module.

Before:
<img width="1130" height="932" alt="image" src="https://github.com/user-attachments/assets/5e17968d-845c-41f4-b085-c8a7c55fbe1b" />

After:
<img width="1188" height="882" alt="image" src="https://github.com/user-attachments/assets/9cf42531-f4ea-40c6-9bde-8ca1ae064008" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
