### PR TITLE
fix: asset info related source map can set null

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -495,6 +495,10 @@ export declare class VirtualFileStore {
 }
 export type JsVirtualFileStore = VirtualFileStore
 
+export interface AssetInfoRelated {
+  sourceMap?: string | null
+}
+
 export declare function async(path: string, request: string): Promise<ResolveResult>
 
 export interface BuiltinPlugin {
@@ -672,10 +676,6 @@ export interface JsAssetEmittedArgs {
   filename: string
   outputPath: string
   targetPath: string
-}
-
-export interface JsAssetInfoRelated {
-  sourceMap?: string
 }
 
 export interface JsBannerContentFnCtx {
@@ -1503,7 +1503,7 @@ export interface KnownAssetInfo {
   /** when asset is javascript and an ESM */
   javascriptModule?: boolean
   /** related object to other assets, keyed by type of relation (only points from parent to child) */
-  related?: JsAssetInfoRelated
+  related?: AssetInfoRelated
   /** unused css local ident for the css chunk */
   cssUnusedIdents?: Array<string>
   /** whether this asset is over the size limit */

--- a/packages/rspack-test-tools/tests/configCases/asset/update-asset-sourcemap-null/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/update-asset-sourcemap-null/rspack.config.js
@@ -1,0 +1,25 @@
+const assert = require("assert");
+const fs = require("fs");
+
+/**
+ * @type {import('@rspack/core').Configuration}
+ */
+module.exports = {
+	context: __dirname,
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("PLUGIN", compilation => {
+					compilation.hooks.processAssets.tap("PLUGIN", assets => {
+						for (const name in assets) {
+                            const source = assets[name];
+                            compilation.updateAsset(name, source, {
+                                related: { sourceMap: null },
+                            });
+                        }
+					});
+				});
+			}
+		}
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/asset/update-asset-sourcemap-null/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/update-asset-sourcemap-null/rspack.config.js
@@ -5,21 +5,21 @@ const fs = require("fs");
  * @type {import('@rspack/core').Configuration}
  */
 module.exports = {
-	context: __dirname,
-	plugins: [
-		{
-			apply(compiler) {
-				compiler.hooks.compilation.tap("PLUGIN", compilation => {
-					compilation.hooks.processAssets.tap("PLUGIN", assets => {
-						for (const name in assets) {
+    context: __dirname,
+    plugins: [
+        {
+            apply(compiler) {
+                compiler.hooks.compilation.tap("PLUGIN", compilation => {
+                    compilation.hooks.processAssets.tap("PLUGIN", assets => {
+                        for (const name in assets) {
                             const source = assets[name];
                             compilation.updateAsset(name, source, {
                                 related: { sourceMap: null },
                             });
                         }
-					});
-				});
-			}
-		}
-	]
+                    });
+                });
+            }
+        }
+    ]
 };


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR fixes an issue where asset info related source map fields could not be set to null. The fix allows the sourceMap property in the related object to accept null values in addition to string values.

Close https://github.com/web-infra-dev/rspack/issues/11291

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
