### PR TITLE
fix: inline value with properties access

### DIFF
--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -8,7 +8,7 @@ use rspack_cacheable::{
 use rspack_util::{atom::Atom, json_stringify, ryu_js};
 use rustc_hash::FxHashSet as HashSet;
 
-use crate::DependencyId;
+use crate::{DependencyId, property_access};
 
 pub static NEXT_EXPORTS_INFO_UKEY: AtomicU32 = AtomicU32::new(0);
 pub static NEXT_EXPORT_INFO_UKEY: AtomicU32 = AtomicU32::new(0);
@@ -83,8 +83,8 @@ impl EvaluatedInlinableValue {
     Self::String(v)
   }
 
-  pub fn render(&self) -> Cow<'_, str> {
-    match self {
+  pub fn render(&self) -> String {
+    let s: Cow<str> = match self {
       Self::Null => "null".into(),
       Self::Undefined => "undefined".into(),
       Self::Boolean(v) => if *v { "true" } else { "false" }.into(),
@@ -93,7 +93,8 @@ impl EvaluatedInlinableValue {
         buf.format(*v).to_string().into()
       }
       Self::String(v) => json_stringify(v.as_str()).into(),
-    }
+    };
+    format!("({s})")
   }
 }
 
@@ -118,20 +119,41 @@ pub enum UsedNameItem {
 }
 
 #[derive(Debug, Clone)]
+pub struct InlinedUsedName {
+  value: EvaluatedInlinableValue,
+  suffix: Vec<Atom>,
+}
+
+impl InlinedUsedName {
+  pub fn new(value: EvaluatedInlinableValue) -> Self {
+    Self {
+      value,
+      suffix: Vec::new(),
+    }
+  }
+
+  pub fn render(&self) -> String {
+    let mut inlined = self.value.render();
+    inlined.push_str(&property_access(&self.suffix, 0));
+    inlined
+  }
+}
+
+#[derive(Debug, Clone)]
 pub enum UsedName {
   Normal(Vec<Atom>),
-  Inlined(EvaluatedInlinableValue),
+  Inlined(InlinedUsedName),
 }
 
 impl UsedName {
   pub fn is_inlined(&self) -> bool {
-    matches!(self, UsedName::Inlined(_))
+    matches!(self, UsedName::Inlined { .. })
   }
 
-  pub fn inlined(&self) -> Option<&EvaluatedInlinableValue> {
+  pub fn append(&mut self, item: impl IntoIterator<Item = Atom>) {
     match self {
-      UsedName::Inlined(inlined) => Some(inlined),
-      _ => None,
+      UsedName::Normal(vec) => vec.extend(item),
+      UsedName::Inlined(inlined) => inlined.suffix.extend(item),
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -195,7 +195,7 @@ impl DependencyTemplate for CommonJsSelfReferenceDependencyTemplate {
         UsedName::Normal(used) => format!("{}{}", base, property_access(used, 0)),
         // Export a inlinable const from cjs is not possible for now, so self reference a inlinable
         // const is also not possible for now, but we compat it here
-        UsedName::Inlined(inlined) => inlined.render().into_owned(),
+        UsedName::Inlined(inlined) => inlined.render(),
       },
       None,
     )

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -852,7 +852,7 @@ impl ESMExportImportedSpecifierDependency {
       ValueKey::Name => name,
       ValueKey::UsedName(used) => match used {
         UsedName::Normal(used) => format!("{}{}", name, property_access(used, 0)),
-        UsedName::Inlined(inlined) => inlined.render().into_owned(),
+        UsedName::Inlined(inlined) => inlined.render(),
       },
     }
   }

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -113,7 +113,7 @@ async fn render_startup(
         match used_name {
           UsedNameItem::Str(used_name) =>
             format!("__webpack_exports__{}", property_access(vec![used_name], 0)),
-          UsedNameItem::Inlined(inlined) => inlined.render().into_owned(),
+          UsedNameItem::Inlined(inlined) => inlined.render(),
         }
       )));
     }

--- a/packages/rspack-test-tools/tests/configCases/inline-const/basic/index.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-const/basic/index.js
@@ -18,13 +18,13 @@ it("should inline constants", () => {
   expect(constants.REMOVE_m).toBe(13);
   // END:A
   const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
-  expect(block.includes(`(/* inlined export .REMOVE_n */ null).toBe(null)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_u */ undefined).toBe(undefined)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_b */ true).toBe(true)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_i */ 123456).toBe(123456)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_f */ 123.45).toBe(123.45)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_s */ "remove").toBe("remove")`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_m */ 13).toBe(13)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_n */ (null)).toBe(null)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_u */ (undefined)).toBe(undefined)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_b */ (true)).toBe(true)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_i */ (123456)).toBe(123456)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_f */ (123.45)).toBe(123.45)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_s */ ("remove")).toBe("remove")`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_m */ (13)).toBe(13)`)).toBe(true);
 })
 
 it("should inline constants with re-export", () => {
@@ -37,12 +37,12 @@ it("should inline constants with re-export", () => {
   expect(reexported.REMOVE_s).toBe("remove");
   // END:B
   const block = generated.match(/\/\/ START:B([\s\S]*)\/\/ END:B/)[1];
-  expect(block.includes(`(/* inlined export .REMOVE_n */ null).toBe(null)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_u */ undefined).toBe(undefined)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_b */ true).toBe(true)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_i */ 123456).toBe(123456)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_f */ 123.45).toBe(123.45)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_s */ "remove").toBe("remove")`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_n */ (null)).toBe(null)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_u */ (undefined)).toBe(undefined)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_b */ (true)).toBe(true)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_i */ (123456)).toBe(123456)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_f */ (123.45)).toBe(123.45)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_s */ ("remove")).toBe("remove")`)).toBe(true);
 })
 
 it("should not inline constants with destructing", () => {
@@ -66,9 +66,9 @@ it("should allow inline constants if the rest exports is not used with destructi
   expect(destructing.REMOVE_s).toBe("remove");
   // END:D
   const block = generated.match(/\/\/ START:D([\s\S]*)\/\/ END:D/)[1];
-  expect(block.includes(`(/* inlined export .REMOVE_i */ 123456).toBe(123456)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_f */ 123.45).toBe(123.45)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .REMOVE_s */ "remove").toBe("remove")`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_i */ (123456)).toBe(123456)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_f */ (123.45)).toBe(123.45)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_s */ ("remove")).toBe("remove")`)).toBe(true);
 })
 
 it("should respect side effects when inline constants", () => {
@@ -77,7 +77,7 @@ it("should respect side effects when inline constants", () => {
   expect(globalThis.__sideEffects).toBe("constants.side-effects.js");
   // END:E
   const block = generated.match(/\/\/ START:E([\s\S]*)\/\/ END:E/)[1];
-  expect(block.includes(`(/* inlined export .REMOVE_CONST */ true).toBe(true)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .REMOVE_CONST */ (true)).toBe(true)`)).toBe(true);
 })
 
 it("should not inline and link to re-export module when have side effects", () => {

--- a/packages/rspack-test-tools/tests/configCases/inline-const/suffix-properties/index.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-const/suffix-properties/index.js
@@ -1,0 +1,15 @@
+import * as constants from "../basic/constants";
+
+const generated = /** @type {string} */ (__non_webpack_require__("fs").readFileSync(__filename, "utf-8"));
+
+it("should generate correct code for inline value with properties access", () => {
+  // START:A
+  expect(constants.REMOVE_s.toUpperCase()).toBe("REMOVE");
+  expect(constants.REMOVE_b.valueOf().toString()).toBe("true");
+  expect(constants.REMOVE_i["toFixed"](1)).toBe("123456.0");
+  // END:A
+  const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
+  expect(block.includes(`/* inlined export .REMOVE_s.toUpperCase */ ("remove").toUpperCase()`)).toBe(true);
+  expect(block.includes(`/* inlined export .REMOVE_b.valueOf */ (true).valueOf().toString()`)).toBe(true);
+  expect(block.includes(`/* inlined export .REMOVE_i.toFixed */ (123456).toFixed(1)`)).toBe(true);
+})

--- a/packages/rspack-test-tools/tests/configCases/inline-const/suffix-properties/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-const/suffix-properties/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		moduleIds: "named"
+	},
+	experiments: {
+		inlineConst: true
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/inline-enum/basic/index.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-enum/basic/index.js
@@ -13,8 +13,8 @@ it("should inline enums", () => {
   expect(enums.E.B).toBe(1);
   // END:A
   const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
-  expect(block.includes(`(/* inlined export .E.A */ 0).toBe(0)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .E.B */ 1).toBe(1)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.A */ (0)).toBe(0)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.B */ (1)).toBe(1)`)).toBe(true);
 })
 
 it("should inline enums with re-export", () => {
@@ -23,8 +23,8 @@ it("should inline enums with re-export", () => {
   expect(reexported.E.B).toBe(1);
   // END:B
   const block = generated.match(/\/\/ START:B([\s\S]*)\/\/ END:B/)[1];
-  expect(block.includes(`(/* inlined export .E.A */ 0).toBe(0)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .E.B */ 1).toBe(1)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.A */ (0)).toBe(0)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.B */ (1)).toBe(1)`)).toBe(true);
 })
 
 it("should not inline enums with destructing", () => {
@@ -45,8 +45,8 @@ it("should allow inline enums if the rest exports is not used with destructing",
   expect(destructing.E.D).toBe(3);
   // END:D
   const block = generated.match(/\/\/ START:D([\s\S]*)\/\/ END:D/)[1];
-  expect(block.includes(`(/* inlined export .E.C */ 2).toBe(2)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .E.D */ 3).toBe(3)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.C */ (2)).toBe(2)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.D */ (3)).toBe(3)`)).toBe(true);
 })
 
 it("should respect side effects when inline enums", () => {
@@ -55,7 +55,7 @@ it("should respect side effects when inline enums", () => {
   expect(globalThis.__sideEffects).toBe("enum.side-effects.ts");
   // END:E
   const block = generated.match(/\/\/ START:E([\s\S]*)\/\/ END:E/)[1];
-  expect(block.includes(`(/* inlined export .E.A */ 0).toBe(0)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.A */ (0)).toBe(0)`)).toBe(true);
 })
 
 it("should respect side effects when inline enums with re-exports", () => {

--- a/packages/rspack-test-tools/tests/configCases/inline-enum/const-enum-only/index.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-enum/const-enum-only/index.js
@@ -18,6 +18,6 @@ it("should inline for const enum for const-only mode", () => {
   expect(E2.B).toBe(1);
   // END:B
   const block = generated.match(/\/\/ START:B([\s\S]*)\/\/ END:B/)[1];
-  expect(block.includes(`(/* inlined export .E2.A */ 0).toBe(0)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .E2.B */ 1).toBe(1)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E2.A */ (0)).toBe(0)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E2.B */ (1)).toBe(1)`)).toBe(true);
 })

--- a/packages/rspack-test-tools/tests/configCases/inline-enum/enum-merging/index.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-enum/enum-merging/index.js
@@ -8,6 +8,6 @@ it("should inline for enum merging", () => {
   expect(E.B).toBe(1);
   // END:A
   const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
-  expect(block.includes(`(/* inlined export .E.A */ 0).toBe(0)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .E.B */ 1).toBe(1)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.A */ (0)).toBe(0)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.B */ (1)).toBe(1)`)).toBe(true);
 })

--- a/packages/rspack-test-tools/tests/configCases/inline-enum/member-value-undefined/only-a.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-enum/member-value-undefined/only-a.js
@@ -6,7 +6,7 @@ export const test = (it, generated) => {
     expect(E.A).toBe("a");
     // END:ONLY_A
     const block = generated.match(/\/\/ START:ONLY_A([\s\S]*)\/\/ END:ONLY_A/)[1];
-    expect(block.includes(`(/* inlined export .E.A */ "a").toBe("a")`)).toBe(true);
+    expect(block.includes(`(/* inlined export .E.A */ ("a")).toBe("a")`)).toBe(true);
   })
 
   it("should remove the module if only enum member A is used", () => {

--- a/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/index.js
+++ b/packages/rspack-test-tools/tests/configCases/inline-enum/not-last-loader/index.js
@@ -8,6 +8,6 @@ it("should inline for enum when builtin:swc-loader is not the last loader", () =
   expect(E.B).toBe(1);
   // END:A
   const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
-  expect(block.includes(`(/* inlined export .E.A */ 0).toBe(0)`)).toBe(true);
-  expect(block.includes(`(/* inlined export .E.B */ 1).toBe(1)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.A */ (0)).toBe(0)`)).toBe(true);
+  expect(block.includes(`(/* inlined export .E.B */ (1)).toBe(1)`)).toBe(true);
 })


### PR DESCRIPTION
## Summary

Fix `inlineNum.toString()` replaced to `1()`, should be `(1).toString()`
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
