### PR TITLE
ci: fix lazy-compilation/persistent-cache ci failed

### DIFF
--- a/tests/e2e/cases/lazy-compilation/persistent-cache/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/index.test.ts
@@ -18,9 +18,9 @@ test("should load success", async ({ page, rspack }) => {
 	await expect(page.locator("#dyn")).toHaveCount(1);
 	expect(has_dyn_module(rspack.compiler.__modules)).toBe(true);
 
-	await rspack.reboot();
-	await page.reload();
 	// trigger other import compile
+	await rspack.reboot();
+
 	await expect(page.locator("#Component")).toHaveCount(1);
 	await expect(page.locator("#dyn")).toHaveCount(0);
 	expect(has_dyn_module(rspack.compiler.__modules)).toBe(true);


### PR DESCRIPTION
## Summary

Rspack.reboot() will automatically reload the page, remove page.reload() to avoid playwright errors.

<img width="2506" height="1460" alt="image" src="https://github.com/user-attachments/assets/6fc69834-d964-4af7-8054-039562852bf7" />


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
