### PR TITLE
fix: should walk call member chain args for dynamic import referenced

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -166,7 +166,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
   fn call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    _expr: &CallExpr,
+    expr: &CallExpr,
     for_name: &str,
     members: &[Atom],
     members_optionals: &[bool],
@@ -188,6 +188,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
     parser
       .dynamic_import_references
       .add_import_reference(data.import_span, ids.to_vec());
+    parser.walk_expr_or_spread(&expr.args);
     Some(true)
   }
 

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import/index.js
@@ -40,7 +40,7 @@ it("should not tree-shake if reassigin", async () => {
 	expect(m.default).toBe(3);
 	expect(m.usedExports).toBe(true);
 	m = {};
-})
+});
 
 it("should tree-shake if its member call and strictThisContextOnImports is false", async () => {
 	let m = await import("./dir4/a");
@@ -50,4 +50,13 @@ it("should tree-shake if its member call and strictThisContextOnImports is false
 	expect(m2.b.f()).toBe(1);
 	expect(m2.b.usedExports).toEqual(true);
 	expect(m2.usedExports).toEqual(["b", "usedExports"]);
-})
+});
+
+it("should analyze arguments in call member chain", async () => {
+	let m = await import("./dir4/lib?2");
+	m.b.f((async () => {
+		let m2 = await import("./dir4/a?2");
+		expect(m2.a).toBe(1);
+		expect(m2.usedExports).toEqual(["a", "usedExports"]);
+	})());
+});


### PR DESCRIPTION
## Summary

```js
let m = await import("./dir4/lib?2");
m.b.f(
  require("./m") // should walk these args of f()
);
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
