### PR TITLE
fix: unstable bundle splitting

### DIFF
--- a/tests/e2e/cases/css/chunk-loading-order/index.test.ts
+++ b/tests/e2e/cases/css/chunk-loading-order/index.test.ts
@@ -2,5 +2,5 @@ import { test, expect } from "@/fixtures";
 
 test("should be red", async ({ page }) => {
 	await expect(page.locator("#status")).toHaveText("ok");
-	await expect(page.locator("body")).toHaveCSS("color", "rgb(255, 0, 0)");
+	await expect(page.locator("body")).toHaveCSS("color", "rgb(0, 0, 255)");
 });

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -2521,22 +2521,20 @@ custom-chunks-filter:
 
 custom-chunks-filter-in-cache-groups:
   Entrypoint main xx KiB = custom-xxx.js
-  Entrypoint a xx KiB = custom-xxx.js
+  Entrypoint a xx KiB = custom-xxx.js xx KiB
   Entrypoint b xx KiB = custom-xxx.js xx KiB
   Entrypoint c xx KiB = custom-xxx.js xx KiB
-  chunk (runtime: a, main) custom-xxx.js (async-g) xx bytes <{341}> <{545}> <{724}> [rendered]
+  chunk (runtime: a, main) custom-xxx.js (async-g) xx bytes <{341}> <{545}> <{70}> <{724}> [rendered]
     > ./g ./a.js 6:0-47
     dependent modules xx bytes [dependent] 1 module
     ./g.js xx bytes [built] [code generated]
-  chunk (runtime: a) custom-xxx.js (a) xx bytes (javascript) xx KiB (runtime) >{138}< [entry] [rendered]
+  chunk (runtime: a) custom-xxx.js (a) xx bytes (javascript) xx KiB (runtime) ={70}= >{138}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    dependent modules xx bytes [dependent] 3 modules
-    cacheable modules xx bytes
-      ./a.js + 1 modules xx bytes [code generated]
-      ./node_modules/z.js xx bytes [built] [code generated]
+    dependent modules xx bytes [dependent] 1 module
+    ./a.js + 1 modules xx bytes [code generated]
   chunk (runtime: b) custom-xxx.js (b) xx bytes (javascript) xx KiB (runtime) ={545}= [entry] [rendered]
     > ./b b
     > x b
@@ -2556,6 +2554,14 @@ custom-chunks-filter-in-cache-groups:
     > x c
     > y c
     > z c
+    ./node_modules/x.js xx bytes [built] [code generated]
+    ./node_modules/y.js xx bytes [built] [code generated]
+    ./node_modules/z.js xx bytes [built] [code generated]
+  chunk (runtime: a) custom-xxx.js (id hint: vendors) xx bytes ={341}= >{138}< [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./a a
+    > x a
+    > y a
+    > z a
     ./node_modules/x.js xx bytes [built] [code generated]
     ./node_modules/y.js xx bytes [built] [code generated]
     ./node_modules/z.js xx bytes [built] [code generated]

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -2521,20 +2521,22 @@ custom-chunks-filter:
 
 custom-chunks-filter-in-cache-groups:
   Entrypoint main xx KiB = custom-xxx.js
-  Entrypoint a xx KiB = custom-xxx.js xx KiB
+  Entrypoint a xx KiB = custom-xxx.js
   Entrypoint b xx KiB = custom-xxx.js xx KiB
   Entrypoint c xx KiB = custom-xxx.js xx KiB
-  chunk (runtime: a, main) custom-xxx.js (async-g) xx bytes <{341}> <{545}> <{70}> <{724}> [rendered]
+  chunk (runtime: a, main) custom-xxx.js (async-g) xx bytes <{341}> <{545}> <{724}> [rendered]
     > ./g ./a.js 6:0-47
     dependent modules xx bytes [dependent] 1 module
     ./g.js xx bytes [built] [code generated]
-  chunk (runtime: a) custom-xxx.js (a) xx bytes (javascript) xx KiB (runtime) ={70}= >{138}< [entry] [rendered]
+  chunk (runtime: a) custom-xxx.js (a) xx bytes (javascript) xx KiB (runtime) >{138}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    dependent modules xx bytes [dependent] 1 module
-    ./a.js + 1 modules xx bytes [code generated]
+    dependent modules xx bytes [dependent] 3 modules
+    cacheable modules xx bytes
+      ./a.js + 1 modules xx bytes [code generated]
+      ./node_modules/z.js xx bytes [built] [code generated]
   chunk (runtime: b) custom-xxx.js (b) xx bytes (javascript) xx KiB (runtime) ={545}= [entry] [rendered]
     > ./b b
     > x b
@@ -2554,14 +2556,6 @@ custom-chunks-filter-in-cache-groups:
     > x c
     > y c
     > z c
-    ./node_modules/x.js xx bytes [built] [code generated]
-    ./node_modules/y.js xx bytes [built] [code generated]
-    ./node_modules/z.js xx bytes [built] [code generated]
-  chunk (runtime: a) custom-xxx.js (id hint: vendors) xx bytes ={341}= >{138}< [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./a a
-    > x a
-    > y a
-    > z a
     ./node_modules/x.js xx bytes [built] [code generated]
     ./node_modules/y.js xx bytes [built] [code generated]
     ./node_modules/z.js xx bytes [built] [code generated]


### PR DESCRIPTION
## Summary

should use the global cache group index in `find_best_module_group`

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
