### PR TITLE
chore: avoid using `BROWSER` env

### DIFF
--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Build wasm32-wasip1-threads with linux in Docker
         if: ${{ inputs.target == 'wasm32-wasip1-threads' && inputs.profile != 'release' }}
         run: |
-          DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads BROWSER=1 pnpm build:binding:${{ inputs.profile }}
+          DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads RSPACK_TARGET_BROWSER=1 pnpm build:binding:${{ inputs.profile }}
           DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads pnpm build:binding:${{ inputs.profile }}
 
       # WASM Release (use profile = release-wasi) + wasm-opt

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -23,8 +23,8 @@
     "build:release": "node scripts/build.js --profile release",
     "build:dev:wasm": "DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads node scripts/build.js",
     "build:release:wasm": "DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads node scripts/build.js --profile release-wasi",
-    "build:dev:browser": "DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads BROWSER=1 node scripts/build.js",
-    "build:release:browser": "DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads BROWSER=1 node scripts/build.js --profile release-wasi",
+    "build:dev:browser": "DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads RSPACK_TARGET_BROWSER=1 node scripts/build.js",
+    "build:release:browser": "DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads RSPACK_TARGET_BROWSER=1 node scripts/build.js --profile release-wasi",
     "move-binding": "node scripts/move-binding",
     "test": "tsc -p tsconfig.type-test.json"
   },

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -61,7 +61,7 @@ async function build() {
 			args.push("--no-default-features");
 			features.push("plugin");
 		}
-		if (process.env.BROWSER) {
+		if (process.env.RSPACK_TARGET_BROWSER) {
 			features.push("browser")
 			// Strip debug format to reduce wasm size of @rspack/browser
 			rustflags.push("-Zfmt-debug=none");
@@ -138,7 +138,7 @@ async function build() {
 				);
 
 				// For browser wasm, we rename the artifacts to distinguish them from node wasm
-				if (process.env.BROWSER) {
+				if (process.env.RSPACK_TARGET_BROWSER) {
 					renameSync("rspack.wasm32-wasi.debug.wasm", "rspack.browser.debug.wasm")
 					renameSync("rspack.wasm32-wasi.wasm", "rspack.browser.wasm")
 				}


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

The `BROWSER` environment usually refer to the browser name that you would like to use.

And in some environment, it would be set to customize the behavior of opening browser.

E.g. on my vscode remote server:

```
❯ echo $BROWSER
/root/.vscode-server/cli/servers/Stable-e3a5acfb517a443235981655413d566533107e92/server/bin/helpers/browser.sh
```

which would result in

```
node:fs:1020
  binding.rename(
          ^

Error: ENOENT: no such file or directory, rename 'rspack.wasm32-wasi.debug.wasm' -> 'rspack.browser.debug.wasm'
    at renameSync (node:fs:1020:11)
    at ChildProcess.<anonymous> (/root/rspack/crates/node_binding/scripts/build.js:142:6)
    at ChildProcess.emit (node:events:518:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'rename',
  path: 'rspack.wasm32-wasi.debug.wasm',
  dest: 'rspack.browser.debug.wasm'
}
```

when building binding.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
