### PR TITLE
chore: add Claude local config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,6 @@ trace.json
 
 # Rsapck bench
 .bench
+
+# Claude
+CLAUDE.local.md


### PR DESCRIPTION
## Summary

Add CLAUDE.local.md to .gitignore to prevent local Claude configuration files from being committed to the repository.

## Changes
- Updated .gitignore to exclude CLAUDE.local.md files

## Test plan
- [x] Verified .gitignore excludes local Claude config files  
- [x] Confirmed no breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)