### PR TITLE
fix: respect to `jsc.output.charset` in swc loader

### DIFF
--- a/crates/rspack_javascript_compiler/src/compiler/minify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/minify.rs
@@ -170,7 +170,7 @@ impl JavaScriptCompiler {
 
         minify_file_comments(
           &comments,
-          opts
+          &opts
             .format
             .comments
             .clone()
@@ -192,7 +192,9 @@ impl JavaScriptCompiler {
           input_source_map: None,
           minify: opts.minify,
           comments: Some(&comments),
-          format: &opts.format,
+          preamble: &opts.format.preamble,
+          ascii_only: opts.format.ascii_only,
+          inline_script: opts.format.inline_script,
         };
 
         self.print(&program, print_options).map_err(|e| e.into())

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -25,8 +25,8 @@ use swc_core::{
   base::{
     BoolOr,
     config::{
-      BuiltInput, Config, ConfigFile, InputSourceMap, JsMinifyCommentOption, JsMinifyFormatOptions,
-      Rc, RootMode, SourceMapsConfig,
+      BuiltInput, Config, ConfigFile, InputSourceMap, JsMinifyCommentOption, OutputCharset, Rc,
+      RootMode, SourceMapsConfig,
     },
     sourcemap,
   },
@@ -301,7 +301,7 @@ impl<'a> JavaScriptTransformer<'a> {
   where
     P: Pass + 'a,
   {
-    let built_input = self.parse_built_input(before_pass)?;
+    let mut built_input = self.parse_built_input(before_pass)?;
 
     let target = built_input.target;
     let source_map_kind: SourceMapKind = match self.options.config.source_maps {
@@ -322,12 +322,13 @@ impl<'a> JavaScriptTransformer<'a> {
 
     inspect_parsed_ast(&built_input.program);
 
-    let (program, diagnostics) = self.transform_with_built_input(built_input)?;
-    let format_opt = JsMinifyFormatOptions {
-      inline_script: false,
-      ascii_only: true,
-      ..Default::default()
-    };
+    let diagnostics = self.transform_with_built_input(&mut built_input)?;
+    let ascii_only = built_input
+      .output
+      .charset
+      .as_ref()
+      .map(|v| matches!(v, OutputCharset::Ascii))
+      .unwrap_or(false);
 
     let print_options = PrintOptions {
       source_len: self.fm.byte_length(),
@@ -337,12 +338,14 @@ impl<'a> JavaScriptTransformer<'a> {
       input_source_map: input_source_map.as_ref(),
       minify,
       comments: Some(&self.comments as &dyn Comments),
-      format: &format_opt,
+      preamble: &built_input.output.preamble,
+      ascii_only,
+      inline_script: built_input.codegen_inline_script,
     };
 
     self
       .javascript_compiler
-      .print(&program, print_options)
+      .print(&built_input.program, print_options)
       .map(|o| o.with_diagnostics(diagnostics))
   }
 
@@ -435,21 +438,19 @@ impl<'a> JavaScriptTransformer<'a> {
 
   fn transform_with_built_input(
     &self,
-    built_input: BuiltInput<impl Pass>,
-  ) -> Result<(Program, Vec<String>), Error> {
-    let program = built_input.program;
-    let mut pass = built_input.pass;
+    built_input: &mut BuiltInput<impl Pass>,
+  ) -> Result<Vec<String>, Error> {
     let mut diagnostics = vec![];
-    let program = self.run(|| {
+    let result = self.run(|| {
       helpers::HELPERS.set(&self.helpers, || {
         let result = try_with_handler(self.cm.clone(), Default::default(), |handler| {
           // Apply external plugin passes to the Program AST.
           // External plugins may emit warnings or inject helpers,
           // so we need a handler to properly process them.
-          let program = program.apply(&mut pass);
+          built_input.pass.process(&mut built_input.program);
           diagnostics.extend(handler.take_diagnostics());
 
-          Ok(program)
+          Ok(())
         });
 
         result.map_err(|err| {
@@ -495,14 +496,12 @@ impl<'a> JavaScriptTransformer<'a> {
 
       minify_file_comments(
         comments,
-        built_input.preserve_comments,
+        &built_input.preserve_comments,
         preserve_annotations,
       );
     }
 
-    program
-      .map(|program| (program, diagnostics))
-      .map_err(|e| e.into())
+    result.map(|_| diagnostics).map_err(|e| e.into())
   }
 
   pub fn input_source_map(

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -327,8 +327,7 @@ impl<'a> JavaScriptTransformer<'a> {
       .output
       .charset
       .as_ref()
-      .map(|v| matches!(v, OutputCharset::Ascii))
-      .unwrap_or(false);
+      .is_some_and(|v| matches!(v, OutputCharset::Ascii));
 
     let print_options = PrintOptions {
       source_len: self.fm.byte_length(),

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -48,7 +48,7 @@ fn test_normalize_custom_filename() {
  */
 pub fn minify_file_comments(
   comments: &SingleThreadedComments,
-  preserve_comments: BoolOr<JsMinifyCommentOption>,
+  preserve_comments: &BoolOr<JsMinifyCommentOption>,
   preserve_annotations: bool,
 ) {
   match preserve_comments {

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/__snapshots__/output.snap.txt
@@ -1,7 +1,7 @@
 ```js title=a.js
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["a"], {
 "./a.js": (function () {
-console.log("\u4F60\u597D");
+console.log("你好");
 
 
 }),

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/__snapshots__/output.snap.txt
@@ -1,0 +1,31 @@
+```js title=a.js
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["a"], {
+"./a.js": (function () {
+console.log("\u4F60\u597D");
+
+
+}),
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__("./a.js"));
+
+}
+]);
+```
+
+```js title=b.js
+(self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["b"], {
+"./b.js": (function () {
+console.log("\u4F60\u597D");
+
+
+}),
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__("./b.js"));
+
+}
+]);
+```

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/a.js
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/a.js
@@ -1,0 +1,1 @@
+console.log("你好")

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/b.js
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/b.js
@@ -1,0 +1,1 @@
+console.log("你好")

--- a/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/swc-loader/charset/rspack.config.js
@@ -1,0 +1,34 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		a: "./a.js",
+		b: "./b.js"
+	},
+	module: {
+		rules: [
+			{
+				test: /a\.js/,
+				use: [
+					{
+						loader: "builtin:swc-loader"
+					}
+				]
+			},
+			{
+				test: /b\.js/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								output: {
+									charset: "ascii"
+								}
+							}
+						}
+					}
+				]
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary

Currently `jsc.output.charset` doesn't take effect because we always pass `ascii_only: true` to swc-loader printer.

Related https://github.com/web-infra-dev/rslib/issues/1204

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
