### PR TITLE
feat: persistent cache save ModuleProfiler

### DIFF
--- a/crates/rspack_core/src/module_graph/module.rs
+++ b/crates/rspack_core/src/module_graph/module.rs
@@ -22,7 +22,6 @@ pub struct ModuleGraphModule {
   pub(crate) pre_order_index: Option<u32>,
   pub post_order_index: Option<u32>,
   pub exports: ExportsInfo,
-  #[cacheable(with=Skip)]
   pub profile: Option<ModuleProfile>,
   pub depth: Option<usize>,
   pub optimization_bailout: Vec<String>,

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use rspack_cacheable::{cacheable, cacheable_dyn, with::Unsupported};
+use rspack_cacheable::{
+  cacheable, cacheable_dyn,
+  with::{AsInner, AsMap},
+};
 use rspack_collections::Identifier;
 use rspack_core::{
   AssetInfo, BoxDependency, BuildMetaExportsType, ChunkGraph, Compilation,
@@ -26,7 +29,7 @@ use crate::{ModuleIdToFileName, dependency::WasmImportDependency};
 #[cacheable]
 #[derive(Debug)]
 pub struct AsyncWasmParserAndGenerator {
-  #[cacheable(with=Unsupported)]
+  #[cacheable(with=AsInner<AsMap>)]
   pub(crate) module_id_to_filename: ModuleIdToFileName,
 }
 


### PR DESCRIPTION
## Summary

1. Remove `#[cacheable(with=Skip)]` for ModuleProfiler, and make ModuleProfiler cacheable.
2. Remove `#[cacheable(with=Unsupported)]` in AsyncWasmParserAndGenerator

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
