### PR TITLE
fix: allow Infinity for stats space options

### DIFF
--- a/packages/rspack/src/schema/config.ts
+++ b/packages/rspack/src/schema/config.ts
@@ -4,7 +4,7 @@ import { createErrorMap, fromZodError } from "zod-validation-error/v4";
 import type * as t from "../config/types";
 import { memoize } from "../util/memoize";
 import { getZodSwcLoaderOptionsSchema } from "./loaders";
-import { anyFunction, numberOrInfinity } from "./utils";
+import { anyFunction, intOrInfinity, numberOrInfinity } from "./utils";
 
 z.config({
 	jitless: true
@@ -1132,16 +1132,16 @@ export const getRspackOptionsSchema = memoize(() => {
 			groupModulesByAttributes: z.boolean(),
 			groupModulesByPath: z.boolean(),
 			groupModulesByExtension: z.boolean(),
-			modulesSpace: z.int(),
-			chunkModulesSpace: z.int(),
-			nestedModulesSpace: z.int(),
+			modulesSpace: intOrInfinity,
+			chunkModulesSpace: intOrInfinity,
+			nestedModulesSpace: intOrInfinity,
 			relatedAssets: z.boolean(),
 			groupAssetsByEmitStatus: z.boolean(),
 			groupAssetsByInfo: z.boolean(),
 			groupAssetsByPath: z.boolean(),
 			groupAssetsByExtension: z.boolean(),
 			groupAssetsByChunk: z.boolean(),
-			assetsSpace: z.int(),
+			assetsSpace: intOrInfinity,
 			orphanModules: z.boolean(),
 			excludeModules: z
 				.array(z.string().or(z.instanceof(RegExp)).or(anyFunction))
@@ -1168,7 +1168,7 @@ export const getRspackOptionsSchema = memoize(() => {
 			chunkOrigins: z.boolean(),
 			runtime: z.boolean(),
 			depth: z.boolean(),
-			reasonsSpace: z.int(),
+			reasonsSpace: intOrInfinity,
 			groupReasonsByOrigin: z.boolean(),
 			errorDetails: z.boolean(),
 			errorStack: z.boolean(),
@@ -1176,8 +1176,8 @@ export const getRspackOptionsSchema = memoize(() => {
 			cachedModules: z.boolean(),
 			cachedAssets: z.boolean(),
 			cached: z.boolean(),
-			errorsSpace: z.int(),
-			warningsSpace: z.int()
+			errorsSpace: intOrInfinity,
+			warningsSpace: intOrInfinity
 		})
 		.partial() satisfies z.ZodType<t.StatsOptions>;
 

--- a/packages/rspack/src/schema/utils.ts
+++ b/packages/rspack/src/schema/utils.ts
@@ -6,6 +6,8 @@ export const numberOrInfinity = z
 	.number()
 	.or(z.literal(Number.POSITIVE_INFINITY));
 
+export const intOrInfinity = z.int().or(z.literal(Number.POSITIVE_INFINITY));
+
 export const anyFunction = z.custom<(...args: unknown[]) => any>(
 	data => typeof data === "function",
 	// Make the similar error message as zod v3

--- a/tests/rspack-test/configCases/stats/assets-space-infinity/index.js
+++ b/tests/rspack-test/configCases/stats/assets-space-infinity/index.js
@@ -1,0 +1,1 @@
+console.log("stats assetsSpace Infinity test");

--- a/tests/rspack-test/configCases/stats/assets-space-infinity/webpack.config.js
+++ b/tests/rspack-test/configCases/stats/assets-space-infinity/webpack.config.js
@@ -1,0 +1,8 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+        context: __dirname,
+        entry: "./index.js",
+        stats: {
+                assetsSpace: Infinity
+        }
+};


### PR DESCRIPTION
## Summary
- accept `Infinity` for stats space options by reusing a shared helper in the config schema
- add a config case that verifies `stats.assetsSpace` accepts `Infinity`

## Testing
- pnpm --filter @rspack/tests test:base -- --runTestsByPath tests/rspack-test/Config.test.js --test stats/assets-space-infinity

------
https://chatgpt.com/codex/tasks/task_e_68ca166e2aa0832da520c971c9fe0a2d