### PR TITLE
refactor: use real_hi for evaluation range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,7 +3911,6 @@ dependencies = [
  "base64",
  "indoc",
  "jsonc-parser",
- "rspack_cacheable",
  "rspack_error",
  "rspack_sources",
  "rspack_util",

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -12,11 +12,10 @@ use tracing::instrument;
 
 use crate::{
   BoxDependency, CompilationId, ContextElementDependency, ContextModule, ContextModuleOptions,
-  DependencyCategory, DependencyId, DependencyType, ErrorSpan, FactoryMeta, ModuleExt,
-  ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, RawModule,
-  ResolveArgs, ResolveContextModuleDependencies, ResolveInnerOptions,
-  ResolveOptionsWithDependencyType, ResolveResult, Resolver, ResolverFactory, SharedPluginDriver,
-  resolve,
+  DependencyCategory, DependencyId, DependencyType, FactoryMeta, ModuleExt, ModuleFactory,
+  ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, RawModule, ResolveArgs,
+  ResolveContextModuleDependencies, ResolveInnerOptions, ResolveOptionsWithDependencyType,
+  ResolveResult, Resolver, ResolverFactory, SharedPluginDriver, resolve,
 };
 
 #[derive(Debug)]
@@ -279,9 +278,7 @@ impl ContextModuleFactory {
       specifier: specifier.as_str(),
       dependency_type: dependency.dependency_type(),
       dependency_category: dependency.category(),
-      span: dependency
-        .range()
-        .map(|range| ErrorSpan::new(range.start, range.end)),
+      span: dependency.range(),
       resolve_options: data.resolve_options.clone(),
       resolve_to_context: true,
       optional: dependency.get_optional(),

--- a/crates/rspack_core/src/dependency/dependency_location.rs
+++ b/crates/rspack_core/src/dependency/dependency_location.rs
@@ -5,11 +5,12 @@ use std::{
 
 use rspack_cacheable::cacheable;
 use rspack_location::{DependencyLocation, RealDependencyLocation, SourcePosition};
+use rspack_util::SpanExt;
 
 /// Represents a range in a dependency, typically used for tracking the span of code in a source file.
 /// It stores the start and end positions (as offsets) of the range, typically using base-0 indexing.
 #[cacheable]
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct DependencyRange {
   pub end: u32,
   pub start: u32,
@@ -27,8 +28,8 @@ impl From<(u32, u32)> for DependencyRange {
 impl From<swc_core::common::Span> for DependencyRange {
   fn from(span: swc_core::common::Span) -> Self {
     Self {
-      start: span.lo.0.saturating_sub(1),
-      end: span.hi.0.saturating_sub(1),
+      start: span.real_lo(),
+      end: span.real_hi(),
     }
   }
 }

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -83,7 +83,7 @@ pub trait Dependency:
     None
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
+  fn range(&self) -> Option<DependencyRange> {
     None
   }
 

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -14,7 +14,6 @@ mod loader_import;
 mod module_dependency;
 mod runtime_requirements_dependency;
 mod runtime_template;
-mod span;
 mod static_exports_dependency;
 
 use std::sync::Arc;
@@ -39,7 +38,6 @@ pub use runtime_requirements_dependency::{
 pub use runtime_template::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
-pub use span::SpanExt;
 pub use static_exports_dependency::{StaticExportsDependency, StaticExportsSpec};
 use swc_core::ecma::atoms::Atom;
 

--- a/crates/rspack_core/src/dependency/module_dependency.rs
+++ b/crates/rspack_core/src/dependency/module_dependency.rs
@@ -2,7 +2,7 @@ use dyn_clone::clone_trait_object;
 use rspack_cacheable::cacheable_dyn;
 
 use super::{Dependency, FactorizeInfo};
-use crate::{DependencyCondition, ErrorSpan};
+use crate::DependencyCondition;
 
 #[cacheable_dyn]
 pub trait ModuleDependency: Dependency {
@@ -10,16 +10,6 @@ pub trait ModuleDependency: Dependency {
 
   fn user_request(&self) -> &str {
     self.request()
-  }
-
-  /// Span for precise source location.
-  /// For example: the source node in an `ImportDeclaration`.
-  /// This is only intended used to display better diagnostics.
-  /// So it might not be precise as it is using [crate::Dependency::span] as the default value.
-  fn source_span(&self) -> Option<ErrorSpan> {
-    self
-      .range()
-      .map(|range| ErrorSpan::new(range.start, range.end))
   }
 
   fn weak(&self) -> bool {

--- a/crates/rspack_core/src/diagnostics.rs
+++ b/crates/rspack_core/src/diagnostics.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use itertools::Itertools;
 use rspack_error::{
   DiagnosticExt, Error, TraceableError, error, impl_diagnostic_transparent,
-  miette::{self, Diagnostic},
+  miette::{self, Diagnostic, diagnostic},
   thiserror::{self, Error},
 };
 use rspack_util::ext::AsAny;
@@ -17,16 +17,19 @@ use crate::{BoxLoader, DependencyRange};
 pub struct EmptyDependency(Box<dyn Diagnostic + Send + Sync>);
 
 impl EmptyDependency {
-  pub fn new(span: DependencyRange) -> Self {
-    Self(
+  pub fn new(span: Option<DependencyRange>) -> Self {
+    let err = if let Some(span) = span {
       TraceableError::from_lazy_file(
         span.start as usize,
         span.end as usize,
         "Empty dependency".to_string(),
         "Expected a non-empty request".to_string(),
       )
-      .boxed(),
-    )
+      .boxed()
+    } else {
+      diagnostic!(code = "Empty dependency", "Expected a non-empty request").into()
+    };
+    Self(err)
   }
 }
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -1,26 +1,24 @@
 use std::{borrow::Cow, sync::Arc};
 
-use rspack_cacheable::cacheable;
 use rspack_error::{Result, error};
 use rspack_hook::define_hook;
 use rspack_loader_runner::{Loader, Scheme, get_scheme};
 use rspack_paths::Utf8PathBuf;
 use rspack_util::MergeFrom;
 use sugar_path::SugarPath;
-use swc_core::common::Span;
 use winnow::prelude::*;
 
 use crate::{
   AssetInlineGeneratorOptions, AssetResourceGeneratorOptions, BoxLoader, BoxModule,
   CompilerOptions, Context, CssAutoGeneratorOptions, CssAutoParserOptions,
-  CssModuleGeneratorOptions, CssModuleParserOptions, Dependency, DependencyCategory,
-  DependencyRange, FactoryMeta, FuncUseCtx, GeneratorOptions, ModuleExt, ModuleFactory,
-  ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer, ModuleRuleEffect,
-  ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader, ModuleType, NormalModule,
-  ParserAndGenerator, ParserOptions, RawModule, Resolve, ResolveArgs,
-  ResolveOptionsWithDependencyType, ResolveResult, Resolver, ResolverFactory, ResourceData,
-  ResourceParsedData, RunnerContext, SharedPluginDriver, diagnostics::EmptyDependency,
-  module_rules_matcher, parse_resource, resolve, stringify_loaders_and_resource,
+  CssModuleGeneratorOptions, CssModuleParserOptions, Dependency, DependencyCategory, FactoryMeta,
+  FuncUseCtx, GeneratorOptions, ModuleExt, ModuleFactory, ModuleFactoryCreateData,
+  ModuleFactoryResult, ModuleIdentifier, ModuleLayer, ModuleRuleEffect, ModuleRuleEnforce,
+  ModuleRuleUse, ModuleRuleUseLoader, ModuleType, NormalModule, ParserAndGenerator, ParserOptions,
+  RawModule, Resolve, ResolveArgs, ResolveOptionsWithDependencyType, ResolveResult, Resolver,
+  ResolverFactory, ResourceData, ResourceParsedData, RunnerContext, SharedPluginDriver,
+  diagnostics::EmptyDependency, module_rules_matcher, parse_resource, resolve,
+  stringify_loaders_and_resource,
 };
 
 define_hook!(NormalModuleFactoryBeforeResolve: SeriesBail(data: &mut ModuleFactoryCreateData) -> bool,tracing=false);
@@ -133,7 +131,7 @@ impl NormalModuleFactory {
       .expect("should be module dependency");
     let dependency_type = *dependency.dependency_type();
     let dependency_category = *dependency.category();
-    let dependency_source_span = dependency.source_span();
+    let dependency_range = dependency.range();
     let dependency_optional = dependency.get_optional();
 
     let importer = data.issuer_identifier;
@@ -218,8 +216,7 @@ impl NormalModuleFactory {
         let second_char = request.next();
 
         if first_char.is_none() {
-          let span = dependency.source_span().unwrap_or_default();
-          return Err(EmptyDependency::new(DependencyRange::new(span.start, span.end)).into());
+          return Err(EmptyDependency::new(dependency.range()).into());
         }
 
         // See: https://webpack.js.org/concepts/loaders/#inline
@@ -314,7 +311,7 @@ impl NormalModuleFactory {
           specifier: &resource,
           dependency_type: &dependency_type,
           dependency_category: &dependency_category,
-          span: dependency_source_span,
+          span: dependency_range,
           resolve_options: data.resolve_options.clone(),
           resolve_to_context: false,
           optional: dependency_optional,
@@ -882,32 +879,6 @@ async fn resolve_each(
     .call(context, loader_resolver, l)
     .await?
     .ok_or_else(|| error!("Unable to resolve loader {}", l.loader))
-}
-
-/// Using `u32` instead of `usize` to reduce memory usage,
-/// `u32` is 4 bytes on 64bit machine, comparing to `usize` which is 8 bytes.
-/// ## Warning
-/// [ErrorSpan] start from zero, and `Span` of `swc` start from one. see https://swc-css.netlify.app/?code=eJzLzC3ILypRSFRIK8rPVVAvSS0u0csqVgcAZaoIKg
-#[cacheable]
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Default, PartialOrd, Ord)]
-pub struct ErrorSpan {
-  pub start: u32,
-  pub end: u32,
-}
-
-impl ErrorSpan {
-  pub fn new(start: u32, end: u32) -> Self {
-    Self { start, end }
-  }
-}
-
-impl From<Span> for ErrorSpan {
-  fn from(span: Span) -> Self {
-    Self {
-      start: span.lo.0.saturating_sub(1),
-      end: span.hi.0.saturating_sub(1),
-    }
-  }
 }
 
 #[derive(Debug)]

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -22,7 +22,7 @@ pub use self::{
   resolver_impl::{ResolveInnerError, ResolveInnerOptions, Resolver},
 };
 use crate::{
-  Context, DependencyCategory, DependencyType, ErrorSpan, ModuleIdentifier, Resolve,
+  Context, DependencyCategory, DependencyRange, DependencyType, ModuleIdentifier, Resolve,
   SharedPluginDriver,
 };
 
@@ -43,7 +43,7 @@ pub struct ResolveArgs<'a> {
   pub specifier: &'a str,
   pub dependency_type: &'a DependencyType,
   pub dependency_category: &'a DependencyCategory,
-  pub span: Option<ErrorSpan>,
+  pub span: Option<DependencyRange>,
   pub resolve_options: Option<Arc<Resolve>>,
   pub resolve_to_context: bool,
   pub optional: bool,

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -414,11 +414,18 @@ fn map_resolver_error(
     return diagnostic!("Module not found: Can't resolve '{request}' in '{context}'").boxed();
   }
 
-  let span = args.span.unwrap_or_default();
   let message = format!("Can't resolve '{request}' in '{context}'");
   TraceableError::from_lazy_file(
-    span.start as usize,
-    span.end as usize,
+    args
+      .span
+      .as_ref()
+      .map(|span| span.start as usize)
+      .unwrap_or_default(),
+    args
+      .span
+      .as_ref()
+      .map(|span| span.end as usize)
+      .unwrap_or_default(),
     "Module not found".to_string(),
     message,
   )

--- a/crates/rspack_javascript_compiler/Cargo.toml
+++ b/crates/rspack_javascript_compiler/Cargo.toml
@@ -40,7 +40,6 @@ swc_error_reporters = { workspace = true }
 swc_node_comments = { workspace = true }
 url = { workspace = true }
 
-rspack_cacheable = { workspace = true }
 rspack_error     = { workspace = true }
 rspack_sources   = { workspace = true }
 rspack_util      = { workspace = true }

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -46,8 +46,8 @@ impl Dependency for CssComposeDependency {
     &DependencyType::CssCompose
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -72,8 +72,8 @@ impl Dependency for CssImportDependency {
     &DependencyType::CssImport
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -67,8 +67,8 @@ impl Dependency for CssUrlDependency {
     &DependencyType::CssUrl
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_extract_css/src/css_dependency.rs
+++ b/crates/rspack_plugin_extract_css/src/css_dependency.rs
@@ -114,8 +114,8 @@ impl Dependency for CssDependency {
   // it can keep the right order, but Rspack uses HashSet,
   // when determining the postOrderIndex, Rspack uses
   // dependency span to set correct order
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn get_layer(&self) -> Option<&rspack_core::ModuleLayer> {

--- a/crates/rspack_plugin_html/src/parser.rs
+++ b/crates/rspack_plugin_html/src/parser.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use rspack_core::{Compilation, ErrorSpan};
+use rspack_core::Compilation;
 use rspack_error::{
   IntoTWithDiagnosticArray, Result, TWithDiagnosticArray, ToStringResultToRspackResultExt,
 };
+use rspack_util::SpanExt;
 use swc_core::common::{FileName, FilePathMapping, GLOBALS, SourceFile, SourceMap, sync::Lrc};
 use swc_html::{
   ast::Document,
@@ -78,11 +79,11 @@ impl<'a> HtmlCompiler<'a> {
 pub fn html_parse_error_to_traceable_error(error: Error, fm: &SourceFile) -> rspack_error::Error {
   let message = error.message();
   let error = error.into_inner();
-  let span: ErrorSpan = error.0.into();
+  let span = error.0;
   let traceable_error = rspack_error::TraceableError::from_source_file(
     fm,
-    span.start as usize,
-    span.end as usize,
+    span.real_lo() as usize,
+    span.real_hi() as usize,
     "HTML parse error".to_string(),
     message.to_string(),
   );

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
@@ -205,8 +205,8 @@ impl Dependency for AMDDefineDependency {
     &self.id
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
@@ -43,8 +43,8 @@ impl Dependency for AMDRequireArrayDependency {
     &self.id
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
@@ -46,8 +46,8 @@ impl Dependency for AMDRequireDependency {
     &self.id
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.outer_range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.outer_range)
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
@@ -39,8 +39,8 @@ impl Dependency for AMDRequireItemDependency {
     &self.id
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    self.range.as_ref()
+  fn range(&self) -> Option<DependencyRange> {
+    self.range
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
@@ -37,8 +37,8 @@ impl Dependency for LocalModuleDependency {
     &self.id
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    self.range.as_ref()
+  fn range(&self) -> Option<DependencyRange> {
+    self.range
   }
 
   fn could_affect_referencing_module(&self) -> AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
@@ -31,8 +31,8 @@ impl Dependency for UnsupportedDependency {
     &self.id
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -86,8 +86,8 @@ impl Dependency for CommonJsExportsDependency {
     &self.id
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -70,8 +70,8 @@ impl Dependency for CommonJsFullRequireDependency {
     self.range.to_loc(self.source_map.as_ref())
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -57,8 +57,8 @@ impl Dependency for CommonJsRequireDependency {
     &DependencyType::CjsRequire
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    self.range_expr.as_ref()
+  fn range(&self) -> Option<DependencyRange> {
+    self.range_expr
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
@@ -124,7 +124,7 @@ impl DependencyTemplate for CommonJsRequireDependencyTemplate {
 
     source.replace(
       dep.range.start,
-      dep.range.end - 1,
+      dep.range.end,
       module_id(
         code_generatable_context.compilation,
         &dep.id,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -44,8 +44,8 @@ impl Dependency for CommonJsSelfReferenceDependency {
     &self.id
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_dependency.rs
@@ -44,8 +44,8 @@ impl Dependency for RequireEnsureDependency {
     &DependencyType::RequireEnsure
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_item_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_item_dependency.rs
@@ -40,8 +40,8 @@ impl Dependency for RequireEnsureItemDependency {
     &DependencyType::RequireEnsureItem
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -44,8 +44,8 @@ impl Dependency for RequireResolveDependency {
     &DependencyType::RequireResolve
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
@@ -52,8 +52,8 @@ impl Dependency for AMDRequireContextDependency {
     &DependencyType::AmdRequireContext
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -62,8 +62,8 @@ impl Dependency for CommonJsRequireContextDependency {
     &DependencyType::CommonJSRequireContext
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -59,8 +59,8 @@ impl Dependency for ImportContextDependency {
     &DependencyType::ImportContext
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -50,8 +50,8 @@ impl Dependency for ImportMetaContextDependency {
     &DependencyType::ImportMetaContext
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -50,8 +50,8 @@ impl Dependency for RequireContextDependency {
     &DependencyType::RequireContext
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
@@ -49,8 +49,8 @@ impl Dependency for RequireResolveContextDependency {
     &DependencyType::RequireResolveContext
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -1075,8 +1075,8 @@ impl Dependency for ESMExportImportedSpecifierDependency {
     self.range.to_loc(self.source_map.as_ref())
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -8,7 +8,7 @@ use rspack_core::{
   ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ErrorSpan, ExportProvided, ExportsType, ExtendedReferencedExport, FactorizeInfo, ForwardId,
+  ExportProvided, ExportsType, ExtendedReferencedExport, FactorizeInfo, ForwardId,
   ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage, LazyUntil,
   ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
   PrefetchExportsInfoMode, ProvidedExports, RuntimeCondition, RuntimeSpec, SharedSourceMap,
@@ -522,8 +522,8 @@ impl Dependency for ESMImportSideEffectDependency {
     self.range.to_loc(self.source_map.as_ref())
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn source_order(&self) -> Option<i32> {
@@ -634,10 +634,6 @@ impl ModuleDependency for ESMImportSideEffectDependency {
 
   fn user_request(&self) -> &str {
     &self.request
-  }
-
-  fn source_span(&self) -> Option<ErrorSpan> {
-    Some(ErrorSpan::new(self.range_src.start, self.range_src.end))
   }
 
   fn get_condition(&self) -> Option<DependencyCondition> {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -150,8 +150,8 @@ impl Dependency for ESMImportSpecifierDependency {
     self.range.to_loc(self.source_map.as_ref())
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn source_order(&self) -> Option<i32> {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -119,8 +119,8 @@ impl Dependency for ImportDependency {
     self.attributes.as_ref()
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -72,8 +72,8 @@ impl Dependency for ImportEagerDependency {
     self.attributes.as_ref()
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -41,8 +41,8 @@ impl Dependency for ImportMetaHotAcceptDependency {
     &DependencyType::ImportMetaHotAccept
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -41,8 +41,8 @@ impl Dependency for ImportMetaHotDeclineDependency {
     &DependencyType::ImportMetaHotDecline
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -41,8 +41,8 @@ impl Dependency for ModuleHotAcceptDependency {
     &DependencyType::ModuleHotAccept
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -41,8 +41,8 @@ impl Dependency for ModuleHotDeclineDependency {
     &DependencyType::ModuleHotDecline
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -34,8 +34,8 @@ impl Dependency for WebpackIsIncludedDependency {
     &DependencyType::WebpackIsIncluded
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn id(&self) -> &DependencyId {

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -63,8 +63,8 @@ impl Dependency for PureExpressionDependency {
     &self.id
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn set_used_by_exports(&mut self, used_by_exports: Option<UsedByExports>) {

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -55,8 +55,8 @@ impl Dependency for URLDependency {
     &DependencyType::NewUrl
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
@@ -37,8 +37,8 @@ impl Dependency for CreateScriptUrlDependency {
     &DependencyType::CreateScriptUrl
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -54,8 +54,8 @@ impl Dependency for WorkerDependency {
     &DependencyType::NewWorker
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 
 use rspack_core::{
   BuildMetaDefaultObject, BuildMetaExportsType, ConstDependency, ContextDependency, ContextMode,
-  ContextNameSpaceObject, ContextOptions, Dependency, DependencyCategory, RuntimeGlobals, SpanExt,
+  ContextNameSpaceObject, ContextOptions, Dependency, DependencyCategory, RuntimeGlobals,
 };
-use rspack_util::atom::Atom;
+use rspack_util::{SpanExt, atom::Atom};
 use rustc_hash::FxHashMap;
 use swc_core::{
   common::Spanned,
@@ -162,8 +162,7 @@ impl AMDDefineDependencyParserPlugin {
           parser.dependencies.push(Box::new(dep));
         }
       }
-      let range = param.range();
-      let dep = AMDRequireArrayDependency::new(deps, (range.0, range.1 - 1).into());
+      let dep = AMDRequireArrayDependency::new(deps, param.range().into());
       parser.presentational_dependencies.push(Box::new(dep));
       return Some(true);
     }
@@ -190,10 +189,7 @@ impl AMDDefineDependencyParserPlugin {
       return Some(true);
     } else if param.is_string() {
       let param_str = param.string();
-      let range = {
-        let (l, h) = param.range();
-        (l, h - 1)
-      };
+      let range = param.range();
 
       let dep = if param_str == "require" {
         Box::new(ConstDependency::new(
@@ -251,7 +247,7 @@ impl AMDDefineDependencyParserPlugin {
     param: &BasicEvaluatedExpression,
   ) -> Option<bool> {
     let call_span = call_expr.span();
-    let param_range = (param.range().0, param.range().1 - 1);
+    let param_range = param.range();
 
     let result = create_context_dependency(param, parser);
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
@@ -1,4 +1,5 @@
-use rspack_core::{ConstDependency, RuntimeGlobals, SpanExt};
+use rspack_core::{ConstDependency, RuntimeGlobals};
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{CallExpr, Expr, MemberExpr, UnaryExpr},

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
@@ -5,10 +5,10 @@ use itertools::Itertools;
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, ConstDependency, ContextDependency, ContextMode,
   ContextNameSpaceObject, ContextOptions, Dependency, DependencyCategory, DependencyRange,
-  RuntimeGlobals, SharedSourceMap, SpanExt,
+  RuntimeGlobals, SharedSourceMap,
 };
 use rspack_error::miette::Severity;
-use rspack_util::atom::Atom;
+use rspack_util::{SpanExt, atom::Atom};
 use swc_core::{
   common::Spanned,
   ecma::ast::{BlockStmtOrExpr, CallExpr, ExprOrSpread, Pat},
@@ -94,7 +94,7 @@ impl AMDRequireDependenciesBlockParserPlugin {
         }
       }
       let range = param.range();
-      let dep = AMDRequireArrayDependency::new(deps, (range.0, range.1 - 1).into());
+      let dep = AMDRequireArrayDependency::new(deps, range.into());
       parser.presentational_dependencies.push(Box::new(dep));
       return Some(true);
     }
@@ -121,10 +121,7 @@ impl AMDRequireDependenciesBlockParserPlugin {
       return Some(true);
     } else if param.is_string() {
       let param_str = param.string();
-      let range = {
-        let (l, h) = param.range();
-        (l, h - 1)
-      };
+      let range = param.range();
 
       if param_str == "require" {
         let dep = Box::new(ConstDependency::new(
@@ -178,7 +175,7 @@ impl AMDRequireDependenciesBlockParserPlugin {
     param: &BasicEvaluatedExpression,
   ) -> Option<bool> {
     let call_span = call_expr.span();
-    let param_range = (param.range().0, param.range().1 - 1);
+    let param_range = param.range();
 
     let result = create_context_dependency(param, parser);
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -1,5 +1,6 @@
-use rspack_core::{ConstDependency, RuntimeGlobals, RuntimeRequirementsDependency, SpanExt};
+use rspack_core::{ConstDependency, RuntimeGlobals, RuntimeRequirementsDependency};
 use rspack_error::{Severity, TraceableError};
+use rspack_util::SpanExt;
 use swc_core::{
   common::{SourceFile, Span, Spanned},
   ecma::ast::{CallExpr, Ident, UnaryExpr},

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -1,6 +1,5 @@
-use rspack_core::{
-  BuildMetaDefaultObject, BuildMetaExportsType, DependencyRange, RuntimeGlobals, SpanExt,
-};
+use rspack_core::{BuildMetaDefaultObject, BuildMetaExportsType, DependencyRange, RuntimeGlobals};
+use rspack_util::SpanExt;
 use swc_core::{
   atoms::Atom,
   common::{Span, Spanned},

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -1,8 +1,9 @@
 use rspack_core::{
   ConstDependency, ContextDependency, ContextMode, ContextNameSpaceObject, ContextOptions,
-  DependencyCategory, DependencyLocation, DependencyRange, SpanExt,
+  DependencyCategory, DependencyLocation, DependencyRange,
 };
 use rspack_error::{DiagnosticExt, Severity};
+use rspack_util::SpanExt;
 use swc_core::{
   common::{Span, Spanned},
   ecma::ast::{AssignExpr, CallExpr, Expr, ExprOrSpread, Ident, MemberExpr, NewExpr, UnaryExpr},
@@ -159,12 +160,11 @@ impl CommonJsImportsParserPlugin {
     weak: bool,
   ) -> bool {
     if param.is_string() {
-      let (start, end) = param.range();
       parser
         .dependencies
         .push(Box::new(RequireResolveDependency::new(
           param.string().to_string(),
-          (start, end - 1).into(),
+          param.range().into(),
           weak,
           parser.in_try,
         )));
@@ -181,9 +181,7 @@ impl CommonJsImportsParserPlugin {
     param: &BasicEvaluatedExpression,
     weak: bool,
   ) {
-    let (start, end) = param.range();
-    let dep =
-      create_require_resolve_context_dependency(parser, param, (start, end - 1).into(), weak);
+    let dep = create_require_resolve_context_dependency(parser, param, param.range().into(), weak);
 
     parser.dependencies.push(Box::new(dep));
   }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -1,5 +1,5 @@
-use rspack_core::{ConstDependency, ContextDependency, DependencyRange, RuntimeGlobals, SpanExt};
-use rspack_util::itoa;
+use rspack_core::{ConstDependency, ContextDependency, DependencyRange, RuntimeGlobals};
+use rspack_util::{SpanExt, itoa};
 use swc_core::{
   atoms::Atom,
   common::Spanned,
@@ -219,7 +219,7 @@ impl JavascriptParserPlugin for CompatibilityPlugin {
     if !nested_require_data.update {
       let shorthand = nested_require_data.in_short_hand;
       deps.push(ConstDependency::new(
-        nested_require_data.loc.clone(),
+        nested_require_data.loc,
         if shorthand {
           format!("{}: {}", ident.sym, name.clone()).into()
         } else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
-use rspack_core::{ConstDependency, SpanExt};
+use rspack_core::ConstDependency;
+use rspack_util::SpanExt;
 use rustc_hash::FxHashSet;
 use swc_core::{
   common::Spanned,
@@ -143,7 +144,7 @@ pub fn statement_if(scanner: &mut JavascriptParser, stmt: &IfStmt) -> Option<boo
     scanner
       .presentational_dependencies
       .push(Box::new(ConstDependency::new(
-        (param.range().0, param.range().1 - 1).into(),
+        param.range().into(),
         boolean.to_string().into_boxed_str(),
         None,
       )));
@@ -177,7 +178,7 @@ pub fn statement_if(scanner: &mut JavascriptParser, stmt: &IfStmt) -> Option<boo
       .push(Box::new(ConstDependency::new(
         (
           branch_to_remove.span().real_lo(),
-          branch_to_remove.span().hi().0 - 1,
+          branch_to_remove.span().real_hi(),
         )
           .into(),
         replacement.into_boxed_str(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/const/logic_expr.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/const/logic_expr.rs
@@ -1,4 +1,5 @@
-use rspack_core::{ConstDependency, SpanExt};
+use rspack_core::ConstDependency;
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{BinExpr, BinaryOp},
@@ -27,7 +28,7 @@ pub fn expression_logic_operator(scanner: &mut JavascriptParser, expr: &BinExpr)
       scanner
         .presentational_dependencies
         .push(Box::new(ConstDependency::new(
-          (param.range().0, param.range().1 - 1).into(),
+          param.range().into(),
           format!(" {boolean}").into(),
           None,
         )));
@@ -39,7 +40,7 @@ pub fn expression_logic_operator(scanner: &mut JavascriptParser, expr: &BinExpr)
       scanner
         .presentational_dependencies
         .push(Box::new(ConstDependency::new(
-          (expr.right.span().real_lo(), expr.right.span().hi().0 - 1).into(),
+          (expr.right.span().real_lo(), expr.right.span().real_hi()).into(),
           "0".into(),
           None,
         )));
@@ -52,7 +53,7 @@ pub fn expression_logic_operator(scanner: &mut JavascriptParser, expr: &BinExpr)
         scanner
           .presentational_dependencies
           .push(Box::new(ConstDependency::new(
-            (param.range().0, param.range().1 - 1).into(),
+            param.range().into(),
             " null".into(),
             None,
           )));
@@ -60,7 +61,7 @@ pub fn expression_logic_operator(scanner: &mut JavascriptParser, expr: &BinExpr)
         scanner
           .presentational_dependencies
           .push(Box::new(ConstDependency::new(
-            (expr.right.span().real_lo(), expr.right.span().hi().0 - 1).into(),
+            (expr.right.span().real_lo(), expr.right.span().real_hi()).into(),
             "0".into(),
             None,
           )));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/const/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/const/mod.rs
@@ -33,7 +33,7 @@ impl JavascriptParserPlugin for ConstPlugin {
         parser
           .presentational_dependencies
           .push(Box::new(ConstDependency::new(
-            (param.range().0, param.range().1 - 1).into(),
+            param.range().into(),
             format!(" {bool}").into(),
             None,
           )));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
@@ -6,7 +6,7 @@ use std::{
   },
 };
 
-use rspack_core::SpanExt as _;
+use rspack_util::SpanExt;
 use swc_core::ecma::ast::Expr;
 
 use super::{VALUE_DEP_PREFIX, utils::gen_const_dep, walk_data::WalkData};
@@ -80,7 +80,7 @@ impl JavascriptParserPlugin for DefineParserPlugin {
         return None;
       }
       self.add_value_dependency(parser, for_name);
-      let evaluated = on_evaluate_typeof(record, parser, expr.span.real_lo(), expr.span.hi.0);
+      let evaluated = on_evaluate_typeof(record, parser, expr.span.real_lo(), expr.span.real_hi());
       self.recurse_typeof.store(false, Ordering::Release);
       return evaluated;
     }
@@ -89,7 +89,7 @@ impl JavascriptParserPlugin for DefineParserPlugin {
       return Some(evaluate_to_string(
         "object".to_string(),
         expr.span.real_lo(),
-        expr.span.hi.0,
+        expr.span.real_hi(),
       ));
     }
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
@@ -1,6 +1,7 @@
 use std::ops::Add;
 
-use rspack_core::{BuildMetaExportsType, ExportsArgument, ModuleArgument, ModuleType, SpanExt};
+use rspack_core::{BuildMetaExportsType, ExportsArgument, ModuleArgument, ModuleType};
+use rspack_util::SpanExt;
 use swc_core::{
   common::{BytePos, Span, Spanned},
   ecma::ast::{Ident, ModuleItem, Program, UnaryExpr},
@@ -107,7 +108,7 @@ impl JavascriptParserPlugin for ESMDetectionParserPlugin {
     for_name: &str,
   ) -> Option<BasicEvaluatedExpression<'a>> {
     (parser.is_esm && is_non_esm_identifier(for_name))
-      .then(|| BasicEvaluatedExpression::with_range(expr.span().real_lo(), expr.span_hi().0))
+      .then(|| BasicEvaluatedExpression::with_range(expr.span().real_lo(), expr.span().real_hi()))
   }
 
   fn r#typeof(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
-use rspack_core::{BoxDependency, ConstDependency, DependencyRange, DependencyType, SpanExt};
+use rspack_core::{BoxDependency, ConstDependency, DependencyRange, DependencyType};
+use rspack_util::SpanExt;
 use swc_core::{
   atoms::Atom,
   common::{Span, Spanned, comments::CommentKind},

--- a/crates/rspack_plugin_javascript/src/parser_plugin/exports_info_api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/exports_info_api_plugin.rs
@@ -1,4 +1,5 @@
-use rspack_core::{ConstDependency, SpanExt};
+use rspack_core::ConstDependency;
+use rspack_util::SpanExt;
 use swc_core::{
   atoms::Atom,
   common::Span,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -1,4 +1,5 @@
-use rspack_core::{BoxDependency, DependencyRange, SpanExt};
+use rspack_core::{BoxDependency, DependencyRange};
+use rspack_util::SpanExt;
 use swc_core::{
   common::{Span, Spanned},
   ecma::{ast::CallExpr, atoms::Atom},
@@ -29,7 +30,7 @@ fn extract_deps(
     if expr.is_string() {
       dependencies.push(create_dependency(
         expr.string().as_str().into(),
-        (expr.range().0, expr.range().1 - 1).into(),
+        expr.range().into(),
       ));
     } else if expr.is_array() {
       expr
@@ -39,7 +40,7 @@ fn extract_deps(
         .for_each(|expr| {
           dependencies.push(create_dependency(
             expr.string().as_str().into(),
-            (expr.range().0, expr.range().1 - 1).into(),
+            expr.range().into(),
           ));
         });
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -1,7 +1,6 @@
-use rspack_core::{
-  ContextMode, ContextNameSpaceObject, ContextOptions, DependencyCategory, SpanExt,
-};
+use rspack_core::{ContextMode, ContextNameSpaceObject, ContextOptions, DependencyCategory};
 use rspack_regex::RspackRegex;
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{CallExpr, Lit},

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
-use rspack_core::{ConstDependency, SpanExt, property_access};
+use rspack_core::{ConstDependency, property_access};
 use rspack_error::miette::Severity;
+use rspack_util::SpanExt;
 use swc_core::{
   common::{Span, Spanned},
   ecma::ast::{Expr, MemberProp, MetaPropKind},
@@ -100,7 +101,7 @@ impl JavascriptParserPlugin for ImportMetaPlugin {
       if member.prop.is_ident() {
         return Some(eval::evaluate_to_undefined(
           member.span().real_lo(),
-          member.span().hi().0,
+          member.span().real_hi(),
         ));
       }
       if let Some(computed) = member.prop.as_computed()
@@ -108,7 +109,7 @@ impl JavascriptParserPlugin for ImportMetaPlugin {
       {
         return Some(eval::evaluate_to_undefined(
           member.span().real_lo(),
-          member.span().hi().0,
+          member.span().real_hi(),
         ));
       }
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -2,10 +2,10 @@ use itertools::Itertools;
 use rspack_core::{
   AsyncDependenciesBlock, ChunkGroupOptions, ContextDependency, ContextNameSpaceObject,
   ContextOptions, DependencyCategory, DependencyRange, DynamicImportFetchPriority,
-  DynamicImportMode, GroupOptions, ImportAttributes, SharedSourceMap, SpanExt,
+  DynamicImportMode, GroupOptions, ImportAttributes, SharedSourceMap,
 };
 use rspack_error::miette::Severity;
-use rspack_util::swc::get_swc_comments;
+use rspack_util::{SpanExt, swc::get_swc_comments};
 use swc_core::{
   common::Spanned,
   ecma::{

--- a/crates/rspack_plugin_javascript/src/parser_plugin/initialize_evaluating.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/initialize_evaluating.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use cow_utils::CowUtils;
-use rspack_core::SpanExt;
+use rspack_util::SpanExt;
 
 use super::JavascriptParserPlugin;
 use crate::utils::eval::BasicEvaluatedExpression;
@@ -47,7 +47,8 @@ impl JavascriptParserPlugin for InitializeEvaluating {
           arg2.map(|a| a.number()),
         )
       }) {
-        let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+        let mut res =
+          BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
         res.set_number(result as f64);
         res.set_side_effects(param.could_have_side_effects());
         return Some(res);
@@ -61,7 +62,8 @@ impl JavascriptParserPlugin for InitializeEvaluating {
       let arg1 = parser.evaluate_expression(&expr.args[0].expr);
       if arg1.is_number() {
         let result = mock_javascript_slice(param.string().as_str(), arg1.number());
-        let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+        let mut res =
+          BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
         res.set_string(result);
         res.set_side_effects(param.could_have_side_effects());
         return Some(res);
@@ -80,7 +82,7 @@ impl JavascriptParserPlugin for InitializeEvaluating {
       if !arg2.is_string() {
         return None;
       }
-      let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+      let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
       // mock js replace
       let s: Cow<'_, str> = if arg1.is_string() {
         param
@@ -153,7 +155,8 @@ impl JavascriptParserPlugin for InitializeEvaluating {
         } else {
           inner_exprs
         };
-        let mut eval = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+        let mut eval =
+          BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
         eval.set_wrapped(prefix, string_suffix, inner);
         return Some(eval);
       } else if param.is_wrapped() {
@@ -167,7 +170,8 @@ impl JavascriptParserPlugin for InitializeEvaluating {
         } else {
           inner_exprs
         };
-        let mut eval = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+        let mut eval =
+          BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
         eval.set_wrapped(param.prefix().cloned(), postfix, inner);
         return Some(eval);
       } else {
@@ -175,7 +179,8 @@ impl JavascriptParserPlugin for InitializeEvaluating {
         if let Some(string_suffix) = &string_suffix {
           new_string += string_suffix.string();
         }
-        let mut eval = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+        let mut eval =
+          BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
         eval.set_string(new_string);
         eval.set_side_effects(
           string_suffix
@@ -204,7 +209,7 @@ impl JavascriptParserPlugin for InitializeEvaluating {
       } else {
         return None;
       };
-      let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+      let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
       res.set_array(array);
       res.set_side_effects(param.could_have_side_effects());
       return Some(res);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use rspack_core::{Dependency, SpanExt, UsedByExports};
+use rspack_core::{Dependency, UsedByExports};
+use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::{
   atoms::Atom,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
@@ -1,7 +1,8 @@
 use rspack_core::{
-  ContextMode, ContextOptions, DependencyCategory, SpanExt, try_convert_str_to_context_mode,
+  ContextMode, ContextOptions, DependencyCategory, try_convert_str_to_context_mode,
 };
 use rspack_regex::RspackRegex;
+use rspack_util::SpanExt;
 use swc_core::{common::Spanned, ecma::ast::CallExpr};
 
 use super::JavascriptParserPlugin;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
@@ -3,8 +3,9 @@ use std::borrow::Cow;
 use either::Either;
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, ChunkGroupOptions, ConstDependency, DependencyRange,
-  GroupOptions, SharedSourceMap, SpanExt,
+  GroupOptions, SharedSourceMap,
 };
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{ArrowExpr, BlockStmtOrExpr, CallExpr, Expr, FnExpr, UnaryExpr},

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -1,4 +1,5 @@
-use rspack_core::{ConstDependency, Dependency, RuntimeGlobals, SpanExt};
+use rspack_core::{ConstDependency, Dependency, RuntimeGlobals};
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{Expr, ExprOrSpread, MemberExpr, MetaPropKind, NewExpr},

--- a/crates/rspack_plugin_javascript/src/parser_plugin/webpack_included_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/webpack_included_plugin.rs
@@ -1,4 +1,5 @@
-use rspack_core::{ConstDependency, SpanExt};
+use rspack_core::ConstDependency;
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{CallExpr, UnaryExpr},
@@ -25,7 +26,7 @@ impl JavascriptParserPlugin for WebpackIsIncludedPlugin {
     parser
       .dependencies
       .push(Box::new(WebpackIsIncludedDependency::new(
-        (expr.span().real_lo(), expr.span().hi().0 - 1).into(),
+        (expr.span().real_lo(), expr.span().real_hi()).into(),
         request.string().to_string(),
       )));
 
@@ -42,7 +43,7 @@ impl JavascriptParserPlugin for WebpackIsIncludedPlugin {
       parser
         .presentational_dependencies
         .push(Box::new(ConstDependency::new(
-          (expr.span().real_lo(), expr.span().hi().0 - 1).into(),
+          (expr.span().real_lo(), expr.span().real_hi()).into(),
           "'function'".into(),
           None,
         )));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -3,9 +3,10 @@ use std::hash::Hash;
 use itertools::Itertools;
 use rspack_core::{
   AsyncDependenciesBlock, ConstDependency, DependencyRange, EntryOptions, GroupOptions,
-  SharedSourceMap, SpanExt,
+  SharedSourceMap,
 };
 use rspack_hash::RspackHash;
+use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
   atoms::Atom,

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -27,7 +27,7 @@ use rspack_collections::{Identifier, IdentifierDashMap, IdentifierLinkedMap, Ide
 use rspack_core::{
   BoxModule, ChunkGraph, ChunkGroupUkey, ChunkInitFragments, ChunkRenderContext, ChunkUkey,
   CodeGenerationDataTopLevelDeclarations, Compilation, CompilationId, ConcatenatedModuleIdent,
-  ExportsArgument, IdentCollector, Module, RuntimeGlobals, SourceType, SpanExt, basic_function,
+  ExportsArgument, IdentCollector, Module, RuntimeGlobals, SourceType, basic_function,
   concatenated_module::find_new_name,
   render_init_fragments,
   reserved_names::RESERVED_NAMES,
@@ -38,7 +38,7 @@ use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_hook::plugin;
 use rspack_javascript_compiler::ast::Ast;
-use rspack_util::{diff_mode, fx_hash::FxDashMap};
+use rspack_util::{SpanExt, diff_mode, fx_hash::FxDashMap};
 pub use side_effects_flag_plugin::*;
 use swc_core::{
   atoms::Atom,

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_array_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_array_expr.rs
@@ -1,4 +1,4 @@
-use rspack_core::SpanExt;
+use rspack_util::SpanExt;
 use swc_core::ecma::ast::ArrayLit;
 
 use super::BasicEvaluatedExpression;
@@ -21,7 +21,7 @@ pub fn eval_array_expression<'a>(
     }
   }
 
-  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
   res.set_items(items);
   Some(res)
 }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
@@ -1,4 +1,5 @@
-use rspack_core::{DependencyRange, SpanExt};
+use rspack_core::DependencyRange;
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{BinExpr, BinaryOp},
@@ -83,7 +84,7 @@ fn handle_strict_equality_comparison<'a>(
 ) -> Option<BasicEvaluatedExpression<'a>> {
   assert!(expr.op == BinaryOp::EqEqEq || expr.op == BinaryOp::NotEqEq);
   let right = scanner.evaluate_expression(&expr.right);
-  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
   let left_const = left.is_compile_time_value();
   let right_const = right.is_compile_time_value();
 
@@ -128,7 +129,7 @@ fn handle_abstract_equality_comparison<'a>(
 ) -> Option<BasicEvaluatedExpression<'a>> {
   assert!(expr.op == BinaryOp::EqEq || expr.op == BinaryOp::NotEq);
   let right = scanner.evaluate_expression(&expr.right);
-  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
 
   let left_const = left.is_compile_time_value();
   let right_const = right.is_compile_time_value();
@@ -161,12 +162,12 @@ fn handle_nullish_coalescing<'a>(
       if left.could_have_side_effects() {
         right.set_side_effects(true)
       }
-      right.set_range(expr.span.real_lo(), expr.span.hi().0);
+      right.set_range(expr.span.real_lo(), expr.span.real_hi());
       Some(right)
     }
     Some(false) => {
       let mut res = left.clone();
-      res.set_range(expr.span.real_lo(), expr.span.hi().0);
+      res.set_range(expr.span.real_lo(), expr.span.real_hi());
       Some(res)
     }
     _ => None,
@@ -183,7 +184,7 @@ fn handle_logical_or<'a>(
   match left_bool {
     Some(true) => {
       let mut res = left.clone();
-      res.set_range(expr.span.real_lo(), expr.span.hi().0);
+      res.set_range(expr.span.real_lo(), expr.span.real_hi());
       Some(res)
     }
     Some(false) => {
@@ -191,13 +192,14 @@ fn handle_logical_or<'a>(
       if left.could_have_side_effects() {
         right.set_side_effects(true)
       }
-      right.set_range(expr.span.real_lo(), expr.span.hi().0);
+      right.set_range(expr.span.real_lo(), expr.span.real_hi());
       Some(right)
     }
     _ => {
       let right_bool = scanner.evaluate_expression(&expr.right).as_bool();
       if right_bool.is_some_and(|x| x) {
-        let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+        let mut res =
+          BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
         res.set_truthy();
         Some(res)
       } else {
@@ -220,18 +222,19 @@ fn handle_logical_and<'a>(
       if left.could_have_side_effects() {
         right.set_side_effects(true)
       }
-      right.set_range(expr.span.real_lo(), expr.span.hi().0);
+      right.set_range(expr.span.real_lo(), expr.span.real_hi());
       Some(right)
     }
     Some(false) => {
       let mut res = left.clone();
-      res.set_range(expr.span.real_lo(), expr.span.hi().0);
+      res.set_range(expr.span.real_lo(), expr.span.real_hi());
       Some(res)
     }
     None => {
       let right_bool = scanner.evaluate_expression(&expr.right).as_bool();
       if right_bool.is_some_and(|x| !x) {
-        let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+        let mut res =
+          BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
         res.set_falsy();
         Some(res)
       } else {
@@ -249,7 +252,7 @@ fn handle_add<'a>(
 ) -> Option<BasicEvaluatedExpression<'a>> {
   assert_eq!(expr.op, BinaryOp::Add);
   let right = scanner.evaluate_expression(&expr.right);
-  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
   if left.could_have_side_effects() || right.could_have_side_effects() {
     res.set_side_effects(true)
   }
@@ -413,7 +416,7 @@ pub fn handle_const_operation<'a>(
     return None;
   }
 
-  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
   res.set_side_effects(left.could_have_side_effects() || right.could_have_side_effects());
 
   match expr.op {
@@ -526,7 +529,7 @@ pub fn eval_binary_expression<'a>(
     .or_else(|| {
       Some(BasicEvaluatedExpression::with_range(
         expr.span().real_lo(),
-        expr.span_hi().0,
+        expr.span().real_hi(),
       ))
     });
   }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_cond_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_cond_expr.rs
@@ -1,4 +1,4 @@
-use rspack_core::SpanExt;
+use rspack_util::SpanExt;
 use swc_core::ecma::ast::CondExpr;
 
 use super::BasicEvaluatedExpression;
@@ -38,6 +38,6 @@ pub fn eval_cond_expression<'a>(
       res.add_options(vec![alt])
     }
   }
-  res.set_range(cond.span.real_lo(), cond.span.hi.0);
+  res.set_range(cond.span.real_lo(), cond.span.real_hi());
   Some(res)
 }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_lit_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_lit_expr.rs
@@ -1,4 +1,4 @@
-use rspack_core::SpanExt;
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{Lit, Str},
@@ -8,28 +8,29 @@ use super::BasicEvaluatedExpression;
 
 #[inline]
 pub fn eval_str(str: &Str) -> BasicEvaluatedExpression<'_> {
-  let mut res = BasicEvaluatedExpression::with_range(str.span().real_lo(), str.span_hi().0);
+  let mut res = BasicEvaluatedExpression::with_range(str.span().real_lo(), str.span().real_hi());
   res.set_string(str.value.to_string());
   res
 }
 
 #[inline]
 pub fn eval_number(num: &swc_core::ecma::ast::Number) -> BasicEvaluatedExpression<'_> {
-  let mut res = BasicEvaluatedExpression::with_range(num.span().real_lo(), num.span_hi().0);
+  let mut res = BasicEvaluatedExpression::with_range(num.span().real_lo(), num.span().real_hi());
   res.set_number(num.value);
   res
 }
 
 #[inline]
 pub fn eval_bool(bool: &swc_core::ecma::ast::Bool) -> BasicEvaluatedExpression<'_> {
-  let mut res = BasicEvaluatedExpression::with_range(bool.span().real_lo(), bool.span_hi().0);
+  let mut res = BasicEvaluatedExpression::with_range(bool.span().real_lo(), bool.span().real_hi());
   res.set_bool(bool.value);
   res
 }
 
 #[inline]
 pub fn eval_bigint(bigint: &swc_core::ecma::ast::BigInt) -> BasicEvaluatedExpression<'_> {
-  let mut res = BasicEvaluatedExpression::with_range(bigint.span().real_lo(), bigint.span_hi().0);
+  let mut res =
+    BasicEvaluatedExpression::with_range(bigint.span().real_lo(), bigint.span().real_hi());
   res.set_bigint((*bigint.value).clone());
   res
 }
@@ -40,12 +41,12 @@ pub fn eval_lit_expr(expr: &Lit) -> Option<BasicEvaluatedExpression<'_>> {
     Lit::Str(str) => Some(eval_str(str)),
     Lit::Regex(regexp) => {
       let mut res =
-        BasicEvaluatedExpression::with_range(regexp.span().real_lo(), regexp.span_hi().0);
+        BasicEvaluatedExpression::with_range(regexp.span().real_lo(), regexp.span().real_hi());
       res.set_regexp(regexp.exp.to_string(), regexp.flags.to_string());
       Some(res)
     }
     Lit::Null(null) => {
-      let mut res = BasicEvaluatedExpression::with_range(null.span.real_lo(), null.span.hi().0);
+      let mut res = BasicEvaluatedExpression::with_range(null.span.real_lo(), null.span.real_hi());
       res.set_null();
       Some(res)
     }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
@@ -1,4 +1,4 @@
-use rspack_core::SpanExt;
+use rspack_util::SpanExt;
 use swc_core::ecma::ast::{Expr, MemberExpr};
 
 use super::BasicEvaluatedExpression;
@@ -22,13 +22,13 @@ pub fn eval_member_expression<'a>(
         parser,
         &info.name,
         member.span.real_lo(),
-        member.span.hi().0,
+        member.span.real_hi(),
       )
       .or_else(|| parser.plugin_drive.clone().evaluate(parser, expr))
       .or_else(|| {
         // TODO: fallback with `evaluateDefinedIdentifier`
         let mut eval =
-          BasicEvaluatedExpression::with_range(member.span.real_lo(), member.span.hi().0);
+          BasicEvaluatedExpression::with_range(member.span.real_lo(), member.span.real_hi());
         eval.set_identifier(
           info.name.into(),
           info.root_info,

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
@@ -1,4 +1,4 @@
-use rspack_core::SpanExt;
+use rspack_util::SpanExt;
 use swc_core::ecma::ast::NewExpr;
 
 use super::BasicEvaluatedExpression;
@@ -16,13 +16,13 @@ pub fn eval_new_expression<'a>(
   }
   // FIXME: should detect RegExpr variable info
   let Some(args) = &expr.args else {
-    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_regexp(String::new(), String::new());
     return Some(res);
   };
 
   let Some(arg1) = args.first() else {
-    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_regexp(String::new(), String::new());
     return Some(res);
   };
@@ -51,7 +51,7 @@ pub fn eval_new_expression<'a>(
     String::new()
   };
 
-  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
   res.set_regexp(reg_exp, flags);
   Some(res)
 }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_prop_name.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_prop_name.rs
@@ -1,4 +1,4 @@
-use rspack_core::SpanExt;
+use rspack_util::SpanExt;
 use swc_core::{common::Spanned, ecma::ast::PropName};
 
 use crate::{
@@ -17,7 +17,7 @@ pub fn eval_prop_name<'a>(
     PropName::BigInt(bigint) => eval_bigint(bigint),
     PropName::Ident(ident) => {
       let mut evaluated =
-        BasicEvaluatedExpression::with_range(ident.span().real_lo(), ident.span_hi().0);
+        BasicEvaluatedExpression::with_range(ident.span().real_lo(), ident.span().real_hi());
       evaluated.set_string(ident.sym.to_string());
       evaluated
     }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_source.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_source.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Display, sync::Arc};
 
 use rspack_error::{TraceableError, miette::Severity};
+use rspack_util::SpanExt;
 use serde_json::json;
 use swc_core::{
   common::{FileName, Spanned},
@@ -32,13 +33,12 @@ pub fn eval_source<T: Display>(
   );
   match result {
     Err(err) => {
-      let span = err.span();
       // Push the error to diagnostics
       parser.warning_diagnostics.push(Box::new(
         TraceableError::from_source_file(
           &fm,
-          span.lo.0.saturating_sub(1) as usize,
-          span.hi.0.saturating_sub(1) as usize,
+          err.span().real_lo() as usize,
+          err.span().real_hi() as usize,
           format!("{error_title} warning"),
           format!("failed to parse {}", json!(fm.src.as_str())),
         )

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_tpl_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_tpl_expr.rs
@@ -1,4 +1,4 @@
-use rspack_core::SpanExt;
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{TaggedTpl, Tpl},
@@ -43,14 +43,14 @@ fn get_simplified_template_result<'a>(
         // We can merge quasi + expr + quasi when expr
         // is a const string
         prev_expr.set_string(format!("{}{}{}", prev_expr.string(), str, quasi));
-        prev_expr.set_range(prev_expr.range().0, quasi_expr.span_hi().0);
+        prev_expr.set_range(prev_expr.range().0, quasi_expr.span().real_hi());
         // We unset the expression as it doesn't match to a single expression
         prev_expr.set_expression(None);
 
         // also merge for quasis
         let prev_expr = quasis.last_mut().expect("should not empty");
         prev_expr.set_string(format!("{}{}{}", prev_expr.string(), str, quasi));
-        prev_expr.set_range(prev_expr.range().0, quasi_expr.span_hi().0);
+        prev_expr.set_range(prev_expr.range().0, quasi_expr.span().real_hi());
         prev_expr.set_expression(None);
         continue;
       }
@@ -60,7 +60,7 @@ fn get_simplified_template_result<'a>(
     let part = || {
       let mut part = BasicEvaluatedExpression::new();
       part.set_string(quasi.to_string());
-      part.set_range(quasi_expr.span().real_lo(), quasi_expr.span_hi().0);
+      part.set_range(quasi_expr.span().real_lo(), quasi_expr.span().real_hi());
       part
     };
     // part.set_expression(Some(quasi_expr));
@@ -80,10 +80,10 @@ pub fn eval_tpl_expression<'a>(
   let (quasis, mut parts) = get_simplified_template_result(scanner, kind, tpl);
   if parts.len() == 1 {
     let mut part = parts.remove(0);
-    part.set_range(tpl.span().real_lo(), tpl.span().hi().0);
+    part.set_range(tpl.span().real_lo(), tpl.span().real_hi());
     Some(part)
   } else {
-    let mut res = BasicEvaluatedExpression::with_range(tpl.span().real_lo(), tpl.span().hi().0);
+    let mut res = BasicEvaluatedExpression::with_range(tpl.span().real_lo(), tpl.span().real_hi());
     res.set_template_string(quasis, parts, kind);
     Some(res)
   }
@@ -102,7 +102,7 @@ pub fn eval_tagged_tpl_expression<'a>(
   let tpl = &tagged_tpl.tpl;
   let (quasis, parts) = get_simplified_template_result(scanner, kind, tpl);
   let mut res =
-    BasicEvaluatedExpression::with_range(tagged_tpl.span().real_lo(), tagged_tpl.span().hi().0);
+    BasicEvaluatedExpression::with_range(tagged_tpl.span().real_lo(), tagged_tpl.span().real_hi());
   res.set_template_string(quasis, parts, kind);
   Some(res)
 }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
@@ -1,4 +1,4 @@
-use rspack_core::SpanExt;
+use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
   ecma::ast::{Lit, UnaryExpr, UnaryOp},
@@ -55,7 +55,7 @@ fn eval_typeof<'a>(
   {
     return Some(res);
   } else if expr.arg.as_fn_expr().is_some() {
-    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_string("function".to_string());
     return Some(res);
   }
@@ -64,7 +64,7 @@ fn eval_typeof<'a>(
   if arg.is_unknown() {
     let arg = &*expr.arg;
     if arg.as_fn_expr().is_some() || arg.as_class().is_some() {
-      let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+      let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
       res.set_string("function".to_string());
       Some(res)
     } else if let Some(unary) = arg.as_unary()
@@ -72,34 +72,34 @@ fn eval_typeof<'a>(
       && let Some(lit) = unary.arg.as_lit()
       && matches!(lit, Lit::Num(_))
     {
-      let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+      let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
       res.set_string("number".to_string());
       Some(res)
     } else {
       None
     }
   } else if arg.is_string() {
-    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_string("string".to_string());
     Some(res)
   } else if arg.is_undefined() {
-    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_string("undefined".to_string());
     Some(res)
   } else if arg.is_number() {
-    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_string("number".to_string());
     Some(res)
   } else if arg.is_null() || arg.is_regexp() || arg.is_array() {
-    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_string("object".to_string());
     Some(res)
   } else if arg.is_bool() {
-    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_string("boolean".to_string());
     Some(res)
   } else if arg.is_bigint() {
-    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_string("bigint".to_string());
     Some(res)
   } else {
@@ -118,7 +118,8 @@ pub fn eval_unary_expression<'a>(
     UnaryOp::Bang => {
       let arg = scanner.evaluate_expression(&expr.arg);
       let boolean = arg.as_bool()?;
-      let mut eval = BasicEvaluatedExpression::with_range(expr.span().real_lo(), expr.span_hi().0);
+      let mut eval =
+        BasicEvaluatedExpression::with_range(expr.span().real_lo(), expr.span().real_hi());
       eval.set_bool(!boolean);
       eval.set_side_effects(arg.could_have_side_effects());
       Some(eval)
@@ -126,7 +127,8 @@ pub fn eval_unary_expression<'a>(
     UnaryOp::Tilde => {
       let arg = scanner.evaluate_expression(&expr.arg);
       let number = arg.as_int()?;
-      let mut eval = BasicEvaluatedExpression::with_range(expr.span().real_lo(), expr.span_hi().0);
+      let mut eval =
+        BasicEvaluatedExpression::with_range(expr.span().real_lo(), expr.span().real_hi());
       eval.set_number(!number as f64);
       eval.set_side_effects(arg.could_have_side_effects());
       Some(eval)
@@ -139,7 +141,8 @@ pub fn eval_unary_expression<'a>(
         UnaryOp::Plus => number,
         _ => unreachable!(),
       };
-      let mut eval = BasicEvaluatedExpression::with_range(expr.span().real_lo(), expr.span_hi().0);
+      let mut eval =
+        BasicEvaluatedExpression::with_range(expr.span().real_lo(), expr.span().real_hi());
       eval.set_number(res);
       eval.set_side_effects(arg.could_have_side_effects());
       Some(eval)

--- a/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
@@ -540,7 +540,7 @@ impl<'a> BasicEvaluatedExpression<'a> {
   }
 
   pub fn range(&self) -> (u32, u32) {
-    let range = self.range.clone().expect("range should not empty");
+    let range = self.range.expect("range should not empty");
     (range.start, range.end)
   }
 

--- a/crates/rspack_plugin_javascript/src/utils/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/mod.rs
@@ -2,8 +2,9 @@ pub mod eval;
 pub mod mangle_exports;
 pub mod object_properties;
 
-use rspack_core::{ErrorSpan, ModuleType};
+use rspack_core::ModuleType;
 use rspack_error::TraceableError;
+use rspack_util::SpanExt;
 use rustc_hash::FxHashSet as HashSet;
 use swc_core::common::{SourceFile, Span, Spanned};
 
@@ -54,11 +55,10 @@ pub fn ecma_parse_error_deduped_to_rspack_error(
     ModuleType::JsAuto | ModuleType::JsDynamic | ModuleType::JsEsm => "JavaScript",
     _ => unreachable!("Only JavaScript module type is supported"),
   };
-  let span: ErrorSpan = span.into();
   rspack_error::TraceableError::from_source_file(
     fm,
-    span.start as usize,
-    span.end as usize,
+    span.real_lo() as usize,
+    span.real_hi() as usize,
     format!("{file_type} parse error"),
     message,
   )

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
@@ -79,10 +79,10 @@ pub fn create_context_dependency(
               TemplateStringKind::Raw => "String.raw`",
             }
           );
-          replaces.push((value, param.range().0, part.range().1 - 1));
+          replaces.push((value, param.range().0, part.range().1));
         } else if i == parts.len() - 1 {
           let value = format!("{postfix}`");
-          replaces.push((value, part.range().0, param.range().1 - 1));
+          replaces.push((value, part.range().0, param.range().1));
         } else {
           let value = match param.template_string_kind() {
             TemplateStringKind::Cooked => {
@@ -91,7 +91,7 @@ pub fn create_context_dependency(
             TemplateStringKind::Raw => part.string().to_owned(),
           };
           let range = part.range();
-          replaces.push((value, range.0, range.1 - 1));
+          replaces.push((value, range.0, range.1));
         }
       } else if let Some(expr) = part.expression() {
         parser.walk_expression(expr);
@@ -99,12 +99,11 @@ pub fn create_context_dependency(
     }
 
     if let Some(true) = parser.javascript_options.wrapped_context_critical {
-      let range = param.range();
       let warn: Diagnostic = create_traceable_error(
         "Critical dependency".into(),
         "a part of the request of a dependency is an expression".to_string(),
         parser.source_file,
-        rspack_core::ErrorSpan::new(range.0, range.1),
+        param.range().into(),
       )
       .with_severity(Severity::Warn)
       .boxed()
@@ -163,23 +162,18 @@ pub fn create_context_dependency(
 
     let mut replaces = Vec::new();
     if let Some(prefix_range) = prefix_range {
-      replaces.push((json_stringify(&prefix), prefix_range.0, prefix_range.1 - 1))
+      replaces.push((json_stringify(&prefix), prefix_range.0, prefix_range.1))
     }
     if let Some(postfix_range) = postfix_range {
-      replaces.push((
-        json_stringify(&postfix),
-        postfix_range.0,
-        postfix_range.1 - 1,
-      ))
+      replaces.push((json_stringify(&postfix), postfix_range.0, postfix_range.1))
     }
 
     if let Some(true) = parser.javascript_options.wrapped_context_critical {
-      let range = param.range();
       let warn: Diagnostic = create_traceable_error(
         "Critical dependency".into(),
         "a part of the request of a dependency is an expression".to_string(),
         parser.source_file,
-        rspack_core::ErrorSpan::new(range.0, range.1),
+        param.range().into(),
       )
       .with_severity(Severity::Warn)
       .boxed()
@@ -206,12 +200,11 @@ pub fn create_context_dependency(
     }
   } else {
     if let Some(true) = parser.javascript_options.expr_context_critical {
-      let range = param.range();
       let warn: Diagnostic = create_traceable_error(
         "Critical dependency".into(),
         "the request of a dependency is an expression".to_string(),
         parser.source_file,
-        rspack_core::ErrorSpan::new(range.0, range.1),
+        param.range().into(),
       )
       .with_severity(Severity::Warn)
       .boxed()

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -1,4 +1,4 @@
-use rspack_core::ErrorSpan;
+use rspack_core::DependencyRange;
 use rspack_error::{
   TraceableError,
   miette::{Severity, diagnostic},
@@ -260,7 +260,7 @@ pub fn create_traceable_error(
   title: String,
   message: String,
   fm: &SourceFile,
-  span: ErrorSpan,
+  span: DependencyRange,
 ) -> TraceableError {
   TraceableError::from_source_file(fm, span.start as usize, span.end as usize, title, message)
 }
@@ -268,7 +268,7 @@ pub fn create_traceable_error(
 pub fn context_reg_exp(
   expr: &str,
   flags: &str,
-  error_span: Option<ErrorSpan>,
+  error_span: Option<DependencyRange>,
   parser: &mut JavascriptParser,
 ) -> Option<RspackRegex> {
   if expr.is_empty() {
@@ -280,7 +280,7 @@ pub fn context_reg_exp(
 
 pub fn clean_regexp_in_context_module(
   regexp: RspackRegex,
-  error_span: Option<ErrorSpan>,
+  error_span: Option<DependencyRange>,
   parser: &mut JavascriptParser,
 ) -> Option<RspackRegex> {
   if regexp.sticky() || regexp.global() {

--- a/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
+++ b/crates/rspack_plugin_library/src/modern_module/import_dependency.rs
@@ -71,8 +71,8 @@ impl Dependency for ModernModuleImportDependency {
     self.attributes.as_ref()
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -67,7 +67,7 @@ pub fn replace_import_dependencies_for_external_modules(
                 import_dependency.request.as_str().into(),
                 external_module.request.clone(),
                 external_module.external_type.clone(),
-                import_dependency.range.clone(),
+                import_dependency.range,
                 import_dependency.get_attributes().cloned(),
                 import_dependency.comments.clone(),
               );

--- a/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
@@ -65,8 +65,8 @@ impl Dependency for MockModuleIdDependency {
     &DependencyType::RstestMockModuleId
   }
 
-  fn range(&self) -> Option<&DependencyRange> {
-    Some(&self.range)
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -1,7 +1,7 @@
 use camino::Utf8PathBuf;
 use rspack_core::{
   AsyncDependenciesBlock, ConstDependency, Dependency, DependencyRange, ImportAttributes,
-  SharedSourceMap, SpanExt,
+  SharedSourceMap,
 };
 use rspack_plugin_javascript::{
   JavascriptParserPlugin,
@@ -12,7 +12,7 @@ use rspack_plugin_javascript::{
   },
   visitors::JavascriptParser,
 };
-use rspack_util::{atom::Atom, json_stringify, swc::get_swc_comments};
+use rspack_util::{SpanExt, atom::Atom, json_stringify, swc::get_swc_comments};
 use swc_core::{
   common::{Span, Spanned},
   ecma::ast::{CallExpr, Ident, MemberExpr, UnaryExpr},
@@ -81,8 +81,7 @@ impl RstestParserPlugin {
         if let Some(lit) = first_arg.expr.as_lit()
           && let Some(lit) = lit.as_str()
         {
-          let mut range_expr: DependencyRange = first_arg.span().into();
-          range_expr.end += 1; // TODO:
+          let range_expr: DependencyRange = first_arg.span().into();
           let dep = CommonJsRequireDependency::new(
             lit.value.to_string(),
             range_expr,
@@ -96,7 +95,7 @@ impl RstestParserPlugin {
           parser
             .presentational_dependencies
             .push(Box::new(RequireHeaderDependency::new(
-              range.clone(),
+              range,
               Some(parser.source_map.clone()),
             )));
 

--- a/crates/rspack_util/src/lib.rs
+++ b/crates/rspack_util/src/lib.rs
@@ -18,6 +18,7 @@ pub mod queue;
 pub mod ryu_js;
 pub mod size;
 pub mod source_map;
+pub mod span;
 pub mod swc;
 pub mod test;
 pub mod tracing_preset;
@@ -25,6 +26,7 @@ pub mod tracing_preset;
 use std::future::Future;
 
 pub use merge::{MergeFrom, merge_from_optional_with};
+pub use span::SpanExt;
 
 pub async fn try_any<T, Fut, F, E>(it: impl IntoIterator<Item = T>, f: F) -> Result<bool, E>
 where

--- a/crates/rspack_util/src/span.rs
+++ b/crates/rspack_util/src/span.rs
@@ -9,11 +9,11 @@ pub trait SpanExt {
 impl SpanExt for Span {
   #[inline]
   fn real_lo(&self) -> u32 {
-    self.lo().0 - 1
+    self.lo().0.saturating_sub(1)
   }
 
   #[inline]
   fn real_hi(&self) -> u32 {
-    self.hi().0 - 1
+    self.hi().0.saturating_sub(1)
   }
 }

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
@@ -1730,7 +1730,7 @@ Object {
             Object {
               active: true,
               explanation: undefined,
-              loc: 2:12-18,
+              loc: 2:12-17,
               moduleId: 679,
               moduleIdentifier: <TEST_TOOLS_ROOT>/tests/fixtures/c.js?c=3,
               moduleName: ./fixtures/c.js?c=3,
@@ -2320,7 +2320,7 @@ exports.c = require("./c?c=3");,
         Object {
           active: true,
           explanation: undefined,
-          loc: 2:12-18,
+          loc: 2:12-17,
           moduleId: 679,
           moduleIdentifier: <TEST_TOOLS_ROOT>/tests/fixtures/c.js?c=3,
           moduleName: ./fixtures/c.js?c=3,

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -237,7 +237,7 @@ ERROR in ./index.js 1:0-19
   × Module not found: Can't resolve 'not-exist' in '<TEST_TOOLS_ROOT>/tests/statsOutputCases/nonexistent-import-source-error'
    ╭────
  1 │ import "not-exist";
-   ·        ───────────
+   · ───────────────────
    ╰────
 
 Rspack compiled with 1 error
@@ -384,7 +384,7 @@ exports[`statsOutput statsOutput/reasons should print correct stats for 1`] = `
   entry ./index
 ./a.js 55 bytes [built] [code generated]
   cjs self exports reference self ./a.js
-  cjs require ./a ./index.js 1:18-24
+  cjs require ./a ./index.js 1:18-23
 `;
 
 exports[`statsOutput statsOutput/resolve-overflow-error should print correct stats for 1`] = `
@@ -393,9 +393,9 @@ assets by status 348 bytes [cached] 1 asset
 
 ERROR in ./index.js 1:0-34
   × Module not found: Can't resolve 'cycle-alias/a' in '<TEST_TOOLS_ROOT>/tests/statsOutputCases/resolve-overflow-error'
-   ╭─[1:18]
+   ╭─[1:0]
  1 │ import { a } from "cycle-alias/a";
-   ·                   ───────────────
+   · ──────────────────────────────────
  2 │ console.log(a);
    ╰────
   help: maybe it had cyclic aliases
@@ -470,7 +470,7 @@ Rspack compiled successfully
 `;
 
 exports[`statsOutput statsOutput/try-require-module should print correct stats for 1`] = `
-WARNING in ./index.js 2:12-31
+WARNING in ./index.js 2:12-30
   ⚠ Module not found: Can't resolve './missing-module' in '<TEST_TOOLS_ROOT>/tests/statsOutputCases/try-require-module'
    ╭─[2:4]
  1 │ try {

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/pnp-disable/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/pnp-disable/stats.err
@@ -1,8 +1,8 @@
 ERROR in ./index.js 1:0-32
   × Module not found: Can't resolve 'the-answer' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/config/pnp-disable'
-   ╭─[1:19]
+   ╭─[1:0]
  1 │ import answer from 'the-answer';
-   ·                    ────────────
+   · ────────────────────────────────
  2 │ it('load_dep_from_pnp', () => {
  3 │     expect(answer).toBe(42);
    ╰────

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-bom/raw-error.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-bom/raw-error.err
@@ -1,6 +1,6 @@
 Array [
   Object {
-    loc: 1:8-20,
+    loc: 1:8-19,
     moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-bom/index.js,
     moduleName: ./index.js,
   },

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-bom/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-bom/stats.err
@@ -1,4 +1,4 @@
-ERROR in ./index.js 1:8-20
+ERROR in ./index.js 1:8-19
   × JSON parse error: BOM character found in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-bom/node_modules/bommodule/package.json'
    ╭─[1:0]
  1 │ ﻿{

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-broken-json/raw-error.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-broken-json/raw-error.err
@@ -1,6 +1,6 @@
 Array [
   Object {
-    loc: 1:8-14,
+    loc: 1:8-13,
     moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-broken-json/index.js,
     moduleName: ./index.js,
   },

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-broken-json/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-broken-json/stats.err
@@ -1,4 +1,4 @@
-ERROR in ./index.js 1:8-14
+ERROR in ./index.js 1:8-13
   × JSON parse error: control character (/u0000-/u001F) found while parsing a string at line 3 column 0 in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-broken-json/node_modules/foo/package.json'
    ╭─[3:0]
  1 │ {

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/stats.err
@@ -1,15 +1,15 @@
 ERROR in ./node_modules/some-module/a.ts 1:0-23
   × Module not found: Can't resolve './b.js' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module'
-   ╭─[1:14]
+   ╭─[1:0]
  1 │ export * from "./b.js";
-   ·               ────────
+   · ───────────────────────
  2 │ export * from "./c.js";
    ╰────
 
 ERROR in ./node_modules/some-module/a.ts 2:0-23
   × Module not found: Can't resolve './c.js' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module'
-   ╭─[2:14]
+   ╭─[2:0]
  1 │ export * from "./b.js";
  2 │ export * from "./c.js";
-   ·               ────────
+   · ───────────────────────
    ╰────

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/stats.err
@@ -2,5 +2,5 @@ ERROR in ./node_modules/some-module/a.ts 1:0-23
   × Module not found: Can't resolve './b.js' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/node_modules/some-module'
    ╭────
  1 │ export * from "./b.js";
-   ·               ────────
+   · ───────────────────────
    ╰────

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-loader/raw-error.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-loader/raw-error.err
@@ -1,6 +1,6 @@
 Array [
   Object {
-    loc: 2:8-14,
+    loc: 2:8-13,
     moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-loader/loader.js!<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-loader/index.js,
     moduleName: ./index.js,
   },

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-loader/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-loader/stats.err
@@ -1,4 +1,4 @@
-ERROR in ./index.js 2:8-14
+ERROR in ./index.js 2:8-13
   × Module not found: Can't resolve './a' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-loader'
    ╭─[2:0]
  1 │ // THIS SHOULD BE INCLUDED IN THE DIAGNOSTIC

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve/stats.err
@@ -2,5 +2,5 @@ ERROR in ./index.js 1:0-12
   × Module not found: Can't resolve './a' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve'
    ╭────
  1 │ import "./a"
-   ·        ─────
+   · ────────────
    ╰────

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/empty-dependency/raw-error.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/empty-dependency/raw-error.err
@@ -1,6 +1,6 @@
 Array [
   Object {
-    loc: 1:8-11,
+    loc: 1:8-10,
     moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/empty-dependency/index.js,
     moduleName: ./index.js,
   },

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/empty-dependency/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/empty-dependency/stats.err
@@ -1,4 +1,4 @@
-ERROR in ./index.js 1:8-11
+ERROR in ./index.js 1:8-10
   × Empty dependency: Expected a non-empty request
    ╭─[1:0]
  1 │ require("")
@@ -8,8 +8,8 @@ ERROR in ./index.js 1:8-11
 
 ERROR in ./index.js 2:0-9
   × Empty dependency: Expected a non-empty request
-   ╭─[2:7]
+   ╭─[2:0]
  1 │ require("")
  2 │ import ""
-   ·        ──
+   · ─────────
    ╰────

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/fully-specified-resolve-suggestions/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/fully-specified-resolve-suggestions/stats.err
@@ -2,7 +2,7 @@ ERROR in ./index.js 1:0-14
   × Module not found: Can't resolve './foo' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/fully-specified-resolve-suggestions'
    ╭────
  1 │ import "./foo"
-   ·        ───────
+   · ──────────────
    ╰────
   help: Did you mean './foo.js'?
         

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/mismatched-module-type/raw-error.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/mismatched-module-type/raw-error.err
@@ -45,7 +45,7 @@ Array [
     moduleName: ./app.ts,
   },
   Object {
-    loc: 34:14-26,
+    loc: 34:14-25,
     moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/mismatched-module-type/index.js,
     moduleName: ./index.js,
   },

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/mismatched-module-type/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/mismatched-module-type/stats.err
@@ -116,5 +116,5 @@ ERROR in ./app.ts
   help: 
         You may need an appropriate loader to handle this file type.
 
-ERROR in ./index.js 34:14-26
+ERROR in ./index.js 34:14-25
   × No parser registered for 'ts'

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-module/raw-warning.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-module/raw-warning.err
@@ -1,6 +1,6 @@
 Array [
   Object {
-    loc: 4:16-35,
+    loc: 4:16-34,
     moduleIdentifier: <TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/missing-module/index.js,
     moduleName: ./index.js,
   },

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-module/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/missing-module/stats.err
@@ -1,4 +1,4 @@
-WARNING in ./index.js 4:16-35
+WARNING in ./index.js 4:16-34
   ⚠ Module not found: Can't resolve './missing-module' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/missing-module'
    ╭─[4:8]
  2 │     let errored = false;

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/prefer-relative-resolve-suggestions/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/prefer-relative-resolve-suggestions/stats.err
@@ -2,7 +2,7 @@ ERROR in ./index.js 1:0-15
   × Module not found: Can't resolve 'foo.js' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/prefer-relative-resolve-suggestions'
    ╭────
  1 │ import "foo.js"
-   ·        ────────
+   · ───────────────
    ╰────
   help: Did you mean './foo.js'?
         

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/resolve-extensions-error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/resolve-extensions-error/stats.err
@@ -2,7 +2,7 @@ ERROR in ./err/index.js 1:0-21
   × Module not found: Can't resolve '../a' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/resolve-extensions-error/err'
    ╭────
  1 │ import a from '../a';
-   ·               ──────
+   · ─────────────────────
    ╰────
   help: Found module '../a.txt'. However, it's not possible to request this module without the extension
         if its extension was not listed in the `resolve.extensions`. Here're some possible solutions:
@@ -12,10 +12,10 @@ ERROR in ./err/index.js 1:0-21
 
 ERROR in ./index.js 2:0-16
   × Module not found: Can't resolve './test' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/resolve-extensions-error'
-   ╭─[2:7]
+   ╭─[2:0]
  1 │ import './err';
  2 │ import './test';
-   ·        ────────
+   · ────────────────
  3 │ import a from './a';
    ╰────
   help: Found module './test/index.txt'. However, it's not possible to request this module without the extension
@@ -26,11 +26,11 @@ ERROR in ./index.js 2:0-16
 
 ERROR in ./index.js 3:0-20
   × Module not found: Can't resolve './a' in '<TEST_TOOLS_ROOT>/tests/diagnosticsCases/factorize/resolve-extensions-error'
-   ╭─[3:14]
+   ╭─[3:0]
  1 │ import './err';
  2 │ import './test';
  3 │ import a from './a';
-   ·               ─────
+   · ────────────────────
    ╰────
   help: Found module './a.txt'. However, it's not possible to request this module without the extension
         if its extension was not listed in the `resolve.extensions`. Here're some possible solutions:

--- a/packages/rspack-test-tools/tests/errorCases/error-map.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-map.js
@@ -34,7 +34,7 @@ module.exports = {
 		      "line": 1,
 		    },
 		  },
-		  "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   ·                        ──────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
+		  "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ─────────────────────────────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
 		  "module": NormalModule {
 		    "buildInfo": KnownBuildInfo {},
 		    "buildMeta": Object {},

--- a/packages/rspack-test-tools/tests/errorCases/error-test-filter.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-test-filter.js
@@ -39,7 +39,7 @@ module.exports = {
 		      "line": 1,
 		    },
 		  },
-		  "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   ·                        ──────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
+		  "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ─────────────────────────────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
 		  "module": NormalModule {
 		    "buildInfo": KnownBuildInfo {},
 		    "buildMeta": Object {},

--- a/packages/rspack-test-tools/tests/errorCases/error-test-push.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-test-push.js
@@ -32,7 +32,7 @@ module.exports = {
 		    },
 		    Object {
 		      "loc": "1:0-33",
-		      "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   ·                        ──────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
+		      "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ─────────────────────────────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
 		      "moduleId": "./resolve-fail-esm/index.js",
 		      "moduleIdentifier": "javascript/esm|<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm/index.js",
 		      "moduleName": "./resolve-fail-esm/index.js",

--- a/packages/rspack-test-tools/tests/errorCases/error-test-splice-2.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-test-splice-2.js
@@ -25,7 +25,7 @@ module.exports = {
 		    },
 		    Object {
 		      "loc": "1:0-33",
-		      "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   ·                        ──────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
+		      "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ─────────────────────────────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
 		      "moduleId": "./resolve-fail-esm/index.js",
 		      "moduleIdentifier": "javascript/esm|<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm/index.js",
 		      "moduleName": "./resolve-fail-esm/index.js",

--- a/packages/rspack-test-tools/tests/errorCases/resolve-fail-esm.js
+++ b/packages/rspack-test-tools/tests/errorCases/resolve-fail-esm.js
@@ -12,7 +12,7 @@ module.exports = {
 		  "errors": Array [
 		    Object {
 		      "loc": "1:0-33",
-		      "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   ·                        ──────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
+		      "message": "  × Module not found: Can't resolve './answer' in '<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm'\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ─────────────────────────────────\\n   ╰────\\n  help: Did you mean './answer.js'?\\n        \\n        The request './answer' failed to resolve only because it was resolved as fully specified,\\n        probably because the origin is strict EcmaScript Module,\\n        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"'.\\n        \\n        The extension in the request is mandatory for it to be fully specified.\\n        Add the extension to the request.\\n",
 		      "moduleId": "./resolve-fail-esm/index.js",
 		      "moduleIdentifier": "javascript/esm|<TEST_TOOLS_ROOT>/tests/fixtures/errors/resolve-fail-esm/index.js",
 		      "moduleName": "./resolve-fail-esm/index.js",

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -325,7 +325,7 @@ chunk (runtime: main) bundle.js (main) xx bytes (javascript) xx KiB (runtime) >{
   > ./index main
   ./a.js xx bytes [dependent] [built] [code generated]
     cjs self exports reference self ./a.js
-    cjs require ./a ./index.js 1:8-14
+    cjs require ./a ./index.js 1:8-13
     X (resolving: X, building: X)
   ./index.js xx bytes [built] [code generated]
     entry ./index
@@ -364,8 +364,8 @@ chunk (runtime: main) bundle.js (main) xx bytes (javascript) xx KiB (runtime) >{
   > ./index main
   ./a.js xx bytes [dependent] [built] [code generated]
     cjs self exports reference self ./a.js
-    cjs require ./a ./e.js 1:8-14
-    cjs require ./a ./index.js 1:8-14
+    cjs require ./a ./e.js 1:8-13
+    cjs require ./a ./index.js 1:8-13
     X (resolving: X, building: X)
   ./index.js xx bytes [built] [code generated]
     entry ./index
@@ -1039,7 +1039,7 @@ Rspack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for module-not-found-error 1`] = `
-"ERROR in ./index.js 1:8-17
+"ERROR in ./index.js 1:8-16
   × Module not found: Can't resolve 'buffer' in 'Xdir/module-not-found-error'
    ╭─[1:0]
  1 │ require('buffer')
@@ -1047,7 +1047,7 @@ exports[`StatsTestCases should print correct stats for module-not-found-error 1`
  2 │ require('os')
    ╰────
 
-ERROR in ./index.js 2:8-13
+ERROR in ./index.js 2:8-12
   × Module not found: Can't resolve 'os' in 'Xdir/module-not-found-error'
    ╭─[2:0]
  1 │ require('buffer')
@@ -1065,8 +1065,8 @@ cacheable modules xx bytes
   ./index.js + 2 modules xx bytes [code generated]
     entry ./index
   ./c.js xx bytes [built] [code generated]
-    cjs require ./c ./a.js 1:8-14
-    cjs require ./c ./b.js 1:8-14
+    cjs require ./c ./a.js 1:8-13
+    cjs require ./c ./b.js 1:8-13
 Rspack x.x.x compiled successfully in X.23"
 `;
 
@@ -1078,7 +1078,7 @@ modules with errors xx bytes [errors]
 ./index.js xx bytes [built] [code generated]
 ./inner.js xx bytes [built] [code generated]
 
-ERROR in ./not-xxx.js 1:8-25
+ERROR in ./not-xxx.js 1:8-24
   × Module not found: Can't resolve 'does-not-exist' in 'Xdir/module-trace-disabled-in-error'
    ╭────
  1 │ require('does-not-exist')
@@ -1111,7 +1111,7 @@ modules with errors xx bytes [errors]
 ./index.js xx bytes [built] [code generated]
 ./inner.js xx bytes [built] [code generated]
 
-ERROR in ./not-xxx.js 1:8-25
+ERROR in ./not-xxx.js 1:8-24
   × Module not found: Can't resolve 'does-not-exist' in 'Xdir/module-trace-enabled-in-error'
    ╭────
  1 │ require('does-not-exist')
@@ -1552,7 +1552,7 @@ LOG from LogTestPlugin
 <e> Error
 + 14 hidden lines
 
-ERROR in ./index.js 1:8-25
+ERROR in ./index.js 1:8-24
   × Module not found: Can't resolve 'does-not-exist' in 'Xdir/preset-errors-only-error'
    ╭────
  1 │ require('does-not-exist')


### PR DESCRIPTION
## Summary

- Before `BasicEvaluationExpression::with_range` take `(span.real_lo(), span.hi /* span.real_hi() + 1 */)`, and `- 1` in dependency replacement. This PR use `real_hi` and remove `- 1`, keep consistent with other dependency replacements
- Remove `ErrorSpan`, use `DependencyRange` instead, since DependencyRange is exact the same with ErrorSpan (`{ start: swc_common::Span.lo - 1, end: swc_common::Span.hi - 1 }`)
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
