### PR TITLE
chore(ci): add fallback value for scheduled workflow run

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -68,11 +68,11 @@ jobs:
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
     uses: ./.github/workflows/reusable-build.yml
     with:
-      ref: ${{inputs.commit}}
+      ref: ${{inputs.commit || github.sha}}
       target: ${{ matrix.array.target }}
       runner: ${{ matrix.array.runner }}
-      profile: ${{inputs.profile}}
-      test: ${{inputs.test}}
+      profile: ${{inputs.profile || 'release'}}
+      test: ${{inputs.test || false}}
 
   release:
     name: Release Canary


### PR DESCRIPTION
## Summary
Schduled workflow run doesn't have inputs.
So fallback values should be provided

Verified by forked repo https://github.com/stormslowly/rspack/actions/runs/17633394874 
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
