### PR TITLE
fix: should analyze correct variable for dynamic import

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -140,6 +140,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
       && call.callee.is_import()
       && let Some(binding) = declarator.name.as_ident()
     {
+      parser.define_variable(binding.id.sym.clone());
       tag_dynamic_import_referenced(parser, call, binding.id.sym.clone());
     }
     None

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import/index.js
@@ -60,3 +60,13 @@ it("should analyze arguments in call member chain", async () => {
 		expect(m2.usedExports).toEqual(["a", "usedExports"]);
 	})());
 });
+
+it("should analyze usage of variable that in correct scope", async () => {
+	var m = { b: 1 };
+	expect(m.b).toBe(1);
+	await (async () => {
+		var m = await import("./dir4/a?3");
+		expect(m.a).toBe(1);
+		expect(m.usedExports).toEqual(["a", "usedExports"]);
+	})();
+});


### PR DESCRIPTION
## Summary

Forgot the `defineVariable` causes analyze to the same name variable that declared in upper scope
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
