### PR TITLE
fix: should handle import.meta.webpackHot in production

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -100,7 +100,7 @@ impl JavascriptParserPlugin for ImportMetaPlugin {
       if member.prop.is_ident() {
         return Some(eval::evaluate_to_undefined(
           member.span().real_lo(),
-          member.span().real_hi(),
+          member.span().hi().0,
         ));
       }
       if let Some(computed) = member.prop.as_computed()
@@ -108,7 +108,7 @@ impl JavascriptParserPlugin for ImportMetaPlugin {
       {
         return Some(eval::evaluate_to_undefined(
           member.span().real_lo(),
-          member.span().real_hi(),
+          member.span().hi().0,
         ));
       }
     }

--- a/packages/rspack-test-tools/tests/configCases/parsing/import-meta-hot-prod/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/import-meta-hot-prod/index.js
@@ -1,0 +1,9 @@
+it('should transform import.meta.webpackHot to false', () => {
+	let hot = false;
+	if (import.meta.webpackHot) {
+		hot = true;
+    import.meta.webpackHot.accept();
+  }
+
+	expect(hot).toBe(false);
+})

--- a/packages/rspack-test-tools/tests/configCases/parsing/import-meta-hot-prod/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/import-meta-hot-prod/rspack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	mode: "production",
+	target: "web",
+	devServer: {
+		hot: true
+	}
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Evaluate should use range.hi() instead of real_hi()

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
