### PR TITLE
feat: tree shake statically analyse-able dynamic import

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -134,8 +134,8 @@ pub struct ContextOptions {
   pub replaces: Vec<(String, u32, u32)>,
   pub start: u32,
   pub end: u32,
-  #[cacheable(with=AsOption<AsVec<AsPreset>>)]
-  pub referenced_exports: Option<Vec<Atom>>,
+  #[cacheable(with=AsOption<AsVec<AsVec<AsPreset>>>)]
+  pub referenced_exports: Option<Vec<Vec<Atom>>>,
   pub attributes: Option<ImportAttributes>,
 }
 
@@ -1115,10 +1115,12 @@ fn create_identifier(options: &ContextModuleOptions) -> Identifier {
   }
   if let Some(exports) = &options.context_options.referenced_exports {
     id += "|referencedExports: ";
-    id += &format!(
-      "[{}]",
-      exports.iter().map(|x| format!(r#""{x}""#)).join(",")
-    );
+    id += "[";
+    for ids in exports {
+      id += &ids.iter().map(|x| format!(r#""{x}""#)).join(".");
+      id += ", ";
+    }
+    id += "]";
   }
 
   if let Some(GroupOptions::ChunkGroup(group)) = &options.context_options.group_options {

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -141,6 +141,10 @@ impl AsyncDependenciesBlock {
     std::mem::take(&mut self.dependencies)
   }
 
+  pub fn dependencies_mut(&mut self) -> &mut [BoxDependency] {
+    &mut self.dependencies
+  }
+
   pub fn add_block(&mut self, _block: AsyncDependenciesBlock) {
     unimplemented!("Nested block are not implemented");
     // self.block_ids.push(block.id);

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -28,8 +28,8 @@ pub struct ContextElementDependency {
   pub context: Context,
   pub layer: Option<ModuleLayer>,
   pub resource_identifier: String,
-  #[cacheable(with=AsOption<AsVec<AsPreset>>)]
-  pub referenced_exports: Option<Vec<Atom>>,
+  #[cacheable(with=AsOption<AsVec<AsVec<AsPreset>>>)]
+  pub referenced_exports: Option<Vec<Vec<Atom>>>,
   pub dependency_type: DependencyType,
   pub attributes: Option<ImportAttributes>,
   pub factorize_info: FactorizeInfo,
@@ -86,48 +86,46 @@ impl Dependency for ContextElementDependency {
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ExtendedReferencedExport> {
     if let Some(referenced_exports) = &self.referenced_exports {
-      if matches!(
-        self.dependency_type,
-        DependencyType::ContextElement(ContextTypePrefix::Import)
-      ) && referenced_exports
-        .first()
-        .is_some_and(|export| export == "default")
-      {
-        let is_strict = module_graph
-          .get_parent_module(&self.id)
-          .and_then(|id| module_graph.module_by_identifier(id))
-          .and_then(|m| m.as_context_module())
-          .map(|m| {
-            matches!(
-              m.get_context_options().namespace_object,
-              ContextNameSpaceObject::Strict
-            )
+      for referenced_export in referenced_exports {
+        if matches!(
+          self.dependency_type,
+          DependencyType::ContextElement(ContextTypePrefix::Import)
+        ) && referenced_export
+          .first()
+          .is_some_and(|export| export == "default")
+        {
+          let is_strict = module_graph
+            .get_parent_module(&self.id)
+            .and_then(|id| module_graph.module_by_identifier(id))
+            .and_then(|m| m.as_context_module())
+            .map(|m| {
+              matches!(
+                m.get_context_options().namespace_object,
+                ContextNameSpaceObject::Strict
+              )
+            });
+
+          let exports_type = is_strict.and_then(|is_strict| {
+            module_graph
+              .get_module_by_dependency_id(&self.id)
+              .map(|m| m.get_exports_type(module_graph, module_graph_cache, is_strict))
           });
 
-        let exports_type = is_strict.and_then(|is_strict| {
-          module_graph
-            .get_module_by_dependency_id(&self.id)
-            .map(|m| m.get_exports_type(module_graph, module_graph_cache, is_strict))
-        });
-
-        if let Some(exports_type) = exports_type
-          && matches!(
-            exports_type,
-            ExportsType::DefaultOnly | ExportsType::DefaultWithNamed
-          )
-        {
-          return create_exports_object_referenced();
+          if let Some(exports_type) = exports_type
+            && matches!(
+              exports_type,
+              ExportsType::DefaultOnly | ExportsType::DefaultWithNamed
+            )
+          {
+            return create_exports_object_referenced();
+          }
         }
       }
 
       referenced_exports
         .iter()
         .map(|export| {
-          ExtendedReferencedExport::Export(ReferencedExport::new(
-            vec![export.clone()],
-            false,
-            false,
-          ))
+          ExtendedReferencedExport::Export(ReferencedExport::new(export.clone(), false, false))
         })
         .collect_vec()
     } else {

--- a/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
@@ -51,7 +51,11 @@ fn create_resource_identifier_for_context_dependency(
   let referenced_exports = options
     .referenced_exports
     .as_ref()
-    .map(|x| x.iter().map(|x| format!(r#""{x}""#)).join(","))
+    .map(|x| {
+      x.iter()
+        .map(|x| x.iter().map(|x| format!(r#""{x}""#)).join("."))
+        .join(",")
+    })
     .unwrap_or_default();
   let mut group_options = String::new();
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -15,14 +15,16 @@ use super::create_resource_identifier_for_esm_dependency;
 
 pub fn create_import_dependency_referenced_exports(
   dependency_id: &DependencyId,
-  referenced_exports: &Option<Vec<Atom>>,
+  referenced_exports: &Option<Vec<Vec<Atom>>>,
   mg: &ModuleGraph,
   mg_cache: &ModuleGraphCacheArtifact,
 ) -> Vec<ExtendedReferencedExport> {
   if let Some(referenced_exports) = referenced_exports {
     let mut refs = vec![];
     for referenced_export in referenced_exports {
-      if referenced_export == "default" {
+      if let Some(first) = referenced_export.first()
+        && first == "default"
+      {
         let Some(strict) = mg
           .get_parent_module(dependency_id)
           .and_then(|id| mg.module_by_identifier(id))
@@ -45,7 +47,7 @@ pub fn create_import_dependency_referenced_exports(
         }
       }
       refs.push(ExtendedReferencedExport::Export(ReferencedExport::new(
-        vec![referenced_export.clone()],
+        referenced_export.clone(),
         false,
         false,
       )));
@@ -63,8 +65,8 @@ pub struct ImportDependency {
   #[cacheable(with=AsPreset)]
   pub request: Atom,
   pub range: DependencyRange,
-  #[cacheable(with=AsOption<AsVec<AsPreset>>)]
-  pub referenced_exports: Option<Vec<Atom>>,
+  #[cacheable(with=AsOption<AsVec<AsVec<AsPreset>>>)]
+  pub referenced_exports: Option<Vec<Vec<Atom>>>,
   pub attributes: Option<ImportAttributes>,
   pub comments: Vec<(bool, String)>,
   pub resource_identifier: String,
@@ -76,7 +78,7 @@ impl ImportDependency {
   pub fn new(
     request: Atom,
     range: DependencyRange,
-    referenced_exports: Option<Vec<Atom>>,
+    referenced_exports: Option<Vec<Vec<Atom>>>,
     attributes: Option<ImportAttributes>,
     optional: bool,
     comments: Vec<(bool, String)>,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -22,8 +22,8 @@ pub struct ImportEagerDependency {
   #[cacheable(with=AsPreset)]
   request: Atom,
   range: DependencyRange,
-  #[cacheable(with=AsOption<AsVec<AsPreset>>)]
-  referenced_exports: Option<Vec<Atom>>,
+  #[cacheable(with=AsOption<AsVec<AsVec<AsPreset>>>)]
+  referenced_exports: Option<Vec<Vec<Atom>>>,
   attributes: Option<ImportAttributes>,
   resource_identifier: String,
   factorize_info: FactorizeInfo,
@@ -33,7 +33,7 @@ impl ImportEagerDependency {
   pub fn new(
     request: Atom,
     range: DependencyRange,
-    referenced_exports: Option<Vec<Atom>>,
+    referenced_exports: Option<Vec<Vec<Atom>>>,
     attributes: Option<ImportAttributes>,
   ) -> Self {
     let resource_identifier =

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -53,7 +53,7 @@ pub(crate) use self::{
   exports_info_api_plugin::ExportsInfoApiPlugin,
   import_meta_context_dependency_parser_plugin::ImportMetaContextDependencyParserPlugin,
   import_meta_plugin::{ImportMetaDisabledPlugin, ImportMetaPlugin},
-  import_parser_plugin::ImportParserPlugin,
+  import_parser_plugin::{ImportParserPlugin, ImportsReferencesState},
   initialize_evaluating::InitializeEvaluating,
   inline_const::{InlineConstPlugin, InlineValueDependencyCondition},
   inner_graph::{get_dependency_used_by_exports_condition, plugin::*, state::InnerGraphState},

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -34,7 +34,7 @@ use swc_core::{
 };
 
 use crate::{
-  BoxJavascriptParserPlugin,
+  BoxJavascriptParserPlugin, ImportsReferencesState,
   dependency::local_module::LocalModule,
   parser_plugin::{self, InnerGraphState, JavaScriptParserPluginDrive, JavascriptParserPlugin},
   utils::eval::{self, BasicEvaluatedExpression},
@@ -255,6 +255,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) is_esm: bool,
   pub(crate) destructuring_assignment_properties:
     Option<FxHashMap<Span, FxHashSet<DestructuringAssignmentProperty>>>,
+  pub(crate) dynamic_import_references: ImportsReferencesState,
   pub(crate) worker_index: u32,
   pub(crate) parser_exports_state: Option<bool>,
   pub(crate) local_modules: Vec<LocalModule>,
@@ -422,6 +423,7 @@ impl<'parser> JavascriptParser<'parser> {
       module_identifier,
       member_expr_in_optional_chain: false,
       destructuring_assignment_properties: None,
+      dynamic_import_references: Default::default(),
       semicolons,
       statement_path: Default::default(),
       current_tag_info: None,


### PR DESCRIPTION
## Summary

Port: https://github.com/webpack/webpack/pull/19818

```js
let m = await import("./m");
m.a; // a is used, rest can be tree-shaken
m.f() // f is used, rest can be tree-shaken if strictThisContextOnImports = false
m // m namespace is used, can't be tree-shaken
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
