### PR TITLE
refactor: rspack module profiler

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1353,11 +1353,6 @@ export interface JsStatsLogging {
   trace?: Array<string>
 }
 
-export interface JsStatsMillisecond {
-  secs: number
-  subsecMillis: number
-}
-
 export interface JsStatsModule {
   commonAttributes: JsStatsModuleCommonAttributes
   dependent?: boolean
@@ -1402,8 +1397,8 @@ export interface JsStatsModuleIssuer {
 }
 
 export interface JsStatsModuleProfile {
-  factory: JsStatsMillisecond
-  building: JsStatsMillisecond
+  factory: number
+  building: number
 }
 
 export interface JsStatsModuleReason {

--- a/crates/rspack_binding_api/src/stats.rs
+++ b/crates/rspack_binding_api/src/stats.rs
@@ -680,30 +680,17 @@ impl<'a> TryFrom<StatsModule<'a>> for JsStatsModule<'a> {
 
 #[napi(object, object_from_js = false)]
 pub struct JsStatsModuleProfile {
-  pub factory: JsStatsMillisecond,
-  pub building: JsStatsMillisecond,
+  // use f64 to make js side as a number type
+  pub factory: f64,
+  pub building: f64,
 }
 
 impl From<rspack_core::StatsModuleProfile> for JsStatsModuleProfile {
   fn from(value: rspack_core::StatsModuleProfile) -> Self {
     Self {
-      factory: value.factory.into(),
-      building: value.building.into(),
-    }
-  }
-}
-
-#[napi(object, object_from_js = false)]
-pub struct JsStatsMillisecond {
-  pub secs: u32,
-  pub subsec_millis: u32,
-}
-
-impl From<rspack_core::StatsMillisecond> for JsStatsMillisecond {
-  fn from(value: rspack_core::StatsMillisecond) -> Self {
-    Self {
-      secs: value.secs as u32,
-      subsec_millis: value.subsec_millis,
+      // The time is short and no data will be lost when converting from u64 to f64
+      factory: value.factory as f64,
+      building: value.building as f64,
     }
   }
 }

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/add.rs
@@ -14,7 +14,7 @@ pub struct AddTask {
   pub module: Box<dyn Module>,
   pub module_graph_module: Box<ModuleGraphModule>,
   pub dependencies: Vec<BoxDependency>,
-  pub current_profile: Option<Box<ModuleProfile>>,
+  pub current_profile: Option<ModuleProfile>,
   pub from_unlazy: bool,
 }
 

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/build.rs
@@ -18,7 +18,7 @@ pub struct BuildTask {
   pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
   pub module: Box<dyn Module>,
-  pub current_profile: Option<Box<ModuleProfile>>,
+  pub current_profile: Option<ModuleProfile>,
   pub resolver_factory: Arc<ResolverFactory>,
   pub compiler_options: Arc<CompilerOptions>,
   pub plugin_driver: SharedPluginDriver,
@@ -88,7 +88,7 @@ struct BuildResultTask {
   pub module: Box<dyn Module>,
   pub build_result: Box<BuildResult>,
   pub plugin_driver: SharedPluginDriver,
-  pub current_profile: Option<Box<ModuleProfile>>,
+  pub current_profile: Option<ModuleProfile>,
   pub forwarded_ids: ForwardedIdSet,
 }
 

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/build.rs
@@ -38,12 +38,12 @@ impl Task<TaskContext> for BuildTask {
       compiler_options,
       resolver_factory,
       plugin_driver,
-      current_profile,
+      mut current_profile,
       mut module,
       fs,
       forwarded_ids,
     } = *self;
-    if let Some(current_profile) = &current_profile {
+    if let Some(current_profile) = &mut current_profile {
       current_profile.mark_building_start();
     }
 
@@ -67,7 +67,7 @@ impl Task<TaskContext> for BuildTask {
       )
       .await;
 
-    if let Some(current_profile) = &current_profile {
+    if let Some(current_profile) = &mut current_profile {
       current_profile.mark_building_end();
     }
 

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/factorize.rs
@@ -35,8 +35,8 @@ impl Task<TaskContext> for FactorizeTask {
   fn get_task_type(&self) -> TaskType {
     TaskType::Background
   }
-  async fn background_run(self: Box<Self>) -> TaskResult<TaskContext> {
-    if let Some(current_profile) = &self.current_profile {
+  async fn background_run(mut self: Box<Self>) -> TaskResult<TaskContext> {
+    if let Some(current_profile) = &mut self.current_profile {
       current_profile.mark_factory_start();
     }
     let dependency = &self.dependencies[0];
@@ -110,7 +110,7 @@ impl Task<TaskContext> for FactorizeTask {
       }
     };
 
-    if let Some(current_profile) = &self.current_profile {
+    if let Some(current_profile) = &mut self.current_profile {
       current_profile.mark_factory_end();
     }
 

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/factorize.rs
@@ -25,7 +25,7 @@ pub struct FactorizeTask {
   pub dependencies: Vec<BoxDependency>,
   pub resolve_options: Option<Arc<Resolve>>,
   pub options: Arc<CompilerOptions>,
-  pub current_profile: Option<Box<ModuleProfile>>,
+  pub current_profile: Option<ModuleProfile>,
   pub resolver_factory: Arc<ResolverFactory>,
   pub from_unlazy: bool,
 }
@@ -145,7 +145,7 @@ pub struct FactorizeResultTask {
   /// Result will be available if [crate::ModuleFactory::create] returns `Ok`.
   pub factory_result: Option<ModuleFactoryResult>,
   pub dependencies: Vec<BoxDependency>,
-  pub current_profile: Option<Box<ModuleProfile>>,
+  pub current_profile: Option<ModuleProfile>,
   pub exports_info_related: ExportsInfoData,
   pub factorize_info: FactorizeInfo,
   pub from_unlazy: bool,

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/mod.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/mod.rs
@@ -45,10 +45,7 @@ pub async fn repair(
           let dependency = module_graph
             .dependency_by_id(&dep_id)
             .expect("dependency not found");
-          let current_profile = compilation
-            .options
-            .profile
-            .then(Box::<ModuleProfile>::default);
+          let current_profile = compilation.options.profile.then(ModuleProfile::default);
           Box::new(factorize::FactorizeTask {
             compiler_id: compilation.compiler_id(),
             compilation_id: compilation.id(),

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/process_dependencies.rs
@@ -73,7 +73,7 @@ impl Task<TaskContext> for ProcessDependenciesTask {
       let current_profile = context
         .compiler_options
         .profile
-        .then(Box::<ModuleProfile>::default);
+        .then(ModuleProfile::default);
       let original_module_source = module_graph
         .module_by_identifier(&original_module_identifier)
         .and_then(|m| m.as_normal_module())

--- a/crates/rspack_core/src/compilation/make/module_executor/entry.rs
+++ b/crates/rspack_core/src/compilation/make/module_executor/entry.rs
@@ -78,7 +78,7 @@ impl Task<ExecutorTaskContext> for EntryTask {
           current_profile: origin_context
             .compiler_options
             .profile
-            .then(Box::<ModuleProfile>::default),
+            .then(ModuleProfile::default),
           resolver_factory: origin_context.resolver_factory.clone(),
           from_unlazy: false,
         })]));

--- a/crates/rspack_core/src/module_graph/module.rs
+++ b/crates/rspack_core/src/module_graph/module.rs
@@ -23,7 +23,7 @@ pub struct ModuleGraphModule {
   pub post_order_index: Option<u32>,
   pub exports: ExportsInfo,
   #[cacheable(with=Skip)]
-  pub profile: Option<Box<ModuleProfile>>,
+  pub profile: Option<ModuleProfile>,
   pub depth: Option<usize>,
   pub optimization_bailout: Vec<String>,
 }
@@ -70,12 +70,12 @@ impl ModuleGraphModule {
     &self.outgoing_connections
   }
 
-  pub fn set_profile(&mut self, profile: Box<ModuleProfile>) {
+  pub fn set_profile(&mut self, profile: ModuleProfile) {
     self.profile = Some(profile);
   }
 
   pub fn profile(&self) -> Option<&ModuleProfile> {
-    self.profile.as_deref()
+    self.profile.as_ref()
   }
 
   pub fn set_issuer_if_unset(&mut self, issuer: Option<ModuleIdentifier>) {

--- a/crates/rspack_core/src/module_profile.rs
+++ b/crates/rspack_core/src/module_profile.rs
@@ -20,7 +20,7 @@ impl ProfileState {
         let time = Instant::now().duration_since(*i);
         *self = Self::Finish(time.as_millis() as u64)
       }
-      _ => panic!("Unable to end a unstarted profiler"),
+      _ => panic!("Unable to end an unstarted profiler"),
     }
   }
 

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -904,13 +904,10 @@ impl Stats<'_> {
         .count() as u32;
 
       let profile = if let Some(p) = mgm.profile()
-        && let Some(factory) = p.factory.duration()
-        && let Some(building) = p.building.duration()
+        && let Some(factory) = p.factory_duration()
+        && let Some(building) = p.building_duration()
       {
-        Some(StatsModuleProfile {
-          factory: StatsMillisecond::new(factory.as_secs(), factory.subsec_millis()),
-          building: StatsMillisecond::new(building.as_secs(), building.subsec_millis()),
-        })
+        Some(StatsModuleProfile { factory, building })
       } else {
         None
       };

--- a/crates/rspack_core/src/stats/struct.rs
+++ b/crates/rspack_core/src/stats/struct.rs
@@ -198,8 +198,8 @@ pub enum StatsUsedExports {
 
 #[derive(Debug)]
 pub struct StatsModuleProfile {
-  pub factory: StatsMillisecond,
-  pub building: StatsMillisecond,
+  pub factory: u64,
+  pub building: u64,
 }
 
 #[derive(Debug)]
@@ -289,21 +289,6 @@ pub struct StatsModuleReason<'s> {
   pub explanation: Option<&'static str>,
   pub active: bool,
   pub loc: Option<String>,
-}
-
-#[derive(Debug)]
-pub struct StatsMillisecond {
-  pub secs: u64,
-  pub subsec_millis: u32,
-}
-
-impl StatsMillisecond {
-  pub fn new(secs: u64, subsec_millis: u32) -> Self {
-    Self {
-      secs,
-      subsec_millis,
-    }
-  }
 }
 
 #[derive(Debug)]

--- a/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
@@ -60,7 +60,6 @@ import {
 	iterateConfig,
 	mergeToObject,
 	moduleGroup,
-	resolveStatsMillisecond,
 	sortByField,
 	spaceLimited
 } from "./statsFactoryUtils";
@@ -1352,8 +1351,8 @@ const SIMPLE_EXTRACTORS: SimpleExtractors = {
 	},
 	profile: {
 		_: (object, profile) => {
-			const factory = resolveStatsMillisecond(profile.factory);
-			const building = resolveStatsMillisecond(profile.building);
+			const factory = profile.factory;
+			const building = profile.building;
 			const statsProfile: StatsProfile = {
 				total: factory + building,
 				resolving: factory,

--- a/packages/rspack/src/stats/statsFactoryUtils.ts
+++ b/packages/rspack/src/stats/statsFactoryUtils.ts
@@ -660,10 +660,6 @@ export const mergeToObject = (
 	return obj;
 };
 
-export function resolveStatsMillisecond(s: binding.JsStatsMillisecond) {
-	return s.secs * 1000 + s.subsecMillis;
-}
-
 export const errorsSpaceLimit = (errors: StatsError[], max: number) => {
 	let filtered = 0;
 	// Can not fit into limit


### PR DESCRIPTION
## Summary

1. Update ModuleProfiler to be implemented as an enum and store time consumption in u64 to save more space.
``` diff
- pub struct TimeRange {
-   start: OnceCell<Instant>,
-   end: OnceCell<Instant>,
- }
+ enum ProfileState {
+   Pending,
+   Started(Instant),
+   Finish(u64),
+ }
```
2. Replace Option<Box<ModuleProfiler>> to Option<ModuleProfiler>

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
