### PR TITLE
docs: fix zh readme miss two line in credits

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,7 +96,7 @@ Rstack 是一个以 Rspack 为核心的 JavaScript 统一工具链，具有优�
 - [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin) 项目（由 [@kevlened](https://github.com/kevlened) 创建），它启发了 Rspack 内的 CopyPlugin 实现。
 - [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity) 项目（由 [@jscheid](https://github.com/jscheid) 创建），它启发了 Rspack 内的 SubresourceIntegrityPlugin 实现。
 - [circular-dependency-plugin](https://github.com/aackerman/circular-dependency-plugin) 项目（由 [@aackerman](https://github.com/aackerman) 创建），它启发 Rspack 中循环依赖插件的实现。
-- [tracing-chrome](https://github.com/thoren-d/tracing-chrome) 项目（由 [thoren-d](https://github.com/thoren-d) 创建），它启发 Rspack 追踪功能的实现。
+- [tracing-chrome](https://github.com/thoren-d/tracing-chrome) 项目（由 [thoren-d](https://github.com/thoren-d) 创建），它启发 Rspack tracing 功能的实现。
 
 ## License
 


### PR DESCRIPTION
[this link](https://github.com/web-infra-dev/rspack/edit/main/README.md#credits)
<img width="1033" height="682" alt="image" src="https://github.com/user-attachments/assets/0f6569e3-58e5-4bcc-a82a-50154dd162d8" />

[this link](https://github.com/web-infra-dev/rspack/blob/main/README.zh-CN.md#%E8%87%B4%E8%B0%A2)
<img width="1047" height="644" alt="image" src="https://github.com/user-attachments/assets/56abed28-c9b1-4bd1-82db-e8ba5098c1a7" />


## Summary

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
