### PR TITLE
fix: should use external source as name hint

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -448,7 +448,7 @@ impl EsmLibraryPlugin {
                     "",
                     &all_used_names,
                     escaped_identifiers
-                      .get(&readable_identifier)
+                      .get(source)
                       .expect("should have escaped identifier"),
                   )
                 } else {

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -353,13 +353,19 @@ impl EsmLibraryPlugin {
           }
         }
         format!(
-          "import {}{{ {} }} from {source_str};\n",
+          "import {}{}from {source_str};\n",
           if let Some(default_import) = &symbols.default_import {
-            format!("{default_import}, ")
+            format!("{default_import} ")
           } else {
             String::new()
           },
-          imports.join(", ")
+          if imports.is_empty() {
+            String::default()
+          } else if symbols.default_import.is_some() {
+            format!(", {{ {} }} ", imports.join(", "))
+          } else {
+            format!("{{ {} }} ", imports.join(", "))
+          }
         )
       };
       final_source.add(RawStringSource::from(import_str));

--- a/tests/rspack-test/esmOutputCases/externals/externals-import-render/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/externals-import-render/__snapshots__/esm.snap.txt
@@ -1,0 +1,25 @@
+```mjs title=main.mjs
+import fs from "fs";
+import { join, resolve } from "path";
+
+// fs
+
+// path
+
+// ./index.js
+
+
+
+
+it('should compile', () => {
+	console.log.bind([fs, join, resolve])
+})
+
+
+```
+
+```mjs title=runtime.mjs
+
+
+
+```

--- a/tests/rspack-test/esmOutputCases/externals/externals-import-render/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/externals-import-render/index.js
@@ -1,0 +1,7 @@
+import fs from 'fs'
+
+import { join, resolve } from 'path'
+
+it('should compile', () => {
+	console.log.bind([fs, join, resolve])
+})

--- a/tests/rspack-test/esmOutputCases/externals/externals-import-render/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/externals-import-render/rspack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	externals: {
+		fs: "module fs",
+		path: "module path",
+	},
+	externalsType: "module-import",
+}

--- a/tests/rspack-test/esmOutputCases/re-exports/re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/re-export-external/__snapshots__/esm.snap.txt
@@ -1,5 +1,5 @@
 ```mjs title=main.mjs
-import external_fs_, { readFile as external_fs_readFile } from "fs";
+import fs_0 , { readFile as external_fs_readFile } from "fs";
 
 // fs
 
@@ -35,7 +35,7 @@ it('should compile and import success', async () => {
 	expect(readFile).toBeDefined()
 })
 
-export { external_fs_ as fs, external_fs_readFile as r, external_fs_readFile as readFile, named, starExports };
+export { external_fs_readFile as r, external_fs_readFile as readFile, fs_0 as fs, named, starExports };
 export * from "fs";
 
 ```


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->
should use external import source as the symbol name hint, instead of readable identifier, and do not render unnecessary empty import brackets

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
