### PR TITLE
perf: add fast path for `get_scheme`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3981,6 +3981,7 @@ dependencies = [
  "anymap3",
  "async-trait",
  "derive_more",
+ "memchr",
  "once_cell",
  "rspack_cacheable",
  "rspack_collections",

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 anymap      = { workspace = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
+memchr      = { workspace = true }
 rustc-hash  = { workspace = true }
 tokio       = { workspace = true, features = ["test-util"] }
 

--- a/crates/rspack_loader_runner/src/scheme.rs
+++ b/crates/rspack_loader_runner/src/scheme.rs
@@ -87,6 +87,12 @@ const HASH: char = '#';
 const QUERY: char = '?';
 
 pub fn get_scheme(specifier: &str) -> Scheme {
+  // Fast path: most modules don't have a scheme
+  let bytes = specifier.as_bytes();
+  if memchr::memchr(b':', bytes).is_none() {
+    return Scheme::None;
+  }
+
   let mut chars = specifier.chars().enumerate().peekable();
 
   // First char maybe only a letter


### PR DESCRIPTION
## Summary

Assume most modules don't contain scheme

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
