### PR TITLE
feat: rslib supports add shims for js/esm

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2723,6 +2723,11 @@ export interface RawRslibPluginOptions {
    * @default `false`
    */
   compactExternalModuleDynamicImport?: boolean
+  /**
+   * Add shims for javascript/esm modules
+   * @default `false`
+   */
+  forceNodeShims?: boolean
 }
 
 export interface RawRspackFuture {

--- a/crates/rspack_binding_api/src/rslib.rs
+++ b/crates/rspack_binding_api/src/rslib.rs
@@ -11,6 +11,9 @@ pub struct RawRslibPluginOptions {
   /// This field should not be set to `true` when using `modern-module` with ESM output, as it is already in use.
   /// @default `false`
   pub compact_external_module_dynamic_import: Option<bool>,
+  /// Add shims for javascript/esm modules
+  /// @default `false`
+  pub force_node_shims: Option<bool>,
 }
 
 impl From<RawRslibPluginOptions> for RslibPluginOptions {
@@ -20,6 +23,7 @@ impl From<RawRslibPluginOptions> for RslibPluginOptions {
       compact_external_module_dynamic_import: value
         .compact_external_module_dynamic_import
         .unwrap_or_default(),
+      force_node_shims: value.force_node_shims.unwrap_or_default(),
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -19,7 +19,7 @@ mod initialize_evaluating;
 mod inline_const;
 mod inner_graph;
 mod javascript_meta_info_plugin;
-mod node_stuff_plugin;
+pub mod node_stuff_plugin;
 mod override_strict_plugin;
 mod require_context_dependency_parser_plugin;
 mod require_ensure_dependencies_block_parse_plugin;

--- a/tests/rspack-test/configCases/rslib/shims-for-js-esm/index.js
+++ b/tests/rspack-test/configCases/rslib/shims-for-js-esm/index.js
@@ -1,0 +1,6 @@
+it('should add shims for js/esm modules', () => {
+	const fs = __non_webpack_require__('fs');
+	const path = __non_webpack_require__('path');
+	const content = fs.readFileSync(path.resolve(__dirname, 'bundle.mjs'), 'utf-8');
+	expect(content).toContain('__webpack_fileURLToPath__');
+})

--- a/tests/rspack-test/configCases/rslib/shims-for-js-esm/rspack.config.js
+++ b/tests/rspack-test/configCases/rslib/shims-for-js-esm/rspack.config.js
@@ -1,0 +1,41 @@
+const {
+	experiments: { RslibPlugin }
+} = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		index: "./index.js",
+	},
+	target: "node",
+	node: {
+		__filename: 'node-module',
+		__dirname: 'node-module'
+	},
+	experiments: {
+		outputModule: true,
+	},
+	optimization: {
+		concatenateModules: false
+	},
+	module: {
+		rules: [
+			{
+				// set every module type to javascript/esm
+				type: 'javascript/esm',
+			}
+		]
+	},
+	output: {
+		module: true,
+		library: {
+			type: "modern-module"
+		},
+		filename: 'bundle.mjs'
+	},
+	plugins: [
+		new RslibPlugin({
+			forceNodeShims: true
+		})
+	]
+}

--- a/tests/rspack-test/configCases/rslib/shims-for-js-esm/test.config.js
+++ b/tests/rspack-test/configCases/rslib/shims-for-js-esm/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+		findBundle: () => {
+			return ['bundle.mjs'];
+		}
+	}


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Rslib supports add shims for javascript/esm, register the NodeStuff parser plugin if user uses shims

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
