### PR TITLE
fix(rslib): only treat "module" as normal variable when module have ESM syntax

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -247,7 +247,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) semicolons: &'parser mut FxHashSet<BytePos>,
   pub(crate) statement_path: Vec<StatementPath>,
   pub(crate) prev_statement: Option<StatementPath>,
-  pub(crate) is_esm: bool,
+  pub is_esm: bool,
   pub(crate) destructuring_assignment_properties:
     Option<FxHashMap<Span, FxHashSet<DestructuringAssignmentProperty>>>,
   pub(crate) dynamic_import_references: ImportsReferencesState,

--- a/crates/rspack_plugin_rslib/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rslib/src/parser_plugin.rs
@@ -1,4 +1,10 @@
-use rspack_plugin_javascript::{JavascriptParserPlugin, visitors::JavascriptParser};
+use rspack_plugin_javascript::{
+  JavascriptParserPlugin, utils::eval::BasicEvaluatedExpression, visitors::JavascriptParser,
+};
+use swc_core::{
+  atoms::Atom,
+  ecma::ast::{AssignExpr, CallExpr, Ident, MemberExpr, UnaryExpr},
+};
 
 #[derive(PartialEq, Debug, Default)]
 pub struct RslibParserPlugin {
@@ -14,12 +20,45 @@ impl RslibParserPlugin {
 }
 
 impl JavascriptParserPlugin for RslibParserPlugin {
-  fn member(
+  fn assign_member_chain(
     &self,
-    _parser: &mut JavascriptParser,
-    _member_expr: &swc_core::ecma::ast::MemberExpr,
+    parser: &mut JavascriptParser,
+    _assign_expr: &AssignExpr,
+    _remaining: &[Atom],
     for_name: &str,
   ) -> Option<bool> {
+    if parser.is_esm && for_name == "module" {
+      return Some(true);
+    }
+
+    None
+  }
+
+  fn identifier(
+    &self,
+    parser: &mut JavascriptParser,
+    _ident: &Ident,
+    for_name: &str,
+  ) -> Option<bool> {
+    // Intercept CommonJsExportsParsePlugin, not APIPlugin, but put it here.
+    // crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+    if for_name == "module" && parser.is_esm {
+      return Some(true);
+    }
+
+    None
+  }
+
+  fn member(
+    &self,
+    parser: &mut JavascriptParser,
+    _member_expr: &MemberExpr,
+    for_name: &str,
+  ) -> Option<bool> {
+    if parser.is_esm && (for_name == "module" || for_name.starts_with("module.")) {
+      return Some(true);
+    }
+
     if for_name == "require.cache"
       || for_name == "require.extensions"
       || for_name == "require.config"
@@ -29,6 +68,67 @@ impl JavascriptParserPlugin for RslibParserPlugin {
     {
       return Some(true);
     }
+    None
+  }
+
+  fn member_chain(
+    &self,
+    parser: &mut JavascriptParser,
+    _expr: &MemberExpr,
+    for_name: &str,
+    _members: &[Atom],
+    _members_optionals: &[bool],
+    _member_ranges: &[swc_core::common::Span],
+  ) -> Option<bool> {
+    if parser.is_esm && for_name == "module" {
+      return Some(true);
+    }
+
+    None
+  }
+
+  fn call_member_chain(
+    &self,
+    parser: &mut JavascriptParser,
+    _expr: &CallExpr,
+    for_name: &str,
+    _members: &[Atom],
+    _members_optionals: &[bool],
+    _member_ranges: &[swc_core::common::Span],
+  ) -> Option<bool> {
+    if parser.is_esm && for_name == "module" {
+      return Some(true);
+    }
+
+    None
+  }
+
+  fn evaluate_typeof<'a>(
+    &self,
+    parser: &mut JavascriptParser,
+    _expr: &'a UnaryExpr,
+    for_name: &str,
+  ) -> Option<BasicEvaluatedExpression<'a>> {
+    if parser.is_esm && for_name == "module" {
+      let span = _expr.span;
+      let mut eval = BasicEvaluatedExpression::with_range(span.lo.0, span.hi.0);
+      eval.set_side_effects(false);
+      return Some(eval);
+    }
+
+    None
+  }
+
+  fn r#typeof(
+    &self,
+    parser: &mut JavascriptParser,
+    _expr: &UnaryExpr,
+    for_name: &str,
+  ) -> Option<bool> {
+    if parser.is_esm && for_name == "module" {
+      return Some(true);
+    }
+
     None
   }
 }

--- a/tests/rspack-test/configCases/rslib/plugin-api/cjsFile.cjs
+++ b/tests/rspack-test/configCases/rslib/plugin-api/cjsFile.cjs
@@ -1,0 +1,7 @@
+const value = () => 42
+
+// Make the export immutable
+Object.defineProperty(module, 'exports', {
+	enumerable: true,
+	get: value
+});

--- a/tests/rspack-test/configCases/rslib/plugin-api/index.js
+++ b/tests/rspack-test/configCases/rslib/plugin-api/index.js
@@ -1,7 +1,50 @@
+import value from "./cjsFile.cjs";
+export { value }
+
 console.log(require.cache)
 console.log(require.extensions)
 console.log(require.config)
 console.log(require.version)
 console.log(require.include)
 console.log(require.onError)
+console.log(value);
 
+export function filterModuleChildren() {
+  console.log(module);
+  if (module.children) {
+    module.children = module.children.filter((item) => item.filename !== path);
+  }
+}
+
+export function rewriteModuleExports() {
+  if (typeof module === "undefined") {
+    return undefined;
+  }
+
+  const original = module.exports;
+
+  try {
+    module.exports = {
+      ...module.exports,
+      test: () => "ok"
+    };
+
+    return module.exports.test();
+  } finally {
+    module.exports = original;
+  }
+}
+
+export function callModuleMethod() {
+  if (typeof module === "undefined") {
+    return undefined;
+  }
+
+  if (module.exports && module.exports.test) {
+    return module.exports.test();
+  }
+
+  return undefined;
+}
+
+export const moduleType = typeof module;

--- a/tests/rspack-test/configCases/rslib/plugin-api/rspack.config.js
+++ b/tests/rspack-test/configCases/rslib/plugin-api/rspack.config.js
@@ -11,6 +11,11 @@ module.exports = [
 			__filename: false,
 			__dirname: false
 		},
+		output: {
+			library: {
+				type: "commonjs"
+			}
+		},
 		plugins: [
 			new RslibPlugin({
 				interceptApiPlugin: true
@@ -19,6 +24,9 @@ module.exports = [
 	},
 	{
 		entry: "./test.js",
+		externals: {
+			"./bundle0.js": "commonjs ./bundle0.js"
+		},
 		target: "node",
 		node: {
 			__filename: false,

--- a/tests/rspack-test/configCases/rslib/plugin-api/test.js
+++ b/tests/rspack-test/configCases/rslib/plugin-api/test.js
@@ -5,10 +5,55 @@ const file = path.resolve(__dirname, 'bundle0.js')
 const content = fs.readFileSync(file, 'utf-8');
 
 it ('some expressions should not be handled by APIPlugin', () => {
-	expect(content).toContain('console.log(require.cache)')
-	expect(content).toContain('console.log(require.extensions)')
-	expect(content).toContain('console.log(require.config)')
-	expect(content).toContain('console.log(require.version)')
-	expect(content).toContain('console.log(require.include)')
-	expect(content).toContain('console.log(require.onError)')
+	expect(content).toContain(`
+console.log(require.cache)
+console.log(require.extensions)
+console.log(require.config)
+console.log(require.version)
+console.log(require.include)
+console.log(require.onError)
+console.log((_cjsFile_cjs__WEBPACK_IMPORTED_MODULE_0___default()));
+
+function filterModuleChildren() {
+  console.log(module);
+  if (module.children) {
+    module.children = module.children.filter((item) => item.filename !== path);
+  }
+}
+
+function rewriteModuleExports() {
+  if (typeof module === "undefined") {
+    return undefined;
+  }
+
+  const original = module.exports;
+
+  try {
+    module.exports = {
+      ...module.exports,
+      test: () => "ok"
+    };
+
+    return module.exports.test();
+  } finally {
+    module.exports = original;
+  }
+}
+
+function callModuleMethod() {
+  if (typeof module === "undefined") {
+    return undefined;
+  }
+
+  if (module.exports && module.exports.test) {
+    return module.exports.test();
+  }
+
+  return undefined;
+}
+
+const moduleType = typeof module;
+`)
+	const exported = require('./bundle0.js')
+	expect(exported.value).toBe(42)
 })


### PR DESCRIPTION
## Summary

This is a revised version of 15ba68e.

This PR mainly do:

when `parser.is_esm` is `true` (which means the CJS exports is useless due to the presence of ESM syntax) add parser hooks just like what `crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs` do to `module` variable. and simply return `true` to bailout the afterwards hooks.

<!-- Describe what this PR does and why. -->

## Related links

revised version of https://github.com/web-infra-dev/rspack/pull/11588. only ignore`"module"` variable when ESM `import / export` are present.

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
