### PR TITLE
refactor: disable incremental buildChunkGraph by default

### DIFF
--- a/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
@@ -23,7 +23,7 @@ Object {
     css: undefined,
     futureDefaults: false,
     incremental: Object {
-      buildChunkGraph: true,
+      buildChunkGraph: false,
       chunkIds: true,
       chunksHashes: true,
       chunksRender: true,

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/available-modules-change/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/available-modules-change/rspack.config.js
@@ -3,5 +3,10 @@ module.exports = {
 	optimization: {
 		splitChunks: false,
 		sideEffects: false
+	},
+	experiments: {
+		incremental: {
+			buildChunkGraph: true
+		}
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/basic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/basic/rspack.config.js
@@ -2,5 +2,10 @@
 module.exports = {
 	optimization: {
 		splitChunks: false
+	},
+	experiments: {
+		incremental: {
+			buildChunkGraph: true
+		}
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-add-then-change-ava-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-add-then-change-ava-module/rspack.config.js
@@ -3,5 +3,10 @@ module.exports = {
 	optimization: {
 		splitChunks: false,
 		sideEffects: false
+	},
+	experiments: {
+		incremental: {
+			buildChunkGraph: true
+		}
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-modify/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-modify/rspack.config.js
@@ -3,5 +3,10 @@ module.exports = {
 	optimization: {
 		splitChunks: false,
 		sideEffects: false
+	},
+	experiments: {
+		incremental: {
+			buildChunkGraph: true
+		}
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-remove/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/chunk-remove/rspack.config.js
@@ -3,5 +3,10 @@ module.exports = {
 	optimization: {
 		splitChunks: false,
 		sideEffects: false
+	},
+	experiments: {
+		incremental: {
+			buildChunkGraph: true
+		}
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/keep-order-index/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/keep-order-index/rspack.config.js
@@ -11,6 +11,11 @@ module.exports = {
 			}
 		]
 	},
+	experiments: {
+		incremental: {
+			buildChunkGraph: true
+		}
+	},
 	optimization: {
 		splitChunks: {
 			cacheGroups: {

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/pre-order-index/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/pre-order-index/rspack.config.js
@@ -2,5 +2,10 @@
 module.exports = {
 	optimization: {
 		splitChunks: false
+	},
+	experiments: {
+		incremental: {
+			buildChunkGraph: true
+		}
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/runtime-chunk-recover-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/runtime-chunk-recover-error/rspack.config.js
@@ -10,7 +10,10 @@ const config = (index, parallelCodeSplitting) => ({
 		runtimeChunk: "single"
 	},
 	experiments: {
-		parallelCodeSplitting
+		parallelCodeSplitting,
+		incremental: {
+			buildChunkGraph: true
+		}
 	}
 });
 

--- a/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/runtime-chunk/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/build-chunk-graph/runtime-chunk/rspack.config.js
@@ -5,5 +5,10 @@ module.exports = {
 	},
 	optimization: {
 		runtimeChunk: true
+	},
+	experiments: {
+		incremental: {
+			buildChunkGraph: true
+		}
 	}
 };

--- a/packages/rspack-test-tools/tests/watchCases/chunk-ids/update-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/chunk-ids/update-module/rspack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	experiments: {
+		incremental: {
+			buildChunkGraph: true
+		}
+	}
+};

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -242,7 +242,7 @@ const applyExperimentsDefaults = (
 		D(experiments.incremental, "providedExports", true);
 		D(experiments.incremental, "dependenciesDiagnostics", true);
 		D(experiments.incremental, "sideEffects", true);
-		D(experiments.incremental, "buildChunkGraph", true);
+		D(experiments.incremental, "buildChunkGraph", false);
 		D(experiments.incremental, "moduleIds", true);
 		D(experiments.incremental, "chunkIds", true);
 		D(experiments.incremental, "modulesHashes", true);


### PR DESCRIPTION
## Summary

fix #11515
fix #11530

Temporarily disable incremental buildChunkGraph

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
