### PR TITLE
fix(loader-runner): add missing break statements in switch cases

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -43,7 +43,6 @@
 				"noDynamicNamespaceImportAccess": "off"
 			},
 			"suspicious": {
-				"noFallthroughSwitchClause": "off",
 				"noConfusingVoidType": "off",
 				"noPrototypeBuiltins": "off",
 				"noAssignInExpressions": "off",

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -877,6 +877,7 @@ export async function runLoaders(
 					case RequestType.GetLogger: {
 						const [type, name, arg] = args;
 						(loaderContext.getLogger(name) as any)[type](...arg);
+						break;
 					}
 					case RequestType.EmitError: {
 						const workerError = args[0];

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -461,6 +461,7 @@ async function loaderImpl(
 					break;
 				}
 			}
+			break;
 		}
 		case JsLoaderState.Normal: {
 			while (loaderContext.loaderIndex >= 0) {

--- a/packages/rspack/src/logging/createConsoleLogger.ts
+++ b/packages/rspack/src/logging/createConsoleLogger.ts
@@ -134,6 +134,7 @@ const createConsoleLogger = ({
 					}
 					break;
 				}
+			// falls through
 			case LogType.group:
 				if (!debug && loglevel > LogLevel.log) return;
 

--- a/packages/rspack/src/logging/createConsoleLogger.ts
+++ b/packages/rspack/src/logging/createConsoleLogger.ts
@@ -123,6 +123,7 @@ const createConsoleLogger = ({
 				if (!debug) return;
 				console.trace();
 				break;
+			// biome-ignore lint/suspicious/noFallthroughSwitchClause: This case is falling through to the next case.
 			case LogType.groupCollapsed:
 				if (!debug && loglevel > LogLevel.log) return;
 				if (!debug && loglevel > LogLevel.verbose) {
@@ -133,8 +134,6 @@ const createConsoleLogger = ({
 					}
 					break;
 				}
-				break;
-			// falls through
 			case LogType.group:
 				if (!debug && loglevel > LogLevel.log) return;
 

--- a/packages/rspack/src/logging/createConsoleLogger.ts
+++ b/packages/rspack/src/logging/createConsoleLogger.ts
@@ -133,6 +133,7 @@ const createConsoleLogger = ({
 					}
 					break;
 				}
+				break;
 			// falls through
 			case LogType.group:
 				if (!debug && loglevel > LogLevel.log) return;


### PR DESCRIPTION
## Summary

- Adds missing break statements in switch cases.
- Enables Biomes's `noFallthroughSwitchClause` rule to disallow fallthrough of `switch` clauses.

## Related links

Fix https://github.com/web-infra-dev/rspack/issues/11771

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
