### PR TITLE
chore: enable Rslint rule: no-empty-interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:js": "pnpm run lint-ci:js --write",
     "lint-ci:js": "biome check --diagnostic-level=warn --no-errors-on-unmatched --max-diagnostics=none --error-on-warnings",
     "lint:rs": "cargo clippy --workspace --all-targets",
-    "lint:type": "rslint --config rslint.json --max-warnings=2456",
+    "lint:type": "rslint --config rslint.json --max-warnings=2261",
     "build:binding:dev": "pnpm --filter @rspack/binding run build:dev",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",
     "build:binding:ci": "pnpm --filter @rspack/binding run build:ci",

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -1756,8 +1756,7 @@ type DevMiddlewareOptions<RequestInternal extends IncomingMessage_2 = IncomingMe
 };
 
 // @public
-export interface DevServer extends DevServerOptions {
-}
+export type DevServer = DevServerOptions;
 
 // @public (undocumented)
 export type DevServerMiddleware<RequestInternal extends Request_2 = Request_2, ResponseInternal extends Response_2 = Response_2> = MiddlewareObject<RequestInternal, ResponseInternal> | MiddlewareHandler<RequestInternal, ResponseInternal>;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2848,7 +2848,7 @@ export type WatchOptions = {
 /**
  * Options for devServer, it based on `webpack-dev-server@5`
  * */
-export interface DevServer extends DevServerOptions {}
+export type DevServer = DevServerOptions;
 
 export type { Middleware as DevServerMiddleware } from "./devServer";
 //#endregion

--- a/rslint.json
+++ b/rslint.json
@@ -3,7 +3,8 @@
     "language": "javascript",
     "files": [],
     "ignores": [
-      "packages/rspack/src/runtime/moduleFederationDefaultRuntime.js"
+      "packages/rspack/src/runtime/moduleFederationDefaultRuntime.js",
+      "packages/rspack/compiled/**"
     ],
     "languageOptions": {
       "parserOptions": {
@@ -43,8 +44,7 @@
       ],
       "@typescript-eslint/no-var-requires": "warn",
       "@typescript-eslint/no-require-imports": "warn",
-      "@typescript-eslint/no-empty-function": "warn",
-      "@typescript-eslint/no-empty-interface": "warn"
+      "@typescript-eslint/no-empty-function": "warn"
     },
     "plugins": ["@typescript-eslint"]
   }


### PR DESCRIPTION
## Summary

Enable Rslint rule and fix lint issues:

@typescript-eslint/no-empty-interface

## Related links

[https://github.com/web-infra-dev/rspack/issues/11761](https://github.com/web-infra-dev/rspack/issues/11761)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
