### PR TITLE
fix: add tsEnumIsMutable option to SWC loader schema

### DIFF
--- a/packages/rspack/src/schema/loaders.ts
+++ b/packages/rspack/src/schema/loaders.ts
@@ -289,6 +289,7 @@ export const getZodSwcLoaderOptionsSchema = memoize(() => {
 			decoratorMetadata: z.boolean(),
 			decoratorVersion: z.enum(["2021-12", "2022-03"]),
 			treatConstEnumAsEnum: z.boolean(),
+			tsEnumIsMutable: z.boolean(),
 			useDefineForClassFields: z.boolean(),
 			verbatimModuleSyntax: z.boolean()
 		})


### PR DESCRIPTION
## Summary

Add `tsEnumIsMutable` option to swc loader schema to fix the schema validation error in https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/inline-const-enum

<img width="1021" height="299" alt="Screenshot 2025-08-27 at 15 08 35" src="https://github.com/user-attachments/assets/9212522e-e4f3-47bb-8b5a-a56ce850b5e8" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
