### PR TITLE
perf: drop some big data in rayon

### DIFF
--- a/crates/rspack_core/src/module_graph/exports_info.rs
+++ b/crates/rspack_core/src/module_graph/exports_info.rs
@@ -61,7 +61,8 @@ impl<'a> ModuleGraph<'a> {
     let Some(active_partial) = &mut self.active else {
       panic!("should have active partial");
     };
-    active_partial.exports_info_map.insert(id, info);
+    let old = active_partial.exports_info_map.insert(id, info);
+    rayon::spawn(move || drop(old));
   }
 
   pub fn active_all_exports_info(&mut self) {

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -244,6 +244,8 @@ impl SplitChunksPlugin {
       .await?;
     logger.time_end(start);
 
+    rayon::spawn(move || drop(combinator));
+
     Ok(())
   }
 }

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -548,7 +548,8 @@ impl SplitChunksPlugin {
       .collect::<Vec<_>>();
 
     keys_of_invalid_group.into_iter().for_each(|key| {
-      module_group_map.remove(&key);
+      let old = module_group_map.remove(&key);
+      rayon::spawn(move || drop(old));
     });
   }
 }


### PR DESCRIPTION
## Summary

We should drop some big data structs in `rayon::spawn` if the task only run on main thread.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
