### PR TITLE
refactor: use Atom for parser variable name

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
@@ -167,8 +167,8 @@ impl JavascriptParserPlugin for AMDParserPlugin {
   ) -> Option<BasicEvaluatedExpression<'static>> {
     if for_name == DEFINE_AMD {
       return Some(evaluate_to_identifier(
-        for_name.to_string(),
-        "define".to_string(),
+        for_name.into(),
+        "define".into(),
         Some(true),
         start,
         end,
@@ -177,8 +177,8 @@ impl JavascriptParserPlugin for AMDParserPlugin {
 
     if for_name == REQUIRE_AMD {
       return Some(evaluate_to_identifier(
-        for_name.to_string(),
-        "require".to_string(),
+        for_name.into(),
+        "require".into(),
         Some(true),
         start,
         end,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -140,13 +140,13 @@ impl JavascriptParser<'_> {
   }
 
   fn is_module_ident(&mut self, ident: &Ident) -> bool {
-    ident.sym == MODULE_NAME && self.is_unresolved_ident(MODULE_NAME)
+    ident.sym == MODULE_NAME && !self.is_variable_defined(&MODULE_NAME.into())
   }
 
   fn is_exports_ident<E: ExprLike>(&mut self, expr: &E) -> bool {
-    expr
-      .as_ident()
-      .is_some_and(|ident| ident.sym == EXPORTS_NAME && self.is_unresolved_ident(EXPORTS_NAME))
+    expr.as_ident().is_some_and(|ident| {
+      ident.sym == EXPORTS_NAME && !self.is_variable_defined(&EXPORTS_NAME.into())
+    })
   }
 
   fn is_exports_expr<E: ExprLike>(&mut self, expr: &E) -> bool {
@@ -243,7 +243,7 @@ impl JavascriptParser<'_> {
       .map(|expr| {
         if matches!(
           &**expr,
-          Expr::Ident(ident) if &ident.sym == "require" && self.is_unresolved_ident("require")
+          Expr::Ident(ident) if &ident.sym == "require" && !self.is_variable_defined(&ident.sym)
         ) {
           return true;
         }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_plugin.rs
@@ -19,8 +19,8 @@ impl JavascriptParserPlugin for CommonJsPlugin {
   ) -> Option<BasicEvaluatedExpression<'static>> {
     if for_name == expr_name::MODULE_HOT {
       Some(evaluate_to_identifier(
-        expr_name::MODULE_HOT.to_string(),
-        expr_name::MODULE.to_string(),
+        expr_name::MODULE_HOT.into(),
+        expr_name::MODULE.into(),
         None,
         start,
         end,
@@ -34,9 +34,9 @@ impl JavascriptParserPlugin for CommonJsPlugin {
     &self,
     parser: &mut JavascriptParser,
     expr: &swc_core::ecma::ast::UnaryExpr,
-    _for_name: &str,
+    for_name: &str,
   ) -> Option<bool> {
-    if expr_matcher::is_module(&*expr.arg) && parser.is_unresolved_ident("module") {
+    if for_name == expr_name::MODULE {
       parser
         .presentational_dependencies
         .push(Box::new(ConstDependency::new(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
@@ -56,7 +56,7 @@ impl JavascriptParserPlugin for DefineParserPlugin {
     if let Some(first_key) = self.walk_data.can_rename.get(str) {
       self.add_value_dependency(parser, str);
       if let Some(first_key) = first_key
-        && let Some(info) = parser.get_variable_info(first_key)
+        && let Some(info) = parser.get_variable_info(&first_key.as_ref().into())
         && !info.is_free()
       {
         return Some(false);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -114,7 +114,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
     name: &Atom,
   ) -> Option<bool> {
     parser.tag_variable::<ESMSpecifierData>(
-      name.to_string(),
+      name.clone(),
       ESM_SPECIFIER_TAG,
       Some(ESMSpecifierData {
         name: name.clone(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -141,8 +141,8 @@ impl JavascriptParserPlugin for ModuleHotReplacementParserPlugin {
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'static>> {
     if for_name == expr_name::MODULE_HOT {
       Some(eval::evaluate_to_identifier(
-        expr_name::MODULE_HOT.to_string(),
-        expr_name::MODULE.to_string(),
+        expr_name::MODULE_HOT.into(),
+        expr_name::MODULE.into(),
         Some(true),
         start,
         end,
@@ -208,8 +208,8 @@ impl JavascriptParserPlugin for ImportMetaHotReplacementParserPlugin {
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'static>> {
     if for_name == expr_name::IMPORT_META_WEBPACK_HOT {
       Some(eval::evaluate_to_identifier(
-        expr_name::IMPORT_META_WEBPACK_HOT.to_string(),
-        expr_name::IMPORT_META.to_string(),
+        expr_name::IMPORT_META_WEBPACK_HOT.into(),
+        expr_name::IMPORT_META.into(),
         Some(true),
         start,
         end,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -118,8 +118,8 @@ impl JavascriptParserPlugin for ImportMetaContextDependencyParserPlugin {
   ) -> Option<BasicEvaluatedExpression<'static>> {
     if for_name == expr_name::IMPORT_META_WEBPACK_CONTEXT {
       Some(eval::evaluate_to_identifier(
-        expr_name::IMPORT_META_WEBPACK_CONTEXT.to_string(),
-        expr_name::IMPORT_META.to_string(),
+        expr_name::IMPORT_META_WEBPACK_CONTEXT.into(),
+        expr_name::IMPORT_META.into(),
         Some(true),
         start,
         end,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -93,7 +93,7 @@ impl JavascriptParserPlugin for InlineConstPlugin {
       let evaluated = parser.evaluate_expression(init);
       if let Some(inlinable) = to_evaluated_inlinable_value(&evaluated) {
         parser.tag_variable(
-          name.id.sym.to_string(),
+          name.id.sym.clone(),
           INLINABLE_CONST_TAG,
           Some(InlinableConstData { value: inlinable }),
         );

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -310,7 +310,7 @@ impl InnerGraphPlugin {
     parser: &mut crate::visitors::JavascriptParser,
     name: &Atom,
   ) -> TopLevelSymbol {
-    parser.define_variable(name.to_string());
+    parser.define_variable(name.clone());
 
     let existing = parser.get_variable_info(name);
     if let Some(existing) = existing
@@ -324,7 +324,7 @@ impl InnerGraphPlugin {
 
     let symbol = TopLevelSymbol::new(name.clone());
     parser.tag_variable_with_flags(
-      name.to_string(),
+      name.clone(),
       TOP_LEVEL_SYMBOL,
       Some(symbol.clone()),
       VariableInfoFlags::NORMAL,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
@@ -37,7 +37,7 @@ impl JavascriptParserPlugin for JavascriptMetaInfoPlugin {
       .map(|(name, _)| Atom::new(name))
       .collect();
     for name in variables {
-      if parser.get_free_info_from_variable(&name).is_none() {
+      if parser.is_variable_defined(&name) {
         parser
           .build_info
           .top_level_declarations

--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -18,16 +18,12 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
     &self,
     parser: &mut crate::visitors::JavascriptParser,
     ident: &swc_core::ecma::ast::Ident,
-    _for_name: &str,
+    for_name: &str,
   ) -> Option<bool> {
     let Some(node_option) = parser.compiler_options.node.as_ref() else {
       unreachable!("ensure only invoke `NodeStuffPlugin` when node options is enabled");
     };
-    let str = ident.sym.as_str();
-    if !parser.is_unresolved_ident(str) {
-      return None;
-    }
-    if str == DIR_NAME {
+    if for_name == DIR_NAME {
       let dirname = match node_option.dirname {
         NodeDirnameOption::Mock => Some("/".to_string()),
         NodeDirnameOption::WarnMock => Some("/".to_string()),
@@ -91,7 +87,7 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
           )));
         return Some(true);
       }
-    } else if str == FILE_NAME {
+    } else if for_name == FILE_NAME {
       let filename = match node_option.filename {
         NodeFilenameOption::Mock => Some("/index.js".to_string()),
         NodeFilenameOption::WarnMock => Some("/index.js".to_string()),
@@ -145,7 +141,7 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
           )));
         return Some(true);
       }
-    } else if str == GLOBAL
+    } else if for_name == GLOBAL
       && matches!(
         node_option.global,
         NodeGlobalOption::True | NodeGlobalOption::Warn

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
@@ -7,7 +7,7 @@ use swc_core::{common::Spanned, ecma::ast::CallExpr};
 use super::JavascriptParserPlugin;
 use crate::{
   dependency::RequireContextDependency,
-  visitors::{JavascriptParser, clean_regexp_in_context_module, expr_matcher::is_require_context},
+  visitors::{JavascriptParser, clean_regexp_in_context_module},
 };
 
 pub struct RequireContextDependencyParserPlugin;
@@ -15,12 +15,8 @@ pub struct RequireContextDependencyParserPlugin;
 const DEFAULT_REGEXP_STR: &str = r"^\.\/.*$";
 
 impl JavascriptParserPlugin for RequireContextDependencyParserPlugin {
-  fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, _name: &str) -> Option<bool> {
-    if expr
-      .callee
-      .as_expr()
-      .is_none_or(|expr| !is_require_context(&**expr))
-    {
+  fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, for_name: &str) -> Option<bool> {
+    if for_name != "require.context" {
       return None;
     }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
@@ -14,7 +14,7 @@ use super::JavascriptParserPlugin;
 use crate::{
   dependency::{RequireEnsureDependency, RequireEnsureItemDependency},
   utils::eval::{self, BasicEvaluatedExpression},
-  visitors::{JavascriptParser, Statement, expr_matcher::is_require_ensure},
+  visitors::{JavascriptParser, Statement},
 };
 
 pub struct RequireEnsureDependenciesBlockParserPlugin;
@@ -53,12 +53,8 @@ impl JavascriptParserPlugin for RequireEnsureDependenciesBlockParserPlugin {
     })
   }
 
-  fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, _for_name: &str) -> Option<bool> {
-    if expr
-      .callee
-      .as_expr()
-      .is_none_or(|expr| !is_require_ensure(&**expr))
-    {
+  fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, for_name: &str) -> Option<bool> {
+    if for_name != "require.ensure" {
       return None;
     }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -283,7 +283,7 @@ impl JavascriptParserPlugin for WorkerPlugin {
       && self.pattern_syntax.contains_key(ident.sym.as_str())
     {
       parser.tag_variable(
-        ident.sym.to_string(),
+        ident.sym.clone(),
         WORKER_SPECIFIER_TAG,
         Some(WorkerSpecifierData {
           key: ident.sym.clone(),
@@ -297,7 +297,7 @@ impl JavascriptParserPlugin for WorkerPlugin {
   fn pattern(&self, parser: &mut JavascriptParser, ident: &Ident, for_name: &str) -> Option<bool> {
     if self.pattern_syntax.contains_key(for_name) {
       parser.tag_variable(
-        ident.sym.to_string(),
+        ident.sym.clone(),
         WORKER_SPECIFIER_TAG,
         Some(WorkerSpecifierData {
           key: ident.sym.clone(),

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
@@ -28,7 +28,7 @@ pub fn eval_member_expression<'a>(
         let mut eval =
           BasicEvaluatedExpression::with_range(member.span.real_lo(), member.span.hi().0);
         eval.set_identifier(
-          info.name,
+          info.name.into(),
           info.root_info,
           Some(info.members),
           Some(info.members_optionals),

--- a/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
@@ -73,7 +73,7 @@ pub struct BasicEvaluatedExpression<'a> {
   bigint: Option<Bigint>,
   regexp: Option<Regexp>,
   array: Option<Vec<String>>,
-  identifier: Option<String>,
+  identifier: Option<Atom>,
   root_info: Option<ExportedVariableInfo>,
   members: Option<Vec<Atom>>,
   members_optionals: Option<Vec<bool>>,
@@ -434,7 +434,7 @@ impl<'a> BasicEvaluatedExpression<'a> {
 
   pub fn set_identifier(
     &mut self,
-    name: String,
+    name: Atom,
     root_info: ExportedVariableInfo,
     members: Option<Vec<Atom>>,
     members_optionals: Option<Vec<bool>>,
@@ -501,7 +501,7 @@ impl<'a> BasicEvaluatedExpression<'a> {
     self.string.as_ref().expect("make sure string exist")
   }
 
-  pub fn identifier(&self) -> &str {
+  pub fn identifier(&self) -> &Atom {
     assert!(self.is_identifier());
     self
       .identifier
@@ -663,8 +663,8 @@ pub fn evaluate_to_undefined<'a>(start: u32, end: u32) -> BasicEvaluatedExpressi
 }
 
 pub fn evaluate_to_identifier<'a>(
-  identifier: String,
-  root_info: String,
+  identifier: Atom,
+  root_info: Atom,
   truthy: Option<bool>,
   start: u32,
   end: u32,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
@@ -105,7 +105,7 @@ impl JavascriptParser<'_> {
 
   fn block_pre_walk_class_declaration(&mut self, decl: MaybeNamedClassDecl) {
     if let Some(ident) = decl.ident() {
-      self.define_variable(ident.sym.to_string())
+      self.define_variable(ident.sym.clone())
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
@@ -59,7 +59,7 @@ impl JavascriptParser<'_> {
             .import_specifier(self, decl, source, Some(export_name), identifier_name)
             .unwrap_or_default()
           {
-            self.define_variable(identifier_name.to_string())
+            self.define_variable(identifier_name.clone())
           }
         }
         ImportSpecifier::Default(default) => {
@@ -68,7 +68,7 @@ impl JavascriptParser<'_> {
             .import_specifier(self, decl, source, Some(&"default".into()), identifier_name)
             .unwrap_or_default()
           {
-            self.define_variable(identifier_name.to_string())
+            self.define_variable(identifier_name.clone())
           }
         }
         ImportSpecifier::Namespace(namespace) => {
@@ -77,7 +77,7 @@ impl JavascriptParser<'_> {
             .import_specifier(self, decl, source, None, identifier_name)
             .unwrap_or_default()
           {
-            self.define_variable(identifier_name.to_string())
+            self.define_variable(identifier_name.clone())
           }
         }
       }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
@@ -137,7 +137,7 @@ impl JavascriptParser<'_> {
 
   pub fn pre_walk_function_declaration(&mut self, decl: MaybeNamedFunctionDecl) {
     if let Some(ident) = decl.ident() {
-      self.define_variable(ident.sym.to_string());
+      self.define_variable(ident.sym.clone());
     }
   }
 
@@ -200,7 +200,7 @@ impl JavascriptParser<'_> {
         .unwrap_or_default()
       {
         self.enter_pattern(Cow::Borrowed(&declarator.name), |this, ident| {
-          this.define_variable(ident.sym.to_string());
+          this.define_variable(ident.sym.clone());
         });
       }
     }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -1,11 +1,11 @@
-use rspack_core::{ConstDependency, ErrorSpan};
+use rspack_core::ErrorSpan;
 use rspack_error::{
   TraceableError,
   miette::{Severity, diagnostic},
 };
 use rspack_regex::RspackRegex;
 use swc_core::{
-  common::{SourceFile, Spanned},
+  common::SourceFile,
   ecma::{ast::*, atoms::Atom},
 };
 
@@ -167,25 +167,11 @@ pub(crate) mod expr_matcher {
   // - Matching would ignore Span and SyntaxContext
   define_expr_matchers!({
     is_require: "require",
-    is_require_main: "require.main",
-    is_require_context: "require.context",
-    is_require_cache: "require.cache",
-    is_module: "module",
     is_module_id: "module.id",
     is_module_loaded: "module.loaded",
     is_module_exports: "module.exports",
     is_module_require: "module.require",
-    is_webpack_module_id: "__webpack_module__.id",
     is_object_define_property: "Object.defineProperty",
-    is_require_ensure: "require.ensure",
-    is_require_version: "require.version",
-    is_require_onerror: "require.onError",
-    // unsupported
-    is_require_extensions: "require.extensions",
-    is_require_config: "require.config",
-    is_require_include: "require.include",
-    is_require_main_require: "require.main.require",
-    is_module_parent_require: "module.parent.require",
   });
 }
 
@@ -262,30 +248,6 @@ pub fn is_require_call_start(expr: &Expr) -> bool {
     Expr::Member(MemberExpr { obj, .. }) => is_require_call_start(obj),
     _ => false,
   }
-}
-
-pub fn expression_not_supported(
-  file: &SourceFile,
-  name: &str,
-  expr: &Expr,
-) -> (Box<TraceableError>, Box<ConstDependency>) {
-  (
-    Box::new(
-      create_traceable_error(
-        "Unsupported feature".into(),
-        format!("{name} is not supported by Rspack."),
-        file,
-        expr.span().into(),
-      )
-      .with_severity(Severity::Warning)
-      .with_hide_stack(Some(true)),
-    ),
-    Box::new(ConstDependency::new(
-      expr.span().into(),
-      "(void 0)".into(),
-      None,
-    )),
-  )
 }
 
 pub fn extract_member_root(mut expr: &Expr) -> Option<Ident> {
@@ -410,21 +372,6 @@ mod test {
     assert!(
       expr_matcher::is_module_exports(&Expr::Member(e)),
       "should support evaluate with `Expr::Member(MemberExpr {{ .. }})`"
-    );
-
-    let e = Ident {
-      ctxt: Default::default(),
-      span: DUMMY_SP,
-      sym: "module".into(),
-      optional: false,
-    };
-    assert!(
-      expr_matcher::is_module(&e),
-      "should support evaluate with `Ident`"
-    );
-    assert!(
-      expr_matcher::is_module(&Expr::Ident(e)),
-      "should support evaluate with `Expr::Ident(Ident {{ .. }})`"
     );
   }
 }

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -208,7 +208,7 @@ impl RstestParserPlugin {
       && import_call.callee.as_import().is_some()
     {
       parser.tag_variable::<bool>(
-        self.compose_rstest_import_call_key(import_call),
+        self.compose_rstest_import_call_key(import_call).into(),
         RSTEST_MOCK_FIRST_ARG_TAG,
         Some(true),
       );
@@ -515,7 +515,7 @@ impl JavascriptParserPlugin for RstestParserPlugin {
     let first_arg = self.handle_mock_first_arg(parser, call_expr);
     if first_arg.is_some() {
       let tag_data = parser.get_tag_data(
-        &self.compose_rstest_import_call_key(call_expr),
+        &self.compose_rstest_import_call_key(call_expr).into(),
         RSTEST_MOCK_FIRST_ARG_TAG,
       );
 
@@ -658,16 +658,11 @@ impl JavascriptParserPlugin for RstestParserPlugin {
   fn identifier(
     &self,
     parser: &mut rspack_plugin_javascript::visitors::JavascriptParser,
-    ident: &Ident,
-    _for_name: &str,
+    _ident: &Ident,
+    for_name: &str,
   ) -> Option<bool> {
-    let str = ident.sym.as_str();
-    if !parser.is_unresolved_ident(str) {
-      return None;
-    }
-
     if self.module_path_name {
-      match str {
+      match for_name {
         DIR_NAME => {
           parser
             .presentational_dependencies


### PR DESCRIPTION
## Summary

- use Atom for variable name instead of String
- use for_name instead of extract name from ast in parser plugin

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
