### PR TITLE
perf(core): adjust default_blocking_threads to 4 in linux with slower fs

### DIFF
--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -500,11 +500,7 @@ fn init() {
   const ENV_BLOCKING_THREADS: &str = "RSPACK_BLOCKING_THREADS";
   // reduce default blocking threads on macOS cause macOS holds IORWLock on every file open
   // reference from https://github.com/oven-sh/bun/pull/17577/files#diff-c9bc275f9466e5179bb80454b6445c7041d2a0fb79932dd5de7a5c3196bdbd75R144
-  let default_blocking_threads = if std::env::consts::OS == "macos" {
-    8
-  } else {
-    512
-  };
+  let default_blocking_threads = 4;
   let blocking_threads = std::env::var(ENV_BLOCKING_THREADS)
     .ok()
     .and_then(|v| v.parse::<usize>().ok())


### PR DESCRIPTION
## Summary
We found huge performance regression in linux with slower fs (5 times slower) which causes huge thread contention(512 blocking threads).

Since we use blocking_threads as IO threads, so we adjust it's default value to 4 (which aligns with libuv's default fs threads number)

<img width="2730" height="1729" alt="image" src="https://github.com/user-attachments/assets/087ddae4-763a-4af8-9d3e-e012d44842cb" />


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->
https://docs.libuv.org/en/v1.x/threadpool.html?utm_source=chatgpt.com

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
