### PR TITLE
test: use case directory name as case names to match the filter

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -37,7 +37,7 @@ export class BasicCaseCreator<T extends ECompilerType> {
     // (undocumented)
     protected createEnv(testConfig: TTestConfig<T>): ITestEnv;
     // (undocumented)
-    protected createTester(name: string, src: string, dist: string, temp: string | void, testConfig: TTestConfig<T>): ITester;
+    protected createTester(name: string, src: string, dist: string, temp: string | undefined, testConfig: TTestConfig<T>): ITester;
     // (undocumented)
     protected currentConcurrent: number;
     // (undocumented)

--- a/packages/rspack-test-tools/src/helper/directory.ts
+++ b/packages/rspack-test-tools/src/helper/directory.ts
@@ -65,7 +65,7 @@ export function describeByWalk(
 					describeDirectory(caseName, currentLevel - 1);
 				} else {
 					const name = escapeSep(
-						path.join(testId, caseName).split(".").shift()!
+						path.join(`${testId}Cases`, caseName).split(".").shift()!
 					);
 					describeFn(name, () => {
 						const source = path.join(sourceBase, caseName);

--- a/packages/rspack-test-tools/src/test/creator.ts
+++ b/packages/rspack-test-tools/src/test/creator.ts
@@ -360,13 +360,14 @@ export class BasicCaseCreator<T extends ECompilerType> {
 		name: string,
 		src: string,
 		dist: string,
-		temp: string | void,
+		temp: string | undefined,
 		testConfig: TTestConfig<T>
 	): ITester {
 		return new Tester({
 			name,
 			src,
 			dist,
+			temp,
 			testConfig,
 			contextValue: this._options.contextValue,
 			runnerFactory: this._options.runner,

--- a/packages/rspack-test-tools/src/test/tester.ts
+++ b/packages/rspack-test-tools/src/test/tester.ts
@@ -1,3 +1,4 @@
+import fs from "fs-extra";
 import type {
 	ITestContext,
 	ITestEnv,
@@ -30,6 +31,11 @@ export class Tester implements ITester {
 		return this.context;
 	}
 	async prepare() {
+		fs.mkdirSync(this.context.getDist(), { recursive: true });
+		const tempDir = this.context.getTemp();
+		if (tempDir) {
+			fs.mkdirSync(tempDir, { recursive: true });
+		}
 		for (const i of this.steps) {
 			if (typeof i.beforeAll === "function") {
 				await i.beforeAll(this.context);

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -16,13 +16,17 @@ import binding from '@rspack/binding';
 import { Buffer as Buffer_2 } from 'buffer';
 import { BuiltinPlugin } from '@rspack/binding';
 import { BuiltinPluginName } from '@rspack/binding';
+import { CacheFacade as CacheFacade_2 } from './lib/CacheFacade';
 import type { Callback } from '@rspack/lite-tapable';
 import { Chunk } from '@rspack/binding';
 import { ChunkGraph } from '@rspack/binding';
 import { ChunkGroup } from '@rspack/binding';
+import { Compiler as Compiler_2 } from '..';
 import { ConcatenatedModule } from '@rspack/binding';
+import { Configuration as Configuration_2 } from '..';
 import { ContextModule } from '@rspack/binding';
 import { createReadStream } from 'fs';
+import { default as default_2 } from './util/hash';
 import { Dependency } from '@rspack/binding';
 import type { DependencyLocation } from '@rspack/binding';
 import { EnforceExtension } from '@rspack/binding';
@@ -58,9 +62,11 @@ import type { JsStats } from '@rspack/binding';
 import type { JsStatsCompilation } from '@rspack/binding';
 import type { JsStatsError } from '@rspack/binding';
 import * as liteTapable from '@rspack/lite-tapable';
+import { Logger } from './logging/Logger';
 import { Module } from '@rspack/binding';
 import type { ModuleGraphConnection } from '@rspack/binding';
 import { NormalModule } from '@rspack/binding';
+import { OutputFileSystem as OutputFileSystem_3 } from '..';
 import { RawCopyPattern } from '@rspack/binding';
 import { RawCssExtractPluginOption } from '@rspack/binding';
 import type { RawFuncUseCtx } from '@rspack/binding';
@@ -76,7 +82,9 @@ import { RawSubresourceIntegrityPluginOptions } from '@rspack/binding';
 import { readFileSync } from 'fs';
 import { ReadStream as ReadStream_2 } from 'fs';
 import { ResolverFactory as ResolverFactory_2 } from '@rspack/binding';
+import { ResolverWithOptions as ResolverWithOptions_2 } from './ResolverFactory';
 import { RspackError } from '@rspack/binding';
+import { RspackOptionsNormalized as RspackOptionsNormalized_2 } from '.';
 import { Server } from 'net';
 import { Server as Server_2 } from 'tls';
 import { Server as Server_3 } from 'http';
@@ -377,8 +385,8 @@ export const BannerPlugin: {
         name: string;
         _args: [args: BannerPluginArgument];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -932,11 +940,11 @@ export class Compilation {
     getAssetPathWithInfo(filename: string, data?: PathData): binding.PathWithInfo;
     getAssets(): ReadonlyArray<Asset>;
     // (undocumented)
-    getCache(name: string): CacheFacade;
+    getCache(name: string): CacheFacade_2;
     // (undocumented)
     getErrors(): WebpackError_2[];
     // (undocumented)
-    getLogger(name: string | (() => string)): Logger;
+    getLogger(name: string | (() => string)): Logger_3;
     // (undocumented)
     getPath(filename: string, data?: PathData): string;
     // (undocumented)
@@ -1128,7 +1136,7 @@ export class Compiler {
     // (undocumented)
     getCache(name: string): CacheFacade;
     // (undocumented)
-    getInfrastructureLogger(name: string | (() => string)): Logger;
+    getInfrastructureLogger(name: string | (() => string)): Logger_3;
     // (undocumented)
     hooks: {
         done: liteTapable.AsyncSeriesHook<Stats>;
@@ -1493,8 +1501,8 @@ export const ContextReplacementPlugin: {
         name: string;
         _args: [resourceRegExp: RegExp, newContentResource?: any, newContentRecursive?: any, newContentRegExp?: any];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -1512,8 +1520,8 @@ export const CopyRspackPlugin: {
         name: string;
         _args: [copy: CopyRspackPluginOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -1562,8 +1570,8 @@ const CssChunkingPlugin: {
         name: string;
         _args: [options?: CssChunkingPluginOptions | undefined];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): binding.BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): binding.BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -1700,8 +1708,8 @@ export const DefinePlugin: {
         name: string;
         _args: [define: DefinePluginOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -1993,8 +2001,8 @@ const ElectronTargetPlugin: {
         name: string;
         _args: [context?: string | undefined];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -2053,8 +2061,8 @@ const EnableWasmLoadingPlugin: {
         name: string;
         _args: [type: string];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -2284,8 +2292,8 @@ export const EvalDevToolModulePlugin: {
         name: string;
         _args: [options: EvalDevToolModulePluginOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -2297,8 +2305,8 @@ export const EvalSourceMapDevToolPlugin: {
         name: string;
         _args: [options: SourceMapDevToolPluginOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -2691,8 +2699,8 @@ const FetchCompileAsyncWasmPlugin: {
         name: string;
         _args: [];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -2815,7 +2823,7 @@ export type GeneratorOptionsByModuleTypeKnown = {
 export type GeneratorOptionsByModuleTypeUnknown = Record<string, Record<string, any>>;
 
 // @public (undocumented)
-type GetChildLogger = (name: string | (() => string)) => Logger;
+type GetChildLogger = (name: string | (() => string)) => Logger_3;
 
 // @public (undocumented)
 export const getNormalizedRspackOptions: (config: RspackOptions) => RspackOptionsNormalized;
@@ -3122,8 +3130,8 @@ export const IgnorePlugin: {
         name: string;
         _args: [options: IgnorePluginOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -4199,8 +4207,8 @@ export const LightningCssMinimizerRspackPlugin: {
         name: string;
         _args: [options?: LightningCssMinimizerRspackPluginOptions | undefined];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -4236,8 +4244,8 @@ const LimitChunkCountPlugin: {
         name: string;
         _args: [options: LimitChunkCountOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -4276,7 +4284,7 @@ export interface LoaderContext<OptionsType = {}> {
     getContextDependencies(): string[];
     // (undocumented)
     getDependencies(): string[];
-    getLogger(name: string): Logger;
+    getLogger(name: string): Logger_3;
     // (undocumented)
     getMissingDependencies(): string[];
     getOptions(schema?: any): OptionsType;
@@ -4413,7 +4421,10 @@ export interface LogEntry {
 type LogFunction = (type: LogTypeEnum, args: any[]) => void;
 
 // @public (undocumented)
-class Logger {
+type Logger_2 = ReturnType<Compiler["getInfrastructureLogger"]>;
+
+// @public (undocumented)
+class Logger_3 {
     // (undocumented)
     [LOG_SYMBOL]: any;
     // (undocumented)
@@ -4462,9 +4473,6 @@ class Logger {
     // (undocumented)
     warn(...args: any[]): void;
 }
-
-// @public (undocumented)
-type Logger_2 = ReturnType<Compiler["getInfrastructureLogger"]>;
 
 // @public
 const LogType: Readonly<{
@@ -4779,7 +4787,7 @@ export class MultiCompiler {
     get intermediateFileSystem(): IntermediateFileSystem;
     set intermediateFileSystem(value: IntermediateFileSystem);
     // (undocumented)
-    get options(): RspackOptionsNormalized[] & MultiCompilerOptions;
+    get options(): RspackOptionsNormalized_2[] & MultiCompilerOptions;
     // (undocumented)
     _options: MultiCompilerOptions;
     // (undocumented)
@@ -4970,8 +4978,8 @@ const NodeTargetPlugin: {
         name: string;
         _args: [];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -4993,8 +5001,8 @@ export const NoEmitOnErrorsPlugin: {
         name: string;
         _args: [];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -5033,7 +5041,7 @@ type NormalModuleCreateData = binding.JsNormalModuleFactoryCreateModuleArgs & {
 export class NormalModuleFactory {
     constructor(resolverFactory: ResolverFactory);
     // (undocumented)
-    getResolver(type: string, resolveOptions: ResolveOptionsWithDependencyType): ResolverWithOptions;
+    getResolver(type: string, resolveOptions: ResolveOptionsWithDependencyType): ResolverWithOptions_2;
     // (undocumented)
     hooks: {
         resolveForScheme: liteTapable.HookMap<liteTapable.AsyncSeriesBailHook<[ResourceDataWithData], true | void>>;
@@ -5056,8 +5064,8 @@ export const NormalModuleReplacementPlugin: {
         name: string;
         _args: [resourceRegExp: RegExp, newResource: string | ((data: ResolveData) => void)];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -5273,8 +5281,8 @@ const OriginEntryPlugin: {
         name: string;
         _args: [context: string, entry: string, options?: string | EntryOptions | undefined];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -5364,7 +5372,7 @@ export interface OutputFileSystem {
 }
 
 // @public (undocumented)
-type OutputFileSystem_2 = OutputFileSystem & {
+type OutputFileSystem_2 = OutputFileSystem_3 & {
     createReadStream?: createReadStream;
     statSync: StatSyncFn;
     readFileSync: readFileSync;
@@ -5634,8 +5642,8 @@ export const ProgressPlugin: {
         name: string;
         _args: [progress?: ProgressPluginArgument];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -5660,8 +5668,8 @@ export const ProvidePlugin: {
         name: string;
         _args: [provide: ProvidePluginOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -5986,8 +5994,8 @@ const RemoveDuplicateModulesPlugin: {
         name: string;
         _args: [];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -6183,8 +6191,8 @@ const RslibPlugin: {
         name: string;
         _args: [rslib: RawRslibPluginOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -6230,7 +6238,7 @@ abstract class RspackBuiltinPlugin implements RspackPluginInstance {
 }
 
 // @public (undocumented)
-type RspackConfiguration = Configuration;
+type RspackConfiguration = Configuration_2;
 
 export { RspackError }
 
@@ -6733,8 +6741,8 @@ const RstestPlugin: {
         name: string;
         _args: [rstest: RawRstestPluginOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -6823,8 +6831,8 @@ const RuntimeChunkPlugin: {
         name: string;
         _args: [options: RawRuntimeChunkOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -6972,8 +6980,8 @@ const RuntimePluginImpl: {
         name: string;
         _args: [];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): binding.BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): binding.BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -7173,8 +7181,8 @@ export const SourceMapDevToolPlugin: {
         name: string;
         _args: [options: SourceMapDevToolPluginOptions];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -7570,8 +7578,8 @@ export const SwcJsMinimizerRspackPlugin: {
         name: string;
         _args: [options?: SwcJsMinimizerRspackPluginOptions | undefined];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 
@@ -8830,7 +8838,7 @@ export type UseInputFileSystem = false | RegExp[];
 
 // @public (undocumented)
 export const util: {
-    createHash: (algorithm: "debug" | "xxhash64" | "md4" | "native-md4" | (string & {}) | (new () => Hash)) => Hash;
+    createHash: (algorithm: "debug" | "xxhash64" | "md4" | "native-md4" | (string & {}) | (new () => default_2)) => default_2;
     cleverMerge: <First, Second>(first: First, second: Second) => First | Second | (First & Second);
 };
 
@@ -8889,8 +8897,8 @@ export const WarnCaseSensitiveModulesPlugin: {
         name: string;
         _args: [];
         affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
     };
 };
 

--- a/tests/rspack-test/__snapshots__/Serial.test.js.snap
+++ b/tests/rspack-test/__snapshots__/Serial.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`serial serial/css/css-modules-no-space exported tests should allow to create css modules: cssContent 1`] = `
+exports[`serial serialCases/css/css-modules-no-space exported tests should allow to create css modules: cssContent 1`] = `
 /*!**************************!*\\
   !*** ./style.module.css ***!
   \\**************************/
@@ -31,13 +31,13 @@ exports[`serial serial/css/css-modules-no-space exported tests should allow to c
 }
 `;
 
-exports[`serial serial/css/css-modules-no-space exported tests should allow to create css modules: x 1`] = `
+exports[`serial serialCases/css/css-modules-no-space exported tests should allow to create css modules: x 1`] = `
 Object {
   class: _style_module_css-class,
 }
 `;
 
-exports[`serial serial/css/escape-unescape exported tests should work with URLs in CSS: classes 1`] = `
+exports[`serial serialCases/css/escape-unescape exported tests should work with URLs in CSS: classes 1`] = `
 Object {
   #: _style_modules_css-#,
   ##: _style_modules_css-##,
@@ -92,7 +92,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/escape-unescape exported tests should work with URLs in CSS: classes 2`] = `
+exports[`serial serialCases/css/escape-unescape exported tests should work with URLs in CSS: classes 2`] = `
 Object {
   #: _style_modules_css-#,
   ##: _style_modules_css-##,
@@ -147,7 +147,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/escape-unescape exported tests should work with URLs in CSS: css 1`] = `
+exports[`serial serialCases/css/escape-unescape exported tests should work with URLs in CSS: css 1`] = `
 Array [
   /*!***************************!*\\
   !*** ./style.modules.css ***!
@@ -289,7 +289,7 @@ details {
 ]
 `;
 
-exports[`serial serial/css/escape-unescape exported tests should work with URLs in CSS: css 2`] = `
+exports[`serial serialCases/css/escape-unescape exported tests should work with URLs in CSS: css 2`] = `
 Array [
   /*!***************************!*\\
   !*** ./style.modules.css ***!
@@ -431,19 +431,19 @@ details {
 ]
 `;
 
-exports[`serial serial/css/large exported tests should allow to create css modules: 0_dev 1`] = `
+exports[`serial serialCases/css/large exported tests should allow to create css modules: 0_dev 1`] = `
 Object {
   placeholder: my-app-_tailwind_module_css-placeholder-gray-700,
 }
 `;
 
-exports[`serial serial/css/large exported tests should allow to create css modules: 1_prod 1`] = `
+exports[`serial serialCases/css/large exported tests should allow to create css modules: 1_prod 1`] = `
 Object {
   placeholder: _6d72b53b84605386-placeholder-gray-700,
 }
 `;
 
-exports[`serial serial/css/no-extra-runtime-in-js exported tests should compile 1`] = `
+exports[`serial serialCases/css/no-extra-runtime-in-js exported tests should compile 1`] = `
 Array [
   /*!*******************!*\\
   !*** ./style.css ***!
@@ -510,7 +510,7 @@ Array [
 ]
 `;
 
-exports[`serial serial/css/pseudo-import exported tests should compile 1`] = `
+exports[`serial serialCases/css/pseudo-import exported tests should compile 1`] = `
 Array [
   /*!***************************!*\\
   !*** ./style.modules.css ***!
@@ -683,7 +683,7 @@ Array [
 ]
 `;
 
-exports[`serial serial/css/pure-css exported tests should compile 1`] = `
+exports[`serial serialCases/css/pure-css exported tests should compile 1`] = `
 Array [
   /*!***************************************!*\\
   !*** ../css-modules/style.module.css ***!
@@ -924,7 +924,7 @@ Array [
 ]
 `;
 
-exports[`serial serial/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 0_style1 1`] = `
+exports[`serial serialCases/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 0_style1 1`] = `
 Object {
   getPropertyValue: [Function],
   nested-dir: url(../../bundle0/assets/img2.png),
@@ -933,7 +933,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 0_style2 1`] = `
+exports[`serial serialCases/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 0_style2 1`] = `
 Object {
   getPropertyValue: [Function],
   nested-dir: url(../../bundle0/assets/img3.png),
@@ -942,7 +942,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 0_style3 1`] = `
+exports[`serial serialCases/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 0_style3 1`] = `
 Object {
   getPropertyValue: [Function],
   outer-dir: url(../../bundle0/assets/img2.png),
@@ -951,7 +951,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 1_style1 1`] = `
+exports[`serial serialCases/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 1_style1 1`] = `
 Object {
   getPropertyValue: [Function],
   nested-dir: url(https://test.cases/path/bundle1/assets/img2.png),
@@ -960,7 +960,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 1_style2 1`] = `
+exports[`serial serialCases/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 1_style2 1`] = `
 Object {
   getPropertyValue: [Function],
   nested-dir: url(https://test.cases/path/bundle1/assets/img3.png),
@@ -969,7 +969,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 1_style3 1`] = `
+exports[`serial serialCases/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 1_style3 1`] = `
 Object {
   getPropertyValue: [Function],
   outer-dir: url(https://test.cases/path/bundle1/assets/img2.png),
@@ -978,7 +978,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 2_style1 1`] = `
+exports[`serial serialCases/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 2_style1 1`] = `
 Object {
   getPropertyValue: [Function],
   nested-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img2.png),
@@ -987,7 +987,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 2_style2 1`] = `
+exports[`serial serialCases/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 2_style2 1`] = `
 Object {
   getPropertyValue: [Function],
   nested-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img3.png),
@@ -996,7 +996,7 @@ Object {
 }
 `;
 
-exports[`serial serial/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 2_style3 1`] = `
+exports[`serial serialCases/css/url-and-asset-module-filename exported tests should generate correct url public path with css filename: 2_style3 1`] = `
 Object {
   getPropertyValue: [Function],
   outer-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img2.png),
@@ -1005,7 +1005,7 @@ Object {
 }
 `;
 
-exports[`serial serial/custom-modules/json-custom exported tests should transform toml to json 1`] = `
+exports[`serial serialCases/custom-modules/json-custom exported tests should transform toml to json 1`] = `
 Object {
   owner: Object {
     bio: GitHub Cofounder & CEO

--- a/tests/rspack-test/__snapshots__/StatsAPI.test.js.snap
+++ b/tests/rspack-test/__snapshots__/StatsAPI.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`statsAPI statsAPI/basic should have stats 1`] = `
+exports[`statsAPI statsAPICases/basic should have stats 1`] = `
 Object {
   assets: Array [
     Object {
@@ -281,7 +281,7 @@ Object {
 }
 `;
 
-exports[`statsAPI statsAPI/exports should have usedExports and providedExports stats 1`] = `
+exports[`statsAPI statsAPICases/exports should have usedExports and providedExports stats 1`] = `
 Object {
   assets: Array [
     Object {
@@ -1478,7 +1478,7 @@ Object {
 }
 `;
 
-exports[`statsAPI statsAPI/ids should have ids when ids is true 1`] = `
+exports[`statsAPI statsAPICases/ids should have ids when ids is true 1`] = `
 Object {
   assets: Array [
     Object {
@@ -1582,7 +1582,7 @@ Object {
 }
 `;
 
-exports[`statsAPI statsAPI/layer-stats should have module layer 1`] = `
+exports[`statsAPI statsAPICases/layer-stats should have module layer 1`] = `
 Object {
   filteredModules: undefined,
   modules: Array [
@@ -1612,7 +1612,7 @@ Object {
 }
 `;
 
-exports[`statsAPI statsAPI/with-query should output stats with query 1`] = `
+exports[`statsAPI statsAPICases/with-query should output stats with query 1`] = `
 Object {
   assets: Array [
     Object {

--- a/tests/rspack-test/__snapshots__/StatsOutput.test.js.snap
+++ b/tests/rspack-test/__snapshots__/StatsOutput.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`statsOutput statsOutput/auxiliary-files-test should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/auxiliary-files-test should print correct stats for 1`] = `
 PublicPath: auto
 asset bundle.js xx KiB {889} [emitted] (name: main)
 asset 98396dbfd5c74c34.png 7 bytes ({889}) [emitted] [immutable] [from: raw.png] (auxiliary name: main)
@@ -61,7 +61,7 @@ runtime modules xx KiB
 Rspack compiled successfully (97e4ff8d4fa12b75)
 `;
 
-exports[`statsOutput statsOutput/builtin-swc-loader-parse-error should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/builtin-swc-loader-parse-error should print correct stats for 1`] = `
 ERROR in ./index.ts
   × Module build failed:
   ├─▶   ×   x Expected '{', got 'error'
@@ -76,14 +76,14 @@ ERROR in ./index.ts
 Rspack compiled with 1 error
 `;
 
-exports[`statsOutput statsOutput/concatenated-modules should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/concatenated-modules should print correct stats for 1`] = `
 asset main.js 234 bytes [emitted] (name: main)
 orphan modules 141 bytes [orphan] 4 modules
 ./index.js + 3 modules 141 bytes [code generated]
 Rspack x.x.x compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/css-concat should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/css-concat should print correct stats for 1`] = `
 asset main.js xx KiB [emitted] (name: main)
 asset main.css 24 bytes [emitted] (name: main)
 Entrypoint main xx KiB = main.js xx KiB main.css 24 bytes
@@ -94,7 +94,7 @@ cacheable modules 62 bytes (javascript) 23 bytes (css)
 Rspack x.x.x compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/filename should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/filename should print correct stats for 1`] = `
 asset 889.xxxx.js xx KiB [emitted] (name: main)
 asset 769.xxxx.js 320 bytes [emitted]
 runtime modules xx KiB 11 modules
@@ -104,27 +104,27 @@ cacheable modules 70 bytes
 Rspack x.x.x compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/hot+production should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/hot+production should print correct stats for 1`] = `
 asset main.js xx KiB [emitted] (name: main)
 runtime modules xx KiB 12 modules
 ./index.js 25 bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/ignore-plugin should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/ignore-plugin should print correct stats for 1`] = `
 runtime modules 88 bytes 1 module
 ./index.js 103 bytes [built] [code generated]
 <TEST_TOOLS_ROOT>/statsOutputCases/ignore-plugin/locals|sync|/^\\.\\/.*$/ 160 bytes [built] [code generated]
 ./locals/en.js 30 bytes [built] [code generated]
 `;
 
-exports[`statsOutput statsOutput/ignore-warning should print correct stats for 1`] = `Rspack compiled successfully`;
+exports[`statsOutput statsOutputCases/ignore-warning should print correct stats for 1`] = `Rspack compiled successfully`;
 
-exports[`statsOutput statsOutput/issue-3558 should print correct stats for 1`] = `Rspack compiled successfully`;
+exports[`statsOutput statsOutputCases/issue-3558 should print correct stats for 1`] = `Rspack compiled successfully`;
 
-exports[`statsOutput statsOutput/legacy-ie-css-warning should print correct stats for 1`] = `Rspack compiled successfully`;
+exports[`statsOutput statsOutputCases/legacy-ie-css-warning should print correct stats for 1`] = `Rspack compiled successfully`;
 
-exports[`statsOutput statsOutput/let-keyword-as-variable-name-error should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/let-keyword-as-variable-name-error should print correct stats for 1`] = `
 ERROR in ./index.js
   × Module parse failed:
   ╰─▶   × JavaScript parse error: Unexpected token \`let\`. Expected let is reserved in const, let, class declaration
@@ -139,7 +139,7 @@ ERROR in ./index.js
 Rspack compiled with 1 error
 `;
 
-exports[`statsOutput statsOutput/limit-chunk-count-plugin should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/limit-chunk-count-plugin should print correct stats for 1`] = `
 1 chunks:
   asset bundle1.js xx KiB [emitted] (name: main)
   chunk (runtime: main) bundle1.js (main) 219 bytes (javascript) xx KiB (runtime) <{889}> >{889}< [entry] [rendered]
@@ -189,7 +189,7 @@ exports[`statsOutput statsOutput/limit-chunk-count-plugin should print correct s
   4 chunks (Rspack x.x.x) compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/logging-loader should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/logging-loader should print correct stats for 1`] = `
 DEBUG LOG from TestLoader|<TEST_TOOLS_ROOT>/statsOutputCases/logging-loader/index.js
 <-> group
   <i> info something
@@ -197,13 +197,13 @@ DEBUG LOG from TestLoader|<TEST_TOOLS_ROOT>/statsOutputCases/logging-loader/inde
     -------
 `;
 
-exports[`statsOutput statsOutput/match-resource-data-url should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/match-resource-data-url should print correct stats for 1`] = `
 runtime modules 647 bytes 3 modules
 ./index.js 150 bytes [built] [code generated]
 ./a.js!=!data:javascript,var __looooooooo.. 98 bytes [built] [code generated]
 `;
 
-exports[`statsOutput statsOutput/minify-error should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/minify-error should print correct stats for 1`] = `
 ERROR in main.js
   × Chunk minification failed:
   ╰─▶   × JavaScript parse error: 'const' declarations must be initialized
@@ -227,12 +227,12 @@ ERROR in main.js
 Rspack compiled with 2 errors
 `;
 
-exports[`statsOutput statsOutput/named-chunk-group should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/named-chunk-group should print correct stats for 1`] = `
 Entrypoint main xx KiB = main.js
 Chunk Group cimanyd 319 bytes = cimanyd.js
 `;
 
-exports[`statsOutput statsOutput/nonexistent-import-source-error should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/nonexistent-import-source-error should print correct stats for 1`] = `
 ERROR in ./index.js 1:0-19
   × Module not found: Can't resolve 'not-exist' in '<TEST_TOOLS_ROOT>/statsOutputCases/nonexistent-import-source-error'
    ╭────
@@ -243,7 +243,7 @@ ERROR in ./index.js 1:0-19
 Rspack compiled with 1 error
 `;
 
-exports[`statsOutput statsOutput/optimization-chunk-ids-natural should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/optimization-chunk-ids-natural should print correct stats for 1`] = `
 Entrypoint e1 xx KiB = e1.js
 Entrypoint e2 xx KiB = e2.js
 chunk (runtime: e1) 0.js 52 bytes [rendered]
@@ -253,7 +253,7 @@ chunk (runtime: e1) e1.js (e1) 74 bytes (javascript) xx KiB (runtime) [entry] [r
 chunk (runtime: e2) e2.js (e2) 51 bytes (javascript) xx KiB (runtime) [entry] [rendered]
 `;
 
-exports[`statsOutput statsOutput/optimization-runtime-chunk should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/optimization-runtime-chunk should print correct stats for 1`] = `
 Entrypoint e1 xx KiB = e1~runtime.js xx KiB e1.js 458 bytes
 Entrypoint e2 xx KiB = e2~runtime.js xx KiB e2.js 458 bytes
 chunk (runtime: e1~runtime) e1.js (e1) 27 bytes [entry] [rendered]
@@ -262,7 +262,7 @@ chunk (runtime: e2~runtime) e2.js (e2) 27 bytes [entry] [rendered]
 chunk (runtime: e2~runtime) e2~runtime.js (e2~runtime) xx KiB [initial] [rendered]
 `;
 
-exports[`statsOutput statsOutput/optimization-runtime-chunk-multiple should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/optimization-runtime-chunk-multiple should print correct stats for 1`] = `
 Entrypoint e1 xx KiB = runtime~e1.js xx KiB e1.js 458 bytes
 Entrypoint e2 xx KiB = runtime~e2.js xx KiB e2.js 458 bytes
 chunk (runtime: runtime~e1) e1.js (e1) 27 bytes [entry] [rendered]
@@ -271,7 +271,7 @@ chunk (runtime: runtime~e1) runtime~e1.js (runtime~e1) xx KiB [initial] [rendere
 chunk (runtime: runtime~e2) runtime~e2.js (runtime~e2) xx KiB [initial] [rendered]
 `;
 
-exports[`statsOutput statsOutput/optimization-runtime-chunk-single should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/optimization-runtime-chunk-single should print correct stats for 1`] = `
 Entrypoint e1 xx KiB = runtime.js xx KiB e1.js 458 bytes
 Entrypoint e2 xx KiB = runtime.js xx KiB e2.js 458 bytes
 chunk (runtime: runtime) e1.js (e1) 27 bytes [entry] [rendered]
@@ -279,7 +279,7 @@ chunk (runtime: runtime) e2.js (e2) 27 bytes [entry] [rendered]
 chunk (runtime: runtime) runtime.js (runtime) xx KiB [initial] [rendered]
 `;
 
-exports[`statsOutput statsOutput/optimization-runtime-chunk-true should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/optimization-runtime-chunk-true should print correct stats for 1`] = `
 Entrypoint e1 xx KiB = runtime~e1.js xx KiB e1.js 458 bytes
 Entrypoint e2 xx KiB = runtime~e2.js xx KiB e2.js 458 bytes
 chunk (runtime: runtime~e1) e1.js (e1) 27 bytes [entry] [rendered]
@@ -288,7 +288,7 @@ chunk (runtime: runtime~e1) runtime~e1.js (runtime~e1) xx KiB [initial] [rendere
 chunk (runtime: runtime~e2) runtime~e2.js (runtime~e2) xx KiB [initial] [rendered]
 `;
 
-exports[`statsOutput statsOutput/parse-error should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/parse-error should print correct stats for 1`] = `
 ERROR in ./b.js
   × Module parse failed:
   ╰─▶   × JavaScript parse error: Expected ';', '}' or <eof>
@@ -307,7 +307,7 @@ ERROR in ./b.js
 Rspack compiled with 1 error
 `;
 
-exports[`statsOutput statsOutput/performance-disabled should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/performance-disabled should print correct stats for 1`] = `
 asset main.js xx KiB [emitted] (name: main)
 asset 266.js 128 bytes [emitted]
 asset 327.js 128 bytes [emitted]
@@ -323,7 +323,7 @@ cacheable modules xx KiB
 Rspack x.x.x compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/performance-error should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/performance-error should print correct stats for 1`] = `
 asset main.js xx KiB [emitted] [big] (name: main)
 asset 266.js 128 bytes [emitted]
 asset 327.js 128 bytes [emitted]
@@ -349,7 +349,7 @@ ERROR in × entrypoint size limit: The following entrypoint(s) combined asset si
 Rspack x.x.x compiled with 2 errors in X s
 `;
 
-exports[`statsOutput statsOutput/performance-no-hints should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/performance-no-hints should print correct stats for 1`] = `
 asset main.js xx KiB [emitted] [big] (name: main)
 asset 266.js 128 bytes [emitted]
 asset 327.js 128 bytes [emitted]
@@ -365,7 +365,7 @@ cacheable modules xx KiB
 Rspack x.x.x compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/prefetch-preload-mixed should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/prefetch-preload-mixed should print correct stats for 1`] = `
 chunk (runtime: main) c1.js (c1) 1 bytes <{907}> [rendered]
 chunk (runtime: main) a.js (a) 136 bytes <{889}> >{934}< >{987}< (prefetch: {934} {987}) [rendered]
 chunk (runtime: main) b.js (b) 203 bytes <{889}> >{685}< >{899}< >{940}< (prefetch: {685} {899}) (preload: {940}) [rendered]
@@ -379,7 +379,7 @@ chunk (runtime: main) a2.js (a2) 1 bytes <{341}> [rendered]
 chunk (runtime: main) c2.js (c2) 1 bytes <{907}> [rendered]
 `;
 
-exports[`statsOutput statsOutput/reasons should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/reasons should print correct stats for 1`] = `
 ./index.js 44 bytes [built] [code generated]
   entry ./index
 ./a.js 55 bytes [built] [code generated]
@@ -387,7 +387,7 @@ exports[`statsOutput statsOutput/reasons should print correct stats for 1`] = `
   cjs require ./a ./index.js 1:18-23
 `;
 
-exports[`statsOutput statsOutput/resolve-overflow-error should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/resolve-overflow-error should print correct stats for 1`] = `
 assets by status 348 bytes [cached] 1 asset
 ./index.js 51 bytes [built] [code generated] [1 error]
 
@@ -403,7 +403,7 @@ ERROR in ./index.js 1:0-34
 Rspack x.x.x compiled with 1 error in X s
 `;
 
-exports[`statsOutput statsOutput/resolve-unexpected-exports-in-pkg-error should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/resolve-unexpected-exports-in-pkg-error should print correct stats for 1`] = `
 asset bundle.js xx KiB [emitted] (name: main)
 runtime modules 274 bytes 1 module
 ./index.js 39 bytes [built] [code generated] [1 error]
@@ -414,14 +414,14 @@ ERROR in ./index.js 1:0-22
 Rspack x.x.x compiled with 1 error in X s
 `;
 
-exports[`statsOutput statsOutput/runtime-modules should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/runtime-modules should print correct stats for 1`] = `
 ./index.js 19 bytes [built] [code generated]
 webpack/runtime/define_property_getters 285 bytes [code generated]
 webpack/runtime/has_own_property 88 bytes [code generated]
 webpack/runtime/make_namespace_object 274 bytes [code generated]
 `;
 
-exports[`statsOutput statsOutput/runtime-specific-exports should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/runtime-specific-exports should print correct stats for 1`] = `
 asset main.js xx KiB [emitted] (name: main)
 ./example.js 70 bytes [built] [code generated]
   [no exports used]
@@ -434,7 +434,7 @@ asset main.js xx KiB [emitted] (name: main)
 Rspack x.x.x compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/side-effects-bailouts should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/side-effects-bailouts should print correct stats for 1`] = `
 asset main.js 177 bytes {889} [emitted] (name: main)
 chunk {889} (runtime: main) main.js (main) 91 bytes [entry] [rendered]
 orphan modules 91 bytes [orphan] 2 modules
@@ -446,14 +446,14 @@ orphan modules 91 bytes [orphan] 2 modules
 Rspack x.x.x compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/simple-export should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/simple-export should print correct stats for 1`] = `
 asset bundle.js xx KiB [emitted] (name: main)
 runtime modules 647 bytes 3 modules
 ./index.js 26 bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 `;
 
-exports[`statsOutput statsOutput/simple-module-source should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/simple-module-source should print correct stats for 1`] = `
 asset bundle.js 2 KiB [emitted] (name: main)
 runtime modules 637 bytes 3 modules
 orphan modules 1 bytes [orphan] 1 module
@@ -463,13 +463,13 @@ cacheable modules 82 bytes
 Rspack compiled successfully
 `;
 
-exports[`statsOutput statsOutput/stats-hooks should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/stats-hooks should print correct stats for 1`] = `
 asset main.js 69 bytes [emitted111] (name: main) [testA: aaaaaa]
 ./index.js 26 bytes [built] [code generated]
 Rspack compiled successfully
 `;
 
-exports[`statsOutput statsOutput/try-require-module should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/try-require-module should print correct stats for 1`] = `
 WARNING in ./index.js 2:12-30
   ⚠ Module not found: Can't resolve './missing-module' in '<TEST_TOOLS_ROOT>/statsOutputCases/try-require-module'
    ╭─[2:4]
@@ -483,7 +483,7 @@ WARNING in ./index.js 2:12-30
 Rspack compiled with 1 warning
 `;
 
-exports[`statsOutput statsOutput/try-require-resolve-module should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/try-require-resolve-module should print correct stats for 1`] = `
 WARNING in ./index.js
   ⚠ Module not found: Can't resolve './missing-module' in '<TEST_TOOLS_ROOT>/statsOutputCases/try-require-resolve-module'
    ╭─[2:20]
@@ -497,7 +497,7 @@ WARNING in ./index.js
 Rspack compiled with 1 warning
 `;
 
-exports[`statsOutput statsOutput/try-require-resolve-weak-module should print correct stats for 1`] = `
+exports[`statsOutput statsOutputCases/try-require-resolve-weak-module should print correct stats for 1`] = `
 WARNING in ./index.js
   ⚠ Module not found: Can't resolve './missing-module' in '<TEST_TOOLS_ROOT>/statsOutputCases/try-require-resolve-weak-module'
    ╭─[2:24]

--- a/tests/rspack-test/compilerCases/splitchunks-minchunks.js
+++ b/tests/rspack-test/compilerCases/splitchunks-minchunks.js
@@ -22,12 +22,12 @@ module.exports = {
 		});
 	},
 	async check({ context }) {
-		const errors = context.getError('compiler/splitchunks-minchunks');
+		const errors = context.getError('compilerCases/splitchunks-minchunks');
 		expect(Array.isArray(errors)).toBeTruthy();
 		expect(errors.length).toBe(1);
 		expect(errors[0].toString()).toContain(
 			'Number must be greater or equal to 1 at "optimization.splitChunks.minChunks"'
 		);
-		context.clearError('compiler/splitchunks-minchunks');
+		context.clearError('compilerCases/splitchunks-minchunks');
 	}
 };

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/wth-css-extract-postcss/rspack.config.js
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/wth-css-extract-postcss/rspack.config.js
@@ -22,7 +22,7 @@ module.exports = {
 						loader: "postcss-loader",
 						options: {
 							postcssOptions: {
-								plugins: ["postcss-pxtorem"]
+								plugins: [require.resolve("postcss-pxtorem")]
 							}
 						}
 					}

--- a/tests/rspack-test/configCases/postcss-loader/pxtorem/rspack.config.js
+++ b/tests/rspack-test/configCases/postcss-loader/pxtorem/rspack.config.js
@@ -11,7 +11,7 @@ module.exports = {
 						loader: "postcss-loader",
 						options: {
 							postcssOptions: {
-								plugins: ["postcss-pxtorem"]
+								plugins: [require.resolve("postcss-pxtorem")]
 							}
 						}
 					}

--- a/tests/rspack-test/configCases/postcss-loader/with-previous-source-map/rspack.config.js
+++ b/tests/rspack-test/configCases/postcss-loader/with-previous-source-map/rspack.config.js
@@ -13,7 +13,7 @@ module.exports = {
 						loader: "postcss-loader",
 						options: {
 							postcssOptions: {
-								plugins: ["postcss-pxtorem"]
+								plugins: [require.resolve("postcss-pxtorem")]
 							}
 						}
 					},

--- a/tests/rspack-test/configCases/postcss-loader/with-source-map/rspack.config.js
+++ b/tests/rspack-test/configCases/postcss-loader/with-source-map/rspack.config.js
@@ -13,7 +13,7 @@ module.exports = {
 						loader: "postcss-loader",
 						options: {
 							postcssOptions: {
-								plugins: ["postcss-pxtorem"]
+								plugins: [require.resolve("postcss-pxtorem")]
 							}
 						}
 					}

--- a/website/docs/en/contribute/development/testing-rspack.mdx
+++ b/website/docs/en/contribute/development/testing-rspack.mdx
@@ -14,7 +14,7 @@ You can run these test cases in the following ways:
 - To update snapshots, run `npm run test -- -u` from the `tests/rspack-test` directory.
 - To pass specific jest cli arguments, run `npm run test -- {args}` from the `tests/rspack-test` directory.
 - To filter specific test cases, run `npm run test -- -t path-of-spec` from the `tests/rspack-test` directory.
-  - Like `npm run test -- -t config/asset` to only run test cases from the `tests/rspack-test/configCases/asset` folder (config will be automatically mapped to configCases, and other folders will work in a similar way).
+  - Like `npm run test -- -t configCases/asset` to only run test cases from the `tests/rspack-test/configCases/asset` folder (config will be automatically mapped to configCases, and other folders will work in a similar way).
 - To use Rspack Wasm for running test cases, you need to additionally configure the following environment variables:
   1. `NAPI_RS_FORCE_WASI=1`: Forces the use of Rspack Wasm instead of native binding
   2. `WASM=1`: Enables Wasm-specific test configurations

--- a/website/docs/en/contribute/development/testing.mdx
+++ b/website/docs/en/contribute/development/testing.mdx
@@ -58,7 +58,7 @@ You can run Rspack tests by running `./x test unit` or `pnpm run test:unit` at t
 You can also go to the `tests/rspack-test` folder and run `npm run test` to run test cases and add some arguments:
 
 - **When refreshing test snapshots is needed**: Add `-u`, like `npm run test -- -u`
-- **When filtering test cases is needed**: Add `-t`, like `npm run test -- -t config/asset` to only run test cases from the `tests/rspack-test/configCases/asset` folder (`config` will be automatically mapped to `configCases`, and other folders work similarly). Pattern matching supports regex, see [jest](https://jestjs.io/docs/cli#--testnamepatternregex) for details.
+- **When filtering test cases is needed**: Add `-t`, like `npm run test -- -t configCases/asset` to only run test cases from the `tests/rspack-test/configCases/asset` folder (`config` will be automatically mapped to `configCases`, and other folders work similarly). Pattern matching supports regex, see [jest](https://jestjs.io/docs/cli#--testnamepatternregex) for details.
 
 > For more details, please refer to: [Rspack Testing](./testing-rspack).
 

--- a/website/docs/zh/contribute/development/testing-rspack.mdx
+++ b/website/docs/zh/contribute/development/testing-rspack.mdx
@@ -14,7 +14,7 @@ Rspack 的测试用例包括如下：
 - 如需更新 snapshot，在 `tests/rspack-test` 目录下运行 `npm run test -- -u`。
 - 如需传入特定 jest cli 参数，在 `tests/rspack-test` 目录下运行 `npm run test -- {args}`。
 - 如需过滤特定测试用例，在 `tests/rspack-test` 目录下运行 `npm run test  -- -t path-of-spec`。
-  - 如 `npm run test -- -t config/asset` 即可仅运行 `tests/rspack-test/configCases/asset` 文件夹下的用例（config 会自动映射到 configCases，其他文件夹类似）。
+  - 如 `npm run test -- -t configCases/asset` 即可仅运行 `tests/rspack-test/configCases/asset` 文件夹下的用例（config 会自动映射到 configCases，其他文件夹类似）。
 - 如需使用 Rspack Wasm 运行测试用例，需要额外配置以下环境变量：
   1. `NAPI_RS_FORCE_WASI=1`： 强制使用 Rspack Wasm 而不是原生绑定
   2. `WASM=1`：启用 Wasm 专用的测试配置

--- a/website/docs/zh/contribute/development/testing.mdx
+++ b/website/docs/zh/contribute/development/testing.mdx
@@ -58,7 +58,7 @@ Rspack 的测试用例存放在在 `tests/rspack-test` 文件夹下，包括独�
 也可以进入 `tests/rspack-test` 文件夹并运行 `npm run test` 来运行测试用例，并且对测试流程进行更精细的控制：
 
 - **需要刷新测试快照时**：添加 `-u` 参数，如 `npm run test -- -u`
-- **需要过滤测试用例时**：添加 `-t` 参数，如 `npm run test -- -t config/asset` 即可仅运行 `tests/rspack-test/configCases/asset` 文件夹下的用例（`config` 会自动映射到 `configCases`，其他文件夹类似）。匹配支持正则，详见 [jest](https://jestjs.io/docs/cli#--testnamepatternregex)
+- **需要过滤测试用例时**：添加 `-t` 参数，如 `npm run test -- -t configCases/asset` 即可仅运行 `tests/rspack-test/configCases/asset` 文件夹下的用例（`config` 会自动映射到 `configCases`，其他文件夹类似）。匹配支持正则，详见 [jest](https://jestjs.io/docs/cli#--testnamepatternregex)
 
 > 更多细节请参考：[Rspack 测试](./testing-rspack)
 


### PR DESCRIPTION
## Summary

use case directory name as case names to match the filter, now you can use `-t configCases/a/b` to match the test cases instead of `config/a/b` which is not the same with the real folders.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
