### PR TITLE
fix: update event handling to support batch processing of FsEvents

### DIFF
--- a/crates/rspack_fs/src/watcher/executor.rs
+++ b/crates/rspack_fs/src/watcher/executor.rs
@@ -10,7 +10,7 @@ use tokio::sync::{
 };
 
 use super::{EventAggregateHandler, EventHandler, FsEventKind};
-use crate::watcher::BatchEvents;
+use crate::watcher::EventBatch;
 
 type ThreadSafetyReceiver<T> = ThreadSafety<UnboundedReceiver<T>>;
 type ThreadSafety<T> = Arc<Mutex<T>>;
@@ -33,7 +33,7 @@ impl FilesData {
 /// deleted files, and coordinates the event handling logic.
 pub struct Executor {
   aggregate_timeout: u32,
-  rx: ThreadSafetyReceiver<BatchEvents>,
+  rx: ThreadSafetyReceiver<EventBatch>,
   files_data: ThreadSafety<FilesData>,
   exec_aggregate_tx: UnboundedSender<ExecAggregateEvent>,
   exec_aggregate_rx: ThreadSafetyReceiver<ExecAggregateEvent>,
@@ -60,13 +60,13 @@ enum ExecAggregateEvent {
 }
 
 enum ExecEvent {
-  Execute(BatchEvents),
+  Execute(EventBatch),
   Close,
 }
 
 impl Executor {
   /// Create a new `WatcherExecutor` with the given receiver and optional aggregate timeout.
-  pub fn new(rx: UnboundedReceiver<BatchEvents>, aggregate_timeout: Option<u32>) -> Self {
+  pub fn new(rx: UnboundedReceiver<EventBatch>, aggregate_timeout: Option<u32>) -> Self {
     let (exec_aggregate_tx, exec_aggregate_rx) = mpsc::unbounded_channel::<ExecAggregateEvent>();
     let (exec_tx, exec_rx) = mpsc::unbounded_channel::<ExecEvent>();
 

--- a/crates/rspack_fs/src/watcher/mod.rs
+++ b/crates/rspack_fs/src/watcher/mod.rs
@@ -39,7 +39,7 @@ pub(crate) struct FsEvent {
   pub kind: FsEventKind,
 }
 
-pub(crate) type BatchEvents = Vec<FsEvent>;
+pub(crate) type EventBatch = Vec<FsEvent>;
 
 /// `EventAggregateHandler` is a trait for handling aggregated file system events.
 /// It provides methods to handle changes and deletions of files, as well as errors.

--- a/crates/rspack_fs/src/watcher/mod.rs
+++ b/crates/rspack_fs/src/watcher/mod.rs
@@ -39,6 +39,8 @@ pub(crate) struct FsEvent {
   pub kind: FsEventKind,
 }
 
+pub(crate) type BatchEvents = Vec<FsEvent>;
+
 /// `EventAggregateHandler` is a trait for handling aggregated file system events.
 /// It provides methods to handle changes and deletions of files, as well as errors.
 /// Implementors of this trait can define custom behavior for these events.

--- a/crates/rspack_fs/src/watcher/scanner.rs
+++ b/crates/rspack_fs/src/watcher/scanner.rs
@@ -3,16 +3,17 @@ use std::{ops::Deref, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::{FsEvent, FsEventKind, PathManager};
+use crate::watcher::BatchEvents;
 
 // Scanner will scann the path whether it is exist or not in disk on initialization
 pub struct Scanner {
   path_manager: Arc<PathManager>,
-  tx: Option<UnboundedSender<Vec<FsEvent>>>,
+  tx: Option<UnboundedSender<BatchEvents>>,
 }
 
 impl Scanner {
   /// Creates a new `Scanner` that will send events to the provided sender when paths are scanned.
-  pub fn new(tx: UnboundedSender<Vec<FsEvent>>, path_manager: Arc<PathManager>) -> Self {
+  pub fn new(tx: UnboundedSender<BatchEvents>, path_manager: Arc<PathManager>) -> Self {
     Self {
       path_manager,
       tx: Some(tx),

--- a/crates/rspack_fs/src/watcher/scanner.rs
+++ b/crates/rspack_fs/src/watcher/scanner.rs
@@ -3,17 +3,17 @@ use std::{ops::Deref, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::{FsEvent, FsEventKind, PathManager};
-use crate::watcher::BatchEvents;
+use crate::watcher::EventBatch;
 
 // Scanner will scann the path whether it is exist or not in disk on initialization
 pub struct Scanner {
   path_manager: Arc<PathManager>,
-  tx: Option<UnboundedSender<BatchEvents>>,
+  tx: Option<UnboundedSender<EventBatch>>,
 }
 
 impl Scanner {
   /// Creates a new `Scanner` that will send events to the provided sender when paths are scanned.
-  pub fn new(tx: UnboundedSender<BatchEvents>, path_manager: Arc<PathManager>) -> Self {
+  pub fn new(tx: UnboundedSender<EventBatch>, path_manager: Arc<PathManager>) -> Self {
     Self {
       path_manager,
       tx: Some(tx),

--- a/crates/rspack_fs/src/watcher/trigger.rs
+++ b/crates/rspack_fs/src/watcher/trigger.rs
@@ -5,7 +5,7 @@ use rspack_paths::ArcPath;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::{FsEvent, FsEventKind};
-use crate::watcher::{BatchEvents, paths::PathManager};
+use crate::watcher::{EventBatch, paths::PathManager};
 /// `DependencyFinder` provides references to sets of files, directories, and missing paths,
 /// allowing efficient lookup and dependency resolution for a given path.
 ///
@@ -91,12 +91,12 @@ pub struct Trigger {
   /// Shared reference to the path register, which tracks watched files/directories/missing.
   path_manager: Arc<PathManager>,
   /// Sender for communicating file system events to the watcher executor.
-  tx: UnboundedSender<BatchEvents>,
+  tx: UnboundedSender<EventBatch>,
 }
 
 impl Trigger {
   /// Create a new `Trigger` with the given path register and event sender.
-  pub fn new(path_manager: Arc<PathManager>, tx: UnboundedSender<BatchEvents>) -> Self {
+  pub fn new(path_manager: Arc<PathManager>, tx: UnboundedSender<EventBatch>) -> Self {
     Self { path_manager, tx }
   }
 

--- a/crates/rspack_fs/src/watcher/trigger.rs
+++ b/crates/rspack_fs/src/watcher/trigger.rs
@@ -134,7 +134,7 @@ impl Trigger {
     }
   }
 
-  /// Sends a group file system events for the given path and event kind.
+  /// Sends a group of file system events for the given path and event kind.
   /// If the event is successfully sent, it returns true; otherwise, it returns false.
   fn trigger_events(&self, events: Vec<(ArcPath, FsEventKind)>) -> bool {
   /// Returns `Ok(())` if the event is successfully sent, or an error otherwise.

--- a/crates/rspack_fs/src/watcher/trigger.rs
+++ b/crates/rspack_fs/src/watcher/trigger.rs
@@ -137,7 +137,8 @@ impl Trigger {
   /// Sends a group file system events for the given path and event kind.
   /// If the event is successfully sent, it returns true; otherwise, it returns false.
   fn trigger_events(&self, events: Vec<(ArcPath, FsEventKind)>) -> bool {
-    // TODO: handle a result
+  /// Returns `Ok(())` if the event is successfully sent, or an error otherwise.
+  fn trigger_events(&self, events: Vec<(ArcPath, FsEventKind)>) -> Result<(), tokio::sync::mpsc::error::SendError<Vec<FsEvent>>> {
     self
       .tx
       .send(

--- a/crates/rspack_fs/src/watcher/trigger.rs
+++ b/crates/rspack_fs/src/watcher/trigger.rs
@@ -137,8 +137,6 @@ impl Trigger {
   /// Sends a group of file system events for the given path and event kind.
   /// If the event is successfully sent, it returns true; otherwise, it returns false.
   fn trigger_events(&self, events: Vec<(ArcPath, FsEventKind)>) -> bool {
-  /// Returns `Ok(())` if the event is successfully sent, or an error otherwise.
-  fn trigger_events(&self, events: Vec<(ArcPath, FsEventKind)>) -> Result<(), tokio::sync::mpsc::error::SendError<Vec<FsEvent>>> {
     self
       .tx
       .send(

--- a/crates/rspack_fs/src/watcher/trigger.rs
+++ b/crates/rspack_fs/src/watcher/trigger.rs
@@ -5,7 +5,7 @@ use rspack_paths::ArcPath;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::{FsEvent, FsEventKind};
-use crate::watcher::paths::PathManager;
+use crate::watcher::{BatchEvents, paths::PathManager};
 /// `DependencyFinder` provides references to sets of files, directories, and missing paths,
 /// allowing efficient lookup and dependency resolution for a given path.
 ///
@@ -91,12 +91,12 @@ pub struct Trigger {
   /// Shared reference to the path register, which tracks watched files/directories/missing.
   path_manager: Arc<PathManager>,
   /// Sender for communicating file system events to the watcher executor.
-  tx: UnboundedSender<Vec<FsEvent>>,
+  tx: UnboundedSender<BatchEvents>,
 }
 
 impl Trigger {
   /// Create a new `Trigger` with the given path register and event sender.
-  pub fn new(path_manager: Arc<PathManager>, tx: UnboundedSender<Vec<FsEvent>>) -> Self {
+  pub fn new(path_manager: Arc<PathManager>, tx: UnboundedSender<BatchEvents>) -> Self {
     Self { path_manager, tx }
   }
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
This PR refactors the file system event handling architecture to support batch processing of FsEvents. 

The batch event will so fast consume if user setting watchOptions.aggregateTimeout as zero.

We should batch processing associated_event by trigger finding. Otherwise it will trigger twice callback.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
