### PR TITLE
docs(loader-api): add new sections for handling source maps

### DIFF
--- a/website/docs/en/api/loader-api/_meta.json
+++ b/website/docs/en/api/loader-api/_meta.json
@@ -1,1 +1,1 @@
-["index", "types", "context", "inline", "inline-match-resource"]
+["index", "writing-loaders", "context", "inline", "inline-match-resource"]

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -74,7 +74,7 @@ module.exports = function loader(source) {
 
 Tells Rspack that this loader will be called asynchronously. Returns [this.callback](#thiscallback).
 
-> See [Async loader](/api/loader-api/types#async-loader) for more details.
+> See [Async loader](/api/loader-api/writing-loaders#async-loader) for more details.
 
 ## this.cacheable()
 
@@ -103,7 +103,7 @@ module.exports = function loader(source) {
 function callback(
   err: Error | null,
   content: string | Buffer,
-  sourceMap?: SourceMap,
+  sourceMap?: Rspack.RawSourceMap,
   meta?: any,
 ): void;
 ```
@@ -115,7 +115,7 @@ A function that can be called synchronously or asynchronously in order to return
 3. The third parameter is a source map that can be processed by the loader.
 4. The fourth parameter is ignored by Rspack and can be anything (e.g. some metadata).
 
-> See [Sync loader](/api/loader-api/types#sync-loader) for more details.
+> See [Sync loader](/api/loader-api/writing-loaders#sync-loader) for more details.
 
 :::warning
 In case this function is called, you should return `undefined` to avoid ambiguous loader results.
@@ -685,6 +685,8 @@ module.exports = function loader(source) {
 Tells if source map should be generated.
 
 Since generating source maps can be an expensive task, you should check if source maps are actually requested.
+
+See [Handling source maps](/api/loader-api/writing-loaders#handling-source-maps) for more details.
 
 ## this.getLogger()
 

--- a/website/docs/en/api/loader-api/index.mdx
+++ b/website/docs/en/api/loader-api/index.mdx
@@ -6,9 +6,9 @@ Rspack is committed to being compatible with the loaders within the webpack ecos
 
 Currently, Rspack is compatible with most of webpack's loader APIs. If you find that a webpack loader cannot be used in Rspack, feel free to file an issue in the [Rspack repository](https://github.com/web-infra-dev/rspack).
 
-## Loader types
+## Writing loaders
 
-We provide some basic examples of different types of loaders. If you want to write a loader, you can refer to [Loader types](/api/loader-api/types) to get started.
+We provide some basic examples of different types of loaders. If you want to write a loader, you can refer to [Writing loaders](/api/loader-api/writing-loaders) to get started.
 
 If you need to use an existing loader, you can refer to [Features - Loader](/guide/features/loader) to learn how to use it.
 

--- a/website/docs/en/api/loader-api/index.mdx
+++ b/website/docs/en/api/loader-api/index.mdx
@@ -16,6 +16,6 @@ If you need to use an existing loader, you can refer to [Features - Loader](/gui
 
 Loader API includes:
 
-- [Loader Context](/api/loader-api/context): Represents the properties that are available inside of a loader assigned to the `this` property.
+- [Loader context](/api/loader-api/context): Represents the properties that are available inside of a loader assigned to the `this` property.
 - [Inline loader](/api/loader-api/inline): Specify a loader in an `import` statement.
 - [Inline matchResource](/api/loader-api/inline-match-resource): Allows you to dynamically change the matching rules when loading resources.

--- a/website/docs/en/api/loader-api/writing-loaders.mdx
+++ b/website/docs/en/api/loader-api/writing-loaders.mdx
@@ -103,8 +103,7 @@ By exporting `raw: true` in the loader file, a loader can receive the original `
 - CJS:
 
 ```js title="raw-loader.js"
-module.exports = function (source) {
-  // Process binary source
+  // Process binary content
   // Here source is a Buffer instance
   const processed = someBufferOperation(source);
 

--- a/website/docs/en/api/loader-api/writing-loaders.mdx
+++ b/website/docs/en/api/loader-api/writing-loaders.mdx
@@ -2,27 +2,31 @@ import WebpackLicense from '@components/WebpackLicense';
 
 <WebpackLicense from="https://webpack.js.org/api/loaders/#examples" />
 
-# Loader types
+# Writing loaders
+
+Learn how to create custom loaders for Rspack to transform files.
+
+## Loader types
 
 Rspack supports multiple loader types, including sync loader, async loader, ESM loader, Raw loader, and Pitching loader.
 
 The following sections provide some basic examples of the different types of loaders.
 
-## Sync loader
+### Sync loader
 
 Sync loaders are the most basic type of loader. They can synchronously return transformed content using either a `return` statement or the `this.callback` method:
 
 ```js title="sync-loader.js"
-module.exports = function (content, map, meta) {
-  return someSyncOperation(content);
+module.exports = function (source, map, meta) {
+  return someSyncOperation(source);
 };
 ```
 
 Compared to the `return` statement, the `this.callback` method offers more flexibility as it allows passing multiple parameters, including error information, source maps, and metadata:
 
 ```js title="sync-loader-with-callback.js"
-module.exports = function (content, map, meta) {
-  this.callback(null, someSyncOperation(content), map, meta);
+module.exports = function (source, map, meta) {
+  this.callback(null, someSyncOperation(source), map, meta);
 
   // Return undefined when calling callback() to avoid return value conflicts
   return;
@@ -31,24 +35,24 @@ module.exports = function (content, map, meta) {
 
 ::: info
 
-- The `map` and `meta` parameters are optional, see [this.callback](/api/loader-api/context#thiscallback) for more details.
+- The `map` and `meta` parameters are optional, see [this.callback](/api/loader-api/context#thiscallback) and [Handling source maps](#handling-source-maps) for more details.
 - Rspack will internally convert loaders to async, regardless of whether it's a synchronous loader, for technical and performance reasons.
 
 :::
 
-## Async loader
+### Async loader
 
 When you need to perform async operations (such as file I/O, network requests, etc.), you should use an async loader. Call the [this.async()](/api/loader-api/context#thisasync) method to get a `callback` function, informing Rspack that this loader requires async processing.
 
 The `callback` of an async loader can also pass multiple parameters, including transformed content, source maps, and metadata:
 
 ```js title="async-loader.js"
-module.exports = function (content, map, meta) {
+module.exports = function (source, map, meta) {
   // Get the async callback function
   const callback = this.async();
 
   // Perform async operation
-  someAsyncOperation(content, function (err, result) {
+  someAsyncOperation(source, function (err, result) {
     // Handle error case
     if (err) return callback(err);
 
@@ -58,14 +62,14 @@ module.exports = function (content, map, meta) {
 };
 ```
 
-## ESM loader
+### ESM loader
 
 Rspack supports ESM loaders, you can write loaders using ESM syntax and export the loader function using `export default`.
 
 When writing ESM loaders, the file name needs to end with `.mjs`, or set `type` to `module` in the nearest `package.json`.
 
 ```js title="my-loader.mjs"
-export default function loader(content, map, meta) {
+export default function loader(source, map, meta) {
   // ...
 }
 ```
@@ -73,7 +77,7 @@ export default function loader(content, map, meta) {
 If you need to export options like [raw](#raw-loader) or [pitch](#pitching-loader), you can use named exports:
 
 ```js title="my-loader.mjs"
-export default function loader(content) {
+export default function loader(source) {
   // ...
 }
 
@@ -90,48 +94,7 @@ export function pitch(remainingRequest, precedingRequest, data) {
 ESM loader and CommonJS loader have the same functionality, but use different module syntax. You can choose the format based on your project needs.
 :::
 
-## Write with TypeScript
-
-If you write Rspack loader using TypeScript, you can use `LoaderDefinition` to provide complete type definitions for your loader.
-
-```ts title="my-loader.ts"
-import type { LoaderDefinition } from '@rspack/core';
-
-// Declare the type of loader options
-type MyLoaderOptions = {
-  foo: string;
-};
-
-const myLoader: LoaderDefinition<MyLoaderOptions> = function (source) {
-  const options = this.getOptions();
-  console.log(options); // { foo: 'bar' }
-  // Transform the source code
-  return `// Processed by my-loader\n${source}`;
-};
-
-export default myLoader;
-```
-
-Alternatively, you can import `LoaderContext` to add types to the loader context:
-
-```ts title="my-loader.ts"
-import type { LoaderContext } from '@rspack/core';
-
-type MyLoaderOptions = {
-  foo: string;
-};
-
-export default function myLoader(
-  this: LoaderContext<MyLoaderOptions>,
-  source: string,
-) {
-  const options = this.getOptions();
-  console.log(options); // { foo: 'bar' }
-  return `// Processed by my-loader\n${source}`;
-}
-```
-
-## Raw loader
+### Raw loader
 
 By default, Rspack converts file content into UTF-8 strings before passing it to loaders for processing. However, when handling binary files (such as images, audio, or font files), we need to work directly with the raw binary data rather than string representations.
 
@@ -140,10 +103,10 @@ By exporting `raw: true` in the loader file, a loader can receive the original `
 - CJS:
 
 ```js title="raw-loader.js"
-module.exports = function (content) {
-  // Process binary content
-  // Here content is a Buffer instance
-  const processed = someBufferOperation(content);
+module.exports = function (source) {
+  // Process binary source
+  // Here source is a Buffer instance
+  const processed = someBufferOperation(source);
 
   // Return the processed result
   return processed;
@@ -156,7 +119,7 @@ module.exports.raw = true;
 - ESM:
 
 ```js title="raw-loader.mjs"
-export default function loader(content) {
+export default function loader(source) {
   // ...
 }
 
@@ -167,7 +130,7 @@ When multiple loaders are chained together, each loader can choose to receive an
 
 Raw Loaders are particularly useful in scenarios involving image compression, binary resource transformation, file encoding, etc. For example, when developing a loader to process images, direct manipulation of binary data is typically required to properly handle image formats.
 
-## Pitching loader
+### Pitching loader
 
 In Rspack's loader execution process, the default exported loader function is always called **from right to left** (called normal stage). However, sometimes a loader may only care about the request's metadata rather than the processing result of the previous loader. To address this need, Rspack provides a pitching stage — a special stage that each loader can define before its normal execution.
 
@@ -214,8 +177,8 @@ So why might a loader take advantage of the pitching stage?
 First, the data passed to the pitch method is exposed in the execution stage as well under this.data and could be useful for capturing and sharing information from earlier in the cycle.
 
 ```js
-module.exports = function (content) {
-  return someSyncOperation(content, this.data.value);
+module.exports = function (source) {
+  return someSyncOperation(source, this.data.value);
 };
 
 module.exports.pitch = function (remainingRequest, precedingRequest, data) {
@@ -227,8 +190,8 @@ Second, if a loader delivers a result in the pitch method, the process turns aro
 In our example above, if the b-loaders pitch method returned something:
 
 ```js
-module.exports = function (content) {
-  return someSyncOperation(content);
+module.exports = function (source) {
+  return someSyncOperation(source);
 };
 
 module.exports.pitch = function (remainingRequest, precedingRequest, data) {
@@ -252,3 +215,115 @@ The steps above would be shortened to:
 
 For a real world example, `style-loader` leverages the second advantage to dispatch requests.
 Please visit [style-loader](https://github.com/webpack-contrib/style-loader/blob/eb06baeb3ac4e3107732a21170b0a7f358c5423f/src/index.js#L39) for details.
+
+## Write with TypeScript
+
+If you write Rspack loader using TypeScript, you can use `LoaderDefinition` to provide complete type definitions for your loader.
+
+```ts title="my-loader.ts"
+import type { LoaderDefinition } from '@rspack/core';
+
+// Declare the type of loader options
+type MyLoaderOptions = {
+  foo: string;
+};
+
+const myLoader: LoaderDefinition<MyLoaderOptions> = function (source) {
+  const options = this.getOptions();
+  console.log(options); // { foo: 'bar' }
+  // Transform the source code
+  return `// Processed by my-loader\n${source}`;
+};
+
+export default myLoader;
+```
+
+Alternatively, you can import `LoaderContext` to add types to the loader context:
+
+```ts title="my-loader.ts"
+import type { LoaderContext } from '@rspack/core';
+
+type MyLoaderOptions = {
+  foo: string;
+};
+
+export default function myLoader(
+  this: LoaderContext<MyLoaderOptions>,
+  source: string,
+) {
+  const options = this.getOptions();
+  console.log(options); // { foo: 'bar' }
+  return `// Processed by my-loader\n${source}`;
+}
+```
+
+## Handling source maps
+
+When developing loaders, properly handling source maps is essential for providing accurate debugging information.
+
+Loader APIs related to source maps:
+
+- Use [this.sourceMap](/api/loader-api/context#thissourcemap) to determine whether source map generation is required.
+- Use [this.callback](/api/loader-api/context#thiscallback) or [this.async](/api/loader-api/context#thisasync) methods to return the processed source map.
+
+### Automatic source map handling
+
+Some transformers support automatic source map handling. For example, SWC can automatically generate new source maps based on input source maps.
+
+Here's an example using Rspack's [SWC API](/api/javascript-api/swc):
+
+```js title="myLoader.js"
+import { rspack } from '@rspack/core';
+
+const { swc } = rspack.experiments;
+
+export default async function myLoader(source, inputSourceMap) {
+  const callback = this.async();
+
+  try {
+    const result = await swc.transform(source, {
+      inputSourceMap,
+      sourceMaps: this.sourceMap,
+      // ...other options
+    });
+
+    callback(null, result.code, this.sourceMap ? result.map : undefined);
+  } catch (err) {
+    callback(err);
+  }
+}
+```
+
+### Manual source map merging
+
+You can also manually merge multiple source maps using third-party libraries such as [@jridgewell/remapping](https://www.npmjs.com/package/@jridgewell/remapping):
+
+```js title="myLoader.js"
+import remapping from '@jridgewell/remapping';
+
+const mergeSourceMap = (inputSourceMap, newSourceMap) => {
+  return remapping([newSourceMap, inputSourceMap], () => null);
+};
+
+export default async function myLoader(source, inputSourceMap) {
+  const callback = this.async();
+
+  try {
+    const { code, sourceMap: newSourceMap } = await someTransformFunction(
+      source,
+      { sourceMap: this.sourceMap },
+    );
+
+    if (this.sourceMap) {
+      const mergedSourceMap = inputSourceMap
+        ? mergeSourceMap(inputSourceMap, newSourceMap)
+        : newSourceMap;
+      callback(null, code, mergedSourceMap);
+    } else {
+      callback(null, code);
+    }
+  } catch (err) {
+    callback(err);
+  }
+}
+```

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -2304,7 +2304,7 @@ export default {
 
 There are two phases that all loaders enter one after the other:
 
-- **Pitching phase:** the `pitch` method on loaders is called in the order `post, inline, normal, pre`. See [Pitching Loader](/api/loader-api/types#pitching-loader) for details.
+- **Pitching phase:** the `pitch` method on loaders is called in the order `post, inline, normal, pre`. See [Pitching Loader](/api/loader-api/writing-loaders#pitching-loader) for details.
 - **Normal phase:** the default method on loaders is executed in the order `pre, normal, inline, post`. Transformation on the source code of a module happens in this phase.
 
 ### Rule.type

--- a/website/docs/en/guide/features/loader.mdx
+++ b/website/docs/en/guide/features/loader.mdx
@@ -12,9 +12,9 @@ Rspack allows you to use most webpack loaders in the community. See [awesome-rsp
 
 If you find an unsupported loader, please feel free to communicate with us through [GitHub Issues](https://github.com/web-infra-dev/rspack/issues).
 
-## Developing a loader
+## Writing loaders
 
-Refer to [Loader API - loader types](/api/loader-api/types) to learn how to develop a loader.
+Refer to [Writing loaders](/api/loader-api/writing-loaders) to learn how to develop a loader.
 
 ## Example
 

--- a/website/docs/zh/api/loader-api/_meta.json
+++ b/website/docs/zh/api/loader-api/_meta.json
@@ -1,1 +1,1 @@
-["index", "types", "context", "inline", "inline-match-resource"]
+["index", "writing-loaders", "context", "inline", "inline-match-resource"]

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -74,7 +74,7 @@ module.exports = function loader(source) {
 
 告诉 Rspack 这个 loader 将会异步被调用。返回值为 [this.callback](#thiscallback)。
 
-> 查看 [异步 loader](/api/loader-api/types#异步-loader) 了解如何使用。
+> 查看 [异步 loader](/api/loader-api/writing-loaders#异步-loader) 了解如何使用。
 
 ## this.cacheable()
 
@@ -101,7 +101,7 @@ module.exports = function loader(source) {
 function callback(
   err: Error | null,
   content: string | Buffer,
-  sourceMap?: SourceMap,
+  sourceMap?: Rspack.RawSourceMap,
   meta?: any,
 ): void;
 ```
@@ -110,7 +110,7 @@ function callback(
 
 第一个参数必须是 `Error` 或者 `null`，会标记当前模块为编译失败，第二个参数是一个 `string` 或者 `Buffer`，表示模块被该 Loader 处理后的文件内容，第三个参数是一个可以该 Loader 处理后的 source map，第四个参数会被 Rspack 忽略，可以是任何东西（例如一些元数据）。
 
-> 查看 [同步 loader](/api/loader-api/types#同步-loader) 了解如何使用。
+> 查看 [同步 loader](/api/loader-api/writing-loaders#同步-loader) 了解如何使用。
 
 :::warning
 当这个函数被调用时，你应该返回 `undefined` 以避免 loader 结果的歧义。
@@ -674,6 +674,8 @@ module.exports = function loader(source) {
 是否应该生成 source map。
 
 由于生成 source map 通常是一项耗费资源的任务，你应该检查是否需要 source map。
+
+详见 [处理 Source Map](/api/loader-api/writing-loaders#处理-source-map)。
 
 ## this.getLogger()
 

--- a/website/docs/zh/api/loader-api/index.mdx
+++ b/website/docs/zh/api/loader-api/index.mdx
@@ -6,9 +6,9 @@ Rspack 致力于兼容 webpack 生态中的 loader。我们确保 Rspack 尽可�
 
 目前 Rspack 已经兼容了 webpack 绝大部分的 loader API，如果你发现某个 webpack loader 无法在 Rspack 中使用，欢迎到 [Rspack 仓库](https://github.com/web-infra-dev/rspack) 通过 issue 反馈。
 
-## Loader 类型
+## 编写 Loader
 
-我们提供了不同类型 loader 的一些基本示例，如果你想要编写一个 loader，可以参考 [Loader 类型](/api/loader-api/types) 来上手。
+我们提供了不同类型 loader 的一些基本示例，如果你想要编写一个 loader，可以参考 [编写 Loader](/api/loader-api/writing-loaders) 来上手。
 
 如果你需要使用一个已有的 loader，可以参考 [特性 - loader](/guide/features/loader) 来了解如何使用。
 

--- a/website/docs/zh/api/loader-api/writing-loaders.mdx
+++ b/website/docs/zh/api/loader-api/writing-loaders.mdx
@@ -2,27 +2,31 @@ import WebpackLicense from '@components/WebpackLicense';
 
 <WebpackLicense from="https://webpack.docschina.org/api/loaders/#examples" />
 
-# Loader 类型
+# 编写 Loader
+
+学习如何为 Rspack 编写自定义 loader 来处理文件转换。
+
+## Loader 类型
 
 Rspack 支持多种 loader 类型，包括同步 loader、异步 loader、ESM loader、Raw loader 和 Pitching loader 等。
 
 以下部分提供了不同类型 loader 的一些基本示例。
 
-## 同步 Loader
+### 同步 Loader
 
 同步 loader 是最基本的 loader 类型，它可以通过 `return` 语句或 `this.callback` 方法同步返回转换后的内容：
 
 ```js title="sync-loader.js"
-module.exports = function (content, map, meta) {
-  return someSyncOperation(content);
+module.exports = function (source, map, meta) {
+  return someSyncOperation(source);
 };
 ```
 
 相比于 `return` 语句，`this.callback` 方法更加灵活，它允许传递多个参数，包括错误信息、source map 和 meta 数据：
 
 ```js title="sync-loader-with-callback.js"
-module.exports = function (content, map, meta) {
-  this.callback(null, someSyncOperation(content), map, meta);
+module.exports = function (source, map, meta) {
+  this.callback(null, someSyncOperation(source), map, meta);
 
   // 调用 callback() 时需要返回 undefined，避免返回值冲突
   return;
@@ -31,24 +35,24 @@ module.exports = function (content, map, meta) {
 
 ::: info
 
-- `map` 和 `meta` 参数是可选的，查看 [this.callback](/api/loader-api/context#thiscallback) 了解更多。
+- `map` 和 `meta` 参数是可选的，查看 [this.callback](/api/loader-api/context#thiscallback) 和 [处理 Source Map](#处理-source-map) 了解更多。
 - 出于技术和性能方面的考虑，Rspack 会在内部将 loader 转换为异步，无论它是否为同步 loader。
 
 :::
 
-## 异步 Loader
+### 异步 Loader
 
 当需要执行异步操作（如文件读写、网络请求等）时，应该使用异步 loader。通过调用 [this.async()](/api/loader-api/context#thisasync) 方法获取 `callback` 函数，告知 Rspack 该 loader 需要异步处理。
 
 异步 loader 的 `callback` 也可以传递多个参数，包括转换后的内容、source maps 和 meta 数据：
 
 ```js title="async-loader.js"
-module.exports = function (content, map, meta) {
+module.exports = function (source, map, meta) {
   // 获取异步回调函数
   const callback = this.async();
 
   // 执行异步操作
-  someAsyncOperation(content, function (err, result) {
+  someAsyncOperation(source, function (err, result) {
     // 处理错误情况
     if (err) return callback(err);
 
@@ -58,14 +62,14 @@ module.exports = function (content, map, meta) {
 };
 ```
 
-## ESM loader
+### ESM loader
 
 Rspack 支持 ESM 格式的 loader，你可以使用 ESM 语法编写 loader，通过 `export default` 导出 loader 函数。
 
 在编写 ESM Loader 时，文件名需要以 `.mjs` 结尾，或者在最近的 `package.json` 中将 `type` 设置为 `module`。
 
 ```js title="my-loader.mjs"
-export default function loader(content, map, meta) {
+export default function loader(source, map, meta) {
   // ...
 }
 ```
@@ -73,7 +77,7 @@ export default function loader(content, map, meta) {
 如果需要导出 [raw](#raw-loader) 或 [pitch](#pitching-loader) 等选项，可以使用具名导出：
 
 ```js title="my-loader.mjs"
-export default function loader(content) {
+export default function loader(source) {
   // ...
 }
 
@@ -90,48 +94,7 @@ export function pitch(remainingRequest, precedingRequest, data) {
 ESM loader 和 CommonJS loader 的功能完全相同，只是使用了不同的模块语法。你可以根据项目需求选择使用哪种格式。
 :::
 
-## 使用 TypeScript 编写
-
-如果你使用 TypeScript 编写 Rspack loader，可以使用 `LoaderDefinition` 为你的 loader 提供完整的类型定义。
-
-```ts title="my-loader.ts"
-import type { LoaderDefinition } from '@rspack/core';
-
-// 声明 loader 选项的类型
-type MyLoaderOptions = {
-  foo: string;
-};
-
-const myLoader: LoaderDefinition<MyLoaderOptions> = function (source) {
-  const options = this.getOptions();
-  console.log(options); // { foo: 'bar' }
-  // Transform the source code
-  return `// Processed by my-loader\n${source}`;
-};
-
-export default myLoader;
-```
-
-或者，你也可以导入 `LoaderContext` 为 loader 上下文添加类型：
-
-```ts title="my-loader.ts"
-import type { LoaderContext } from '@rspack/core';
-
-type MyLoaderOptions = {
-  foo: string;
-};
-
-export default function myLoader(
-  this: LoaderContext<MyLoaderOptions>,
-  source: string,
-) {
-  const options = this.getOptions();
-  console.log(options); // { foo: 'bar' }
-  return `// Processed by my-loader\n${source}`;
-}
-```
-
-## Raw loader
+### Raw loader
 
 默认情况下，Rspack 会将文件内容转换为 UTF-8 字符串，然后传递给 loader 进行处理。然而，在处理二进制文件（如图片、音频或字体文件）时，我们需要直接操作原始二进制数据，而不是字符串形式。
 
@@ -140,10 +103,10 @@ export default function myLoader(
 - CJS：
 
 ```js title="raw-loader.js"
-module.exports = function (content) {
+module.exports = function (source) {
   // 对二进制内容进行处理
-  // 此时 content 是 Buffer 实例
-  const processed = someBufferOperation(content);
+  // 此时 source 是 Buffer 实例
+  const processed = someBufferOperation(source);
 
   // 返回处理后的结果
   return processed;
@@ -156,7 +119,7 @@ module.exports.raw = true;
 - ESM：
 
 ```js title="raw-loader.mjs"
-export default function loader(content) {
+export default function loader(source) {
   // ...
 }
 
@@ -167,7 +130,7 @@ export const raw = true;
 
 Raw Loader 在处理图片压缩、二进制资源转换、文件编码等场景中特别有用。例如，当开发处理图片的 loader 时，通常需要直接操作二进制数据以便正确处理图像格式。
 
-## Pitching loader
+### Pitching loader
 
 在 Rspack 的 loader 执行过程中，默认导出的 loader 函数总是**从右向左**被调用（称为 normal 阶段）。但有时，loader 可能只关注文件的元数据，而非前一个 loader 的处理结果。为了解决这类需求，Rspack 提供了 "pitching" 阶段 —— 在 loader 的常规执行前，每个 loader 可以定义的特殊阶段。
 
@@ -214,8 +177,8 @@ module.exports = function (source) {};
 首先，传递给 `pitch` 方法的数据在执行阶段也暴露在 `this.data` 下，可以用来捕获和共享 loader 生命周期中早期的信息。
 
 ```js
-module.exports = function (content) {
-  return someSyncOperation(content, this.data.value);
+module.exports = function (source) {
+  return someSyncOperation(source, this.data.value);
 };
 
 module.exports.pitch = function (remainRequest, precedingRequest, data) {
@@ -228,8 +191,8 @@ module.exports.pitch = function (remainRequest, precedingRequest, data) {
 在我们上面的例子中，如果 b-loaders 的 `pitch` 方法返回了一些内容：
 
 ```js
-module.exports = function (content) {
-  return someSyncOperation(content);
+module.exports = function (source) {
+  return someSyncOperation(source);
 };
 
 module.exports.pitch = function (remainingRequest, precedingRequest, data) {
@@ -253,3 +216,115 @@ module.exports.pitch = function (remainingRequest, precedingRequest, data) {
 
 一个实际应用的例子是 `style-loader`，它利用了第二个优势来处理请求的调度。
 请访问 [style-loader](https://github.com/webpack-contrib/style-loader/blob/eb06baeb3ac4e3107732a21170b0a7f358c5423f/src/index.js#L39) 了解详情。
+
+## 使用 TypeScript 编写
+
+如果你使用 TypeScript 编写 Rspack loader，可以使用 `LoaderDefinition` 为你的 loader 提供完整的类型定义。
+
+```ts title="my-loader.ts"
+import type { LoaderDefinition } from '@rspack/core';
+
+// 声明 loader 选项的类型
+type MyLoaderOptions = {
+  foo: string;
+};
+
+const myLoader: LoaderDefinition<MyLoaderOptions> = function (source) {
+  const options = this.getOptions();
+  console.log(options); // { foo: 'bar' }
+  // Transform the source code
+  return `// Processed by my-loader\n${source}`;
+};
+
+export default myLoader;
+```
+
+或者，你也可以导入 `LoaderContext` 为 loader 上下文添加类型：
+
+```ts title="my-loader.ts"
+import type { LoaderContext } from '@rspack/core';
+
+type MyLoaderOptions = {
+  foo: string;
+};
+
+export default function myLoader(
+  this: LoaderContext<MyLoaderOptions>,
+  source: string,
+) {
+  const options = this.getOptions();
+  console.log(options); // { foo: 'bar' }
+  return `// Processed by my-loader\n${source}`;
+}
+```
+
+## 处理 Source map
+
+在开发 loader 时，正确处理 source map 对于有助于提供准确的调试信息。
+
+与 source map 相关的 Loader API：
+
+- 使用 [this.sourceMap](/api/loader-api/context#thissourcemap) 判断是否需要生成 source map。
+- 使用 [this.callback](/api/loader-api/context#thiscallback) 或 [this.async](/api/loader-api/context#thisasync) 方法返回处理后的 source map。
+
+### 自动处理 source map
+
+一些 transformer 支持自动处理 source map，例如 SWC 能够自动基于输入的 source map 生成新的 source map。
+
+下面是一个使用 Rspack 的 [SWC API](/api/javascript-api/swc) 的示例：
+
+```js title="myLoader.js"
+import { rspack } from '@rspack/core';
+
+const { swc } = rspack.experiments;
+
+export default async function myLoader(source, inputSourceMap) {
+  const callback = this.async();
+
+  try {
+    const result = await swc.transform(source, {
+      inputSourceMap,
+      sourceMaps: this.sourceMap,
+      // ...other options
+    });
+
+    callback(null, result.code, this.sourceMap ? result.map : undefined);
+  } catch (err) {
+    callback(err);
+  }
+}
+```
+
+### 手动合并 source map
+
+你也可以使用 [@jridgewell/remapping](https://www.npmjs.com/package/@jridgewell/remapping) 等三方库手动合并多个 source map：
+
+```js title="myLoader.js"
+import remapping from '@jridgewell/remapping';
+
+const mergeSourceMap = (inputSourceMap, newSourceMap) => {
+  return remapping([newSourceMap, inputSourceMap], () => null);
+};
+
+export default async function myLoader(source, inputSourceMap) {
+  const callback = this.async();
+
+  try {
+    const { code, sourceMap: newSourceMap } = await someTransformFunction(
+      source,
+      { sourceMap: this.sourceMap },
+    );
+
+    if (this.sourceMap) {
+      const mergedSourceMap = inputSourceMap
+        ? mergeSourceMap(inputSourceMap, newSourceMap)
+        : newSourceMap;
+      callback(null, code, mergedSourceMap);
+    } else {
+      callback(null, code);
+    }
+  } catch (err) {
+    callback(err);
+  }
+}
+```

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -2299,7 +2299,7 @@ export default {
 
 所有 loader 都会进入以下两个阶段：
 
-- **Pitching 阶段:** loader 导出的 `pitch` 方法在 `post, inline, normal, pre` 顺序下被调用。详见 [Pitching Loader](/api/loader-api/types#pitching-loader)。
+- **Pitching 阶段:** loader 导出的 `pitch` 方法在 `post, inline, normal, pre` 顺序下被调用。详见 [Pitching Loader](/api/loader-api/writing-loaders#pitching-loader)。
 - **Normal 阶段:** loader 导出的默认方法在 `pre, normal, inline, post` 顺序下被执行。模块的源码转换发生在该阶段。
 
 ### Rule.type

--- a/website/docs/zh/guide/features/loader.mdx
+++ b/website/docs/zh/guide/features/loader.mdx
@@ -14,9 +14,9 @@ Rspack 允许你使用社区中绝大多数的 webpack loaders。查看 [awesome
 
 如果你发现有 Rspack 不支持的 loader，欢迎通过 [GitHub Issues](https://github.com/web-infra-dev/rspack/issues) 与我们交流。
 
-## 开发 Loader
+## 编写 Loader
 
-参考 [Loader API - Loader 类型](/api/loader-api/types) 了解如何开发一个 Loader。
+参考 [编写 Loader](/api/loader-api/writing-loaders) 了解如何开发一个 Loader。
 
 ## 示例
 

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -75,6 +75,7 @@ jantimon
 JavaScript
 jerrykingxyz
 jkzing
+jridgewell
 jscexperimentalplugins
 jserfeng
 kaffi


### PR DESCRIPTION
## Summary

- Added new sections for handling source maps in Rspack loaders.
- Renamed the `Loader types` page to `Writing loaders`.
- Updated all internal links and references from "Loader types" to "Writing loaders" across the documentation

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
