### PR TITLE
docs: remove `Preview with stackblitz` section

### DIFF
--- a/crates/node_binding/webcontainer-fallback.cjs
+++ b/crates/node_binding/webcontainer-fallback.cjs
@@ -1,7 +1,3 @@
-/**
- * Based on  https://github.com/oxc-project/oxc/blob/main/napi/parser/webcontainer-fallback.js
- */
-
 const fs = require('node:fs');
 const path = require('node:path');
 const childProcess = require('node:child_process');

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -119,32 +119,6 @@ If you need to migrate from an existing project to Rspack, you can refer to the 
 - [Migrating from Tsup to Rslib](https://rslib.rs/guide/migration/tsup)
 - [Migrating from Storybook](/guide/migration/storybook)
 
-## Preview with StackBlitz
-
-Rspack >= 1.4 includes a Wasm binding, which makes Rspack available in [StackBlitz](https://stackblitz.com/) (WebContainers). Currently, if you want to preview your Rspack projects on StackBlitz, you need to specify the CPU architecture when installing dependencies. Different package managers have different ways to do it.
-
-For npm, you can specify the conditions for optional dependencies with `--cpu` option:
-
-```bash
-npm install --cpu=wasm32
-```
-
-For pnpm, you need to specify [supportedArchitectures](https://pnpm.io/settings#supportedarchitectures) in your `package.json`:
-
-```json title="package.json"
-{
-  "pnpm": {
-    "supportedArchitectures": {
-      "cpu": ["wasm32"]
-    }
-  }
-}
-```
-
-For other package managers, please refer to their respective documentation.
-
-In the future, we will continue to optimize the workflow, making users seamlessly preview Rspack projects. Additionally, we are planing to provide `@rspack/browser` package, allowing you to use Rspack directly in the browser.
-
 ## Install canary version
 
 When you need to test or verify the features of Rspack that are not yet released to the stable version, you may need to use the canary version.

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -119,32 +119,6 @@ npm init -y
 - [从 Tsup 迁移到 Rslib](https://rslib.rs/zh/guide/migration/tsup)
 - [从 Storybook 迁移](/guide/migration/storybook)
 
-## 使用 StackBlitz 在线预览
-
-Rspack >= 1.4 实现了 Wasm 版本，支持直接在 [StackBlitz](https://stackblitz.com/) (WebContainers) 中使用。在当前版本下，如果你想在 StackBlitz 上预览你的 Rspack 项目，需要在安装依赖的时候指定 CPU 架构。不同包管理器指定 CPU 架构的方式有所不同。
-
-对于 npm，可以通过 `--cpu` 指定可选依赖需要满足的条件：
-
-```bash
-npm install --cpu=wasm32
-```
-
-对于 pnpm，需要在项目的 `package.json` 中指定 [supportedArchitectures](https://pnpm.io/settings#supportedarchitectures)：
-
-```json title="package.json"
-{
-  "pnpm": {
-    "supportedArchitectures": {
-      "cpu": ["wasm32"]
-    }
-  }
-}
-```
-
-其余包管理器可自行查阅相应的文档。
-
-未来我们会持续优化使用流程，使用户可以无缝地预览 Rspack 项目。此外，我们也计划提供 `@rspack/browser` 包，允许你在浏览器上直接使用 Rspack。
-
 ## 安装 canary 版本
 
 当你需要测试或验证 Rspack 未发布至稳定版的功能时，可能需要使用 canary 版本。


### PR DESCRIPTION
## Summary

After https://github.com/web-infra-dev/rspack/pull/11526 there's no need to do that. I have bump rspack versions in the examples.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
