### PR TITLE
refactor: remove expect for lazy barrel pending forwarded ids

### DIFF
--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/add.rs
@@ -88,8 +88,7 @@ impl Task<TaskContext> for AddTask {
           let pending_forwarded_ids = context
             .artifact
             .module_to_lazy_make
-            .as_pending_forwarded_ids(module_identifier)
-            .expect("should be pending if module is not in the module graph");
+            .pending_forwarded_ids(module_identifier);
           pending_forwarded_ids.append(forwarded_ids);
         }
       }


### PR DESCRIPTION
## Summary

Just reset the state to pending here to avoid the `expect()`

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
