### PR TITLE
chore: clean up unused dependencies in test tools package

### DIFF
--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -72,7 +72,8 @@
     "chalk": "^4.1.2",
     "source-map": "^0.7.6",
     "terser": "5.43.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "wast-loader": "^1.14.1"
   },
   "peerDependencies": {
     "@rspack/core": ">=1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      wast-loader:
+        specifier: ^1.14.1
+        version: 1.14.1
 
   scripts:
     devDependencies:


### PR DESCRIPTION
## Summary

The Rspack test cases has been moved to the https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test folder. So most devDependencies of `@rspack/test-tools` can be removed as they are no longer used.

Fixes the pnpm cyclic warning:

<img width="1030" height="130" alt="Screenshot 2025-10-15 at 19 34 42" src="https://github.com/user-attachments/assets/3ad61561-387e-46cc-85c6-1ae7aacd029f" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
