### PR TITLE
chore: fix invalid lint:rs script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "format:toml": "taplo format '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'",
     "lint:js": "pnpm run lint-ci:js --write",
     "lint-ci:js": "biome check --diagnostic-level=warn --no-errors-on-unmatched --max-diagnostics=none --error-on-warnings",
-    "lint:rs": "node ./scripts/check_rust_dependency.cjs",
+    "lint:rs": "cargo clippy --workspace --all-targets",
     "lint:type": "rslint --config rslint.json --max-warnings=2486",
     "build:binding:dev": "pnpm --filter @rspack/binding run build:dev",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",


### PR DESCRIPTION
## Summary

Fix invalid `lint:rs` script in the root package.json, the `./scripts/check_rust_dependency.cjs` file does not exist.

<img width="2186" height="710" alt="image" src="https://github.com/user-attachments/assets/d5f81f31-124d-49f3-853a-cc8d2c31d82b" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
