### PR TITLE
chore(swc_plugin_import): inherit workspace lint config

### DIFF
--- a/crates/swc_plugin_import/Cargo.toml
+++ b/crates/swc_plugin_import/Cargo.toml
@@ -15,3 +15,6 @@ swc_core   = { workspace = true, features = ["common", "ecma_ast", "ecma_visit"]
 
 [package.metadata.cargo-machete]
 ignored = ["Inflector"]
+
+[lints]
+workspace = true

--- a/crates/swc_plugin_import/src/lib.rs
+++ b/crates/swc_plugin_import/src/lib.rs
@@ -251,8 +251,7 @@ impl ImportPlugin<'_> {
     let should_ignore = &config
       .ignore_es_component
       .as_ref()
-      .map(|list| list.iter().any(|c| c == &name))
-      .unwrap_or(false);
+      .is_some_and(|list| list.iter().any(|c| c == &name));
 
     if *should_ignore {
       return (None, None);
@@ -261,8 +260,7 @@ impl ImportPlugin<'_> {
     let should_ignore_css = &config
       .ignore_style_component
       .as_ref()
-      .map(|list| list.iter().any(|c| c == &name))
-      .unwrap_or(false);
+      .is_some_and(|list| list.iter().any(|c| c == &name));
 
     let transformed_name = if config.camel_to_dash_component_name.unwrap_or(true) {
       name.to_kebab_case()
@@ -297,8 +295,7 @@ impl ImportPlugin<'_> {
       HANDLER.with(|handler| {
         handler.err(&format!(
           "[builtin:swc-loader] Failed to parse option \
-       \"rspackExperiments.import[i].customName\".\nReason: {}",
-          err
+       \"rspackExperiments.import[i].customName\".\nReason: {err}"
         ));
       });
       None
@@ -324,8 +321,7 @@ impl ImportPlugin<'_> {
               HANDLER.with(|handler| {
                 handler.err(&format!(
                   "[builtin:swc-loader] Failed to parse option \
-                  \"rspackExperiments.import[i].customStyleName\".\nReason: {}",
-                  err
+                  \"rspackExperiments.import[i].customStyleName\".\nReason: {err}"
                 ));
               });
               None
@@ -352,8 +348,7 @@ impl ImportPlugin<'_> {
                 HANDLER.with(|handler| {
                   handler.err(&format!(
                     "[builtin:swc-loader] Failed to parse option \
-                     \"rspackExperiments.import[i].style\".\nReason: {}",
-                    err
+                     \"rspackExperiments.import[i].style\".\nReason: {err}"
                   ));
                 });
                 None
@@ -441,7 +436,6 @@ impl VisitMut for ImportPlugin<'_> {
                   }
                 } else if type_ident_referenced(&s.local) {
                   // type referenced
-                  continue;
                 } else {
                   // not referenced, should tree shaking
                   rm_specifier.insert(specifier_idx);

--- a/crates/swc_plugin_import/src/template.rs
+++ b/crates/swc_plugin_import/src/template.rs
@@ -34,14 +34,14 @@ impl fmt::Display for TemplateError {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       TemplateError::UnclosedTag { value } => {
-        write!(f, "unclosed tag in template string \"{}\"", value)
+        write!(f, "unclosed tag in template string \"{value}\"")
       }
       TemplateError::InvalidTemplateString { value } => {
-        write!(f, "invalid template string `{{{{ {} }}}}`", value)
+        write!(f, "invalid template string `{{{{ {value} }}}}`")
       }
-      TemplateError::UnknownHelper { name } => write!(f, "invalid helper \"{}\"", name),
-      TemplateError::MissingValue { name } => write!(f, "missing value for `{}`", name),
-      TemplateError::TemplateNotFound { name } => write!(f, "template `{}` not found", name),
+      TemplateError::UnknownHelper { name } => write!(f, "invalid helper \"{name}\""),
+      TemplateError::MissingValue { name } => write!(f, "missing value for `{name}`"),
+      TemplateError::TemplateNotFound { name } => write!(f, "template `{name}` not found"),
     }
   }
 }


### PR DESCRIPTION
## Summary

Inherit workspace lint config in `swc_plugin_import` and fix lint issues:

- Replace string formatting with inline variable syntax
- Use `is_some_and` for cleaner option handling
- Remove redundant continue statement

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
