### PR TITLE
docs: add guide for setting thread pool size via environment variable

### DIFF
--- a/website/docs/en/guide/optimization/profile.mdx
+++ b/website/docs/en/guide/optimization/profile.mdx
@@ -60,7 +60,7 @@ Rspack internally uses a dedicated thread pool to handle blocking operations suc
 
 By default, the pool size is set to `4`, matching Node.js's [libuv](https://docs.libuv.org/en/v1.x/threadpool.html) behavior, which provides stable performance across most development and CI environments.
 
-If your build environment uses high-speed storage, you can adjust the thread count via the `RSPACK_BLOCKING_THREADS` environment variable, for example:
+If your build environment uses high-speed storage, you can adjust the thread count via the `RSPACK_BLOCKING_THREADS` environment variable to improve parallelism and potentially reduce build time, for example:
 
 ```bash
 # Need to install cross-env package to set environment variables

--- a/website/docs/zh/guide/optimization/profile.mdx
+++ b/website/docs/zh/guide/optimization/profile.mdx
@@ -62,7 +62,7 @@ Rspack 在内部使用一个专门的线程池来执行文件系统读写等阻�
 
 默认情况下，这个线程池的大小是 `4`，与 Node.js 的 [libuv](https://docs.libuv.org/en/v1.x/threadpool.html) 保持一致，能在大多数开发与 CI 环境中提供稳定性能。
 
-如果你的构建环境使用高速存储，可以通过设置 `RSPACK_BLOCKING_THREADS` 环境变量来修改线程数，例如：
+如果你的构建环境使用高速存储，可以通过设置 `RSPACK_BLOCKING_THREADS` 环境变量来修改线程数，以获得更高的并发度和潜在的性能提升，例如：
 
 ```bash
 # 需要安装 cross-env 包来设置环境变量


### PR DESCRIPTION
## Summary

Add guide to explain how to configure `RSPACK_BLOCKING_THREADS` to improve build performance.

## Related links

- https://github.com/web-infra-dev/rspack/pull/11908
- https://docs.libuv.org/en/v1.x/threadpool.html

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
