### PR TITLE
fix: wrong match object logic in `SwcJsMinimizerRspackPlugin`

### DIFF
--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -368,10 +368,10 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 }
 
 pub fn match_object(obj: &PluginOptions, str: &str) -> bool {
-  if let Some(condition) = &obj.test
-    && !condition.try_match(str)
-  {
-    return false;
+  if let Some(condition) = &obj.test {
+    if !condition.try_match(str) {
+      return false;
+    }
   } else if !JAVASCRIPT_ASSET_REGEXP.is_match(str) {
     return false;
   }

--- a/packages/rspack-test-tools/tests/configCases/plugins/rspack-issue-11183/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/rspack-issue-11183/index.js
@@ -1,0 +1,11 @@
+const fs = require("node:fs")
+
+console.log("line1")
+console.log("line2")
+console.log("line3")
+
+it('should minimize *.bundle', () => {
+  const content = fs.readFileSync(__filename, "utf-8");
+
+  expect(content.split(/\r?\n/).length).toBe(1);
+});

--- a/packages/rspack-test-tools/tests/configCases/plugins/rspack-issue-11183/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/rspack-issue-11183/rspack.config.js
@@ -1,0 +1,16 @@
+const { rspack } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].bundle"
+	},
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin({
+				test: /\.bundle$/
+			})
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/rspack-issue-11183/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/rspack-issue-11183/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["main.bundle"];
+	}
+};


### PR DESCRIPTION
## Summary

I forget to add test case in https://github.com/web-infra-dev/rspack/pull/11231.
And the regression happens in https://github.com/web-infra-dev/rspack/pull/11217

## Related links

fixes https://github.com/web-infra-dev/rspack/issues/11183

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
