### PR TITLE
ci: fix lazy-compilation persistent cache e2e case

### DIFF
--- a/tests/e2e/cases/lazy-compilation/persistent-cache/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/index.test.ts
@@ -1,17 +1,30 @@
 import { expect, test } from "@/fixtures";
 
-// Ref: https://github.com/web-infra-dev/rspack/issues/11829
-test.skip("should load success", async ({ page, rspack }) => {
-	await page.getByText("Click me").click();
-	let component_count = await page.getByText("Component").count();
-	expect(component_count).toBe(1);
+function has_dyn_module(modules: string[]) {
+	for (const m of modules) {
+		if (m.endsWith("/src/dyn.js") && !m.startsWith("lazy-compilation-proxy|")) {
+			return true;
+		}
+	}
+	return false;
+}
+
+test("should load success", async ({ page, rspack }) => {
+	// rspack.compiler.__modules is injected by plugin in rspack.config.js
+	await expect(page.locator("#Component")).toHaveCount(1);
+	await expect(page.locator("#dyn")).toHaveCount(0);
+	expect(has_dyn_module(rspack.compiler.__modules)).toBe(false);
+	await page.locator("#click_button").click();
+	await expect(page.locator("#dyn")).toHaveCount(1);
+	expect(has_dyn_module(rspack.compiler.__modules)).toBe(true);
 
 	await rspack.reboot();
 	await page.reload();
-
 	// trigger other import compile
-	await page.getByText("Click me").click();
-	await page.waitForEvent('console')
-	const dynImported = await page.getByText("dyn imported").count();
-	expect(dynImported).toBe(1);
+	await expect(page.locator("#Component")).toHaveCount(1);
+	await expect(page.locator("#dyn")).toHaveCount(0);
+	expect(has_dyn_module(rspack.compiler.__modules)).toBe(true);
+	await page.locator("#click_button").click();
+	await expect(page.locator("#dyn")).toHaveCount(1);
+	expect(has_dyn_module(rspack.compiler.__modules)).toBe(true);
 });

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/rspack.config.js
@@ -8,7 +8,17 @@ module.exports = {
 	},
 	stats: "none",
 	mode: "production",
-	plugins: [new rspack.HtmlRspackPlugin()],
+	plugins: [
+		new rspack.HtmlRspackPlugin(),
+		{
+			apply(compiler) {
+				compiler.hooks.done.tap("TEST", function (stats) {
+					const { modules } = stats.toJson();
+					compiler.__modules = modules.map(item => item.identifier);
+				});
+			}
+		}
+	],
 	cache: true,
 	lazyCompilation: true,
 	experiments: {
@@ -21,7 +31,7 @@ module.exports = {
 		client: {
 			overlay: {
 				// hide warnings for incremental
-				warnings: false,
+				warnings: false
 			}
 		}
 	}

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/src/component.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/src/component.js
@@ -1,3 +1,4 @@
 const button = document.createElement("button");
 button.textContent = "Component";
+button.id = "Component";
 document.body.appendChild(button);

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/src/dyn.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/src/dyn.js
@@ -1,4 +1,4 @@
 const div = document.createElement("div");
 div.textContent = "dyn imported";
+div.id = "dyn";
 document.body.appendChild(div);
-console.log('dyn imported')

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/src/index.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/src/index.js
@@ -1,7 +1,8 @@
 const button = document.createElement("button");
 button.textContent = "Click me";
+button.id = "click_button";
 document.body.appendChild(button);
 
 button.addEventListener("click", async () => {
-	import('./dyn')
-})
+	import("./dyn");
+});

--- a/tests/e2e/cases/make/remove-dynamic-entry-with-loader/index.test.ts
+++ b/tests/e2e/cases/make/remove-dynamic-entry-with-loader/index.test.ts
@@ -1,19 +1,35 @@
 import { expect, test } from "@/fixtures";
 
 test("should compile", async ({ page, fileAction, rspack }) => {
+	// rspack.compiler.__sharedObj is injected by plugin in rspack.config.js
 	await expect(page.getByText("index1")).toBeVisible();
 	await expect(page.getByText("index2")).toBeVisible();
 
-	fileAction.updateFile("src/index2.js", content => content.replace("div.innerText = \"index2\";", "div.innerText = \"index2 updated\";"));
-	fileAction.updateFile("src/index1.js", content => content.replace("div.innerText = \"index1\";", "div.innerText = \"index1 updated\";"));
+	rspack.compiler.__sharedObj.useFullEntry = false;
+	fileAction.updateFile("src/index2.js", content =>
+		content.replace(
+			'div.innerText = "index2";',
+			'div.innerText = "index2 updated";'
+		)
+	);
+	fileAction.updateFile("src/index1.js", content =>
+		content.replace(
+			'div.innerText = "index1";',
+			'div.innerText = "index1 updated";'
+		)
+	);
 
 	await expect(async () => {
 		await page.reload();
 		expect(await page.locator("#index1").innerText()).toBe("index1 updated");
 	}).toPass();
 	await expect(page.locator("#index2")).toHaveCount(0);
-	await expect(page.locator("#webpack-dev-server-client-overlay")).toHaveCount(0);
+	await expect(page.locator("#webpack-dev-server-client-overlay")).toHaveCount(
+		0
+	);
 
-	const stats = rspack.compiler._lastCompilation?.getStats().toJson({ all: false, errors: true });
+	const stats = rspack.compiler._lastCompilation
+		?.getStats()
+		.toJson({ all: false, errors: true });
 	expect(stats?.errors?.length).toBe(0);
 });

--- a/tests/e2e/cases/make/remove-dynamic-entry-with-loader/rspack.config.js
+++ b/tests/e2e/cases/make/remove-dynamic-entry-with-loader/rspack.config.js
@@ -1,25 +1,27 @@
 const rspack = require("@rspack/core");
 
-let first = true;
+const sharedObj = {
+	useFullEntry: true
+};
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: async () => {
-		if (first) {
+		if (sharedObj.useFullEntry) {
 			return {
 				main: {
-					import: "./loader.js!./src/index1.js",
+					import: "./loader.js!./src/index1.js"
 				},
 				main2: {
 					import: "./loader.js!./src/index2.js"
 				}
-			}
+			};
 		} else {
 			return {
 				main: {
-					import: "./loader.js!./src/index1.js",
-				},
-			}
+					import: "./loader.js!./src/index1.js"
+				}
+			};
 		}
 	},
 	context: __dirname,
@@ -27,12 +29,10 @@ module.exports = {
 	plugins: [
 		new rspack.HtmlRspackPlugin(),
 		function (compiler) {
-			compiler.hooks.done.tap('t', () => {
-				first = false;
-			})
+			compiler.__sharedObj = sharedObj;
 		}
 	],
 	devServer: {
 		hot: true
-	},
+	}
 };

--- a/tests/e2e/cases/make/rewrite-factorize-request/index.test.ts
+++ b/tests/e2e/cases/make/rewrite-factorize-request/index.test.ts
@@ -8,12 +8,15 @@ async function expect_content(page: any, data: string) {
 }
 
 test("should compile", async ({ page, fileAction, rspack }) => {
+	// rspack.compiler.__sharedObj is injected by plugin in rspack.config.js
 	await expect_content(page, "2");
 
+	rspack.compiler.__sharedObj.time++;
 	fileAction.updateFile("file.js", content => content.replace("1", "2"));
 
 	await expect_content(page, "4");
 
+	rspack.compiler.__sharedObj.time++;
 	fileAction.updateFile("file.js", content => content.replace("2", "3"));
 
 	await expect_content(page, "6");

--- a/tests/e2e/cases/make/rewrite-factorize-request/rspack.config.js
+++ b/tests/e2e/cases/make/rewrite-factorize-request/rspack.config.js
@@ -1,5 +1,9 @@
 const { rspack } = require("@rspack/core");
 
+const sharedObj = {
+	time: 1
+};
+
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: "./index.js",
@@ -13,7 +17,7 @@ module.exports = {
 		new rspack.HtmlRspackPlugin(),
 		{
 			apply(compiler) {
-				let time = 0;
+				compiler.__sharedObj = sharedObj;
 				compiler.hooks.compilation.tap(
 					"PLUGIN",
 					(_, { normalModuleFactory }) => {
@@ -21,8 +25,7 @@ module.exports = {
 							"PLUGIN",
 							async resolveData => {
 								if (resolveData.request == "./file") {
-									time++;
-									resolveData.request = `./loader.js?time=${time}!./file`;
+									resolveData.request = `./loader.js?time=${sharedObj.time}!./file`;
 								}
 							}
 						);

--- a/tests/e2e/cases/persistent-cache/rename-file/index.test.ts
+++ b/tests/e2e/cases/persistent-cache/rename-file/index.test.ts
@@ -7,15 +7,9 @@ async function expect_content(page: any, data: string) {
 	}).toPass();
 }
 
-test("should compile", async ({
-	page,
-	fileAction,
-	rspack,
-	rspackIncremental
-}) => {
+test("should compile", async ({ page, fileAction, rspack }) => {
 	await expect_content(page, "ab");
 	await rspack.stop();
-	await rspackIncremental.stop();
 	await new Promise(res => {
 		setTimeout(res, 500);
 	});
@@ -25,6 +19,5 @@ test("should compile", async ({
 	fileAction.renameFile("temp.js", "b.js");
 
 	await rspack.start();
-	await rspackIncremental.start();
 	await expect_content(page, "ba");
 });

--- a/tests/e2e/fixtures/fileAction.ts
+++ b/tests/e2e/fixtures/fileAction.ts
@@ -19,9 +19,6 @@ export const fileActionFixtures: Fixtures<
 	RspackFixtures
 > = {
 	fileAction: async ({ rspack }, use) => {
-		// null means this file needs to be deleted
-		const fileOriginContent: Record<string, string | null> = {};
-
 		await use({
 			renameFile(oldPath, newPath) {
 				const oldFilePath = path.resolve(rspack.projectDir, oldPath);
@@ -33,10 +30,6 @@ export const fileActionFixtures: Fixtures<
 				const fileExists = fs.existsSync(filePath);
 				const content = fileExists ? fs.readFileSync(filePath).toString() : "";
 
-				if (fileOriginContent[filePath] === undefined) {
-					fileOriginContent[filePath] = fileExists ? content : null;
-				}
-
 				fs.writeFileSync(filePath, fn(content));
 			},
 			deleteFile(relativePath) {
@@ -46,24 +39,8 @@ export const fileActionFixtures: Fixtures<
 					return;
 				}
 
-				if (fileOriginContent[filePath] === undefined) {
-					fileOriginContent[filePath] = fs.readFileSync(filePath).toString();
-				}
-
 				fs.unlinkSync(filePath);
 			}
 		});
-
-		for (const [filePath, content] of Object.entries(fileOriginContent)) {
-			if (content === null) {
-				fs.unlinkSync(filePath);
-			} else {
-				fs.writeFileSync(filePath, content);
-			}
-		}
-		if (Object.keys(fileOriginContent).length) {
-			// has recovery file
-			await rspack.waitingForBuild();
-		}
 	}
 };

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig<RspackOptions>({
 	// Fail the build on CI if you accidentally left test.only in the source code.
 	forbidOnly: !!process.env.CI,
 	build: {
-		external: ['**/moduleFederationDefaultRuntime.js']
+		external: ["**/moduleFederationDefaultRuntime.js"]
 	},
 	retries: 0,
 
@@ -47,7 +47,31 @@ export default defineConfig<RspackOptions>({
 			name: "chromium",
 			use: {
 				rspackConfig: {
+					basePort: 8000,
 					handleConfig: (config: any) => {
+						return config;
+					}
+				},
+				...devices["Desktop Chrome"]
+			}
+		},
+		{
+			name: "chromium-incremental",
+			use: {
+				rspackConfig: {
+					basePort: 8200,
+					handleConfig: (config: any) => {
+						config.experiments ??= {};
+						config.experiments.incremental = true;
+						const cache = config.experiments.cache;
+						if (typeof cache === "object" && cache.type === "persistent") {
+							cache.storage = {
+								type: "filesystem",
+								...cache.storage,
+								//rewrite directory
+								directory: "node_modules/.cache/incremental"
+							};
+						}
 						return config;
 					}
 				},


### PR DESCRIPTION
## Summary

fix: https://github.com/web-infra-dev/rspack/issues/11829

* Update e2e rspack fixture to split incremental test into new playwright project.
* Removed useless file recovery in fileAction fixture, since all file operations are in temporary directory.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
