### PR TITLE
feat(mf): inject remoteInfos to support lazy compilation

### DIFF
--- a/packages/rspack/src/runtime/moduleFederationDefaultRuntime.js
+++ b/packages/rspack/src/runtime/moduleFederationDefaultRuntime.js
@@ -161,6 +161,11 @@ module.exports = function () {
 		);
 		early(
 			__webpack_require__.federation.bundlerRuntimeOptions.remotes,
+			"remoteInfos",
+			() => __module_federation_remote_infos__
+		);
+		early(
+			__webpack_require__.federation.bundlerRuntimeOptions.remotes,
 			"idToExternalAndNameMapping",
 			() => {
 				const remotesLoadingIdToExternalAndNameMappingMapping = {};
@@ -262,7 +267,7 @@ module.exports = function () {
 						throw new Error(
 							'Module "' + module + '" does not exist in container.'
 						);
-					});
+				  });
 			__webpack_require__.R = undefined;
 			return getScope;
 		});


### PR DESCRIPTION
## Summary

Inject remotesInfos into `__webpack_require__.federation.bundlerRuntimeOptions.remotes` to help MF support lazy compilation . 

MF will update the remote chunkMapping and moduleMap with the updated module data . And it needs the `remotesInfos` which is generated at first build, so we need to inject it into bundler runtime to store it .

## Related links
https://github.com/module-federation/core/pull/4095
<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
