### PR TITLE
feat: transform url in new URL without runtime

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -589,6 +589,7 @@ export declare enum BuiltinPluginName {
   RstestPlugin = 'RstestPlugin',
   RslibPlugin = 'RslibPlugin',
   CircularDependencyRspackPlugin = 'CircularDependencyRspackPlugin',
+  URLPlugin = 'URLPlugin',
   JsLoaderRspackPlugin = 'JsLoaderRspackPlugin',
   LazyCompilationPlugin = 'LazyCompilationPlugin',
   ModuleInfoHeaderPlugin = 'ModuleInfoHeaderPlugin',

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -64,7 +64,7 @@ use rspack_plugin_ignore::IgnorePlugin;
 use rspack_plugin_javascript::{
   FlagDependencyExportsPlugin, FlagDependencyUsagePlugin, InferAsyncModulesPlugin, JsPlugin,
   MangleExportsPlugin, ModuleConcatenationPlugin, SideEffectsFlagPlugin, api_plugin::APIPlugin,
-  define_plugin::DefinePlugin, provide_plugin::ProvidePlugin,
+  define_plugin::DefinePlugin, provide_plugin::ProvidePlugin, url_plugin::URLPlugin,
 };
 use rspack_plugin_json::JsonPlugin;
 use rspack_plugin_library::enable_library_plugin;
@@ -221,6 +221,7 @@ pub enum BuiltinPluginName {
   RstestPlugin,
   RslibPlugin,
   CircularDependencyRspackPlugin,
+  URLPlugin,
 
   // rspack js adapter plugins
   // naming format follow XxxRspackPlugin
@@ -300,6 +301,9 @@ impl<'a> BuiltinPlugin<'a> {
         )
         .boxed();
         plugins.push(plugin);
+      }
+      BuiltinPluginName::URLPlugin => {
+        plugins.push(URLPlugin::default().boxed());
       }
       BuiltinPluginName::BannerPlugin => {
         let plugin = BannerPlugin::new(

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -38,6 +38,9 @@ impl CodeGenerationDataUrl {
 pub struct CodeGenerationPublicPathAutoReplace(pub bool);
 
 #[derive(Clone, Debug)]
+pub struct URLStaticMode;
+
+#[derive(Clone, Debug)]
 pub struct CodeGenerationDataFilename {
   filename: String,
   public_path: String,

--- a/crates/rspack_core/src/dependency/dependency_id.rs
+++ b/crates/rspack_core/src/dependency/dependency_id.rs
@@ -11,6 +11,10 @@ impl DependencyId {
     let id = fetch_new_dependency_id();
     Self(id)
   }
+
+  pub fn as_u32(&self) -> u32 {
+    self.0
+  }
 }
 
 impl Default for DependencyId {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -146,6 +146,7 @@ impl fmt::Display for DynamicImportFetchPriority {
 pub enum JavascriptParserUrl {
   Enable,
   Disable,
+  NewUrlRelative,
   Relative,
 }
 
@@ -154,6 +155,7 @@ impl From<&str> for JavascriptParserUrl {
     match value {
       "false" => Self::Disable,
       "relative" => Self::Relative,
+      "new-url-relative" => Self::NewUrlRelative,
       _ => Self::Enable,
     }
   }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -1,4 +1,4 @@
-use rspack_core::{ConstDependency, RuntimeGlobals};
+use rspack_core::{ConstDependency, JavascriptParserUrl, RuntimeGlobals};
 use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
@@ -45,7 +45,7 @@ pub fn get_url_request(
 }
 
 pub struct URLPlugin {
-  pub relative: bool,
+  pub mode: Option<JavascriptParserUrl>,
 }
 
 impl JavascriptParserPlugin for URLPlugin {
@@ -96,7 +96,7 @@ impl JavascriptParserPlugin for URLPlugin {
         request.into(),
         expr.span.into(),
         (start, end).into(),
-        self.relative,
+        self.mode,
       );
       let dep_idx = parser.next_dependency_idx();
       parser.add_dependency(Box::new(dep));

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -16,6 +16,7 @@ pub mod infer_async_modules_plugin;
 mod mangle_exports_plugin;
 pub mod module_concatenation_plugin;
 mod side_effects_flag_plugin;
+pub mod url_plugin;
 
 pub use drive::*;
 pub use flag_dependency_exports_plugin::*;

--- a/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
@@ -1,0 +1,116 @@
+use std::sync::Arc;
+
+use rspack_core::{
+  ChunkInitFragments, ChunkUkey, CodeGenerationDataFilename, Compilation, CompilationParams,
+  CompilerCompilation, DependencyId, JavascriptParserUrl, Module, ModuleType,
+  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, URLStaticMode,
+  rspack_sources::ReplaceSource,
+};
+use rspack_error::Result;
+use rspack_hook::{plugin, plugin_hook};
+
+use crate::{
+  JavascriptModulesRenderModuleContent, JsPlugin, RenderSource,
+  dependency::{URL_STATIC_PLACEHOLDER, URL_STATIC_PLACEHOLDER_RE},
+  parser_and_generator::JavaScriptParserAndGenerator,
+};
+
+#[plugin]
+#[derive(Debug, Default)]
+pub struct URLPlugin {}
+
+#[plugin_hook(CompilerCompilation for URLPlugin)]
+async fn compilation(
+  &self,
+  compilation: &mut Compilation,
+  _params: &mut CompilationParams,
+) -> Result<()> {
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  hooks
+    .write()
+    .await
+    .render_module_content
+    .tap(render_module_content::new(self));
+  Ok(())
+}
+#[plugin_hook(NormalModuleFactoryParser for URLPlugin)]
+async fn normal_module_factory_parser(
+  &self,
+  _module_type: &ModuleType,
+  parser: &mut dyn ParserAndGenerator,
+  parser_options: Option<&ParserOptions>,
+) -> Result<()> {
+  if let Some(parser) = parser.downcast_mut::<JavaScriptParserAndGenerator>() {
+    let options = parser_options
+      .and_then(|p| p.get_javascript())
+      .expect("should at least have a global javascript parser options");
+
+    if !matches!(options.url, Some(JavascriptParserUrl::Disable)) {
+      parser.add_parser_plugin(Box::new(crate::parser_plugin::URLPlugin {
+        mode: options.url,
+      }));
+    }
+  }
+
+  Ok(())
+}
+
+#[plugin_hook(JavascriptModulesRenderModuleContent for URLPlugin,tracing=false)]
+async fn render_module_content(
+  &self,
+  compilation: &Compilation,
+  chunk_ukey: &ChunkUkey,
+  module: &dyn Module,
+  render_source: &mut RenderSource,
+  _init_fragments: &mut ChunkInitFragments,
+) -> Result<()> {
+  let runtime = compilation.chunk_by_ukey.expect_get(chunk_ukey).runtime();
+  let module_graph = compilation.get_module_graph();
+  let codegen_result = compilation
+    .code_generation_results
+    .get(&module.identifier(), Some(runtime));
+  if codegen_result.data.contains::<URLStaticMode>() {
+    let content = render_source.source.source().clone();
+    let mut replace_source = ReplaceSource::new(render_source.source.clone());
+    let replacement = URL_STATIC_PLACEHOLDER_RE
+      .find_iter(&content)
+      .map(|cap| (cap.start(), cap.end()));
+
+    for (start, end) in replacement {
+      let dep_id = &content[start + URL_STATIC_PLACEHOLDER.len()..end];
+      let dep_id: DependencyId = dep_id
+        .parse::<u32>()
+        .unwrap_or_else(|_| panic!("should be valid dependency id \"{dep_id}\""))
+        .into();
+      let Some(module) = module_graph.module_identifier_by_dependency_id(&dep_id) else {
+        continue;
+      };
+      let codegen_result = compilation
+        .code_generation_results
+        .get(module, Some(runtime));
+      let Some(filename) = codegen_result.data.get::<CodeGenerationDataFilename>() else {
+        unreachable!()
+      };
+
+      replace_source.replace(start as u32, end as u32, filename.filename(), None);
+    }
+
+    render_source.source = Arc::new(replace_source);
+  }
+  Ok(())
+}
+
+impl Plugin for URLPlugin {
+  fn name(&self) -> &'static str {
+    "rspack.URLPlugin"
+  }
+
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
+    ctx
+      .normal_module_factory_hooks
+      .parser
+      .tap(normal_module_factory_parser::new(self));
+    Ok(())
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -13,8 +13,8 @@ use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
   CompilerOptions, DependencyRange, FactoryMeta, JavascriptParserCommonjsExportsOption,
-  JavascriptParserOptions, JavascriptParserUrl, ModuleIdentifier, ModuleLayer, ModuleType,
-  ParseMeta, ResourceData, TypeReexportPresenceMode,
+  JavascriptParserOptions, ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta, ResourceData,
+  TypeReexportPresenceMode,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_util::SpanExt;
@@ -370,12 +370,6 @@ impl<'parser> JavascriptParser<'parser> {
         compiler_options.output.module,
       )));
       plugins.push(Box::new(parser_plugin::ImportParserPlugin));
-      let parse_url = javascript_options.url;
-      if !matches!(parse_url, Some(JavascriptParserUrl::Disable)) {
-        plugins.push(Box::new(parser_plugin::URLPlugin {
-          relative: matches!(parse_url, Some(JavascriptParserUrl::Relative)),
-        }));
-      }
       plugins.push(Box::new(parser_plugin::WorkerPlugin::new(
         javascript_options
           .worker

--- a/packages/rspack-test-tools/src/runner/node/index.ts
+++ b/packages/rspack-test-tools/src/runner/node/index.ts
@@ -412,8 +412,13 @@ export class NodeRunner<T extends ECompilerType = ECompilerType.Rspack>
 					// no attribute
 					url: `${pathToFileURL(file.path).href}?${esmIdentifier}`,
 					context: esmContext,
-					initializeImportMeta: (meta: { url: string }, _: any) => {
+					initializeImportMeta: (
+						meta: { url: string; dirname?: string; filename?: string },
+						_: any
+					) => {
 						meta.url = pathToFileURL(file!.path).href;
+						meta.dirname = path.dirname(file!.path);
+						meta.filename = file!.path;
 					},
 					importModuleDynamically: async (
 						specifier: any,

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3377,7 +3377,7 @@ export type JavascriptParserOptions = {
     dynamicImportPrefetch?: boolean | number;
     dynamicImportFetchPriority?: "low" | "high" | "auto";
     importMeta?: boolean;
-    url?: "relative" | boolean;
+    url?: "relative" | "new-url-relative" | boolean;
     exprContextCritical?: boolean;
     unknownContextCritical?: boolean;
     wrappedContextCritical?: boolean;

--- a/packages/rspack/src/builtin-plugin/URLPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/URLPlugin.ts
@@ -1,0 +1,5 @@
+import { BuiltinPluginName } from "@rspack/binding";
+
+import { create } from "./base";
+
+export const URLPlugin = create(BuiltinPluginName.URLPlugin, () => {});

--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -76,6 +76,7 @@ export * from "./SourceMapDevToolPlugin";
 export * from "./SplitChunksPlugin";
 export * from "./SubresourceIntegrityPlugin";
 export * from "./SwcJsMinimizerPlugin";
+export * from "./URLPlugin";
 export * from "./WarnCaseSensitiveModulesPlugin";
 export * from "./WebWorkerTemplatePlugin";
 export * from "./WorkerPlugin";

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1059,7 +1059,7 @@ export type JavascriptParserOptions = {
 	 * Enable parsing of new URL() syntax.
 	 * @default true
 	 * */
-	url?: "relative" | boolean;
+	url?: "relative" | "new-url-relative" | boolean;
 
 	/**
 	 * Enable warnings for full dynamic dependencies

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -65,6 +65,7 @@ import {
 	SizeLimitsPlugin,
 	SourceMapDevToolPlugin,
 	SplitChunksPlugin,
+	URLPlugin,
 	WorkerPlugin
 } from "./builtin-plugin";
 import MemoryCachePlugin from "./lib/cache/MemoryCachePlugin";
@@ -221,6 +222,7 @@ export class RspackOptionsApply {
 		}
 
 		new JavascriptModulesPlugin().apply(compiler);
+		new URLPlugin().apply(compiler);
 		new JsonModulesPlugin().apply(compiler);
 		new AssetModulesPlugin().apply(compiler);
 		if (options.experiments.asyncWebAssembly) {

--- a/packages/rspack/src/schema/config.ts
+++ b/packages/rspack/src/schema/config.ts
@@ -630,7 +630,11 @@ export const getRspackOptionsSchema = memoize(() => {
 	const dynamicImportPreload = z.union([z.boolean(), numberOrInfinity]);
 	const dynamicImportPrefetch = z.union([z.boolean(), numberOrInfinity]);
 	const dynamicImportFetchPriority = z.enum(["low", "high", "auto"]);
-	const javascriptParserUrl = z.union([z.literal("relative"), z.boolean()]);
+	const javascriptParserUrl = z.union([
+		z.literal("relative"),
+		z.literal("new-url-relative"),
+		z.boolean()
+	]);
 	const exprContextCritical = z.boolean();
 	const wrappedContextCritical = z.boolean();
 	const unknownContextCritical = z.boolean();

--- a/tests/rspack-test/configCases/asset-url/new-url-relative/index.js
+++ b/tests/rspack-test/configCases/asset-url/new-url-relative/index.js
@@ -1,0 +1,8 @@
+import fs from 'fs'
+import path from 'path'
+
+it('should have correct url', () => {
+	const file = fs.readFileSync(path.resolve(import.meta.dirname, `./test-${INDEX}.mjs`), 'utf-8');
+	expect(file).toContain('new URL(');
+	expect(file).toContain('import.meta.url');
+})

--- a/tests/rspack-test/configCases/asset-url/new-url-relative/rspack.config.js
+++ b/tests/rspack-test/configCases/asset-url/new-url-relative/rspack.config.js
@@ -1,0 +1,70 @@
+const rspack = require('@rspack/core');
+
+/**@type {import('@rspack/core').Configuration} */
+const common = {
+	entry: {
+		main: './index.js',
+		test: './test.js',
+	},
+	optimization:{
+		splitChunks: {
+			cacheGroups: {
+				test: {
+					chunks: 'all',
+					minSize: 0,
+					test: /test\.js/,
+					name: 'test',
+				}
+			}
+		}
+	},
+	module: {
+		parser: {
+			javascript: {
+				url: 'new-url-relative',
+				importMeta: false,
+			}
+		},
+		generator: {
+			asset: {
+				filename: 'asset/static-[name].js'
+			}
+		}
+	},
+	experiments: {
+		outputModule: true,
+	},
+}
+
+module.exports = [
+	{
+		...common,
+		optimization: {
+			...common.optimization,
+			concatenateModules: true,
+		},
+		output: {
+			filename: `[name]-0.mjs`
+		},
+		plugins: [
+			new rspack.DefinePlugin({
+				INDEX: 0,
+			})
+		]
+	},
+	{
+		...common,
+		optimization: {
+			...common.optimization,
+			concatenateModules: false,
+		},
+		output: {
+			filename: `[name]-1.mjs`
+		},
+		plugins: [
+			new rspack.DefinePlugin({
+				INDEX: 1,
+			})
+		]
+	}
+]

--- a/tests/rspack-test/configCases/asset-url/new-url-relative/test.config.js
+++ b/tests/rspack-test/configCases/asset-url/new-url-relative/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: () => {
+		return ['main-0.mjs', 'main-1.mjs']
+	}
+}

--- a/tests/rspack-test/configCases/asset-url/new-url-relative/test.js
+++ b/tests/rspack-test/configCases/asset-url/new-url-relative/test.js
@@ -1,0 +1,1 @@
+new URL('./asset.js', import.meta.url)

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -278,21 +278,38 @@ export default {
 ### module.parser.javascript.url
 
 <PropertyType
-  type="true | false | 'relative'"
+  type="true | false | 'relative' | 'new-url-relative'"
   defaultValueList={[{ defaultValue: 'true' }]}
 />
 
 Enable parsing of `new URL()` syntax.
 
-When use 'relative', Rspack would generate relative URLs for `new URL()` syntax, i.e., there's no base URL included in the result URL:
+- `true`: Generate absolute URLs that include the root URL (default behavior).
+- `'relative'`: Generate relative URLs without the root URL.
+- `'new-url-relative'`: Generate static relative URLs that are replaced at compile-time with the correct public path.
 
-```html
-<!-- with 'relative' -->
-<img src="icon.svg" />
+When using `'new-url-relative'`, Rspack generates relative URLs that will be replaced at compile-time with the correct public path:
 
-<!-- without 'relative' -->
-<img src="file:///path/to/project/dist/icon.svg" />
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        url: 'new-url-relative',
+      },
+    },
+  },
+};
 ```
+
+```js
+new URL('./icon.svg', import.meta.url);
+
+// would become 👇
+new URL('./icon[hash].svg', import.meta.url);
+```
+
+When using `'relative'`, Rspack generates runtime code to calculate relative URLs for `new URL()` syntax, i.e., there's no base URL included in the result URL:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -304,6 +321,14 @@ export default {
     },
   },
 };
+```
+
+```html
+<!-- with 'relative' -->
+<img src="icon.svg" />
+
+<!-- without 'relative' -->
+<img src="file:///path/to/project/dist/icon.svg" />
 ```
 
 ### module.parser.javascript.exprContextCritical

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -278,21 +278,38 @@ export default {
 ### module.parser.javascript.url
 
 <PropertyType
-  type="true | false | 'relative'"
+  type="true | false | 'relative' | 'new-url-relative'"
   defaultValueList={[{ defaultValue: 'true' }]}
 />
 
 启用 `new URL()` 语法解析。
 
-当使用 'relative' 时，webpack 将为 `new URL()` 语法生成相对的 URL，即结果 URL 中不包含根 URL
+- `true`：生成包含根 URL 的绝对 URL（默认行为）。
+- `'relative'`：生成不包含根 URL 的相对 URL。
+- `'new-url-relative'`：相对于公共路径的相对 URL。
 
-```html
-<!-- 使用 'relative' -->
-<img src="icon.svg" />
+当使用 `'new-url-relative'` 时，Rspack 将在编译时计算出相对于公共路径的相对 URL：
 
-<!-- 不使用 'relative' -->
-<img src="file:///path/to/project/dist/icon.svg" />
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        url: 'new-url-relative',
+      },
+    },
+  },
+};
 ```
+
+```js
+new URL('./icon.svg', import.meta.url);
+
+// 转换成 👇
+new URL('./icon[hash].svg', import.meta.url);
+```
+
+当使用 `'relative'` 时，Rspack 将生成运行时代码，为 `new URL()` 语法计算出相对的 URL，结果 URL 中不包含根 URL：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -304,6 +321,14 @@ export default {
     },
   },
 };
+```
+
+```html
+<!-- 使用 'relative' -->
+<img src="icon.svg" />
+
+<!-- 不使用 'relative' -->
+<img src="file:///path/to/project/dist/icon.svg" />
 ```
 
 ### module.parser.javascript.exprContextCritical


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Support new way to render url dependency, transform `new URL('./', import.meta.url)` without adding runtime

Config name is 'new-url-relative', it's useful for library cases

```js
new URL('./foo', import.meta.url)

// transforms without any runtime code
new URL('./foo-[hash].js', import.meta.url)
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
