### PR TITLE
perf: rspack sources buffer function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4938,8 +4938,7 @@ dependencies = [
 [[package]]
 name = "rspack_sources"
 version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f2297ec566365aa29f1cc33c9c40db32789bc6116651f2b3e15d1f234b953b"
+source = "git+https://github.com/web-infra-dev/rspack-sources.git?rev=79e2dfc99b8350cd4ac655d112f986de5da05969#79e2dfc99b8350cd4ac655d112f986de5da05969"
 dependencies = [
  "dashmap 6.1.0",
  "dyn-clone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aliasable"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,7 +683,7 @@ version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -1762,12 +1756,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2091,7 +2079,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -2735,30 +2723,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
-name = "ouroboros"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
-dependencies = [
- "aliasable",
- "ouroboros_macro",
- "static_assertions",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.95",
-]
-
-[[package]]
 name = "outref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,19 +3072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.95",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -3573,7 +3524,7 @@ dependencies = [
  "derive_more",
  "futures",
  "glob",
- "heck 0.5.0",
+ "heck",
  "napi",
  "napi-derive",
  "once_cell",
@@ -4217,7 +4168,7 @@ dependencies = [
  "atomic_refcell",
  "cow-utils",
  "css-module-lexer",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "once_cell",
  "regex",
@@ -4987,14 +4938,12 @@ dependencies = [
 [[package]]
 name = "rspack_sources"
 version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e817d9e5e309f4248b8866bc32601dd48663c6e488abd7484ac7e059f4a5a75d"
+source = "git+https://github.com/web-infra-dev/rspack-sources.git?rev=1004eb239edadb8559bdafed4b69c59ff5aa0e4c#1004eb239edadb8559bdafed4b69c59ff5aa0e4c"
 dependencies = [
  "dashmap 6.1.0",
  "dyn-clone",
  "itertools 0.13.0",
  "memchr",
- "ouroboros",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -5025,7 +4974,7 @@ version = "0.5.6"
 dependencies = [
  "cow-utils",
  "handlebars",
- "heck 0.5.0",
+ "heck",
  "rustc-hash",
  "serde",
  "swc_core",
@@ -7571,7 +7520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cec945b902cacd960fe5d441b60146b24639d81b887451a30bf86824a8185d79"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.95",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,8 +4937,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.4.10"
-source = "git+https://github.com/web-infra-dev/rspack-sources.git?rev=1004eb239edadb8559bdafed4b69c59ff5aa0e4c#1004eb239edadb8559bdafed4b69c59ff5aa0e4c"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede63b6f16d4421a0b06e89d3b01839d8d27f11c0dd4a4c7e7c93b1ad5a66770"
 dependencies = [
  "dashmap 6.1.0",
  "dyn-clone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -519,7 +519,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.0.8",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -750,7 +750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1410,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1447,7 +1447,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1504,7 +1504,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2059,7 +2059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4986,8 +4986,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.4.8"
-source = "git+https://github.com/SyMind/rspack-sources.git?rev=608e8090b8ed875c3c2cefb9737c4829d6b19d5b#608e8090b8ed875c3c2cefb9737c4829d6b19d5b"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e817d9e5e309f4248b8866bc32601dd48663c6e488abd7484ac7e059f4a5a75d"
 dependencies = [
  "dashmap 6.1.0",
  "dyn-clone",
@@ -5125,7 +5126,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5429,7 +5430,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6698,7 +6699,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.42",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -7611,7 +7612,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7820,7 +7821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.9.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,7 +689,7 @@ version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -1756,6 +1762,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2079,7 +2091,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -2723,6 +2735,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
 name = "outref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,6 +3108,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -3524,7 +3573,7 @@ dependencies = [
  "derive_more",
  "futures",
  "glob",
- "heck",
+ "heck 0.5.0",
  "napi",
  "napi-derive",
  "once_cell",
@@ -4168,7 +4217,7 @@ dependencies = [
  "atomic_refcell",
  "cow-utils",
  "css-module-lexer",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "once_cell",
  "regex",
@@ -4938,12 +4987,13 @@ dependencies = [
 [[package]]
 name = "rspack_sources"
 version = "0.4.8"
-source = "git+https://github.com/web-infra-dev/rspack-sources.git?rev=79e2dfc99b8350cd4ac655d112f986de5da05969#79e2dfc99b8350cd4ac655d112f986de5da05969"
+source = "git+https://github.com/SyMind/rspack-sources.git?rev=608e8090b8ed875c3c2cefb9737c4829d6b19d5b#608e8090b8ed875c3c2cefb9737c4829d6b19d5b"
 dependencies = [
  "dashmap 6.1.0",
  "dyn-clone",
  "itertools 0.13.0",
  "memchr",
+ "ouroboros",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -4974,7 +5024,7 @@ version = "0.5.6"
 dependencies = [
  "cow-utils",
  "handlebars",
- "heck",
+ "heck 0.5.0",
  "rustc-hash",
  "serde",
  "swc_core",
@@ -7520,7 +7570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cec945b902cacd960fe5d441b60146b24639d81b887451a30bf86824a8185d79"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.95",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ regex-syntax        = { version = "0.8.5", default-features = false, features = 
 regress             = { version = "0.10.4", default-features = false, features = ["pattern"] }
 ropey               = { version = "1.6.1", default-features = false }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.3", default-features = false }
-rspack_sources      = { git = "https://github.com/web-infra-dev/rspack-sources.git", rev = "79e2dfc99b8350cd4ac655d112f986de5da05969", default-features = false }
+rspack_sources      = { git = "https://github.com/SyMind/rspack-sources.git", rev = "608e8090b8ed875c3c2cefb9737c4829d6b19d5b", default-features = false }
 rustc-hash          = { version = "2.1.0", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ regex-syntax        = { version = "0.8.5", default-features = false, features = 
 regress             = { version = "0.10.4", default-features = false, features = ["pattern"] }
 ropey               = { version = "1.6.1", default-features = false }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.3", default-features = false }
-rspack_sources      = { git = "https://github.com/web-infra-dev/rspack-sources.git", rev = "1004eb239edadb8559bdafed4b69c59ff5aa0e4c", default-features = false }
+rspack_sources      = { version = "=0.4.11", default-features = false }
 rustc-hash          = { version = "2.1.0", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ regex-syntax        = { version = "0.8.5", default-features = false, features = 
 regress             = { version = "0.10.4", default-features = false, features = ["pattern"] }
 ropey               = { version = "1.6.1", default-features = false }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.3", default-features = false }
-rspack_sources      = { version = "0.4.8", default-features = false }
+rspack_sources      = { git = "https://github.com/web-infra-dev/rspack-sources.git", rev = "79e2dfc99b8350cd4ac655d112f986de5da05969", default-features = false }
 rustc-hash          = { version = "2.1.0", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ regex-syntax        = { version = "0.8.5", default-features = false, features = 
 regress             = { version = "0.10.4", default-features = false, features = ["pattern"] }
 ropey               = { version = "1.6.1", default-features = false }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.3", default-features = false }
-rspack_sources      = { version = "=0.4.10", default-features = false }
+rspack_sources      = { git = "https://github.com/web-infra-dev/rspack-sources.git", rev = "1004eb239edadb8559bdafed4b69c59ff5aa0e4c", default-features = false }
 rustc-hash          = { version = "2.1.0", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ regex-syntax        = { version = "0.8.5", default-features = false, features = 
 regress             = { version = "0.10.4", default-features = false, features = ["pattern"] }
 ropey               = { version = "1.6.1", default-features = false }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.3", default-features = false }
-rspack_sources      = { git = "https://github.com/SyMind/rspack-sources.git", rev = "608e8090b8ed875c3c2cefb9737c4829d6b19d5b", default-features = false }
+rspack_sources      = { version = "=0.4.10", default-features = false }
 rustc-hash          = { version = "2.1.0", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -251,6 +251,7 @@ skip = [
     { crate = "rustix", reason = "external dependency"},
 
     { crate = "winnow", reason = "external dependency"},
+    { crate = "heck", reason = "external dependency"},
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

1. perf: RawBufferSource value_as_string

This PR optimizes the RawBufferSource struct to avoid unnecessary string allocations by using self-referential structs and Cow<'this, str> instead of String. The change leverages the ouroboros crate to create self-referential structures that can borrow from their own data.

https://github.com/web-infra-dev/rspack-sources/pull/167

2. perf: should flatten nested concat sources

This PR implements flattening for nested ConcatSource instances to improve performance by avoiding deeply nested source structures. The optimization flattens ConcatSource children during construction and addition operations.

https://github.com/web-infra-dev/rspack-sources/pull/166

3. perf: using writer to calculate concat source buffer

This PR optimizes buffer calculation by replacing direct buffer concatenation with a writer-based approach to improve performance when calculating source buffers.

https://github.com/web-infra-dev/rspack-sources/pull/165

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
