### PR TITLE
fix(browser): rename and ignore requests with match resource and inline loaders

### DIFF
--- a/packages/rspack/src/browser/BrowserHttpImportEsmPlugin.ts
+++ b/packages/rspack/src/browser/BrowserHttpImportEsmPlugin.ts
@@ -35,7 +35,7 @@ export class BrowserHttpImportEsmPlugin {
 
 				// We don't consider match resource and inline loaders
 				// Because usually they are not used with dependent modules like `sass-loader?react`
-				if (request.includes("!=!")) {
+				if (request.includes("!")) {
 					return;
 				}
 

--- a/packages/rspack/src/browser/BrowserHttpImportEsmPlugin.ts
+++ b/packages/rspack/src/browser/BrowserHttpImportEsmPlugin.ts
@@ -24,7 +24,7 @@ interface BrowserHttpImportPluginOptions {
 /**
  * Convert imports of dependencies in node modules to http imports from esm cdn.
  */
-export class BrowserImportEsmPlugin {
+export class BrowserHttpImportEsmPlugin {
 	constructor(private options: BrowserHttpImportPluginOptions = {}) {}
 
 	apply(compiler: Compiler) {

--- a/packages/rspack/src/browser/index.ts
+++ b/packages/rspack/src/browser/index.ts
@@ -1,5 +1,5 @@
 export * from "../index";
-export { BrowserImportEsmPlugin } from "./BrowserImportEsmPlugin";
+export { BrowserHttpImportEsmPlugin } from "./BrowserHttpImportEsmPlugin";
 
 import { fs, volume } from "./fs";
 export const builtinMemFs = {


### PR DESCRIPTION
## Summary

1. Rename `BrowserImportEsmPlugin` -> `BrowserHttpImportEsmPlugin`. Since `@rspack/browser` is still experimental, this breaking change is acceptable.
2. Ignore requests with match resource and inline loaders by filtering requests including `!`. I think generally there isn't request for dependent modules with inline loader like `sass-loader?react`
3. Only focus on http scheme.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
