### PR TITLE
fix:  align context module element dependence resource identifer with webpack

### DIFF
--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -468,25 +468,28 @@ fn visit_dirs(
         if !reg_exp.test(&r.request) {
           return;
         }
+        let request = format!(
+          "{}{}{}{}",
+          options.addon,
+          r.request,
+          options.resource_query.clone(),
+          options.resource_fragment.clone(),
+        );
+        let resource_identifier = ContextElementDependency::create_resource_identifier(
+          options.resource.as_str(),
+          &request,
+          options.context_options.attributes.as_ref(),
+        );
+
         dependencies.push(ContextElementDependency {
           id: DependencyId::new(),
-          request: format!(
-            "{}{}{}{}",
-            options.addon,
-            r.request,
-            options.resource_query.clone(),
-            options.resource_fragment.clone(),
-          ),
+          request,
           user_request: r.request.to_string(),
           category: options.context_options.category,
           context: options.resource.clone().into(),
           layer: options.layer.clone(),
           options: options.context_options.clone(),
-          resource_identifier: ContextElementDependency::create_resource_identifier(
-            options.resource.as_str(),
-            &path,
-            options.context_options.attributes.as_ref(),
-          ),
+          resource_identifier,
           attributes: options.context_options.attributes.clone(),
           referenced_exports: options.context_options.referenced_exports.clone(),
           dependency_type: DependencyType::ContextElement(options.type_prefix),

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -3,7 +3,6 @@ use rspack_cacheable::{
   cacheable, cacheable_dyn,
   with::{AsOption, AsPreset, AsVec},
 };
-use rspack_paths::Utf8Path;
 use rspack_util::json_stringify;
 use swc_core::ecma::atoms::Atom;
 
@@ -38,7 +37,7 @@ pub struct ContextElementDependency {
 impl ContextElementDependency {
   pub fn create_resource_identifier(
     resource: &str,
-    path: &Utf8Path,
+    path: &str,
     attributes: Option<&ImportAttributes>,
   ) -> String {
     let mut ident = format!("context{resource}|{path}");

--- a/crates/rspack_plugin_module_replacement/src/context_replacement.rs
+++ b/crates/rspack_plugin_module_replacement/src/context_replacement.rs
@@ -93,19 +93,21 @@ async fn cmf_after_resolve(&self, mut result: AfterResolveResult) -> Result<Afte
         let deps = new_content_create_context_map
           .iter()
           .map(|(key, value)| {
+            let request = format!(
+              "{}{}{}",
+              value,
+              options.resource_query.clone(),
+              options.resource_fragment.clone(),
+            );
+
             let resource_identifier = ContextElementDependency::create_resource_identifier(
               options.resource.as_str(),
-              value.as_str().into(),
+              &request,
               options.context_options.attributes.as_ref(),
             );
             ContextElementDependency {
               id: DependencyId::new(),
-              request: format!(
-                "{}{}{}",
-                value,
-                options.resource_query.clone(),
-                options.resource_fragment.clone(),
-              ),
+              request,
               user_request: key.to_string(),
               category: options.context_options.category,
               context: options.resource.clone().into(),

--- a/tests/rspack-test/configCases/context-module/two_files_share_a_request/index.js
+++ b/tests/rspack-test/configCases/context-module/two_files_share_a_request/index.js
@@ -1,0 +1,9 @@
+it("should import context module", async () => {
+  let n = "index.js"
+  const { default: js } = await import(`./sub/${n}`);
+  expect(js).toBe("js")
+
+	n = "index.ts"
+	const { default: ts } = await import(`./sub/${n}`);
+	expect(ts).toBe("ts")
+})

--- a/tests/rspack-test/configCases/context-module/two_files_share_a_request/rspack.config.js
+++ b/tests/rspack-test/configCases/context-module/two_files_share_a_request/rspack.config.js
@@ -1,0 +1,17 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  resolve: {
+    extensions: [".ts", "..."],
+  },
+	optimization: {
+		minimize: false,
+		moduleIds:"named",
+	},
+	module: {
+		rules: [
+			{
+				test: /\.ts$/,
+				type: "javascript/auto"
+			}]
+	},
+};

--- a/tests/rspack-test/configCases/context-module/two_files_share_a_request/sub/index.js
+++ b/tests/rspack-test/configCases/context-module/two_files_share_a_request/sub/index.js
@@ -1,0 +1,1 @@
+export default "js";

--- a/tests/rspack-test/configCases/context-module/two_files_share_a_request/sub/index.ts
+++ b/tests/rspack-test/configCases/context-module/two_files_share_a_request/sub/index.ts
@@ -1,0 +1,1 @@
+export default "ts"


### PR DESCRIPTION
## Summary
close https://github.com/web-infra-dev/rspack/issues/11410 


### Minimal reproduction
[the test case](https://github.com/web-infra-dev/rspack/pull/11674/files#diff-9aeb9960f4b86bce0cb8675d4dfadaa73ec4a38cab38bc49cbeab45348d4bfbe)

```
src/
├── index.ts
└── sub
    ├── index.js
    └── index.ts
```
```ts
// index.ts
const str = "index.ts";

async function bug(str) {
  await import(`./sub/${str}`);
}

bug(str);

// sub/index.js
console.log("js")


// sub/index.js
console.log("ts")
```
`ts` is expected to be printed, but actually `js`

## Root case analyze
A context modules's dependencies are grouped by resolved resource's path named as `sorted_dependecies` which is a hashmap. In reproduction's example, it will be simplified as below.
```
src/sub/index.js: [
	./         -> src/sub/index.js (DepId:4)
	./index    -> src/sub/index.js (DepId:3)
	./index.js -> src/sub/index.js (DepId:2)
]

src/sub/index.ts: [
	./         -> src/sub/index.ts (DepId:7)
	./index    -> src/sub/index.ts (DepId:6)
	./index.ts -> src/sub/index.ts (DepId:5)
]
```

Factorize Tasks will be created for each group. The first factorize task is created with  `Dependence( id=4 request="./")`, it will be resolved to module `src/sub/index.js` and then  connections will be add to `src/sub/index.s` module.
```
context Module -> src/sub/index.js by DepId=4 request="./"
context Module -> src/sub/index.js by DepId=3 request="./index"
context Module -> src/sub/index.js by DepId=2 request="./index.js"
```

The second factorize Task is created with `Dependence( id=7 request="./")`
And the request is resolved to `src/sub/index.js` too. 
So in next `AddTask`  other 3 connection will add to `src/sub/index.js` other than `src/sub/index.ts`。
```
context Module -> src/sub/index.js by DepId=7 request="./"
context Module -> src/sub/index.js by DepId=6 request="./index"
context Module -> src/sub/index.js by DepId=5 request="./index.js"
```
 Here is the problem,  module `src/sub/index.ts` is never created, and all its own connection(DepId 5,6,7) now is adhered to `src/sub/index.js`.
 
So when context module generates the fake map, all request will map to `src/sub/index.js`, including the `./index.ts` That's the bug.

## Solution
Group the  dependencies by *request* other than *resource path*.  Referring to [webpack](https://github.com/webpack/webpack/blob/5b7dee29fff3c1e3ac0d2747db69c66e5ad0e538/lib/dependencies/ModuleDependency.js#L45-L44)
the new `sorted_dependeces` will be like below

```
./ : [
	./         -> src/sub/index.js (DepId:4)
	./         -> src/sub/index.ts (DepId:7)
]

./index : [
	./index    -> src/sub/index.js (DepId:3)
	./index    -> src/sub/index.ts (DepId:6)
]

./index.js : [
	./index.js -> src/sub/index.js (DepId:2)
]

./index.ts: [
	./index.ts -> src/sub/index.ts (DepId:5)
]
```

The connections is listed as below
```
context Module -> src/sub/index.js by DepId=4 request="./"
context Module -> src/sub/index.js by DepId=7 request="./"
context Module -> src/sub/index.js by DepId=3 request="./index"
context Module -> src/sub/index.js by DepId=6 request="./index"
context Module -> src/sub/index.js by DepId=2 request="./index.js"
context Module -> src/sub/index.ts by DepId=5 request="./index.ts"
```
So the connection between context module and `src/sub/index.ts` is created as expect. 


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
