### PR TITLE
fix: build chunk graph incremental logic when dynamic entry with depend on

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -812,7 +812,10 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     let start = logger.time("process queue");
     // Iterative traversal of the Module graph
     // Recursive would be simpler to write but could result in Stack Overflows
-    while !self.queue.is_empty() || !self.queue_connect.is_empty() || !self.queue_delayed.is_empty()
+    while !self.queue.is_empty()
+      || !self.queue_connect.is_empty()
+      || !self.queue_delayed.is_empty()
+      || !self.chunk_groups_for_combining.is_empty()
     {
       self.process_queue(compilation);
 

--- a/packages/rspack-test-tools/tests/watchCases/chunks/depend-on/0/main.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/depend-on/0/main.js
@@ -1,3 +1,0 @@
-it("should recompile correctly when a shared entry specified in 'dependOn' is modified during watch mode", (done) => {
-    done();
-});

--- a/packages/rspack-test-tools/tests/watchCases/chunks/depend-on/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/depend-on/rspack.config.js
@@ -1,7 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
     entry: {
-        main: "./main.js",
         shared: "./shared.js",
         index1: {
             import: "./index1.js",

--- a/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/0/foo.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/0/foo.js
@@ -1,0 +1,1 @@
+export default "foo";

--- a/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/0/shared.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/0/shared.js
@@ -1,0 +1,1 @@
+import("./foo")

--- a/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/0/shared.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/0/shared.js
@@ -1,1 +1,1 @@
-import("./foo")
+import("./foo");

--- a/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/1/main.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/1/main.js
@@ -1,0 +1,7 @@
+
+it("should correctly compile a dynamic entry with `dependOn` when the entry file is created in watch mode", (done) => {
+    import("./foo").then(mod => {
+        expect(mod.default).toBe("foo");
+        done();
+    });
+});

--- a/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/rspack.config.js
@@ -1,12 +1,12 @@
 const fs = require("fs");
 const path = require("path");
 
-let CONTEXT;
+let MAIN;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
     entry() {
-        if (fs.existsSync(path.join(CONTEXT, "main.js"))) {
+        if (fs.existsSync(MAIN)) {
             return {
                 shared: "./shared.js",
                 main: {
@@ -25,9 +25,12 @@ module.exports = {
     plugins: [
         {
             apply(compiler) {
-                CONTEXT = compiler.context;
+                MAIN = path.join(compiler.context, "main.js");
+
                 compiler.hooks.finishMake.tap("PLUGIN", compilation => {
-                    compilation.missingDependencies.add(path.join(CONTEXT, "main.js"));
+                    if (!fs.existsSync(MAIN)) {
+                        compilation.missingDependencies.add(MAIN);
+                    }
                 });
             }
         }

--- a/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/rspack.config.js
@@ -1,0 +1,35 @@
+const fs = require("fs");
+const path = require("path");
+
+let CONTEXT;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+    entry() {
+        if (fs.existsSync(path.join(CONTEXT, "main.js"))) {
+            return {
+                shared: "./shared.js",
+                main: {
+                    import: "./main.js",
+                    dependOn: "shared"
+                },
+            }
+        }
+        return {
+            shared: "./shared.js"
+        }
+    },
+    output: {
+        filename: "[name].js"
+    },
+    plugins: [
+        {
+            apply(compiler) {
+                CONTEXT = compiler.context;
+                compiler.hooks.finishMake.tap("PLUGIN", compilation => {
+                    compilation.missingDependencies.add(path.join(CONTEXT, "main.js"));
+                });
+            }
+        }
+    ]
+}

--- a/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunks/dynamic-entry-with-depend-on/test.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    findBundle(i, config, step) {
+        if (step === "0") {
+            return [];
+        }
+        return ["main.js"];
+    }
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR fixes an issue with building chunk graphs in incremental mode when dealing with dynamic entries that have dependencies. The fix ensures that chunk groups requiring combination are properly processed during the iterative traversal phase.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
