### PR TITLE
chore(ci): add rstest to ecosystem-ci

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -18,6 +18,7 @@ on:
           - rspress
           - rsbuild
           - rslib
+          - rstest
           - examples
           - devserver
           - plugin
@@ -115,6 +116,7 @@ jobs:
               // "nx",
               "rspress",
               "rslib",
+              "rstest",
               "rsbuild",
               "rsdoctor",
               "examples",


### PR DESCRIPTION
## Summary

add rstest to ecosystem-ci.

<!-- Describe what this PR does and why. -->

## Related links

https://github.com/rspack-contrib/rspack-ecosystem-ci/pull/84

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
