### PR TITLE
chore: clean up TODO comments and simplify code

### DIFF
--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -122,11 +122,7 @@ export function setBuiltinEnvArg(
 	envNameSuffix: string,
 	value: any
 ) {
-	const envNames = [
-		// TODO: breaking change
-		// `WEBPACK_${envNameSuffix}`,
-		`RSPACK_${envNameSuffix}`
-	];
+	const envNames = [`RSPACK_${envNameSuffix}`];
 	for (const envName of envNames) {
 		if (envName in env) {
 			continue;

--- a/packages/rspack/module.d.ts
+++ b/packages/rspack/module.d.ts
@@ -217,8 +217,6 @@ declare namespace Rspack {
 
 interface ImportMeta {
 	url: string;
-	// TODO: unsupported
-	// webpack: number;
 	webpackHot?: Rspack.Hot;
 	webpackContext: (
 		request: string,

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -565,8 +565,6 @@ class Compiler {
 				const err = new Error(`compiler.runAsChild callback error: ${e}`);
 				// err.details = e.stack;
 				this.parentCompilation!.errors.push(err);
-				// TODO: remove once this works
-				console.log(e);
 			}
 		};
 

--- a/packages/rspack/src/taps/compilation.ts
+++ b/packages/rspack/src/taps/compilation.ts
@@ -195,8 +195,7 @@ export const createCompilationHooksRegisters: CreatePartialRegisters<
 											codeGenerationResult: new CodeGenerationResult(result),
 											moduleObject
 										},
-										// TODO: Simplify this without assignments once https://github.com/web-infra-dev/rspack/pull/10036 is released in Rslib.
-										{ __webpack_require__: __webpack_require__ }
+										{ __webpack_require__ }
 									),
 								"Compilation.hooks.executeModule"
 							);


### PR DESCRIPTION
## Summary

Remove some outdated TODO comment:

- `WEBPACK_${envNameSuffix}` does not seem to need to be supported
- `import.meta.webpack` does not seem to need to be supported

## Related links

- https://github.com/web-infra-dev/rspack/pull/10036

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
