### PR TITLE
chore: rspack_plugin_esm_library should have description

### DIFF
--- a/crates/rspack_plugin_esm_library/Cargo.toml
+++ b/crates/rspack_plugin_esm_library/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors.workspace       = true
 categories.workspace    = true
+description             = "ESM library plugin for Rspack"
 documentation.workspace = true
 edition                 = "2024"
 homepage.workspace      = true


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR adds a missing description field to the Cargo.toml file for the rspack_plugin_esm_library crate.

```
error: failed to publish to registry at https://crates.io/

Caused by:
  the remote server responded with an error (status 400 Bad Request): missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields
info published rspack_plugin_esm_library v0.5.8
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
