### PR TITLE
perf: not to call module graph modules multiple times

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -666,6 +666,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
   pub fn prepare_input_entrypoints_and_modules(
     &mut self,
+    all_modules: &Vec<ModuleIdentifier>,
     compilation: &mut Compilation,
   ) -> Result<UkeyIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>>> {
     let mut input_entrypoints_and_modules: UkeyIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>> =
@@ -675,9 +676,8 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
     let outgoings = {
       let mg = compilation.get_module_graph();
-      mg.modules()
-        .keys()
-        .par_bridge()
+      all_modules
+        .par_iter()
         .map(|m| {
           (
             *m,
@@ -2006,10 +2006,13 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     }
   }
 
-  pub fn prepare(&mut self, compilation: &Compilation) -> Result<()> {
+  pub fn prepare(
+    &mut self,
+    all_modules: &Vec<ModuleIdentifier>,
+    compilation: &Compilation,
+  ) -> Result<()> {
     let mg = compilation.get_module_graph();
-    let modules = mg.modules().keys().copied().collect::<Vec<_>>();
-    self.prepared_connection_map = modules
+    self.prepared_connection_map = all_modules
       .par_iter()
       .map(|module| {
         let mut connection_map =
@@ -2043,7 +2046,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       })
       .collect::<IdentifierMap<_>>();
 
-    self.prepared_blocks_map = modules
+    self.prepared_blocks_map = all_modules
       .par_iter()
       .map(|module| {
         let mut map =

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use rspack_core::{
   ConnectionState, DependencyCondition, DependencyConditionFn, DependencyId, ExportsInfo,
-  ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, RuntimeSpec, UsageState,
-  UsedByExports,
+  ExportsInfoData, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, RuntimeSpec,
+  UsageState, UsedByExports,
 };
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet;
@@ -45,24 +45,25 @@ fn is_connection_active(
 ) -> bool {
   fn is_export_active(
     name: &Atom,
-    exports_info: &ExportsInfo,
+    exports_info: &ExportsInfoData,
     mg: &ModuleGraph,
     runtime: Option<&RuntimeSpec>,
   ) -> bool {
-    let exports_info = exports_info.as_data(mg);
     if let Some(export_info) = exports_info.named_exports(name) {
       return export_info.get_used(runtime) != UsageState::Unused;
     }
     if let Some(redirect_to) = exports_info.redirect_to() {
-      is_export_active(name, &redirect_to, mg, runtime)
+      let redirect_to = redirect_to.as_data(mg);
+      is_export_active(name, redirect_to, mg, runtime)
     } else {
       exports_info.other_exports_info().get_used(runtime) != UsageState::Unused
     }
   }
 
+  let exports_info = exports_info.as_data(mg);
   used_by_exports
     .iter()
-    .any(|name| is_export_active(name, &exports_info, mg, runtime))
+    .any(|name| is_export_active(name, exports_info, mg, runtime))
 }
 
 // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/InnerGraph.js#L319-L338

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -666,8 +666,9 @@ async fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<O
     std::mem::take(&mut compilation.side_effects_optimize_artifact);
   let module_graph = compilation.get_module_graph();
 
-  let side_effects_state_map: IdentifierMap<ConnectionState> = module_graph
-    .modules()
+  let all_modules = module_graph.modules();
+
+  let side_effects_state_map: IdentifierMap<ConnectionState> = all_modules
     .par_iter()
     .map(|(module_identifier, module)| {
       (
@@ -738,12 +739,12 @@ async fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<O
     logger.log(format!(
       "{} modules are affected, {} in total",
       modules.len(),
-      module_graph.modules().len()
+      all_modules.len()
     ));
 
     modules
   } else {
-    module_graph.modules().keys().copied().collect()
+    all_modules.keys().copied().collect()
   };
   logger.time_end(inner_start);
 

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -326,10 +326,9 @@ async fn optimize_chunk_modules(&self, compilation: &mut Compilation) -> Result<
   }
 
   // 5. Rsdoctor module add issuer_path
-  for module in module_graph.modules() {
+  for (module_id, _) in modules.iter() {
     let mut issuer_path = Vec::new();
-    let (module_id, _) = module;
-    let mut current_issuer = module_graph.get_issuer(&module_id);
+    let mut current_issuer = module_graph.get_issuer(module_id);
 
     while let Some(i) = current_issuer {
       if let Some(rsd_module) = rsd_modules.get_mut(&i.identifier()) {
@@ -343,10 +342,9 @@ async fn optimize_chunk_modules(&self, compilation: &mut Compilation) -> Result<
       current_issuer = module_graph.get_issuer(&i.identifier());
     }
 
-    if let Some(rsd_module) = rsd_modules.get_mut(&module_id) {
+    if let Some(rsd_module) = rsd_modules.get_mut(module_id) {
       rsd_module.issuer_path = Some(issuer_path);
-      let (_, module) = module;
-      let bailout_reason = module_graph.get_optimization_bailout(&module.identifier());
+      let bailout_reason = module_graph.get_optimization_bailout(module_id);
       rsd_module.bailout_reason = bailout_reason.iter().map(|s| s.to_string()).collect();
     }
   }

--- a/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
+++ b/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
@@ -49,11 +49,12 @@ async fn seal(&self, compilation: &mut Compilation) -> Result<()> {
   let start = logger.time("check case sensitive modules");
   let mut diagnostics: Vec<Diagnostic> = vec![];
   let module_graph = compilation.get_module_graph();
+  let all_modules = module_graph.modules();
   let mut not_conflect: FxHashMap<String, Identifier> =
-    HashMap::with_capacity_and_hasher(module_graph.modules().len(), FxBuildHasher);
+    HashMap::with_capacity_and_hasher(all_modules.len(), FxBuildHasher);
   let mut conflict: FxHashMap<String, IdentifierSet> = FxHashMap::default();
 
-  for module in module_graph.modules().values() {
+  for module in all_modules.values() {
     // Ignore `data:` URLs, because it's not a real path
     if let Some(normal_module) = module.as_normal_module()
       && normal_module


### PR DESCRIPTION
## Summary

Should not call `module_graph.modules()` too many times because it cost about 2ms every call

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
