### PR TITLE
fix: unstable render dependency template

### DIFF
--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -194,7 +194,7 @@ pub(super) mod concatenated_module_entries {
   use super::*;
   use crate::ModuleIdentifier;
 
-  pub type ConcatenatedModuleEntriesCacheKey = (ModuleIdentifier, String);
+  pub type ConcatenatedModuleEntriesCacheKey = (ModuleIdentifier, Option<RuntimeKey>);
 
   #[derive(Debug, Default)]
   pub struct ConcatenatedModuleEntriesCache {

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -378,6 +378,7 @@ pub fn module_id(
 
 pub fn import_statement(
   module: &dyn Module,
+  runtime: Option<&RuntimeSpec>,
   compilation: &Compilation,
   runtime_requirements: &mut RuntimeGlobals,
   id: &DependencyId,
@@ -396,7 +397,7 @@ pub fn import_statement(
 
   runtime_requirements.insert(RuntimeGlobals::REQUIRE);
 
-  let import_var = compilation.get_import_var(id);
+  let import_var = compilation.get_import_var(id, runtime);
 
   let opt_declaration = if update { "" } else { "var " };
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -138,10 +138,7 @@ impl ESMExportImportedSpecifierDependency {
     runtime: Option<&RuntimeSpec>,
     module_graph_cache: &ModuleGraphCacheArtifact,
   ) -> ExportMode {
-    let key = (
-      self.id,
-      runtime.map(|runtime| get_runtime_key(runtime).to_owned()),
-    );
+    let key = (self.id, runtime.map(get_runtime_key));
     module_graph_cache.cached_get_mode(key, || {
       self.get_mode_inner(module_graph, module_graph_cache, runtime)
     })
@@ -501,6 +498,7 @@ impl ESMExportImportedSpecifierDependency {
     let TemplateContext {
       module,
       runtime_requirements,
+      runtime,
       ..
     } = ctxt;
     let compilation = ctxt.compilation;
@@ -508,7 +506,7 @@ impl ESMExportImportedSpecifierDependency {
     let mg = &compilation.get_module_graph();
     let mg_cache = &compilation.module_graph_cache_artifact;
     let module_identifier = module.identifier();
-    let import_var = compilation.get_import_var(&self.id);
+    let import_var = compilation.get_import_var(&self.id, *runtime);
     match mode {
       ExportMode::Missing | ExportMode::LazyMake | ExportMode::EmptyStar(_) => {
         fragments.push(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -166,6 +166,7 @@ pub fn esm_import_dependency_apply<T: ModuleDependency>(
 
   let content: (String, String) = import_statement(
     *module,
+    *runtime,
     compilation,
     runtime_requirements,
     module_dependency.id(),
@@ -176,9 +177,10 @@ pub fn esm_import_dependency_apply<T: ModuleDependency>(
     init_fragments,
     compilation,
     module,
+    runtime,
     ..
   } = code_generatable_context;
-  let import_var = compilation.get_import_var(module_dependency.id());
+  let import_var = compilation.get_import_var(module_dependency.id(), *runtime);
 
   // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/dependencies/HarmonyImportDependency.js#L282-L285
   let module_key = ref_module

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -419,7 +419,7 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
         )
       }
     } else {
-      let import_var = compilation.get_import_var(&dep.id);
+      let import_var = compilation.get_import_var(&dep.id, *runtime);
       esm_import_dependency_apply(dep, dep.source_order, code_generatable_context);
       export_from_import(
         code_generatable_context,

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/esm_accept_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/esm_accept_dependency.rs
@@ -109,6 +109,7 @@ impl DependencyTemplate for ESMAcceptDependencyTemplate {
       if let Some(request) = request {
         let stmts = import_statement(
           *module,
+          *runtime,
           compilation,
           runtime_requirements,
           id,

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -91,6 +91,7 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
       runtime_requirements,
       compilation,
       init_fragments,
+      runtime,
       ..
     } = code_generatable_context;
     let dep = dep
@@ -131,6 +132,7 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
     {
       let content: (String, String) = import_statement(
         *module,
+        *runtime,
         compilation,
         runtime_requirements,
         &module_dep_id,


### PR DESCRIPTION
## Summary

- The `get_import_var` is not stable when there are multiple runtimes, so add runtime as key.
- Using `Ustr` as runtime keys to prevent hashing them too many times.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
