### PR TITLE
fix(rslib): treat `module` identifier as normal

### DIFF
--- a/crates/rspack_plugin_rslib/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rslib/src/parser_plugin.rs
@@ -1,4 +1,5 @@
 use rspack_plugin_javascript::{JavascriptParserPlugin, visitors::JavascriptParser};
+use swc_core::ecma::ast::Ident;
 
 #[derive(PartialEq, Debug, Default)]
 pub struct RslibParserPlugin {
@@ -14,6 +15,21 @@ impl RslibParserPlugin {
 }
 
 impl JavascriptParserPlugin for RslibParserPlugin {
+  fn identifier(
+    &self,
+    _parser: &mut JavascriptParser,
+    _ident: &Ident,
+    for_name: &str,
+  ) -> Option<bool> {
+    // Intercept CommonJsExportsParsePlugin, not APIPlugin, but put it here.
+    // crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+    if for_name == "module" {
+      return Some(true);
+    }
+
+    None
+  }
+
   fn member(
     &self,
     _parser: &mut JavascriptParser,

--- a/packages/rspack-test-tools/tests/configCases/rslib/plugin-api/index.js
+++ b/packages/rspack-test-tools/tests/configCases/rslib/plugin-api/index.js
@@ -4,4 +4,11 @@ console.log(require.config)
 console.log(require.version)
 console.log(require.include)
 console.log(require.onError)
+export function g() {
+  console.log(module);
+  if (module.children) {
+    module.children = module.children.filter((item) => item.filename !== path);
+  }
+}
+
 

--- a/packages/rspack-test-tools/tests/configCases/rslib/plugin-api/test.js
+++ b/packages/rspack-test-tools/tests/configCases/rslib/plugin-api/test.js
@@ -11,4 +11,6 @@ it ('some expressions should not be handled by APIPlugin', () => {
 	expect(content).toContain('console.log(require.version)')
 	expect(content).toContain('console.log(require.include)')
 	expect(content).toContain('console.log(require.onError)')
+	expect(content).toContain('module.children = module.children.filter((item) => item.filename !== path)')
+	expect(content).not.toContain('__webpack_require__')
 })


### PR DESCRIPTION
## Summary

do not treat `module` as a special identifier in Rslib.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
