### PR TITLE
docs: add guide for the `@rspack/browser` package

### DIFF
--- a/packages/rspack-browser/README.md
+++ b/packages/rspack-browser/README.md
@@ -1,0 +1,15 @@
+<picture>
+  <img alt="Rspack Banner" src="https://assets.rspack.rs/rspack/rspack-banner.png">
+</picture>
+
+# @rspack/browser
+
+Rspack for running in the browser. This is still in early stage and may not follow the semver.
+
+## Documentation
+
+See <https://rspack.rs/api/javascript-api/browser> for details.
+
+## License
+
+Rspack is [MIT licensed](https://github.com/web-infra-dev/rspack/blob/main/LICENSE).

--- a/website/docs/en/api/javascript-api/_meta.json
+++ b/website/docs/en/api/javascript-api/_meta.json
@@ -7,5 +7,6 @@
   "logger",
   "cache",
   "swc",
-  "resolver"
+  "resolver",
+  "browser"
 ]

--- a/website/docs/en/api/javascript-api/browser.mdx
+++ b/website/docs/en/api/javascript-api/browser.mdx
@@ -69,7 +69,7 @@ builtinMemFs.volume.fromJSON({
 import { BrowserHttpImportEsmPlugin } from '@rspack/browser';
 
 export default {
-  plugins: [new BrowserHttpImportEsmPlugin()],
+  plugins: [new BrowserHttpImportEsmPlugin({ domain: 'https://esm.sh' })],
   experiments: {
     buildHttp: {
       allowedUris: ['https://'],
@@ -84,9 +84,8 @@ As shown below, `BrowserHttpImportEsmPlugin` supports options to specify the ESM
 interface BrowserHttpImportPluginOptions {
   /**
    * ESM CDN domain
-   * @default "https://esm.sh"
    */
-  domain?: string | ((request: string, packageName: string) => string);
+  domain: string | ((request: string, packageName: string) => string);
   /**
    * Specify URLs for particular dependencies
    */

--- a/website/docs/en/api/javascript-api/browser.mdx
+++ b/website/docs/en/api/javascript-api/browser.mdx
@@ -1,0 +1,161 @@
+# Browser API
+
+`@rspack/browser` is a version of Rspack specifically designed for browser environments, without relying on WebContainers or any particular platform. Its API is consistent with the [JavaScript API](/api/javascript-api/) of `@rspack/core`, while additionally providing features and interfaces tailored for the browser environment.
+
+Welcome to try running Rspack in the browser at the [Rspack Playground](https://playground.rspack.rs/).
+
+:::warning
+`@rspack/browser` is currently experimental. We will continue to improve its online bundling capabilities, and future releases may introduce breaking changes.
+:::
+
+## Basic example
+
+The following example demonstrates the basic usage of `@rspack/browser`. Except for the additional APIs used to read and write project files and outputs, other APIs are consistent with the [JavaScript API](/api/javascript-api/) of `@rspack/core`.
+
+```ts
+import { rspack, builtinMemFs } from '@rspack/browser';
+
+// Write files to memfs
+builtinMemFs.volume.fromJSON({
+  // ...project files
+});
+
+rspack({}, (err, stats) => {
+  if (err || stats.hasErrors()) {
+    // ...
+  }
+  // Get output from memfs after bundling
+  const files = builtinMemFs.volume.toJSON();
+});
+```
+
+## In-Memory File system
+
+Since browsers cannot directly access the local file system, `@rspack/browser` provides an in-memory file system object `builtinMemFs` based on [memfs](https://www.npmjs.com/package/memfs) for reading and writing files in the browser environment. All file system reads and writes in both the Node.js and Rust sides are redirected to this in-memory file system, including reading project configuration, source code, `node_modules` dependencies, and writing output files.
+
+Here is a basic usage example. For the full API, please refer to the [memfs documentation](https://github.com/streamich/memfs):
+
+```ts
+import { builtinMemFs } from '@rspack/browser';
+
+// Write files to memfs
+builtinMemFs.volume.fromJSON({
+  // ...project files
+});
+
+// Read files from memfs
+const files = builtinMemFs.volume.toJSON();
+```
+
+## Browser-Specific Plugins
+
+To better meet the bundling needs in browser environments, `@rspack/browser` offers several dedicated plugins.
+
+### BrowserHttpImportEsmPlugin
+
+In local development, developers usually download project dependencies via package managers and store them in the `node_modules` directory at the root of the project. When using `@rspack/browser`, you can pre-write dependencies into the `node_modules` directory within the in-memory file system. However, when the modules your project depends on are uncertain (e.g., allowing users to freely choose third-party dependencies), pre-writing all dependencies becomes impractical.
+
+```ts
+import { builtinMemFs } from '@rspack/browser';
+
+builtinMemFs.volume.fromJSON({
+  '/node_modules/react/index.js': '...',
+});
+```
+
+`@rspack/browser` provides the `BrowserHttpImportEsmPlugin` plugin. This plugin rewrites third-party dependency module specifiers to URLs of ESM CDNs during module resolution. For example, `import React from "react"` will be rewritten as `import React from "https://esm.sh/react"`. Together with Rspack's [buildHttp](/config/experiments#experimentsbuildhttp) feature, dependencies can be dynamically loaded over HTTP during bundling.
+
+```js title="rspack.config.mjs"
+import { BrowserHttpImportEsmPlugin } from '@rspack/browser';
+
+export default {
+  plugins: [new BrowserHttpImportEsmPlugin()],
+  experiments: {
+    buildHttp: {
+      allowedUris: ['https://'],
+    },
+  },
+};
+```
+
+As shown below, `BrowserHttpImportEsmPlugin` supports options to specify the ESM CDN domain or to specify particular versions or URLs for certain dependencies.
+
+```ts
+interface BrowserHttpImportPluginOptions {
+  /**
+   * ESM CDN domain
+   * @default "https://esm.sh"
+   */
+  domain?: string | ((request: string, packageName: string) => string);
+  /**
+   * Specify URLs for particular dependencies
+   */
+  dependencyUrl?:
+    | Record<string, string | undefined>
+    | ((packageName: string) => string | undefined);
+  /**
+   * Specify versions for dependencies.
+   * Defaults to "latest" if not specified.
+   */
+  dependencyVersions?: Record<string, string | undefined>;
+}
+```
+
+### BrowserRequirePlugin
+
+In Rspack, certain scenarios require dynamically loading and executing JavaScript code, such as [Loaders](/guide/features/loader) or the template functions of [HtmlRspackPlugin](/plugins/rspack/html-rspack-plugin#use-template-function). Since this code may come from untrusted users, executing it directly in the browser environment poses potential security risks. To ensure safety, `@rspack/browser` throws errors by default in such cases to prevent unsafe code execution.
+
+:::warning
+Rspack does not execute user code during bundling. For security, it is recommended to run the final bundled output inside an iframe.
+:::
+
+The `BrowserRequirePlugin` plugin enables this capability:
+
+```js title="rspack.config.mjs"
+import { BrowserRequirePlugin } from '@rspack/browser';
+
+export default {
+  plugins: [
+    new BrowserRequirePlugin({ execute: BrowserRequirePlugin.unsafeExecute }),
+  ],
+};
+```
+
+You need to provide an `execute` function to dynamically run and load CommonJS modules and modify `runtime.module.exports` to set the module's exports. `@rspack/browser` provides an unsafe implementation `BrowserRequirePlugin.unsafeExecute` that internally uses `new Function` to execute code. You can also implement a safer version based on this API according to your needs, for example:
+
+```ts
+function safeExecute(code: string, runtime: CommonJsRuntime) {
+  const safeCode = sanitizeCode(code);
+  BrowserRequirePlugin.unsafeExecute(safeCode, runtime);
+}
+
+function uselessExecute(_code: string, runtime: CommonJsRuntime) {
+  runtime.module.exports.hello = 'rspack';
+}
+```
+
+Options for `BrowserRequirePlugin` are as follows:
+
+```ts
+/**
+ * Runtime context for loading CommonJS modules
+ */
+interface CommonJsRuntime {
+  module: any;
+  exports: any;
+  require: BrowserRequire;
+}
+
+interface BrowserRequirePluginOptions {
+  /**
+   * Function to execute dynamic code
+   */
+  execute: (code: string, runtime: CommonJsRuntime) => void;
+}
+```
+
+:::tip How to decide whether to use this plugin?
+If your project does not require dynamic loading and execution of JavaScript code, you do not need this plugin.
+
+If your project does not distribute untrusted code or distributing such code does not cause security issues, you can directly use `BrowserRequirePlugin.unsafeExecute`. For example, the [Rspack Playground](https://playground.rspack.rs/) does not involve user privacy or account security.
+:::

--- a/website/docs/zh/api/javascript-api/_meta.json
+++ b/website/docs/zh/api/javascript-api/_meta.json
@@ -7,5 +7,6 @@
   "logger",
   "cache",
   "swc",
-  "resolver"
+  "resolver",
+  "browser"
 ]

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -105,6 +105,10 @@ interface BrowserHttpImportPluginOptions {
 
 在 Rspack/Webpack 中，某些场景需要动态加载和执行 JavaScript 代码，如 [Loader](/guide/features/loader) 或 [HtmlRspackPlugin 的模板函数](https://rspack.rs/plugins/rspack/html-rspack-plugin#use-template-function)。这些代码可能由不可信用户创建和分发，直接在浏览器执行存在安全隐患，因此 `@rspack/browser` 默认会在这些场景下抛出错误。
 
+:::warning
+Rspack 在打包过程中不会执行项目的业务代码。对于最终的打包产物，你应该在 iframe 中运行它们。
+:::
+
 `BrowserRequirePlugin` 插件开放了此类能力：
 
 ```js title="rspack.config.mjs"

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -103,7 +103,7 @@ interface BrowserHttpImportPluginOptions {
 
 ### BrowserRequirePlugin
 
-在 Rspack/Webpack 中，某些场景需要动态加载和执行 JavaScript 代码，如 [Loader](/guide/features/loader) 或 [HtmlRspackPlugin 的模板函数](https://rspack.rs/plugins/rspack/html-rspack-plugin#use-template-function)。这些代码可能由不可信用户创建和分发，直接在浏览器执行存在安全隐患，因此 `@rspack/browser` 默认会在这些场景下抛出错误。
+在 Rspack 中，某些场景需要动态加载和执行 JavaScript 代码，如 [Loader](/guide/features/loader) 或 [HtmlRspackPlugin 的模板函数](/plugins/rspack/html-rspack-plugin#use-template-function)。由于这些代码可能来自不可信的第三方用户，直接在浏览器环境中执行会带来潜在的安全风险。为了保障安全性，`@rspack/browser` 在遇到此类场景时会默认抛出错误，阻止不安全代码的执行。
 
 :::warning
 Rspack 在打包过程中不会执行项目的用户代码。为了安全起见，建议在 iframe 中运行最终的打包产物。

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -53,7 +53,7 @@ const files = builtinMemFs.volume.toJSON();
 
 ### BrowserHttpImportEsmPlugin
 
-在本地开发环境中，开发者通常通过包管理器将所有依赖下载并存储于项目根目录的 `node_modules` 文件夹。因为 `@rspack/browser` 的行为也与 `@rspack/core` 保持一致，你可以将依赖写入内存文件系统的 `node_modules` 文件夹。但如果项目依赖的模块不确定（如允许用户自由选择第三方依赖），预先写入所有依赖就不现实了。
+在本地开发环境中，开发者通常通过包管理器将项目依赖下载并存储在根目录的 `node_modules` 目录中。在使用 `@rspack/browser ` 时，你可以将依赖项预先写入内存文件系统的 `node_modules` 目录。然而，当项目依赖的模块存在不确定性时（例如允许用户自由选择第三方依赖），预先写入所有依赖就变得不切实际。
 
 ```typescript
 import { builtinMemFs } from '@rspack/browser';

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -1,0 +1,157 @@
+# Browser API
+
+`@rspack/browser` 是专为浏览器环境打造的 Rspack 版本，无需依赖 WebContainers 或特定平台。其 API 与 `@rspack/core` 的 [JavaScript API](/api/javascript-api/) 保持一致，并在此基础上，额外提供了适配浏览器环境的特性和接口。
+
+我们将持续完善在线打包相关能力，欢迎前往 [Rspack Playground](https://playground.rspack.rs/) 体验。
+
+:::warning
+目前 `@rspack/browser` 仍处于实验阶段，后续可能会有不兼容的变更。
+:::
+
+## 基本示例
+
+以下示例展示了 `@rspack/browser` 的基本用法。除了需要使用额外的 API 读写项目文件和产物外，其他 API 与 `@rspack/core` 的 [JavaScript API](/api/javascript-api/) 保持一致。
+
+```typescript
+import { rspack, builtinMemFs } from '@rspack/browser';
+
+// Write files to memfs
+builtinMemFs.volume.fromJSON({
+  // ...project files
+});
+
+rspack({}, (err, stats) => {
+  if (err || stats.hasErrors()) {
+    // ...
+  }
+  // Get output from memfs after bundling
+  const files = builtinMemFs.volume.toJSON();
+});
+```
+
+## 内存文件系统
+
+由于浏览器无法直接访问本地文件系统，`@rspack/browser` 提供了基于 [memfs](https://www.npmjs.com/package/memfs) 的内存文件系统对象 `builtinMemFs`，用于在浏览器环境下读写文件。`@rspack/core` 的 Node.js 和 Rust 层对文件系统的读写均会重定向到该内存文件系统，包括项目配置、源代码、`node_modules` 依赖及产物。
+
+以下是基本用法示例，完整 API 可参考 [memfs 文档](https://github.com/streamich/memfs)：
+
+```typescript
+import { builtinMemFs } from '@rspack/browser';
+
+// Write files to memfs
+builtinMemFs.volume.fromJSON({
+  // ...project files
+});
+
+// Read files from memfs
+const files = builtinMemFs.volume.toJSON();
+```
+
+## 浏览器专用插件
+
+为更好地满足浏览器环境下的打包需求，`@rspack/browser` 提供了若干专用插件。
+
+### BrowserHttpImportEsmPlugin
+
+在本地开发环境中，开发者通常通过包管理器将所有依赖下载并存储于项目根目录的 `node_modules` 文件夹。而由于 `@rspack/browser` 的 API 与 `@rspack/core` 保持一致，你也可以将依赖写入内存文件系统的 `node_modules` 文件夹。但如果项目依赖的模块不确定（如允许用户自由选择第三方依赖），预先写入所有依赖就不现实了。
+
+```typescript
+import { builtinMemFs } from '@rspack/browser';
+
+builtinMemFs.volume.fromJSON({
+  '/node_modules/react/index.js': '...',
+});
+```
+
+为此，`@rspack/browser` 提供了 `BrowserHttpImportEsmPlugin` 插件。该插件在解析模块时，会将第三方依赖的模块名重写为 ESM CDN 的 URL。例如，`import React from "react"` 会被重写为 `import React from "https://esm.sh/react"`。结合 Rspack 的 [buildHttp](/config/experiments#experimentsbuildhttp) 功能，即可在打包时通过 HTTP(S) 动态加载依赖。
+
+```js title="rspack.config.mjs"
+import { BrowserHttpImportEsmPlugin } from '@rspack/browser';
+
+export default {
+  plugins: [new BrowserHttpImportEsmPlugin()],
+  experiments: {
+    buildHttp: {
+      allowedUris: ['https://'],
+    },
+  },
+};
+```
+
+如下所示，`BrowserHttpImportEsmPlugin` 支持通过选项指定 ESM CDN 的域名，或者指定某些依赖的特定版本或 URL。
+
+```typescript
+interface BrowserHttpImportPluginOptions {
+  /**
+   * ESM CDN 域名
+   * @default "https://esm.sh"
+   */
+  domain?: string | ((request: string, packageName: string) => string);
+  /**
+   * 为特定的依赖指定 URL
+   */
+  dependencyUrl?:
+    | Record<string, string | undefined>
+    | ((packageName: string) => string | undefined);
+  /**
+   * 为依赖指定版本。
+   * 如果未指定，默认为 "latest"。
+   */
+  dependencyVersions?: Record<string, string | undefined>;
+}
+```
+
+### BrowserRequirePlugin
+
+在 Rspack/Webpack 中，某些场景需要动态加载和执行 JavaScript 代码，如 [Loader](/guide/features/loader) 或 [HtmlRspackPlugin 的模板函数](https://rspack.rs/plugins/rspack/html-rspack-plugin#use-template-function)。这些代码可能由不可信用户创建和分发，直接在浏览器执行存在安全隐患，因此 `@rspack/browser` 默认会在这些场景下抛出错误。
+
+`BrowserRequirePlugin` 插件则开放了此类能力：
+
+```js title="rspack.config.mjs"
+import { BrowserRequirePlugin } from '@rspack/browser';
+
+export default {
+  plugins: [
+    new BrowserRequirePlugin({ execute: BrowserRequirePlugin.unsafeExecute }),
+  ],
+};
+```
+
+你需要提供一个 `execute` 函数，用于动态执行和加载 CommonJS 模块，并修改 `runtime.module.exports`。`@rspack/browser` 提供了一个不安全的实现 `BrowserRequirePlugin.unsafeExecute`，其内部直接使用 `new Function` 执行代码。你也可以根据实际需求，基于该 API 封装更安全的实现，例如：
+
+```typescript
+function safeExecute(code: string, runtime: CommonJsRuntime) {
+  const safeCode = sanitizeCode(code);
+  BrowserRequirePlugin.unsafeExecute(safeCode, runtime);
+}
+
+function uselessExecute(_code: string, runtime: CommonJsRuntime) {
+  runtime.module.exports.hello = 'rspack';
+}
+```
+
+`BrowserRequirePlugin` 的选项如下：
+
+```typescript
+/**
+ * 加载 CommonJS 模块的运行时上下文
+ */
+interface CommonJsRuntime {
+  module: any;
+  exports: any;
+  require: BrowserRequire;
+}
+
+interface BrowserRequirePluginOptions {
+  /**
+   * 执行动态代码的函数
+   */
+  execute: (code: string, runtime: CommonJsRuntime) => void;
+}
+```
+
+:::tip 如何选择是否使用此插件？
+如果你的项目无需动态加载和执行 JavaScript 代码，则无需使用此插件。
+
+若项目不会分发不可信代码，或即使分发也不会造成安全问题，可直接使用 `BrowserRequirePlugin.unsafeExecute`。例如 [Rspack Playground](https://playground.rspack.rs/) 就不涉及用户隐私或账户安全。
+:::

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -2,7 +2,7 @@
 
 `@rspack/browser` 是专为浏览器环境打造的 Rspack 版本，无需依赖 WebContainers 或特定平台。其 API 与 `@rspack/core` 的 [JavaScript API](/api/javascript-api/) 保持一致，并在此基础上，额外提供了适配浏览器环境的特性和接口。
 
-我们将持续完善在线打包相关能力，欢迎前往 [Rspack Playground](https://playground.rspack.rs/) 体验。
+欢迎前往 [Rspack Playground](https://playground.rspack.rs/) 体验在浏览器中运行 Rspack 的效果。
 
 :::warning
 目前 `@rspack/browser` 仍处于实验阶段，后续可能会有不兼容的变更。

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -31,7 +31,7 @@ rspack({}, (err, stats) => {
 
 ## 内存文件系统
 
-由于浏览器无法直接访问本地文件系统，`@rspack/browser` 提供了基于 [memfs](https://www.npmjs.com/package/memfs) 的内存文件系统对象 `builtinMemFs`，用于在浏览器环境下读写文件。`@rspack/core` 的 Node.js 和 Rust 层对文件系统的读写均会重定向到该内存文件系统，包括项目配置、源代码、`node_modules` 依赖及产物。
+由于浏览器无法直接访问本地文件系统，`@rspack/browser` 提供了基于 [memfs](https://www.npmjs.com/package/memfs) 的内存文件系统对象 `builtinMemFs`，用于在浏览器环境下读写文件。Node.js 和 Rust 层对文件系统的读写均会重定向到该内存文件系统，包括项目配置、源代码、`node_modules` 依赖及产物。
 
 以下是基本用法示例，完整 API 可参考 [memfs 文档](https://github.com/streamich/memfs)：
 

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -35,7 +35,7 @@ rspack({}, (err, stats) => {
 
 以下是基本用法示例，完整 API 可参考 [memfs 文档](https://github.com/streamich/memfs)：
 
-```typescript
+```ts
 import { builtinMemFs } from '@rspack/browser';
 
 // Write files to memfs
@@ -55,7 +55,7 @@ const files = builtinMemFs.volume.toJSON();
 
 在本地开发环境中，开发者通常通过包管理器将项目依赖下载并存储在根目录的 `node_modules` 目录中。在使用 `@rspack/browser ` 时，你可以将依赖项预先写入内存文件系统的 `node_modules` 目录。然而，当项目依赖的模块存在不确定性时（例如允许用户自由选择第三方依赖），预先写入所有依赖就变得不切实际。
 
-```typescript
+```ts
 import { builtinMemFs } from '@rspack/browser';
 
 builtinMemFs.volume.fromJSON({
@@ -80,7 +80,7 @@ export default {
 
 如下所示，`BrowserHttpImportEsmPlugin` 支持通过选项指定 ESM CDN 的域名，或者指定某些依赖的特定版本或 URL。
 
-```typescript
+```ts
 interface BrowserHttpImportPluginOptions {
   /**
    * ESM CDN 域名
@@ -123,7 +123,7 @@ export default {
 
 你需要提供一个 `execute` 函数，用于动态执行和加载 CommonJS 模块，并修改 `runtime.module.exports` 来设置该模块导出的内容。`@rspack/browser` 提供了一个不安全的实现 `BrowserRequirePlugin.unsafeExecute`，其内部直接使用 `new Function` 执行代码。你也可以根据实际需求，基于该 API 封装更安全的实现，例如：
 
-```typescript
+```ts
 function safeExecute(code: string, runtime: CommonJsRuntime) {
   const safeCode = sanitizeCode(code);
   BrowserRequirePlugin.unsafeExecute(safeCode, runtime);
@@ -136,7 +136,7 @@ function uselessExecute(_code: string, runtime: CommonJsRuntime) {
 
 `BrowserRequirePlugin` 的选项如下：
 
-```typescript
+```ts
 /**
  * 加载 CommonJS 模块的运行时上下文
  */

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -12,7 +12,7 @@
 
 以下示例展示了 `@rspack/browser` 的基本用法。除了需要使用额外的 API 读写项目文件和产物外，其他 API 与 `@rspack/core` 的 [JavaScript API](/api/javascript-api/) 保持一致。
 
-```typescript
+```ts
 import { rspack, builtinMemFs } from '@rspack/browser';
 
 // Write files to memfs

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -106,7 +106,7 @@ interface BrowserHttpImportPluginOptions {
 在 Rspack/Webpack 中，某些场景需要动态加载和执行 JavaScript 代码，如 [Loader](/guide/features/loader) 或 [HtmlRspackPlugin 的模板函数](https://rspack.rs/plugins/rspack/html-rspack-plugin#use-template-function)。这些代码可能由不可信用户创建和分发，直接在浏览器执行存在安全隐患，因此 `@rspack/browser` 默认会在这些场景下抛出错误。
 
 :::warning
-Rspack 在打包过程中不会执行项目的业务代码。对于最终的打包产物，你应该在 iframe 中运行它们。
+Rspack 在打包过程中不会执行项目的用户代码。为了安全起见，建议在 iframe 中运行最终的打包产物。
 :::
 
 `BrowserRequirePlugin` 插件开放了此类能力：

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -69,7 +69,7 @@ builtinMemFs.volume.fromJSON({
 import { BrowserHttpImportEsmPlugin } from '@rspack/browser';
 
 export default {
-  plugins: [new BrowserHttpImportEsmPlugin()],
+  plugins: [new BrowserHttpImportEsmPlugin({ domain: 'https://esm.sh' })],
   experiments: {
     buildHttp: {
       allowedUris: ['https://'],
@@ -84,9 +84,8 @@ export default {
 interface BrowserHttpImportPluginOptions {
   /**
    * ESM CDN 域名
-   * @default "https://esm.sh"
    */
-  domain?: string | ((request: string, packageName: string) => string);
+  domain: string | ((request: string, packageName: string) => string);
   /**
    * 为特定的依赖指定 URL
    */

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -53,7 +53,7 @@ const files = builtinMemFs.volume.toJSON();
 
 ### BrowserHttpImportEsmPlugin
 
-在本地开发环境中，开发者通常通过包管理器将所有依赖下载并存储于项目根目录的 `node_modules` 文件夹。而由于 `@rspack/browser` 的 API 与 `@rspack/core` 保持一致，你也可以将依赖写入内存文件系统的 `node_modules` 文件夹。但如果项目依赖的模块不确定（如允许用户自由选择第三方依赖），预先写入所有依赖就不现实了。
+在本地开发环境中，开发者通常通过包管理器将所有依赖下载并存储于项目根目录的 `node_modules` 文件夹。因为 `@rspack/browser` 的行为也与 `@rspack/core` 保持一致，你可以将依赖写入内存文件系统的 `node_modules` 文件夹。但如果项目依赖的模块不确定（如允许用户自由选择第三方依赖），预先写入所有依赖就不现实了。
 
 ```typescript
 import { builtinMemFs } from '@rspack/browser';
@@ -63,7 +63,7 @@ builtinMemFs.volume.fromJSON({
 });
 ```
 
-为此，`@rspack/browser` 提供了 `BrowserHttpImportEsmPlugin` 插件。该插件在解析模块时，会将第三方依赖的模块名重写为 ESM CDN 的 URL。例如，`import React from "react"` 会被重写为 `import React from "https://esm.sh/react"`。结合 Rspack 的 [buildHttp](/config/experiments#experimentsbuildhttp) 功能，即可在打包时通过 HTTP(S) 动态加载依赖。
+`@rspack/browser` 提供了 `BrowserHttpImportEsmPlugin` 插件。该插件在解析模块时，会将第三方依赖的模块名重写为 ESM CDN 的 URL。例如，`import React from "react"` 会被重写为 `import React from "https://esm.sh/react"`。结合 Rspack 的 [buildHttp](/config/experiments#experimentsbuildhttp) 功能，即可在打包时通过 HTTP 动态加载依赖。
 
 ```js title="rspack.config.mjs"
 import { BrowserHttpImportEsmPlugin } from '@rspack/browser';
@@ -105,7 +105,7 @@ interface BrowserHttpImportPluginOptions {
 
 在 Rspack/Webpack 中，某些场景需要动态加载和执行 JavaScript 代码，如 [Loader](/guide/features/loader) 或 [HtmlRspackPlugin 的模板函数](https://rspack.rs/plugins/rspack/html-rspack-plugin#use-template-function)。这些代码可能由不可信用户创建和分发，直接在浏览器执行存在安全隐患，因此 `@rspack/browser` 默认会在这些场景下抛出错误。
 
-`BrowserRequirePlugin` 插件则开放了此类能力：
+`BrowserRequirePlugin` 插件开放了此类能力：
 
 ```js title="rspack.config.mjs"
 import { BrowserRequirePlugin } from '@rspack/browser';
@@ -117,7 +117,7 @@ export default {
 };
 ```
 
-你需要提供一个 `execute` 函数，用于动态执行和加载 CommonJS 模块，并修改 `runtime.module.exports`。`@rspack/browser` 提供了一个不安全的实现 `BrowserRequirePlugin.unsafeExecute`，其内部直接使用 `new Function` 执行代码。你也可以根据实际需求，基于该 API 封装更安全的实现，例如：
+你需要提供一个 `execute` 函数，用于动态执行和加载 CommonJS 模块，并修改 `runtime.module.exports` 来设置该模块导出的内容。`@rspack/browser` 提供了一个不安全的实现 `BrowserRequirePlugin.unsafeExecute`，其内部直接使用 `new Function` 执行代码。你也可以根据实际需求，基于该 API 封装更安全的实现，例如：
 
 ```typescript
 function safeExecute(code: string, runtime: CommonJsRuntime) {

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -5,7 +5,7 @@
 欢迎前往 [Rspack Playground](https://playground.rspack.rs/) 体验在浏览器中运行 Rspack 的效果。
 
 :::warning
-目前 `@rspack/browser` 仍处于实验阶段，后续可能会有不兼容的变更。
+目前 `@rspack/browser` 仍处于实验阶段，我们将持续完善在线打包能力，后续可能会引入不兼容变更。
 :::
 
 ## 基本示例


### PR DESCRIPTION
## Summary

This pull request adds documentation and README for the new `@rspack/browser` package, which enables Rspack to run directly in browser environments.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
