### PR TITLE
docs: sync zh and en readme 

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,7 +87,7 @@ Rstack 是一个以 Rspack 为核心的 JavaScript 统一工具链，具有优�
 
 ## 基准测试
 
-看 [基准测试](https://ecosystem-benchmark.rspack.rs/)。
+参考 [基准测试](https://ecosystem-benchmark.rspack.rs/)。
 
 ## 致谢
 


### PR DESCRIPTION
By en and web-infra-dev other project (rsbuild, rslib, rsdoctor) of zh-en readme

1. Missing one bange, and the npm bange link is not the same

[this part link](https://github.com/web-infra-dev/rsbuild/blob/main/README.zh-CN.md#rsbuild)
<img width="938" height="463" alt="image" src="https://github.com/user-attachments/assets/66011b2c-fb6b-450e-97d8-8fff1b881706" />

[this part link](https://github.com/web-infra-dev/rspack/edit/main/README.md#rspack)
<img width="1048" height="451" alt="image" src="https://github.com/user-attachments/assets/38fedaf0-8af6-4e28-9dba-eb8ffd30ab25" />

zh:
<img width="525" height="169" alt="image" src="https://github.com/user-attachments/assets/dd5b44c0-eabf-424b-8c77-f0d8e71039c4" />

en:
<img width="491" height="197" alt="image" src="https://github.com/user-attachments/assets/656e3899-cb19-4c6c-91cc-7bb9a1f68402" />

2. coummity location

other project location:
[rsbuild en](https://github.com/web-infra-dev/rsbuild?tab=readme-ov-file#%E2%80%8D-community) [rsbuild zh](https://github.com/web-infra-dev/rsbuild/blob/main/README.zh-CN.md#%E2%80%8D-%E7%A4%BE%E5%8C%BA)
[rslib en](https://github.com/web-infra-dev/rslib?tab=readme-ov-file#%E2%80%8D-community) [rslib zh](https://github.com/web-infra-dev/rslib/blob/main/README.zh-CN.md#%E2%80%8D-%E7%A4%BE%E5%8C%BA) 
[rsdoctor en](https://github.com/web-infra-dev/rsdoctor?tab=readme-ov-file#%E2%80%8D-community) [rsdoctor zh](https://github.com/web-infra-dev/rsdoctor/blob/main/README.zh-CN.md#%E2%80%8D-%E7%A4%BE%E5%8C%BA) 

So coummity should not License after

zh:
<img width="626" height="279" alt="image" src="https://github.com/user-attachments/assets/a0400b95-94bf-4819-a6ff-ed5c1353415a" />

en:
<img width="935" height="331" alt="image" src="https://github.com/user-attachments/assets/88ac37be-0f39-4921-8f22-c5e9ff0d4391" />

3. Missing Contributors and Benchmark

other project:
[rsbuild zh](https://github.com/web-infra-dev/rsbuild/blob/main/README.zh-CN.md#%E8%B4%A1%E7%8C%AE%E8%80%85) and  [rslib zh](https://github.com/web-infra-dev/rslib/blob/main/README.zh-CN.md#%E8%B4%A1%E7%8C%AE%E8%80%85) en and zh has contributors prat ,  rsdoctor zh and en has not contributors prat

zh:
<img width="579" height="375" alt="image" src="https://github.com/user-attachments/assets/82b2eacf-6573-4e48-992b-7ffd7365b2d9" />

en:
<img width="935" height="482" alt="image" src="https://github.com/user-attachments/assets/53dff1e3-1514-45e6-b489-4409b6fafef9" />



## Summary

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
