### PR TITLE
docs(style): remove unexpected borders on code block focus

### DIFF
--- a/website/theme/index.css
+++ b/website/theme/index.css
@@ -107,3 +107,12 @@ th:nth-child(25), td:nth-child(25) { grid-area: y; }
 
 /* prettier-ignore */
 th:nth-child(26), td:nth-child(26) { grid-area: z; }
+
+/* Fix: Remove unexpected borders on code block focus */
+pre:focus,
+code:focus,
+pre:focus-visible,
+code:focus-visible {
+  outline: none;
+  border: none;
+}


### PR DESCRIPTION
## Summary

Fix unexpected borders that appear when focusing on code blocks in the Rspack website. When users click on code blocks and press keys, browsers apply default focus outlines/borders. This fix removes these default focus styles specifically for code blocks using CSS pseudo-classes.

## Changes

- Added CSS rules in `website/theme/index.css` to remove `outline` and `border` properties for `pre:focus`, `code:focus`, `pre:focus-visible`, and `code:focus-visible` selectors
- This prevents browser default focus styles from appearing on code blocks while preserving focus behavior for other elements

## Related links

Fixes issue #11775

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
