### PR TITLE
fix: don't throw error when browserslist config is resolved from env var

### DIFF
--- a/packages/rspack/src/config/target.ts
+++ b/packages/rspack/src/config/target.ts
@@ -143,7 +143,12 @@ const TARGETS: Array<
 			const inlineQuery = rest ? rest.trim() : null;
 			const browsers = binding.loadBrowserslist(inlineQuery, context);
 
-			if (!browsers || (!inlineQuery && !hasBrowserslistConfig(context))) {
+			if (
+				!browsers ||
+				(!inlineQuery &&
+					!hasBrowserslistConfig(context) &&
+					!process.env.BROWSERSLIST)
+			) {
 				throw new Error(`No browserslist config found to handle the 'browserslist' target.
 See https://github.com/browserslist/browserslist#queries for possible ways to provide a config.
 The recommended way is to add a 'browserslist' key to your package.json and list supported browsers (resp. node.js versions).


### PR DESCRIPTION
## Summary

This pr fix browserslist config loading when browserslist-rs correctly resolved query.

## Description

If browserslist-rs correctly resolve query (for example from environment variable) don't need to throw the error

## Related links

closes #11527

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
