### PR TITLE
refactor: update type definitions to fix Rslint issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:js": "pnpm run lint-ci:js --write",
     "lint-ci:js": "biome check --diagnostic-level=warn --no-errors-on-unmatched --max-diagnostics=none --error-on-warnings",
     "lint:rs": "node ./scripts/check_rust_dependency.cjs",
-    "lint:type": "rslint --config rslint.json --max-warnings=2536",
+    "lint:type": "rslint --config rslint.json --max-warnings=2486",
     "build:binding:dev": "pnpm --filter @rspack/binding run build:dev",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",
     "build:binding:ci": "pnpm --filter @rspack/binding run build:ci",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:js": "pnpm run lint-ci:js --write",
     "lint-ci:js": "biome check --diagnostic-level=warn --no-errors-on-unmatched --max-diagnostics=none --error-on-warnings",
     "lint:rs": "node ./scripts/check_rust_dependency.cjs",
-    "lint:type": "rslint --config rslint.json --max-warnings=2602",
+    "lint:type": "rslint --config rslint.json --max-warnings=2536",
     "build:binding:dev": "pnpm --filter @rspack/binding run build:dev",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",
     "build:binding:ci": "pnpm --filter @rspack/binding run build:ci",

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -583,7 +583,7 @@ type CacheHookMap = Map<string, SyncBailHook<[any[], StatsFactoryContext], any>[
 export type CacheOptions = boolean;
 
 // @public (undocumented)
-type Callback_2 = (stats?: Stats | MultiStats | undefined) => any;
+type Callback_2 = (stats?: Stats | MultiStats) => any;
 
 // @public (undocumented)
 type CallbackCache<T> = (err?: WebpackError_2 | null, result?: T) => void;
@@ -671,7 +671,7 @@ export type CircularDependencyRspackPluginOptions = {
     failOnError?: boolean;
     allowAsyncCycles?: boolean;
     exclude?: RegExp;
-    ignoredConnections?: Array<[string | RegExp, string | RegExp]>;
+    ignoredConnections?: [string | RegExp, string | RegExp][];
     onDetected?(entrypoint: Module, modules: string[], compilation: Compilation): void;
     onIgnored?(entrypoint: Module, modules: string[], compilation: Compilation): void;
     onStart?(compilation: Compilation): void;
@@ -878,7 +878,7 @@ export class Compilation {
     // (undocumented)
     chunkGraph: ChunkGraph;
     // (undocumented)
-    get chunkGroups(): ReadonlyArray<ChunkGroup>;
+    get chunkGroups(): readonly ChunkGroup[];
     // (undocumented)
     get chunks(): ReadonlySet<Chunk>;
     // (undocumented)
@@ -930,7 +930,7 @@ export class Compilation {
     getAssetPath(filename: string, data?: PathData): string;
     // (undocumented)
     getAssetPathWithInfo(filename: string, data?: PathData): binding.PathWithInfo;
-    getAssets(): ReadonlyArray<Asset>;
+    getAssets(): readonly Asset[];
     // (undocumented)
     getCache(name: string): CacheFacade;
     // (undocumented)
@@ -2343,9 +2343,9 @@ export type ExperimentCacheNormalized = boolean | {
     buildDependencies: string[];
     version: string;
     snapshot: {
-        immutablePaths: Array<string | RegExp>;
-        unmanagedPaths: Array<string | RegExp>;
-        managedPaths: Array<string | RegExp>;
+        immutablePaths: (string | RegExp)[];
+        unmanagedPaths: (string | RegExp)[];
+        managedPaths: (string | RegExp)[];
     };
     storage: {
         type: "filesystem";
@@ -2361,9 +2361,9 @@ export type ExperimentCacheOptions = boolean | {
     buildDependencies?: string[];
     version?: string;
     snapshot?: {
-        immutablePaths?: Array<string | RegExp>;
-        unmanagedPaths?: Array<string | RegExp>;
-        managedPaths?: Array<string | RegExp>;
+        immutablePaths?: (string | RegExp)[];
+        unmanagedPaths?: (string | RegExp)[];
+        managedPaths?: (string | RegExp)[];
     };
     storage?: {
         type: "filesystem";
@@ -2938,10 +2938,10 @@ interface HasSpan {
 }
 
 // @public (undocumented)
-type Headers_2 = Array<{
+type Headers_2 = {
     key: string;
     value: string;
-}> | Record<string, string | string[]>;
+}[] | Record<string, string | string[]>;
 
 // @public (undocumented)
 type HistoryApiFallbackOptions = {
@@ -3002,7 +3002,7 @@ export type HotUpdateMainFilename = FilenameTemplate;
 export const HtmlRspackPlugin: typeof HtmlRspackPluginImpl & {
     getHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
     getCompilationHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
-    createHtmlTagObject: (tagName: string, attributes?: Record<string, string | boolean>, innerHTML?: string | undefined) => JsHtmlPluginTag;
+    createHtmlTagObject: (tagName: string, attributes?: Record<string, string | boolean>, innerHTML?: string) => JsHtmlPluginTag;
     version: number;
 };
 
@@ -4842,7 +4842,7 @@ export interface MultiCompilerOptions {
 }
 
 // @public (undocumented)
-export type MultiRspackOptions = ReadonlyArray<RspackOptions> & MultiCompilerOptions;
+export type MultiRspackOptions = readonly RspackOptions[] & MultiCompilerOptions;
 
 // @public (undocumented)
 export class MultiStats {
@@ -5150,7 +5150,7 @@ export type Optimization = {
     moduleIds?: "named" | "natural" | "deterministic";
     chunkIds?: "natural" | "named" | "deterministic" | "size" | "total-size";
     minimize?: boolean;
-    minimizer?: Array<"..." | Plugin_2>;
+    minimizer?: ("..." | Plugin_2)[];
     mergeDuplicateChunks?: boolean;
     splitChunks?: false | OptimizationSplitChunksOptions;
     runtimeChunk?: OptimizationRuntimeChunk;
@@ -5748,7 +5748,7 @@ type ProvidesV1Config = {
 };
 
 // @public (undocumented)
-type ProxyConfigArray = (ProxyConfigArrayItem | ((req?: Request_2 | undefined, res?: Response_2 | undefined, next?: NextFunction | undefined) => ProxyConfigArrayItem))[];
+type ProxyConfigArray = (ProxyConfigArrayItem | ((req?: Request_2, res?: Response_2, next?: NextFunction) => ProxyConfigArrayItem))[];
 
 // @public (undocumented)
 type ProxyConfigArrayItem = {
@@ -5975,7 +5975,7 @@ type RealPathSync = {
 // @public (undocumented)
 type RecursiveArrayOrRecord<T> = {
     [index: string]: RecursiveArrayOrRecord<T>;
-} | Array<RecursiveArrayOrRecord<T>> | T;
+} | RecursiveArrayOrRecord<T>[] | T;
 
 // @public (undocumented)
 interface RegExpLiteral extends Node_4, HasSpan {
@@ -6196,8 +6196,8 @@ const RsdoctorPluginImpl: {
 
 // @public (undocumented)
 type RsdoctorPluginOptions = {
-    moduleGraphFeatures?: boolean | Array<"graph" | "ids" | "sources">;
-    chunkGraphFeatures?: boolean | Array<"graph" | "assets">;
+    moduleGraphFeatures?: boolean | ("graph" | "ids" | "sources")[];
+    chunkGraphFeatures?: boolean | ("graph" | "assets")[];
     sourceMapFeatures?: {
         module?: boolean;
         cheap?: boolean;

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -441,7 +441,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		);
 	}
 
-	get chunkGroups(): ReadonlyArray<ChunkGroup> {
+	get chunkGroups(): readonly ChunkGroup[] {
 		return this.#inner.chunkGroups;
 	}
 
@@ -570,8 +570,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			// properties in the prototype chain
 			const options: Partial<NormalizedStatsOptions> = {};
 			for (const key in optionsOrPreset) {
-				options[key as keyof NormalizedStatsOptions] =
-					optionsOrPreset[key as keyof StatsValue];
+				options[key] = optionsOrPreset[key as keyof StatsValue];
 			}
 			if (options.preset !== undefined) {
 				this.hooks.statsPreset.for(options.preset).call(options, context);
@@ -651,7 +650,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	/**
 	 * Get an array of Asset
 	 */
-	getAssets(): ReadonlyArray<Asset> {
+	getAssets(): readonly Asset[] {
 		const assets = this.#inner.getAssets();
 
 		return assets.map(asset => {

--- a/packages/rspack/src/Diagnostics.ts
+++ b/packages/rspack/src/Diagnostics.ts
@@ -125,7 +125,7 @@ export function createDiagnosticArray(
 				value: RspackError,
 				index: number,
 				array: RspackError[]
-			) => U | ReadonlyArray<U>,
+			) => U | readonly U[],
 			thisArg?: This
 		): U[] {
 			return adm.values().flatMap(callbackfn, thisArg);

--- a/packages/rspack/src/ExecuteModulePlugin.ts
+++ b/packages/rspack/src/ExecuteModulePlugin.ts
@@ -15,7 +15,7 @@ export default class ExecuteModulePlugin {
 					const moduleObject = options.moduleObject;
 					const source = options.codeGenerationResult.get("javascript");
 					if (source === undefined) return;
-					const code = source as string;
+					const code = source;
 
 					try {
 						const fn = vm.runInThisContext(

--- a/packages/rspack/src/MultiCompiler.ts
+++ b/packages/rspack/src/MultiCompiler.ts
@@ -51,7 +51,7 @@ export interface MultiCompilerOptions {
 	parallelism?: number;
 }
 
-export type MultiRspackOptions = ReadonlyArray<RspackOptions> &
+export type MultiRspackOptions = readonly RspackOptions[] &
 	MultiCompilerOptions;
 
 export class MultiCompiler {

--- a/packages/rspack/src/Watching.ts
+++ b/packages/rspack/src/Watching.ts
@@ -320,7 +320,7 @@ export class Watching {
 					});
 					return;
 				}
-				this._done(null, this.compiler._lastCompilation!);
+				this._done(null, this.compiler._lastCompilation);
 			};
 
 			this.compiler.compile(onCompiled);
@@ -425,7 +425,7 @@ export class Watching {
 				}
 			});
 			for (const cb of cbs) cb(null);
-			this.compiler.hooks.afterDone.call(stats!);
+			this.compiler.hooks.afterDone.call(stats);
 		});
 	}
 

--- a/packages/rspack/src/builtin-loader/swc/pluginImport.ts
+++ b/packages/rspack/src/builtin-loader/swc/pluginImport.ts
@@ -13,8 +13,8 @@ type RawPluginImportConfig = {
 	style?: RawStyleConfig;
 	camelToDashComponentName?: boolean;
 	transformToDefaultImport?: boolean;
-	ignoreEsComponent?: Array<string>;
-	ignoreStyleComponent?: Array<string>;
+	ignoreEsComponent?: string[];
+	ignoreStyleComponent?: string[];
 };
 
 type PluginImportConfig = {

--- a/packages/rspack/src/builtin-plugin/CircularDependencyRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/CircularDependencyRspackPlugin.ts
@@ -36,7 +36,7 @@ export type CircularDependencyRspackPluginOptions = {
 	 * module "app/design/components/Button.tsx". When the entry is a RegExp,
 	 * it is tested against the entire identifier.
 	 */
-	ignoredConnections?: Array<[string | RegExp, string | RegExp]>;
+	ignoredConnections?: [string | RegExp, string | RegExp][];
 	/**
 	 * Called once for every detected cycle. Providing this handler overrides the
 	 * default behavior of adding diagnostics to the compilation.

--- a/packages/rspack/src/builtin-plugin/DefinePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/DefinePlugin.ts
@@ -69,5 +69,5 @@ type NormalizedCodeValue = RecursiveArrayOrRecord<NormalizedCodeValuePrimitive>;
 
 type RecursiveArrayOrRecord<T> =
 	| { [index: string]: RecursiveArrayOrRecord<T> }
-	| Array<RecursiveArrayOrRecord<T>>
+	| RecursiveArrayOrRecord<T>[]
 	| T;

--- a/packages/rspack/src/builtin-plugin/HttpUriPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HttpUriPlugin.ts
@@ -66,13 +66,11 @@ function compatibleFetch(
 					/** @type {Readable} */
 					let stream = res;
 					if (contentEncoding === "gzip") {
-						stream = stream.pipe(createGunzip()) as any as IncomingMessage;
+						stream = stream.pipe(createGunzip()) as IncomingMessage;
 					} else if (contentEncoding === "br") {
-						stream = stream.pipe(
-							createBrotliDecompress()
-						) as any as IncomingMessage;
+						stream = stream.pipe(createBrotliDecompress()) as IncomingMessage;
 					} else if (contentEncoding === "deflate") {
-						stream = stream.pipe(createInflate()) as any as IncomingMessage;
+						stream = stream.pipe(createInflate()) as IncomingMessage;
 					}
 					const chunks: Buffer[] = [];
 					stream.on("data", chunk => {

--- a/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
@@ -60,8 +60,8 @@ export declare namespace RsdoctorPluginData {
 }
 
 export type RsdoctorPluginOptions = {
-	moduleGraphFeatures?: boolean | Array<"graph" | "ids" | "sources">;
-	chunkGraphFeatures?: boolean | Array<"graph" | "assets">;
+	moduleGraphFeatures?: boolean | ("graph" | "ids" | "sources")[];
+	chunkGraphFeatures?: boolean | ("graph" | "assets")[];
 	sourceMapFeatures?: {
 		module?: boolean;
 		cheap?: boolean;

--- a/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
@@ -34,8 +34,8 @@ type HtmlTagObject = {
 type BeforeAssetTagGenerationData = {
 	assets: {
 		publicPath: string;
-		js: Array<string>;
-		css: Array<string>;
+		js: string[];
+		css: string[];
 		favicon?: string;
 		manifest?: string;
 		[extraAssetType: string]: unknown;
@@ -269,7 +269,7 @@ export class SubresourceIntegrityPlugin extends NativeSubresourceIntegrityPlugin
 						) {
 							return;
 						}
-						const hwpHooks = getHooks!(compilation);
+						const hwpHooks = getHooks(compilation);
 						hwpHooks.beforeAssetTagGeneration.tapPromise(
 							PLUGIN_NAME,
 							async data => {

--- a/packages/rspack/src/builtin-plugin/css-extract/index.ts
+++ b/packages/rspack/src/builtin-plugin/css-extract/index.ts
@@ -98,7 +98,7 @@ export class CssExtractRspackPlugin {
 
 		const normalzedOptions: RawCssExtractPluginOption = {
 			filename: options.filename || DEFAULT_FILENAME,
-			chunkFilename: chunkFilename!,
+			chunkFilename: chunkFilename,
 			ignoreOrder: options.ignoreOrder ?? false,
 			runtime: options.runtime ?? true,
 			insert:
@@ -112,7 +112,7 @@ export class CssExtractRspackPlugin {
 						? undefined
 						: JSON.stringify(options.linkType),
 			attributes: options.attributes
-				? (Reflect.ownKeys(options.attributes)
+				? Reflect.ownKeys(options.attributes)
 						.map(k => [
 							JSON.stringify(k),
 							JSON.stringify(options.attributes![k as string])
@@ -120,7 +120,7 @@ export class CssExtractRspackPlugin {
 						.reduce((obj: Record<string, string>, [k, v]) => {
 							obj[k] = v;
 							return obj;
-						}, {}) as Record<string, string>)
+						}, {})
 				: {},
 			pathinfo: options.pathinfo ?? false,
 			enforceRelative: options.enforceRelative ?? false

--- a/packages/rspack/src/builtin-plugin/css-extract/loader.ts
+++ b/packages/rspack/src/builtin-plugin/css-extract/loader.ts
@@ -105,7 +105,7 @@ export const pitch: LoaderDefinition["pitch"] = function (request, _, data) {
 
 	this.addDependency(filepath);
 
-	let { publicPath } = this._compilation!.outputOptions;
+	let { publicPath } = this._compilation.outputOptions;
 
 	if (typeof options.publicPath === "string") {
 		// eslint-disable-next-line prefer-destructuring
@@ -221,9 +221,7 @@ export const pitch: LoaderDefinition["pitch"] = function (request, _, data) {
 					);
 
 					const localsString = identifiers
-						.map(
-							([id, key]) => `\nvar ${id} = ${stringifyLocal(locals![key])};`
-						)
+						.map(([id, key]) => `\nvar ${id} = ${stringifyLocal(locals[key])};`)
 						.join("");
 					const exportsString = `export { ${identifiers
 						.map(([id, key]) => `${id} as ${JSON.stringify(key)}`)

--- a/packages/rspack/src/builtin-plugin/html-plugin/plugin.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/plugin.ts
@@ -254,7 +254,7 @@ const HtmlRspackPlugin = HtmlRspackPluginImpl as typeof HtmlRspackPluginImpl & {
 	createHtmlTagObject: (
 		tagName: string,
 		attributes?: Record<string, string | boolean>,
-		innerHTML?: string | undefined
+		innerHTML?: string
 	) => JsHtmlPluginTag;
 	version: number;
 };
@@ -280,7 +280,7 @@ const voidTags = [
 HtmlRspackPlugin.createHtmlTagObject = (
 	tagName: string,
 	attributes?: Record<string, string | boolean>,
-	innerHTML?: string | undefined
+	innerHTML?: string
 ): JsHtmlPluginTag => {
 	return {
 		tagName,

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -199,7 +199,7 @@ export function getRawResolve(resolve: Resolve): RawOptions["resolve"] {
 		fallback: getRawAlias(resolve.fallback),
 		extensionAlias: getRawExtensionAlias(resolve.extensionAlias) as Record<
 			string,
-			Array<string>
+			string[]
 		>,
 		tsconfig: getRawTsConfig(resolve.tsConfig),
 		byDependency: getRawResolveByDependency(resolve.byDependency)

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -1206,7 +1206,7 @@ const A = <T, P extends keyof T>(
 			if (item === "...") {
 				if (newArray === undefined) {
 					newArray = value.slice(0, i);
-					obj[prop] = newArray as any;
+					obj[prop] = newArray;
 				}
 				const items = factory();
 				if (items !== undefined) {

--- a/packages/rspack/src/config/devServer.ts
+++ b/packages/rspack/src/config/devServer.ts
@@ -40,10 +40,10 @@ type ModifyResponseData<
 	byteLength: number
 ) => ResponseData;
 type Headers =
-	| Array<{
+	| {
 			key: string;
 			value: string;
-	  }>
+	  }[]
 	| Record<string, string | string[]>;
 type OutputFileSystem = import("..").OutputFileSystem & {
 	createReadStream?: typeof import("fs").createReadStream;
@@ -188,12 +188,12 @@ type ByPass = (
 type ProxyConfigArray = (
 	| ProxyConfigArrayItem
 	| ((
-			req?: Request | undefined,
-			res?: Response | undefined,
-			next?: NextFunction | undefined
+			req?: Request,
+			res?: Response,
+			next?: NextFunction
 	  ) => ProxyConfigArrayItem)
 )[];
-type Callback = (stats?: Stats | MultiStats | undefined) => any;
+type Callback = (stats?: Stats | MultiStats) => any;
 type DevMiddlewareContext<
 	_RequestInternal extends IncomingMessage = IncomingMessage,
 	_ResponseInternal extends ServerResponse = ServerResponse

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -509,15 +509,12 @@ const keyedNestedConfig = <T, R>(
 	const result =
 		value === undefined
 			? {}
-			: Object.keys(value).reduce(
-					(obj, key) => {
-						obj[key] = (customKeys && key in customKeys ? customKeys[key] : fn)(
-							value[key]
-						);
-						return obj;
-					},
-					{} as Record<string, R>
-				);
+			: Object.keys(value).reduce<Record<string, R>>((obj, key) => {
+					obj[key] = (customKeys && key in customKeys ? customKeys[key] : fn)(
+						value[key]
+					);
+					return obj;
+				}, {});
 	if (customKeys) {
 		for (const key of Object.keys(customKeys)) {
 			if (!(key in result)) {
@@ -619,9 +616,9 @@ export type ExperimentCacheNormalized =
 			buildDependencies: string[];
 			version: string;
 			snapshot: {
-				immutablePaths: Array<string | RegExp>;
-				unmanagedPaths: Array<string | RegExp>;
-				managedPaths: Array<string | RegExp>;
+				immutablePaths: (string | RegExp)[];
+				unmanagedPaths: (string | RegExp)[];
+				managedPaths: (string | RegExp)[];
 			};
 			storage: {
 				type: "filesystem";

--- a/packages/rspack/src/config/target.ts
+++ b/packages/rspack/src/config/target.ts
@@ -132,9 +132,12 @@ const versionDependent = (
 	};
 };
 
-const TARGETS: Array<
-	[string, string, RegExp, (...args: string[]) => Partial<TargetProperties>]
-> = [
+const TARGETS: [
+	string,
+	string,
+	RegExp,
+	(...args: string[]) => Partial<TargetProperties>
+][] = [
 	[
 		"browserslist / browserslist:env / browserslist:query / browserslist:path-to-config / browserslist:path-to-config:env",
 		"Resolve features from browserslist. Will resolve browserslist config automatically. Only browser or node queries are supported (electron is not supported). Examples: 'browserslist:modern' to use 'modern' environment from browserslist config",
@@ -389,7 +392,7 @@ const mergeTargetProperties = (
 ): TargetProperties => {
 	const keys = new Set<keyof TargetProperties>();
 	for (const tp of targetProperties) {
-		for (const key of Object.keys(tp) as Array<keyof TargetProperties>) {
+		for (const key of Object.keys(tp) as (keyof TargetProperties)[]) {
 			keys.add(key);
 		}
 	}

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2383,7 +2383,7 @@ export type Optimization = {
 	 * Customize the minimizer.
 	 * By default, `rspack.SwcJsMinimizerRspackPlugin` and `rspack.LightningCssMinimizerRspackPlugin` are used.
 	 */
-	minimizer?: Array<"..." | Plugin>;
+	minimizer?: ("..." | Plugin)[];
 
 	/**
 	 * Whether to merge chunks which contain the same modules.
@@ -2513,9 +2513,9 @@ export type ExperimentCacheOptions =
 			buildDependencies?: string[];
 			version?: string;
 			snapshot?: {
-				immutablePaths?: Array<string | RegExp>;
-				unmanagedPaths?: Array<string | RegExp>;
-				managedPaths?: Array<string | RegExp>;
+				immutablePaths?: (string | RegExp)[];
+				unmanagedPaths?: (string | RegExp)[];
+				managedPaths?: (string | RegExp)[];
 			};
 			storage?: {
 				type: "filesystem";

--- a/packages/rspack/src/lib/cache/getLazyHashedEtag.ts
+++ b/packages/rspack/src/lib/cache/getLazyHashedEtag.ts
@@ -42,7 +42,7 @@ class LazyHashedEtag {
 		if (this._hash === undefined) {
 			const hash = createHash(this._hashFunction);
 			this._obj.updateHash(hash);
-			this._hash = hash.digest("base64") as string;
+			this._hash = hash.digest("base64");
 		}
 		return this._hash;
 	}

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -629,7 +629,7 @@ export async function runLoaders(
 		} else {
 			source = new RawSource(content);
 		}
-		loaderContext._module.emitFile(name, source!, assetInfo!);
+		loaderContext._module.emitFile(name, source!, assetInfo);
 	};
 	loaderContext.fs = compiler.inputFileSystem;
 	loaderContext.experiments = {

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -239,7 +239,7 @@ async function loaderImpl(
 		},
 		createHash: type => {
 			return createHash(
-				type || loaderContext._compilation.outputOptions!.hashFunction!
+				type || loaderContext._compilation.outputOptions.hashFunction!
 			);
 		}
 	};

--- a/packages/rspack/src/runtime/cssExtractHmr.ts
+++ b/packages/rspack/src/runtime/cssExtractHmr.ts
@@ -83,7 +83,7 @@ function getCurrentScriptUrl(moduleId: string) {
 		srcByModuleId[moduleId] = src;
 	}
 
-	return (fileMap: string): Option<Array<string>> | null => {
+	return (fileMap: string): Option<string[]> | null => {
 		if (!src) {
 			return null;
 		}
@@ -176,7 +176,7 @@ function updateCss(el: HTMLLinkElement & Record<string, any>, url?: string) {
 	}
 }
 
-function getReloadUrl(href: string, src: Array<string>): string {
+function getReloadUrl(href: string, src: string[]): string {
 	let ret = "";
 
 	const normalizedHref = normalizeUrl(href);
@@ -190,7 +190,7 @@ function getReloadUrl(href: string, src: Array<string>): string {
 	return ret;
 }
 
-function reloadStyle(src: Option<Array<string>>): boolean {
+function reloadStyle(src: Option<string[]>): boolean {
 	if (!src) {
 		return false;
 	}

--- a/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
@@ -970,7 +970,7 @@ const SIMPLE_EXTRACTORS: SimpleExtractors = {
 			const statsCompilation = getStatsCompilation(compilation);
 			const array = statsCompilation.modules;
 			const groupedModules = factory.create(`${type}.modules`, array, context);
-			const limited = spaceLimited(groupedModules, options.modulesSpace!);
+			const limited = spaceLimited(groupedModules, options.modulesSpace);
 			object.modules = limited.children;
 			object.filteredModules = limited.filteredChildren;
 		},
@@ -1001,7 +1001,7 @@ const SIMPLE_EXTRACTORS: SimpleExtractors = {
 					!chunkGroupChildren &&
 					array.every(({ chunkGroup }) => {
 						if (chunkGroup.chunks.length !== 1) return false;
-						const chunk = chunks[chunkGroup.chunks[0]!];
+						const chunk = chunks[chunkGroup.chunks[0]];
 						return (
 							chunk &&
 							chunk.files.size === 1 &&

--- a/packages/rspack/src/stats/DefaultStatsPresetPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsPresetPlugin.ts
@@ -319,7 +319,7 @@ export class DefaultStatsPresetPlugin {
 	apply(compiler: Compiler) {
 		compiler.hooks.compilation.tap("DefaultStatsPresetPlugin", compilation => {
 			for (const key of Object.keys(NAMED_PRESETS)) {
-				const defaults = NAMED_PRESETS[key as keyof typeof NAMED_PRESETS];
+				const defaults = NAMED_PRESETS[key];
 				compilation.hooks.statsPreset
 					.for(key)
 					.tap("DefaultStatsPresetPlugin", options => {

--- a/packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts
@@ -613,7 +613,7 @@ const SIMPLE_PRINTERS: Record<
 	"error.moduleName": (moduleName, { bold }) => {
 		return moduleName.includes("!")
 			? `${bold(moduleName.replace(/^(\s|\S)*!/, ""))} (${moduleName})`
-			: `${bold(moduleName)}`;
+			: bold(moduleName);
 	},
 	"error.loc": (loc, { green }) => green(loc),
 	"error.message": (message, { bold, formatError }) =>
@@ -1006,12 +1006,12 @@ const indent = (str: string, prefix: string, noPrefixInFirstLine?: boolean) => {
 };
 
 const joinExplicitNewLine = (
-	items: Array<
+	items: (
 		| {
 				content?: string;
 		  }
 		| false
-	>,
+	)[],
 	indenter: string
 ) => {
 	let firstInLine = true;
@@ -1278,7 +1278,7 @@ const AVAILABLE_FORMATS: Pick_FORMAT<
 		}
 		let timeStr = time.toString();
 		if (time > 1000) {
-			timeStr = `${(time / 1000).toFixed(2)}`;
+			timeStr = (time / 1000).toFixed(2);
 			unit = " s";
 		}
 		return `${boldQuantity ? bold(timeStr) : timeStr}${unit}`;
@@ -1374,8 +1374,7 @@ export class DefaultStatsPrinterPlugin {
 									) {
 										start = options.colors[color];
 									} else {
-										start =
-											AVAILABLE_COLORS[color as keyof typeof AVAILABLE_COLORS];
+										start = AVAILABLE_COLORS[color];
 									}
 								}
 

--- a/packages/rspack/src/trace/index.ts
+++ b/packages/rspack/src/trace/index.ts
@@ -145,13 +145,12 @@ export class JavaScriptTracer {
 		};
 	}
 	static pushEvent(event: ChromeEvent) {
-		const stringifiedArgs = Object.keys(event.args || {}).reduce(
-			(acc, key) => {
-				acc[key as string] = JSON.stringify(event.args![key]);
-				return acc;
-			},
-			{} as Record<string, any>
-		);
+		const stringifiedArgs = Object.keys(event.args || {}).reduce<
+			Record<string, string>
+		>((acc, key) => {
+			acc[key] = JSON.stringify(event.args![key]);
+			return acc;
+		}, {});
 		this.events.push({
 			...event,
 			args: stringifiedArgs

--- a/packages/rspack/src/util/ArrayQueue.ts
+++ b/packages/rspack/src/util/ArrayQueue.ts
@@ -12,8 +12,8 @@
  * @template T
  */
 class ArrayQueue<T> {
-	_list: Array<T>;
-	_listReversed: Array<T>;
+	_list: T[];
+	_listReversed: T[];
 
 	constructor(items?: T[]) {
 		this._list = items ? Array.from(items) : [];

--- a/packages/rspack/src/util/comparators.ts
+++ b/packages/rspack/src/util/comparators.ts
@@ -42,7 +42,7 @@ const concatComparatorsCache: TwoKeyWeakMap<
 	Comparator
 > = new TwoKeyWeakMap();
 
-export const concatComparators = (...comps: Array<Comparator>): Comparator => {
+export const concatComparators = (...comps: Comparator[]): Comparator => {
 	const [c1, c2, ...cRest] = comps;
 
 	if (c2 === undefined) {

--- a/rslint.json
+++ b/rslint.json
@@ -38,7 +38,12 @@
       "@typescript-eslint/no-unnecessary-boolean-literal-compare": "warn",
       "@typescript-eslint/restrict-plus-operands": "warn",
       "@typescript-eslint/no-implied-eval": "warn",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          "argsIgnorePattern": "^_"
+        }
+      ],
       "@typescript-eslint/class-literal-property-style": "warn",
       "@typescript-eslint/no-var-requires": "warn",
       "@typescript-eslint/no-require-imports": "warn",

--- a/rslint.json
+++ b/rslint.json
@@ -8,14 +8,11 @@
     "languageOptions": {
       "parserOptions": {
         "projectService": false,
-        "project": [
-          "./packages/rspack/tsconfig.json"
-        ]
+        "project": ["./packages/rspack/tsconfig.json"]
       }
     },
     "rules": {
       "@typescript-eslint/no-redundant-type-constituents": "warn",
-      "@typescript-eslint/no-duplicate-type-constituents": "warn",
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unsafe-argument": "warn",
       "@typescript-eslint/no-unsafe-member-access": "warn",
@@ -30,7 +27,6 @@
       "@typescript-eslint/promise-function-async": "warn",
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "warn",
       "@typescript-eslint/require-await": "warn",
-      "@typescript-eslint/no-unnecessary-type-assertion": "warn",
       "@typescript-eslint/switch-exhaustiveness-check": "warn",
       "@typescript-eslint/await-thenable": "warn",
       "@typescript-eslint/return-await": "warn",
@@ -39,12 +35,9 @@
       "@typescript-eslint/no-misused-spread": "warn",
       "@typescript-eslint/unbound-method": "warn",
       "@typescript-eslint/prefer-promise-reject-errors": "warn",
-      "@typescript-eslint/prefer-reduce-type-parameter": "warn",
       "@typescript-eslint/no-unnecessary-boolean-literal-compare": "warn",
       "@typescript-eslint/restrict-plus-operands": "warn",
-      "@typescript-eslint/no-unnecessary-template-expression": "warn",
       "@typescript-eslint/no-implied-eval": "warn",
-      "@typescript-eslint/array-type": "warn",
       "@typescript-eslint/no-unused-vars": "warn",
       "@typescript-eslint/class-literal-property-style": "warn",
       "@typescript-eslint/no-var-requires": "warn",
@@ -52,8 +45,6 @@
       "@typescript-eslint/no-empty-function": "warn",
       "@typescript-eslint/no-empty-interface": "warn"
     },
-    "plugins": [
-      "@typescript-eslint"
-    ]
+    "plugins": ["@typescript-eslint"]
   }
 ]


### PR DESCRIPTION
## Summary

Update type definitions to fix Rslint issues (warnings: `2602` -> `2486`).

- Enable `@typescript-eslint/no-duplicate-type-constituents`
- Enable `@typescript-eslint/prefer-reduce-type-parameter`
- Enable `@typescript-eslint/no-unnecessary-template-expression`
- Enable `@typescript-eslint/no-unnecessary-type-assertion`
- Enable `@typescript-eslint/array-type`

## Related links

- https://github.com/web-infra-dev/rspack/issues/11761

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
