### PR TITLE
perf: improve data structures of bundle splitting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4800,6 +4800,7 @@ dependencies = [
  "dashmap 6.1.0",
  "derive_more",
  "futures",
+ "itertools 0.14.0",
  "rayon",
  "regex",
  "rspack_collections",

--- a/crates/rspack_collections/src/identifier.rs
+++ b/crates/rspack_collections/src/identifier.rs
@@ -83,6 +83,10 @@ impl Identifier {
   pub fn to_string(&self) -> String {
     self.0.to_owned()
   }
+
+  pub fn precomputed_hash(&self) -> u64 {
+    self.0.precomputed_hash()
+  }
 }
 
 impl fmt::Display for Identifier {

--- a/crates/rspack_core/src/exports/export_info_setter.rs
+++ b/crates/rspack_core/src/exports/export_info_setter.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 use rspack_util::atom::Atom;
 
 use super::{ExportInfoData, ExportInfoTargetValue, Inlinable, UsageFilterFnTy, UsageState};
-use crate::{DependencyId, ExportsInfo, Nullable, RuntimeSpec};
+use crate::{DependencyId, Nullable, RuntimeSpec};
 
 impl ExportInfoData {
   pub fn reset_provide_info(&mut self) {
@@ -212,17 +212,12 @@ impl ExportInfoData {
     changed
   }
 
-  pub fn set_has_use_info(&mut self, nested_exports_info: &mut Vec<ExportsInfo>) {
+  pub fn set_has_use_info(&mut self) {
     if !self.has_use_in_runtime_info() {
       self.set_has_use_in_runtime_info(true);
     }
     if self.can_mangle_use().is_none() {
       self.set_can_mangle_use(Some(true));
-    }
-    if self.exports_info_owned()
-      && let Some(exports_info) = self.exports_info()
-    {
-      nested_exports_info.push(exports_info);
     }
   }
 }

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -163,30 +163,6 @@ impl ExportsInfo {
     new_info_id
   }
 
-  pub fn set_has_use_info(&self, mg: &mut ModuleGraph) {
-    let mut nested_exports_info = vec![];
-    let exports_info = self.as_data_mut(mg);
-    for export_info in exports_info.exports_mut().values_mut() {
-      export_info.set_has_use_info(&mut nested_exports_info);
-    }
-    exports_info
-      .side_effects_only_info_mut()
-      .set_has_use_info(&mut nested_exports_info);
-    if let Some(redirect) = exports_info.redirect_to() {
-      redirect.set_has_use_info(mg);
-    } else {
-      let other_exports_info = exports_info.other_exports_info_mut();
-      other_exports_info.set_has_use_info(&mut nested_exports_info);
-      if other_exports_info.can_mangle_use().is_none() {
-        other_exports_info.set_can_mangle_use(Some(true));
-      }
-    }
-
-    for nested_exports_info in nested_exports_info {
-      nested_exports_info.set_has_use_info(mg);
-    }
-  }
-
   pub fn set_used_without_info(&self, mg: &mut ModuleGraph, runtime: Option<&RuntimeSpec>) -> bool {
     let mut changed = false;
     let exports_info = self.as_data_mut(mg);

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -146,7 +146,7 @@ pub enum ExportProvided {
   Unknown,
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, Default, Clone)]
 pub struct UsageKey(pub Vec<Either<Box<UsageKey>, UsageState>>);
 
 impl UsageKey {

--- a/crates/rspack_core/src/module_graph/exports_info.rs
+++ b/crates/rspack_core/src/module_graph/exports_info.rs
@@ -1,0 +1,98 @@
+use std::collections::hash_map::Entry;
+
+use rayon::prelude::*;
+
+use crate::{
+  ExportsInfo, ExportsInfoData, ExportsInfoGetter, ModuleGraph, ModuleIdentifier,
+  PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper,
+};
+
+impl<'a> ModuleGraph<'a> {
+  pub fn get_exports_info(&self, module_identifier: &ModuleIdentifier) -> ExportsInfo {
+    self
+      .module_graph_module_by_identifier(module_identifier)
+      .expect("should have mgm")
+      .exports
+  }
+
+  pub fn get_prefetched_exports_info_optional<'b>(
+    &'b self,
+    module_identifier: &ModuleIdentifier,
+    mode: PrefetchExportsInfoMode<'b>,
+  ) -> Option<PrefetchedExportsInfoWrapper<'b>> {
+    self
+      .module_graph_module_by_identifier(module_identifier)
+      .map(move |mgm| ExportsInfoGetter::prefetch(&mgm.exports, self, mode))
+  }
+
+  pub fn get_prefetched_exports_info<'b>(
+    &'b self,
+    module_identifier: &ModuleIdentifier,
+    mode: PrefetchExportsInfoMode<'b>,
+  ) -> PrefetchedExportsInfoWrapper<'b> {
+    let exports_info = self.get_exports_info(module_identifier);
+    ExportsInfoGetter::prefetch(&exports_info, self, mode)
+  }
+
+  pub fn get_exports_info_by_id(&self, id: &ExportsInfo) -> &ExportsInfoData {
+    self
+      .try_get_exports_info_by_id(id)
+      .expect("should have exports info")
+  }
+
+  pub fn try_get_exports_info_by_id(&self, id: &ExportsInfo) -> Option<&ExportsInfoData> {
+    self.loop_partials(|p| p.exports_info_map.get(id))
+  }
+
+  pub fn get_exports_info_mut_by_id(&mut self, id: &ExportsInfo) -> &mut ExportsInfoData {
+    self
+      .loop_partials_mut(
+        |p| p.exports_info_map.contains_key(id),
+        |p, search_result| {
+          p.exports_info_map.insert(*id, search_result);
+        },
+        |p| p.exports_info_map.get(id).cloned(),
+        |p| p.exports_info_map.get_mut(id),
+      )
+      .expect("should have exports info")
+  }
+
+  pub fn set_exports_info(&mut self, id: ExportsInfo, info: ExportsInfoData) {
+    let Some(active_partial) = &mut self.active else {
+      panic!("should have active partial");
+    };
+    active_partial.exports_info_map.insert(id, info);
+  }
+
+  pub fn active_all_exports_info(&mut self) {
+    let active_partial = self.active.as_mut().expect("should have active partial");
+    for partial in self.partials.iter().rev().flatten() {
+      for (id, exports_info) in partial.exports_info_map.iter() {
+        match active_partial.exports_info_map.entry(*id) {
+          Entry::Occupied(_) => {}
+          Entry::Vacant(entry) => {
+            entry.insert(exports_info.clone());
+          }
+        }
+      }
+    }
+  }
+
+  pub fn reset_all_exports_info_used(&mut self) {
+    let exports_info_map = &mut self
+      .active
+      .as_mut()
+      .expect("should have active partial")
+      .exports_info_map;
+
+    exports_info_map
+      .par_iter_mut()
+      .for_each(|(_, exports_info)| {
+        for export_info in exports_info.exports_mut().values_mut() {
+          export_info.set_has_use_info();
+        }
+        exports_info.side_effects_only_info_mut().set_has_use_info();
+        exports_info.other_exports_info_mut().set_has_use_info();
+      });
+  }
+}

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -48,6 +48,9 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
 
   fn apply(&mut self) {
     let mut module_graph = self.compilation.get_module_graph_mut();
+    module_graph.active_all_exports_info();
+    module_graph.reset_all_exports_info_used();
+
     for mgm in module_graph.module_graph_modules().values() {
       self
         .exports_info_module_map
@@ -55,9 +58,6 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     }
     let mut q = Queue::new();
     let mg = &mut module_graph;
-    for exports_info in self.exports_info_module_map.keys() {
-      exports_info.set_has_use_info(mg);
-    }
 
     // SAFETY: we can make sure that entries will not be used other place at the same time,
     // this take is aiming to avoid use self ref and mut ref at the same time;

--- a/crates/rspack_plugin_split_chunks/Cargo.toml
+++ b/crates/rspack_plugin_split_chunks/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 dashmap            = { workspace = true }
 derive_more        = { workspace = true, features = ["debug"] }
 futures            = { workspace = true }
+itertools          = { workspace = true }
 rayon              = { workspace = true }
 regex              = { workspace = true }
 rspack_collections = { workspace = true }

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -1,4 +1,5 @@
 use derive_more::Debug;
+use itertools::Itertools;
 use rspack_collections::{IdentifierSet, UkeySet};
 use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
 use rustc_hash::FxHashMap;
@@ -27,11 +28,15 @@ pub(crate) struct ModuleGroup {
   /// If the `ModuleGroup` is going to create a chunk, which will be named using `chunk_name`
   /// A module
   pub chunk_name: Option<String>,
-  pub sizes: SplitChunkSizes,
+
   pub source_types_modules: FxHashMap<SourceType, IdentifierSet>,
   /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[debug(skip)]
   pub chunks: UkeySet<ChunkUkey>,
+  added: Vec<ModuleIdentifier>,
+  removed: Vec<ModuleIdentifier>,
+  sizes: SplitChunkSizes,
+  total_size: f64,
 }
 
 impl ModuleGroup {
@@ -49,6 +54,9 @@ impl ModuleGroup {
       source_types_modules: Default::default(),
       chunks: Default::default(),
       chunk_name,
+      added: Default::default(),
+      removed: Default::default(),
+      total_size: 0.0,
     }
   }
 
@@ -81,39 +89,65 @@ impl ModuleGroup {
     }
   }
 
-  pub fn add_module(&mut self, module: ModuleIdentifier, module_sizes: &ModuleSizes) {
+  pub fn add_module(&mut self, module: ModuleIdentifier) {
     if self.modules.insert(module) {
-      let module_sizes = module_sizes.get(&module).expect("should have module size");
-      for (ty, s) in module_sizes.iter() {
-        let size = self.sizes.entry(*ty).or_default();
-        *size += s;
-        self
-          .source_types_modules
-          .entry(*ty)
-          .or_default()
-          .insert(module);
-      }
+      self.added.push(module);
     }
   }
 
-  pub fn remove_module(&mut self, module: ModuleIdentifier, module_sizes: &ModuleSizes) {
+  pub fn remove_module(&mut self, module: ModuleIdentifier) {
     if self.modules.remove(&module) {
-      let module_sizes = module_sizes.get(&module).expect("should have module size");
-      for (ty, s) in module_sizes.iter() {
-        let size = self.sizes.entry(*ty).or_default();
-        *size -= s;
-        *size = size.max(0.0);
-        self
-          .source_types_modules
-          .entry(*ty)
-          .or_default()
-          .remove(&module);
-      }
+      self.removed.push(module);
     }
   }
 
   pub fn get_cache_group<'a>(&self, cache_groups: &'a [CacheGroup]) -> &'a CacheGroup {
     &cache_groups[self.cache_group_index]
+  }
+
+  pub fn get_total_size(&self) -> f64 {
+    if !self.added.is_empty() || !self.removed.is_empty() {
+      unreachable!("should update sizes before get total size");
+    }
+    self.total_size
+  }
+
+  pub fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes {
+    if !self.added.is_empty() {
+      let added = std::mem::take(&mut self.added);
+      for module in added {
+        let module_sizes = module_sizes.get(&module).expect("should have module size");
+        for (ty, s) in module_sizes.iter() {
+          let size = self.sizes.entry(*ty).or_default();
+          *size += s;
+          self.total_size += s;
+          self
+            .source_types_modules
+            .entry(*ty)
+            .or_default()
+            .insert(module);
+        }
+      }
+    }
+    if !self.removed.is_empty() {
+      let removed = std::mem::take(&mut self.removed);
+      for module in removed {
+        let module_sizes = module_sizes.get(&module).expect("should have module size");
+        for (ty, s) in module_sizes.iter() {
+          let size = self.sizes.entry(*ty).or_default();
+          *size -= s;
+          *size = size.max(0.0);
+          self.total_size -= s;
+          self
+            .source_types_modules
+            .entry(*ty)
+            .or_default()
+            .remove(&module);
+        }
+      }
+    }
+
+    self.sizes.clone()
   }
 }
 
@@ -127,14 +161,16 @@ pub(crate) fn compare_entries(
     return diff_priority;
   }
   // 2. by number of chunks
-  let diff_count = a.chunks.len() as f64 - b.chunks.len() as f64;
+  let a_chunks_len = a.chunks.len();
+  let b_chunks_len = b.chunks.len();
+  let diff_count = a_chunks_len as f64 - b_chunks_len as f64;
   if diff_count != 0f64 {
     return diff_count;
   }
 
   // 3. by size reduction
-  let a_size_reduce = total_size(&a.sizes) * (a.chunks.len() - 1) as f64;
-  let b_size_reduce = total_size(&b.sizes) * (b.chunks.len() - 1) as f64;
+  let a_size_reduce = a.get_total_size() * (a_chunks_len - 1) as f64;
+  let b_size_reduce = b.get_total_size() * (b_chunks_len - 1) as f64;
   let diff_size_reduce = a_size_reduce - b_size_reduce;
   if diff_size_reduce != 0f64 {
     return diff_size_reduce;
@@ -154,13 +190,17 @@ pub(crate) fn compare_entries(
     return diff;
   }
 
-  let mut modules_a = a.modules.iter().collect::<Vec<_>>();
-  let mut modules_b = b.modules.iter().collect::<Vec<_>>();
-  modules_a.sort_unstable();
-  modules_b.sort_unstable();
+  let mut modules_a = a
+    .modules
+    .iter()
+    .sorted_unstable_by(|a, b| a.precomputed_hash().cmp(&b.precomputed_hash()));
+  let mut modules_b = b
+    .modules
+    .iter()
+    .sorted_unstable_by(|a, b| a.precomputed_hash().cmp(&b.precomputed_hash()));
 
   loop {
-    match (modules_a.pop(), modules_b.pop()) {
+    match (modules_a.next(), modules_b.next()) {
       (None, None) => break,
       (Some(a), Some(b)) => {
         let res = a.cmp(b);
@@ -173,12 +213,4 @@ pub(crate) fn compare_entries(
   }
 
   a_key.cmp(b_key) as i32 as f64
-}
-
-fn total_size(sizes: &SplitChunkSizes) -> f64 {
-  let mut size = 0f64;
-  for ty_size in sizes.0.values() {
-    size += ty_size;
-  }
-  size
 }

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -42,7 +42,7 @@ impl SplitChunksPlugin {
   ) -> bool {
     // Find out what `SourceType`'s size is not fit the min_size
     let violating_source_types: Box<[SourceType]> = module_group
-    .sizes
+    .get_sizes(module_sizes)
     .iter()
     .filter_map(|(module_group_ty, module_group_ty_size)| {
       let cache_group_ty_min_size = cache_group
@@ -79,7 +79,7 @@ impl SplitChunksPlugin {
     // may not fit again. But Webpack seems ignore this case. Not sure if it is on purpose.
     violating_modules
       .into_iter()
-      .for_each(|violating_module| module_group.remove_module(violating_module, module_sizes));
+      .for_each(|violating_module| module_group.remove_module(violating_module));
 
     module_group.modules.is_empty()
   }
@@ -97,6 +97,7 @@ impl SplitChunksPlugin {
         let cache_group = module_group.get_cache_group(&self.cache_groups);
         // Fast path
         if cache_group.min_size.is_empty() {
+          let _ = module_group.get_sizes(module_sizes);
           tracing::debug!(
             "ModuleGroup({}) skips `minSize` checking. Reason: min_size of CacheGroup({}) is empty",
             module_group_key,
@@ -111,7 +112,7 @@ impl SplitChunksPlugin {
           cache_group,
           module_sizes,
         ) || !Self::check_min_size_reduction(
-          &module_group.sizes,
+          &module_group.get_sizes(module_sizes),
           &cache_group.min_size_reduction,
           module_group.chunks.len(),
         ) {

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -57,7 +57,7 @@ impl SplitChunksPlugin {
     let module_chunks = Self::get_module_chunks(&all_modules, compilation);
 
     let mut module_group_map = self
-      .prepare_module_group_map(&all_modules, compilation, &module_sizes, &module_chunks)
+      .prepare_module_group_map(&all_modules, compilation, &module_chunks)
       .await?;
     tracing::trace!("prepared module_group_map {:#?}", module_group_map);
     logger.time_end(start);


### PR DESCRIPTION
## Summary

improve data structures of bundle splitting and flag dependency usage plugin.
- lazy calculating the sizes of module groups to prevent lock competition of dashmap during `prepare_module_group_map`
- sort modules with precomputed hashes of `Ustr` to improve `find_best_module_group`
- prepare chunk combinations before `prepare_module_group_map` to prevent lock competition of dashmap and reduce the cost of `get_key` of chunks
- parallel set used info of exports info
- move methods that relate to exports info to another file

before:
<img width="462" height="56" alt="image" src="https://github.com/user-attachments/assets/dcd6615a-b372-4088-88cc-6762f2e6cfeb" />

after:
<img width="470" height="48" alt="image" src="https://github.com/user-attachments/assets/6dc4e0ac-d031-47ee-85d2-ee4a74fb5ac8" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
