### PR TITLE
feat: add css field support in Experiments configuration

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2111,6 +2111,7 @@ parallelCodeSplitting: boolean
 rspackFuture?: RawRspackFuture
 cache: boolean | { type: "persistent" } & RawExperimentCacheOptionsPersistent | { type: "memory" }
 useInputFileSystem?: false | Array<RegExp>
+css: boolean
 inlineConst: boolean
 inlineEnum: boolean
 typeReexportsPresence: boolean

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2111,7 +2111,7 @@ parallelCodeSplitting: boolean
 rspackFuture?: RawRspackFuture
 cache: boolean | { type: "persistent" } & RawExperimentCacheOptionsPersistent | { type: "memory" }
 useInputFileSystem?: false | Array<RegExp>
-css: boolean
+css?: boolean
 inlineConst: boolean
 inlineEnum: boolean
 typeReexportsPresence: boolean

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -3675,7 +3675,7 @@ impl From<Experiments> for ExperimentsBuilder {
       parallel_code_splitting: Some(value.parallel_code_splitting),
       output_module: None,
       future_defaults: None,
-      css: None,
+      css: Some(value.css),
       async_web_assembly: None,
     }
   }
@@ -3793,6 +3793,7 @@ impl ExperimentsBuilder {
       rspack_future,
       parallel_code_splitting,
       cache,
+      css: d!(self.css, false),
       inline_const: false,
       inline_enum: false,
       type_reexports_presence: false,

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1477,6 +1477,7 @@ CompilerOptions {
         top_level_await: true,
         rspack_future: RspackFuture,
         cache: Disabled,
+        css: false,
         inline_const: false,
         inline_enum: false,
         type_reexports_presence: false,

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
@@ -26,6 +26,7 @@ pub struct RawExperiments {
   pub cache: RawExperimentCacheOptions,
   #[napi(ts_type = "false | Array<RegExp>")]
   pub use_input_file_system: Option<WithFalse<Vec<RspackRegex>>>,
+  pub css: bool,
   pub inline_const: bool,
   pub inline_enum: bool,
   pub type_reexports_presence: bool,
@@ -47,6 +48,7 @@ impl From<RawExperiments> for Experiments {
       top_level_await: value.top_level_await,
       rspack_future: value.rspack_future.unwrap_or_default().into(),
       cache: normalize_raw_experiment_cache_options(value.cache),
+      css: value.css,
       inline_const: value.inline_const,
       inline_enum: value.inline_enum,
       type_reexports_presence: value.type_reexports_presence,

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
@@ -26,7 +26,7 @@ pub struct RawExperiments {
   pub cache: RawExperimentCacheOptions,
   #[napi(ts_type = "false | Array<RegExp>")]
   pub use_input_file_system: Option<WithFalse<Vec<RspackRegex>>>,
-  pub css: bool,
+  pub css: Option<bool>,
   pub inline_const: bool,
   pub inline_enum: bool,
   pub type_reexports_presence: bool,
@@ -48,7 +48,7 @@ impl From<RawExperiments> for Experiments {
       top_level_await: value.top_level_await,
       rspack_future: value.rspack_future.unwrap_or_default().into(),
       cache: normalize_raw_experiment_cache_options(value.cache),
-      css: value.css,
+      css: value.css.unwrap_or(false),
       inline_const: value.inline_const,
       inline_enum: value.inline_enum,
       type_reexports_presence: value.type_reexports_presence,

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -15,6 +15,7 @@ pub struct Experiments {
   pub top_level_await: bool,
   pub rspack_future: RspackFuture,
   pub cache: ExperimentCacheOptions,
+  pub css: bool,
   pub inline_const: bool,
   pub inline_enum: bool,
   pub type_reexports_presence: bool,


### PR DESCRIPTION
## Summary

Enable `css` field to be properly passed from JavaScript/TypeScript interface layer through NAPI binding to Rust core layer.

## Changes

- Add `css` field to `Experiments` struct in `rspack_core`
- Add `css` field to `RawExperiments` struct in `rspack_binding_api`  
- Update type mapping from `RawExperiments` to `Experiments`
- Fix `ExperimentsBuilder` to properly handle css field conversion

## Test plan

- [x] All existing tests pass
- [x] Compilation succeeds for all relevant packages (`rspack_core`, `rspack_binding_api`, `rspack`)
- [x] Type system validates correct field transmission

This allows `experiments.css` configuration to be correctly transmitted from the JavaScript configuration to the Rust implementation, completing the configuration chain from NAPI layer to core.

🤖 Generated with [Claude Code](https://claude.ai/code)