### PR TITLE
perf: replace `Mutex<Option<T>>` with `OnceLock<T>`

### DIFF
--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -379,8 +379,12 @@ async fn this_compilation(
     DependencyType::ConsumeSharedFallback,
     params.normal_module_factory.clone(),
   );
-  self.init_context(compilation);
-  self.init_resolver(compilation);
+  if self.compiler_context.get().is_none() {
+    self.init_context(compilation);
+  }
+  if self.resolver.get().is_none() {
+    self.init_resolver(compilation);
+  }
   self
     .init_matched_consumes(compilation, self.get_resolver())
     .await;


### PR DESCRIPTION
## Summary

The fields are only initialized once, so there's no need to use mutex.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
