### PR TITLE
fix: css runtime

### DIFF
--- a/crates/rspack_plugin_extract_css/src/runtime/css_load.js
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_load.js
@@ -37,6 +37,9 @@ var findStylesheet = function (href, fullhref) {
 	for (var i = 0; i < existingLinkTags.length; i++) {
 		var tag = existingLinkTags[i];
 		var dataHref = tag.getAttribute("data-href") || tag.getAttribute("href");
+		if (dataHref) {
+			dataHref = dataHref.split('?')[0]
+		}
 		if (tag.rel === "stylesheet" && (dataHref === href || dataHref === fullhref)) return tag;
 	}
 

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/2.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.hot-update.js, size: 7115
+- Update: main.hot-update.js, size: 7153
 
 ## Manifest
 
@@ -80,8 +80,9 @@ function updateCss(el, url) {
     let normalizedUrl;
     if (url) normalizedUrl = url;
     else {
-        if (!el.href) return;
-        normalizedUrl = el.href.split("?")[0];
+        let href = el.getAttribute("href");
+        if (!href) return;
+        normalizedUrl = href.split("?")[0];
     }
     if (!isUrlRequest(normalizedUrl) || !1 === el.isLoaded || !normalizedUrl || !(normalizedUrl.indexOf(".css") > -1)) return;
     el.visited = !0;

--- a/packages/rspack/src/runtime/cssExtractHmr.ts
+++ b/packages/rspack/src/runtime/cssExtractHmr.ts
@@ -109,11 +109,12 @@ function getCurrentScriptUrl(moduleId: string) {
 function updateCss(el: HTMLLinkElement & Record<string, any>, url?: string) {
 	let normalizedUrl: string;
 	if (!url) {
-		if (!el.href) {
+		const href = el.getAttribute("href");
+		if (!href) {
 			return;
 		}
 
-		normalizedUrl = el.href.split("?")[0];
+		normalizedUrl = href.split("?")[0];
 	} else {
 		normalizedUrl = url;
 	}

--- a/tests/e2e/cases/css/update-initial-chunks-after-hmr/index.test.ts
+++ b/tests/e2e/cases/css/update-initial-chunks-after-hmr/index.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@/fixtures";
+
+const COLOR_BLUE = "rgb(163, 255, 255)"
+const COLOR_WHITE = "rgb(255, 255, 255)"
+
+test("should update body css", async ({ page, fileAction }) => {
+	await expect(page.locator("body")).toHaveCSS("background-color", COLOR_BLUE);
+
+	// trigger css hmr
+	fileAction.updateFile("src/index.js", content =>
+		content.replace('import "./blue.css";', '// import "./blue.css";')
+	);
+
+	await expect(page.locator("body")).toHaveCSS("background-color", COLOR_WHITE);
+
+	// initial css chunk update, without css hmr
+	fileAction.updateFile("src/index.js", content =>
+		content.replace("//", "")
+	);
+
+	await expect(page.locator("body")).toHaveCSS("background-color", COLOR_BLUE);
+});

--- a/tests/e2e/cases/css/update-initial-chunks-after-hmr/rspack.config.js
+++ b/tests/e2e/cases/css/update-initial-chunks-after-hmr/rspack.config.js
@@ -1,0 +1,51 @@
+const { rspack } = require("@rspack/core");
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+	context: __dirname,
+	mode: "development",
+	entry: {
+		main: ["./src/index.css", "./src/index.js"]
+	},
+	devServer: {
+		hot: true
+	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./src/index.html",
+			inject: "body"
+		}),
+		new rspack.CssExtractRspackPlugin({
+			filename: "static/style.css",
+		})
+	],
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [
+					rspack.CssExtractRspackPlugin.loader,
+					"css-loader",
+				]
+			}
+		]
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				style: {
+					name: "style",
+					test: /\.css$/,
+					chunks: "all",
+					enforce: true
+				}
+			}
+		}
+	},
+	watchOptions: {
+		poll: 1000
+	},
+	experiments: {
+		css: false
+	}
+};

--- a/tests/e2e/cases/css/update-initial-chunks-after-hmr/src/blue.css
+++ b/tests/e2e/cases/css/update-initial-chunks-after-hmr/src/blue.css
@@ -1,0 +1,3 @@
+body {
+    background-color: rgb(163, 255, 255);
+}

--- a/tests/e2e/cases/css/update-initial-chunks-after-hmr/src/index.css
+++ b/tests/e2e/cases/css/update-initial-chunks-after-hmr/src/index.css
@@ -1,0 +1,3 @@
+body {
+  background-color: #ffffff;
+}

--- a/tests/e2e/cases/css/update-initial-chunks-after-hmr/src/index.html
+++ b/tests/e2e/cases/css/update-initial-chunks-after-hmr/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+</head>
+
+<body>
+    <div id="root"></div>
+</body>
+
+</html>

--- a/tests/e2e/cases/css/update-initial-chunks-after-hmr/src/index.js
+++ b/tests/e2e/cases/css/update-initial-chunks-after-hmr/src/index.js
@@ -1,0 +1,3 @@
+import "./blue.css";
+
+module.hot.accept()


### PR DESCRIPTION
## Summary

fix #11532

This pr contains 2 errors in runtime

1. CSS hmr should get `href` through attributes instead of field, `link.href` will get the concrete url, which will break the assumption for `findStylesheet`. `link.href` returns 'http://localhost:3000/index.css' while link.getAttribute('href') returns 'index.css'.
2. `findStylesheet` should find url exclude the query part

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
