### PR TITLE
docs: remove incorrect `emitRecords` compiler hook

### DIFF
--- a/website/docs/en/api/plugin-api/compiler-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compiler-hooks.mdx
@@ -105,7 +105,6 @@ HookAfterEmit --> HookNeedAdditionalPass{hooks.needAdditionalPass}
 HookNeedAdditionalPass --> |true| HookAdditionalDone(hooks.done)
 HookAdditionalDone --> HookAdditionPass(hooks.additionalPass)
 HookAdditionPass --> Compile
-HookNeedAdditionalPass --> |false| HookEmitRecords(hooks.emitRecords)
 HookEmitRecords --> HookDone
 HookDone --> HookFailed(<a href="#failed">hooks.failed</a>)
 HookFailed --> Callback("callback(err, stats)")

--- a/website/docs/zh/api/plugin-api/compiler-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compiler-hooks.mdx
@@ -106,7 +106,6 @@ HookAfterEmit --> HookNeedAdditionalPass{hooks.needAdditionalPass}
 HookNeedAdditionalPass --> |是| HookAdditionalDone(hooks.done)
 HookAdditionalDone --> HookAdditionPass(hooks.additionalPass)
 HookAdditionPass --> Compile
-HookNeedAdditionalPass --> |否| HookEmitRecords(hooks.emitRecords)
 HookEmitRecords --> HookDone
 HookDone --> HookFailed(<a href="#failed">hooks.failed</a>)
 HookFailed --> Callback("callback(err, stats)")


### PR DESCRIPTION
## Summary

* Removed the `hooks.emitRecords` from the compiler hooks diagram, as Rspack does not provide this hook.

<img width="1394" height="768" alt="image" src="https://github.com/user-attachments/assets/02dd6bfe-c01c-4fad-a1e4-3c980ef8abf1" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ x Documentation updated (or not required).
