### PR TITLE
docs: explain how `resolve.alias` affects package resolution

### DIFF
--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -28,6 +28,14 @@ At this point:
 - `require("abc")` will attempt to resolve `<root>/src/abc`.
 - `require("abc/file.js")` will not match, and it will attempt to resolve `node_modules/abc/file.js`.
 
+:::tip
+Using aliases to point to packages in `monorepo` or `node_modules` changes the default module resolution logic. When an alias matches and replaces a path, the subsequent resolution process treats the result as a regular relative path and no longer performs the complete package resolution process.
+
+This may cause certain resolution mechanisms for `node_modules` packages to fail. For example, the `exports` field in `package.json` will no longer take effect. This aligns with Node.js standard behavior: the [`exports`](https://nodejs.org/api/packages.html#exports) field is only applied when importing via the package name, and is bypassed once the import is resolved to a specific file path.
+
+The same principle applies to packages referencing each other within a `monorepo`. It is not recommended to use aliases to force Rspack to resolve `"@my-scope/lib"` as a sibling package. Instead, use the workspace features of `npm`, `yarn`, or `pnpm` to symlink packages into `node_modules`.
+:::
+
 ## resolve.aliasFields
 
 - **Type:** `string[]`

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -33,7 +33,7 @@ At this point:
 When you use `resolve.alias` to redirect a package import (for example, `import 'lib'`) to a specific directory inside a monorepo or within `node_modules`, the module resolution behavior changes:
 
 - **Default behavior**: If the import is a package name, Rspack performs the full package resolution process: it reads the package's `package.json` and determines the entry file and subpath mappings according to the [`exports`](https://nodejs.org/api/packages.html#exports) field.
-- **When aliased**: When an alias resolves to a file system path— for example, `./node_modules/lib` — Rspack no longer treats it as a package name and resolves it as a regular path. This bypasses the standard package resolution logic, causing fields such as `exports` in `package.json` to no longer take effect. This is the intended and standard behavior of Node.js.
+- **When aliased**: When an alias resolves to a file system path — for example, `./node_modules/lib` — Rspack no longer treats it as a package name and resolves it as a regular path. This bypasses the standard package resolution logic, causing fields such as `exports` in `package.json` to no longer take effect. This is the intended and standard behavior of Node.js.
 
 ### Monorepo usage
 

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -28,13 +28,17 @@ At this point:
 - `require("abc")` will attempt to resolve `<root>/src/abc`.
 - `require("abc/file.js")` will not match, and it will attempt to resolve `node_modules/abc/file.js`.
 
-:::tip
-Using aliases to point to packages in `monorepo` or `node_modules` changes the default module resolution logic. When an alias matches and replaces a path, the subsequent resolution process treats the result as a regular relative path and no longer performs the complete package resolution process.
+### Impact on package resolution
 
-This may cause certain resolution mechanisms for `node_modules` packages to fail. For example, the `exports` field in `package.json` will no longer take effect. This aligns with Node.js standard behavior: the [`exports`](https://nodejs.org/api/packages.html#exports) field is only applied when importing via the package name, and is bypassed once the import is resolved to a specific file path.
+When you use `resolve.alias` to redirect a package import (for example, `import 'lib'`) to a specific directory inside a monorepo or within `node_modules`, the module resolution behavior changes:
 
-The same principle applies to packages referencing each other within a `monorepo`. It is not recommended to use aliases to force Rspack to resolve `"@my-scope/lib"` as a sibling package. Instead, use the workspace features of `npm`, `yarn`, or `pnpm` to symlink packages into `node_modules`.
-:::
+- **Default behavior**: If the import is a package name, Rspack performs the full package resolution process: it reads the package's `package.json` and determines the entry file and subpath mappings according to the [`exports`](https://nodejs.org/api/packages.html#exports) field.
+- **When aliased**: When an alias resolves to a file system path— for example, `./node_modules/lib` — Rspack no longer treats it as a package name and resolves it as a regular path. This bypasses the standard package resolution logic, causing fields such as `exports` in `package.json` to no longer take effect. This is the intended and standard behavior of Node.js.
+
+### Monorepo usage
+
+If you want packages within a monorepo to retain the same resolution behavior as regular npm packages, avoid using `alias` to point a package name directly to its source directory.
+The recommended approach is to use your package manager's workspace feature to symlink sub-packages into `node_modules`, so they can be resolved just like normal dependencies.
 
 ## resolve.aliasFields
 

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -28,6 +28,14 @@ import WebpackLicense from '@components/WebpackLicense';
 - `require("abc")` 会尝试解析 `<root>/src/abc`。
 - `require("abc/file.js")` 不会命中匹配规则，它会尝试去解析 `node_modules/abc/files.js`。
 
+:::tip
+使用 alias 指向 `monorepo` 或 `node_modules` 中的包会改变模块的默认解析逻辑。当 `alias` 匹配并替换路径后，后续的解析过程会将替换结果视为普通相对路径，而不再执行完整的包解析流程。
+
+这会导致针对 `node_modules` 的某些解析机制失效，例如 `package.json` 中的 `exports` 字段将不再生效。这是 Node.js 的标准行为：[`exports`](https://nodejs.org/api/packages.html#exports) 仅在通过包名导入时应用，一旦解析为具体路径就会被跳过。
+
+同样的原则适用于 `monorepo` 中相互引用的包。不建议使用 `alias` 让 Rspack 将 `"@my-scope/lib"` 强制解析为同级包，而应通过 `npm`、`yarn` 或 `pnpm` 的工作区功能将包符号链接到 `node_modules` 中。
+:::
+
 ## resolve.aliasFields
 
 - **类型：** `string[]`

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -28,13 +28,17 @@ import WebpackLicense from '@components/WebpackLicense';
 - `require("abc")` 会尝试解析 `<root>/src/abc`。
 - `require("abc/file.js")` 不会命中匹配规则，它会尝试去解析 `node_modules/abc/files.js`。
 
-:::tip
-使用 alias 指向 `monorepo` 或 `node_modules` 中的包会改变模块的默认解析逻辑。当 `alias` 匹配并替换路径后，后续的解析过程会将替换结果视为普通相对路径，而不再执行完整的包解析流程。
+### 对包解析的影响
 
-这会导致针对 `node_modules` 的某些解析机制失效，例如 `package.json` 中的 `exports` 字段将不再生效。这是 Node.js 的标准行为：[`exports`](https://nodejs.org/api/packages.html#exports) 仅在通过包名导入时应用，一旦解析为具体路径就会被跳过。
+当你使用 `resolve.alias` 将包名导入（例如 `import 'lib'`）重定向到 monorepo 或 `node_modules` 中的具体目录时，模块的解析方式会发生变化：
 
-同样的原则适用于 `monorepo` 中相互引用的包。不建议使用 `alias` 让 Rspack 将 `"@my-scope/lib"` 强制解析为同级包，而应通过 `npm`、`yarn` 或 `pnpm` 的工作区功能将包符号链接到 `node_modules` 中。
-:::
+- **默认情况**：如果导入的是包名，Rspack 会执行完整的包解析流程：读取该包的 `package.json`，并根据 `[exports](https://nodejs.org/api/packages.html#exports)` 字段决定入口文件和子路径映射。
+- **重定向后**：当别名被替换成实际的文件系统路径，例如 `./node_modules/lib`，Rspack 不再将其视为包名，而是按普通路径进行解析。这会跳过包的默认解析逻辑，导致 `package.json` 中的 `exports` 等字段不再生效。这是 Node.js 的标准解析行为。
+
+### Monorepo 场景
+
+如果希望 monorepo 中的各个包依然保持和正常 npm 包一致的解析方式，不建议通过 `alias` 将包名直接指向源码目录。
+推荐的做法是使用包管理器的工作区功能，将子包符号链接到 `node_modules` 中，让它们像普通依赖一样被解析。
 
 ## resolve.aliasFields
 


### PR DESCRIPTION
## Summary

Adds documentation about how `resolve.alias` affects package resolution, clarify the difference between default package resolution and aliased paths, especially in monorepo scenarios, and recommend best practices for maintaining standard package resolution behavior.

## Related links

https://github.com/web-infra-dev/rsbuild/issues/5311

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
