### PR TITLE
perf: rm UkeySet and UkeyMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,6 +3720,7 @@ dependencies = [
  "indexmap",
  "rayon",
  "rspack_cacheable",
+ "rustc-hash",
  "serde",
  "ustr-fxhash",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4521,7 +4521,6 @@ name = "rspack_plugin_merge_duplicate_chunks"
 version = "0.5.3"
 dependencies = [
  "rayon",
- "rspack_collections",
  "rspack_core",
  "rspack_error",
  "rspack_hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,6 +4203,7 @@ dependencies = [
  "rspack_hook",
  "rspack_plugin_css",
  "rspack_regex",
+ "rustc-hash",
  "tokio",
  "tracing",
 ]
@@ -4510,6 +4511,7 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hook",
+ "rustc-hash",
  "tracing",
 ]
 

--- a/crates/rspack_binding_api/src/chunk.rs
+++ b/crates/rspack_binding_api/src/chunk.rs
@@ -5,9 +5,9 @@ use napi::{
   bindgen_prelude::{Object, ToNapiValue},
 };
 use napi_derive::napi;
-use rspack_collections::UkeyMap;
 use rspack_core::{Compilation, CompilationId};
 use rspack_napi::OneShotRef;
+use rustc_hash::FxHashMap;
 
 use crate::{chunk_group::ChunkGroupWrapper, compilation::entries::EntryOptionsDTO};
 
@@ -247,7 +247,7 @@ impl Chunk {
 }
 
 thread_local! {
-  static CHUNK_INSTANCE_REFS: RefCell<UkeyMap<CompilationId, UkeyMap<rspack_core::ChunkUkey, OneShotRef>>> = Default::default();
+  static CHUNK_INSTANCE_REFS: RefCell<FxHashMap<CompilationId, FxHashMap<rspack_core::ChunkUkey, OneShotRef>>> = Default::default();
 }
 
 pub struct ChunkWrapper {
@@ -289,7 +289,7 @@ impl ToNapiValue for ChunkWrapper {
         let refs = match entry {
           std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
           std::collections::hash_map::Entry::Vacant(entry) => {
-            let refs = UkeyMap::default();
+            let refs = FxHashMap::default();
             entry.insert(refs)
           }
         };

--- a/crates/rspack_binding_api/src/chunk_group.rs
+++ b/crates/rspack_binding_api/src/chunk_group.rs
@@ -2,9 +2,9 @@ use std::{cell::RefCell, ptr::NonNull};
 
 use napi::{Either, Env, JsString, bindgen_prelude::ToNapiValue};
 use napi_derive::napi;
-use rspack_collections::UkeyMap;
 use rspack_core::{Compilation, CompilationId};
 use rspack_napi::OneShotRef;
+use rustc_hash::FxHashMap;
 
 use crate::{
   chunk::ChunkWrapper,
@@ -183,7 +183,7 @@ impl ChunkGroup {
 }
 
 thread_local! {
-  static CHUNK_GROUP_INSTANCE_REFS: RefCell<UkeyMap<CompilationId, UkeyMap<rspack_core::ChunkGroupUkey, OneShotRef>>> = Default::default();
+  static CHUNK_GROUP_INSTANCE_REFS: RefCell<FxHashMap<CompilationId, FxHashMap<rspack_core::ChunkGroupUkey, OneShotRef>>> = Default::default();
 }
 
 pub struct ChunkGroupWrapper {
@@ -222,7 +222,7 @@ impl ToNapiValue for ChunkGroupWrapper {
         let refs = match entry {
           std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
           std::collections::hash_map::Entry::Vacant(entry) => {
-            let refs = UkeyMap::default();
+            let refs = FxHashMap::default();
             entry.insert(refs)
           }
         };

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -106,7 +106,6 @@ use std::{
 
 use napi::{CallContext, bindgen_prelude::*};
 pub use raw_options::{CustomPluginBuilder, register_custom_plugin};
-use rspack_collections::UkeyMap;
 use rspack_core::{
   BoxDependency, Compilation, CompilerId, EntryOptions, ModuleIdentifier, PluginExt,
 };
@@ -145,7 +144,7 @@ use crate::{
 pub const EXPECTED_RSPACK_CORE_VERSION: &str = rspack_workspace::rspack_pkg_version!();
 
 thread_local! {
-  static COMPILER_REFERENCES: RefCell<UkeyMap<CompilerId, WeakReference<JsCompiler>>> = Default::default();
+  static COMPILER_REFERENCES: RefCell<FxHashMap<CompilerId, WeakReference<JsCompiler>>> = Default::default();
 }
 
 #[js_function(1)]

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -3,7 +3,7 @@ use std::{any::TypeId, cell::RefCell, ptr::NonNull, sync::Arc};
 
 use napi::{CallContext, JsObject, JsString, JsSymbol, NapiRaw};
 use napi_derive::napi;
-use rspack_collections::{IdentifierMap, UkeyMap};
+use rspack_collections::IdentifierMap;
 use rspack_core::{
   BindingCell, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, Compilation, CompilerId,
   FactoryMeta, LibIdentOptions, Module as _, ModuleIdentifier, RuntimeModuleStage, SourceType,
@@ -14,6 +14,7 @@ use rspack_napi::{
 };
 use rspack_plugin_runtime::RuntimeModuleFromJs;
 use rspack_util::source_map::SourceMapKind;
+use rustc_hash::FxHashMap;
 
 use crate::{
   COMPILER_REFERENCES, JsCompiler,
@@ -490,7 +491,7 @@ type ModuleInstanceMutRef<'a> = Either5<
 
 type ModuleInstanceNapiRefs = IdentifierMap<ModuleInstanceNapiRef>;
 
-type ModuleInstanceNapiRefsByCompilerId = RefCell<UkeyMap<CompilerId, ModuleInstanceNapiRefs>>;
+type ModuleInstanceNapiRefsByCompilerId = RefCell<FxHashMap<CompilerId, ModuleInstanceNapiRefs>>;
 
 thread_local! {
   static MODULE_INSTANCE_REFS: ModuleInstanceNapiRefsByCompilerId = Default::default();

--- a/crates/rspack_binding_api/src/module_graph_connection.rs
+++ b/crates/rspack_binding_api/src/module_graph_connection.rs
@@ -2,9 +2,9 @@ use std::{cell::RefCell, ptr::NonNull};
 
 use napi::bindgen_prelude::ToNapiValue;
 use napi_derive::napi;
-use rspack_collections::UkeyMap;
 use rspack_core::{Compilation, CompilationId, DependencyId, ModuleGraph};
 use rspack_napi::OneShotRef;
+use rustc_hash::FxHashMap;
 
 use crate::{dependency::DependencyWrapper, module::ModuleObject};
 
@@ -89,10 +89,10 @@ impl ModuleGraphConnection {
   }
 }
 
-type ModuleGraphConnectionRefs = UkeyMap<DependencyId, OneShotRef>;
+type ModuleGraphConnectionRefs = FxHashMap<DependencyId, OneShotRef>;
 
 type ModuleGraphConnectionRefsByCompilationId =
-  RefCell<UkeyMap<CompilationId, ModuleGraphConnectionRefs>>;
+  RefCell<FxHashMap<CompilationId, ModuleGraphConnectionRefs>>;
 
 thread_local! {
   static MODULE_GRAPH_CONNECTION_INSTANCE_REFS: ModuleGraphConnectionRefsByCompilationId = Default::default();
@@ -134,7 +134,7 @@ impl ToNapiValue for ModuleGraphConnectionWrapper {
         let refs = match entry {
           std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
           std::collections::hash_map::Entry::Vacant(entry) => {
-            let refs = UkeyMap::default();
+            let refs = FxHashMap::default();
             entry.insert(refs)
           }
         };

--- a/crates/rspack_collections/Cargo.toml
+++ b/crates/rspack_collections/Cargo.toml
@@ -14,5 +14,6 @@ hashlink         = { workspace = true }
 indexmap         = { workspace = true }
 rayon            = { workspace = true }
 rspack_cacheable = { workspace = true }
+rustc-hash       = { workspace = true }
 serde            = { workspace = true, features = ["derive"] }
 ustr             = { workspace = true, features = ["serde"] }

--- a/crates/rspack_collections/src/ukey.rs
+++ b/crates/rspack_collections/src/ukey.rs
@@ -20,7 +20,6 @@ macro_rules! impl_item_ukey {
   };
 }
 
-pub type UkeyMap<K, V> = HashMap<K, V, BuildHasherDefault<UkeyHasher>>;
 pub type UkeyIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<UkeyHasher>>;
 pub type UkeyDashMap<K, V> = DashMap<K, V, BuildHasherDefault<UkeyHasher>>;
 

--- a/crates/rspack_collections/src/ukey.rs
+++ b/crates/rspack_collections/src/ukey.rs
@@ -4,7 +4,6 @@ use std::{
   hash::{BuildHasherDefault, Hash},
 };
 
-use dashmap::DashSet;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -18,8 +17,6 @@ macro_rules! impl_item_ukey {
     }
   };
 }
-
-pub type UkeyDashSet<K> = DashSet<K, BuildHasherDefault<UkeyHasher>>;
 
 pub trait ItemUkey {
   fn ukey(&self) -> Ukey;

--- a/crates/rspack_collections/src/ukey.rs
+++ b/crates/rspack_collections/src/ukey.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use dashmap::DashSet;
-use indexmap::IndexSet;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -20,7 +19,6 @@ macro_rules! impl_item_ukey {
   };
 }
 
-pub type UkeyIndexSet<K> = IndexSet<K, BuildHasherDefault<UkeyHasher>>;
 pub type UkeyDashSet<K> = DashSet<K, BuildHasherDefault<UkeyHasher>>;
 
 pub trait ItemUkey {

--- a/crates/rspack_collections/src/ukey.rs
+++ b/crates/rspack_collections/src/ukey.rs
@@ -1,10 +1,7 @@
-use std::{
-  collections::HashMap,
-  fmt::Debug,
-  hash::{BuildHasherDefault, Hash},
-};
+use std::{fmt::Debug, hash::Hash};
 
 use rayon::prelude::*;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 #[macro_export]
@@ -49,23 +46,6 @@ impl From<Ukey> for u32 {
   }
 }
 
-#[derive(Copy, Clone, Debug, Default)]
-pub struct UkeyHasher(u32);
-
-impl std::hash::Hasher for UkeyHasher {
-  fn write(&mut self, _bytes: &[u8]) {
-    unimplemented!("UkeyHasher should only used for UKey")
-  }
-
-  fn write_u32(&mut self, i: u32) {
-    self.0 = i;
-  }
-
-  fn finish(&self) -> u64 {
-    self.0 as u64
-  }
-}
-
 pub trait DatabaseItem
 where
   Self: Sized,
@@ -75,7 +55,7 @@ where
 }
 
 pub struct Database<Item: DatabaseItem> {
-  inner: HashMap<<Item as DatabaseItem>::ItemUkey, Item, BuildHasherDefault<UkeyHasher>>,
+  inner: FxHashMap<<Item as DatabaseItem>::ItemUkey, Item>,
 }
 
 impl<Item: DatabaseItem> Debug for Database<Item> {

--- a/crates/rspack_collections/src/ukey.rs
+++ b/crates/rspack_collections/src/ukey.rs
@@ -1,5 +1,5 @@
 use std::{
-  collections::{HashMap, HashSet},
+  collections::HashMap,
   fmt::Debug,
   hash::{BuildHasherDefault, Hash},
 };
@@ -23,7 +23,6 @@ macro_rules! impl_item_ukey {
 pub type UkeyIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<UkeyHasher>>;
 pub type UkeyDashMap<K, V> = DashMap<K, V, BuildHasherDefault<UkeyHasher>>;
 
-pub type UkeySet<K> = HashSet<K, BuildHasherDefault<UkeyHasher>>;
 pub type UkeyIndexSet<K> = IndexSet<K, BuildHasherDefault<UkeyHasher>>;
 pub type UkeyDashSet<K> = DashSet<K, BuildHasherDefault<UkeyHasher>>;
 

--- a/crates/rspack_collections/src/ukey.rs
+++ b/crates/rspack_collections/src/ukey.rs
@@ -4,8 +4,8 @@ use std::{
   hash::{BuildHasherDefault, Hash},
 };
 
-use dashmap::{DashMap, DashSet};
-use indexmap::{IndexMap, IndexSet};
+use dashmap::DashSet;
+use indexmap::IndexSet;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -19,9 +19,6 @@ macro_rules! impl_item_ukey {
     }
   };
 }
-
-pub type UkeyIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<UkeyHasher>>;
-pub type UkeyDashMap<K, V> = DashMap<K, V, BuildHasherDefault<UkeyHasher>>;
 
 pub type UkeyIndexSet<K> = IndexSet<K, BuildHasherDefault<UkeyHasher>>;
 pub type UkeyDashSet<K> = DashSet<K, BuildHasherDefault<UkeyHasher>>;

--- a/crates/rspack_core/src/artifacts/chunk_hashes_artifact.rs
+++ b/crates/rspack_core/src/artifacts/chunk_hashes_artifact.rs
@@ -1,10 +1,10 @@
-use rspack_collections::UkeyMap;
+use rustc_hash::FxHashMap;
 
 use crate::{ChunkHashesResult, ChunkUkey};
 
 #[derive(Debug, Default)]
 pub struct ChunkHashesArtifact {
-  chunk_to_hashes: UkeyMap<ChunkUkey, ChunkHashesResult>,
+  chunk_to_hashes: FxHashMap<ChunkUkey, ChunkHashesResult>,
 }
 
 impl ChunkHashesArtifact {

--- a/crates/rspack_core/src/artifacts/mod.rs
+++ b/crates/rspack_core/src/artifacts/mod.rs
@@ -1,5 +1,6 @@
-use rspack_collections::{IdentifierMap, IdentifierSet, UkeyMap};
+use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_error::Diagnostic;
+use rustc_hash::FxHashMap;
 
 use crate::{ChunkRenderResult, ChunkUkey, ModuleId, RuntimeGlobals, chunk_graph_chunk::ChunkId};
 
@@ -24,6 +25,6 @@ pub use side_effects_do_optimize_artifact::*;
 pub type AsyncModulesArtifact = IdentifierSet;
 pub type DependenciesDiagnosticsArtifact = IdentifierMap<Vec<Diagnostic>>;
 pub type ModuleIdsArtifact = IdentifierMap<ModuleId>;
-pub type ChunkIdsArtifact = UkeyMap<ChunkUkey, ChunkId>;
-pub type CgcRuntimeRequirementsArtifact = UkeyMap<ChunkUkey, RuntimeGlobals>;
-pub type ChunkRenderArtifact = UkeyMap<ChunkUkey, ChunkRenderResult>;
+pub type ChunkIdsArtifact = FxHashMap<ChunkUkey, ChunkId>;
+pub type CgcRuntimeRequirementsArtifact = FxHashMap<ChunkUkey, RuntimeGlobals>;
+pub type ChunkRenderArtifact = FxHashMap<ChunkUkey, ChunkRenderResult>;

--- a/crates/rspack_core/src/artifacts/side_effects_do_optimize_artifact.rs
+++ b/crates/rspack_core/src/artifacts/side_effects_do_optimize_artifact.rs
@@ -1,5 +1,5 @@
-use rspack_collections::UkeyMap;
 use rspack_util::atom::Atom;
+use rustc_hash::FxHashMap;
 
 use crate::{DependencyId, ExportInfo, ModuleIdentifier};
 
@@ -16,4 +16,4 @@ pub struct SideEffectsDoOptimizeMoveTarget {
   pub target_export: Option<Vec<Atom>>,
 }
 
-pub type SideEffectsOptimizeArtifact = UkeyMap<DependencyId, Option<SideEffectsDoOptimize>>;
+pub type SideEffectsOptimizeArtifact = FxHashMap<DependencyId, Option<SideEffectsDoOptimize>>;

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -10,7 +10,7 @@ use num_bigint::BigUint;
 use rayon::prelude::*;
 use rspack_collections::{
   Database, DatabaseItem, IdentifierHasher, IdentifierIndexSet, IdentifierMap, IdentifierSet, Ukey,
-  UkeyIndexMap, UkeyIndexSet, UkeyMap, UkeySet, impl_item_ukey,
+  UkeyIndexMap, UkeyIndexSet, UkeySet, impl_item_ukey,
 };
 use rspack_error::{Diagnostic, Error, Result, error};
 use rspack_util::itoa;
@@ -106,7 +106,7 @@ impl ChunkGroupInfo {
   fn calculate_resulting_available_modules(
     &mut self,
     chunk_group: &ChunkGroup,
-    mask_by_chunk: &UkeyMap<ChunkUkey, BigUint>,
+    mask_by_chunk: &HashMap<ChunkUkey, BigUint>,
   ) {
     if self.resulting_available_modules.is_some() {
       return;
@@ -226,10 +226,10 @@ pub(crate) type BlockModulesRuntimeMap = HashMap<Option<Arc<RuntimeSpec>>, Block
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CodeSplitter {
-  pub(crate) chunk_group_info_map: UkeyMap<ChunkGroupUkey, CgiUkey>,
+  pub(crate) chunk_group_info_map: HashMap<ChunkGroupUkey, CgiUkey>,
   pub(crate) chunk_group_infos: Database<ChunkGroupInfo>,
   outdated_order_index_chunk_groups: HashSet<CgiUkey>,
-  pub(crate) incoming_blocks_by_cgi: UkeyMap<CgiUkey, HashSet<DependenciesBlockIdentifier>>,
+  pub(crate) incoming_blocks_by_cgi: HashMap<CgiUkey, HashSet<DependenciesBlockIdentifier>>,
   pub(crate) runtime_chunks: UkeySet<ChunkUkey>,
   next_free_module_pre_order_index: u32,
   next_free_module_post_order_index: u32,
@@ -250,7 +250,7 @@ pub(crate) struct CodeSplitter {
   pub(crate) named_async_entrypoints: HashMap<String, CgiUkey>,
   pub(crate) block_modules_runtime_map: BlockModulesRuntimeMap,
   pub(crate) ordinal_by_module: IdentifierMap<u64>,
-  pub(crate) mask_by_chunk: UkeyMap<ChunkUkey, BigUint>,
+  pub(crate) mask_by_chunk: HashMap<ChunkUkey, BigUint>,
 
   stat_processed_queue_items: u32,
   stat_processed_blocks: u32,

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -10,10 +10,10 @@ use num_bigint::BigUint;
 use rayon::prelude::*;
 use rspack_collections::{
   Database, DatabaseItem, IdentifierHasher, IdentifierIndexSet, IdentifierMap, IdentifierSet, Ukey,
-  UkeyIndexMap, UkeyIndexSet, impl_item_ukey,
+  UkeyIndexSet, impl_item_ukey,
 };
 use rspack_error::{Diagnostic, Error, Result, error};
-use rspack_util::itoa;
+use rspack_util::{fx_hash::FxIndexMap, itoa};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 
 use super::incremental::ChunkCreateData;
@@ -236,7 +236,7 @@ pub(crate) struct CodeSplitter {
   next_chunk_group_index: u32,
   queue: Vec<QueueAction>,
   queue_delayed: Vec<QueueAction>,
-  queue_connect: UkeyIndexMap<CgiUkey, IndexSet<(CgiUkey, Option<ProcessBlock>)>>,
+  queue_connect: FxIndexMap<CgiUkey, IndexSet<(CgiUkey, Option<ProcessBlock>)>>,
   chunk_groups_for_combining: UkeyIndexSet<CgiUkey>,
   pub(crate) outdated_chunk_group_info: UkeyIndexSet<CgiUkey>,
   chunk_groups_for_merging: IndexSet<(CgiUkey, Option<ProcessBlock>)>,
@@ -669,9 +669,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     &mut self,
     all_modules: &Vec<ModuleIdentifier>,
     compilation: &mut Compilation,
-  ) -> Result<UkeyIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>>> {
-    let mut input_entrypoints_and_modules: UkeyIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>> =
-      UkeyIndexMap::default();
+  ) -> Result<FxIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>>> {
+    let mut input_entrypoints_and_modules: FxIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>> =
+      FxIndexMap::default();
 
     let entries = compilation.entries.keys().cloned().collect::<Vec<_>>();
 
@@ -724,7 +724,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
   pub fn prepare_entries(
     &mut self,
-    input_entrypoints_and_modules: UkeyIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>>,
+    input_entrypoints_and_modules: FxIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>>,
     compilation: &mut Compilation,
   ) -> Result<()> {
     let logger = compilation.get_logger("rspack.buildChunkGraph");

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -10,7 +10,7 @@ use num_bigint::BigUint;
 use rayon::prelude::*;
 use rspack_collections::{
   Database, DatabaseItem, IdentifierHasher, IdentifierIndexSet, IdentifierMap, IdentifierSet, Ukey,
-  UkeyIndexMap, UkeyIndexSet, UkeySet, impl_item_ukey,
+  UkeyIndexMap, UkeyIndexSet, impl_item_ukey,
 };
 use rspack_error::{Diagnostic, Error, Result, error};
 use rspack_util::itoa;
@@ -230,7 +230,7 @@ pub(crate) struct CodeSplitter {
   pub(crate) chunk_group_infos: Database<ChunkGroupInfo>,
   outdated_order_index_chunk_groups: HashSet<CgiUkey>,
   pub(crate) incoming_blocks_by_cgi: HashMap<CgiUkey, HashSet<DependenciesBlockIdentifier>>,
-  pub(crate) runtime_chunks: UkeySet<ChunkUkey>,
+  pub(crate) runtime_chunks: HashSet<ChunkUkey>,
   next_free_module_pre_order_index: u32,
   next_free_module_post_order_index: u32,
   next_chunk_group_index: u32,
@@ -244,7 +244,7 @@ pub(crate) struct CodeSplitter {
 
   // outgoing blocks for a chunk group
   // 2 direction map
-  pub(crate) block_owner: HashMap<AsyncDependenciesBlockIdentifier, UkeySet<CgiUkey>>,
+  pub(crate) block_owner: HashMap<AsyncDependenciesBlockIdentifier, HashSet<CgiUkey>>,
 
   pub(crate) named_chunk_groups: HashMap<String, CgiUkey>,
   pub(crate) named_async_entrypoints: HashMap<String, CgiUkey>,

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -10,10 +10,13 @@ use num_bigint::BigUint;
 use rayon::prelude::*;
 use rspack_collections::{
   Database, DatabaseItem, IdentifierHasher, IdentifierIndexSet, IdentifierMap, IdentifierSet, Ukey,
-  UkeyIndexSet, impl_item_ukey,
+  impl_item_ukey,
 };
 use rspack_error::{Diagnostic, Error, Result, error};
-use rspack_util::{fx_hash::FxIndexMap, itoa};
+use rspack_util::{
+  fx_hash::{FxIndexMap, FxIndexSet},
+  itoa,
+};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 
 use super::incremental::ChunkCreateData;
@@ -54,11 +57,11 @@ pub struct ChunkGroupInfo {
   pub skipped_items: IdentifierIndexSet,
   pub skipped_module_connections: IndexSet<(ModuleIdentifier, Vec<DependencyId>)>,
   // set of children chunk groups, that will be revisited when available_modules shrink
-  pub children: UkeyIndexSet<CgiUkey>,
+  pub children: FxIndexSet<CgiUkey>,
   // set of chunk groups that are the source for min_available_modules
-  pub available_sources: UkeyIndexSet<CgiUkey>,
+  pub available_sources: FxIndexSet<CgiUkey>,
   // set of chunk groups which depend on the this chunk group as available_source
-  pub available_children: UkeyIndexSet<CgiUkey>,
+  pub available_children: FxIndexSet<CgiUkey>,
 
   // set of modules available including modules from this chunk group
   // A derived attribute, therefore utilizing interior mutability to manage updates
@@ -237,8 +240,8 @@ pub(crate) struct CodeSplitter {
   queue: Vec<QueueAction>,
   queue_delayed: Vec<QueueAction>,
   queue_connect: FxIndexMap<CgiUkey, IndexSet<(CgiUkey, Option<ProcessBlock>)>>,
-  chunk_groups_for_combining: UkeyIndexSet<CgiUkey>,
-  pub(crate) outdated_chunk_group_info: UkeyIndexSet<CgiUkey>,
+  chunk_groups_for_combining: FxIndexSet<CgiUkey>,
+  pub(crate) outdated_chunk_group_info: FxIndexSet<CgiUkey>,
   chunk_groups_for_merging: IndexSet<(CgiUkey, Option<ProcessBlock>)>,
   pub(crate) block_to_chunk_group: HashMap<DependenciesBlockIdentifier, CgiUkey>,
 

--- a/crates/rspack_core/src/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/build_chunk_graph/incremental.rs
@@ -1,10 +1,9 @@
 use std::{collections::HashSet, hash::BuildHasherDefault, sync::Arc};
 
 use num_bigint::BigUint;
-use rspack_collections::{
-  IdentifierHasher, IdentifierIndexSet, IdentifierMap, IdentifierSet, UkeySet,
-};
+use rspack_collections::{IdentifierHasher, IdentifierIndexSet, IdentifierMap, IdentifierSet};
 use rspack_error::Result;
+use rustc_hash::FxHashSet;
 use tracing::instrument;
 
 use super::code_splitter::{CgiUkey, CodeSplitter, DependenciesBlockIdentifier};
@@ -78,7 +77,7 @@ impl CodeSplitter {
         let chunk = compilation.chunk_by_ukey.expect_get(chunk);
         chunk.groups().clone()
       })
-      .collect::<UkeySet<ChunkGroupUkey>>();
+      .collect::<FxHashSet<ChunkGroupUkey>>();
 
     chunk_graph.remove_module(module);
 
@@ -298,7 +297,7 @@ impl CodeSplitter {
     modules: impl Iterator<Item = ModuleIdentifier>,
   ) -> HashSet<AsyncDependenciesBlockIdentifier, BuildHasherDefault<IdentifierHasher>> {
     let chunk_graph: &crate::ChunkGraph = &compilation.chunk_graph;
-    let mut chunk_groups = UkeySet::default();
+    let mut chunk_groups = FxHashSet::default();
     let mut removed: HashSet<
       AsyncDependenciesBlockIdentifier,
       BuildHasherDefault<IdentifierHasher>,
@@ -518,7 +517,7 @@ impl CodeSplitter {
         .copied(),
     );
 
-    let mut removed_entries = UkeySet::default();
+    let mut removed_entries = FxHashSet::default();
     for (name, chunk_group) in compilation.entrypoints() {
       if !compilation.entries.contains_key(name) {
         removed_entries.insert(*chunk_group);

--- a/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/new_code_splitter.rs
@@ -9,7 +9,7 @@ use indexmap::IndexSet;
 use rayon::prelude::*;
 use rspack_collections::{
   DatabaseItem, IdentifierDashMap, IdentifierHasher, IdentifierIndexMap, IdentifierIndexSet,
-  IdentifierMap, IdentifierSet, Ukey, UkeyMap,
+  IdentifierMap, IdentifierSet, Ukey,
 };
 use rspack_error::{Diagnostic, Result, error};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -54,7 +54,7 @@ pub struct CacheableChunkItem {
 #[derive(Debug, Default)]
 pub struct CodeSplitter {
   cache_chunk_desc: HashMap<CreateChunkRoot, Vec<CacheableChunkItem>>,
-  cache_chunks: UkeyMap<CacheUkey, Chunk>,
+  cache_chunks: HashMap<CacheUkey, Chunk>,
   pub module_deps: ModuleDeps,
   pub module_ordinal: IdentifierMap<u64>,
 }
@@ -916,7 +916,7 @@ impl CodeSplitter {
 
     let mut pre_order_indices = IdentifierMap::default();
     let mut post_order_indices = IdentifierMap::default();
-    let mut chunk_group_indices = UkeyMap::default();
+    let mut chunk_group_indices = HashMap::default();
 
     let global_deps = compilation.global_entry.dependencies.iter();
     let global_included_deps = compilation.global_entry.include_dependencies.iter();

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -7,7 +7,7 @@ use std::{
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rayon::prelude::*;
-use rspack_collections::{DatabaseItem, IdentifierSet, UkeyIndexMap, UkeyIndexSet, UkeySet};
+use rspack_collections::{DatabaseItem, IdentifierSet, UkeyIndexMap, UkeyIndexSet};
 use rspack_error::Diagnostic;
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
@@ -65,7 +65,7 @@ pub struct Chunk {
   filename_template: Option<Filename>,
   css_filename_template: Option<Filename>,
   prevent_integration: bool,
-  groups: UkeySet<ChunkGroupUkey>,
+  groups: HashSet<ChunkGroupUkey>,
   runtime: RuntimeSpec,
   files: HashSet<String>,
   auxiliary_files: HashSet<String>,
@@ -141,7 +141,7 @@ impl Chunk {
     self.id_name_hints.insert(hint);
   }
 
-  pub fn groups(&self) -> &UkeySet<ChunkGroupUkey> {
+  pub fn groups(&self) -> &HashSet<ChunkGroupUkey> {
     &self.groups
   }
 
@@ -356,13 +356,13 @@ impl Chunk {
     chunk_group_by_ukey: &ChunkGroupByUkey,
   ) -> UkeyIndexSet<ChunkUkey> {
     let mut chunks = UkeyIndexSet::default();
-    let mut visit_chunk_groups = UkeySet::default();
+    let mut visit_chunk_groups = HashSet::default();
 
     fn add_chunks(
       chunk_group_ukey: &ChunkGroupUkey,
       chunks: &mut UkeyIndexSet<ChunkUkey>,
       chunk_group_by_ukey: &ChunkGroupByUkey,
-      visit_chunk_groups: &mut UkeySet<ChunkGroupUkey>,
+      visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
       let group = chunk_group_by_ukey.expect_get(chunk_group_ukey);
 
@@ -400,13 +400,13 @@ impl Chunk {
     chunk_group_by_ukey: &ChunkGroupByUkey,
   ) -> UkeyIndexSet<ChunkUkey> {
     let mut chunks = UkeyIndexSet::default();
-    let mut visit_chunk_groups = UkeySet::default();
+    let mut visit_chunk_groups = HashSet::default();
 
     fn add_chunks(
       chunk_group_ukey: &ChunkGroupUkey,
       chunks: &mut UkeyIndexSet<ChunkUkey>,
       chunk_group_by_ukey: &ChunkGroupByUkey,
-      visit_chunk_groups: &mut UkeySet<ChunkGroupUkey>,
+      visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
       let group = chunk_group_by_ukey.expect_get(chunk_group_ukey);
 
@@ -445,13 +445,13 @@ impl Chunk {
     chunk_group_by_ukey: &ChunkGroupByUkey,
   ) -> UkeyIndexSet<ChunkGroupUkey> {
     let mut async_entrypoints = UkeyIndexSet::default();
-    let mut visit_chunk_groups = UkeySet::default();
+    let mut visit_chunk_groups = HashSet::default();
 
     fn add_async_entrypoints(
       chunk_group_ukey: &ChunkGroupUkey,
       async_entrypoints: &mut UkeyIndexSet<ChunkGroupUkey>,
       chunk_group_by_ukey: &ChunkGroupByUkey,
-      visit_chunk_groups: &mut UkeySet<ChunkGroupUkey>,
+      visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
       let group = chunk_group_by_ukey.expect_get(chunk_group_ukey);
 
@@ -506,11 +506,11 @@ impl Chunk {
       .groups
       .iter()
       .map(|chunk_group| chunk_group_by_ukey.expect_get(chunk_group))
-      .map(|group| group.chunks.iter().copied().collect::<UkeySet<_>>())
-      .reduce(|acc, prev| acc.intersection(&prev).copied().collect::<UkeySet<_>>())
+      .map(|group| group.chunks.iter().copied().collect::<HashSet<_>>())
+      .reduce(|acc, prev| acc.intersection(&prev).copied().collect::<HashSet<_>>())
       .unwrap_or_default();
 
-    let mut visit_chunk_groups = UkeySet::default();
+    let mut visit_chunk_groups = HashSet::default();
 
     for chunk_group_ukey in self.get_sorted_groups_iter(chunk_group_by_ukey) {
       if let Some(chunk_group) = chunk_group_by_ukey.get(chunk_group_ukey) {
@@ -528,9 +528,9 @@ impl Chunk {
 
     fn check_chunks(
       chunk_group_by_ukey: &ChunkGroupByUkey,
-      initial_chunks: &UkeySet<ChunkUkey>,
+      initial_chunks: &HashSet<ChunkUkey>,
       chunk_group_ukey: &ChunkGroupUkey,
-      visit_chunk_groups: &mut UkeySet<ChunkGroupUkey>,
+      visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) -> bool {
       let Some(chunk_group) = chunk_group_by_ukey.get(chunk_group_ukey) else {
         return false;
@@ -581,8 +581,8 @@ impl Chunk {
       .groups
       .iter()
       .map(|chunk_group| chunk_group_by_ukey.expect_get(chunk_group))
-      .map(|group| group.chunks.iter().copied().collect::<UkeySet<_>>())
-      .reduce(|acc, prev| acc.intersection(&prev).copied().collect::<UkeySet<_>>())
+      .map(|group| group.chunks.iter().copied().collect::<HashSet<_>>())
+      .reduce(|acc, prev| acc.intersection(&prev).copied().collect::<HashSet<_>>())
       .unwrap_or_default();
 
     let mut initial_queue = self
@@ -590,7 +590,7 @@ impl Chunk {
       .map(|c| c.to_owned())
       .collect::<UkeyIndexSet<ChunkGroupUkey>>();
 
-    let mut visit_chunk_groups = UkeySet::default();
+    let mut visit_chunk_groups = HashSet::default();
 
     fn add_to_queue(
       chunk_group_by_ukey: &ChunkGroupByUkey,
@@ -628,9 +628,9 @@ impl Chunk {
     fn add_chunks(
       chunk_group_by_ukey: &ChunkGroupByUkey,
       chunks: &mut UkeyIndexSet<ChunkUkey>,
-      initial_chunks: &UkeySet<ChunkUkey>,
+      initial_chunks: &HashSet<ChunkUkey>,
       chunk_group_ukey: &ChunkGroupUkey,
-      visit_chunk_groups: &mut UkeySet<ChunkGroupUkey>,
+      visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
       if let Some(chunk_group) = chunk_group_by_ukey.get(chunk_group_ukey) {
         for chunk_ukey in chunk_group.chunks.iter() {

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -7,9 +7,10 @@ use std::{
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rayon::prelude::*;
-use rspack_collections::{DatabaseItem, IdentifierSet, UkeyIndexMap, UkeyIndexSet};
+use rspack_collections::{DatabaseItem, IdentifierSet, UkeyIndexSet};
 use rspack_error::Diagnostic;
 use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_util::fx_hash::FxIndexMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 
 use crate::{
@@ -784,7 +785,7 @@ impl Chunk {
       }
     });
 
-    let mut result: UkeyIndexMap<ChunkGroupUkey, UkeyIndexSet<ChunkUkey>> = UkeyIndexMap::default();
+    let mut result: FxIndexMap<ChunkGroupUkey, UkeyIndexSet<ChunkUkey>> = FxIndexMap::default();
     for (_, group_ukey, child_group_ukey) in list.iter() {
       let child_group = chunk_group_by_ukey.expect_get(child_group_ukey);
       result

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -7,10 +7,10 @@ use std::{
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rayon::prelude::*;
-use rspack_collections::{DatabaseItem, IdentifierSet, UkeyIndexSet};
+use rspack_collections::{DatabaseItem, IdentifierSet};
 use rspack_error::Diagnostic;
 use rspack_hash::{RspackHash, RspackHashDigest};
-use rspack_util::fx_hash::FxIndexMap;
+use rspack_util::fx_hash::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 
 use crate::{
@@ -355,13 +355,13 @@ impl Chunk {
   pub fn get_all_referenced_chunks(
     &self,
     chunk_group_by_ukey: &ChunkGroupByUkey,
-  ) -> UkeyIndexSet<ChunkUkey> {
-    let mut chunks = UkeyIndexSet::default();
+  ) -> FxIndexSet<ChunkUkey> {
+    let mut chunks = FxIndexSet::default();
     let mut visit_chunk_groups = HashSet::default();
 
     fn add_chunks(
       chunk_group_ukey: &ChunkGroupUkey,
-      chunks: &mut UkeyIndexSet<ChunkUkey>,
+      chunks: &mut FxIndexSet<ChunkUkey>,
       chunk_group_by_ukey: &ChunkGroupByUkey,
       visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
@@ -399,13 +399,13 @@ impl Chunk {
   pub fn get_all_initial_chunks(
     &self,
     chunk_group_by_ukey: &ChunkGroupByUkey,
-  ) -> UkeyIndexSet<ChunkUkey> {
-    let mut chunks = UkeyIndexSet::default();
+  ) -> FxIndexSet<ChunkUkey> {
+    let mut chunks = FxIndexSet::default();
     let mut visit_chunk_groups = HashSet::default();
 
     fn add_chunks(
       chunk_group_ukey: &ChunkGroupUkey,
-      chunks: &mut UkeyIndexSet<ChunkUkey>,
+      chunks: &mut FxIndexSet<ChunkUkey>,
       chunk_group_by_ukey: &ChunkGroupByUkey,
       visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
@@ -444,13 +444,13 @@ impl Chunk {
   pub fn get_all_referenced_async_entrypoints(
     &self,
     chunk_group_by_ukey: &ChunkGroupByUkey,
-  ) -> UkeyIndexSet<ChunkGroupUkey> {
-    let mut async_entrypoints = UkeyIndexSet::default();
+  ) -> FxIndexSet<ChunkGroupUkey> {
+    let mut async_entrypoints = FxIndexSet::default();
     let mut visit_chunk_groups = HashSet::default();
 
     fn add_async_entrypoints(
       chunk_group_ukey: &ChunkGroupUkey,
-      async_entrypoints: &mut UkeyIndexSet<ChunkGroupUkey>,
+      async_entrypoints: &mut FxIndexSet<ChunkGroupUkey>,
       chunk_group_by_ukey: &ChunkGroupByUkey,
       visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
@@ -501,7 +501,7 @@ impl Chunk {
     // is about loading the async chunks, so even the chunk is inside Entrypoint but loading it indeed need the
     // chunk loading runtime.
     // For a real case checkout the test: `rspack-test-tools/configCases/chunk-loading/depend-on-with-chunk-load`
-    let mut queue = UkeyIndexSet::default();
+    let mut queue = FxIndexSet::default();
 
     let initial_chunks = self
       .groups
@@ -574,9 +574,9 @@ impl Chunk {
   pub fn get_all_async_chunks(
     &self,
     chunk_group_by_ukey: &ChunkGroupByUkey,
-  ) -> UkeyIndexSet<ChunkUkey> {
-    let mut queue = UkeyIndexSet::default();
-    let mut chunks = UkeyIndexSet::default();
+  ) -> FxIndexSet<ChunkUkey> {
+    let mut queue = FxIndexSet::default();
+    let mut chunks = FxIndexSet::default();
 
     let initial_chunks = self
       .groups
@@ -589,14 +589,14 @@ impl Chunk {
     let mut initial_queue = self
       .get_sorted_groups_iter(chunk_group_by_ukey)
       .map(|c| c.to_owned())
-      .collect::<UkeyIndexSet<ChunkGroupUkey>>();
+      .collect::<FxIndexSet<ChunkGroupUkey>>();
 
     let mut visit_chunk_groups = HashSet::default();
 
     fn add_to_queue(
       chunk_group_by_ukey: &ChunkGroupByUkey,
-      queue: &mut UkeyIndexSet<ChunkGroupUkey>,
-      initial_queue: &mut UkeyIndexSet<ChunkGroupUkey>,
+      queue: &mut FxIndexSet<ChunkGroupUkey>,
+      initial_queue: &mut FxIndexSet<ChunkGroupUkey>,
       chunk_group_ukey: &ChunkGroupUkey,
     ) {
       if let Some(chunk_group) = chunk_group_by_ukey.get(chunk_group_ukey) {
@@ -628,7 +628,7 @@ impl Chunk {
 
     fn add_chunks(
       chunk_group_by_ukey: &ChunkGroupByUkey,
-      chunks: &mut UkeyIndexSet<ChunkUkey>,
+      chunks: &mut FxIndexSet<ChunkUkey>,
       initial_chunks: &HashSet<ChunkUkey>,
       chunk_group_ukey: &ChunkGroupUkey,
       visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
@@ -785,7 +785,7 @@ impl Chunk {
       }
     });
 
-    let mut result: FxIndexMap<ChunkGroupUkey, UkeyIndexSet<ChunkUkey>> = FxIndexMap::default();
+    let mut result: FxIndexMap<ChunkGroupUkey, FxIndexSet<ChunkUkey>> = FxIndexMap::default();
     for (_, group_ukey, child_group_ukey) in list.iter() {
       let child_group = chunk_group_by_ukey.expect_get(child_group_ukey);
       result

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -7,10 +7,10 @@ use std::{
 };
 
 use rspack_cacheable::cacheable;
-use rspack_collections::{IdentifierSet, UkeySet};
+use rspack_collections::IdentifierSet;
 use rspack_hash::RspackHashDigest;
 use rspack_util::ext::DynHash;
-use rustc_hash::FxHasher;
+use rustc_hash::{FxHashSet, FxHasher};
 use serde::{Serialize, Serializer};
 
 use crate::{
@@ -75,9 +75,9 @@ impl ModuleId {
 
 #[derive(Debug, Clone, Default)]
 pub struct ChunkGraphModule {
-  pub(super) entry_in_chunks: UkeySet<ChunkUkey>,
-  pub chunks: UkeySet<ChunkUkey>,
-  pub(super) runtime_in_chunks: UkeySet<ChunkUkey>,
+  pub(super) entry_in_chunks: FxHashSet<ChunkUkey>,
+  pub chunks: FxHashSet<ChunkUkey>,
+  pub(super) runtime_in_chunks: FxHashSet<ChunkUkey>,
 }
 
 impl ChunkGraphModule {
@@ -176,7 +176,7 @@ impl ChunkGraph {
       .get_mut(&module_identifier)
   }
 
-  pub fn get_module_chunks(&self, module_identifier: ModuleIdentifier) -> &UkeySet<ChunkUkey> {
+  pub fn get_module_chunks(&self, module_identifier: ModuleIdentifier) -> &FxHashSet<ChunkUkey> {
     let chunk_graph_module = self
       .chunk_graph_module_by_module_identifier
       .get(&module_identifier)
@@ -298,7 +298,7 @@ impl ChunkGraph {
   pub fn try_get_module_chunks(
     &self,
     module_identifier: &ModuleIdentifier,
-  ) -> Option<&UkeySet<ChunkUkey>> {
+  ) -> Option<&FxHashSet<ChunkUkey>> {
     self
       .chunk_graph_module_by_module_identifier
       .get(module_identifier)

--- a/crates/rspack_core/src/chunk_graph/mod.rs
+++ b/crates/rspack_core/src/chunk_graph/mod.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::{borrow::Cow, collections::HashSet};
 
 use itertools::Itertools;
-use rspack_collections::{IdentifierMap, UkeyMap};
+use rspack_collections::IdentifierMap;
 use rspack_util::env::has_query;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -21,7 +21,7 @@ pub struct ChunkGraph {
   pub(crate) block_to_chunk_group_ukey: HashMap<AsyncDependenciesBlockIdentifier, ChunkGroupUkey>,
 
   pub(crate) chunk_graph_module_by_module_identifier: IdentifierMap<ChunkGraphModule>,
-  chunk_graph_chunk_by_chunk_ukey: UkeyMap<ChunkUkey, ChunkGraphChunk>,
+  chunk_graph_chunk_by_chunk_ukey: HashMap<ChunkUkey, ChunkGraphChunk>,
 
   runtime_ids: HashMap<String, Option<String>>,
 }

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -6,9 +6,9 @@ use std::{
 use indexmap::IndexSet;
 use itertools::Itertools;
 use rspack_cacheable::cacheable;
-use rspack_collections::{DatabaseItem, IdentifierMap, UkeySet};
+use rspack_collections::{DatabaseItem, IdentifierMap};
 use rspack_error::{Result, error};
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 
 use crate::{
   Chunk, ChunkByUkey, ChunkGroupByUkey, ChunkGroupUkey, ChunkLoading, ChunkUkey, Compilation,
@@ -37,13 +37,13 @@ pub struct ChunkGroup {
   pub kind: ChunkGroupKind,
   pub chunks: Vec<ChunkUkey>,
   pub index: Option<u32>,
-  pub parents: UkeySet<ChunkGroupUkey>,
+  pub parents: FxHashSet<ChunkGroupUkey>,
   pub(crate) module_pre_order_indices: IdentifierMap<usize>,
   pub(crate) module_post_order_indices: IdentifierMap<usize>,
 
   // keep order for children
   pub children: IndexSet<ChunkGroupUkey>,
-  async_entrypoints: UkeySet<ChunkGroupUkey>,
+  async_entrypoints: FxHashSet<ChunkGroupUkey>,
   // ChunkGroupInfo
   pub(crate) next_pre_order_index: usize,
   pub(crate) next_post_order_index: usize,
@@ -190,9 +190,9 @@ impl ChunkGroup {
     self.async_entrypoints.iter()
   }
 
-  pub fn ancestors(&self, chunk_group_by_ukey: &ChunkGroupByUkey) -> UkeySet<ChunkGroupUkey> {
+  pub fn ancestors(&self, chunk_group_by_ukey: &ChunkGroupByUkey) -> FxHashSet<ChunkGroupUkey> {
     let mut queue = vec![];
-    let mut ancestors = UkeySet::default();
+    let mut ancestors = FxHashSet::default();
 
     queue.extend(self.parents.iter().copied());
 

--- a/crates/rspack_core/src/compilation/make/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/make/module_executor/execute.rs
@@ -1,10 +1,10 @@
 use std::{collections::VecDeque, iter::once, sync::atomic::AtomicU32};
 
 use itertools::Itertools;
-use rspack_collections::{DatabaseItem, Identifier, IdentifierSet, UkeySet};
+use rspack_collections::{DatabaseItem, Identifier, IdentifierSet};
 use rspack_error::Error;
 use rspack_paths::ArcPathSet;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 use tokio::sync::oneshot::Sender;
 
 use super::context::{ExecutorTaskContext, ImportModuleMeta};
@@ -286,8 +286,8 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
       .await?;
     compilation
       .process_chunks_runtime_requirements(
-        UkeySet::from_iter([chunk_ukey]),
-        UkeySet::from_iter([chunk_ukey]),
+        FxHashSet::from_iter([chunk_ukey]),
+        FxHashSet::from_iter([chunk_ukey]),
         compilation.plugin_driver.clone(),
       )
       .await?;

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -17,7 +17,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsOption, AsPreset},
 };
-use rspack_collections::{DatabaseItem, IdentifierDashMap, IdentifierMap, IdentifierSet, UkeySet};
+use rspack_collections::{DatabaseItem, IdentifierDashMap, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -1256,7 +1256,7 @@ impl Compilation {
       self
         .chunk_render_artifact
         .retain(|chunk, _| self.chunk_by_ukey.contains(chunk));
-      let chunks: UkeySet<ChunkUkey> = mutations
+      let chunks: HashSet<ChunkUkey> = mutations
         .iter()
         .filter_map(|mutation| match mutation {
           Mutation::ChunkSetHashes { chunk } => Some(*chunk),
@@ -2073,8 +2073,8 @@ impl Compilation {
   #[instrument(name = "Compilation:process_chunks_runtime_requirements", target=TRACING_BENCH_TARGET skip_all)]
   pub async fn process_chunks_runtime_requirements(
     &mut self,
-    chunks: UkeySet<ChunkUkey>,
-    entries: UkeySet<ChunkUkey>,
+    chunks: HashSet<ChunkUkey>,
+    entries: HashSet<ChunkUkey>,
     plugin_driver: SharedPluginDriver,
   ) -> Result<()> {
     let logger = self.get_logger("rspack.Compilation");
@@ -2240,7 +2240,7 @@ impl Compilation {
     // possible to depend on full hash, but for library type commonjs/module, it's possible to
     // have non-runtime chunks depend on full hash, the library format plugin is using
     // dependent_full_hash hook to declare it.
-    let mut full_hash_chunks = UkeySet::default();
+    let mut full_hash_chunks = HashSet::default();
     for chunk_ukey in self.chunk_by_ukey.keys() {
       let chunk_dependent_full_hash = plugin_driver
         .compilation_hooks
@@ -2314,7 +2314,7 @@ impl Compilation {
       Ok(())
     }
 
-    let unordered_runtime_chunks: UkeySet<ChunkUkey> = self.get_chunk_graph_entries().collect();
+    let unordered_runtime_chunks: HashSet<ChunkUkey> = self.get_chunk_graph_entries().collect();
     let start = logger.time("hashing: hash chunks");
     let other_chunks: Vec<_> = create_hash_chunks
       .iter()

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -17,9 +17,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsOption, AsPreset},
 };
-use rspack_collections::{
-  DatabaseItem, IdentifierDashMap, IdentifierMap, IdentifierSet, UkeyMap, UkeySet,
-};
+use rspack_collections::{DatabaseItem, IdentifierDashMap, IdentifierMap, IdentifierSet, UkeySet};
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -1302,7 +1300,7 @@ impl Compilation {
     })
     .await;
 
-    let mut chunk_render_results: UkeyMap<ChunkUkey, ChunkRenderResult> = Default::default();
+    let mut chunk_render_results: HashMap<ChunkUkey, ChunkRenderResult> = Default::default();
     for result in results {
       let item = result.to_rspack_result()?;
       let (key, value) = item?;
@@ -2098,7 +2096,7 @@ impl Compilation {
 
         (*chunk_ukey, set)
       })
-      .collect::<UkeyMap<_, _>>();
+      .collect::<HashMap<_, _>>();
 
     for (chunk_ukey, mut set) in chunk_requirements {
       plugin_driver

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use either::Either;
 use itertools::Itertools;
-use rspack_collections::UkeyMap;
 use rspack_util::{atom::Atom, ext::DynHash};
+use rustc_hash::FxHashMap;
 
 use super::{
   ExportInfoData, ExportProvided, ExportsInfo, ProvidedExports, UsageState, UsedName, UsedNameItem,
@@ -31,7 +31,7 @@ pub struct PrefetchedExportsInfoWrapper<'a> {
    * stored in a map to prevent circular references
    * When redirect, this data can be cloned to generate a new PrefetchedExportsInfoWrapper with a new entry
    */
-  exports: Arc<UkeyMap<ExportsInfo, &'a ExportsInfoData>>,
+  exports: Arc<FxHashMap<ExportsInfo, &'a ExportsInfoData>>,
   /**
    * The entry of the current exports info
    */
@@ -569,7 +569,7 @@ impl ExportsInfoGetter {
     fn prefetch_exports<'a>(
       id: &ExportsInfo,
       mg: &'a ModuleGraph,
-      res: &mut UkeyMap<ExportsInfo, &'a ExportsInfoData>,
+      res: &mut FxHashMap<ExportsInfo, &'a ExportsInfoData>,
       mode: PrefetchExportsInfoMode<'a>,
     ) {
       if res.contains_key(id) {
@@ -617,7 +617,7 @@ impl ExportsInfoGetter {
       }
     }
 
-    let mut res = UkeyMap::default();
+    let mut res = FxHashMap::default();
     prefetch_exports(id, mg, &mut res, mode.clone());
     PrefetchedExportsInfoWrapper {
       exports: Arc::new(res),
@@ -745,7 +745,7 @@ impl ExportsInfoGetter {
     let exports = exports
       .into_iter()
       .map(|e| (e, mg.get_exports_info_by_id(&e)))
-      .collect::<UkeyMap<_, _>>();
+      .collect::<FxHashMap<_, _>>();
 
     PrefetchedExportsInfoWrapper {
       exports: Arc::new(exports),

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry;
 
 use rayon::prelude::*;
-use rspack_collections::{IdentifierMap, UkeyMap};
+use rspack_collections::IdentifierMap;
 use rspack_error::Result;
 use rspack_hash::RspackHashDigest;
 use rustc_hash::FxHashMap as HashMap;
@@ -85,7 +85,7 @@ pub struct ModuleGraphPartial {
   dependency_id_to_parents: HashMap<DependencyId, Option<DependencyParents>>,
 
   // Module's ExportsInfo is also a part of ModuleGraph
-  exports_info_map: UkeyMap<ExportsInfo, ExportsInfoData>,
+  exports_info_map: HashMap<ExportsInfo, ExportsInfoData>,
   // TODO try move condition as connection field
   connection_to_condition: HashMap<DependencyId, DependencyCondition>,
   dep_meta_map: HashMap<DependencyId, DependencyExtraMeta>,

--- a/crates/rspack_core/src/utils/find_graph_roots.rs
+++ b/crates/rspack_core/src/utils/find_graph_roots.rs
@@ -2,7 +2,7 @@
 
 use std::{hash::Hash, sync::atomic::AtomicU32};
 
-use rspack_collections::{Database, DatabaseItem, ItemUkey, Ukey, UkeySet};
+use rspack_collections::{Database, DatabaseItem, ItemUkey, Ukey};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 #[allow(clippy::enum_variant_names)]
@@ -146,12 +146,12 @@ pub fn find_graph_roots<
 
   // Set of current root modules
   // items will be removed if a new reference to it has been found
-  let mut roots: UkeySet<NodeUkey<Item>> = UkeySet::default();
+  let mut roots: FxHashSet<NodeUkey<Item>> = FxHashSet::default();
 
   // Set of current cycles without references to it
   // cycles will be removed if a new reference to it has been found
   // that is not part of the cycle
-  let mut root_cycles: UkeySet<CycleUkey<NodeUkey<Item>>> = UkeySet::default();
+  let mut root_cycles: FxHashSet<CycleUkey<NodeUkey<Item>>> = FxHashSet::default();
 
   let mut keys = db.keys().copied().collect::<Vec<_>>();
   keys.sort_by(|a, b| db.expect_get(a).item.cmp(&db.expect_get(b).item));
@@ -288,7 +288,7 @@ pub fn find_graph_roots<
   for cycle in root_cycles {
     let mut max = 0;
 
-    let mut cycle_roots: UkeySet<NodeUkey<Item>> = Default::default();
+    let mut cycle_roots: FxHashSet<NodeUkey<Item>> = Default::default();
     let nodes = &cycle_db.expect_get(&cycle).nodes;
     for node in nodes.iter() {
       for dep in db.expect_get(node).dependencies.clone() {

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -1,5 +1,5 @@
 use rayon::prelude::*;
-use rspack_collections::{DatabaseItem, UkeyMap};
+use rspack_collections::DatabaseItem;
 use rspack_core::{CompilationChunkIds, Plugin, incremental::IncrementalPasses};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -72,7 +72,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
         ),
       )
     })
-    .collect::<UkeyMap<_, _>>();
+    .collect::<FxHashMap<_, _>>();
 
   let mut ordered_chunk_modules_cache = Default::default();
 

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -10,7 +10,7 @@ use itertools::{
   Itertools,
 };
 use regex::Regex;
-use rspack_collections::{DatabaseItem, UkeyMap};
+use rspack_collections::DatabaseItem;
 use rspack_core::{
   BoxModule, Chunk, ChunkGraph, ChunkGroupByUkey, ChunkUkey, Compilation, ModuleGraph,
   ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact, compare_runtime,
@@ -21,7 +21,7 @@ use rspack_util::{
   itoa,
   number_hash::get_number_hash,
 };
-use rustc_hash::{FxHashSet, FxHasher};
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 
 #[allow(clippy::type_complexity)]
 #[allow(clippy::collapsible_else_if)]
@@ -359,7 +359,7 @@ fn compare_chunks_by_modules<'a>(
   module_ids: &'a ModuleIdsArtifact,
   a: &Chunk,
   b: &Chunk,
-  ordered_chunk_modules_cache: &mut UkeyMap<ChunkUkey, Vec<Option<&'a str>>>,
+  ordered_chunk_modules_cache: &mut FxHashMap<ChunkUkey, Vec<Option<&'a str>>>,
 ) -> Ordering {
   let a_ukey = a.ukey();
   let b_ukey = b.ukey();
@@ -426,7 +426,7 @@ pub fn compare_chunks_natural<'a>(
   module_ids: &'a ModuleIdsArtifact,
   a: &Chunk,
   b: &Chunk,
-  ordered_chunk_modules_cache: &mut UkeyMap<ChunkUkey, Vec<Option<&'a str>>>,
+  ordered_chunk_modules_cache: &mut FxHashMap<ChunkUkey, Vec<Option<&'a str>>>,
 ) -> Ordering {
   let name_ordering = compare_ids(a.name().unwrap_or_default(), b.name().unwrap_or_default());
   if name_ordering != Ordering::Equal {

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -1,5 +1,5 @@
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
-use rspack_collections::{DatabaseItem, UkeyIndexSet, UkeySet};
+use rspack_collections::{DatabaseItem, UkeyIndexSet};
 use rspack_core::{
   ChunkGraph, ChunkIdsArtifact, ChunkUkey, Compilation, CompilationChunkIds, Logger, Plugin,
   chunk_graph_chunk::ChunkId,
@@ -13,7 +13,7 @@ use crate::id_helpers::{compare_chunks_natural, get_long_chunk_name, get_short_c
 
 #[tracing::instrument(skip_all)]
 fn assign_named_chunk_ids(
-  chunks: UkeySet<ChunkUkey>,
+  chunks: FxHashSet<ChunkUkey>,
   compilation: &Compilation,
   delimiter: &str,
   used_ids: &mut FxHashMap<ChunkId, ChunkUkey>,
@@ -183,7 +183,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     .mutations_read(IncrementalPasses::CHUNK_IDS)
   {
     tracing::debug!(target: incremental::TRACING_TARGET, passes = %IncrementalPasses::CHUNK_IDS, %mutations);
-    let mut affected_chunks: UkeySet<ChunkUkey> = UkeySet::default();
+    let mut affected_chunks: FxHashSet<ChunkUkey> = FxHashSet::default();
     for mutation in mutations.iter() {
       match mutation {
         Mutation::ChunkRemove { chunk } => {
@@ -200,10 +200,10 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
       .retain(|chunk, _| compilation.chunk_by_ukey.contains(chunk));
     affected_chunks
   } else {
-    UkeySet::default()
+    FxHashSet::default()
   };
 
-  let mut chunks: UkeySet<ChunkUkey> = compilation
+  let mut chunks: FxHashSet<ChunkUkey> = compilation
     .chunk_by_ukey
     .values()
     .filter(|chunk| chunk.id(&compilation.chunk_ids_artifact).is_none())

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -1,12 +1,12 @@
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
-use rspack_collections::{DatabaseItem, UkeyIndexSet};
+use rspack_collections::DatabaseItem;
 use rspack_core::{
   ChunkGraph, ChunkIdsArtifact, ChunkUkey, Compilation, CompilationChunkIds, Logger, Plugin,
   chunk_graph_chunk::ChunkId,
   incremental::{self, IncrementalPasses, Mutation, Mutations},
 };
 use rspack_hook::{plugin, plugin_hook};
-use rspack_util::itoa;
+use rspack_util::{fx_hash::FxIndexSet, itoa};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::id_helpers::{compare_chunks_natural, get_long_chunk_name, get_short_chunk_name};
@@ -40,7 +40,7 @@ fn assign_named_chunk_ids(
       (item, name)
     })
     .collect();
-  let mut name_to_items: FxHashMap<String, UkeyIndexSet<ChunkUkey>> = FxHashMap::default();
+  let mut name_to_items: FxHashMap<String, FxIndexSet<ChunkUkey>> = FxHashMap::default();
   let mut invalid_and_repeat_names: FxHashSet<String> = std::iter::once(String::new()).collect();
   for (item, name) in item_name_pair {
     let items = name_to_items.entry(name.clone()).or_default();

--- a/crates/rspack_plugin_css_chunking/Cargo.toml
+++ b/crates/rspack_plugin_css_chunking/Cargo.toml
@@ -14,6 +14,7 @@ rspack_error       = { workspace = true }
 rspack_hook        = { workspace = true }
 rspack_plugin_css  = { workspace = true }
 rspack_regex       = { workspace = true }
+rustc-hash         = { workspace = true }
 tokio              = { workspace = true }
 tracing            = { workspace = true }
 

--- a/crates/rspack_plugin_css_chunking/src/lib.rs
+++ b/crates/rspack_plugin_css_chunking/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use rspack_collections::{
-  Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet, UkeySet,
+  Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
 use rspack_core::{
   ChunkUkey, Compilation, CompilationOptimizeChunks, CompilationParams, CompilerCompilation,
@@ -11,7 +11,7 @@ use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_css::CssPlugin;
 use rspack_regex::RspackRegex;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 const MIN_CSS_CHUNK_SIZE: f64 = 30_f64 * 1024_f64;
 const MAX_CSS_CHUNK_SIZE: f64 = 100_f64 * 1024_f64;
@@ -388,7 +388,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
   let start = logger.time("apply split chunks");
   let chunk_graph = &mut compilation.chunk_graph;
   for chunk_state in chunk_states.values() {
-    let mut chunks: UkeySet<ChunkUkey> = UkeySet::default();
+    let mut chunks: FxHashSet<ChunkUkey> = FxHashSet::default();
     for module_identifier in &chunk_state.modules {
       if let Some(new_chunk_ukey) = new_chunks_by_module.get(module_identifier) {
         chunk_graph.disconnect_chunk_and_module(&chunk_state.chunk, *module_identifier);

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -7,7 +7,7 @@ use std::{
 use cow_utils::CowUtils;
 use regex::Regex;
 use rspack_cacheable::cacheable;
-use rspack_collections::{DatabaseItem, IdentifierMap, IdentifierSet, UkeySet};
+use rspack_collections::{DatabaseItem, IdentifierMap, IdentifierSet};
 use rspack_core::{
   AssetInfo, Chunk, ChunkGraph, ChunkGroupUkey, ChunkKind, ChunkUkey, Compilation,
   CompilationContentHash, CompilationParams, CompilationRenderManifest,
@@ -26,7 +26,7 @@ use rspack_plugin_javascript::{
   BoxJavascriptParserPlugin, parser_and_generator::JavaScriptParserAndGenerator,
 };
 use rspack_plugin_runtime::GetChunkFilenameRuntimeModule;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use ustr::Ustr;
 
 use crate::{
@@ -128,7 +128,7 @@ impl PluginCssExtract {
     compilation: &'comp Compilation,
     module_graph: &'comp ModuleGraph<'comp>,
   ) -> (Vec<&'comp dyn Module>, Option<Vec<CssOrderConflicts>>) {
-    let mut module_deps_reasons: IdentifierMap<IdentifierMap<UkeySet<ChunkGroupUkey>>> = modules
+    let mut module_deps_reasons: IdentifierMap<IdentifierMap<FxHashSet<ChunkGroupUkey>>> = modules
       .iter()
       .map(|m| (m.identifier(), Default::default()))
       .collect();

--- a/crates/rspack_plugin_extract_css/src/runtime.rs
+++ b/crates/rspack_plugin_extract_css/src/runtime.rs
@@ -1,12 +1,11 @@
 use cow_utils::CowUtils;
-use rspack_collections::UkeySet;
 use rspack_core::{
   ChunkUkey, Compilation, CrossOriginLoading, RuntimeGlobals, RuntimeModule, RuntimeModuleStage,
   impl_runtime_module,
 };
 use rspack_error::Result;
 use rspack_plugin_runtime::get_chunk_runtime_requirements;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::plugin::{InsertType, SOURCE_TYPE};
 
@@ -33,8 +32,8 @@ impl CssLoadingRuntimeModule {
     Self::with_default(chunk, attributes, link_type, insert)
   }
 
-  fn get_css_chunks(&self, compilation: &Compilation) -> UkeySet<ChunkUkey> {
-    let mut set: UkeySet<ChunkUkey> = Default::default();
+  fn get_css_chunks(&self, compilation: &Compilation) -> FxHashSet<ChunkUkey> {
+    let mut set: FxHashSet<ChunkUkey> = Default::default();
     let module_graph = compilation.get_module_graph();
 
     let chunk = compilation.chunk_by_ukey.expect_get(&self.chunk);

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -3,7 +3,7 @@ mod hot_module_replacement;
 use std::collections::hash_map;
 
 use hot_module_replacement::HotModuleReplacementRuntimeModule;
-use rspack_collections::{DatabaseItem, IdentifierSet, UkeyMap};
+use rspack_collections::{DatabaseItem, IdentifierSet};
 use rspack_core::{
   AssetInfo, Chunk, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationAsset, CompilationParams,
@@ -84,7 +84,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   }
 
   let mut updated_runtime_modules: IdentifierSet = Default::default();
-  let mut updated_chunks: UkeyMap<ChunkUkey, HashSet<String>> = Default::default();
+  let mut updated_chunks: HashMap<ChunkUkey, HashSet<String>> = Default::default();
   for (identifier, old_runtime_module_hash) in &old_runtime_modules {
     if let Some(new_runtime_module_hash) = compilation.runtime_modules_hash.get(identifier) {
       // updated

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -1,7 +1,7 @@
 use std::collections::{VecDeque, hash_map::Entry};
 
 use rayon::prelude::*;
-use rspack_collections::{IdentifierMap, UkeyMap};
+use rspack_collections::IdentifierMap;
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, CanInlineUse, Compilation,
   CompilationOptimizeDependencies, ConnectionState, DependenciesBlock, DependencyId, ExportsInfo,
@@ -32,7 +32,7 @@ enum ProcessModuleReferencedExports {
 pub struct FlagDependencyUsagePluginProxy<'a> {
   global: bool,
   compilation: &'a mut Compilation,
-  exports_info_module_map: UkeyMap<ExportsInfo, ModuleIdentifier>,
+  exports_info_module_map: HashMap<ExportsInfo, ModuleIdentifier>,
 }
 
 #[allow(unused)]
@@ -41,7 +41,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     Self {
       global,
       compilation,
-      exports_info_module_map: UkeyMap::default(),
+      exports_info_module_map: HashMap::default(),
     }
   }
 

--- a/crates/rspack_plugin_limit_chunk_count/Cargo.toml
+++ b/crates/rspack_plugin_limit_chunk_count/Cargo.toml
@@ -12,6 +12,7 @@ rspack_collections = { workspace = true }
 rspack_core        = { workspace = true }
 rspack_error       = { workspace = true }
 rspack_hook        = { workspace = true }
+rustc-hash         = { workspace = true }
 tracing            = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_limit_chunk_count/src/lib.rs
+++ b/crates/rspack_plugin_limit_chunk_count/src/lib.rs
@@ -3,16 +3,17 @@ mod chunk_combination;
 use std::collections::HashSet;
 
 use chunk_combination::{ChunkCombination, ChunkCombinationBucket, ChunkCombinationUkey};
-use rspack_collections::{UkeyMap, UkeySet};
+use rspack_collections::UkeySet;
 use rspack_core::{
   ChunkSizeOptions, ChunkUkey, Compilation, CompilationOptimizeChunks, Plugin,
   compare_chunks_with_graph, incremental::Mutation,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
+use rustc_hash::FxHashMap;
 
 fn add_to_set_map(
-  map: &mut UkeyMap<ChunkUkey, UkeySet<ChunkCombinationUkey>>,
+  map: &mut FxHashMap<ChunkUkey, UkeySet<ChunkCombinationUkey>>,
   key: &ChunkUkey,
   value: ChunkCombinationUkey,
 ) {
@@ -93,8 +94,8 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
   // we keep a mapping from chunk to all combinations
   // but this mapping is not kept up-to-date with deletions
   // so `deleted` flag need to be considered when iterating this
-  let mut combinations_by_chunk: UkeyMap<ChunkUkey, UkeySet<ChunkCombinationUkey>> =
-    UkeyMap::default();
+  let mut combinations_by_chunk: FxHashMap<ChunkUkey, UkeySet<ChunkCombinationUkey>> =
+    FxHashMap::default();
 
   let chunk_size_option = ChunkSizeOptions {
     chunk_overhead: self.options.chunk_overhead,

--- a/crates/rspack_plugin_merge_duplicate_chunks/Cargo.toml
+++ b/crates/rspack_plugin_merge_duplicate_chunks/Cargo.toml
@@ -8,13 +8,12 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rayon              = { workspace = true }
-rspack_collections = { workspace = true }
-rspack_core        = { workspace = true }
-rspack_error       = { workspace = true }
-rspack_hook        = { workspace = true }
-rustc-hash         = { workspace = true }
-tracing            = { workspace = true }
+rayon        = { workspace = true }
+rspack_core  = { workspace = true }
+rspack_error = { workspace = true }
+rspack_hook  = { workspace = true }
+rustc-hash   = { workspace = true }
+tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -1,5 +1,4 @@
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use rspack_collections::UkeySet;
 use rspack_core::{
   ChunkUkey, Compilation, CompilationOptimizeChunks, ExportsInfo, ModuleGraph, Plugin, RuntimeSpec,
   incremental::Mutation, is_runtime_equal,
@@ -29,7 +28,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
       // already remove by duplicates
       continue;
     }
-    let mut possible_duplicates: Option<UkeySet<ChunkUkey>> = None;
+    let mut possible_duplicates: Option<HashSet<ChunkUkey>> = None;
     for module in compilation
       .chunk_graph
       .get_chunk_modules_identifier(&chunk_ukey)

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use rspack_collections::{IdentifierLinkedMap, UkeyIndexSet};
+use rspack_collections::IdentifierLinkedMap;
 use rspack_core::{
   Chunk, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation, PathData,
   RuntimeGlobals, SourceType, get_js_chunk_filename_template,
@@ -52,14 +52,14 @@ pub fn get_all_chunks(
   exclude_chunk1: &ChunkUkey,
   exclude_chunk2: Option<&ChunkUkey>,
   chunk_group_by_ukey: &ChunkGroupByUkey,
-) -> UkeyIndexSet<ChunkUkey> {
+) -> FxIndexSet<ChunkUkey> {
   fn add_chunks(
     chunk_group_by_ukey: &ChunkGroupByUkey,
-    chunks: &mut UkeyIndexSet<ChunkUkey>,
+    chunks: &mut FxIndexSet<ChunkUkey>,
     entrypoint_ukey: &ChunkGroupUkey,
     exclude_chunk1: &ChunkUkey,
     exclude_chunk2: Option<&ChunkUkey>,
-    visit_chunk_groups: &mut UkeyIndexSet<ChunkGroupUkey>,
+    visit_chunk_groups: &mut FxIndexSet<ChunkGroupUkey>,
   ) {
     if let Some(entrypoint) = chunk_group_by_ukey.get(entrypoint_ukey) {
       for chunk in &entrypoint.chunks {
@@ -95,8 +95,8 @@ pub fn get_all_chunks(
     }
   }
 
-  let mut chunks = UkeyIndexSet::default();
-  let mut visit_chunk_groups = UkeyIndexSet::default();
+  let mut chunks = FxIndexSet::default();
+  let mut visit_chunk_groups = FxIndexSet::default();
 
   add_chunks(
     chunk_group_by_ukey,

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -9,6 +9,7 @@ use rspack_core::{
 use rspack_error::{Result, error};
 use rspack_hash::RspackHash;
 use rspack_plugin_javascript::runtime::stringify_chunks_to_array;
+use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::FxHashSet as HashSet;
 
 pub fn update_hash_for_entry_startup(

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rspack_cacheable::with::Unsupported;
-use rspack_collections::{DatabaseItem, Identifier, UkeyIndexSet};
+use rspack_collections::{DatabaseItem, Identifier};
 use rspack_core::{
   Chunk, ChunkGraph, ChunkUkey, Compilation, Filename, PathData, RuntimeGlobals, RuntimeModule,
   SourceType, get_filename_without_hash_length, impl_runtime_module,
@@ -178,7 +178,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
             None
           }
         })
-        .collect::<UkeyIndexSet<ChunkUkey>>();
+        .collect::<FxIndexSet<ChunkUkey>>();
       let (fake_filename, hash_len_map) =
         get_filename_without_hash_length(&Filename::from(dynamic_filename.to_string()));
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rspack_cacheable::with::Unsupported;
-use rspack_collections::{DatabaseItem, Identifier, UkeyIndexMap, UkeyIndexSet};
+use rspack_collections::{DatabaseItem, Identifier, UkeyIndexSet};
 use rspack_core::{
   Chunk, ChunkGraph, ChunkUkey, Compilation, Filename, PathData, RuntimeGlobals, RuntimeModule,
   SourceType, get_filename_without_hash_length, impl_runtime_module,
@@ -124,7 +124,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
     let mut max_chunk_set_size = 0;
     let mut chunk_filenames = Vec::<(Filename, ChunkUkey)>::new();
     let mut chunk_set_sizes_by_filenames = FxHashMap::<String, usize>::default();
-    let mut chunk_map = UkeyIndexMap::default();
+    let mut chunk_map = FxIndexMap::default();
 
     if let Some(chunks) = chunks {
       chunks

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -8,7 +8,10 @@ use rspack_core::{
   Chunk, ChunkGraph, ChunkUkey, Compilation, Filename, PathData, RuntimeGlobals, RuntimeModule,
   SourceType, get_filename_without_hash_length, impl_runtime_module,
 };
-use rspack_util::itoa;
+use rspack_util::{
+  fx_hash::{FxIndexMap, FxIndexSet},
+  itoa,
+};
 use rustc_hash::FxHashMap;
 
 use super::{stringify_dynamic_chunk_map, stringify_static_chunk_map};

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -1,6 +1,6 @@
 use cow_utils::CowUtils;
 use itertools::Itertools;
-use rspack_collections::{UkeyIndexMap, UkeyIndexSet};
+use rspack_collections::UkeyIndexSet;
 use rspack_core::{
   Chunk, ChunkLoading, ChunkUkey, Compilation, PathData, SourceType, chunk_graph_chunk::ChunkId,
   get_js_chunk_filename_template, get_undo_path,
@@ -143,7 +143,7 @@ pub fn unquoted_stringify(chunk_id: Option<&ChunkId>, str: &str) -> String {
 pub fn stringify_dynamic_chunk_map<F>(
   f: F,
   chunks: &UkeyIndexSet<ChunkUkey>,
-  chunk_map: &UkeyIndexMap<ChunkUkey, &Chunk>,
+  chunk_map: &FxIndexMap<ChunkUkey, &Chunk>,
   compilation: &Compilation,
 ) -> String
 where

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -1,6 +1,5 @@
 use cow_utils::CowUtils;
 use itertools::Itertools;
-use rspack_collections::UkeyIndexSet;
 use rspack_core::{
   Chunk, ChunkLoading, ChunkUkey, Compilation, PathData, SourceType, chunk_graph_chunk::ChunkId,
   get_js_chunk_filename_template, get_undo_path,
@@ -142,7 +141,7 @@ pub fn unquoted_stringify(chunk_id: Option<&ChunkId>, str: &str) -> String {
 
 pub fn stringify_dynamic_chunk_map<F>(
   f: F,
-  chunks: &UkeyIndexSet<ChunkUkey>,
+  chunks: &FxIndexSet<ChunkUkey>,
   chunk_map: &FxIndexMap<ChunkUkey, &Chunk>,
   compilation: &Compilation,
 ) -> String

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -4,8 +4,11 @@ use rspack_core::{
   Chunk, ChunkLoading, ChunkUkey, Compilation, PathData, SourceType, chunk_graph_chunk::ChunkId,
   get_js_chunk_filename_template, get_undo_path,
 };
-use rspack_util::test::{
-  HOT_TEST_ACCEPT, HOT_TEST_DISPOSE, HOT_TEST_OUTDATED, HOT_TEST_RUNTIME, HOT_TEST_UPDATED,
+use rspack_util::{
+  fx_hash::{FxIndexMap, FxIndexSet},
+  test::{
+    HOT_TEST_ACCEPT, HOT_TEST_DISPOSE, HOT_TEST_OUTDATED, HOT_TEST_RUNTIME, HOT_TEST_UPDATED,
+  },
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 

--- a/crates/rspack_plugin_split_chunks/src/common.rs
+++ b/crates/rspack_plugin_split_chunks/src/common.rs
@@ -5,7 +5,7 @@ use std::{
 
 use derive_more::Debug;
 use futures::future::BoxFuture;
-use rspack_collections::{IdentifierMap, UkeySet};
+use rspack_collections::IdentifierMap;
 use rspack_core::{ChunkUkey, Compilation, Module, SourceType};
 use rspack_error::Result;
 use rspack_regex::RspackRegex;
@@ -202,4 +202,4 @@ pub struct FallbackCacheGroup {
 }
 
 pub(crate) type ModuleSizes = IdentifierMap<FxHashMap<SourceType, f64>>;
-pub(crate) type ModuleChunks = IdentifierMap<UkeySet<ChunkUkey>>;
+pub(crate) type ModuleChunks = IdentifierMap<FxHashSet<ChunkUkey>>;

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -2,9 +2,9 @@ use std::cmp::Ordering;
 
 use derive_more::Debug;
 use itertools::Itertools;
-use rspack_collections::{IdentifierSet, UkeySet};
+use rspack_collections::IdentifierSet;
 use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   CacheGroup,
@@ -52,7 +52,7 @@ pub(crate) struct ModuleGroup {
   pub source_types_modules: FxHashMap<SourceType, IdentifierSet>,
   /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[debug(skip)]
-  pub chunks: UkeySet<ChunkUkey>,
+  pub chunks: FxHashSet<ChunkUkey>,
   added: Vec<ModuleIdentifier>,
   removed: Vec<ModuleIdentifier>,
   sizes: SplitChunkSizes,

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -1,6 +1,7 @@
 use rayon::prelude::*;
-use rspack_collections::{DatabaseItem, IdentifierMap, UkeySet};
+use rspack_collections::{DatabaseItem, IdentifierMap};
 use rspack_core::{Chunk, ChunkUkey, Compilation, ModuleIdentifier, incremental::Mutation};
+use rustc_hash::FxHashSet;
 
 use crate::{SplitChunksPlugin, common::ModuleChunks, module_group::ModuleGroup};
 
@@ -172,7 +173,7 @@ impl SplitChunksPlugin {
     &self,
     item: &ModuleGroup,
     new_chunk: ChunkUkey,
-    original_chunks: &UkeySet<ChunkUkey>,
+    original_chunks: &FxHashSet<ChunkUkey>,
     compilation: &mut Compilation,
   ) {
     let modules = item
@@ -210,7 +211,7 @@ impl SplitChunksPlugin {
   pub(crate) fn split_from_original_chunks(
     &self,
     _item: &ModuleGroup,
-    original_chunks: &UkeySet<ChunkUkey>,
+    original_chunks: &FxHashSet<ChunkUkey>,
     new_chunk: ChunkUkey,
     compilation: &mut Compilation,
   ) {

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_request.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_request.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
-use rspack_collections::{DatabaseItem, UkeySet};
+use rspack_collections::DatabaseItem;
 use rspack_core::{ChunkUkey, Compilation};
+use rustc_hash::FxHashSet;
 
 use crate::{CacheGroup, SplitChunksPlugin};
 
@@ -13,7 +14,7 @@ impl SplitChunksPlugin {
     &self,
     compilation: &Compilation,
     cache_group: &CacheGroup,
-    used_chunks: &mut Cow<UkeySet<ChunkUkey>>,
+    used_chunks: &mut Cow<FxHashSet<ChunkUkey>>,
   ) {
     let chunk_db = &compilation.chunk_by_ukey;
     let chunk_group_db = &compilation.chunk_group_by_ukey;

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -11,7 +11,7 @@ use std::sync::LazyLock;
 use std::{borrow::Cow, hash::Hash};
 
 use regex::Regex;
-use rspack_collections::{DatabaseItem, UkeyMap};
+use rspack_collections::DatabaseItem;
 use rspack_core::{
   ChunkUkey, Compilation, CompilerOptions, DEFAULT_DELIMITER, Module, ModuleIdentifier, SourceType,
   incremental::Mutation,
@@ -19,7 +19,7 @@ use rspack_core::{
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_util::identifier::make_paths_relative;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::MaxSizeSetting;
 use crate::{SplitChunkSizes, SplitChunksPlugin};
@@ -483,7 +483,7 @@ impl SplitChunksPlugin {
   pub(super) async fn ensure_max_size_fit(
     &self,
     compilation: &mut Compilation,
-    max_size_setting_map: &UkeyMap<ChunkUkey, MaxSizeSetting>,
+    max_size_setting_map: &FxHashMap<ChunkUkey, MaxSizeSetting>,
   ) -> Result<()> {
     let fallback_cache_group = &self.fallback_cache_group;
     let chunk_group_db = &compilation.chunk_group_by_ukey;

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -7,12 +7,12 @@ mod module_group;
 use std::{borrow::Cow, cmp::Ordering, fmt::Debug};
 
 use itertools::Itertools;
-use rspack_collections::{IdentifierMap, UkeySet};
+use rspack_collections::IdentifierMap;
 use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::tracing_preset::TRACING_BENCH_TARGET;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::instrument;
 
 use crate::{
@@ -84,7 +84,7 @@ impl SplitChunksPlugin {
     }
 
     let mut max_size_setting_map: FxHashMap<ChunkUkey, MaxSizeSetting> = Default::default();
-    let mut removed_module_chunks: IdentifierMap<UkeySet<ChunkUkey>> = IdentifierMap::default();
+    let mut removed_module_chunks: IdentifierMap<FxHashSet<ChunkUkey>> = IdentifierMap::default();
 
     let mut combinator = module_group::Combinator::default();
     let module_graph = compilation.get_module_graph();

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -7,7 +7,7 @@ mod module_group;
 use std::{borrow::Cow, cmp::Ordering, fmt::Debug};
 
 use itertools::Itertools;
-use rspack_collections::{IdentifierMap, UkeyMap, UkeySet};
+use rspack_collections::{IdentifierMap, UkeySet};
 use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -83,7 +83,7 @@ impl SplitChunksPlugin {
       priority_cache_groups.push((priority, cache_groups.into_iter().collect::<Vec<_>>()));
     }
 
-    let mut max_size_setting_map: UkeyMap<ChunkUkey, MaxSizeSetting> = Default::default();
+    let mut max_size_setting_map: FxHashMap<ChunkUkey, MaxSizeSetting> = Default::default();
     let mut removed_module_chunks: IdentifierMap<UkeySet<ChunkUkey>> = IdentifierMap::default();
 
     let mut combinator = module_group::Combinator::default();

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -7,13 +7,13 @@ use std::{
 use dashmap::DashMap;
 use futures::future::join_all;
 use rayon::prelude::*;
-use rspack_collections::{IdentifierMap, UkeyIndexMap};
+use rspack_collections::IdentifierMap;
 use rspack_core::{
   ChunkByUkey, ChunkUkey, Compilation, Module, ModuleGraph, ModuleIdentifier,
   PrefetchExportsInfoMode, RuntimeKeyMap, UsageKey, get_runtime_key,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_util::tracing_preset::TRACING_BENCH_TARGET;
+use rspack_util::{fx_hash::FxIndexMap, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use tracing::instrument;
 
@@ -148,7 +148,7 @@ impl Combinator {
 
   fn get_combinations(
     chunk_sets_in_graph: FxHashMap<ChunksKey, FxHashSet<ChunkUkey>>,
-    chunk_sets_by_count: UkeyIndexMap<u32, Vec<FxHashSet<ChunkUkey>>>,
+    chunk_sets_by_count: FxIndexMap<u32, Vec<FxHashSet<ChunkUkey>>>,
   ) -> FxHashMap<ChunksKey, Vec<FxHashSet<ChunkUkey>>> {
     chunk_sets_in_graph
       .into_par_iter()
@@ -190,7 +190,7 @@ impl Combinator {
       })
       .collect::<FxHashMap<_, _>>();
 
-    let mut chunk_sets_by_count = UkeyIndexMap::<u32, Vec<FxHashSet<ChunkUkey>>>::default();
+    let mut chunk_sets_by_count = FxIndexMap::<u32, Vec<FxHashSet<ChunkUkey>>>::default();
     for chunks in chunk_sets_in_graph.values() {
       let count = chunks.len();
 
@@ -243,7 +243,7 @@ impl Combinator {
 
     let mut used_exports_chunk_sets_in_graph = FxHashMap::default();
     let mut used_exports_chunk_sets_by_count =
-      UkeyIndexMap::<u32, Vec<FxHashSet<ChunkUkey>>>::default();
+      FxIndexMap::<u32, Vec<FxHashSet<ChunkUkey>>>::default();
     for used_exports_chunks in used_exports_chunks {
       for (chunk_key, chunks) in used_exports_chunks {
         if used_exports_chunk_sets_in_graph


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

The Rust HashMap implementation utilizes the Swiss Tables algorithm. For specific design details, please refer to: https://abseil.io/about/design/swisstables.

> For performance reasons, it is important that you use a hash function that distributes entropy across the entire bit space well.

However, a monotonically increasing Ukey does not meet this requirement. Therefore, the UkeyHasher has been replaced with the `FxHasher` as the default hasher for `HashMap` and `HashSet`.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
