### PR TITLE
feat(esm): remove empty unneeded runtime chunks

### DIFF
--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -26,7 +26,7 @@ use swc_core::common::sync::Lazy;
 
 use crate::{
   chunk_link::{ChunkLinkContext, Ref},
-  plugin::{CONCATENATED_MODULES_MAP, LINKS},
+  plugin::{CONCATENATED_MODULES_MAP, LINKS, RSPACK_ESM_RUNTIME_CHUNK},
   runtime::RegisterModuleRuntime,
 };
 
@@ -186,6 +186,9 @@ impl EsmLibraryPlugin {
 
     // render webpack runtime
     if chunk.has_runtime(&compilation.chunk_group_by_ukey) {
+      asset_info
+        .extras
+        .insert(RSPACK_ESM_RUNTIME_CHUNK.into(), "true".into());
       // render chunk needs to render *all* runtimes in the whole tree
       let tree_runtime_requirements =
         ChunkGraph::get_tree_runtime_requirements(compilation, chunk_ukey);

--- a/tests/rspack-test/esmOutputCases/deconflict/deconflit-local/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/deconflit-local/__snapshots__/esm.snap.txt
@@ -17,9 +17,3 @@ it('should have deconflicted symbol', () => {
 
 
 ```
-
-```mjs title=runtime.mjs
-
-
-
-```

--- a/tests/rspack-test/esmOutputCases/deconflict/other-chunk-local/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/other-chunk-local/__snapshots__/esm.snap.txt
@@ -34,9 +34,3 @@ const value = foo_value
 export { value };
 
 ```
-
-```mjs title=runtime.mjs
-
-
-
-```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-self/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-self/__snapshots__/esm.snap.txt
@@ -14,12 +14,6 @@ it('should have access to the value from the same file', async () => {
 
 ```
 
-```mjs title=runtime.mjs
-
-
-
-```
-
 ```mjs title=value_js.mjs
 // ./value.js
 const conflict = 24

--- a/tests/rspack-test/esmOutputCases/externals/externals-import-render/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/externals-import-render/__snapshots__/esm.snap.txt
@@ -17,9 +17,3 @@ it('should compile', () => {
 
 
 ```
-
-```mjs title=runtime.mjs
-
-
-
-```

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm/__snapshots__/esm.snap.txt
@@ -25,9 +25,3 @@ it('should re-export esm correctly', async () => {
 export { lib2_lib2 as lib2, lib3_lib3 as lib3, lib_lib as lib };
 
 ```
-
-```mjs title=runtime.mjs
-
-
-
-```

--- a/tests/rspack-test/esmOutputCases/re-exports/re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/re-export-external/__snapshots__/esm.snap.txt
@@ -39,9 +39,3 @@ export { external_fs_readFile as r, external_fs_readFile as readFile, fs_0 as fs
 export * from "fs";
 
 ```
-
-```mjs title=runtime.mjs
-
-
-
-```


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

`runtimeChunk: 'single'` will generate a runtime chunk, if user uses all clean esm modules, there should be no rspack runtime, but the chunk is still there. When we know a chunk content is emptry and it's the runtime chunk, we can remove the asset

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
