### PR TITLE
fix: should check http url using `link.href` for extract-css runtime

### DIFF
--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/2.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.hot-update.js, size: 7153
+- Update: main.hot-update.js, size: 7147
 
 ## Manifest
 
@@ -84,7 +84,7 @@ function updateCss(el, url) {
         if (!href) return;
         normalizedUrl = href.split("?")[0];
     }
-    if (!isUrlRequest(normalizedUrl) || !1 === el.isLoaded || !normalizedUrl || !(normalizedUrl.indexOf(".css") > -1)) return;
+    if (!isUrlRequest(el.href) || !1 === el.isLoaded || !normalizedUrl || !(normalizedUrl.indexOf(".css") > -1)) return;
     el.visited = !0;
     let newEl = el.cloneNode();
     newEl.isLoaded = !1, newEl.addEventListener("load", ()=>{

--- a/packages/rspack/src/runtime/cssExtractHmr.ts
+++ b/packages/rspack/src/runtime/cssExtractHmr.ts
@@ -119,7 +119,7 @@ function updateCss(el: HTMLLinkElement & Record<string, any>, url?: string) {
 		normalizedUrl = url;
 	}
 
-	if (!isUrlRequest(normalizedUrl)) {
+	if (!isUrlRequest(el.href)) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

css hmr runtime using `link.href` to check if link url is correct http link, but should use `href` attribute to create the new link tag

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
