### PR TITLE
feat: static analyze in operator for esm import specifier

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_evaluated_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_evaluated_import_specifier_dependency.rs
@@ -1,2 +1,0 @@
-// TODO
-// pub struct ESMEvaluatedImportSpecifierDependency {}

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -235,11 +235,7 @@ pub trait JavascriptParserPlugin {
 
   /// Return:
   /// - `None` means should walk left and right;
-  fn binary_expression(
-    &self,
-    _parser: &mut JavascriptParser,
-    _expr: &BinExpr,
-  ) -> Option<KeepRight> {
+  fn binary_expression(&self, _parser: &mut JavascriptParser, _expr: &BinExpr) -> Option<bool> {
     None
   }
 

--- a/packages/rspack-test-tools/tests/configCases/parsing/esm-in-operator/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/esm-in-operator/index.js
@@ -1,0 +1,12 @@
+import * as m from "./m";
+
+const generated = /** @type {string} */ (__non_webpack_require__("fs").readFileSync(__filename, "utf-8"));
+
+it("should tree shake b", () => {
+  // START:A
+  expect("a" in m).toBe(true);
+  // END:A
+  const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
+  expect(block.includes(`expect( true).toBe(true)`)).toBe(true);
+  expect(m.usedB).toBe(false);
+})

--- a/packages/rspack-test-tools/tests/configCases/parsing/esm-in-operator/m.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/esm-in-operator/m.js
@@ -1,0 +1,4 @@
+export const a = 1;
+export const b = 2;
+export const usedA = __webpack_exports_info__.a.used;
+export const usedB = __webpack_exports_info__.b.used;


### PR DESCRIPTION
## Summary

```js
import * as m from "./m"
("a" in m)
```

Before `./m` won't tree shaking, because `in m` is an namespace usage. In this PR we will identify `"a" in m` as only uses `.a` and tree shaking rest exports

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
