### PR TITLE
fix: revert "fix(rslib): treat `module` identifier as normal (#11588)"

### DIFF
--- a/crates/rspack_plugin_rslib/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rslib/src/parser_plugin.rs
@@ -1,5 +1,4 @@
 use rspack_plugin_javascript::{JavascriptParserPlugin, visitors::JavascriptParser};
-use swc_core::ecma::ast::Ident;
 
 #[derive(PartialEq, Debug, Default)]
 pub struct RslibParserPlugin {
@@ -15,21 +14,6 @@ impl RslibParserPlugin {
 }
 
 impl JavascriptParserPlugin for RslibParserPlugin {
-  fn identifier(
-    &self,
-    _parser: &mut JavascriptParser,
-    _ident: &Ident,
-    for_name: &str,
-  ) -> Option<bool> {
-    // Intercept CommonJsExportsParsePlugin, not APIPlugin, but put it here.
-    // crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
-    if for_name == "module" {
-      return Some(true);
-    }
-
-    None
-  }
-
   fn member(
     &self,
     _parser: &mut JavascriptParser,

--- a/tests/rspack-test/configCases/rslib/plugin-api/index.js
+++ b/tests/rspack-test/configCases/rslib/plugin-api/index.js
@@ -4,11 +4,4 @@ console.log(require.config)
 console.log(require.version)
 console.log(require.include)
 console.log(require.onError)
-export function g() {
-  console.log(module);
-  if (module.children) {
-    module.children = module.children.filter((item) => item.filename !== path);
-  }
-}
-
 

--- a/tests/rspack-test/configCases/rslib/plugin-api/test.js
+++ b/tests/rspack-test/configCases/rslib/plugin-api/test.js
@@ -11,6 +11,4 @@ it ('some expressions should not be handled by APIPlugin', () => {
 	expect(content).toContain('console.log(require.version)')
 	expect(content).toContain('console.log(require.include)')
 	expect(content).toContain('console.log(require.onError)')
-	expect(content).toContain('module.children = module.children.filter((item) => item.filename !== path)')
-	expect(content).not.toContain('__webpack_require__')
 })


### PR DESCRIPTION
This reverts commit 15ba68ed9c9fd0b2da495702387a938c341b4fec.

## Summary

`"modulle"` identifier hook is commonly used in bundling CJS module, can't be removed directly. this PR will break bundling in Rslib.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
