### PR TITLE
docs: update TypeScript config file guide

### DIFF
--- a/website/docs/en/config/index.mdx
+++ b/website/docs/en/config/index.mdx
@@ -72,11 +72,17 @@ See [Extending Configurations](./extends.mdx) for details on how to extend confi
 
 ## TypeScript configuration file
 
-When using `rspack.config.ts`, you need to use a runtime that supports TypeScript, or install additional dependencies to resolve TypeScript files. You can choose one of the following:
+When using `rspack.config.ts`, you can choose from one of the following approaches:
+
+### Default behavior
+
+Starting from v1.5.0, Rspack CLI has built-in support for TypeScript configuration, using SWC by default to transform TypeScript code into CommonJS format JavaScript code.
+
+If you're using a Rspack CLI earlier than v1.5.0, it's recommended to upgrade to the latest version. You no longer need to load configuration files through `ts-node` or `esbuild-register`, and these dependencies can be removed.
 
 ### Native support
 
-If your JavaScript runtime already natively supports TypeScript, you can use the built-in TS transformation to load the configuration file without needing to install additional dependencies.
+If your JavaScript runtime already natively supports TypeScript, you can use the built-in TS transformation to load the configuration file, ensuring that module resolution behavior is consistent with native behavior.
 
 For example, Node.js already natively supports TypeScript, you can use the following command to use the Node.js native loader to load the configuration file:
 

--- a/website/docs/zh/config/index.mdx
+++ b/website/docs/zh/config/index.mdx
@@ -72,11 +72,17 @@ Rspack 支持以下配置文件格式：
 
 ## TypeScript 配置文件
 
-在使用 `rspack.config.ts` 时，你需要使用支持 TypeScript 的运行时，或者安装额外的依赖来解析 TypeScript 文件，你可以选择以下任意一种：
+在使用 `rspack.config.ts` 时，你可以选择以下任意一种方式：
+
+### 默认行为
+
+Rspack CLI 从 1.5.0 版本开始内置对 TypeScript 配置的支持，默认使用 SWC 来将 TypeScript 代码转换为 CommonJS 格式的 JavaScript 代码。
+
+如果你使用的 Rspack CLI 版本小于 1.5.0，建议升级到最新版本，无需再通过 `ts-node` 或 `esbuild-register` 加载配置文件，这些依赖可以被移除。
 
 ### 原生支持
 
-如果你使用的 JavaScript 运行时已经原生支持 TypeScript，你可以使用内置的 TS 转换来加载配置文件，而无需安装额外的依赖。
+如果你使用的 JavaScript 运行时已经原生支持 TypeScript，你可以使用内置的 TS 转换来加载配置文件，确保模块解析行为与原生行为一致。
 
 例如，Node.js 已经原生支持 TypeScript，你可以使用以下命令来使用 Node.js 原生加载器来加载配置文件：
 
@@ -91,34 +97,6 @@ Rspack 支持以下配置文件格式：
 ```
 
 详见 [Node.js - Running TypeScript Natively](https://nodejs.org/en/learn/typescript/run-natively#running-typescript-natively)。
-
-### 使用 esbuild
-
-对于低于 Node.js v22.7.0 的版本，你可以使用 `esbuild-register` 来加载配置文件。
-
-安装 [esbuild](https://npmjs.com/package/esbuild) 和 [esbuild-register](https://npmjs.com/package/esbuild-register) 即可，不需要任何配置。
-
-<PackageManagerTabs command="add esbuild esbuild-register -D" />
-
-### 使用 ts-node
-
-你也可以使用 [ts-node](https://npmjs.com/package/ts-node) 来加载配置文件。
-
-1. 安装 `ts-node`：
-
-<PackageManagerTabs command="add ts-node -D" />
-
-2. 然后在 `tsconfig.json` 中配置 `ts-node` 使用 `CommonJS` 模块：
-
-```json title="tsconfig.json"
-{
-  "ts-node": {
-    "compilerOptions": {
-      "module": "CommonJS"
-    }
-  }
-}
-```
 
 ### 配置类型检查
 


### PR DESCRIPTION
## Summary

Remove outdated instructions for `esbuild-register` and `ts-node`, and add details about built-in SWC support in Rspack CLI v1.5.0+.

## Related links

- https://github.com/web-infra-dev/rspack/releases/tag/v1.5.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
