### PR TITLE
fix: remove `serde` feature of `lightningcss`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,6 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitvec"
@@ -1082,7 +1079,6 @@ dependencies = [
  "dtoa-short",
  "itoa",
  "phf",
- "serde",
  "smallvec",
 ]
 
@@ -2249,7 +2245,6 @@ dependencies = [
  "parcel_sourcemap",
  "paste",
  "pathdiff",
- "serde",
  "smallvec",
  "static-self",
 ]
@@ -2778,7 +2773,6 @@ dependencies = [
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
- "serde",
  "smallvec",
  "static-self",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.14", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 jsonc-parser        = { version = "0.26.2", default-features = false, features = ["serde"] }
-lightningcss        = { version = "1.0.0-alpha.67", default-features = false, features = ["serde"] }
+lightningcss        = { version = "1.0.0-alpha.67", default-features = false }
 linked_hash_set     = { version = "0.1.5", default-features = false }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.7.5", default-features = false }

--- a/crates/rspack_cacheable/src/with/as_preset/lightningcss.rs
+++ b/crates/rspack_cacheable/src/with/as_preset/lightningcss.rs
@@ -15,6 +15,60 @@ pub struct BrowsersResolver {
   value: String,
 }
 
+// Helper functions for custom serialization without serde
+fn browsers_to_string(browsers: &Browsers) -> String {
+  let parts = vec![
+    browsers.android.map(|v| format!("android:{}", v)),
+    browsers.chrome.map(|v| format!("chrome:{}", v)),
+    browsers.edge.map(|v| format!("edge:{}", v)),
+    browsers.firefox.map(|v| format!("firefox:{}", v)),
+    browsers.ie.map(|v| format!("ie:{}", v)),
+    browsers.ios_saf.map(|v| format!("ios_saf:{}", v)),
+    browsers.opera.map(|v| format!("opera:{}", v)),
+    browsers.safari.map(|v| format!("safari:{}", v)),
+    browsers.samsung.map(|v| format!("samsung:{}", v)),
+  ];
+
+  parts.into_iter().flatten().collect::<Vec<_>>().join(",")
+}
+
+fn string_to_browsers(s: &str) -> Result<Browsers, DeserializeError> {
+  let mut browsers = Browsers::default();
+
+  if s.is_empty() {
+    return Ok(browsers);
+  }
+
+  for part in s.split(',') {
+    let mut split = part.split(':');
+    let browser = split
+      .next()
+      .ok_or_else(|| DeserializeError::MessageError("invalid browser format"))?;
+    let version_str = split
+      .next()
+      .ok_or_else(|| DeserializeError::MessageError("invalid browser format"))?;
+
+    let version = version_str
+      .parse::<u32>()
+      .map_err(|_| DeserializeError::MessageError("invalid version format"))?;
+
+    match browser {
+      "android" => browsers.android = Some(version),
+      "chrome" => browsers.chrome = Some(version),
+      "edge" => browsers.edge = Some(version),
+      "firefox" => browsers.firefox = Some(version),
+      "ie" => browsers.ie = Some(version),
+      "ios_saf" => browsers.ios_saf = Some(version),
+      "opera" => browsers.opera = Some(version),
+      "safari" => browsers.safari = Some(version),
+      "samsung" => browsers.samsung = Some(version),
+      _ => return Err(DeserializeError::MessageError("unknown browser")),
+    }
+  }
+
+  Ok(browsers)
+}
+
 impl ArchiveWith<Browsers> for AsPreset {
   type Archived = ArchivedString;
   type Resolver = BrowsersResolver;
@@ -35,8 +89,7 @@ where
     field: &Browsers,
     serializer: &mut S,
   ) -> Result<Self::Resolver, SerializeError> {
-    let value = serde_json::to_string(field)
-      .map_err(|_| SerializeError::MessageError("serialize serde_json value failed"))?;
+    let value = browsers_to_string(field);
     let inner = ArchivedString::serialize_from_str(&value, serializer)?;
     Ok(BrowsersResolver { value, inner })
   }
@@ -50,7 +103,6 @@ where
     field: &ArchivedString,
     _deserializer: &mut D,
   ) -> Result<Browsers, DeserializeError> {
-    serde_json::from_str(field.as_str())
-      .map_err(|_| DeserializeError::MessageError("deserialize serde_json value failed"))
+    string_to_browsers(field.as_str())
   }
 }

--- a/crates/rspack_cacheable_test/tests/with/as_preset/lightningcss.rs
+++ b/crates/rspack_cacheable_test/tests/with/as_preset/lightningcss.rs
@@ -20,3 +20,85 @@ fn test_preset_lightningcss() {
   let new_config: Config = from_bytes(&bytes, &()).unwrap();
   assert_eq!(config.browsers.chrome, new_config.browsers.chrome);
 }
+
+#[test]
+fn test_preset_lightningcss_multiple_browsers() {
+  let config = Config {
+    browsers: Browsers {
+      chrome: Some(222),
+      firefox: Some(123),
+      safari: Some(17),
+      edge: Some(127),
+      ..Default::default()
+    },
+  };
+
+  let bytes = to_bytes(&config, &()).unwrap();
+  let new_config: Config = from_bytes(&bytes, &()).unwrap();
+
+  assert_eq!(config.browsers.chrome, new_config.browsers.chrome);
+  assert_eq!(config.browsers.firefox, new_config.browsers.firefox);
+  assert_eq!(config.browsers.safari, new_config.browsers.safari);
+  assert_eq!(config.browsers.edge, new_config.browsers.edge);
+}
+
+#[test]
+fn test_preset_lightningcss_large_versions() {
+  let config = Config {
+    browsers: Browsers {
+      chrome: Some(999999),
+      firefox: Some(123456),
+      ..Default::default()
+    },
+  };
+
+  let bytes = to_bytes(&config, &()).unwrap();
+  let new_config: Config = from_bytes(&bytes, &()).unwrap();
+
+  assert_eq!(config.browsers.chrome, new_config.browsers.chrome);
+  assert_eq!(config.browsers.firefox, new_config.browsers.firefox);
+}
+
+#[test]
+fn test_preset_lightningcss_all_browsers() {
+  let config = Config {
+    browsers: Browsers {
+      android: Some(108),
+      chrome: Some(222),
+      edge: Some(127),
+      firefox: Some(123),
+      ie: Some(11),
+      ios_saf: Some(16),
+      opera: Some(107),
+      safari: Some(17),
+      samsung: Some(20),
+    },
+  };
+
+  let bytes = to_bytes(&config, &()).unwrap();
+  let new_config: Config = from_bytes(&bytes, &()).unwrap();
+
+  assert_eq!(config.browsers.android, new_config.browsers.android);
+  assert_eq!(config.browsers.chrome, new_config.browsers.chrome);
+  assert_eq!(config.browsers.edge, new_config.browsers.edge);
+  assert_eq!(config.browsers.firefox, new_config.browsers.firefox);
+  assert_eq!(config.browsers.ie, new_config.browsers.ie);
+  assert_eq!(config.browsers.ios_saf, new_config.browsers.ios_saf);
+  assert_eq!(config.browsers.opera, new_config.browsers.opera);
+  assert_eq!(config.browsers.safari, new_config.browsers.safari);
+  assert_eq!(config.browsers.samsung, new_config.browsers.samsung);
+}
+
+#[test]
+fn test_preset_lightningcss_empty_browsers() {
+  let config = Config {
+    browsers: Browsers::default(),
+  };
+
+  let bytes = to_bytes(&config, &()).unwrap();
+  let new_config: Config = from_bytes(&bytes, &()).unwrap();
+
+  assert_eq!(config.browsers.chrome, new_config.browsers.chrome);
+  assert_eq!(config.browsers.firefox, new_config.browsers.firefox);
+  assert_eq!(config.browsers.safari, new_config.browsers.safari);
+}


### PR DESCRIPTION
## Summary

Remove the `serde` feature of `lightningcss`.

## Related links

Bump `swc_core` needs to bump `serde`, which would cause compile error.

- https://github.com/parcel-bundler/lightningcss/issues/1056
- https://github.com/swc-project/swc/issues/11092
- https://github.com/web-infra-dev/rspack/pull/11702#issuecomment-3306064858

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
