### PR TITLE
docs: update test path

### DIFF
--- a/website/docs/en/contribute/development/testing-rspack.mdx
+++ b/website/docs/en/contribute/development/testing-rspack.mdx
@@ -10,11 +10,11 @@ Rspack's test cases include the following:
 You can run these test cases in the following ways:
 
 - Run `./x test unit` or `pnpm run test:unit` from the root directory.
-- Or run `npm run test` from the `packages/rspack-test-tools` directory.
-- To update snapshots, run `npm run test -- -u` from the `packages/rspack-test-tools` directory.
-- To pass specific jest cli arguments, run `npm run test -- {args}` from the `packages/rspack-test-tools` directory.
-- To filter specific test cases, run `npm run test -- -t path-of-spec` from the `packages/rspack-test-tools` directory.
-  - Like `npm run test -- -t config/asset` to only run test cases from the `packages/rspack-test-tools/configCases/asset` folder (config will be automatically mapped to configCases, and other folders will work in a similar way).
+- Or run `npm run test` from the `tests/rspack-test` directory.
+- To update snapshots, run `npm run test -- -u` from the `tests/rspack-test` directory.
+- To pass specific jest cli arguments, run `npm run test -- {args}` from the `tests/rspack-test` directory.
+- To filter specific test cases, run `npm run test -- -t path-of-spec` from the `tests/rspack-test` directory.
+  - Like `npm run test -- -t config/asset` to only run test cases from the `tests/rspack-test/configCases/asset` folder (config will be automatically mapped to configCases, and other folders will work in a similar way).
 - To use Rspack Wasm for running test cases, you need to additionally configure the following environment variables:
   1. `NAPI_RS_FORCE_WASI=1`: Forces the use of Rspack Wasm instead of native binding
   2. `WASM=1`: Enables Wasm-specific test configurations
@@ -208,7 +208,7 @@ In the test code, you can use the `WATCH_STEP` variable to get the current batch
 | Default Configuration | [StatsProcessor](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/stats.ts#L190) |
 | Run Output            | `No`                                                                                                                       |
 
-The writing of the cases is the same as in a regular rspack project. After running, the console output information will be captured in snapshots and stored in `rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap`.
+The writing of the cases is the same as in a regular rspack project. After running, the console output information will be captured in snapshots and stored in `tests/rspack-test/__snapshots__/StatsOutput.test.js.snap`.
 
 :::tip
 As some StatsOutput test cases contain hashes, when you modify the output code, please use the `-u` parameter to update the snapshots for these cases.
@@ -223,7 +223,7 @@ As some StatsOutput test cases contain hashes, when you modify the output code, 
 | Default Configuration | [`None`](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/stats-api.ts) |
 | Run Output            | `No`                                                                                                              |
 
-This test uses `rspack-test-tools/tests/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
+This test uses `tests/rspack-test/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
 
 ```js title="{case}.js"
 type TStatsAPICaseConfig = {
@@ -283,7 +283,7 @@ module.exports = {
 | Default Configuration | [None](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/simple.ts) |
 | Run Output            | No                                                                                                           |
 
-This test uses `rspack-test-tools/tests/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
+This test uses `tests/rspack-test/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
 
 ```js title="{case.js}"
 interface TCompilerCaseConfig {
@@ -314,14 +314,14 @@ module.exports = {
 | Default Configuration | [None](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/defaults.ts) |
 | Run Output            | No                                                                                                             |
 
-This test does not execute real builds; it only generates build configurations and observes the differences from the default configuration. The basic default configuration will be snapshot and stored in `rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap`.
+This test does not execute real builds; it only generates build configurations and observes the differences from the default configuration. The basic default configuration will be snapshot and stored in `tests/rspack-test/__snapshots__/Defaults.test.js.snap`.
 
-This test uses `rspack-test-tools/tests/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
+This test uses `tests/rspack-test/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
 
 ```js title="{case}.js"
 interface TDefaultsCaseConfig {
   description: string; // Description of the test case
-  cwd?: string; // process.cwd for generating the build configuration of the test case, default is the `rspack-test-tools` directory
+  cwd?: string; // process.cwd for generating the build configuration of the test case, default is the `tests/rspack-test` directory
   options?: (context: ITestContext) => TCompilerOptions<ECompilerType.Rspack>; // Test case build configuration
   diff: (
     diff: jest.JestMatchers<Diff>,
@@ -347,7 +347,7 @@ The details for the Error test are as follows:
 | Default Configuration | [ErrorProcessor](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/error.ts#L84) |
 | Run Output            | No                                                                                                                        |
 
-This test uses `rspack-test-tools/tests/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
+This test uses `tests/rspack-test/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
 
 ```js title="{case}.js"
 interface TErrorCaseConfig {
@@ -378,7 +378,7 @@ module.exports = {
 
 This test records the input and output of the hook and stores it in the snapshot `hooks.snap.txt`. The snapshot of the final product code is stored in `output.snap.txt`.
 
-This test uses `rspack-test-tools/tests/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
+This test uses `tests/rspack-test/fixtures` as the source code for the build, so the test case is written as a single file. Its structure is as follows:
 
 ```js title="{case}/test.js"
 interface THookCaseConfig {

--- a/website/docs/en/contribute/development/testing.mdx
+++ b/website/docs/en/contribute/development/testing.mdx
@@ -55,10 +55,10 @@ Rspack's test cases are stored in the `tests/rspack-test` folder, including uniq
 
 You can run Rspack tests by running `./x test unit` or `pnpm run test:unit` at the root folder.
 
-You can also go to the `packages/rspack-test-tools` folder and run `npm run test` to run test cases and add some arguments:
+You can also go to the `tests/rspack-test` folder and run `npm run test` to run test cases and add some arguments:
 
 - **When refreshing test snapshots is needed**: Add `-u`, like `npm run test -- -u`
-- **When filtering test cases is needed**: Add `-t`, like `npm run test -- -t config/asset` to only run test cases from the `packages/rspack-test-tools/configCases/asset` folder (`config` will be automatically mapped to `configCases`, and other folders work similarly). Pattern matching supports regex, see [jest](https://jestjs.io/docs/cli#--testnamepatternregex) for details.
+- **When filtering test cases is needed**: Add `-t`, like `npm run test -- -t config/asset` to only run test cases from the `tests/rspack-test/configCases/asset` folder (`config` will be automatically mapped to `configCases`, and other folders work similarly). Pattern matching supports regex, see [jest](https://jestjs.io/docs/cli#--testnamepatternregex) for details.
 
 > For more details, please refer to: [Rspack Testing](./testing-rspack).
 

--- a/website/docs/zh/contribute/development/testing-rspack.mdx
+++ b/website/docs/zh/contribute/development/testing-rspack.mdx
@@ -10,11 +10,11 @@ Rspack 的测试用例包括如下：
 可以通过如下方式运行这些测试用例：
 
 - 根目录下运行 `./x test unit` 或 `pnpm run test:unit`。
-- 或在 `packages/rspack-test-tools` 目录下运行 `npm run test`。
-- 如需更新 snapshot，在 `packages/rspack-test-tools` 目录下运行 `npm run test -- -u`。
-- 如需传入特定 jest cli 参数，在 `packages/rspack-test-tools` 目录下运行 `npm run test -- {args}`。
-- 如需过滤特定测试用例，在 `packages/rspack-test-tools` 目录下运行 `npm run test  -- -t path-of-spec`。
-  - 如 `npm run test -- -t config/asset` 即可仅运行 `packages/rspack-test-tools/configCases/asset` 文件夹下的用例（config 会自动映射到 configCases，其他文件夹类似）。
+- 或在 `tests/rspack-test` 目录下运行 `npm run test`。
+- 如需更新 snapshot，在 `tests/rspack-test` 目录下运行 `npm run test -- -u`。
+- 如需传入特定 jest cli 参数，在 `tests/rspack-test` 目录下运行 `npm run test -- {args}`。
+- 如需过滤特定测试用例，在 `tests/rspack-test` 目录下运行 `npm run test  -- -t path-of-spec`。
+  - 如 `npm run test -- -t config/asset` 即可仅运行 `tests/rspack-test/configCases/asset` 文件夹下的用例（config 会自动映射到 configCases，其他文件夹类似）。
 - 如需使用 Rspack Wasm 运行测试用例，需要额外配置以下环境变量：
   1. `NAPI_RS_FORCE_WASI=1`： 强制使用 Rspack Wasm 而不是原生绑定
   2. `WASM=1`：启用 Wasm 专用的测试配置
@@ -206,7 +206,7 @@ Snapshot 结构如下：
 | 默认配置 | [StatsProcessor](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/stats.ts#L190) |
 | 产物运行 | `否`                                                                                                                       |
 
-用例的编写与常规的 rspack 项目相同，运行后会将控制台输出信息生成快照并存放在 `rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap` 中。
+用例的编写与常规的 rspack 项目相同，运行后会将控制台输出信息生成快照并存放在 `tests/rspack-test/__snapshots__/StatsOutput.test.js.snap` 中。
 
 :::tip
 由于部分 StatsOutput 测试用例包含 hash。因此当你修改了产物代码时，请通过 `-u` 参数刷新这些用例的快照。
@@ -221,7 +221,7 @@ Snapshot 结构如下：
 | 默认配置 | [`无`](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/stats-api.ts) |
 | 产物运行 | `否`                                                                                                            |
 
-此测试固定使用 `rspack-test-tools/tests/fixtures` 作为构建的源码，因此用例以单文件编写，其输出结构如下：
+此测试固定使用 `tests/rspack-test/fixtures` 作为构建的源码，因此用例以单文件编写，其输出结构如下：
 
 ```js title="{case}.js"
 type TStatsAPICaseConfig = {
@@ -281,7 +281,7 @@ module.exports = {
 | 默认配置 | [`无`](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/simple.ts) |
 | 产物运行 | `否`                                                                                                         |
 
-此测试固定使用 `rspack-test-tools/tests/fixtures` 作为构建的源码，因此用例以单文件编写，其输出结构如下：
+此测试固定使用 `tests/rspack-test/fixtures` 作为构建的源码，因此用例以单文件编写，其输出结构如下：
 
 ```js title="{case.js}"
 interface TCompilerCaseConfig {
@@ -312,14 +312,14 @@ module.exports = {
 | 默认配置 | [`无`](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/defaults.ts) |
 | 产物运行 | `否`                                                                                                           |
 
-此测试不会执行真实的构建，仅会生成构建配置并观察与默认配置的差异。基础的默认配置会生成快照并存放在 `rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap` 中。
+此测试不会执行真实的构建，仅会生成构建配置并观察与默认配置的差异。基础的默认配置会生成快照并存放在 `tests/rspack-test/__snapshots__/Defaults.test.js.snap` 中。
 
-此测试固定使用 `rspack-test-tools/tests/fixtures` 作为构建的源码，因此用例以单文件编写，其输出结构如下：
+此测试固定使用 `tests/rspack-test/fixtures` 作为构建的源码，因此用例以单文件编写，其输出结构如下：
 
 ```js title="{case}.js"
 interface TDefaultsCaseConfig {
   description: string; // 用例描述
-  cwd?: string; // 用例的生成构建配置时的 process.cwd，默认为 `rspack-test-tools` 目录
+  cwd?: string; // 用例的生成构建配置时的 process.cwd，默认为 `tests/rspack-test` 目录
   options?: (context: ITestContext) => TCompilerOptions<ECompilerType.Rspack>; // 用例构建配置
   diff: (
     diff: jest.JestMatchers<Diff>,
@@ -343,7 +343,7 @@ module.exports = {
 | 默认配置 | [ErrorProcessor](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack-test-tools/src/processor/error.ts#L84) |
 | 产物运行 | `否`                                                                                                                      |
 
-此测试的用例固定使用 `rspack-test-tools/tests/fixtures` 作为构建的源码，因此测试用例以特定的配置结构编写：
+此测试的用例固定使用 `tests/rspack-test/fixtures` 作为构建的源码，因此测试用例以特定的配置结构编写：
 
 ```js title="{case}.js"
 interface TErrorCaseConfig {
@@ -374,7 +374,7 @@ module.exports = {
 
 会记录 hook 的出入参并存放在快照 `hooks.snap.txt` 中，最终产物代码的快照存放在 `output.snap.txt` 中。
 
-此测试的用例固定使用 `rspack-test-tools/tests/fixtures` 作为构建的源码，因此测试用例以特定的配置结构编写：
+此测试的用例固定使用 `tests/rspack-test/fixtures` 作为构建的源码，因此测试用例以特定的配置结构编写：
 
 ```js title="{case}/test.js"
 interface THookCaseConfig {

--- a/website/docs/zh/contribute/development/testing.mdx
+++ b/website/docs/zh/contribute/development/testing.mdx
@@ -55,10 +55,10 @@ Rspack 的测试用例存放在在 `tests/rspack-test` 文件夹下，包括独�
 
 通过在根文件夹下运行 `./x test unit` 或 `pnpm run test:unit` 即可运行 Rspack 测试。
 
-也可以进入 `packages/rspack-test-tools` 文件夹并运行 `npm run test` 来运行测试用例，并且对测试流程进行更精细的控制：
+也可以进入 `tests/rspack-test` 文件夹并运行 `npm run test` 来运行测试用例，并且对测试流程进行更精细的控制：
 
 - **需要刷新测试快照时**：添加 `-u` 参数，如 `npm run test -- -u`
-- **需要过滤测试用例时**：添加 `-t` 参数，如 `npm run test -- -t config/asset` 即可仅运行 `packages/rspack-test-tools/configCases/asset` 文件夹下的用例（`config` 会自动映射到 `configCases`，其他文件夹类似）。匹配支持正则，详见 [jest](https://jestjs.io/docs/cli#--testnamepatternregex)
+- **需要过滤测试用例时**：添加 `-t` 参数，如 `npm run test -- -t config/asset` 即可仅运行 `tests/rspack-test/configCases/asset` 文件夹下的用例（`config` 会自动映射到 `configCases`，其他文件夹类似）。匹配支持正则，详见 [jest](https://jestjs.io/docs/cli#--testnamepatternregex)
 
 > 更多细节请参考：[Rspack 测试](./testing-rspack)
 


### PR DESCRIPTION
## Summary

update the test path from `packages/rspack-test-tools` to `tests/rspack-test` because the test cases have been moved

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
