### PR TITLE
refactor: commonjs export parser plugin

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -1,13 +1,12 @@
 use rspack_core::{
-  BuildMetaDefaultObject, BuildMetaExportsType, DependencyRange, RuntimeGlobals,
-  RuntimeRequirementsDependency, SpanExt,
+  BuildMetaDefaultObject, BuildMetaExportsType, DependencyRange, RuntimeGlobals, SpanExt,
 };
 use swc_core::{
   atoms::Atom,
-  common::Spanned,
+  common::{Span, Spanned},
   ecma::ast::{
-    AssignExpr, AssignTarget, CallExpr, Callee, Expr, ExprOrSpread, Ident, Lit, MemberExpr,
-    ObjectLit, Prop, PropName, PropOrSpread, SimpleAssignTarget, ThisExpr, UnaryExpr, UnaryOp,
+    AssignExpr, CallExpr, Expr, ExprOrSpread, Ident, Lit, MemberExpr, ObjectLit, Prop, PropName,
+    PropOrSpread, UnaryExpr, UnaryOp,
   },
 };
 
@@ -18,64 +17,11 @@ use crate::{
     ExportsBase, ModuleDecoratorDependency,
   },
   utils::eval::{self, BasicEvaluatedExpression},
-  visitors::{
-    AllowedMemberTypes, JavascriptParser, MemberExpressionInfo, TopLevelScope, expr_like::ExprLike,
-    expr_matcher,
-  },
+  visitors::JavascriptParser,
 };
 
-const MODULE_NAME: &str = "module";
-const EXPORTS_NAME: &str = "exports";
-
-fn get_member_expression_info<E: ExprLike>(
-  parser: &mut JavascriptParser,
-  expr: &E,
-  is_module_exports_start: Option<bool>,
-) -> Option<Vec<Atom>> {
-  let is_module_exports_start = match is_module_exports_start {
-    Some(v) => v,
-    None => is_module_exports_member_expr_start(expr),
-  };
-  expr.as_member().and_then(|expr: &MemberExpr| {
-    let members = parser
-      .get_member_expression_info(expr, AllowedMemberTypes::Expression)
-      .and_then(|info| match info {
-        MemberExpressionInfo::Call(_) => None,
-        MemberExpressionInfo::Expression(info) => Some(info.members),
-      })
-      .map(|members| {
-        members
-          .iter()
-          .skip(if is_module_exports_start { 1 } else { 0 })
-          .map(|n| n.to_owned())
-          .collect::<Vec<_>>()
-      })?;
-    match &*expr.obj {
-      Expr::Call(_) => Some(members),
-      Expr::Ident(_) => Some(members),
-      Expr::MetaProp(_) => Some(members),
-      Expr::This(_) => Some(members),
-      _ if expr_matcher::is_module_exports(&*expr.obj) => Some(members),
-      _ => None,
-    }
-  })
-}
-
-fn is_module_exports_member_expr_start<E: ExprLike>(expr: &E) -> bool {
-  fn walk_each<E: ExprLike>(expr: &E) -> bool {
-    if expr_matcher::is_module_exports(expr) {
-      true
-    } else if let Some(MemberExpr { obj, .. }) = expr.as_member() {
-      walk_each(&**obj)
-    } else {
-      false
-    }
-  }
-  walk_each(expr)
-}
-
-fn get_value_of_property_description(expr_or_spread: &ExprOrSpread) -> Option<&Expr> {
-  if let Expr::Object(ObjectLit { props, .. }) = &*expr_or_spread.expr {
+fn get_value_of_property_description(expr: &Expr) -> Option<&Expr> {
+  if let Expr::Object(ObjectLit { props, .. }) = expr {
     for prop in props {
       if let PropOrSpread::Prop(prop) = prop
         && let Prop::KeyValue(key_value_prop) = &**prop
@@ -126,49 +72,6 @@ fn is_lit_truthy_literal(lit: &Lit) -> bool {
 }
 
 impl JavascriptParser<'_> {
-  fn is_exports_member_expr_start<E: ExprLike>(&mut self, expr: &E) -> bool {
-    fn walk_each<E: ExprLike>(parser: &mut JavascriptParser, expr: &E) -> bool {
-      if parser.is_exports_expr(expr) {
-        true
-      } else if let Some(MemberExpr { obj, .. }) = expr.as_member() {
-        walk_each(parser, &**obj)
-      } else {
-        false
-      }
-    }
-    walk_each(self, expr)
-  }
-
-  fn is_module_ident(&mut self, ident: &Ident) -> bool {
-    ident.sym == MODULE_NAME && !self.is_variable_defined(&MODULE_NAME.into())
-  }
-
-  fn is_exports_ident<E: ExprLike>(&mut self, expr: &E) -> bool {
-    expr.as_ident().is_some_and(|ident| {
-      ident.sym == EXPORTS_NAME && !self.is_variable_defined(&EXPORTS_NAME.into())
-    })
-  }
-
-  fn is_exports_expr<E: ExprLike>(&mut self, expr: &E) -> bool {
-    expr
-      .as_ident()
-      .is_some_and(|ident| self.is_exports_ident(ident))
-  }
-
-  fn is_top_level_this(&self, _expr: &ThisExpr) -> bool {
-    !matches!(self.top_level_scope, TopLevelScope::False)
-  }
-
-  fn is_top_level_this_expr<E: ExprLike>(&self, expr: &E) -> bool {
-    expr.as_this().is_some_and(|e| self.is_top_level_this(e))
-  }
-
-  fn is_exports_or_module_exports_or_this_expr(&mut self, expr: &Expr) -> bool {
-    self.is_exports_expr(expr)
-      || expr_matcher::is_module_exports(expr)
-      || self.is_top_level_this_expr(expr)
-  }
-
   // can't scan `__esModule` value
   fn bailout(&mut self) {
     if matches!(self.parser_exports_state, Some(true)) {
@@ -222,62 +125,242 @@ impl JavascriptParser<'_> {
       self.set_dynamic();
     }
   }
+}
 
-  fn is_this_member_expr_start<E: ExprLike>(&self, expr: &E) -> bool {
-    fn walk_each<E: ExprLike>(parser: &JavascriptParser, expr: &E) -> bool {
-      if parser.is_top_level_this_expr(expr) {
-        true
-      } else if let Some(MemberExpr { obj, .. }) = expr.as_member() {
-        walk_each(parser, &**obj)
-      } else {
-        false
-      }
+fn parse_require_call<'a>(
+  parser: &mut JavascriptParser,
+  expr: &'a Expr,
+) -> Option<(BasicEvaluatedExpression<'a>, Vec<Atom>)> {
+  let mut ids = Vec::new();
+  // while let Some(member) = expr.as_member() {
+  //   if let Some(prop) = member.prop.as_ident() {
+  //     ids.push(prop.sym.clone());
+  //   } else if let Some(prop) = member.prop.as_computed()
+  //     && let prop = parser.evaluate_expression(&*prop.expr)
+  //     && let Some(prop) = prop.as_string()
+  //   {
+  //     ids.push(prop.into());
+  //   } else {
+  //     return None;
+  //   }
+  //   expr = &*member.obj;
+  // }
+  if let Some(call) = expr.as_call()
+    && call.args.len() == 1
+    && let Some(callee) = call.callee.as_expr()
+    && let Some(callee) = callee.as_ident()
+    && let Some(info) = parser.get_free_info_from_variable(&callee.sym)
+    && info.name == "require"
+  {
+    let arg = &call.args[0];
+    if arg.spread.is_some() {
+      return None;
     }
-    walk_each(self, expr)
+    let arg = parser.evaluate_expression(&arg.expr);
+    ids.reverse();
+    return Some((arg, ids));
   }
+  None
+}
 
-  fn is_require_call(&mut self, node: &CallExpr) -> bool {
-    node
-      .callee
-      .as_expr()
-      .map(|expr| {
-        if matches!(
-          &**expr,
-          Expr::Ident(ident) if &ident.sym == "require" && !self.is_variable_defined(&ident.sym)
-        ) {
-          return true;
-        }
-        false
-      })
-      .unwrap_or_default()
+fn handle_assign_export(
+  parser: &mut JavascriptParser,
+  assign_expr: &AssignExpr,
+  remaining: &[Atom],
+  base: ExportsBase,
+) -> Option<bool> {
+  if parser.is_esm {
+    return None;
   }
-
-  fn is_require_call_expr(&mut self, expr: &Expr) -> bool {
-    matches!(expr, Expr::Call(call_expr) if self.is_require_call(call_expr))
-  }
-
-  // FIXME: this function should be deleted because it just a hack
-  fn append_module_runtime(&mut self) {
-    self
-      .presentational_dependencies
-      .push(Box::new(RuntimeRequirementsDependency::new(
-        RuntimeGlobals::MODULE,
+  if (remaining.is_empty() || remaining.first().is_some_and(|i| i != "__esModule"))
+    && let Some((arg, _ids)) = parse_require_call(parser, &assign_expr.right)
+    && arg.is_string()
+  {
+    parser.enable();
+    if remaining.is_empty() {
+      // exports = require('xx');
+      // module.exports = require('xx');
+      // this = require('xx');
+      // It's possible to reexport __esModule, so we must convert to a dynamic module
+      parser.set_dynamic();
+    }
+    // exports.aaa = require('xx');
+    // module.exports.aaa = require('xx');
+    // this.aaa = require('xx');
+    let range: DependencyRange = assign_expr.span.into();
+    parser
+      .dependencies
+      .push(Box::new(CommonJsExportRequireDependency::new(
+        arg.string().to_string(),
+        parser.in_try,
+        range,
+        base,
+        remaining.to_vec(),
+        !parser.is_statement_level_expression(assign_expr.span()),
       )));
+    return Some(true);
   }
+
+  if remaining.is_empty() {
+    return None;
+  }
+
+  parser.enable();
+  // exports.__esModule = true;
+  // module.exports.__esModule = true;
+  // this.__esModule = true;
+  if let Some(first_member) = remaining.first()
+    && first_member == "__esModule"
+  {
+    parser.check_namespace(
+      // const flagIt = () => (exports.__esModule = true); => stmt_level = 1, last_stmt_is_expr_stmt = false
+      // const flagIt = () => { exports.__esModule = true }; => stmt_level = 2, last_stmt_is_expr_stmt = true
+      // (exports.__esModule = true); => stmt_level = 1, last_stmt_is_expr_stmt = true
+      parser.statement_path.len() == 1 && parser.is_statement_level_expression(assign_expr.span()),
+      Some(&assign_expr.right),
+    );
+  }
+  // exports.a = 1;
+  // module.exports.a = 1;
+  // this.a = 1;
+  parser
+    .dependencies
+    .push(Box::new(CommonJsExportsDependency::new(
+      assign_expr.left.span().into(),
+      None,
+      base,
+      remaining.to_owned(),
+    )));
+  parser.walk_expression(&assign_expr.right);
+  Some(true)
+}
+
+fn handle_access_export(
+  parser: &mut JavascriptParser,
+  expr_span: Span,
+  remaining: &[Atom],
+  base: ExportsBase,
+  call_args: Option<&Vec<ExprOrSpread>>,
+) -> Option<bool> {
+  if parser.is_esm {
+    return None;
+  }
+  if remaining.is_empty() {
+    parser.bailout();
+  }
+  parser
+    .dependencies
+    .push(Box::new(CommonJsSelfReferenceDependency::new(
+      expr_span.into(),
+      base,
+      remaining.to_vec(),
+      true,
+    )));
+  if let Some(call_args) = call_args {
+    parser.walk_expr_or_spread(call_args);
+  }
+  Some(true)
 }
 
 pub struct CommonJsExportsParserPlugin;
 
 impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
+  fn assign_member_chain(
+    &self,
+    parser: &mut JavascriptParser,
+    assign_expr: &AssignExpr,
+    remaining: &[Atom],
+    for_name: &str,
+  ) -> Option<bool> {
+    if for_name == "exports" {
+      // exports.x = y;
+      return handle_assign_export(parser, assign_expr, remaining, ExportsBase::Exports);
+    }
+    if for_name == "module" && matches!(remaining.first(), Some(first) if first == "exports") {
+      // module.exports.x = y;
+      return handle_assign_export(
+        parser,
+        assign_expr,
+        &remaining[1..],
+        ExportsBase::ModuleExports,
+      );
+    }
+    if for_name == "this" && parser.is_top_level_scope() {
+      // this.x = y
+      return handle_assign_export(parser, assign_expr, remaining, ExportsBase::This);
+    }
+    None
+  }
+
+  fn call(
+    &self,
+    parser: &mut JavascriptParser,
+    call_expr: &CallExpr,
+    for_name: &str,
+  ) -> Option<bool> {
+    if parser.is_esm {
+      return None;
+    }
+    if for_name == "Object.defineProperty"
+      && parser.is_statement_level_expression(call_expr.span())
+      && call_expr.args.len() == 3
+      && let Some(ExprOrSpread {
+        spread: None,
+        expr: arg0,
+      }) = call_expr.args.first()
+      && let Some(ExprOrSpread {
+        spread: None,
+        expr: arg1,
+      }) = call_expr.args.get(1)
+      && let Some(ExprOrSpread {
+        spread: None,
+        expr: arg2,
+      }) = call_expr.args.get(2)
+    {
+      let exports_arg = parser.evaluate_expression(arg0);
+      if !exports_arg.is_identifier() {
+        return None;
+      }
+      let base = match exports_arg.identifier().as_str() {
+        "exports" => ExportsBase::DefinePropertyExports,
+        "module.exports" => ExportsBase::DefinePropertyModuleExports,
+        "this" if parser.is_top_level_scope() => ExportsBase::DefinePropertyThis,
+        _ => return None,
+      };
+      let property = parser.evaluate_expression(arg1).as_string()?;
+      parser.enable();
+      // Object.defineProperty(exports, "__esModule", { value: true });
+      // Object.defineProperty(module.exports, "__esModule", { value: true });
+      // Object.defineProperty(this, "__esModule", { value: true });
+      if &property == "__esModule" {
+        parser.check_namespace(
+          parser.statement_path.len() == 1,
+          get_value_of_property_description(arg2),
+        );
+      }
+      parser
+        .dependencies
+        .push(Box::new(CommonJsExportsDependency::new(
+          call_expr.span.into(),
+          Some(arg2.span().into()),
+          base,
+          vec![property.into()],
+        )));
+
+      parser.walk_expression(arg2);
+      return Some(true);
+    }
+
+    None
+  }
+
   fn identifier(
     &self,
     parser: &mut JavascriptParser,
     ident: &Ident,
-    _for_name: &str,
+    for_name: &str,
   ) -> Option<bool> {
-    if parser.is_module_ident(ident) {
-      parser.append_module_runtime();
-      // matches!( self.build_meta.exports_type, BuildMetaExportsType::Namespace)
+    if for_name == "module" {
       let decorator = if parser.is_esm {
         RuntimeGlobals::ESM_MODULE_DECORATOR
       } else {
@@ -290,21 +373,15 @@ impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
           decorator,
           !parser.is_esm,
         )));
-      Some(true)
-    } else if !parser.is_esm && parser.is_exports_ident(ident) {
-      parser.bailout();
-      parser
-        .dependencies
-        .push(Box::new(CommonJsSelfReferenceDependency::new(
-          ident.span().into(),
-          ExportsBase::Exports,
-          vec![],
-          false,
-        )));
-      Some(true)
-    } else {
-      None
+      return Some(true);
     }
+
+    if for_name == "exports" {
+      // exports
+      return handle_access_export(parser, ident.span(), &[], ExportsBase::Exports, None);
+    }
+
+    None
   }
 
   fn this(
@@ -312,262 +389,102 @@ impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
     parser: &mut JavascriptParser,
     expr: &swc_core::ecma::ast::ThisExpr,
   ) -> Option<bool> {
-    if parser.is_esm {
-      None
-    } else if parser.is_top_level_this(expr) {
-      parser.bailout();
-      parser
-        .dependencies
-        .push(Box::new(CommonJsSelfReferenceDependency::new(
-          expr.span().into(),
-          ExportsBase::This,
-          vec![],
-          false,
-        )));
-      Some(true)
-    } else {
-      None
+    if parser.is_top_level_this() {
+      // this
+      return handle_access_export(parser, expr.span(), &[], ExportsBase::This, None);
     }
+    None
   }
 
-  fn member(&self, parser: &mut JavascriptParser, expr: &MemberExpr, _name: &str) -> Option<bool> {
-    if parser.is_esm {
-      return None;
-    }
-
-    let handle_remaining = |parser: &mut JavascriptParser, base: ExportsBase| {
-      let is_module_exports_start = matches!(base, ExportsBase::ModuleExports);
-      if let Some(remaining) =
-        get_member_expression_info(parser, expr, Some(is_module_exports_start))
-      {
-        if remaining.is_empty() {
-          parser.bailout();
-        }
-        parser
-          .dependencies
-          .push(Box::new(CommonJsSelfReferenceDependency::new(
-            expr.span().into(),
-            base,
-            remaining,
-            false,
-          )));
-        Some(true)
-      } else {
-        None
-      }
-    };
-    if parser.is_exports_member_expr_start(expr) {
-      // `exports.x.y`
-      handle_remaining(parser, ExportsBase::Exports)
-    } else if is_module_exports_member_expr_start(expr) {
-      // `module.exports.x.y`
-      parser.append_module_runtime();
-      handle_remaining(parser, ExportsBase::ModuleExports)
-    } else if parser.is_this_member_expr_start(expr) {
-      // `this.x.y`
-      handle_remaining(parser, ExportsBase::This)
-    } else {
-      None
-    }
-  }
-
-  fn assign(
+  fn member(
     &self,
     parser: &mut JavascriptParser,
-    assign_expr: &AssignExpr,
-    _for_name: Option<&str>,
+    expr: &MemberExpr,
+    for_name: &str,
   ) -> Option<bool> {
-    if parser.is_esm {
-      return None;
+    if for_name == "module.exports" {
+      // module.exports
+      return handle_access_export(parser, expr.span(), &[], ExportsBase::ModuleExports, None);
     }
-    let AssignTarget::Simple(SimpleAssignTarget::Member(left_expr)) = &assign_expr.left else {
-      return None;
-    };
-
-    let handle_remaining = |parser: &mut JavascriptParser, base: ExportsBase| {
-      let is_module_exports_start = matches!(base, ExportsBase::ModuleExports);
-      let remaining = get_member_expression_info(parser, left_expr, Some(is_module_exports_start))?;
-
-      if (remaining.is_empty() || remaining.first().is_some_and(|i| i != "__esModule"))
-        && parser.is_require_call_expr(&assign_expr.right)
-        && let Some(right_expr) = assign_expr.right.as_call()
-        && let Some(first_arg) = right_expr.args.first().map(|arg| &arg.expr)
-      {
-        let param = parser.evaluate_expression(first_arg);
-        if param.is_string() {
-          parser.enable();
-          if remaining.is_empty() {
-            // exports = require('xx');
-            // module.exports = require('xx');
-            // this = require('xx');
-            // It's possible to reexport __esModule, so we must convert to a dynamic module
-            parser.set_dynamic();
-          }
-          // exports.aaa = require('xx');
-          // module.exports.aaa = require('xx');
-          // this.aaa = require('xx');
-          let range: DependencyRange = assign_expr.span.into();
-          parser
-            .dependencies
-            .push(Box::new(CommonJsExportRequireDependency::new(
-              param.string().to_string(),
-              parser.in_try,
-              range,
-              base,
-              remaining,
-              !parser.is_statement_level_expression(assign_expr.span()),
-            )));
-          return Some(true);
-        }
-      }
-
-      if remaining.is_empty() {
-        return None;
-      }
-
-      parser.enable();
-      // exports.__esModule = true;
-      // module.exports.__esModule = true;
-      // this.__esModule = true;
-      if let Some(first_member) = remaining.first()
-        && first_member == "__esModule"
-      {
-        parser.check_namespace(
-          // const flagIt = () => (exports.__esModule = true); => stmt_level = 1, last_stmt_is_expr_stmt = false
-          // const flagIt = () => { exports.__esModule = true }; => stmt_level = 2, last_stmt_is_expr_stmt = true
-          // (exports.__esModule = true); => stmt_level = 1, last_stmt_is_expr_stmt = true
-          parser.statement_path.len() == 1
-            && parser.is_statement_level_expression(assign_expr.span()),
-          Some(&assign_expr.right),
-        );
-      }
-      // exports.a = 1;
-      // module.exports.a = 1;
-      // this.a = 1;
-      parser
-        .dependencies
-        .push(Box::new(CommonJsExportsDependency::new(
-          left_expr.span().into(),
-          None,
-          base,
-          remaining.to_owned(),
-        )));
-      parser.walk_expression(&assign_expr.right);
-      Some(true)
-    };
-
-    if parser.is_exports_member_expr_start(left_expr) {
-      // exports.x = y;
-      handle_remaining(parser, ExportsBase::Exports)
-    } else if is_module_exports_member_expr_start(left_expr) {
-      // module.exports.x = y;
-      parser.append_module_runtime();
-      handle_remaining(parser, ExportsBase::ModuleExports)
-    } else if parser.is_this_member_expr_start(left_expr) {
-      // this.x = y
-      handle_remaining(parser, ExportsBase::This)
-    } else {
-      None
-    }
+    None
   }
 
-  fn call(&self, parser: &mut JavascriptParser, call_expr: &CallExpr, _name: &str) -> Option<bool> {
-    if parser.is_esm {
-      None
-    } else if let Callee::Expr(expr) = &call_expr.callee {
-      let handle_remaining = |parser: &mut JavascriptParser, base: ExportsBase| {
-        let is_module_exports_start = matches!(base, ExportsBase::ModuleExports);
-        if let Some(remaining) =
-          get_member_expression_info(parser, &**expr, Some(is_module_exports_start))
-        {
-          // exports()
-          // module.exports()
-          // this()
-          if remaining.is_empty() {
-            parser.bailout();
-          }
-
-          // exports.a.b()
-          // module.exports.a.b()
-          // this.a.b()
-          parser
-            .dependencies
-            .push(Box::new(CommonJsSelfReferenceDependency::new(
-              expr.span().into(),
-              base,
-              remaining,
-              true,
-            )));
-          parser.walk_expr_or_spread(&call_expr.args);
-          Some(true)
-        } else {
-          None
-        }
-      };
-      // Object.defineProperty(exports, "xxx", { value: 1 });
-      // Object.defineProperty(module.exports, "xxx", { value: 1 });
-      // Object.defineProperty(this, "xxx", { value: 1 });
-      if expr_matcher::is_object_define_property(&**expr)
-        && parser.is_statement_level_expression(call_expr.span())
-        && let Some(ExprOrSpread { expr, .. }) = call_expr.args.first()
-        && parser.is_exports_or_module_exports_or_this_expr(expr)
-        && let Some(arg2) = call_expr.args.get(2)
-      {
-        let ExprOrSpread { expr, .. } = call_expr.args.get(1)?;
-        let Expr::Lit(Lit::Str(str)) = &**expr else {
-          return None;
-        };
-
-        parser.enable();
-        // Object.defineProperty(exports, "__esModule", { value: true });
-        // Object.defineProperty(module.exports, "__esModule", { value: true });
-        // Object.defineProperty(this, "__esModule", { value: true });
-        if str.value == "__esModule" {
-          parser.check_namespace(
-            parser.statement_path.len() == 1,
-            get_value_of_property_description(arg2),
-          );
-        }
-
-        let ExprOrSpread {
-          expr: first_expr, ..
-        } = call_expr.args.first()?;
-        let base = if parser.is_exports_expr(&**first_expr) {
-          ExportsBase::DefinePropertyExports
-        } else if expr_matcher::is_module_exports(&**first_expr) {
-          ExportsBase::DefinePropertyModuleExports
-        } else if parser.is_top_level_this_expr(&**first_expr) {
-          ExportsBase::DefinePropertyThis
-        } else {
-          panic!("Unexpected expr type");
-        };
-        parser
-          .dependencies
-          .push(Box::new(CommonJsExportsDependency::new(
-            call_expr.span.into(),
-            Some(arg2.span().into()),
-            base,
-            vec![str.value.clone()],
-          )));
-
-        parser.walk_expression(&arg2.expr);
-        Some(true)
-      } else if parser.is_exports_member_expr_start(&**expr) {
-        // exports.x()
-        handle_remaining(parser, ExportsBase::Exports)
-      } else if is_module_exports_member_expr_start(&**expr) {
-        // module.exports.x()
-        parser.append_module_runtime();
-        handle_remaining(parser, ExportsBase::ModuleExports)
-      } else if parser.is_this_member_expr_start(&**expr) {
-        // this.x()
-        handle_remaining(parser, ExportsBase::This)
-      } else {
-        None
-      }
-    } else {
-      None
+  fn member_chain(
+    &self,
+    parser: &mut JavascriptParser,
+    expr: &MemberExpr,
+    for_name: &str,
+    members: &[Atom],
+    _members_optionals: &[bool],
+    _member_ranges: &[Span],
+  ) -> Option<bool> {
+    if for_name == "exports" {
+      // exports.a.b.c
+      return handle_access_export(parser, expr.span(), members, ExportsBase::Exports, None);
     }
+
+    if for_name == "module" && matches!(members.first(), Some(first) if first == "exports") {
+      // module.exports.a.b.c
+      return handle_access_export(
+        parser,
+        expr.span(),
+        &members[1..],
+        ExportsBase::ModuleExports,
+        None,
+      );
+    }
+
+    if for_name == "this" && parser.is_top_level_scope() {
+      // this.a.b.c
+      return handle_access_export(parser, expr.span(), members, ExportsBase::This, None);
+    }
+
+    None
+  }
+
+  fn call_member_chain(
+    &self,
+    parser: &mut JavascriptParser,
+    expr: &CallExpr,
+    for_name: &str,
+    members: &[Atom],
+    _members_optionals: &[bool],
+    _member_ranges: &[Span],
+  ) -> Option<bool> {
+    if for_name == "exports" {
+      // exports.a.b.c()
+      return handle_access_export(
+        parser,
+        expr.callee.span(),
+        members,
+        ExportsBase::Exports,
+        Some(&expr.args),
+      );
+    }
+
+    if for_name == "module" && matches!(members.first(), Some(first) if first == "exports") {
+      // module.exports.a.b.c()
+      return handle_access_export(
+        parser,
+        expr.callee.span(),
+        &members[1..],
+        ExportsBase::ModuleExports,
+        Some(&expr.args),
+      );
+    }
+
+    if for_name == "this" && parser.is_top_level_scope() {
+      // this.a.b.c()
+      return handle_access_export(
+        parser,
+        expr.callee.span(),
+        members,
+        ExportsBase::This,
+        Some(&expr.args),
+      );
+    }
+
+    None
   }
 
   fn evaluate_typeof<'a>(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -5,10 +5,7 @@ use rspack_core::{
 use rspack_error::{DiagnosticExt, Severity};
 use swc_core::{
   common::{Span, Spanned},
-  ecma::ast::{
-    AssignExpr, AssignTarget, CallExpr, Expr, ExprOrSpread, Ident, MemberExpr, NewExpr,
-    SimpleAssignTarget, UnaryExpr,
-  },
+  ecma::ast::{AssignExpr, CallExpr, Expr, ExprOrSpread, Ident, MemberExpr, NewExpr, UnaryExpr},
 };
 
 use super::JavascriptParserPlugin;
@@ -571,16 +568,10 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
   fn assign(
     &self,
     parser: &mut JavascriptParser,
-    expr: &AssignExpr,
-    for_name: Option<&str>,
+    _expr: &AssignExpr,
+    for_name: &str,
   ) -> Option<bool> {
-    let AssignTarget::Simple(SimpleAssignTarget::Ident(_)) = &expr.left else {
-      return None;
-    };
-
-    if let Some(for_name) = for_name
-      && for_name == expr_name::REQUIRE
-    {
+    if for_name == expr_name::REQUIRE {
       parser
         .presentational_dependencies
         .push(Box::new(ConstDependency::new(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -222,10 +222,27 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     &self,
     parser: &mut JavascriptParser,
     expr: &swc_core::ecma::ast::AssignExpr,
-    for_name: Option<&str>,
+    for_name: &str,
   ) -> Option<bool> {
     for plugin in &self.plugins {
       let res = plugin.assign(parser, expr, for_name);
+      // `SyncBailHook`
+      if res.is_some() {
+        return res;
+      }
+    }
+    None
+  }
+
+  fn assign_member_chain(
+    &self,
+    parser: &mut JavascriptParser,
+    expr: &swc_core::ecma::ast::AssignExpr,
+    members: &[Atom],
+    for_name: &str,
+  ) -> Option<bool> {
+    for plugin in &self.plugins {
+      let res = plugin.assign_member_chain(parser, expr, members, for_name);
       // `SyncBailHook`
       if res.is_some() {
         return res;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_top_level_this_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_top_level_this_plugin.rs
@@ -1,7 +1,7 @@
 use rspack_core::ConstDependency;
 
 use super::JavascriptParserPlugin;
-use crate::visitors::{JavascriptParser, TopLevelScope};
+use crate::visitors::JavascriptParser;
 
 pub struct ESMTopLevelThisParserPlugin;
 
@@ -11,7 +11,7 @@ impl JavascriptParserPlugin for ESMTopLevelThisParserPlugin {
     parser: &mut JavascriptParser,
     expr: &swc_core::ecma::ast::ThisExpr,
   ) -> Option<bool> {
-    (parser.is_esm && !matches!(parser.top_level_scope, TopLevelScope::False)).then(|| {
+    (parser.is_esm && parser.is_top_level_this()).then(|| {
       // TODO: esm_export::is_enabled
       parser
         .presentational_dependencies

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -13,9 +13,7 @@ use crate::{
     BasicEvaluatedExpression, evaluate_to_boolean, evaluate_to_null, evaluate_to_number,
     evaluate_to_string, evaluate_to_undefined,
   },
-  visitors::{
-    JavascriptParser, TagInfoData, TopLevelScope, VariableDeclaration, VariableDeclarationKind,
-  },
+  visitors::{JavascriptParser, TagInfoData, VariableDeclaration, VariableDeclarationKind},
 };
 
 pub const INLINABLE_CONST_TAG: &str = "inlinable const";
@@ -83,7 +81,7 @@ impl JavascriptParserPlugin for InlineConstPlugin {
     declarator: &VarDeclarator,
     declaration: VariableDeclaration<'_>,
   ) -> Option<bool> {
-    if !parser.has_inlinable_const_decls || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+    if !parser.has_inlinable_const_decls || !parser.is_top_level_scope() {
       return None;
     }
     if matches!(declaration.kind(), VariableDeclarationKind::Const)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -17,8 +17,7 @@ use crate::{
   is_pure_class, is_pure_class_member, is_pure_expression, is_pure_function,
   parser_plugin::{DEFAULT_STAR_JS_WORD, JavascriptParserPlugin},
   visitors::{
-    JavascriptParser, Statement, TagInfoData, TopLevelScope, VariableDeclaration,
-    scope_info::VariableInfoFlags,
+    JavascriptParser, Statement, TagInfoData, VariableDeclaration, scope_info::VariableInfoFlags,
   },
 };
 
@@ -363,7 +362,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
       return None;
     }
 
-    if matches!(parser.top_level_scope, TopLevelScope::Top)
+    if parser.is_top_level_scope()
       && let Some(fn_decl) = stmt.as_function_decl()
     {
       let name = &fn_decl
@@ -388,7 +387,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     parser: &mut crate::visitors::JavascriptParser,
     stmt: Statement,
   ) -> Option<bool> {
-    if !parser.inner_graph.is_enabled() || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+    if !parser.inner_graph.is_enabled() || !parser.is_top_level_scope() {
       return None;
     }
 
@@ -415,7 +414,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     parser: &mut crate::visitors::JavascriptParser,
     export_decl: &ModuleDecl,
   ) -> Option<bool> {
-    if !parser.inner_graph.is_enabled() || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+    if !parser.inner_graph.is_enabled() || !parser.is_top_level_scope() {
       return None;
     }
 
@@ -472,7 +471,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     decl: &VarDeclarator,
     _stmt: VariableDeclaration<'_>,
   ) -> Option<bool> {
-    if !parser.inner_graph.is_enabled() || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+    if !parser.inner_graph.is_enabled() || !parser.is_top_level_scope() {
       return None;
     }
 
@@ -515,7 +514,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     parser: &mut crate::visitors::JavascriptParser,
     stmt: Statement,
   ) -> Option<bool> {
-    if !parser.inner_graph.is_enabled() || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+    if !parser.inner_graph.is_enabled() || !parser.is_top_level_scope() {
       return None;
     }
 
@@ -527,7 +526,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
   }
 
   fn module_declaration(&self, parser: &mut JavascriptParser, stmt: &ModuleDecl) -> Option<bool> {
-    if !parser.inner_graph.is_enabled() || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+    if !parser.inner_graph.is_enabled() || !parser.is_top_level_scope() {
       return None;
     }
 
@@ -581,7 +580,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     super_class: &Expr,
     class_decl_or_expr: crate::visitors::ClassDeclOrExpr,
   ) -> Option<bool> {
-    if !parser.inner_graph.is_enabled() || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+    if !parser.inner_graph.is_enabled() || !parser.is_top_level_scope() {
       return None;
     }
 
@@ -617,7 +616,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     _element: &swc_core::ecma::ast::ClassMember,
     class_decl_or_expr: crate::visitors::ClassDeclOrExpr,
   ) -> Option<bool> {
-    if !parser.inner_graph.is_enabled() || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+    if !parser.inner_graph.is_enabled() || !parser.is_top_level_scope() {
       return None;
     }
 
@@ -639,7 +638,7 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     expr_span: Span,
     class_decl_or_expr: crate::visitors::ClassDeclOrExpr,
   ) -> Option<bool> {
-    if !parser.inner_graph.is_enabled() || !matches!(parser.top_level_scope, TopLevelScope::Top) {
+    if !parser.inner_graph.is_enabled() || !parser.is_top_level_scope() {
       return None;
     }
     if let Some(v) = parser
@@ -759,9 +758,8 @@ impl JavascriptParserPlugin for InnerGraphPlugin {
     &self,
     parser: &mut JavascriptParser,
     expr: &swc_core::ecma::ast::AssignExpr,
-    for_name: Option<&str>,
+    for_name: &str,
   ) -> Option<bool> {
-    let for_name = for_name?;
     if !parser.inner_graph.is_enabled() || for_name != TOP_LEVEL_SYMBOL {
       return None;
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -292,12 +292,21 @@ pub trait JavascriptParserPlugin {
     None
   }
 
-  // FIXME: should remove
   fn assign(
     &self,
     _parser: &mut JavascriptParser,
     _expr: &AssignExpr,
-    _for_name: Option<&str>,
+    _for_name: &str,
+  ) -> Option<bool> {
+    None
+  }
+
+  fn assign_member_chain(
+    &self,
+    _parser: &mut JavascriptParser,
+    _expr: &AssignExpr,
+    _members: &[Atom],
+    _for_name: &str,
   ) -> Option<bool> {
     None
   }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_lit_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_lit_expr.rs
@@ -1,34 +1,34 @@
 use rspack_core::SpanExt;
 use swc_core::{
   common::Spanned,
-  ecma::ast::{Expr, Lit, PropName, Str},
+  ecma::ast::{Lit, Str},
 };
 
 use super::BasicEvaluatedExpression;
 
 #[inline]
-fn eval_str(str: &Str) -> BasicEvaluatedExpression<'_> {
+pub fn eval_str(str: &Str) -> BasicEvaluatedExpression<'_> {
   let mut res = BasicEvaluatedExpression::with_range(str.span().real_lo(), str.span_hi().0);
   res.set_string(str.value.to_string());
   res
 }
 
 #[inline]
-fn eval_number(num: &swc_core::ecma::ast::Number) -> BasicEvaluatedExpression<'_> {
+pub fn eval_number(num: &swc_core::ecma::ast::Number) -> BasicEvaluatedExpression<'_> {
   let mut res = BasicEvaluatedExpression::with_range(num.span().real_lo(), num.span_hi().0);
   res.set_number(num.value);
   res
 }
 
 #[inline]
-fn eval_bool(bool: &swc_core::ecma::ast::Bool) -> BasicEvaluatedExpression<'_> {
+pub fn eval_bool(bool: &swc_core::ecma::ast::Bool) -> BasicEvaluatedExpression<'_> {
   let mut res = BasicEvaluatedExpression::with_range(bool.span().real_lo(), bool.span_hi().0);
   res.set_bool(bool.value);
   res
 }
 
 #[inline]
-fn eval_bigint(bigint: &swc_core::ecma::ast::BigInt) -> BasicEvaluatedExpression<'_> {
+pub fn eval_bigint(bigint: &swc_core::ecma::ast::BigInt) -> BasicEvaluatedExpression<'_> {
   let mut res = BasicEvaluatedExpression::with_range(bigint.span().real_lo(), bigint.span_hi().0);
   res.set_bigint((*bigint.value).clone());
   res
@@ -53,22 +53,5 @@ pub fn eval_lit_expr(expr: &Lit) -> Option<BasicEvaluatedExpression<'_>> {
     Lit::Bool(bool) => Some(eval_bool(bool)),
     Lit::BigInt(bigint) => Some(eval_bigint(bigint)),
     Lit::JSXText(_) => unreachable!(),
-  }
-}
-
-#[inline]
-pub fn eval_prop_name(prop_name: &PropName) -> Option<BasicEvaluatedExpression<'_>> {
-  match prop_name {
-    PropName::Str(str) => Some(eval_str(str)),
-    PropName::Num(num) => Some(eval_number(num)),
-    PropName::BigInt(bigint) => Some(eval_bigint(bigint)),
-    // TODO:
-    PropName::Ident(_) => None,
-    PropName::Computed(computed) => match &*computed.expr {
-      Expr::Lit(Lit::Str(str)) => Some(eval_str(str)),
-      Expr::Lit(Lit::Num(num)) => Some(eval_number(num)),
-      // TODO: more computed expr
-      _ => None,
-    },
   }
 }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_prop_name.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_prop_name.rs
@@ -1,0 +1,26 @@
+use rspack_core::SpanExt;
+use swc_core::{common::Spanned, ecma::ast::PropName};
+
+use crate::{
+  utils::eval::{BasicEvaluatedExpression, eval_bigint, eval_number, eval_str},
+  visitors::JavascriptParser,
+};
+
+#[inline]
+pub fn eval_prop_name<'a>(
+  parser: &mut JavascriptParser,
+  prop_name: &'a PropName,
+) -> BasicEvaluatedExpression<'a> {
+  match prop_name {
+    PropName::Str(str) => eval_str(str),
+    PropName::Num(num) => eval_number(num),
+    PropName::BigInt(bigint) => eval_bigint(bigint),
+    PropName::Ident(ident) => {
+      let mut evaluated =
+        BasicEvaluatedExpression::with_range(ident.span().real_lo(), ident.span_hi().0);
+      evaluated.set_string(ident.sym.to_string());
+      evaluated
+    }
+    PropName::Computed(computed) => parser.evaluate_expression(&computed.expr),
+  }
+}

--- a/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
@@ -5,6 +5,7 @@ mod eval_cond_expr;
 mod eval_lit_expr;
 mod eval_member_expr;
 mod eval_new_expr;
+mod eval_prop_name;
 mod eval_source;
 mod eval_tpl_expr;
 mod eval_unary_expr;
@@ -19,9 +20,10 @@ pub use self::{
   eval_binary_expr::eval_binary_expression,
   eval_call_expr::eval_call_expression,
   eval_cond_expr::eval_cond_expression,
-  eval_lit_expr::{eval_lit_expr, eval_prop_name},
+  eval_lit_expr::{eval_bigint, eval_bool, eval_lit_expr, eval_number, eval_str},
   eval_member_expr::eval_member_expression,
   eval_new_expr::eval_new_expression,
+  eval_prop_name::eval_prop_name,
   eval_source::eval_source,
   eval_tpl_expr::{TemplateStringKind, eval_tagged_tpl_expression, eval_tpl_expression},
   eval_unary_expr::eval_unary_expression,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -430,6 +430,14 @@ impl<'parser> JavascriptParser<'parser> {
     }
   }
 
+  pub fn is_top_level_scope(&self) -> bool {
+    matches!(self.top_level_scope, TopLevelScope::Top)
+  }
+
+  pub fn is_top_level_this(&self) -> bool {
+    !matches!(self.top_level_scope, TopLevelScope::False)
+  }
+
   pub fn add_local_module(&mut self, name: &str) -> LocalModule {
     let m = LocalModule::new(name.into(), self.local_modules.len());
     self.local_modules.push(m.clone());

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
@@ -161,7 +161,7 @@ impl JavascriptParser<'_> {
   }
 
   fn pre_walk_for_of_statement(&mut self, stmt: &ForOfStmt) {
-    if stmt.is_await && matches!(self.top_level_scope, super::TopLevelScope::Top) {
+    if stmt.is_await && self.is_top_level_scope() {
       self
         .plugin_drive
         .clone()
@@ -221,8 +221,8 @@ impl JavascriptParser<'_> {
               shorthand: false,
             });
           } else {
-            let name = eval::eval_prop_name(&prop.key);
-            if let Some(id) = name.and_then(|id| id.as_string()) {
+            let name = eval::eval_prop_name(self, &prop.key);
+            if let Some(id) = name.as_string() {
               keys.insert(DestructuringAssignmentProperty {
                 id: id.into(),
                 range: prop.key.span().into(),

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -167,11 +167,7 @@ pub(crate) mod expr_matcher {
   // - Matching would ignore Span and SyntaxContext
   define_expr_matchers!({
     is_require: "require",
-    is_module_id: "module.id",
-    is_module_loaded: "module.loaded",
-    is_module_exports: "module.exports",
     is_module_require: "module.require",
-    is_object_define_property: "Object.defineProperty",
   });
 }
 
@@ -340,38 +336,5 @@ mod test {
     test!("module.require.a().b", false);
     test!("module.require.a.b", false);
     test!("a.module.require.b", false);
-  }
-
-  #[test]
-  fn supports_expr_like() {
-    let e = MemberExpr {
-      span: DUMMY_SP,
-      obj: Box::new(
-        Ident {
-          ctxt: Default::default(),
-          span: DUMMY_SP,
-          sym: "module".into(),
-          optional: false,
-        }
-        .into(),
-      ),
-      prop: MemberProp::Ident(
-        Ident {
-          ctxt: Default::default(),
-          span: DUMMY_SP,
-          sym: "exports".into(),
-          optional: false,
-        }
-        .into(),
-      ),
-    };
-    assert!(
-      expr_matcher::is_module_exports(&e),
-      "should support evaluate with `MemberExpr`"
-    );
-    assert!(
-      expr_matcher::is_module_exports(&Expr::Member(e)),
-      "should support evaluate with `Expr::Member(MemberExpr {{ .. }})`"
-    );
   }
 }


### PR DESCRIPTION
## Summary

use for_name instead of extracting info from ast

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
