### PR TITLE
chore: enable canary nightly release

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,6 +1,9 @@
 name: Release Canary
 
 on:
+  schedule:
+    - cron: "0 17 * * *"
+
   workflow_dispatch:
     inputs:
       commit:


### PR DESCRIPTION
## Summary
- Ensure release workflow is working
- `0 17` is 1 o'lock in utc-8
 

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
