### PR TITLE
fix: distinguish external modules when there are import attributes

### DIFF
--- a/tests/rspack-test/configCases/externals/import-attributes/index.js
+++ b/tests/rspack-test/configCases/externals/import-attributes/index.js
@@ -1,7 +1,9 @@
 import * as staticPkg from "./static-package.json" with { type: "json" };
+import * as staticPkgPure from "./static-package.json";
 import * as staticPkgStr from "./static-package-str.json" with { "type": "json" };
 
 it("should allow async externals", async () => {
+	expect(staticPkgPure.default.foo).toBe("static");
 	expect(staticPkg.default.foo).toBe("static");
 	expect(staticPkgStr.default.foo).toBe("static-str");
 
@@ -11,10 +13,12 @@ it("should allow async externals", async () => {
 
 	expect(dynamicPkg.default.foo).toBe("dynamic");
 
+	const dynamicPkgPure = await import("./dynamic-package-str.json")
 	const dynamicPkgStr = await import("./dynamic-package-str.json", {
 		"with": { "type": "json" }
 	})
 
+	expect(dynamicPkgPure.default.foo).toBe("dynamic-str");
 	expect(dynamicPkgStr.default.foo).toBe("dynamic-str");
 
 	const eagerPkg = await import(/* webpackMode: "eager" */ "./eager.json", {

--- a/tests/rspack-test/configCases/externals/import-attributes/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/import-attributes/rspack.config.js
@@ -44,6 +44,14 @@ module.exports = {
 									new RawSource(content)
 								);
 							});
+
+							const content = compilation.getAsset("bundle0.mjs").source.source()
+							const esmImportSpecifier1 = content.match(/import (.+) from "\.\/static-package\.json" with \{"type":"json"\};/);
+							const esmImportSpecifier2 = content.match(/import (.+) from "\.\/static-package\.json";/);
+							expect(esmImportSpecifier1[1]).not.toBe(esmImportSpecifier2[1]);
+							const importChunkId1 = content.match(/const dynamicPkgPure = await __webpack_require__.e\(\/\* import\(\) \*\/ "(.+)"\)/)
+							const importChunkId2 = content.match(/const dynamicPkgStr = await __webpack_require__.e\(\/\* import\(\) \*\/ "(.+)"\)/)
+							expect(importChunkId1[1]).not.toBe(importChunkId2[1]);
 						}
 					);
 				});


### PR DESCRIPTION
## Summary

previously, there's no difference when importing an external module with and without import attributes, as the ChunkInitFragment key didn't counting import attributes.

source

```js
import { a1 } from 'a'
import { a2 } from 'a' with { type: "json" }
console.log(a1, a2)
```

result before

```js
import { a1, a2 } from 'a' // sometimes it suffixs with attributes, it's a race condition.
console.log(a1, a2)
```

result now

```js
import { a1 } from 'a'
import { a2 } from 'a' with { type: "json" }
console.log(a1, a2)
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
