### PR TITLE
test: close compiler

### DIFF
--- a/packages/rspack-test-tools/src/test/tester.ts
+++ b/packages/rspack-test-tools/src/test/tester.ts
@@ -82,9 +82,9 @@ export class Tester implements ITester {
 		for (const i of this.steps) {
 			if (typeof i.afterAll === "function") {
 				await i.afterAll(this.context);
-				await this.context.closeCompiler(this.config.name);
 			}
 		}
+		await this.context.closeCompiler(this.config.name);
 	}
 
 	private async runStepMethods(


### PR DESCRIPTION
## Summary

Should close compiler when afterAll is not defined

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
