### PR TITLE
fix(swcLoader): should correctly generate the default value of env_na…

### DIFF
--- a/crates/rspack_loader_swc/src/options.rs
+++ b/crates/rspack_loader_swc/src/options.rs
@@ -187,9 +187,66 @@ impl TryFrom<&str> for SwcCompilerOptionsWithAdditional {
           schema,
           source_map_ignore_list,
         },
-        ..Default::default()
+        ..serde_json::from_value(serde_json::Value::Object(Default::default()))?
       },
       rspack_experiments: rspack_experiments.unwrap_or_default().into(),
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_specially_default_values_in_swc_options() {
+    // Verifies that fields using `#[serde(default = "...")]`
+    // receive the correct default value from the initializations of
+    // both SwcCompilerOptionsWithAdditional and swc_core::base::config::Options.
+    let raw_options = "{}";
+    let swc_options_with_additional: SwcCompilerOptionsWithAdditional = raw_options
+      .try_into()
+      .expect("Parse SwcCompilerOptionsWithAdditional from empty JSON string failed");
+
+    let swc_options_from_rspack: Options = swc_options_with_additional.swc_options;
+
+    let swc_options_from_native_lib: Options =
+      serde_json::from_value(serde_json::from_str(raw_options).unwrap()).unwrap();
+
+    assert_eq!(
+      swc_options_from_rspack.env_name,
+      swc_options_from_native_lib.env_name
+    );
+    assert_eq!(swc_options_from_rspack.cwd, swc_options_from_native_lib.cwd);
+    assert_eq!(
+      swc_options_from_rspack.swcrc,
+      swc_options_from_native_lib.swcrc
+    );
+  }
+
+  #[test]
+  fn test_swc_loader_js_options_ignore_unexpected_field() {
+    let raw_options = "{ \"envName\": \"my-env\" }";
+    let swc_options_with_additional: SwcCompilerOptionsWithAdditional = raw_options
+      .try_into()
+      .expect("Parse SwcCompilerOptionsWithAdditional from JSON string failed");
+
+    let swc_options_from_rspack: Options = swc_options_with_additional.swc_options;
+
+    let swc_options_from_native_lib: Options =
+      serde_json::from_value(serde_json::from_str(raw_options).unwrap()).unwrap();
+
+    assert_eq!(
+      swc_options_from_native_lib.env_name, "my-env",
+      "native options should parse envName from JSON"
+    );
+    assert_ne!(
+      swc_options_from_rspack.env_name, "my-env",
+      "SwcCompilerOptionsWithAdditional should ignore unexpected field envName"
+    );
+    assert!(
+      !swc_options_from_rspack.env_name.is_empty(),
+      "SwcCompilerOptionsWithAdditional should receive a default value of env_name"
+    )
   }
 }


### PR DESCRIPTION
…me in swc options (#11903)

## Summary

In the previous implementation, the remaining fields of the `Options` struct (`swc_core::base::config::Options`) were initialized using `..Default::default()`. However, this approach can result in some fields having default values that do not match the expected behavior. The root cause is that the fields in Options are defined with serde macros, and custom logic is used to generate default values during deserialization.

```rust
pub(crate) fn default_env_name() -> String {
    if let Ok(v) = env::var("SWC_ENV") {
        return v;
    }

    match env::var("NODE_ENV") {
        Ok(v) => v,
        Err(_) => "development".into(),
    }
}

pub struct Options {
    #[serde(default = "default_env_name")]
    pub env_name: String,

    #[serde(default = "default_swcrc")]
    pub swcrc: bool,

    #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
    #[serde(default = "default_cwd")]
    pub cwd: PathBuf,
    // ...
}
```

When initializing `Options` with `..Default::default()`, this custom logic is bypassed, leading to discrepancies between the generated fields and the original behavior in `swc-loader`. This inconsistency may cause certain swc plugins (such as `@swc/plugin-emotion`) to behave unexpectedly.

To address this issue and ensure consistency with the original swc implementation, the initialization of the remaining fields in Options has been changed to use deserialization from an empty JSON object via `serde_json` (which is the approach used in the swc source code). This ensures that the configuration is generated in a manner consistent with the original swc behavior.

## Related links
https://github.com/web-infra-dev/rspack/issues/11903

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
