### PR TITLE
chore: enable Rslint rule: no-require-imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:js": "pnpm run lint-ci:js --write",
     "lint-ci:js": "biome check --diagnostic-level=warn --no-errors-on-unmatched --max-diagnostics=none --error-on-warnings",
     "lint:rs": "cargo clippy --workspace --all-targets",
-    "lint:type": "rslint --config rslint.json --max-warnings=2456",
+    "lint:type": "rslint --config rslint.json --max-warnings=2394",
     "build:binding:dev": "pnpm --filter @rspack/binding run build:dev",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",
     "build:binding:ci": "pnpm --filter @rspack/binding run build:ci",

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -8,6 +8,7 @@
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
 import type binding from "@rspack/binding";
+import instanceBinding from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
 import type Watchpack from "watchpack";
 import type { Source } from "webpack-sources";
@@ -857,8 +858,6 @@ class Compiler {
 
 		rawOptions.__virtual_files =
 			VirtualModulesPlugin.__internal__take_virtual_files(this);
-
-		const instanceBinding: typeof binding = require("@rspack/binding");
 
 		this.#registers = this.#createHooksRegisters();
 

--- a/packages/rspack/src/ExecuteModulePlugin.ts
+++ b/packages/rspack/src/ExecuteModulePlugin.ts
@@ -1,3 +1,4 @@
+import vm from "node:vm";
 import { RuntimeGlobals } from ".";
 import type { Compiler } from "./Compiler";
 
@@ -11,7 +12,6 @@ export default class ExecuteModulePlugin {
 			compilation.hooks.executeModule.tap(
 				"executeModule",
 				(options, context) => {
-					const vm = require("node:vm");
 					const moduleObject = options.moduleObject;
 					const source = options.codeGenerationResult.get("javascript");
 					if (source === undefined) return;

--- a/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
@@ -279,7 +279,8 @@ export class SubresourceIntegrityPlugin extends NativeSubresourceIntegrityPlugin
 			try {
 				const htmlPlugin = IS_BROWSER
 					? compiler.__internal_browser_require(this.options.htmlPlugin)
-					: require(this.options.htmlPlugin);
+					: // eslint-disable-next-line @typescript-eslint/no-require-imports
+						require(this.options.htmlPlugin);
 				bindingHtmlHooks(htmlPlugin);
 			} catch (e) {
 				if (

--- a/packages/rspack/src/builtin-plugin/html-plugin/plugin.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/plugin.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
 	BuiltinPluginName,
 	type JsHtmlPluginTag,
@@ -137,7 +138,7 @@ const HtmlRspackPluginImpl = create(
 						const renderer = (
 							IS_BROWSER
 								? this.__internal_browser_require(templateFilePath)
-								: require(templateFilePath)
+								: await import(pathToFileURL(templateFilePath).href)
 						) as (data: Record<string, unknown>) => Promise<string> | string;
 						if (c.templateParameters === false) {
 							return await renderer({});

--- a/packages/rspack/src/config/target.ts
+++ b/packages/rspack/src/config/target.ts
@@ -1,4 +1,5 @@
 import binding from "@rspack/binding";
+import { findConfig } from "browserslist-load-config";
 /**
  * The following code is modified based on
  * https://github.com/webpack/webpack/blob/4b4ca3b/lib/config/target.js
@@ -14,7 +15,6 @@ import * as browserslistTargetHandler from "./browserslistTargetHandler";
 const getBrowserslistTargetHandler = memoize(() => browserslistTargetHandler);
 
 const hasBrowserslistConfig = (context: string) => {
-	const { findConfig } = require("browserslist-load-config");
 	return Boolean(findConfig(context));
 };
 

--- a/packages/rspack/src/container/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/container/ModuleFederationPlugin.ts
@@ -206,7 +206,8 @@ function getDefaultEntryRuntime(
 		)}`,
 		IS_BROWSER
 			? MF_RUNTIME_CODE
-			: compiler.webpack.Template.getFunctionContent(
+			: // eslint-disable-next-line @typescript-eslint/no-require-imports
+				compiler.webpack.Template.getFunctionContent(
 					require("./moduleFederationDefaultRuntime.js")
 				)
 	].join(";");

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -63,11 +63,9 @@ export { Template } from "./Template";
 
 export const WebpackError = Error;
 
+
+export { default as sources } from "webpack-sources";
 export type { Watching } from "./Watching";
-
-import sources = require("webpack-sources");
-
-export { sources };
 
 import {
 	applyRspackOptionsDefaults,

--- a/packages/rspack/src/loader-runner/loadLoader.ts
+++ b/packages/rspack/src/loader-runner/loadLoader.ts
@@ -8,7 +8,7 @@
  * https://github.com/webpack/loader-runner/blob/main/LICENSE
  */
 
-import type Url from "node:url";
+import url from "node:url";
 import type { LoaderDefinitionFunction } from "../config";
 import type { PitchLoaderDefinitionFunction } from "../config/adapterRuleUse";
 import type { Compiler } from "../exports";
@@ -21,8 +21,6 @@ type ModuleObject = {
 	raw?: boolean;
 };
 type LoaderModule = ModuleObject | Function;
-
-let url: undefined | typeof Url;
 
 export default function loadLoader(
 	loader: LoaderObject,
@@ -41,8 +39,7 @@ export default function loadLoader(
 
 	if (loader.type === "module") {
 		try {
-			if (url === undefined) url = require("node:url");
-			const loaderUrl = url!.pathToFileURL(loader.path);
+			const loaderUrl = url.pathToFileURL(loader.path);
 			const modulePromise = import(loaderUrl.toString());
 			modulePromise.then((module: LoaderModule) => {
 				handleResult(loader, module, callback);
@@ -54,6 +51,7 @@ export default function loadLoader(
 	} else {
 		let module: LoaderModule;
 		try {
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
 			module = require(loader.path);
 		} catch (e) {
 			// it is possible for node to choke on a require if the FD descriptor

--- a/packages/rspack/src/loader-runner/service.ts
+++ b/packages/rspack/src/loader-runner/service.ts
@@ -1,3 +1,4 @@
+import { cpus } from "node:os";
 import path from "node:path";
 import { MessageChannel } from "node:worker_threads";
 // biome-ignore syntax/correctness/noTypeOnlyImportAttributes: Biome does not support this
@@ -9,8 +10,7 @@ const ensureLoaderWorkerPool = async () => {
 		return pool;
 	}
 	return (pool = import("tinypool").then(({ Tinypool }) => {
-		const cpus = require("node:os").cpus().length;
-		const availableThreads = Math.max(cpus - 1, 1);
+		const availableThreads = Math.max(cpus().length - 1, 1);
 
 		const pool = new Tinypool({
 			filename: path.resolve(__dirname, "worker.js"),

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -1,10 +1,12 @@
+import fs from "node:fs";
 import querystring from "node:querystring";
 import { promisify } from "node:util";
 import { type MessagePort, receiveMessageOnPort } from "node:worker_threads";
 
 import { JsLoaderState, type NormalModule } from "@rspack/binding";
 import type { LoaderContext } from "../config";
-
+import * as swc from "../swc";
+import { cleverMerge } from "../util/cleverMerge";
 import { createHash } from "../util/createHash";
 import { absolutify, contextify } from "../util/identifier";
 import { memoize } from "../util/memoize";
@@ -249,14 +251,14 @@ async function loaderImpl(
 		rspack: {
 			// @ts-expect-error: some properties are missing.
 			experiments: {
-				swc: require("../swc")
+				swc
 			}
 		},
 		// @ts-expect-error: some properties are missing.
 		webpack: {
 			util: {
-				createHash: require("../util/createHash").createHash,
-				cleverMerge: require("../util/cleverMerge").cleverMerge
+				createHash,
+				cleverMerge
 			}
 		}
 	};
@@ -329,7 +331,7 @@ async function loaderImpl(
 		);
 	};
 
-	loaderContext.fs = require("node:fs");
+	loaderContext.fs = fs;
 
 	Object.defineProperty(loaderContext, "request", {
 		enumerable: true,

--- a/packages/rspack/src/node/NodeWatchFileSystem.ts
+++ b/packages/rspack/src/node/NodeWatchFileSystem.ts
@@ -9,7 +9,7 @@
  */
 
 import util from "node:util";
-import type Watchpack from "watchpack";
+import Watchpack from "watchpack";
 
 import type {
 	FileSystemInfoEntry,
@@ -68,7 +68,7 @@ export default class NodeWatchFileSystem implements WatchFileSystem {
 		}
 
 		const oldWatcher = this.watcher;
-		const Watchpack = require("watchpack");
+
 		this.watcher = new Watchpack(options);
 
 		if (callbackUndelayed) {

--- a/rslint.json
+++ b/rslint.json
@@ -42,7 +42,6 @@
         }
       ],
       "@typescript-eslint/no-var-requires": "warn",
-      "@typescript-eslint/no-require-imports": "warn",
       "@typescript-eslint/no-empty-function": "warn",
       "@typescript-eslint/no-empty-interface": "warn"
     },


### PR DESCRIPTION
## Summary

Enable Rslint rule and fix lint issues:

@typescript-eslint/no-require-imports

## Related links

[https://github.com/web-infra-dev/rspack/issues/11761](https://github.com/web-infra-dev/rspack/issues/11761)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
