### PR TITLE
fix: revert "fix: remove `serde` feature of `lightningcss` (#11706)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,9 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -1079,6 +1082,7 @@ dependencies = [
  "dtoa-short",
  "itoa",
  "phf",
+ "serde",
  "smallvec",
 ]
 
@@ -2226,9 +2230,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.67"
+version = "1.0.0-alpha.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798fba4e1205eed356b8ed7754cc3f7f04914e27855ca641409f4a532e992149"
+checksum = "b407ca668368d1d5a86cea58ac82d9f9f9ca4bac1e9dce6f16f875f0f081a911"
 dependencies = [
  "ahash 0.8.12",
  "bitflags 2.9.1",
@@ -2236,15 +2240,17 @@ dependencies = [
  "cssparser",
  "cssparser-color",
  "data-encoding",
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "indexmap",
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
  "parcel_selectors",
  "parcel_sourcemap",
- "paste",
+ "pastey",
  "pathdiff",
+ "serde",
+ "serde-content",
  "smallvec",
  "static-self",
 ]
@@ -2773,6 +2779,7 @@ dependencies = [
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
+ "serde",
  "smallvec",
  "static-self",
 ]
@@ -2819,6 +2826,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "path-clean"
@@ -5191,28 +5204,37 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.225"
+name = "serde-content"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "3753ca04f350fa92d00b6146a3555e63c55388c9ef2e11e09bce2ff1c0b509c6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.14", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 jsonc-parser        = { version = "0.26.2", default-features = false, features = ["serde"] }
-lightningcss        = { version = "1.0.0-alpha.67", default-features = false }
+lightningcss        = { version = "1.0.0-alpha.68", default-features = false, features = ["serde"] }
 linked_hash_set     = { version = "0.1.5", default-features = false }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.7.5", default-features = false }

--- a/crates/rspack_cacheable/src/with/as_preset/lightningcss.rs
+++ b/crates/rspack_cacheable/src/with/as_preset/lightningcss.rs
@@ -15,60 +15,6 @@ pub struct BrowsersResolver {
   value: String,
 }
 
-// Helper functions for custom serialization without serde
-fn browsers_to_string(browsers: &Browsers) -> String {
-  let parts = vec![
-    browsers.android.map(|v| format!("android:{}", v)),
-    browsers.chrome.map(|v| format!("chrome:{}", v)),
-    browsers.edge.map(|v| format!("edge:{}", v)),
-    browsers.firefox.map(|v| format!("firefox:{}", v)),
-    browsers.ie.map(|v| format!("ie:{}", v)),
-    browsers.ios_saf.map(|v| format!("ios_saf:{}", v)),
-    browsers.opera.map(|v| format!("opera:{}", v)),
-    browsers.safari.map(|v| format!("safari:{}", v)),
-    browsers.samsung.map(|v| format!("samsung:{}", v)),
-  ];
-
-  parts.into_iter().flatten().collect::<Vec<_>>().join(",")
-}
-
-fn string_to_browsers(s: &str) -> Result<Browsers, DeserializeError> {
-  let mut browsers = Browsers::default();
-
-  if s.is_empty() {
-    return Ok(browsers);
-  }
-
-  for part in s.split(',') {
-    let mut split = part.split(':');
-    let browser = split
-      .next()
-      .ok_or_else(|| DeserializeError::MessageError("invalid browser format"))?;
-    let version_str = split
-      .next()
-      .ok_or_else(|| DeserializeError::MessageError("invalid browser format"))?;
-
-    let version = version_str
-      .parse::<u32>()
-      .map_err(|_| DeserializeError::MessageError("invalid version format"))?;
-
-    match browser {
-      "android" => browsers.android = Some(version),
-      "chrome" => browsers.chrome = Some(version),
-      "edge" => browsers.edge = Some(version),
-      "firefox" => browsers.firefox = Some(version),
-      "ie" => browsers.ie = Some(version),
-      "ios_saf" => browsers.ios_saf = Some(version),
-      "opera" => browsers.opera = Some(version),
-      "safari" => browsers.safari = Some(version),
-      "samsung" => browsers.samsung = Some(version),
-      _ => return Err(DeserializeError::MessageError("unknown browser")),
-    }
-  }
-
-  Ok(browsers)
-}
-
 impl ArchiveWith<Browsers> for AsPreset {
   type Archived = ArchivedString;
   type Resolver = BrowsersResolver;
@@ -89,7 +35,8 @@ where
     field: &Browsers,
     serializer: &mut S,
   ) -> Result<Self::Resolver, SerializeError> {
-    let value = browsers_to_string(field);
+    let value = serde_json::to_string(field)
+      .map_err(|_| SerializeError::MessageError("serialize serde_json value failed"))?;
     let inner = ArchivedString::serialize_from_str(&value, serializer)?;
     Ok(BrowsersResolver { value, inner })
   }
@@ -103,6 +50,7 @@ where
     field: &ArchivedString,
     _deserializer: &mut D,
   ) -> Result<Browsers, DeserializeError> {
-    string_to_browsers(field.as_str())
+    serde_json::from_str(field.as_str())
+      .map_err(|_| DeserializeError::MessageError("deserialize serde_json value failed"))
   }
 }


### PR DESCRIPTION
## Summary

This partially reverts commit db3cf1b7a3ab1455df52d1d32ecc4b01b273dcc8, with `lightningcss` crate bumping to 1.0.0-alpha.68.

Since `lightningcss` is now supporting `serde` >= 1.0.220, we can use the `serde` instead of serializing manually.

## Related links

<!-- Related issues or discussions. -->

- https://github.com/parcel-bundler/lightningcss/pull/1062

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
