### PR TITLE
perf: improve deterministic chunk ids

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -12,9 +12,8 @@ use serde::{Serialize, Serializer};
 
 use crate::{
   BoxModule, Chunk, ChunkByUkey, ChunkGraph, ChunkGraphModule, ChunkGroupByUkey, ChunkGroupUkey,
-  ChunkIdsArtifact, ChunkUkey, Compilation, DependencyType, Module, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, RuntimeGlobals, RuntimeModule, SourceType,
-  find_graph_roots, merge_runtime,
+  ChunkIdsArtifact, ChunkUkey, Compilation, Module, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, RuntimeGlobals, RuntimeModule, SourceType, find_graph_roots, merge_runtime,
 };
 
 #[derive(Debug, Clone, Default)]

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -697,14 +697,6 @@ impl ChunkGraph {
       ) {
         for connection in module_graph.get_outgoing_connections(&module) {
           // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/ChunkGraph.js#L290
-          if set.contains(connection.module_identifier()) {
-            let maybe_transitive = module_graph
-              .dependency_by_id(&connection.dependency_id)
-              .is_some_and(|dep| matches!(dep.dependency_type(), DependencyType::ExtractCSS));
-            if !maybe_transitive {
-              continue;
-            }
-          }
           let active_state = connection.active_state(module_graph, None, module_graph_cache);
           match active_state {
             crate::ConnectionState::Active(false) => {

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -684,7 +684,10 @@ impl ChunkGraph {
     module_graph_cache: &ModuleGraphCacheArtifact,
   ) -> Vec<ModuleIdentifier> {
     let cgc = self.expect_chunk_graph_chunk(chunk);
-    let mut modules = find_graph_roots(cgc.modules.iter().copied().collect::<Vec<_>>(), |module| {
+    let mut input = cgc.modules.iter().copied().collect::<Vec<_>>();
+    input.sort_unstable();
+
+    let mut modules = find_graph_roots(input, |module| {
       let mut set: IdentifierSet = Default::default();
       fn add_dependencies(
         module: ModuleIdentifier,

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -87,7 +87,6 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     |a, b| {
       compare_chunks_natural(
         chunk_graph,
-        &module_graph,
         &compilation.chunk_group_by_ukey,
         &compilation.module_ids_artifact,
         a,

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -360,7 +360,6 @@ pub fn assign_ascending_chunk_ids(chunks: &[ChunkUkey], compilation: &mut Compil
 
 fn compare_chunks_by_modules<'a>(
   chunk_graph: &ChunkGraph,
-  module_graph: &ModuleGraph,
   module_ids: &'a ModuleIdsArtifact,
   a: &Chunk,
   b: &Chunk,
@@ -427,7 +426,6 @@ fn compare_chunks_by_groups(
 
 pub fn compare_chunks_natural<'a>(
   chunk_graph: &ChunkGraph,
-  module_graph: &ModuleGraph,
   chunk_group_by_ukey: &ChunkGroupByUkey,
   module_ids: &'a ModuleIdsArtifact,
   a: &Chunk,
@@ -444,14 +442,8 @@ pub fn compare_chunks_natural<'a>(
     return runtime_ordering;
   }
 
-  let modules_ordering = compare_chunks_by_modules(
-    chunk_graph,
-    module_graph,
-    module_ids,
-    a,
-    b,
-    ordered_chunk_modules_cache,
-  );
+  let modules_ordering =
+    compare_chunks_by_modules(chunk_graph, module_ids, a, b, ordered_chunk_modules_cache);
   if modules_ordering != Ordering::Equal {
     return modules_ordering;
   }

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -372,9 +372,9 @@ fn compare_chunks_by_modules<'a>(
     .entry(a_ukey)
     .or_insert_with(|| {
       chunk_graph
-        .get_ordered_chunk_modules(&a_ukey, module_graph)
+        .get_ordered_chunk_normal_modules_identifier(&a_ukey)
         .into_iter()
-        .map(|m| ChunkGraph::get_module_id(module_ids, m.identifier()).map(|s| s.as_str()))
+        .map(|m| ChunkGraph::get_module_id(module_ids, m).map(|s| s.as_str()))
         .collect_vec()
     })
     .clone();
@@ -382,9 +382,9 @@ fn compare_chunks_by_modules<'a>(
     .entry(b_ukey)
     .or_insert_with(|| {
       chunk_graph
-        .get_ordered_chunk_modules(&b_ukey, module_graph)
+        .get_ordered_chunk_normal_modules_identifier(&b_ukey)
         .into_iter()
-        .map(|m| ChunkGraph::get_module_id(module_ids, m.identifier()).map(|s| s.as_str()))
+        .map(|m| ChunkGraph::get_module_id(module_ids, m).map(|s| s.as_str()))
         .collect_vec()
     })
     .clone();

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -119,7 +119,6 @@ fn assign_named_chunk_ids(
         let b = compilation.chunk_by_ukey.expect_get(b);
         compare_chunks_natural(
           chunk_graph,
-          &module_graph,
           &compilation.chunk_group_by_ukey,
           &compilation.module_ids_artifact,
           a,
@@ -154,7 +153,6 @@ fn assign_named_chunk_ids(
     let b = compilation.chunk_by_ukey.expect_get(b);
     compare_chunks_natural(
       chunk_graph,
-      &module_graph,
       &compilation.chunk_group_by_ukey,
       &compilation.module_ids_artifact,
       a,

--- a/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
@@ -24,7 +24,6 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
 
   let module_ids = &compilation.module_ids_artifact;
   let chunk_graph = &compilation.chunk_graph;
-  let module_graph = &compilation.get_module_graph();
   let mut ordered_chunk_modules_cache = Default::default();
 
   let chunks = compilation
@@ -34,7 +33,6 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     .sorted_unstable_by(|a, b| {
       compare_chunks_natural(
         chunk_graph,
-        module_graph,
         &compilation.chunk_group_by_ukey,
         module_ids,
         a,

--- a/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
@@ -39,7 +39,6 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<
   }
 
   let chunk_graph = &compilation.chunk_graph;
-  let module_graph = &compilation.get_module_graph();
   let chunk_group_by_ukey = &compilation.chunk_group_by_ukey;
   let mut occurs_in_initial_chunks_map = HashMap::new();
 
@@ -81,7 +80,6 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<
 
       compare_chunks_natural(
         chunk_graph,
-        module_graph,
         &compilation.chunk_group_by_ukey,
         &compilation.module_ids_artifact,
         a,


### PR DESCRIPTION
## Summary

We can make sure that chunk module exists when it is not a runtime module, then we can prevent finding all modules on module graph by `loop_partial` which needs to indexing multiple times.

Before:
<img width="588" height="56" alt="image" src="https://github.com/user-attachments/assets/a0773f76-8a6f-49fd-8cad-b7b29b7fe202" />


After:
<img width="554" height="54" alt="image" src="https://github.com/user-attachments/assets/f5c08ff6-1267-470c-b32d-3f231cd07037" />


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
