### PR TITLE
fix: updated dependencies sync to persistent cache

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -34,7 +34,7 @@ impl MakeOccasion {
       module_graph_partial,
       module_to_lazy_make,
       affected_modules,
-      affected_dependencies: _,
+      affected_dependencies,
       issuer_update_modules,
       // skip
       entry_dependencies: _,
@@ -49,6 +49,14 @@ impl MakeOccasion {
 
     let mut need_update_modules = issuer_update_modules.clone();
     need_update_modules.extend(affected_modules.active());
+
+    // The updated dependencies should be synced to persistent cache.
+    let mg = ModuleGraph::new([Some(module_graph_partial), None], None);
+    for dep_id in affected_dependencies.updated() {
+      if let Some(m) = mg.get_parent_module(dep_id) {
+        need_update_modules.insert(*m);
+      }
+    }
 
     module_graph::save_module_graph(
       module_graph_partial,

--- a/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
+++ b/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
@@ -57,7 +57,7 @@ export class HotUpdatePlugin {
 				);
 				// match command
 				if (command === "delete") {
-					await fs.unlink(filePath);
+					await fs.remove(filePath);
 					return;
 				}
 				if (command === "force_write") {

--- a/tests/rspack-test/cacheCases/make/refactorize_dep/data1.js
+++ b/tests/rspack-test/cacheCases/make/refactorize_dep/data1.js
@@ -1,0 +1,5 @@
+export const name = "data1";
+---
+<delete>
+---
+<delete>

--- a/tests/rspack-test/cacheCases/make/refactorize_dep/data2.js
+++ b/tests/rspack-test/cacheCases/make/refactorize_dep/data2.js
@@ -1,0 +1,1 @@
+export const name = "data2";

--- a/tests/rspack-test/cacheCases/make/refactorize_dep/file.js
+++ b/tests/rspack-test/cacheCases/make/refactorize_dep/file.js
@@ -1,0 +1,5 @@
+import { name } from "data";
+
+export function getName() {
+	return name;
+}

--- a/tests/rspack-test/cacheCases/make/refactorize_dep/index.js
+++ b/tests/rspack-test/cacheCases/make/refactorize_dep/index.js
@@ -1,0 +1,15 @@
+import { getName } from "./file";
+
+it("should refactorize dep works", async () => {
+	if (COMPILER_INDEX == 0) {
+		expect(getName()).toBe("data1");
+		await NEXT_HMR();
+		expect(getName()).toBe("data2");
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(getName()).toBe("data2");
+	}
+});
+
+module.hot.accept("./file");

--- a/tests/rspack-test/cacheCases/make/refactorize_dep/rspack.config.js
+++ b/tests/rspack-test/cacheCases/make/refactorize_dep/rspack.config.js
@@ -1,0 +1,22 @@
+const path = require("path");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	experiments: {
+		cache: {
+			type: "persistent"
+		}
+	},
+	optimization: {
+		providedExports: false
+	},
+	resolve: {
+		alias: {
+			data: [
+				path.resolve(__dirname, "./data1.js"),
+				path.resolve(__dirname, "./data2.js")
+			]
+		}
+	}
+};


### PR DESCRIPTION
## Summary

The ModuleGraph's persistent cache will save the module and its child dependencies, but sometimes the dependencies will be rebuilt due to file changes, but the parent module will not, the persistent cache will be updated based on the module only, which will cause the persistent cache to be out of sync with the memory and cause a panic.

There are a example

<img width="3472" height="693" alt="image" src="https://github.com/user-attachments/assets/77bad301-547b-4f36-bb2f-7d8790b2ce9c" />


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
