### PR TITLE
fix: correct infrastructureLog type and add documentation

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -376,7 +376,7 @@ export const BannerPlugin: {
     new (args: BannerPluginArgument): {
         name: string;
         _args: [args: BannerPluginArgument];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -1130,38 +1130,7 @@ export class Compiler {
     // (undocumented)
     getInfrastructureLogger(name: string | (() => string)): Logger;
     // (undocumented)
-    hooks: {
-        done: liteTapable.AsyncSeriesHook<Stats>;
-        afterDone: liteTapable.SyncHook<Stats>;
-        thisCompilation: liteTapable.SyncHook<[Compilation, CompilationParams]>;
-        compilation: liteTapable.SyncHook<[Compilation, CompilationParams]>;
-        invalid: liteTapable.SyncHook<[string | null, number]>;
-        compile: liteTapable.SyncHook<[CompilationParams]>;
-        normalModuleFactory: liteTapable.SyncHook<NormalModuleFactory>;
-        contextModuleFactory: liteTapable.SyncHook<ContextModuleFactory>;
-        initialize: liteTapable.SyncHook<[]>;
-        shouldEmit: liteTapable.SyncBailHook<[Compilation], boolean>;
-        infrastructureLog: liteTapable.SyncBailHook<[string, string, any[]], true>;
-        beforeRun: liteTapable.AsyncSeriesHook<[Compiler]>;
-        run: liteTapable.AsyncSeriesHook<[Compiler]>;
-        emit: liteTapable.AsyncSeriesHook<[Compilation]>;
-        assetEmitted: liteTapable.AsyncSeriesHook<[string, AssetEmittedInfo]>;
-        afterEmit: liteTapable.AsyncSeriesHook<[Compilation]>;
-        failed: liteTapable.SyncHook<[Error]>;
-        shutdown: liteTapable.AsyncSeriesHook<[]>;
-        watchRun: liteTapable.AsyncSeriesHook<[Compiler]>;
-        watchClose: liteTapable.SyncHook<[]>;
-        environment: liteTapable.SyncHook<[]>;
-        afterEnvironment: liteTapable.SyncHook<[]>;
-        afterPlugins: liteTapable.SyncHook<[Compiler]>;
-        afterResolvers: liteTapable.SyncHook<[Compiler]>;
-        make: liteTapable.AsyncParallelHook<[Compilation]>;
-        beforeCompile: liteTapable.AsyncSeriesHook<[CompilationParams]>;
-        afterCompile: liteTapable.AsyncSeriesHook<[Compilation]>;
-        finishMake: liteTapable.AsyncSeriesHook<[Compilation]>;
-        entryOption: liteTapable.SyncBailHook<[string, EntryNormalized], any>;
-        additionalPass: liteTapable.AsyncSeriesHook<[]>;
-    };
+    hooks: CompilerHooks;
     // (undocumented)
     idle: boolean;
     // (undocumented)
@@ -1226,6 +1195,44 @@ export class Compiler {
     // (undocumented)
     webpack: typeof rspack;
 }
+
+// @public (undocumented)
+export type CompilerHooks = {
+    done: liteTapable.AsyncSeriesHook<Stats>;
+    afterDone: liteTapable.SyncHook<Stats>;
+    thisCompilation: liteTapable.SyncHook<[Compilation, CompilationParams]>;
+    compilation: liteTapable.SyncHook<[Compilation, CompilationParams]>;
+    invalid: liteTapable.SyncHook<[string | null, number]>;
+    compile: liteTapable.SyncHook<[CompilationParams]>;
+    normalModuleFactory: liteTapable.SyncHook<NormalModuleFactory>;
+    contextModuleFactory: liteTapable.SyncHook<ContextModuleFactory>;
+    initialize: liteTapable.SyncHook<[]>;
+    shouldEmit: liteTapable.SyncBailHook<[Compilation], boolean>;
+    infrastructureLog: liteTapable.SyncBailHook<[
+    string,
+    string,
+    any[]
+    ], true | void>;
+    beforeRun: liteTapable.AsyncSeriesHook<[Compiler]>;
+    run: liteTapable.AsyncSeriesHook<[Compiler]>;
+    emit: liteTapable.AsyncSeriesHook<[Compilation]>;
+    assetEmitted: liteTapable.AsyncSeriesHook<[string, AssetEmittedInfo]>;
+    afterEmit: liteTapable.AsyncSeriesHook<[Compilation]>;
+    failed: liteTapable.SyncHook<[Error]>;
+    shutdown: liteTapable.AsyncSeriesHook<[]>;
+    watchRun: liteTapable.AsyncSeriesHook<[Compiler]>;
+    watchClose: liteTapable.SyncHook<[]>;
+    environment: liteTapable.SyncHook<[]>;
+    afterEnvironment: liteTapable.SyncHook<[]>;
+    afterPlugins: liteTapable.SyncHook<[Compiler]>;
+    afterResolvers: liteTapable.SyncHook<[Compiler]>;
+    make: liteTapable.AsyncParallelHook<[Compilation]>;
+    beforeCompile: liteTapable.AsyncSeriesHook<[CompilationParams]>;
+    afterCompile: liteTapable.AsyncSeriesHook<[Compilation]>;
+    finishMake: liteTapable.AsyncSeriesHook<[Compilation]>;
+    entryOption: liteTapable.SyncBailHook<[string, EntryNormalized], any>;
+    additionalPass: liteTapable.AsyncSeriesHook<[]>;
+};
 
 // @public (undocumented)
 interface ComputedPropName extends Node_4, HasSpan {
@@ -1492,7 +1499,7 @@ export const ContextReplacementPlugin: {
     new (resourceRegExp: RegExp, newContentResource?: any, newContentRecursive?: any, newContentRegExp?: any): {
         name: string;
         _args: [resourceRegExp: RegExp, newContentResource?: any, newContentRecursive?: any, newContentRegExp?: any];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -1511,7 +1518,7 @@ export const CopyRspackPlugin: {
     new (copy: CopyRspackPluginOptions): {
         name: string;
         _args: [copy: CopyRspackPluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -1527,7 +1534,7 @@ function createNativePlugin<T extends any[], R>(name: CustomPluginName, resolve:
     new (...args: T): {
         name: string;
         _args: T;
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): binding.BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -1561,7 +1568,7 @@ const CssChunkingPlugin: {
     new (options?: CssChunkingPluginOptions | undefined): {
         name: string;
         _args: [options?: CssChunkingPluginOptions | undefined];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): binding.BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -1699,7 +1706,7 @@ export const DefinePlugin: {
     new (define: DefinePluginOptions): {
         name: string;
         _args: [define: DefinePluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -1992,7 +1999,7 @@ const ElectronTargetPlugin: {
     new (context?: string | undefined): {
         name: string;
         _args: [context?: string | undefined];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -2019,7 +2026,7 @@ const EnableChunkLoadingPluginInner: {
     new (type: string): {
         name: string;
         _args: [type: string];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -2052,7 +2059,7 @@ const EnableWasmLoadingPlugin: {
     new (type: string): {
         name: string;
         _args: [type: string];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -2283,7 +2290,7 @@ export const EvalDevToolModulePlugin: {
     new (options: EvalDevToolModulePluginOptions): {
         name: string;
         _args: [options: EvalDevToolModulePluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -2296,7 +2303,7 @@ export const EvalSourceMapDevToolPlugin: {
     new (options: SourceMapDevToolPluginOptions): {
         name: string;
         _args: [options: SourceMapDevToolPluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -2690,7 +2697,7 @@ const FetchCompileAsyncWasmPlugin: {
     new (): {
         name: string;
         _args: [];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -3017,7 +3024,7 @@ const HtmlRspackPluginImpl: {
     new (c?: HtmlRspackPluginOptions | undefined): {
         name: string;
         _args: [c?: HtmlRspackPluginOptions | undefined];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -3121,7 +3128,7 @@ export const IgnorePlugin: {
     new (options: IgnorePluginOptions): {
         name: string;
         _args: [options: IgnorePluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -4199,7 +4206,7 @@ export const LightningCssMinimizerRspackPlugin: {
     new (options?: LightningCssMinimizerRspackPluginOptions | undefined): {
         name: string;
         _args: [options?: LightningCssMinimizerRspackPluginOptions | undefined];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -4236,7 +4243,7 @@ const LimitChunkCountPlugin: {
     new (options: LimitChunkCountOptions): {
         name: string;
         _args: [options: LimitChunkCountOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -4771,7 +4778,7 @@ export class MultiCompiler {
         run: liteTapable.MultiHook<liteTapable.AsyncSeriesHook<[Compiler]>>;
         watchClose: liteTapable.SyncHook<[]>;
         watchRun: liteTapable.MultiHook<liteTapable.AsyncSeriesHook<[Compiler]>>;
-        infrastructureLog: liteTapable.MultiHook<liteTapable.SyncBailHook<[string, string, any[]], true>>;
+        infrastructureLog: liteTapable.MultiHook<CompilerHooks["infrastructureLog"]>;
     };
     // (undocumented)
     get inputFileSystem(): InputFileSystem;
@@ -4888,7 +4895,7 @@ const NativeSubresourceIntegrityPlugin: {
     new (options: NativeSubresourceIntegrityPluginOptions): {
         name: string;
         _args: [options: NativeSubresourceIntegrityPluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -4970,7 +4977,7 @@ const NodeTargetPlugin: {
     new (): {
         name: string;
         _args: [];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -4993,7 +5000,7 @@ export const NoEmitOnErrorsPlugin: {
     new (): {
         name: string;
         _args: [];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -5056,7 +5063,7 @@ export const NormalModuleReplacementPlugin: {
     new (resourceRegExp: RegExp, newResource: string | ((data: ResolveData) => void)): {
         name: string;
         _args: [resourceRegExp: RegExp, newResource: string | ((data: ResolveData) => void)];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -5273,7 +5280,7 @@ const OriginEntryPlugin: {
     new (context: string, entry: string, options?: string | EntryOptions | undefined): {
         name: string;
         _args: [context: string, entry: string, options?: string | EntryOptions | undefined];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -5634,7 +5641,7 @@ export const ProgressPlugin: {
     new (progress?: ProgressPluginArgument): {
         name: string;
         _args: [progress?: ProgressPluginArgument];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -5660,7 +5667,7 @@ export const ProvidePlugin: {
     new (provide: ProvidePluginOptions): {
         name: string;
         _args: [provide: ProvidePluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -5986,7 +5993,7 @@ const RemoveDuplicateModulesPlugin: {
     new (): {
         name: string;
         _args: [];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -6162,7 +6169,7 @@ const RsdoctorPluginImpl: {
     new (c?: RsdoctorPluginOptions | undefined): {
         name: string;
         _args: [c?: RsdoctorPluginOptions | undefined];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -6183,7 +6190,7 @@ const RslibPlugin: {
     new (rslib: RawRslibPluginOptions): {
         name: string;
         _args: [rslib: RawRslibPluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -6248,6 +6255,7 @@ declare namespace rspackExports {
         PathData,
         Compilation,
         Compiler,
+        CompilerHooks,
         MultiCompilerOptions,
         MultiRspackOptions,
         MultiCompiler,
@@ -6733,7 +6741,7 @@ const RstestPlugin: {
     new (rstest: RawRstestPluginOptions): {
         name: string;
         _args: [rstest: RawRstestPluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -6823,7 +6831,7 @@ const RuntimeChunkPlugin: {
     new (options: RawRuntimeChunkOptions): {
         name: string;
         _args: [options: RawRuntimeChunkOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -6972,7 +6980,7 @@ const RuntimePluginImpl: {
     new (): {
         name: string;
         _args: [];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): binding.BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -7173,7 +7181,7 @@ export const SourceMapDevToolPlugin: {
     new (options: SourceMapDevToolPluginOptions): {
         name: string;
         _args: [options: SourceMapDevToolPluginOptions];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -7570,7 +7578,7 @@ export const SwcJsMinimizerRspackPlugin: {
     new (options?: SwcJsMinimizerRspackPluginOptions | undefined): {
         name: string;
         _args: [options?: SwcJsMinimizerRspackPluginOptions | undefined];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };
@@ -8889,7 +8897,7 @@ export const WarnCaseSensitiveModulesPlugin: {
     new (): {
         name: string;
         _args: [];
-        affectedHooks: "done" | "compilation" | "run" | "afterDone" | "thisCompilation" | "invalid" | "compile" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "emit" | "assetEmitted" | "afterEmit" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "make" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | "additionalPass" | undefined;
+        affectedHooks: keyof CompilerHooks | undefined;
         raw(compiler: Compiler): BuiltinPlugin;
         apply(compiler: Compiler): void;
     };

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -79,6 +79,50 @@ export interface AssetEmittedInfo {
 
 const COMPILATION_WEAK_MAP = new WeakMap<binding.JsCompilation, Compilation>();
 
+export type CompilerHooks = {
+	done: liteTapable.AsyncSeriesHook<Stats>;
+	afterDone: liteTapable.SyncHook<Stats>;
+	thisCompilation: liteTapable.SyncHook<[Compilation, CompilationParams]>;
+	compilation: liteTapable.SyncHook<[Compilation, CompilationParams]>;
+	invalid: liteTapable.SyncHook<[string | null, number]>;
+	compile: liteTapable.SyncHook<[CompilationParams]>;
+	normalModuleFactory: liteTapable.SyncHook<NormalModuleFactory>;
+	contextModuleFactory: liteTapable.SyncHook<ContextModuleFactory>;
+	initialize: liteTapable.SyncHook<[]>;
+	shouldEmit: liteTapable.SyncBailHook<[Compilation], boolean>;
+	/**
+	 * Called when infrastructure logging is triggered, allowing plugins to intercept, modify, or handle log messages.
+	 * If the hook returns `true`, the default infrastructure logging will be prevented.
+	 * If it returns `undefined`, the default logging will proceed.
+	 * @param name - The name of the logger
+	 * @param type - The log type (e.g., 'log', 'warn', 'error', ...)
+	 * @param args - An array of arguments passed to the logging method
+	 */
+	infrastructureLog: liteTapable.SyncBailHook<
+		[string, string, any[]],
+		true | void
+	>;
+	beforeRun: liteTapable.AsyncSeriesHook<[Compiler]>;
+	run: liteTapable.AsyncSeriesHook<[Compiler]>;
+	emit: liteTapable.AsyncSeriesHook<[Compilation]>;
+	assetEmitted: liteTapable.AsyncSeriesHook<[string, AssetEmittedInfo]>;
+	afterEmit: liteTapable.AsyncSeriesHook<[Compilation]>;
+	failed: liteTapable.SyncHook<[Error]>;
+	shutdown: liteTapable.AsyncSeriesHook<[]>;
+	watchRun: liteTapable.AsyncSeriesHook<[Compiler]>;
+	watchClose: liteTapable.SyncHook<[]>;
+	environment: liteTapable.SyncHook<[]>;
+	afterEnvironment: liteTapable.SyncHook<[]>;
+	afterPlugins: liteTapable.SyncHook<[Compiler]>;
+	afterResolvers: liteTapable.SyncHook<[Compiler]>;
+	make: liteTapable.AsyncParallelHook<[Compilation]>;
+	beforeCompile: liteTapable.AsyncSeriesHook<[CompilationParams]>;
+	afterCompile: liteTapable.AsyncSeriesHook<[Compilation]>;
+	finishMake: liteTapable.AsyncSeriesHook<[Compilation]>;
+	entryOption: liteTapable.SyncBailHook<[string, EntryNormalized], any>;
+	additionalPass: liteTapable.AsyncSeriesHook<[]>;
+};
+
 class Compiler {
 	#instance?: binding.JsCompiler;
 	#initial: boolean;
@@ -95,38 +139,7 @@ class Compiler {
 
 	#ruleSet: RuleSetCompiler;
 
-	hooks: {
-		done: liteTapable.AsyncSeriesHook<Stats>;
-		afterDone: liteTapable.SyncHook<Stats>;
-		thisCompilation: liteTapable.SyncHook<[Compilation, CompilationParams]>;
-		compilation: liteTapable.SyncHook<[Compilation, CompilationParams]>;
-		invalid: liteTapable.SyncHook<[string | null, number]>;
-		compile: liteTapable.SyncHook<[CompilationParams]>;
-		normalModuleFactory: liteTapable.SyncHook<NormalModuleFactory>;
-		contextModuleFactory: liteTapable.SyncHook<ContextModuleFactory>;
-		initialize: liteTapable.SyncHook<[]>;
-		shouldEmit: liteTapable.SyncBailHook<[Compilation], boolean>;
-		infrastructureLog: liteTapable.SyncBailHook<[string, string, any[]], true>;
-		beforeRun: liteTapable.AsyncSeriesHook<[Compiler]>;
-		run: liteTapable.AsyncSeriesHook<[Compiler]>;
-		emit: liteTapable.AsyncSeriesHook<[Compilation]>;
-		assetEmitted: liteTapable.AsyncSeriesHook<[string, AssetEmittedInfo]>;
-		afterEmit: liteTapable.AsyncSeriesHook<[Compilation]>;
-		failed: liteTapable.SyncHook<[Error]>;
-		shutdown: liteTapable.AsyncSeriesHook<[]>;
-		watchRun: liteTapable.AsyncSeriesHook<[Compiler]>;
-		watchClose: liteTapable.SyncHook<[]>;
-		environment: liteTapable.SyncHook<[]>;
-		afterEnvironment: liteTapable.SyncHook<[]>;
-		afterPlugins: liteTapable.SyncHook<[Compiler]>;
-		afterResolvers: liteTapable.SyncHook<[Compiler]>;
-		make: liteTapable.AsyncParallelHook<[Compilation]>;
-		beforeCompile: liteTapable.AsyncSeriesHook<[CompilationParams]>;
-		afterCompile: liteTapable.AsyncSeriesHook<[Compilation]>;
-		finishMake: liteTapable.AsyncSeriesHook<[Compilation]>;
-		entryOption: liteTapable.SyncBailHook<[string, EntryNormalized], any>;
-		additionalPass: liteTapable.AsyncSeriesHook<[]>;
-	};
+	hooks: CompilerHooks;
 
 	webpack: typeof rspack;
 	rspack: typeof rspack;

--- a/packages/rspack/src/MultiCompiler.ts
+++ b/packages/rspack/src/MultiCompiler.ts
@@ -9,7 +9,13 @@
  */
 
 import * as liteTapable from "@rspack/lite-tapable";
-import type { CompilationParams, Compiler, RspackOptions, Stats } from ".";
+import type {
+	CompilationParams,
+	Compiler,
+	CompilerHooks,
+	RspackOptions,
+	Stats
+} from ".";
 import type { WatchOptions } from "./config";
 import ConcurrentCompilationError from "./error/ConcurrentCompilationError";
 import MultiStats from "./MultiStats";
@@ -63,8 +69,11 @@ export class MultiCompiler {
 		run: liteTapable.MultiHook<liteTapable.AsyncSeriesHook<[Compiler]>>;
 		watchClose: liteTapable.SyncHook<[]>;
 		watchRun: liteTapable.MultiHook<liteTapable.AsyncSeriesHook<[Compiler]>>;
+		/**
+		 * @see {@link CompilerHooks['infrastructureLog']}
+		 */
 		infrastructureLog: liteTapable.MultiHook<
-			liteTapable.SyncBailHook<[string, string, any[]], true>
+			CompilerHooks["infrastructureLog"]
 		>;
 	};
 	_options: MultiCompilerOptions;

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -14,7 +14,7 @@ export type {
 	PathData
 } from "./Compilation";
 export { Compilation } from "./Compilation";
-export { Compiler } from "./Compiler";
+export { Compiler, type CompilerHooks } from "./Compiler";
 export type { MultiCompilerOptions, MultiRspackOptions } from "./MultiCompiler";
 export { MultiCompiler } from "./MultiCompiler";
 

--- a/website/docs/en/api/plugin-api/compiler-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compiler-hooks.mdx
@@ -632,3 +632,37 @@ Called when a watching compilation has stopped.
 Called when the compiler is closing.
 
 - **Type:** `AsyncSeriesHook<[]>`
+
+## infrastructureLog
+
+Called when infrastructure logging is triggered, allowing plugins to intercept, modify, or handle log messages.
+
+This hook provides a way to customize Rspack's infrastructure logs - you can filter specific log types, add custom formatting, or completely override the default logging behavior.
+
+If the hook returns `true`, the default infrastructure logging will be prevented. If it returns `undefined`, the default logging will proceed.
+
+- **Type:** `SyncBailHook<[string, string, any[]], true | void>`
+- **Arguments:**
+  - `name`: The name of the logger
+  - `type`: The log type (e.g., 'log', 'warn', 'error', ...)
+  - `args`: An array of arguments passed to the logging method
+- **Example:**
+
+```js
+class ExamplePlugin {
+  apply(compiler) {
+    compiler.hooks.infrastructureLog.tap('MyPlugin', (name, type, args) => {
+      // Custom logging logic
+      if (type === 'error') {
+        console.error(`[${name}] ERROR:`, ...args);
+        return true; // Prevent default logging
+      }
+
+      // Let other log types use default behavior
+      return undefined;
+    });
+  }
+}
+```
+
+> See [infrastructureLogging](/config/infrastructure-logging) to learn more about infrastructure logging.

--- a/website/docs/zh/api/plugin-api/compiler-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compiler-hooks.mdx
@@ -621,3 +621,37 @@ compiler.hooks.invalid.tap('MyPlugin', (fileName, changeTime) => {
 当前 Compiler 关闭时调用。
 
 - **Type:** `AsyncSeriesHook<[]>`
+
+## infrastructureLog
+
+当基础设施日志被触发时调用，允许插件拦截、修改或处理日志消息。
+
+此钩子提供了一种自定义 Rspack 基础设施日志的方法 - 你可以过滤特定的日志类型、添加自定义格式，或完全覆盖默认的日志行为。
+
+如果钩子返回 `true`，将阻止默认的基础设施日志记录。如果返回 `undefined`，将继续执行默认的日志输出。
+
+- **类型：** `SyncBailHook<[string, string, any[]], true | void>`
+- **参数：**
+  - `name`：logger 的名称
+  - `type`：log 类型（例如 'log'、'warn'、'error' 等）
+  - `args`：传递给 logger 方法的参数数组
+- **示例：**
+
+```js
+class ExamplePlugin {
+  apply(compiler) {
+    compiler.hooks.infrastructureLog.tap('MyPlugin', (name, type, args) => {
+      // 自定义日志逻辑
+      if (type === 'error') {
+        console.error(`[${name}] ERROR:`, ...args);
+        return true; // 阻止默认日志输出
+      }
+
+      // 让其他日志类型使用默认行为
+      return undefined;
+    });
+  }
+}
+```
+
+> 查看 [infrastructureLogging](/config/infrastructure-logging) 了解更多关于基础设施日志的信息。


### PR DESCRIPTION
## Summary

- Fix the `infrastructureLog` hook return type, see https://github.com/webpack/webpack/blob/main/types.d.ts#L10875-L10877
- Add documentation for the `compiler.hooks.infrastructureLog`.
- Introduce a new `CompilerHooks` type that defines all compiler hooks.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
