### PR TITLE
refactor: use for_name for cjs import parser plugin

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -2,8 +2,8 @@ use swc_core::{
   atoms::Atom,
   common::Span,
   ecma::ast::{
-    BinExpr, CallExpr, Callee, ClassMember, CondExpr, Expr, IfStmt, MemberExpr, OptChainExpr,
-    UnaryExpr, UnaryOp, VarDeclarator,
+    AssignExpr, BinExpr, CallExpr, Callee, ClassMember, CondExpr, Expr, IfStmt, MemberExpr,
+    OptChainExpr, UnaryExpr, UnaryOp, VarDeclarator,
   },
 };
 
@@ -189,11 +189,23 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   fn member_chain_of_call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    expr: &swc_core::ecma::ast::MemberExpr,
+    member_expr: &MemberExpr,
+    callee_members: &[Atom],
+    call_expr: &CallExpr,
+    members: &[Atom],
+    member_ranges: &[Span],
     for_name: &str,
   ) -> Option<bool> {
     for plugin in &self.plugins {
-      let res = plugin.member_chain_of_call_member_chain(parser, expr, for_name);
+      let res = plugin.member_chain_of_call_member_chain(
+        parser,
+        member_expr,
+        callee_members,
+        call_expr,
+        members,
+        member_ranges,
+        for_name,
+      );
       // `SyncBailHook`
       if res.is_some() {
         return res;
@@ -205,11 +217,23 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   fn call_member_chain_of_call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    expr: &swc_core::ecma::ast::CallExpr,
+    call_expr: &CallExpr,
+    callee_members: &[Atom],
+    inner_call_expr: &CallExpr,
+    members: &[Atom],
+    member_ranges: &[Span],
     for_name: &str,
   ) -> Option<bool> {
     for plugin in &self.plugins {
-      let res = plugin.call_member_chain_of_call_member_chain(parser, expr, for_name);
+      let res = plugin.call_member_chain_of_call_member_chain(
+        parser,
+        call_expr,
+        callee_members,
+        inner_call_expr,
+        members,
+        member_ranges,
+        for_name,
+      );
       // `SyncBailHook`
       if res.is_some() {
         return res;
@@ -221,7 +245,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   fn assign(
     &self,
     parser: &mut JavascriptParser,
-    expr: &swc_core::ecma::ast::AssignExpr,
+    expr: &AssignExpr,
     for_name: &str,
   ) -> Option<bool> {
     for plugin in &self.plugins {
@@ -237,7 +261,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   fn assign_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    expr: &swc_core::ecma::ast::AssignExpr,
+    expr: &AssignExpr,
     members: &[Atom],
     for_name: &str,
   ) -> Option<bool> {
@@ -254,7 +278,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   fn r#typeof(
     &self,
     parser: &mut JavascriptParser,
-    expr: &swc_core::ecma::ast::UnaryExpr,
+    expr: &UnaryExpr,
     for_name: &str,
   ) -> Option<bool> {
     assert!(expr.op == UnaryOp::TypeOf);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -184,19 +184,29 @@ pub trait JavascriptParserPlugin {
     None
   }
 
+  #[allow(clippy::too_many_arguments)]
   fn member_chain_of_call_member_chain(
     &self,
     _parser: &mut JavascriptParser,
-    _expr: &MemberExpr,
+    _member_expr: &MemberExpr,
+    _callee_members: &[Atom],
+    _call_expr: &CallExpr,
+    _members: &[Atom],
+    _member_ranges: &[Span],
     _for_name: &str,
   ) -> Option<bool> {
     None
   }
 
+  #[allow(clippy::too_many_arguments)]
   fn call_member_chain_of_call_member_chain(
     &self,
     _parser: &mut JavascriptParser,
-    _expr: &CallExpr,
+    _call_expr: &CallExpr,
+    _callee_members: &[Atom],
+    _inner_call_expr: &CallExpr,
+    _members: &[Atom],
+    _member_ranges: &[Span],
     _for_name: &str,
   ) -> Option<bool> {
     None

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -725,10 +725,15 @@ impl JavascriptParser<'_> {
           if expr_info
             .root_info
             .call_hooks_name(self, |this, for_name| {
-              this
-                .plugin_drive
-                .clone()
-                .member_chain_of_call_member_chain(this, expr, for_name)
+              this.plugin_drive.clone().member_chain_of_call_member_chain(
+                this,
+                expr,
+                &expr_info.callee_members,
+                &expr_info.call,
+                &expr_info.members,
+                &expr_info.member_ranges,
+                for_name,
+              )
             })
             .unwrap_or_default()
           {
@@ -960,7 +965,15 @@ impl JavascriptParser<'_> {
                 this
                   .plugin_drive
                   .clone()
-                  .call_member_chain_of_call_member_chain(this, expr, for_name)
+                  .call_member_chain_of_call_member_chain(
+                    this,
+                    expr,
+                    &expr_info.callee_members,
+                    &expr_info.call,
+                    &expr_info.members,
+                    &expr_info.member_ranges,
+                    for_name,
+                  )
               })
               .unwrap_or_default()
           {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -4,178 +4,16 @@ use rspack_error::{
   miette::{Severity, diagnostic},
 };
 use rspack_regex::RspackRegex;
-use swc_core::{
-  common::SourceFile,
-  ecma::{ast::*, atoms::Atom},
-};
+use swc_core::common::SourceFile;
 
-use super::{AllowedMemberTypes, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo};
-
-#[allow(dead_code)]
-pub(crate) mod expr_like {
-  use std::any::Any;
-
-  use rspack_util::ext::AsAny;
-  use swc_core::{
-    common::EqIgnoreSpan,
-    ecma::ast::{Expr, Ident, MemberExpr, ThisExpr},
-  };
-
-  pub trait DynEqIgnoreSpan: __::Sealed {
-    fn dyn_eq_ignore_span(&self, other: &dyn Any) -> bool;
-  }
-  impl<T: EqIgnoreSpan + ExprLike + Any> DynEqIgnoreSpan for T {
-    fn dyn_eq_ignore_span(&self, other: &dyn Any) -> bool {
-      if let Some(other) = other.downcast_ref::<T>() {
-        self.eq_ignore_span(other)
-      } else {
-        false
-      }
-    }
-  }
-
-  pub trait ExprLikeEqIgnoreSpan: __::Sealed {
-    fn expr_like_eq_ignore_span(&self, other: &dyn ExprLike) -> bool;
-  }
-  impl ExprLikeEqIgnoreSpan for dyn ExprLike {
-    fn expr_like_eq_ignore_span(&self, other: &dyn ExprLike) -> bool {
-      match (self, other) {
-        (left, right) if left.as_member().is_some() && right.as_member().is_some() => {
-          let left = left
-            .as_member()
-            .expect("`left` is `MemberExpr` in `if_guard`");
-          let right = right
-            .as_member()
-            .expect("`right` is `MemberExpr` in `if_guard`");
-          left.dyn_eq_ignore_span(right)
-        }
-        (left, right) if left.as_ident().is_some() && right.as_ident().is_some() => {
-          let left = left.as_ident().expect("`left` is `Ident` in `if_guard`");
-          let right = right.as_ident().expect("`right` is `Ident` in `if_guard`");
-          left.dyn_eq_ignore_span(right)
-        }
-        _ => false,
-      }
-    }
-  }
-
-  impl PartialEq for dyn ExprLike + '_ {
-    fn eq(&self, other: &Self) -> bool {
-      self.dyn_eq_ignore_span(other.as_any())
-    }
-  }
-
-  mod __ {
-    pub trait Sealed {}
-  }
-
-  macro_rules! expr_like {
-    ($(($ident:ident,$ty:ty),)*) => {
-      use std::fmt::Debug;
-      pub(crate) trait ExprLike: 'static + __::Sealed + Debug + Send + Sync + DynEqIgnoreSpan + AsAny {
-        fn as_expr(&self) -> Option<&Expr> {
-          None
-        }
-        $(
-          fn $ident(&self) -> Option<&$ty> {
-            None
-          }
-        )*
-      }
-      $(
-        impl ExprLike for $ty {
-          fn $ident(&self) -> Option<&$ty> {
-            Some(self)
-          }
-        }
-        impl __::Sealed for $ty {}
-      )*
-    }
-  }
-
-  expr_like! {
-    (as_member, MemberExpr),
-    (as_this, ThisExpr),
-    (as_ident, Ident),
-  }
-
-  impl ExprLike for Expr {
-    fn as_expr(&self) -> Option<&Expr> {
-      Some(self)
-    }
-
-    fn as_member(&self) -> Option<&MemberExpr> {
-      (*self).as_member()
-    }
-
-    fn as_this(&self) -> Option<&ThisExpr> {
-      (*self).as_this()
-    }
-
-    fn as_ident(&self) -> Option<&Ident> {
-      (*self).as_ident()
-    }
-  }
-  impl __::Sealed for Expr {}
-}
-
-pub(crate) mod expr_matcher {
-  use std::sync::{Arc, LazyLock};
-
-  use swc_core::{
-    common::SourceMap,
-    ecma::{ast::Ident, parser::parse_file_as_expr},
-  };
-
-  use super::expr_like::*;
-
-  static PARSED_MEMBER_EXPR_CM: LazyLock<Arc<SourceMap>> = LazyLock::new(Default::default);
-
-  // The usage of define_member_expr_matchers is limited in `member_expr_matcher`.
-  // Do not extends it's usage out of this mod.
-  macro_rules! define_expr_matchers {
-    ({
-      $($fn_name:ident: $first:expr,)*
-    }) => {
-          $(pub(crate) fn $fn_name<E: ExprLike>(expr: &E) -> bool {
-            static TARGET: LazyLock<Box<dyn ExprLike>> = LazyLock::new(|| {
-              let mut errors = vec![];
-              let fm =
-                 PARSED_MEMBER_EXPR_CM.new_source_file(Arc::new(swc_core::common::FileName::Anon), $first.to_string());
-                 let expr = parse_file_as_expr(
-                  &fm,
-                  Default::default(),
-                  Default::default(),
-                  None,
-                  &mut errors,
-                )
-                .unwrap_or_else(|_| panic!("Member matcher parsed failed {:?}", $first));
-                assert!(errors.is_empty());
-                expr
-            });
-            Ident::within_ignored_ctxt(|| {
-              TARGET.expr_like_eq_ignore_span(expr)
-            })
-          })+
-
-      };
-  }
-
-  // Notice:
-  // - `import.meta` is not a MemberExpr
-  // - `import.meta.xxx` is a MemberExpr
-  // - Matching would ignore Span and SyntaxContext
-  define_expr_matchers!({
-    is_require: "require",
-    is_module_require: "module.require",
-  });
-}
+use super::JavascriptParser;
 
 pub mod expr_name {
   pub const MODULE: &str = "module";
   pub const MODULE_HOT: &str = "module.hot";
   pub const MODULE_HOT_ACCEPT: &str = "module.hot.accept";
   pub const MODULE_HOT_DECLINE: &str = "module.hot.decline";
+  pub const MODULE_REQUIRE: &str = "module.require";
   pub const REQUIRE: &str = "require";
   pub const REQUIRE_RESOLVE: &str = "require.resolve";
   pub const REQUIRE_RESOLVE_WEAK: &str = "require.resolveWeak";
@@ -193,66 +31,6 @@ pub fn parse_order_string(x: &str) -> Option<i32> {
     "true" => Some(0),
     "false" => None,
     _ => x.parse::<i32>().ok(),
-  }
-}
-
-pub fn extract_require_call_info(
-  parser: &mut JavascriptParser,
-  expr: &MemberExpr,
-) -> Option<(Vec<Atom>, ExprOrSpread)> {
-  let Some((members, args, root)) = parser
-    .get_member_expression_info(expr, AllowedMemberTypes::CallExpression)
-    .and_then(|info| match info {
-      MemberExpressionInfo::Call(info) => Some((info.members, info.call.args, info.root_info)),
-      MemberExpressionInfo::Expression(_) => None,
-    })
-  else {
-    // not require() call
-    return None;
-  };
-
-  // call require() with no param
-  let first_arg = args.first()?;
-
-  if let ExportedVariableInfo::Name(root) = root {
-    if root == "module" && members.first().is_some_and(|m| m == "require") {
-      // module.require().x.x
-      Some((members[1..].to_vec(), first_arg.to_owned()))
-    } else if root == "require" {
-      // require().x.x
-      Some((members, first_arg.to_owned()))
-    } else {
-      None
-    }
-  } else {
-    None
-  }
-}
-
-pub fn is_require_call_start(expr: &Expr) -> bool {
-  match expr {
-    Expr::Call(CallExpr { callee, .. }) => callee
-      .as_expr()
-      .map(|callee| {
-        if expr_matcher::is_require(&**callee) || expr_matcher::is_module_require(&**callee) {
-          true
-        } else {
-          is_require_call_start(callee)
-        }
-      })
-      .unwrap_or(false),
-    Expr::Member(MemberExpr { obj, .. }) => is_require_call_start(obj),
-    _ => false,
-  }
-}
-
-pub fn extract_member_root(mut expr: &Expr) -> Option<Ident> {
-  loop {
-    match expr {
-      Expr::Ident(id) => return Some(id.to_owned()),
-      Expr::Member(MemberExpr { obj, .. }) => expr = obj.as_ref(),
-      _ => return None,
-    }
   }
 }
 
@@ -307,32 +85,5 @@ pub fn clean_regexp_in_context_module(
     None
   } else {
     Some(regexp)
-  }
-}
-
-#[cfg(test)]
-mod test {
-  use super::*;
-
-  #[test]
-  fn test_is_require_call_start() {
-    macro_rules! test {
-      ($tt:tt,$literal:literal) => {{
-        let info = is_require_call_start(&swc_core::quote!($tt as Expr));
-        assert_eq!(info, $literal)
-      }};
-    }
-    test!("require().a.b", true);
-    test!("require().a.b().c", true);
-    test!("require()()", true);
-    test!("require.a().b", false);
-    test!("require.a.b", false);
-    test!("a.require.b", false);
-    test!("module.require().a.b", true);
-    test!("module.require().a.b().c", true);
-    test!("module.require()()", true);
-    test!("module.require.a().b", false);
-    test!("module.require.a.b", false);
-    test!("a.module.require.b", false);
   }
 }

--- a/crates/rspack_plugin_rslib/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rslib/src/parser_plugin.rs
@@ -1,7 +1,4 @@
-use rspack_plugin_javascript::{
-  JavascriptParserPlugin,
-  visitors::{JavascriptParser, extract_member_root},
-};
+use rspack_plugin_javascript::{JavascriptParserPlugin, visitors::JavascriptParser};
 
 #[derive(PartialEq, Debug, Default)]
 pub struct RslibParserPlugin {
@@ -20,29 +17,18 @@ impl JavascriptParserPlugin for RslibParserPlugin {
   fn member(
     &self,
     _parser: &mut JavascriptParser,
-    member_expr: &swc_core::ecma::ast::MemberExpr,
-    _name: &str,
+    _member_expr: &swc_core::ecma::ast::MemberExpr,
+    for_name: &str,
   ) -> Option<bool> {
-    let expr = &swc_core::ecma::ast::Expr::Member(member_expr.to_owned());
-    // Intercept APIPlugin.
-    if self.intercept_api_plugin
-      && let Some(root) = extract_member_root(expr)
+    if for_name == "require.cache"
+      || for_name == "require.extensions"
+      || for_name == "require.config"
+      || for_name == "require.version"
+      || for_name == "require.include"
+      || for_name == "require.onError"
     {
-      let prop = &member_expr.prop;
-      if let swc_core::ecma::ast::MemberProp::Ident(id) = prop
-        && root.sym == "require"
-        && (id.sym == "cache"
-          // not_supported_expr
-            || id.sym == "extensions"
-            || id.sym == "config"
-            || id.sym == "version"
-            || id.sym == "include"
-            || id.sym == "onError")
-      {
-        return Some(true);
-      }
+      return Some(true);
     }
-
     None
   }
 }


### PR DESCRIPTION
## Summary

- use for_name instead of extracting info from AST

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
