### PR TITLE
feat: rspack_cacheable add custom with wrapper

### DIFF
--- a/crates/rspack_cacheable/src/with/custom.rs
+++ b/crates/rspack_cacheable/src/with/custom.rs
@@ -1,0 +1,85 @@
+use std::any::Any;
+
+use rkyv::{
+  Archive, Deserialize, Place, Serialize,
+  de::Pooling,
+  rancor::Fallible,
+  ser::Sharing,
+  with::{ArchiveWith, DeserializeWith, SerializeWith},
+};
+
+use crate::{DeserializeError, SerializeError, cacheable, context::ContextGuard};
+
+/// A trait for writing custom serialization and deserialization.
+///
+/// `#[cacheable(with=Custom)]` will use this trait.
+pub trait CustomConverter {
+  type Target: Archive;
+  fn serialize(&self, ctx: &dyn Any) -> Result<Self::Target, SerializeError>;
+  fn deserialize(data: Self::Target, ctx: &dyn Any) -> Result<Self, DeserializeError>
+  where
+    Self: Sized;
+}
+
+/// A wrapper that use CustomConverter to serialization.
+pub struct Custom;
+
+/// A simple structure to save the generated CustomConverter::Target,
+/// which can avoid some deserialization conflicts.
+#[cacheable(crate=crate)]
+pub struct DataBox<T: Archive>(T);
+
+pub struct CustomResolver<A: Archive> {
+  resolver: DataBoxResolver<A>,
+  value: DataBox<A>,
+}
+
+impl<T> ArchiveWith<T> for Custom
+where
+  T: CustomConverter,
+  T::Target: Archive,
+{
+  type Archived = ArchivedDataBox<T::Target>;
+  type Resolver = CustomResolver<T::Target>;
+
+  #[inline]
+  fn resolve_with(_field: &T, resolver: Self::Resolver, out: Place<Self::Archived>) {
+    let CustomResolver { resolver, value } = resolver;
+    value.resolve(resolver, out)
+  }
+}
+
+impl<T, S> SerializeWith<T, S> for Custom
+where
+  T: CustomConverter,
+  T::Target: Archive + Serialize<S>,
+  S: Fallible<Error = SerializeError> + Sharing + ?Sized,
+{
+  #[inline]
+  fn serialize_with(field: &T, serializer: &mut S) -> Result<Self::Resolver, SerializeError> {
+    let ctx = ContextGuard::sharing_context(serializer)?;
+    let value = DataBox(T::serialize(field, ctx)?);
+    Ok(CustomResolver {
+      resolver: value.serialize(serializer)?,
+      value,
+    })
+  }
+}
+
+impl<T, D> DeserializeWith<ArchivedDataBox<T::Target>, T, D> for Custom
+where
+  T: CustomConverter,
+  T::Target: Archive,
+  ArchivedDataBox<T::Target>: Deserialize<DataBox<T::Target>, D>,
+  D: Fallible<Error = DeserializeError> + Pooling + ?Sized,
+{
+  #[inline]
+  fn deserialize_with(
+    field: &ArchivedDataBox<T::Target>,
+    de: &mut D,
+  ) -> Result<T, DeserializeError> {
+    let value = field.deserialize(de)?;
+    let ctx = ContextGuard::pooling_context(de)?;
+    T::deserialize(value.0, ctx)
+  }
+}

--- a/crates/rspack_cacheable/src/with/custom.rs
+++ b/crates/rspack_cacheable/src/with/custom.rs
@@ -21,10 +21,10 @@ pub trait CustomConverter {
     Self: Sized;
 }
 
-/// A wrapper that use CustomConverter to serialization.
+/// A wrapper that uses CustomConverter for serialization.
 pub struct Custom;
 
-/// A simple structure to save the generated CustomConverter::Target,
+/// A simple structure to save the generated `CustomConverter::Target`,
 /// which can avoid some deserialization conflicts.
 #[cacheable(crate=crate)]
 pub struct DataBox<T: Archive>(T);

--- a/crates/rspack_cacheable/src/with/mod.rs
+++ b/crates/rspack_cacheable/src/with/mod.rs
@@ -9,6 +9,7 @@ mod as_string;
 mod as_tuple2;
 mod as_tuple3;
 mod as_vec;
+mod custom;
 mod inline;
 mod unsupported;
 
@@ -23,6 +24,7 @@ pub use as_string::{AsString, AsStringConverter};
 pub use as_tuple2::AsTuple2;
 pub use as_tuple3::AsTuple3;
 pub use as_vec::{AsVec, AsVecConverter};
+pub use custom::{Custom, CustomConverter};
 pub use inline::Inline;
 pub use rkyv::with::{Map as AsOption, Skip};
 pub use unsupported::Unsupported;

--- a/crates/rspack_cacheable_test/tests/with/custom.rs
+++ b/crates/rspack_cacheable_test/tests/with/custom.rs
@@ -1,0 +1,29 @@
+use std::{any::Any, path::PathBuf};
+
+use rspack_cacheable::{
+  DeserializeError, SerializeError, enable_cacheable as cacheable,
+  with::{Custom, CustomConverter},
+};
+
+#[cacheable(with=Custom)]
+#[derive(Debug, PartialEq, Eq)]
+struct Data(PathBuf);
+
+impl CustomConverter for Data {
+  type Target = String;
+  fn serialize(&self, _ctx: &dyn Any) -> Result<Self::Target, SerializeError> {
+    Ok(self.0.to_string_lossy().to_string())
+  }
+  fn deserialize(data: Self::Target, _ctx: &dyn Any) -> Result<Self, DeserializeError> {
+    Ok(Data(PathBuf::from(&data)))
+  }
+}
+
+#[test]
+fn test_custom() {
+  let data = Data(PathBuf::from("/home/user"));
+
+  let bytes = rspack_cacheable::to_bytes(&data, &()).unwrap();
+  let new_data: Data = rspack_cacheable::from_bytes(&bytes, &()).unwrap();
+  assert_eq!(data, new_data);
+}

--- a/crates/rspack_cacheable_test/tests/with/mod.rs
+++ b/crates/rspack_cacheable_test/tests/with/mod.rs
@@ -9,5 +9,6 @@ mod as_string;
 mod as_tuple2;
 mod as_tuple3;
 mod as_vec;
+mod custom;
 mod inline;
 mod unsupported;


### PR DESCRIPTION
## Summary

This PR will add `Custom` and `CustomConverter` to rspack_cacheable, which we can use to customize serialization and deserialization.

``` rust
#[cacheable(with=Custom)]
struct Data(PathBuf);

impl CustomConverter for Data {
  type Target = String;
  fn serialize(&self, _ctx: &dyn Any) -> Result<Self::Target, SerializeError> {
    Ok(self.0.to_string_lossy().to_string())
  }
  fn deserialize(data: Self::Target, _ctx: &dyn Any) -> Result<Self, DeserializeError> {
    Ok(Data(PathBuf::from(&data)))
  }
}
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
