### PR TITLE
ci: install `rustup` on Windows

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -20,13 +20,20 @@ runs:
   using: composite
   steps:
     - name: Install rustup, if needed
-      if: runner.os != 'Windows'
       shell: bash
       run: |
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+
+          # Resolve the correct CARGO_HOME path depending on OS
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "${CARGO_HOME:-$USERPROFILE/.cargo}/bin" | sed 's|/|\\|g' >> $GITHUB_PATH
+          else
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          fi
         fi
+      env:
+        RUNNER_OS: "${{ runner.os }}"
 
     - name: Get toolchain
       id: get-toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     with:
       target: x86_64-pc-windows-msvc
       profile: "dev"
-      runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
+      runner: '"rspack-windows-2022-large-verify"'
       test-runner: '"windows-latest"'
       test: true
 

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -104,7 +104,7 @@ jobs:
           cargo xtask deny-ext
 
       - uses: cargo-bins/cargo-binstall@79e4beb1e02f733a26129a6bf26c37dab4ab3307 # v1.14.4
-      - run: cargo binstall --no-confirm cargo-shear@1.1.12 --force
+      - run: cargo binstall --no-confirm cargo-shear@1.5.1 --force
       - run: cargo shear
 
   rust_test:


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Install `rustup` on Windows. This would avoid depending on having `rustup` on Windows runner (just like the Linux runner does).

## Related links

<!-- Related issues or discussions. -->

Fork from [`actions-rust-lang/setup-rust-toolchain`](https://github.com/actions-rust-lang/setup-rust-toolchain/blob/ab6845274e2ff01cd4462007e1a9d9df1ab49f42/action.yml#L144).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
