### PR TITLE
fix(lazycompilation): lazy compilation proxied module's removing should rebuild proxing module

### DIFF
--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -411,6 +411,10 @@ pub trait Module:
     false
   }
 
+  fn depends_on_removed(&self, removed_files: &ArcPathSet) -> bool {
+    self.depends_on(removed_files)
+  }
+
   fn need_id(&self) -> bool {
     true
   }

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -164,10 +164,17 @@ impl Module for LazyCompilationProxyModule {
     }
   }
 
-  /// Lazy compilation module do not depends on any files.
-  /// The only way to make this module rebuild is self.need_build() return true.
+  /// Lazy compilation module depends on proxied module's existence only.
+  /// The only way to make this module rebuild to changing its content is self.need_build() return true.
   fn depends_on(&self, _modified_file: &ArcPathSet) -> bool {
     false
+  }
+
+  // Lazy compilation module should be removed when proxied module is removed.
+  fn depends_on_removed(&self, removed_files: &ArcPathSet) -> bool {
+    removed_files
+      .iter()
+      .any(|removed_file| self.resource == removed_file.to_string_lossy())
   }
 
   async fn build(


### PR DESCRIPTION
## Summary

close https://github.com/web-infra-dev/rspack/issues/11691


### Problem 
```txt
src/
├── hello.js
└── index.js
```
```js
import("./hello").then((module) => {
  const hello = module.default;
  console.log(hello);
});
```
After all lazy proxing modules are actived, remove `hello.js` file.
Rspack panic at lazy proxing module's codegen due to accessing `hello.js` in module graph.

### Solution
Removing `hello.js` should trigger `index.js` rebuild, but lazy proxying module stop the propogation from the module removing; because it depends on nothing.

Actuall proxing module depends on proxied module's existence other than its content.
So add a new API to tell a module whether a module should build when some files removed.


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
