### PR TITLE
feat: support webpackIgnore in commonjs require

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2322,6 +2322,10 @@ export interface RawJavascriptParserOptions {
    * @experimental
    */
   requireResolve?: boolean
+  /**
+   * This option is experimental in Rspack only and subject to change or be removed anytime.
+   * @experimental
+   */
   importDynamic?: boolean
   commonjsMagicComments?: boolean
   /**

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2322,10 +2322,6 @@ export interface RawJavascriptParserOptions {
    * @experimental
    */
   requireResolve?: boolean
-  /**
-   * This option is experimental in Rspack only and subject to change or be removed anytime.
-   * @experimental
-   */
   importDynamic?: boolean
   commonjsMagicComments?: boolean
   /**

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2327,6 +2327,7 @@ export interface RawJavascriptParserOptions {
    * @experimental
    */
   importDynamic?: boolean
+  commonjsMagicComments?: boolean
   /**
    * This option is experimental in Rspack only and subject to change or be removed anytime.
    * @experimental

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1714,6 +1714,7 @@ impl ModuleOptionsBuilder {
           require_dynamic: Some(true),
           require_resolve: Some(true),
           import_dynamic: Some(true),
+          commonjs_magic_comments: Some(false),
           inline_const: Some(false),
           ..Default::default()
         }),

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1438,6 +1438,9 @@ CompilerOptions {
                             import_dynamic: Some(
                                 true,
                             ),
+                            commonjs_magic_comments: Some(
+                                false,
+                            ),
                             inline_const: Some(
                                 false,
                             ),

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -288,6 +288,8 @@ pub struct RawJavascriptParserOptions {
   /// This option is experimental in Rspack only and subject to change or be removed anytime.
   /// @experimental
   pub require_resolve: Option<bool>,
+  /// This option is experimental in Rspack only and subject to change or be removed anytime.
+  /// @experimental
   pub import_dynamic: Option<bool>,
   pub commonjs_magic_comments: Option<bool>,
   /// This option is experimental in Rspack only and subject to change or be removed anytime.

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -288,9 +288,8 @@ pub struct RawJavascriptParserOptions {
   /// This option is experimental in Rspack only and subject to change or be removed anytime.
   /// @experimental
   pub require_resolve: Option<bool>,
-  /// This option is experimental in Rspack only and subject to change or be removed anytime.
-  /// @experimental
   pub import_dynamic: Option<bool>,
+  pub commonjs_magic_comments: Option<bool>,
   /// This option is experimental in Rspack only and subject to change or be removed anytime.
   /// @experimental
   pub inline_const: Option<bool>,
@@ -341,6 +340,7 @@ impl From<RawJavascriptParserOptions> for JavascriptParserOptions {
       require_dynamic: value.require_dynamic,
       require_resolve: value.require_resolve,
       import_dynamic: value.import_dynamic,
+      commonjs_magic_comments: value.commonjs_magic_comments,
       inline_const: value.inline_const,
     }
   }

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -282,6 +282,7 @@ pub struct JavascriptParserOptions {
   pub require_dynamic: Option<bool>,
   pub require_resolve: Option<bool>,
   pub import_dynamic: Option<bool>,
+  pub commonjs_magic_comments: Option<bool>,
   pub inline_const: Option<bool>,
 }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -154,10 +154,9 @@ impl CommonJsImportsParserPlugin {
       spread: None,
       expr: argument_expr,
     } = &call_expr.args[0]
+      && Self::has_webpack_ignore_comment(parser, call_expr.span, argument_expr.span())
     {
-      if Self::has_webpack_ignore_comment(parser, call_expr.span, argument_expr.span()) {
-        return;
-      }
+      return;
     }
 
     let argument_expr = &call_expr.args[0].expr;
@@ -229,10 +228,9 @@ impl CommonJsImportsParserPlugin {
       spread: None,
       expr: argument_expr,
     } = arg
+      && Self::has_webpack_ignore_comment(parser, call_expr.span, argument_expr.span())
     {
-      if Self::has_webpack_ignore_comment(parser, call_expr.span, argument_expr.span()) {
-        return None;
-      }
+      return None;
     }
     let param = parser.evaluate_expression(&arg.expr);
     param.is_string().then(|| {
@@ -294,10 +292,9 @@ impl CommonJsImportsParserPlugin {
       spread: None,
       expr: argument_expr,
     } = &args[0]
+      && Self::has_webpack_ignore_comment(parser, expr.span(), argument_expr.span())
     {
-      if Self::has_webpack_ignore_comment(parser, expr.span(), argument_expr.span()) {
-        return Some(true);
-      }
+      return Some(true);
     }
 
     let param = parser.evaluate_expression(&args[0].expr);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -296,7 +296,7 @@ impl CommonJsImportsParserPlugin {
     } = &args[0]
     {
       if Self::has_webpack_ignore_comment(parser, expr.span(), argument_expr.span()) {
-        return None;
+        return Some(true);
       }
     }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -127,6 +127,24 @@ impl CallOrNewExpr<'_> {
 pub struct CommonJsImportsParserPlugin;
 
 impl CommonJsImportsParserPlugin {
+  fn has_webpack_ignore_comment(
+    parser: &mut JavascriptParser,
+    error_span: Span,
+    span: Span,
+  ) -> bool {
+    if !parser
+      .javascript_options
+      .commonjs_magic_comments
+      .unwrap_or(false)
+    {
+      return false;
+    }
+
+    try_extract_webpack_magic_comment(parser, error_span, span)
+      .get_webpack_ignore()
+      .unwrap_or_default()
+  }
+
   fn process_resolve(&self, parser: &mut JavascriptParser, call_expr: &CallExpr, weak: bool) {
     if call_expr.args.len() != 1 {
       return;
@@ -137,12 +155,7 @@ impl CommonJsImportsParserPlugin {
       expr: argument_expr,
     } = &call_expr.args[0]
     {
-      let magic_comment_options =
-        try_extract_webpack_magic_comment(parser, call_expr.span, argument_expr.span());
-      if magic_comment_options
-        .get_webpack_ignore()
-        .unwrap_or_default()
-      {
+      if Self::has_webpack_ignore_comment(parser, call_expr.span, argument_expr.span()) {
         return;
       }
     }
@@ -217,12 +230,7 @@ impl CommonJsImportsParserPlugin {
       expr: argument_expr,
     } = arg
     {
-      let magic_comment_options =
-        try_extract_webpack_magic_comment(parser, call_expr.span, argument_expr.span());
-      if magic_comment_options
-        .get_webpack_ignore()
-        .unwrap_or_default()
-      {
+      if Self::has_webpack_ignore_comment(parser, call_expr.span, argument_expr.span()) {
         return None;
       }
     }
@@ -287,12 +295,7 @@ impl CommonJsImportsParserPlugin {
       expr: argument_expr,
     } = &args[0]
     {
-      let magic_comment_options =
-        try_extract_webpack_magic_comment(parser, expr.span(), argument_expr.span());
-      if magic_comment_options
-        .get_webpack_ignore()
-        .unwrap_or_default()
-      {
+      if Self::has_webpack_ignore_comment(parser, expr.span(), argument_expr.span()) {
         return None;
       }
     }

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3377,6 +3377,7 @@ export type JavascriptParserOptions = {
     requireDynamic?: boolean;
     requireResolve?: boolean;
     importDynamic?: boolean;
+    commonjsMagicComments?: boolean;
     inlineConst?: boolean;
     typeReexportsPresence?: "no-tolerant" | "tolerant" | "tolerant-no-check";
 };

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -584,6 +584,7 @@ function getRawJavascriptParserOptions(
 		requireDynamic: parser.requireDynamic,
 		requireResolve: parser.requireResolve,
 		importDynamic: parser.importDynamic,
+		commonjsMagicComments: parser.commonjsMagicComments,
 		inlineConst: parser.inlineConst,
 		typeReexportsPresence: parser.typeReexportsPresence
 	};

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -318,6 +318,7 @@ const applyJavascriptParserOptionsDefaults = (
 	D(parserOptions, "requireDynamic", true);
 	D(parserOptions, "requireResolve", true);
 	D(parserOptions, "importDynamic", true);
+	D(parserOptions, "commonjsMagicComments", false);
 	D(parserOptions, "worker", ["..."]);
 	D(parserOptions, "importMeta", true);
 	D(parserOptions, "inlineConst", usedExports && inlineConst);

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -318,7 +318,6 @@ const applyJavascriptParserOptionsDefaults = (
 	D(parserOptions, "requireDynamic", true);
 	D(parserOptions, "requireResolve", true);
 	D(parserOptions, "importDynamic", true);
-	D(parserOptions, "commonjsMagicComments", false);
 	D(parserOptions, "worker", ["..."]);
 	D(parserOptions, "importMeta", true);
 	D(parserOptions, "inlineConst", usedExports && inlineConst);

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1108,6 +1108,11 @@ export type JavascriptParserOptions = {
 	// TODO: add docs
 	importDynamic?: boolean;
 
+	/**
+	 * Enable magic comments for CommonJS require() expressions.
+	 */
+	commonjsMagicComments?: boolean;
+
 	/** Inline const values in this module */
 	inlineConst?: boolean;
 

--- a/packages/rspack/src/schema/config.ts
+++ b/packages/rspack/src/schema/config.ts
@@ -651,6 +651,7 @@ export const getRspackOptionsSchema = memoize(() => {
 	const requireDynamic = z.boolean();
 	const requireResolve = z.boolean();
 	const importDynamic = z.boolean();
+	const commonjsMagicComments = z.boolean();
 	const inlineConst = z.boolean();
 	const typeReexportsPresence = z.enum([
 		"no-tolerant",
@@ -676,6 +677,7 @@ export const getRspackOptionsSchema = memoize(() => {
 			strictExportPresence: strictExportPresence,
 			worker: worker,
 			overrideStrict: overrideStrict,
+			commonjsMagicComments: commonjsMagicComments,
 			// #region Not available in webpack yet.
 			requireAsExpression: requireAsExpression,
 			requireDynamic: requireDynamic,

--- a/tests/rspack-test/configCases/parsing/require-ignore/test.filter.js
+++ b/tests/rspack-test/configCases/parsing/require-ignore/test.filter.js
@@ -1,2 +1,2 @@
 
-module.exports = () => "TODO: support require magic comments webpackIgnore"
+module.exports = () => true


### PR DESCRIPTION
## Summary
- respect `webpackIgnore` magic comments in CommonJS `require`/`require.resolve` handling to skip dependency creation
- enable the `configCases/parsing/require-ignore` test by reactivating its filter

## Testing
- pnpm --filter @rspack/tests test:base -- -t require-ignore *(fails: missing @rspack/test-tools module in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cba9f4a1b0832687465af3d346aa1a