### PR TITLE
fix: should update alias resolution when a higher-priority file is created in watch mode

### DIFF
--- a/crates/rspack_core/src/compilation/make/artifact.rs
+++ b/crates/rspack_core/src/compilation/make/artifact.rs
@@ -142,21 +142,22 @@ impl MakeArtifact {
   pub fn revoke_dependency(&mut self, dep_id: &DependencyId, force: bool) -> Vec<BuildDependency> {
     let mut mg = ModuleGraph::new([None, None], Some(&mut self.module_graph_partial));
 
-    let revoke_dep_ids = if let Some(dependency) = mg.dependency_by_id(dep_id)
-      && let Some(info) = FactorizeInfo::get_from(dependency)
+    let revoke_dep_ids = if let Some(factorize_info) = mg
+      .dependency_by_id(dep_id)
+      .and_then(|dependency| FactorizeInfo::get_from(dependency))
     {
       let resource_id = ResourceId::from(dep_id);
       self
         .file_dependencies
-        .remove_files(&resource_id, info.file_dependencies());
+        .remove_files(&resource_id, factorize_info.file_dependencies());
       self
         .context_dependencies
-        .remove_files(&resource_id, info.context_dependencies());
+        .remove_files(&resource_id, factorize_info.context_dependencies());
       self
         .missing_dependencies
-        .remove_files(&resource_id, info.missing_dependencies());
+        .remove_files(&resource_id, factorize_info.missing_dependencies());
       // related_dep_ids will contain dep_id it self
-      info.related_dep_ids().to_vec()
+      factorize_info.related_dep_ids().to_vec()
     } else {
       vec![*dep_id]
     };

--- a/crates/rspack_core/src/compilation/make/artifact.rs
+++ b/crates/rspack_core/src/compilation/make/artifact.rs
@@ -117,10 +117,8 @@ impl MakeArtifact {
       .into_iter()
       .chain(mgm.incoming_connections().clone())
     {
-      if !self.make_failed_dependencies.remove(&dep_id) {
-        continue;
-      }
-      // make failed dependencies clean it.
+      self.make_failed_dependencies.remove(&dep_id);
+
       let dep = mg
         .dependency_by_id_mut(&dep_id)
         .expect("should have dependency");

--- a/crates/rspack_core/src/compilation/make/artifact.rs
+++ b/crates/rspack_core/src/compilation/make/artifact.rs
@@ -111,11 +111,14 @@ impl MakeArtifact {
       .expect("should have mgm");
     for dep_id in mgm
       .all_dependencies
-      .iter()
-      .chain(mgm.incoming_connections())
+      .clone()
+      .into_iter()
+      .chain(mgm.incoming_connections().clone())
     {
-      let dep = mg.dependency_by_id(dep_id).expect("should have dependency");
-      if let Some(info) = FactorizeInfo::get_from(dep) {
+      let dep = mg
+        .dependency_by_id_mut(&dep_id)
+        .expect("should have dependency");
+      if let Some(info) = FactorizeInfo::revoke(dep) {
         let resource_id = ResourceId::from(dep_id);
         self
           .file_dependencies
@@ -143,8 +146,8 @@ impl MakeArtifact {
     let mut mg = ModuleGraph::new([None, None], Some(&mut self.module_graph_partial));
 
     let revoke_dep_ids = if let Some(factorize_info) = mg
-      .dependency_by_id(dep_id)
-      .and_then(|dependency| FactorizeInfo::get_from(dependency))
+      .dependency_by_id_mut(dep_id)
+      .and_then(FactorizeInfo::revoke)
     {
       let resource_id = ResourceId::from(dep_id);
       self

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/factorize.rs
@@ -171,6 +171,11 @@ impl Task<TaskContext> for FactorizeResultTask {
     } = *self;
 
     let artifact = &mut context.artifact;
+    if !factorize_info.is_success() {
+      artifact
+        .make_failed_dependencies
+        .insert(*dependencies[0].id());
+    }
     let resource_id = ResourceId::from(*dependencies[0].id());
     artifact
       .file_dependencies

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/factorize.rs
@@ -171,21 +171,17 @@ impl Task<TaskContext> for FactorizeResultTask {
     } = *self;
 
     let artifact = &mut context.artifact;
-    if !factorize_info.diagnostics().is_empty() {
-      let resource_id = ResourceId::from(*dependencies[0].id());
-      artifact
-        .file_dependencies
-        .add_files(&resource_id, &factorize_info.file_dependencies());
-      artifact
-        .context_dependencies
-        .add_files(&resource_id, &factorize_info.context_dependencies());
-      artifact
-        .missing_dependencies
-        .add_files(&resource_id, &factorize_info.missing_dependencies());
-      artifact
-        .make_failed_dependencies
-        .insert(*dependencies[0].id());
-    }
+    let resource_id = ResourceId::from(*dependencies[0].id());
+    artifact
+      .file_dependencies
+      .add_files(&resource_id, factorize_info.file_dependencies());
+    artifact
+      .context_dependencies
+      .add_files(&resource_id, factorize_info.context_dependencies());
+    artifact
+      .missing_dependencies
+      .add_files(&resource_id, factorize_info.missing_dependencies());
+
     // write factorize_info to dependencies[0] and set success factorize_info to others
     for dep in &mut dependencies {
       let dep_factorize_info = if let Some(d) = dep.as_context_dependency_mut() {

--- a/crates/rspack_core/src/compilation/make/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/make/module_executor/execute.rs
@@ -123,7 +123,6 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
       return Ok(vec![]);
     };
     let make_failed_module = &origin_context.artifact.make_failed_module;
-    let make_failed_dependencies = &origin_context.artifact.make_failed_dependencies;
     let mut queue = VecDeque::from(vec![entry_module_identifier]);
     let mut assets = CompilationAssets::default();
     let mut modules = IdentifierSet::default();
@@ -172,8 +171,10 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
         }
       }
       for dep_id in module.get_dependencies() {
-        if !has_error && make_failed_dependencies.contains(dep_id) {
-          let dep = mg.dependency_by_id(dep_id).expect("should dep exist");
+        let dep = mg.dependency_by_id(dep_id).expect("should dep exist");
+        if let Some(factorize_info) = FactorizeInfo::get_from(dep)
+          && factorize_info.is_success()
+        {
           let diagnostics = FactorizeInfo::get_from(dep)
             .expect("should have factorize info")
             .diagnostics();

--- a/crates/rspack_core/src/compilation/make/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/make/module_executor/execute.rs
@@ -172,13 +172,12 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
       }
       for dep_id in module.get_dependencies() {
         let dep = mg.dependency_by_id(dep_id).expect("should dep exist");
-        if let Some(factorize_info) = FactorizeInfo::get_from(dep)
-          && factorize_info.is_success()
+        if !has_error
+          && let Some(factorize_info) = FactorizeInfo::get_from(dep)
+          && !factorize_info.is_success()
         {
-          let diagnostics = FactorizeInfo::get_from(dep)
-            .expect("should have factorize info")
-            .diagnostics();
-          let errors: Vec<_> = diagnostics
+          let errors: Vec<_> = factorize_info
+            .diagnostics()
             .iter()
             .filter(|d| d.is_error())
             .map(|d| d.message.clone())

--- a/crates/rspack_core/src/dependency/factorize_info.rs
+++ b/crates/rspack_core/src/dependency/factorize_info.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use rspack_cacheable::cacheable;
 use rspack_error::Diagnostic;
 use rspack_paths::ArcPathSet;
@@ -8,16 +6,12 @@ use super::{BoxDependency, DependencyId};
 
 #[cacheable]
 #[derive(Debug, Clone, Default)]
-pub enum FactorizeInfo {
-  #[default]
-  Success,
-  Failed {
-    related_dep_ids: Vec<DependencyId>,
-    file_dependencies: ArcPathSet,
-    context_dependencies: ArcPathSet,
-    missing_dependencies: ArcPathSet,
-    diagnostics: Vec<Diagnostic>,
-  },
+pub struct FactorizeInfo {
+  related_dep_ids: Vec<DependencyId>,
+  file_dependencies: ArcPathSet,
+  context_dependencies: ArcPathSet,
+  missing_dependencies: ArcPathSet,
+  diagnostics: Vec<Diagnostic>,
 }
 
 impl FactorizeInfo {
@@ -28,16 +22,12 @@ impl FactorizeInfo {
     context_dependencies: ArcPathSet,
     missing_dependencies: ArcPathSet,
   ) -> Self {
-    if diagnostics.is_empty() {
-      Self::Success
-    } else {
-      Self::Failed {
-        related_dep_ids,
-        file_dependencies,
-        context_dependencies,
-        missing_dependencies,
-        diagnostics,
-      }
+    Self {
+      related_dep_ids,
+      file_dependencies,
+      context_dependencies,
+      missing_dependencies,
+      diagnostics,
     }
   }
 
@@ -52,51 +42,26 @@ impl FactorizeInfo {
   }
 
   pub fn is_success(&self) -> bool {
-    matches!(self, FactorizeInfo::Success)
+    self.diagnostics.is_empty()
   }
 
-  pub fn related_dep_ids(&self) -> Cow<'_, [DependencyId]> {
-    match &self {
-      Self::Success => Cow::Owned(vec![]),
-      Self::Failed {
-        related_dep_ids, ..
-      } => Cow::Borrowed(related_dep_ids),
-    }
+  pub fn related_dep_ids(&self) -> &[DependencyId] {
+    &self.related_dep_ids
   }
 
-  pub fn file_dependencies(&self) -> Cow<'_, ArcPathSet> {
-    match &self {
-      Self::Success => Cow::Owned(Default::default()),
-      Self::Failed {
-        file_dependencies, ..
-      } => Cow::Borrowed(file_dependencies),
-    }
+  pub fn file_dependencies(&self) -> &ArcPathSet {
+    &self.file_dependencies
   }
 
-  pub fn context_dependencies(&self) -> Cow<'_, ArcPathSet> {
-    match &self {
-      Self::Success => Cow::Owned(Default::default()),
-      Self::Failed {
-        context_dependencies,
-        ..
-      } => Cow::Borrowed(context_dependencies),
-    }
+  pub fn context_dependencies(&self) -> &ArcPathSet {
+    &self.context_dependencies
   }
 
-  pub fn missing_dependencies(&self) -> Cow<'_, ArcPathSet> {
-    match &self {
-      Self::Success => Cow::Owned(Default::default()),
-      Self::Failed {
-        missing_dependencies,
-        ..
-      } => Cow::Borrowed(missing_dependencies),
-    }
+  pub fn missing_dependencies(&self) -> &ArcPathSet {
+    &self.missing_dependencies
   }
 
-  pub fn diagnostics(&self) -> Cow<'_, [Diagnostic]> {
-    match &self {
-      Self::Success => Cow::Owned(vec![]),
-      Self::Failed { diagnostics, .. } => Cow::Borrowed(diagnostics),
-    }
+  pub fn diagnostics(&self) -> &[Diagnostic] {
+    &self.diagnostics
   }
 }

--- a/crates/rspack_core/src/dependency/factorize_info.rs
+++ b/crates/rspack_core/src/dependency/factorize_info.rs
@@ -41,6 +41,16 @@ impl FactorizeInfo {
     }
   }
 
+  pub fn revoke(dep: &mut BoxDependency) -> Option<FactorizeInfo> {
+    if let Some(d) = dep.as_context_dependency_mut() {
+      Some(std::mem::take(d.factorize_info_mut()))
+    } else if let Some(d) = dep.as_module_dependency_mut() {
+      Some(std::mem::take(d.factorize_info_mut()))
+    } else {
+      None
+    }
+  }
+
   pub fn is_success(&self) -> bool {
     self.diagnostics.is_empty()
   }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -478,8 +478,6 @@ impl NormalModuleFactory {
       resource_data.resource().to_owned()
     };
 
-    let file_dependency = resource_data.path().map(|p| p.to_owned());
-
     let resolved_module_type =
       self.calculate_module_type(match_module_type, &resolved_module_rules);
     let resolved_module_layer =
@@ -586,9 +584,6 @@ impl NormalModuleFactory {
       .call(data, &mut create_data, &mut module)
       .await?;
 
-    if let Some(file_dependency) = file_dependency {
-      data.add_file_dependency(file_dependency.into_std_path_buf());
-    }
     data.add_file_dependencies(file_dependencies);
     data.add_missing_dependencies(missing_dependencies);
 

--- a/tests/rspack-test/configCases/context/missing-dependency/rspack.config.js
+++ b/tests/rspack-test/configCases/context/missing-dependency/rspack.config.js
@@ -6,9 +6,9 @@ module.exports = {
 		{
 			apply(compiler) {
 				compiler.hooks.done.tap("DonePlugin", stats => {
-					expect(Array.from(stats.compilation.missingDependencies)).toEqual([
+					expect(Array.from(stats.compilation.missingDependencies)).toContain(
 						path.resolve(__dirname, "./lang")
-					]);
+					);
 				});
 			}
 		}

--- a/tests/rspack-test/watchCases/resolve/alias/0/a.js
+++ b/tests/rspack-test/watchCases/resolve/alias/0/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/tests/rspack-test/watchCases/resolve/alias/0/index.js
+++ b/tests/rspack-test/watchCases/resolve/alias/0/index.js
@@ -1,0 +1,19 @@
+import result from 'multi-alias';
+
+it('should update alias resolution when a higher-priority file is created in watch mode', () => {
+    switch (WATCH_STEP) {
+        case "0":
+            // Initial build:
+            // `b.js` does not exist, so it should fall back to `a.js`.
+            expect(result).toBe("a")
+            break;
+        case "1":
+            // After update (b.js is created):
+            // `b.js` now exists and has higher priority in the alias array.
+            // The build should now resolve to `b.js`.
+            expect(result).toBe("b")
+            break;
+        default:
+            throw new Error('unexpected update');
+    }
+})

--- a/tests/rspack-test/watchCases/resolve/alias/1/b.js
+++ b/tests/rspack-test/watchCases/resolve/alias/1/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/tests/rspack-test/watchCases/resolve/alias/rspack.config.js
+++ b/tests/rspack-test/watchCases/resolve/alias/rspack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+    resolve: {
+        alias: {
+            "multi-alias": [
+                "./b",
+                "./a"
+            ]
+        }
+    }
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR enhances alias resolution in watch mode by ensuring that successful factorizations track missing dependencies. This allows the bundler to properly re-resolve and update module paths when higher-priority alias files or new resolution-relevant files (such as `package.json`) are created or modified.

### Problem

In watch mode, when a user adds or modifies a file that could affect module resolution (e.g., adding a higher-priority alias file or changing `package.json` exports), the resolver should re-resolve affected dependencies to ensure correctness. Previously, the bundler did not track these resolution dependencies, leading to outdated references.

### Example

Given the alias configuration:

```js
alias: ["a.js", "b.js"]
```

Where `a.js` has higher priority than `b.js`, if a user adds `a.js` after the initial build, the bundler should update the resolution from `b.js` to `a.js`. Without tracking missing dependencies during resolution, this update did not occur.

### Implementation Details

The fix tracks **missing dependencies** during alias resolution. When a module is resolved, the resolver records any missing paths that, if created, would change the resolution outcome. This allows the watcher to trigger re-resolution when those files are added.

### Additional Cases Handled

1. Extension priority: For extensions like `['js', 'ts', 'tsx']`, if `a.ts` is added after `a.js` was resolved, the resolver will now correctly update to use `a.ts` (if `ts` has higher priority).

2. Directory index resolution: When `a/index.js` exists and `a.js` is added, the resolution updates from the index file to the higher-priority `a.js`.

3. `package.json` tracking: Adding or modifying package.json (e.g., changing `"main"` or `"exports"`) now triggers re-resolution for modules that depend on it.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
