### PR TITLE
feat(create-rspack): add type annotations to JS configs

### DIFF
--- a/packages/create-rspack/template-react-js/rspack.config.mjs
+++ b/packages/create-rspack/template-react-js/rspack.config.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "@rspack/cli";
@@ -29,6 +30,7 @@ export default defineConfig({
 				use: [
 					{
 						loader: "builtin:swc-loader",
+						/** @type {import('@rspack/core').SwcLoaderOptions} */
 						options: {
 							jsc: {
 								parser: {

--- a/packages/create-rspack/template-react-ts/rspack.config.ts
+++ b/packages/create-rspack/template-react-ts/rspack.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "@rspack/cli";
-import { rspack } from "@rspack/core";
+import { rspack, type SwcLoaderOptions } from "@rspack/core";
 import { ReactRefreshRspackPlugin } from "@rspack/plugin-react-refresh";
 
 const isDev = process.env.NODE_ENV === "development";
@@ -40,7 +40,7 @@ export default defineConfig({
 								}
 							},
 							env: { targets }
-						}
+						} satisfies SwcLoaderOptions
 					}
 				]
 			}

--- a/packages/create-rspack/template-vanilla-js/rspack.config.mjs
+++ b/packages/create-rspack/template-vanilla-js/rspack.config.mjs
@@ -1,8 +1,9 @@
+// @ts-check
 import { defineConfig } from "@rspack/cli";
 import { rspack } from "@rspack/core";
 
 // Target browsers, see: https://github.com/browserslist/browserslist
-const targets = ["last 2 versions", "> 0.2%",  "not dead",  "Firefox ESR"];
+const targets = ["last 2 versions", "> 0.2%", "not dead", "Firefox ESR"];
 
 export default defineConfig({
 	entry: {
@@ -19,6 +20,7 @@ export default defineConfig({
 				use: [
 					{
 						loader: "builtin:swc-loader",
+						/** @type {import('@rspack/core').SwcLoaderOptions} */
 						options: {
 							jsc: {
 								parser: {

--- a/packages/create-rspack/template-vanilla-ts/rspack.config.ts
+++ b/packages/create-rspack/template-vanilla-ts/rspack.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from "@rspack/cli";
-import { rspack } from "@rspack/core";
+import { rspack, type SwcLoaderOptions } from "@rspack/core";
 
 // Target browsers, see: https://github.com/browserslist/browserslist
-const targets = ["last 2 versions", "> 0.2%",  "not dead",  "Firefox ESR"];
+const targets = ["last 2 versions", "> 0.2%", "not dead", "Firefox ESR"];
 
 export default defineConfig({
 	entry: {
@@ -29,7 +29,7 @@ export default defineConfig({
 								}
 							},
 							env: { targets }
-						}
+						} satisfies SwcLoaderOptions
 					}
 				]
 			},
@@ -45,7 +45,7 @@ export default defineConfig({
 								}
 							},
 							env: { targets }
-						}
+						} satisfies SwcLoaderOptions
 					}
 				]
 			}

--- a/packages/create-rspack/template-vue-js/rspack.config.mjs
+++ b/packages/create-rspack/template-vue-js/rspack.config.mjs
@@ -1,10 +1,7 @@
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+// @ts-check
 import { defineConfig } from "@rspack/cli";
 import { rspack } from "@rspack/core";
 import { VueLoaderPlugin } from "vue-loader";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Target browsers, see: https://github.com/browserslist/browserslist
 const targets = ["last 2 versions", "> 0.2%", "not dead", "Firefox ESR"];
@@ -30,6 +27,7 @@ export default defineConfig({
 				use: [
 					{
 						loader: "builtin:swc-loader",
+						/** @type {import('@rspack/core').SwcLoaderOptions} */
 						options: {
 							jsc: {
 								parser: {

--- a/packages/create-rspack/template-vue-ts/rspack.config.ts
+++ b/packages/create-rspack/template-vue-ts/rspack.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from "@rspack/cli";
-import { type RspackPluginFunction, rspack } from "@rspack/core";
+import {
+	type RspackPluginFunction,
+	rspack,
+	type SwcLoaderOptions
+} from "@rspack/core";
 import { VueLoaderPlugin } from "vue-loader";
 
 // Target browsers, see: https://github.com/browserslist/browserslist
@@ -33,7 +37,7 @@ export default defineConfig({
 								}
 							},
 							env: { targets }
-						}
+						} satisfies SwcLoaderOptions
 					}
 				]
 			},


### PR DESCRIPTION
## Summary

- Add `// @ts-check` and type annotations to JS configs to helping users to identify invalid configurations.
- Import and use `SwcLoaderOptions` type in TS configs

## Related links

https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
