### PR TITLE
refactor: remove experiments.layers

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2101,7 +2101,6 @@ export interface RawExperimentCacheOptionsPersistent {
 }
 
 export interface RawExperiments {
-  layers: boolean
   topLevelAwait: boolean
 incremental?: false | { [key: string]: boolean }
 parallelCodeSplitting: boolean

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -3650,8 +3650,6 @@ impl OptimizationOptionsBuilder {
 /// [`Experiments`]: rspack_core::options::Experiments
 #[derive(Debug, Default)]
 pub struct ExperimentsBuilder {
-  /// Whether to enable module layers feature.  
-  layers: Option<bool>,
   /// Incremental passes.
   incremental: Option<IncrementalOptions>,
   /// Whether to enable top level await.
@@ -3676,7 +3674,6 @@ pub struct ExperimentsBuilder {
 impl From<Experiments> for ExperimentsBuilder {
   fn from(value: Experiments) -> Self {
     ExperimentsBuilder {
-      layers: Some(value.layers),
       incremental: Some(value.incremental),
       top_level_await: Some(value.top_level_await),
       rspack_future: Some(value.rspack_future),
@@ -3693,7 +3690,6 @@ impl From<Experiments> for ExperimentsBuilder {
 impl From<&mut ExperimentsBuilder> for ExperimentsBuilder {
   fn from(value: &mut ExperimentsBuilder) -> Self {
     ExperimentsBuilder {
-      layers: value.layers.take(),
       incremental: value.incremental.take(),
       top_level_await: value.top_level_await.take(),
       rspack_future: value.rspack_future.take(),
@@ -3708,12 +3704,6 @@ impl From<&mut ExperimentsBuilder> for ExperimentsBuilder {
 }
 
 impl ExperimentsBuilder {
-  /// Set whether to enable layers.
-  pub fn layers(&mut self, layers: bool) -> &mut Self {
-    self.layers = Some(layers);
-    self
-  }
-
   /// Set the incremental passes.
   pub fn incremental(&mut self, incremental: IncrementalOptions) -> &mut Self {
     self.incremental = Some(incremental);
@@ -3765,7 +3755,6 @@ impl ExperimentsBuilder {
     development: bool,
     production: bool,
   ) -> Result<Experiments> {
-    let layers = d!(self.layers, false);
     let incremental = f!(self.incremental.take(), || {
       let passes = if !production {
         IncrementalPasses::MAKE | IncrementalPasses::EMIT_ASSETS
@@ -3796,7 +3785,6 @@ impl ExperimentsBuilder {
     let parallel_code_splitting = d!(self.parallel_code_splitting, false);
 
     Ok(Experiments {
-      layers,
       incremental,
       top_level_await,
       rspack_future,

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1477,7 +1477,6 @@ CompilerOptions {
     },
     cache: Disabled,
     experiments: Experiments {
-        layers: false,
         incremental: IncrementalOptions {
             silent: true,
             passes: IncrementalPasses(

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
@@ -14,7 +14,6 @@ use super::WithFalse;
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
 pub struct RawExperiments {
-  pub layers: bool,
   pub top_level_await: bool,
   #[napi(ts_type = "false | { [key: string]: boolean }")]
   pub incremental: Option<WithFalse<RawIncremental>>,
@@ -44,7 +43,6 @@ impl From<RawExperiments> for Experiments {
         None => IncrementalOptions::empty_passes(),
       },
       parallel_code_splitting: value.parallel_code_splitting,
-      layers: value.layers,
       top_level_await: value.top_level_await,
       rspack_future: value.rspack_future.unwrap_or_default().into(),
       cache: normalize_raw_experiment_cache_options(value.cache),

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -482,11 +482,6 @@ impl NormalModuleFactory {
       self.calculate_module_type(match_module_type, &resolved_module_rules);
     let resolved_module_layer =
       self.calculate_module_layer(data.issuer_layer.as_ref(), &resolved_module_rules);
-    if resolved_module_layer.is_some() && !self.options.experiments.layers {
-      return Err(error!(
-        "'Rule.layer' is only allowed when 'experiments.layers' is enabled"
-      ));
-    }
 
     let resolved_resolve_options = self.calculate_resolve_options(&resolved_module_rules);
     let (resolved_parser_options, resolved_generator_options) =

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -9,7 +9,6 @@ use crate::incremental::IncrementalOptions;
 // `impl From<Experiments> for ExperimentsBuilder` should be updated.
 #[derive(Debug)]
 pub struct Experiments {
-  pub layers: bool,
   pub incremental: IncrementalOptions,
   pub parallel_code_splitting: bool,
   pub top_level_await: bool,

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2458,7 +2458,7 @@ export interface ExperimentsNormalized {
     inlineConst?: boolean;
     // (undocumented)
     inlineEnum?: boolean;
-    // (undocumented)
+    // @deprecated (undocumented)
     layers?: boolean;
     // (undocumented)
     lazyBarrel?: boolean;

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -218,8 +218,11 @@ const applyExperimentsDefaults = (
 	D(experiments, "lazyCompilation", false);
 	D(experiments, "asyncWebAssembly", experiments.futureDefaults);
 	D(experiments, "css", experiments.futureDefaults ? true : undefined);
-	D(experiments, "layers", false);
-
+	if ("layers" in experiments) {
+		console.warn(
+			"`experiments.layers` config has been deprecated and will be removed in Rspack v2.0. Feature layers will be always enabled. Please remove this option from your Rspack configuration."
+		);
+	}
 	if (experiments.topLevelAwait === false) {
 		console.warn(
 			"`experiments.topLevelAwait` config has been deprecated and will be removed in Rspack v2.0. Top-level await will be always enabled. Please remove this option from your Rspack configuration."

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -638,6 +638,9 @@ export interface ExperimentsNormalized {
 	outputModule?: boolean;
 	topLevelAwait?: boolean;
 	css?: boolean;
+	/**
+	 * @deprecated This option is deprecated, layers is enabled since v1.6.0
+	 */
 	layers?: boolean;
 	incremental?: false | Incremental;
 	parallelCodeSplitting?: boolean;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2733,6 +2733,7 @@ export type Experiments = {
 	css?: boolean;
 	/**
 	 * Enable module layers feature.
+	 * @deprecated This option is deprecated, layers is enabled since v1.6.0
 	 * @default false
 	 */
 	layers?: boolean;

--- a/packages/rspack/src/lib/EntryOptionPlugin.ts
+++ b/packages/rspack/src/lib/EntryOptionPlugin.ts
@@ -82,11 +82,6 @@ export class EntryOptionPlugin {
 			// wasmLoading: desc.wasmLoading,
 			library: desc.library
 		};
-		if (desc.layer !== undefined && !compiler.options.experiments.layers) {
-			throw new Error(
-				"'entryOptions.layer' is only allowed when 'experiments.layers' is enabled"
-			);
-		}
 		// if (desc.chunkLoading) {
 		// 	const EnableChunkLoadingPlugin = require("./javascript/EnableChunkLoadingPlugin");
 		// 	EnableChunkLoadingPlugin.checkEnabled(compiler, desc.chunkLoading);

--- a/tests/rspack-test/configCases/css-extract/module-layer/rspack.config.js
+++ b/tests/rspack-test/configCases/css-extract/module-layer/rspack.config.js
@@ -45,7 +45,6 @@ module.exports = {
 		})
 	],
 	experiments: {
-		layers: true,
 		css: false
 	}
 };

--- a/tests/rspack-test/configCases/entry/dynamic-entry-layer/rspack.config.js
+++ b/tests/rspack-test/configCases/entry/dynamic-entry-layer/rspack.config.js
@@ -7,8 +7,5 @@ module.exports = {
 				layer: "client"
 			}
 		});
-	},
-	experiments: {
-		layers: true
 	}
 };

--- a/tests/rspack-test/configCases/externals/context-info/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/context-info/rspack.config.js
@@ -20,7 +20,4 @@ module.exports = {
 			return callback();
 		}
 	],
-	experiments: {
-		layers: true
-	}
 };

--- a/tests/rspack-test/configCases/layer/context-and-css/rspack.config.js
+++ b/tests/rspack-test/configCases/layer/context-and-css/rspack.config.js
@@ -6,7 +6,6 @@ module.exports = {
 		dark: { import: "./dark.js", layer: "dark" }
 	},
 	experiments: {
-		layers: true,
 		css: true
 	},
 	optimization: {

--- a/tests/rspack-test/configCases/layer/context/rspack.config.js
+++ b/tests/rspack-test/configCases/layer/context/rspack.config.js
@@ -6,9 +6,6 @@ module.exports = {
 		light: { import: "./light.js", layer: "light" },
 		dark: { import: "./dark.js", layer: "dark" }
 	},
-	experiments: {
-		layers: true
-	},
 	output: {
 		filename: "[name].js"
 	},

--- a/tests/rspack-test/configCases/layer/rules/rspack.config.js
+++ b/tests/rspack-test/configCases/layer/rules/rspack.config.js
@@ -49,9 +49,6 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		layers: true
-	},
 	externals: [
 		{
 			external1: "var 42"

--- a/tests/rspack-test/configCases/loader-import-module/with-layer/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-import-module/with-layer/rspack.config.js
@@ -11,7 +11,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		layers: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel-import-module/with-layer/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel-import-module/with-layer/rspack.config.js
@@ -17,7 +17,6 @@ module.exports = {
 		]
 	},
 	experiments: {
-		layers: true,
 		parallelLoader: true
 	}
 };

--- a/tests/rspack-test/configCases/parsing/rspack-issue-7848-disable-layer/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/rspack-issue-7848-disable-layer/rspack.config.js
@@ -5,9 +5,6 @@ module.exports = {
 	entry: {
 		bundle0: "./index.js"
 	},
-	experiments: {
-		layers: false
-	},
 	plugins: [
 		new rspack.DefinePlugin({
 			__RUNTIME_TYPE__: "__webpack_layer__"

--- a/tests/rspack-test/configCases/parsing/rspack-issue-7848-enable-layer/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/rspack-issue-7848-enable-layer/rspack.config.js
@@ -8,9 +8,6 @@ module.exports = {
 			layer: "main"
 		}
 	},
-	experiments: {
-		layers: true
-	},
 	plugins: [
 		new rspack.DefinePlugin({
 			__RUNTIME_TYPE__: "__webpack_layer__"

--- a/tests/rspack-test/configCases/plugins/normal-module-replacement-plugin-args/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/normal-module-replacement-plugin-args/rspack.config.js
@@ -15,7 +15,4 @@ module.exports = /** @type {import("@rspack/core").Configuration} */ ({
 			args.request = args.request.replace(/request\.v1(\.|$)/, "request.v2$1");
 		})
 	],
-	experiments: {
-		layers: true
-	}
 });

--- a/tests/rspack-test/configCases/split-chunks/cache-group-layer-function/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/cache-group-layer-function/rspack.config.js
@@ -10,9 +10,6 @@ module.exports = {
 	output: {
 		filename: "[name].js"
 	},
-	experiments: {
-		layers: true
-	},
 	optimization: {
 		splitChunks: {
 			chunks: "all",

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -45,7 +45,6 @@ module.exports = {
 		    },
 		    inlineConst: false,
 		    inlineEnum: false,
-		    layers: false,
 		    lazyBarrel: false,
 		    lazyCompilation: false,
 		    parallelCodeSplitting: false,

--- a/tests/rspack-test/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
+++ b/tests/rspack-test/diagnosticsCases/plugins/circular-dependency-plugin/rspack.config.js
@@ -14,9 +14,6 @@ module.exports = {
 			layer: "f"
 		}
 	},
-	experiments: {
-		layers: true
-	},
 	module: {
 		rules: [
 			{

--- a/tests/rspack-test/statsAPICases/layer-stats.js
+++ b/tests/rspack-test/statsAPICases/layer-stats.js
@@ -14,9 +14,6 @@ module.exports = {
 					layer: "legacy"
 				}
 			},
-			experiments: {
-				layers: true
-			}
 		};
 	},
 	async check(stats) {

--- a/tests/rspack-test/statsAPICases/layer.js
+++ b/tests/rspack-test/statsAPICases/layer.js
@@ -11,9 +11,6 @@ module.exports = {
 					layer: "test"
 				}
 			},
-			experiments: {
-				layers: true
-			}
 		};
 	},
 	async check(stats) {

--- a/tests/rspack-test/statsOutputCases/context-independence/webpack.config.js
+++ b/tests/rspack-test/statsOutputCases/context-independence/webpack.config.js
@@ -20,9 +20,6 @@ const base = (name, devtool) => ({
 	stats: {
 		relatedAssets: true
 	},
-	experiments: {
-		layers: true
-	},
 	entry: {
 		main: {
 			import: "./index",

--- a/tests/rspack-test/watchCases/cache/changing-module-id/webpack.config.js
+++ b/tests/rspack-test/watchCases/cache/changing-module-id/webpack.config.js
@@ -20,6 +20,5 @@ module.exports = {
 	},
 	experiments: {
 		// cacheUnaffected: true,
-		layers: true
 	}
 };

--- a/tests/webpack-test/Defaults.unittest.js
+++ b/tests/webpack-test/Defaults.unittest.js
@@ -98,7 +98,6 @@ describe("snapshots", () => {
 		    "cacheUnaffected": false,
 		    "css": undefined,
 		    "futureDefaults": false,
-		    "layers": false,
 		    "lazyCompilation": undefined,
 		    "outputModule": false,
 		    "syncWebAssembly": false,

--- a/tests/webpack-test/__snapshots__/Cli.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/Cli.basictest.js.snap
@@ -646,19 +646,6 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
-  "experiments-layers": Object {
-    "configs": Array [
-      Object {
-        "description": "Enable module layers.",
-        "multiple": false,
-        "path": "experiments.layers",
-        "type": "boolean",
-      },
-    ],
-    "description": "Enable module layers.",
-    "multiple": false,
-    "simpleType": "boolean",
-  },
   "experiments-lazy-compilation": Object {
     "configs": Array [
       Object {

--- a/website/docs/en/config/entry.mdx
+++ b/website/docs/en/config/entry.mdx
@@ -225,7 +225,7 @@ The default value can be affected by different [target](/config/target):
 Specifies the layer in which modules of this entrypoint are placed. Make the corresponding configuration take effect through layer matching in split chunks, [rules](/config/module#ruleissuerlayer), stats, and externals.
 
 :::warning
-This configuration will only take effect when [experiments.layers](/config/experiments#experimentslayers) is `true`.
+For version before v1.6.0, this configuration will only take effect when [experiments.layers](/config/experiments#experimentslayers) is `true`.
 :::
 
 ```js title="rspack.config.mjs"
@@ -235,9 +235,6 @@ export default {
       import: './src/index.js',
       layer: 'layer-name',
     },
-  },
-  experiments: {
-    layers: true,
   },
 };
 ```

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -122,10 +122,14 @@ This configuration has been deprecated. Please use [lazyCompilation](/config/laz
 
 ## experiments.layers
 
-<ApiMeta addedVersion="1.0.0-beta.1" />
+<ApiMeta deprecatedVersion="1.6.0" />
 
 - **Type:** `boolean`
 - **Default:** `false`
+
+:::warning
+This config is deprecated, layers is enabled at all time. Please remove this option from your Rspack configuration.
+:::
 
 Controls whether to enable the layer feature. Layers can add an identifier prefix to all modules in a subgraph starting from a module in the module graph, to distinguish them from modules in different layers. For example:
 

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -2064,7 +2064,7 @@ export default {
 Matches all modules that match this resource, and will match against layer of the module that issued the current module.
 
 :::warning
-This configuration will only work if [experiments.layers = true](/config/experiments#experimentslayers).
+For version before v1.6.0, this configuration will only work if [experiments.layers = true](/config/experiments#experimentslayers).
 :::
 
 A basic example:
@@ -2112,9 +2112,6 @@ export default {
         },
       },
     ],
-  },
-  experiments: {
-    layers: true,
   },
 };
 ```
@@ -2472,7 +2469,7 @@ The meanings of all `type` options are as follows:
 Used to mark the layer of the matching module. A group of modules could be united in one layer which could then be used in split chunks, stats or [entry options](/config/entry#entrydescriptionlayer).
 
 :::warning
-This configuration will only work if [experiments.layers = true](/config/experiments#experimentslayers).
+For version before v1.6.0, this configuration will only work if [experiments.layers = true](/config/experiments#experimentslayers).
 :::
 
 ```js title="rspack.config.mjs"

--- a/website/docs/zh/config/entry.mdx
+++ b/website/docs/zh/config/entry.mdx
@@ -225,7 +225,7 @@ export default {
 指定当前入口的模块所在的 layer。用于在 split chunks, [rules](/config/module#ruleissuerlayer)、stats、externals 中通过 layer 匹配使对应的配置生效。
 
 :::warning
-只有在 [experiments.layers = true](/config/experiments#experimentslayers) 时该配置才会生效。
+对于 v1.6.0 之前的版本，只有在 [experiments.layers = true](/config/experiments#experimentslayers) 时该配置才会生效。
 :::
 
 ```js title="rspack.config.mjs"
@@ -235,9 +235,6 @@ export default {
       import: './src/index.js',
       layer: 'layer-name',
     },
-  },
-  experiments: {
-    layers: true,
   },
 };
 ```

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -123,10 +123,14 @@ export default {
 
 ## experiments.layers
 
-<ApiMeta addedVersion="1.0.0-beta.1" />
+<ApiMeta deprecatedVersion="1.6.0" />
 
 - **类型：** `boolean`
 - **默认值：** `false`
+
+:::warning
+该配置项已经废弃，layers 特性已始终开启，请从 Rspack 配置项中移除此配置。
+:::
 
 控制是否启用 layer 功能，layer 可以为模块图中以一个模块作为起点的子图中的所有模块添加标识符前缀，用来与其他不同 layer 的模块进行区分，比如：
 

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -2061,7 +2061,7 @@ export default {
 匹配所有符合这个资源的模块，会与"引入当前模块"的模块的 layer 进行匹配。
 
 :::warning
-只有在 [experiments.layers = true](/config/experiments#experimentslayers) 时该配置才会生效。
+对于 v1.6.0 之前的版本，只有在 [experiments.layers = true](/config/experiments#experimentslayers) 时该配置才会生效。
 :::
 
 一个基础示例：
@@ -2109,9 +2109,6 @@ export default {
         },
       },
     ],
-  },
-  experiments: {
-    layers: true,
   },
 };
 ```
@@ -2468,7 +2465,7 @@ export default {
 用于标识匹配的模块的 layer。可以将一组模块聚合到一个 layer 中，该 layer 随后可以在 split chunks, stats 或 [entry options](/config/entry#entrydescriptionlayer) 中使用。
 
 :::warning
-只有在 [experiments.layers = true](/config/experiments#experimentslayers) 时该配置才会生效。
+对于 v1.6.0 之前的版本，只有在 [experiments.layers = true](/config/experiments#experimentslayers) 时该配置才会生效。
 :::
 
 ```js title="rspack.config.mjs"


### PR DESCRIPTION
## Summary

Remove `experiments.layers` which is used to enable the `layers` feature, now we enable this by default. Now users only need to specify layer in `entry` or `moduleRule`, no need to enable it in `experiments`.

If you use this config before, just delete it will be fine

```diff
export default {
  experiments: {
-  layers: true
  }
}
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
