### PR TITLE
refactor: use Module.needBuild to trigger lazy modules compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4477,6 +4477,7 @@ dependencies = [
  "rspack_regex",
  "rspack_util",
  "rustc-hash",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2347,11 +2347,11 @@ export interface RawJsonParserOptions {
 }
 
 export interface RawLazyCompilationOption {
-  module: ((err: Error | null, arg: RawModuleArg) => RawModuleInfo)
+  currentActiveModules: ((err: Error | null, ) => Set<string>)
   test?: RawLazyCompilationTest
   entries: boolean
   imports: boolean
-  cacheable: boolean
+  client: string
 }
 
 export interface RawLibManifestPluginOptions {
@@ -2407,11 +2407,6 @@ export interface RawLimitChunkCountPluginOptions {
   chunkOverhead?: number
   entryChunkMultiplicator?: number
   maxChunks: number
-}
-
-export interface RawModuleArg {
-  module: string
-  path: string
 }
 
 export interface RawModuleFederationRuntimePluginOptions {

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -714,11 +714,11 @@ impl<'a> BuiltinPlugin<'a> {
         let js_backend = JsBackend::from(&options);
         plugins.push(Box::new(
           rspack_plugin_lazy_compilation::plugin::LazyCompilationPlugin::new(
-            options.cacheable,
             js_backend,
             options.test.map(|test| test.into()),
             options.entries,
             options.imports,
+            options.client,
           ),
         ) as Box<dyn Plugin>)
       }

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_lazy_compilation.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_lazy_compilation.rs
@@ -5,10 +5,11 @@ use napi::{
   bindgen_prelude::{FromNapiValue, ToNapiValue, ValidateNapiValue},
 };
 use napi_derive::napi;
+use rspack_collections::IdentifierSet;
 use rspack_core::{CompilationId, CompilerId, Module, ModuleIdentifier};
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_plugin_lazy_compilation::{
-  backend::{Backend, ModuleInfo},
+  backend::Backend,
   plugin::{LazyCompilationTest, LazyCompilationTestCheck},
 };
 use rspack_regex::RspackRegex;
@@ -88,21 +89,15 @@ pub struct RawModuleInfo {
 
 #[napi(object, object_to_js = false)]
 pub struct RawLazyCompilationOption {
-  pub module: ThreadsafeFunction<RawModuleArg, RawModuleInfo>,
+  pub current_active_modules: ThreadsafeFunction<(), std::collections::HashSet<String>>,
   pub test: Option<RawLazyCompilationTest>,
   pub entries: bool,
   pub imports: bool,
-  pub cacheable: bool,
-}
-
-#[napi(object)]
-pub struct RawModuleArg {
-  pub module: String,
-  pub path: String,
+  pub client: String,
 }
 
 pub(crate) struct JsBackend {
-  module: ThreadsafeFunction<RawModuleArg, RawModuleInfo>,
+  current_active_modules: ThreadsafeFunction<(), std::collections::HashSet<String>>,
 }
 
 impl std::fmt::Debug for JsBackend {
@@ -114,31 +109,20 @@ impl std::fmt::Debug for JsBackend {
 impl From<&RawLazyCompilationOption> for JsBackend {
   fn from(value: &RawLazyCompilationOption) -> Self {
     Self {
-      module: value.module.clone(),
+      current_active_modules: value.current_active_modules.clone(),
     }
   }
 }
 
 #[async_trait::async_trait]
 impl Backend for JsBackend {
-  async fn module(
-    &mut self,
-    identifier: ModuleIdentifier,
-    path: String,
-  ) -> rspack_error::Result<ModuleInfo> {
-    let module_info = self
-      .module
-      .call_with_sync(RawModuleArg {
-        module: identifier.to_string(),
-        path,
-      })
+  async fn current_active_modules(&mut self) -> rspack_error::Result<IdentifierSet> {
+    let active_modules = self
+      .current_active_modules
+      .call_with_sync(())
       .await
       .expect("channel should have result");
 
-    Ok(ModuleInfo {
-      active: module_info.active,
-      client: module_info.client,
-      data: module_info.data,
-    })
+    Ok(active_modules.into_iter().map(Into::into).collect())
   }
 }

--- a/crates/rspack_plugin_lazy_compilation/Cargo.toml
+++ b/crates/rspack_plugin_lazy_compilation/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace       = true
 [dependencies]
 async-trait = { workspace = true }
 rustc-hash  = { workspace = true }
+serde_json  = { workspace = true }
 tokio       = { workspace = true }
 tracing     = { workspace = true }
 

--- a/crates/rspack_plugin_lazy_compilation/src/backend.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/backend.rs
@@ -1,14 +1,7 @@
-use rspack_core::ModuleIdentifier;
+use rspack_collections::IdentifierSet;
 use rspack_error::Result;
-
-pub struct ModuleInfo {
-  pub active: bool,
-  pub data: String,
-  pub client: String,
-}
 
 #[async_trait::async_trait]
 pub trait Backend: std::fmt::Debug + Send + Sync {
-  async fn module(&mut self, original_module: ModuleIdentifier, path: String)
-  -> Result<ModuleInfo>;
+  async fn current_active_modules(&mut self) -> Result<IdentifierSet>;
 }

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -3,15 +3,16 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
+use rspack_collections::IdentifierSet;
 use rspack_core::{
   BoxModule, Compilation, CompilationId, CompilationParams, CompilerCompilation, CompilerId,
-  DependencyType, EntryDependency, LibIdentOptions, Module, ModuleFactory, ModuleFactoryCreateData,
-  NormalModuleCreateData, NormalModuleFactoryModule, Plugin,
+  CompilerMake, DependencyType, EntryDependency, LibIdentOptions, Module, ModuleFactory,
+  ModuleFactoryCreateData, NormalModuleCreateData, NormalModuleFactoryModule, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_regex::RspackRegex;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::{
   backend::Backend, factory::LazyCompilationDependencyFactory, module::LazyCompilationProxyModule,
@@ -63,18 +64,26 @@ pub struct LazyCompilationPlugin<T: Backend, F: LazyCompilationTestCheck> {
   entries: bool, // enable for entries
   imports: bool, // enable for imports
   test: Option<LazyCompilationTest<F>>,
-  cacheable: bool,
+  client: String,
+  active_modules: RwLock<IdentifierSet>,
 }
 
 impl<T: Backend, F: LazyCompilationTestCheck> LazyCompilationPlugin<T, F> {
   pub fn new(
-    cacheable: bool,
     backend: T,
     test: Option<LazyCompilationTest<F>>,
     entries: bool,
     imports: bool,
+    client: String,
   ) -> Self {
-    Self::new_inner(Mutex::new(backend), entries, imports, test, cacheable)
+    Self::new_inner(
+      Mutex::new(backend),
+      entries,
+      imports,
+      test,
+      client,
+      Default::default(),
+    )
   }
 
   async fn check_test(
@@ -180,30 +189,50 @@ async fn normal_module_factory_module(
     return Ok(());
   }
 
-  let mut backend = self.backend.lock().await;
   let module_identifier = module.identifier();
 
   let lib_ident = module.lib_ident(LibIdentOptions {
     context: module_factory_create_data.options.context.as_str(),
   });
-  let info = backend
-    .module(
-      module_identifier,
-      create_data.resource_resolve_data.resource.clone(),
-    )
-    .await?;
 
   *module = Box::new(LazyCompilationProxyModule::new(
     module_identifier,
     lib_ident.map(|ident| ident.into_owned()),
     module_factory_create_data.clone(),
     create_data.resource_resolve_data.resource.clone(),
-    self.cacheable,
-    info.active,
-    info.data,
-    info.client,
+    self
+      .active_modules
+      .read()
+      .await
+      .contains(&format!("lazy-compilation-proxy|{module_identifier}").into()),
+    self.client.clone(),
   ));
 
+  Ok(())
+}
+
+#[plugin_hook(CompilerMake for LazyCompilationPlugin<T: Backend, F: LazyCompilationTestCheck>)]
+async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
+  let active_modules = self.backend.lock().await.current_active_modules().await?;
+  let mut module_graph = compilation.get_module_graph_mut();
+  let mut errors = vec![];
+  for module_id in &active_modules {
+    let Some(active_module) = module_graph.module_by_identifier_mut(module_id) else {
+      errors.push(rspack_error::error!("cannot find module instance for id {module_id}").into());
+      continue;
+    };
+
+    let Some(active_module) = active_module.downcast_mut::<LazyCompilationProxyModule>() else {
+      errors.push(rspack_error::error!("cannot find module instance for id {module_id}").into());
+      continue;
+    };
+
+    active_module.need_build = true;
+  }
+
+  *self.active_modules.write().await = active_modules.into_iter().collect();
+
+  compilation.extend_diagnostics(errors);
   Ok(())
 }
 
@@ -218,6 +247,8 @@ impl<T: Backend + 'static, F: LazyCompilationTestCheck + 'static> Plugin
       .normal_module_factory_hooks
       .module
       .tap(normal_module_factory_module::new(self));
+
+    ctx.compiler_hooks.make.tap(compiler_make::new(self));
     Ok(())
   }
 }

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
@@ -10,7 +10,7 @@
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 69
 - Update: main.LAST_HASH.hot-update.js, size: 582
-- Update: modules_demo_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1412
+- Update: modules_demo_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1436
 
 ## Manifest
 
@@ -79,7 +79,7 @@ self["webpackHotUpdate"]("modules_demo_js_lazy-compilation-proxy", {
   \*********************************************************************************************************************/
 (function (module, __unused_webpack_exports, __webpack_require__) {
 var client = __webpack_require__("../../../../../rspack/hot/lazy-compilation-web.js?http%3A%2F%2Flocalhost%3APORT%2Flazy-compilation-using-");
-var data = "<TEST_TOOLS_ROOT>/dist/helper/loaders/hot-update.js??ruleSet[1].rules[0].use[0]!<TEST_TOOLS_ROOT>/tests/hotCases/lazy-compilation/context/modules/demo.js"
+var data = "lazy-compilation-proxy|<TEST_TOOLS_ROOT>/dist/helper/loaders/hot-update.js??ruleSet[1].rules[0].use[0]!<TEST_TOOLS_ROOT>/tests/hotCases/lazy-compilation/context/modules/demo.js";
         module.exports = __webpack_require__.e(/*! import() */ "modules_demo_js").then(__webpack_require__.bind(__webpack_require__, /*! ./modules/demo.js */ "./modules/demo.js"));
         if (module.hot) {
           module.hot.accept();

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
@@ -11,7 +11,7 @@
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 71
 - Update: main.LAST_HASH.hot-update.js, size: 582
-- Update: modules_module_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1432
+- Update: modules_module_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1456
 
 ## Manifest
 
@@ -80,7 +80,7 @@ self["webpackHotUpdate"]("modules_module_js_lazy-compilation-proxy", {
   \***********************************************************************************************************************/
 (function (module, __unused_webpack_exports, __webpack_require__) {
 var client = __webpack_require__("../../../../../rspack/hot/lazy-compilation-web.js?http%3A%2F%2Flocalhost%3APORT%2Flazy-compilation-using-");
-var data = "<TEST_TOOLS_ROOT>/dist/helper/loaders/hot-update.js??ruleSet[1].rules[0].use[0]!<TEST_TOOLS_ROOT>/tests/hotCases/lazy-compilation/context/modules/module.js"
+var data = "lazy-compilation-proxy|<TEST_TOOLS_ROOT>/dist/helper/loaders/hot-update.js??ruleSet[1].rules[0].use[0]!<TEST_TOOLS_ROOT>/tests/hotCases/lazy-compilation/context/modules/module.js";
         module.exports = __webpack_require__.e(/*! import() */ "modules_module_js").then(__webpack_require__.bind(__webpack_require__, /*! ./modules/module.js */ "./modules/module.js"));
         if (module.hot) {
           module.hot.accept();

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/webpack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/context/webpack.config.js
@@ -3,7 +3,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	lazyCompilation: {
-		cacheable: false,
 		entries: false,
 		imports: true
 	}

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/module-test/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/module-test/__snapshots__/web/1.snap.txt
@@ -10,7 +10,7 @@
 - Bundle: moduleB_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 64
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: moduleA_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1381
+- Update: moduleA_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1405
 
 ## Manifest
 
@@ -64,7 +64,7 @@ self["webpackHotUpdate"]("moduleA_js_lazy-compilation-proxy", {
   \*********************************************************************************************************************/
 (function (module, __unused_webpack_exports, __webpack_require__) {
 var client = __webpack_require__("../../../../../rspack/hot/lazy-compilation-web.js?http%3A%2F%2Flocalhost%3APORT%2Flazy-compilation-using-");
-var data = "<TEST_TOOLS_ROOT>/dist/helper/loaders/hot-update.js??ruleSet[1].rules[0].use[0]!<TEST_TOOLS_ROOT>/tests/hotCases/lazy-compilation/module-test/moduleA.js"
+var data = "lazy-compilation-proxy|<TEST_TOOLS_ROOT>/dist/helper/loaders/hot-update.js??ruleSet[1].rules[0].use[0]!<TEST_TOOLS_ROOT>/tests/hotCases/lazy-compilation/module-test/moduleA.js";
         module.exports = __webpack_require__.e(/*! import() */ "moduleA_js").then(__webpack_require__.bind(__webpack_require__, /*! ./moduleA.js */ "./moduleA.js"));
         if (module.hot) {
           module.hot.accept();

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/module-test/webpack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/module-test/webpack.config.js
@@ -4,7 +4,6 @@
 module.exports = {
 	lazyCompilation: {
 		entries: false,
-		cacheable: false,
 		test: /moduleA/
 	}
 };

--- a/packages/rspack-test-tools/tests/hotCases/lazy-compilation/simple/webpack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/lazy-compilation/simple/webpack.config.js
@@ -3,7 +3,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	lazyCompilation: {
-		entries: false,
-		cacheable: false
+		entries: false
 	}
 };

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4848,7 +4848,7 @@ class MultiWatching {
     // (undocumented)
     compiler: MultiCompiler;
     // (undocumented)
-    invalidate(callback: Callback<Error, void>): void;
+    invalidate(callback?: Callback<Error, void>): void;
     // (undocumented)
     invalidateWithChangesAndRemovals(changedFiles?: Set<string>, removedFiles?: Set<string>, callback?: Callback<Error, void>): void;
     // (undocumented)

--- a/packages/rspack/hot/lazy-compilation-node.js
+++ b/packages/rspack/hot/lazy-compilation-node.js
@@ -1,5 +1,3 @@
-
-
 var urlBase = decodeURIComponent(__resourceQuery.slice(1));
 
 /**
@@ -16,7 +14,7 @@ exports.activate = function (options) {
 	var request = (
 		urlBase.startsWith("https") ? require("https") : require("http")
 	).request(
-		urlBase + data,
+		urlBase + encodeURIComponent(data),
 		{
 			agent: false,
 			headers: { accept: "text/event-stream" }

--- a/packages/rspack/hot/lazy-compilation-web.js
+++ b/packages/rspack/hot/lazy-compilation-web.js
@@ -1,5 +1,3 @@
-
-
 if (typeof EventSource !== "function") {
 	throw new Error(
 		"Environment doesn't support lazy compilation (requires EventSource)"
@@ -16,7 +14,10 @@ var updateEventSource = function updateEventSource() {
 	if (activeEventSource) activeEventSource.close();
 	if (compiling.size) {
 		activeEventSource = new EventSource(
-			urlBase + Array.from(compiling).join("@")
+			urlBase +
+				Array.from(compiling, function (module) {
+					return encodeURIComponent(module);
+				}).join("@")
 		);
 		/**
 		 * @this {EventSource}

--- a/packages/rspack/src/MultiWatching.ts
+++ b/packages/rspack/src/MultiWatching.ts
@@ -25,7 +25,7 @@ class MultiWatching {
 		this.watchings = watchings;
 		this.compiler = compiler;
 	}
-	invalidate(callback: Callback<Error, void>) {
+	invalidate(callback?: Callback<Error, void>) {
 		if (callback) {
 			asyncLib.each(
 				this.watchings,

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/lazyCompilation.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/lazyCompilation.ts
@@ -6,15 +6,11 @@ import { create } from "../base";
 export const BuiltinLazyCompilationPlugin = create(
 	BuiltinPluginName.LazyCompilationPlugin,
 	(
-		module: (args: { module: string; path: string }) => {
-			active: boolean;
-			data: string;
-			client: string;
-		},
-		cacheable: boolean,
+		currentActiveModules: () => Set<string>,
 		entries: boolean,
 		imports: boolean,
+		client: string,
 		test?: RegExp | ((module: Module) => boolean)
-	) => ({ module, cacheable, imports, entries, test }),
+	) => ({ module, imports, entries, test, client, currentActiveModules }),
 	"thisCompilation"
 );

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/index.test.ts
@@ -8,7 +8,9 @@ test("should load success", async ({ page, rspack }) => {
 	await rspack.reboot();
 	await page.reload();
 
+	// trigger other import compile
 	await page.getByText("Click me").click();
-	component_count = await page.getByText("Component").count();
-	expect(component_count).toBe(1);
+	await page.waitForEvent('console')
+	const dynImported = await page.getByText("dyn imported").count();
+	expect(dynImported).toBe(1);
 });

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/src/dyn.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/src/dyn.js
@@ -1,0 +1,4 @@
+const div = document.createElement("div");
+div.textContent = "dyn imported";
+document.body.appendChild(div);
+console.log('dyn imported')

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/src/index.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/src/index.js
@@ -1,3 +1,7 @@
 const button = document.createElement("button");
 button.textContent = "Click me";
 document.body.appendChild(button);
+
+button.addEventListener("click", async () => {
+	import('./dyn')
+})

--- a/tests/webpack-test/hotCases/lazy-compilation/context/webpack.config.js
+++ b/tests/webpack-test/hotCases/lazy-compilation/context/webpack.config.js
@@ -3,7 +3,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	lazyCompilation: {
-		cacheable: false,
 		entries: false,
 		imports: true,
 		backend: {

--- a/tests/webpack-test/hotCases/lazy-compilation/https/webpack.config.js
+++ b/tests/webpack-test/hotCases/lazy-compilation/https/webpack.config.js
@@ -6,7 +6,6 @@ const path = require("path");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	lazyCompilation: {
-		cacheable: false,
 		entries: false,
 		backend: {
 			server: {

--- a/tests/webpack-test/hotCases/lazy-compilation/module-test/webpack.config.js
+++ b/tests/webpack-test/hotCases/lazy-compilation/module-test/webpack.config.js
@@ -4,7 +4,6 @@
 module.exports = {
 	lazyCompilation: {
 		entries: false,
-		cacheable: false,
 		test: /moduleA/
 	}
 };

--- a/tests/webpack-test/hotCases/lazy-compilation/simple/webpack.config.js
+++ b/tests/webpack-test/hotCases/lazy-compilation/simple/webpack.config.js
@@ -4,6 +4,5 @@
 module.exports = {
 	lazyCompilation: {
 		entries: false,
-		cacheable: false
 	}
 };


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Use `Module.needBuild()` to rebuild active lazy modules. Before we use a map that maps a module identifier to the real file path. That has issues:

1. Some modules may not have file path.
2. Need a map to record what is the file path for a module which is unfriendly with persistent cache

Now we use `need_build()`, when a module is been executing in runtime, we report this module is activated, and mark the `need_build` as true, and when we update module graph, it will remove that module and rebuild it with `active: true`.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
