### PR TITLE
chore: Using env to enable sftrace

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -70,12 +70,9 @@ async function build() {
 		if (!values.profile || values.profile === "dev") {
 			features.push("color-backtrace");
 		}
-		if (values.profile === "release-debug" &&
-			(!process.env.RUST_TARGET || process.env.RUST_TARGET.includes("linux") || process.env.RUST_TARGET.includes("darwin"))
-		) {
+		if (process.env.SFTRACE) {
 			features.push("sftrace-setup");
 			rustflags.push("-Zinstrument-xray=always");
-			rustflags.push("-Csymbol-mangling-version=v0");
 		}
 		if (values.profile === "release") {
 			features.push("info-level");


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Use env to enable sftrace support instead of enalbe it auto. this prevents the debug profile from not find symbols on Linux (because we cannot configure weak link).

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
