### PR TITLE
perf: fix drop regression

### DIFF
--- a/crates/rspack_core/src/module_graph/exports_info.rs
+++ b/crates/rspack_core/src/module_graph/exports_info.rs
@@ -61,8 +61,7 @@ impl<'a> ModuleGraph<'a> {
     let Some(active_partial) = &mut self.active else {
       panic!("should have active partial");
     };
-    let old = active_partial.exports_info_map.insert(id, info);
-    rayon::spawn(move || drop(old));
+    active_partial.exports_info_map.insert(id, info);
   }
 
   pub fn active_all_exports_info(&mut self) {


### PR DESCRIPTION
## Summary

Revert async droping of exports info data that introduced in https://github.com/web-infra-dev/rspack/pull/11611 which caused performance regression in benchmark 

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
