### PR TITLE
fix: use stable swc lexer for correct asi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,9 +1778,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hstr"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4933df6fceb5d21a21e9fb5b46e572a83be4108e5b544de7ebe87cc1245b5d23"
+checksum = "ced1416104790052518d199e753d49a7d8130d476c664bc9e53f40cfecb8e615"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
@@ -4427,6 +4427,7 @@ dependencies = [
  "serde_json",
  "sugar_path",
  "swc_core",
+ "swc_ecma_lexer",
  "swc_node_comments",
  "tokio",
  "tracing",
@@ -5945,9 +5946,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lexer"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce0ddc31928f622709555e3fd105e0ae679897c583f5d8a1df5236650fde859"
+checksum = "67c3bd958a5a67e2cc3f74abdd41fda688e54e7a25b866569260ef7018b67972"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ pnp                 = { version = "0.12.1", default-features = false }
 swc                 = { version = "36.0.0", default-features = false }
 swc_config          = { version = "3.1.1", default-features = false }
 swc_core            = { version = "37.0.0", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_lexer      = { version = "=23.0.1", default-features = false }
 swc_ecma_minifier   = { version = "30.0.1", default-features = false }
 swc_error_reporters = { version = "16.0.1", default-features = false }
 swc_html            = { version = "26.0.0", default-features = false }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -50,6 +50,7 @@ swc_core = { workspace = true, features = [
   "base",
   "ecma_quote",
 ] }
+swc_ecma_lexer = { version = "=23.0.1" }
 swc_node_comments = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -50,7 +50,7 @@ swc_core = { workspace = true, features = [
   "base",
   "ecma_quote",
 ] }
-swc_ecma_lexer = { version = "=23.0.1" }
+swc_ecma_lexer = { workspace = true }
 swc_node_comments = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -197,7 +197,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       Some(&comments),
     );
 
-    let lexer = swc_core::ecma::parser::Lexer::new(
+    let lexer = swc_ecma_lexer::Lexer::new(
       Syntax::Es(EsSyntax {
         allow_return_outside_function: matches!(
           module_type,

--- a/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
@@ -3,10 +3,10 @@ use swc_core::{
   common::{BytePos, Span},
   ecma::{
     ast::ClassMember,
-    parser::unstable::{Token, TokenAndSpan},
     visit::{Visit, VisitWith},
   },
 };
+use swc_ecma_lexer::token::{Token, TokenAndSpan};
 
 /// Auto inserted semicolon
 /// See: https://262.ecma-international.org/7.0/#sec-rules-of-automatic-semicolon-insertion

--- a/packages/rspack-test-tools/tests/normalCases/parsing/asi/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/asi/index.js
@@ -31,3 +31,7 @@ function bb() {
 function d() {}
 export function c() {}
 d(), foo();
+
+const tpl = `${1}tpl`
+const arr = []
+foo(arr, tpl)


### PR DESCRIPTION
## Summary

The `swc_ecma_parser::Lexer` will output different tokens when using it in `parse` and `.collect_vec()`

For example: 

```js
import {assert} from './a'

const labelType = `${node}Label`

const node = []
assert(labelType)
```

In `parse` this will have correct tokens, but using with `.collect_vec()` it will have a lexing error: `Error { error: (60..97, UnterminatedTpl) }`

And the lexing error causes rspack collected the wrong semicolons (which is used for adding semicolons before replaced dependency to generate the correct code)

So this PR switch to the stable `swc_ecma_lexer::Lexer`.

<!-- Describe what this PR does and why. -->

## Related links

fix https://github.com/web-infra-dev/rspack/issues/11551

A better solution is using SWC's API https://github.com/swc-project/swc/issues/11053
<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
