### PR TITLE
chore: switch to self-hosted macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     with:
       target: aarch64-apple-darwin
       profile: "ci"
-      runner: ${{ vars.MACOS_RUNNER_LABELS || '"macos-latest"' }}
+      runner: ${{ vars.MAC_SELF_HOSTED_RUNNER_LABELS || '"macos-latest"' }}
       test: true
 
   test-wasm:


### PR DESCRIPTION
## Summary
Use self-hosted macOS to accelerate CI testing
From ~15min to ~5min
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
