### PR TITLE
chore: eliminate pnpm install platform warnings

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -12,15 +12,9 @@
     "directory": "packages/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "os": ["darwin"],
+    "cpu": ["arm64"]
   },
-  "files": [
-    "rspack.darwin-arm64.node"
-  ],
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "arm64"
-  ]
+  "files": ["rspack.darwin-arm64.node"]
 }

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -12,15 +12,9 @@
     "directory": "packages/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "os": ["darwin"],
+    "cpu": ["x64"]
   },
-  "files": [
-    "rspack.darwin-x64.node"
-  ],
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "x64"
-  ]
+  "files": ["rspack.darwin-x64.node"]
 }

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -12,18 +12,10 @@
     "directory": "packages/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "os": ["linux"],
+    "cpu": ["arm64"],
+    "libc": ["glibc"]
   },
-  "files": [
-    "rspack.linux-arm64-gnu.node"
-  ],
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "libc": [
-    "glibc"
-  ]
+  "files": ["rspack.linux-arm64-gnu.node"]
 }

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -12,18 +12,10 @@
     "directory": "packages/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "os": ["linux"],
+    "cpu": ["arm64"],
+    "libc": ["musl"]
   },
-  "files": [
-    "rspack.linux-arm64-musl.node"
-  ],
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "libc": [
-    "musl"
-  ]
+  "files": ["rspack.linux-arm64-musl.node"]
 }

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -12,18 +12,10 @@
     "directory": "packages/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "os": ["linux"],
+    "cpu": ["x64"],
+    "libc": ["glibc"]
   },
-  "files": [
-    "rspack.linux-x64-gnu.node"
-  ],
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "libc": [
-    "glibc"
-  ]
+  "files": ["rspack.linux-x64-gnu.node"]
 }

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -12,18 +12,10 @@
     "directory": "packages/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "os": ["linux"],
+    "cpu": ["x64"],
+    "libc": ["musl"]
   },
-  "files": [
-    "rspack.linux-x64-musl.node"
-  ],
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "libc": [
-    "musl"
-  ]
+  "files": ["rspack.linux-x64-musl.node"]
 }

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -13,9 +13,9 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "cpu": ["wasm32"]
   },
-  "cpu": ["wasm32"],
   "files": [
     "rspack.wasm32-wasi.wasm",
     "rspack.wasi.cjs",

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -12,15 +12,9 @@
     "directory": "packages/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "os": ["win32"],
+    "cpu": ["arm64"]
   },
-  "files": [
-    "rspack.win32-arm64-msvc.node"
-  ],
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "arm64"
-  ]
+  "files": ["rspack.win32-arm64-msvc.node"]
 }

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -12,15 +12,9 @@
     "directory": "packages/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "os": ["win32"],
+    "cpu": ["ia32"]
   },
-  "files": [
-    "rspack.win32-ia32-msvc.node"
-  ],
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "ia32"
-  ]
+  "files": ["rspack.win32-ia32-msvc.node"]
 }

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -12,15 +12,9 @@
     "directory": "packages/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "os": ["win32"],
+    "cpu": ["x64"]
   },
-  "files": [
-    "rspack.win32-x64-msvc.node"
-  ],
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "x64"
-  ]
+  "files": ["rspack.win32-x64-msvc.node"]
 }


### PR DESCRIPTION
## Summary

Move platform configs (os, cpu, libc) into the `publishConfig` field to eliminate pnpm install platform warnings while keeping the same functionality.

<img width="1043" height="275" alt="Screenshot 2025-10-15 at 19 02 25" src="https://github.com/user-attachments/assets/38cffcc2-7545-47c7-bad9-735347ba5097" />

## Testing

Verified via the `pnpm pack` command:

<img width="1736" height="1402" alt="image" src="https://github.com/user-attachments/assets/100343dc-8268-4961-b617-613f0152908b" />

Also tested in an empty package: https://www.npmjs.com/package/@cjh-test/binding-test-linux-x64-gnu?activeTab=code

<img width="1080" height="1330" alt="image" src="https://github.com/user-attachments/assets/3d631ded-3b68-4b6a-8b5b-5491dfe9fc6a" />

## Related links

https://pnpm.io/package_json#publishconfig

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
