### PR TITLE
chore(workflow): allow renovate to update SWC related crates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,7 +33,6 @@
 			excludePackageNames: [
 				"ustr",
 				"textwrap",
-				"styled_components",
 				"owo-colors",
 				"miette",
 				"rkyv",
@@ -45,9 +44,7 @@
 		{
 			groupName: "swc",
 			matchManagers: ["cargo"],
-			matchPackagePrefixes: ["swc"],
-			matchPackageNames: ["styled_components"],
-			enabled: false // manually update swc and related crate since it may contain breaking change in minor | patch version
+			matchPackagePrefixes: ["swc"]
 		},
 		{
 			groupName: "napi",


### PR DESCRIPTION
## Summary

I hope we can follow up on newly released SWC versions more promptly.

This PR re-enables Renovate for SWC, allowing us to upgrade more quickly when SWC releases don't introduce breaking changes.

The `styled_components` crate is no longer used, so I removed it from the list.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
