### PR TITLE
feat: introduce allocative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,16 @@ dependencies = [
 
 [[package]]
 name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ctor"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e9666f4a9a948d4f1dff0c08a4512b0f7c86414b23960104c243c10d79f4c3"
@@ -2485,7 +2495,7 @@ checksum = "3f995fe29e20a4d5bf5af93d3c8384fd53772bbbc1bf3b03e38dce2b1b0425e3"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
- "ctor",
+ "ctor 0.4.1",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
@@ -2508,7 +2518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e6d190d5e09d449b2b38127cdcdb7aed860599e492a15c73f977d5d87df69a5"
 dependencies = [
  "convert_case 0.8.0",
- "ctor",
+ "ctor 0.4.1",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -3419,6 +3429,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rspack-allocative"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942dd788eb5b967d155baa21e4699e4a164e2b217a236ded02f22d86564730a4"
+dependencies = [
+ "atomic_refcell",
+ "camino",
+ "ctor 0.1.26",
+ "dashmap 6.1.0",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "once_cell",
+ "rspack-allocative_derive",
+ "tokio",
+ "ustr-fxhash",
+]
+
+[[package]]
+name = "rspack-allocative_derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125d6c4fea52a20e2baaa381c122e111a825ac4c3cccdbb50605805f025d7197"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
 name = "rspack-libmimalloc-sys"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3541,6 +3580,7 @@ dependencies = [
  "rspack_resolver",
  "rspack_tasks",
  "rspack_tracing",
+ "rspack_tracing_perfetto",
  "rspack_util",
  "rspack_workspace",
  "rustc-hash",
@@ -3618,6 +3658,7 @@ dependencies = [
  "lightningcss",
  "once_cell",
  "rkyv 0.8.8",
+ "rspack-allocative",
  "rspack_macros",
  "rspack_resolver",
  "rspack_sources",
@@ -3655,6 +3696,7 @@ dependencies = [
  "hashlink",
  "indexmap",
  "rayon",
+ "rspack-allocative",
  "rspack_cacheable",
  "serde",
  "ustr-fxhash",
@@ -4979,6 +5021,7 @@ dependencies = [
  "bytes",
  "micromegas-perfetto",
  "prost",
+ "rspack-allocative",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4998,6 +5041,7 @@ dependencies = [
  "once_cell",
  "regex",
  "ropey",
+ "rspack-allocative",
  "rspack_cacheable",
  "rspack_paths",
  "rspack_regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,17 @@ wasmparser          = { version = "0.222.0", default-features = false }
 winnow              = { version = "0.7.12", default-features = false, features = ["std", "simd"] }
 xxhash-rust         = { version = "0.8.14", default-features = false }
 
+allocative       = { package = "rspack-allocative", version = "0.3.5", default-features = false, features = [
+  "camino",
+  "dashmap",
+  "hashbrown",
+  "indexmap",
+  "tokio",
+  "once_cell",
+  "ustr",
+  "atomic_refcell",
+] }
+
 # Pinned
 napi        = { version = "3.1.6", default-features = false }
 napi-build  = { version = "2.2.3", default-features = false }
@@ -417,6 +428,10 @@ trivial_numeric_casts                  = "warn"
 unused_import_braces                   = "warn"
 unused_lifetimes                       = "warn"
 unused_macro_rules                     = "warn"
+
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']
 
 [workspace.lints.clippy]
 cargo_common_metadata   = "allow"

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -17,6 +17,7 @@ debug_tool      = ["rspack_binding_api/debug_tool"]
 info-level      = ["tracing/release_max_level_info"]
 plugin          = ["rspack_binding_api/plugin"]
 sftrace-setup   = ["rspack_binding_api/sftrace-setup"]
+allocative      = ["rspack_binding_api/allocative"]
 
 [package.metadata.cargo-shear]
 # Adding napi-derive as a dependency to workaround an issue where `dts` will no longer work without it.

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -78,6 +78,10 @@ async function build() {
 			features.push("sftrace-setup");
 			rustflags.push("-Zinstrument-xray=always");
 		}
+		if (process.env.ALLOCATIVE) {
+			features.push("allocative");
+			rustflags.push("--cfg=allocative");
+		}
 		if (values.profile === "release") {
 			features.push("info-level");
 		}

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -16,6 +16,12 @@ color-backtrace = ["dep:color-backtrace"]
 debug_tool      = ["rspack_core/debug_tool"]
 plugin          = ["rspack_loader_swc/plugin", "rspack_util/plugin"]
 sftrace-setup   = ["dep:sftrace-setup", "rspack_allocator/sftrace-setup"]
+allocative      = [
+  "rspack_util/allocative",
+  "rspack_collections/allocative",
+  "rspack_cacheable/allocative",
+  "rspack_tracing_perfetto/allocative",
+]
 
 [dependencies]
 anyhow                    = { workspace = true }
@@ -41,7 +47,8 @@ rspack_tasks              = { workspace = true }
 rspack_util               = { workspace = true }
 rspack_workspace          = { workspace = true }
 
-rspack_tracing = { workspace = true }
+rspack_tracing          = { workspace = true }
+rspack_tracing_perfetto = { workspace = true }
 
 async-trait        = { workspace = true }
 cow-utils          = { workspace = true }
@@ -120,7 +127,7 @@ tokio                                  = { workspace = true, features = ["rt", "
 ustr                                   = { workspace = true }
 
 [package.metadata.cargo-shear]
-ignored = ["parking_lot"]
+ignored = ["parking_lot", "rspack_tracing_perfetto"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 # Pin parking_lot version to the same version within the workspace

--- a/crates/rspack_cacheable/Cargo.toml
+++ b/crates/rspack_cacheable/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 noop = []
 
 [dependencies]
+allocative      = { workspace = true, optional = true }
 camino          = { workspace = true }
 dashmap         = { workspace = true }
 hashlink        = { workspace = true }
@@ -27,3 +28,7 @@ smol_str        = { workspace = true }
 swc_core        = { workspace = true, features = ["ecma_ast"] }
 ustr            = { workspace = true }
 xxhash-rust     = { workspace = true, features = ["const_xxh64"] }
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_cacheable/src/with/as_ref_str.rs
+++ b/crates/rspack_cacheable/src/with/as_ref_str.rs
@@ -69,7 +69,9 @@ use std::sync::{Arc, LazyLock};
 
 use dashmap::DashSet;
 
+#[cfg_attr(allocative, allocative::root)]
 pub static CACHED_ARC_STR: LazyLock<DashSet<Arc<str>>> = LazyLock::new(Default::default);
+
 impl AsRefStrConverter for Arc<str> {
   fn as_str(&self) -> &str {
     self.as_ref()

--- a/crates/rspack_collections/Cargo.toml
+++ b/crates/rspack_collections/Cargo.toml
@@ -16,3 +16,9 @@ rayon            = { workspace = true }
 rspack_cacheable = { workspace = true }
 serde            = { workspace = true, features = ["derive"] }
 ustr             = { workspace = true, features = ["serde"] }
+allocative       = { workspace = true, optional = true }
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']
+

--- a/crates/rspack_collections/src/identifier.rs
+++ b/crates/rspack_collections/src/identifier.rs
@@ -36,6 +36,7 @@ pub type IdentifierLinkedSet = LinkedHashSet<Identifier, BuildHasherDefault<Iden
 
 #[cacheable(hashable)]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct Identifier(#[cacheable(with=AsPreset)] Ustr);
 
 impl Deref for Identifier {

--- a/crates/rspack_collections/src/ukey.rs
+++ b/crates/rspack_collections/src/ukey.rs
@@ -35,6 +35,7 @@ pub trait ItemUkey {
 /// Ukey stands for Unique key
 #[rspack_cacheable::cacheable]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct Ukey(u32);
 
 impl Ukey {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -27,6 +27,8 @@ use rspack_hook::define_hook;
 use rspack_paths::{ArcPath, ArcPathIndexSet, ArcPathSet};
 use rspack_sources::{BoxSource, CachedSource, SourceExt};
 use rspack_tasks::CompilerContext;
+#[cfg(allocative)]
+use rspack_util::allocative;
 use rspack_util::{itoa, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 use tracing::instrument;
@@ -132,6 +134,7 @@ pub struct CompilationHooks {
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct CompilationId(pub u32);
 
 impl CompilationId {

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -247,6 +247,10 @@ impl Compiler {
     self.old_cache.begin_idle();
     self.compile_done().await?;
     self.cache.after_compile(&self.compilation).await;
+
+    #[cfg(allocative)]
+    crate::utils::snapshot_allocative("build");
+
     Ok(())
   }
 

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -190,6 +190,9 @@ impl Compiler {
     self.compile_done().await?;
     self.cache.after_compile(&self.compilation).await;
 
+    #[cfg(allocative)]
+    crate::utils::snapshot_allocative("rebuild");
+
     Ok(())
   }
 }

--- a/crates/rspack_core/src/debug_info.rs
+++ b/crates/rspack_core/src/debug_info.rs
@@ -1,7 +1,11 @@
 use std::{fmt::Display, sync::Mutex};
 
+#[cfg(allocative)]
+use rspack_util::allocative;
+
 /// Debug info used when programs panics
 /// Only works with #[cfg(debug_assertions)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct DebugInfo {
   /// The base directory. See [options.context](https://webpack.js.org/configuration/entry-context/#context)
   pub(crate) context: Option<String>,
@@ -40,4 +44,5 @@ impl Display for DebugInfo {
   }
 }
 
+#[cfg_attr(allocative, allocative::root)]
 pub static DEBUG_INFO: Mutex<DebugInfo> = Mutex::new(DebugInfo::new());

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -6,6 +6,8 @@ use rspack_hash::RspackHash;
 pub use rspack_hash::{HashDigest, HashFunction, HashSalt};
 use rspack_macros::MergeFrom;
 use rspack_paths::Utf8PathBuf;
+#[cfg(allocative)]
+use rspack_util::allocative;
 
 use super::CleanOptions;
 use crate::{Chunk, ChunkGroupByUkey, ChunkKind, Compilation, Filename};
@@ -192,6 +194,7 @@ impl From<&str> for WasmLoadingType {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub enum CrossOriginLoading {
   Disable,
   Enable(String),

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -4,6 +4,8 @@ use rspack_cacheable::{
   cacheable,
   with::{AsRefStr, AsVec},
 };
+#[cfg(allocative)]
+use rspack_util::allocative;
 use rustc_hash::FxHashMap;
 use ustr::{Ustr, UstrSet};
 
@@ -11,6 +13,7 @@ use crate::{EntryOptions, EntryRuntime};
 
 #[cacheable]
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct RuntimeSpec {
   #[cacheable(with=AsVec<AsRefStr>)]
   inner: UstrSet,
@@ -157,6 +160,7 @@ pub fn is_runtime_equal(a: &RuntimeSpec, b: &RuntimeSpec) -> bool {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub enum RuntimeCondition {
   Boolean(bool),
   Spec(RuntimeSpec),

--- a/crates/rspack_core/src/ukey.rs
+++ b/crates/rspack_core/src/ukey.rs
@@ -1,6 +1,8 @@
 use std::sync::atomic::AtomicU32;
 
 use rspack_collections::{Ukey, impl_item_ukey};
+#[cfg(allocative)]
+use rspack_util::allocative;
 
 use crate::{Chunk, ChunkGroup};
 
@@ -42,6 +44,7 @@ impl From<u32> for ChunkUkey {
 static NEXT_CHUNK_GROUP_UKEY: AtomicU32 = AtomicU32::new(0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct ChunkGroupUkey(Ukey, std::marker::PhantomData<ChunkGroup>);
 
 impl_item_ukey!(ChunkGroupUkey);

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -211,3 +211,35 @@ pub fn compare_chunks_with_graph(
     .collect();
   compare_module_iterables(&modules_a, &modules_b)
 }
+
+#[cfg(allocative)]
+pub fn snapshot_allocative(name: &str) {
+  use std::{
+    path::PathBuf,
+    sync::{
+      LazyLock,
+      atomic::{self, AtomicUsize},
+    },
+  };
+
+  use rspack_util::allocative;
+
+  static ENABLE: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
+    std::env::var_os("RSPACK_ALLOCATIVE_DIR")
+      .map(|dir| {
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+      })
+      .map(Into::into)
+  });
+  static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+  if let Some(dir) = ENABLE.as_deref() {
+    let mut builder = allocative::FlameGraphBuilder::default();
+    builder.visit_global_roots();
+    let buf = builder.finish_and_write_flame_graph();
+    let count = COUNT.fetch_add(1, atomic::Ordering::Relaxed);
+    let path = dir.join(format!("{}-{}.allocative", count, name));
+    std::fs::write(path, buf).expect("allocative write failed");
+  }
+}

--- a/crates/rspack_loader_swc/Cargo.toml
+++ b/crates/rspack_loader_swc/Cargo.toml
@@ -42,6 +42,9 @@ swc_core                       = { workspace = true, features = ["base", "ecma_a
 tokio                          = { workspace = true }
 tracing                        = { workspace = true }
 
-
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 stacker = { workspace = true }
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -13,6 +13,8 @@ use rspack_core::{COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY, Mode, RunnerContext}
 use rspack_error::{Diagnostic, Error, Result};
 use rspack_javascript_compiler::{JavaScriptCompiler, TransformOutput};
 use rspack_loader_runner::{Identifier, Loader, LoaderContext};
+#[cfg(allocative)]
+use rspack_util::allocative;
 pub use rspack_workspace::rspack_swc_core_version;
 use sugar_path::SugarPath;
 use swc_config::{merge::Merge, types::MergingOption};
@@ -25,8 +27,10 @@ use crate::collect_ts_info::collect_typescript_info;
 
 #[cacheable]
 #[derive(Debug)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct SwcLoader {
   identifier: Identifier,
+  #[cfg_attr(allocative, allocative(skip))]
   options_with_additional: SwcCompilerOptionsWithAdditional,
 }
 

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -5,6 +5,7 @@ license           = "MIT"
 name              = "rspack_plugin_html"
 repository        = "https://github.com/web-infra-dev/rspack"
 version.workspace = true
+
 [features]
 default = []
 
@@ -34,3 +35,7 @@ urlencoding       = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_plugin_html/src/drive.rs
+++ b/crates/rspack_plugin_html/src/drive.rs
@@ -1,5 +1,7 @@
 use rspack_core::CompilationId;
 use rspack_hook::define_hook;
+#[cfg(allocative)]
+use rspack_util::allocative;
 
 use crate::{
   asset::{HtmlPluginAssetTags, HtmlPluginAssets},
@@ -66,11 +68,18 @@ define_hook!(HtmlPluginBeforeEmit: SeriesWaterfall(data: BeforeEmitData) -> Befo
 define_hook!(HtmlPluginAfterEmit: SeriesWaterfall(data: AfterEmitData) -> AfterEmitData);
 
 #[derive(Debug, Default)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct HtmlPluginHooks {
+  #[cfg_attr(allocative, allocative(skip))]
   pub before_asset_tag_generation: HtmlPluginBeforeAssetTagGenerationHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub alter_asset_tags: HtmlPluginAlterAssetTagsHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub alter_asset_tag_groups: HtmlPluginAlterAssetTagGroupsHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub after_template_execution: HtmlPluginAfterTemplateExecutionHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub before_emit: HtmlPluginBeforeEmitHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub after_emit: HtmlPluginAfterEmitHook,
 }

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -9,6 +9,8 @@ use cow_utils::CowUtils;
 use rspack_core::{Compilation, CompilationId, CompilationProcessAssets, Filename, Plugin};
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
+#[cfg(allocative)]
+use rspack_util::allocative;
 use rspack_util::fx_hash::FxDashMap;
 use sugar_path::SugarPath;
 use swc_html::visit::VisitMutWith;
@@ -28,6 +30,7 @@ use crate::{
 /// We should make sure that there's no read-write and write-write conflicts for each hook instance by looking up [HtmlRspackPlugin::get_compilation_hooks_mut]
 type ArcHtmlPluginHooks = Arc<AtomicRefCell<HtmlPluginHooks>>;
 
+#[cfg_attr(allocative, allocative::root)]
 static COMPILATION_HOOKS_MAP: LazyLock<FxDashMap<CompilationId, ArcHtmlPluginHooks>> =
   LazyLock::new(Default::default);
 

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -5,6 +5,7 @@ license           = "MIT"
 name              = "rspack_plugin_javascript"
 repository        = "https://github.com/web-infra-dev/rspack"
 version.workspace = true
+
 [dependencies]
 anymap = { workspace = true }
 async-trait = { workspace = true }
@@ -58,3 +59,7 @@ winnow = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -25,7 +25,10 @@ pub mod import_emitted_runtime {
   use once_cell::sync::OnceCell;
   use rspack_collections::{IdentifierDashMap, IdentifierMap};
   use rspack_core::{ModuleIdentifier, RuntimeCondition};
+  #[cfg(allocative)]
+  use rspack_util::allocative;
 
+  #[cfg_attr(allocative, allocative::root)]
   static IMPORT_EMITTED_MAP: OnceCell<IdentifierDashMap<IdentifierMap<RuntimeCondition>>> =
     OnceCell::new();
 

--- a/crates/rspack_plugin_javascript/src/plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/drive.rs
@@ -4,6 +4,8 @@ use rspack_core::{
 };
 use rspack_hash::RspackHash;
 use rspack_hook::define_hook;
+#[cfg(allocative)]
+use rspack_util::allocative;
 
 define_hook!(JavascriptModulesRenderChunk: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource));
 define_hook!(JavascriptModulesRenderChunkContent: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey, asset_info: &mut AssetInfo) -> RenderSource);
@@ -18,17 +20,29 @@ define_hook!(JavascriptModulesEmbedInRuntimeBailout: SeriesBail(compilation: &Co
 define_hook!(JavascriptModulesStrictRuntimeBailout: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> String);
 
 #[derive(Debug, Default)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct JavascriptModulesPluginHooks {
+  #[cfg_attr(allocative, allocative(skip))]
   pub render_chunk: JavascriptModulesRenderChunkHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub render_chunk_content: JavascriptModulesRenderChunkContentHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub render: JavascriptModulesRenderHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub render_startup: JavascriptModulesRenderStartupHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub render_module_content: JavascriptModulesRenderModuleContentHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub render_module_container: JavascriptModulesRenderModuleContainerHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub render_module_package: JavascriptModulesRenderModulePackageHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub chunk_hash: JavascriptModulesChunkHashHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub inline_in_runtime_bailout: JavascriptModulesInlineInRuntimeBailoutHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub embed_in_runtime_bailout: JavascriptModulesEmbedInRuntimeBailoutHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub strict_runtime_bailout: JavascriptModulesStrictRuntimeBailoutHook,
 }
 

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -39,6 +39,8 @@ use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_hook::plugin;
 use rspack_javascript_compiler::ast::Ast;
+#[cfg(allocative)]
+use rspack_util::allocative;
 use rspack_util::{SpanExt, diff_mode};
 use rustc_hash::FxHashMap;
 pub use side_effects_flag_plugin::*;
@@ -53,6 +55,7 @@ use crate::runtime::{
   render_chunk_modules, render_module, render_runtime_modules, stringify_array,
 };
 
+#[cfg_attr(allocative, allocative::root)]
 static COMPILATION_HOOKS_MAP: LazyLock<
   SyncRwLock<FxHashMap<CompilationId, Arc<RwLock<JavascriptModulesPluginHooks>>>>,
 > = LazyLock::new(Default::default);

--- a/crates/rspack_plugin_mf/Cargo.toml
+++ b/crates/rspack_plugin_mf/Cargo.toml
@@ -34,3 +34,7 @@ tracing     = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing", "rspack_hash"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_plugin_mf/src/container/federation_modules_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/federation_modules_plugin.rs
@@ -14,6 +14,8 @@ use rspack_core::{
 };
 use rspack_error::Result;
 use rspack_hook::{define_hook, plugin, plugin_hook};
+#[cfg(allocative)]
+use rspack_util::allocative;
 use tokio::sync::Mutex as TokioMutex;
 
 use super::{
@@ -25,11 +27,16 @@ define_hook!(AddContainerEntryDependencyHook: Series(dependency: &ContainerEntry
 define_hook!(AddFederationRuntimeDependencyHook: Series(dependency: &FederationRuntimeDependency));
 define_hook!(AddRemoteDependencyHook: Series(dependency: &dyn Dependency));
 
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct FederationModulesPluginCompilationHooks {
+  #[cfg_attr(allocative, allocative(skip))]
   pub add_container_entry_dependency: Arc<TokioMutex<AddContainerEntryDependencyHookHook>>,
+  #[cfg_attr(allocative, allocative(skip))]
   pub add_federation_runtime_dependency: Arc<TokioMutex<AddFederationRuntimeDependencyHookHook>>,
+  #[cfg_attr(allocative, allocative(skip))]
   pub add_remote_dependency: Arc<TokioMutex<AddRemoteDependencyHookHook>>,
 }
+
 impl Default for FederationModulesPluginCompilationHooks {
   fn default() -> Self {
     Self {
@@ -44,6 +51,7 @@ impl Default for FederationModulesPluginCompilationHooks {
   }
 }
 
+#[cfg_attr(allocative, allocative::root)]
 static FEDERATION_MODULES_PLUGIN_HOOKS_MAP: OnceLock<
   Mutex<HashMap<CompilationId, Arc<FederationModulesPluginCompilationHooks>>>,
 > = OnceLock::new();

--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -26,3 +26,7 @@ tracing        = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_plugin_real_content_hash/src/drive.rs
+++ b/crates/rspack_plugin_real_content_hash/src/drive.rs
@@ -2,10 +2,14 @@ use std::sync::Arc;
 
 use rspack_core::{Compilation, rspack_sources::Source};
 use rspack_hook::define_hook;
+#[cfg(allocative)]
+use rspack_util::allocative;
 
 define_hook!(RealContentHashPluginUpdateHash: SeriesBail(compilation: &Compilation, assets: &[Arc<dyn Source>], old_hash: &str) -> String);
 
 #[derive(Debug, Default)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct RealContentHashPluginHooks {
+  #[cfg_attr(allocative, allocative(skip))]
   pub update_hash: RealContentHashPluginUpdateHashHook,
 }

--- a/crates/rspack_plugin_rsdoctor/Cargo.toml
+++ b/crates/rspack_plugin_rsdoctor/Cargo.toml
@@ -25,3 +25,7 @@ tracing               = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_plugin_rsdoctor/src/drive.rs
+++ b/crates/rspack_plugin_rsdoctor/src/drive.rs
@@ -1,4 +1,6 @@
 use rspack_hook::define_hook;
+#[cfg(allocative)]
+use rspack_util::allocative;
 
 use crate::{
   RsdoctorAssetPatch, RsdoctorChunkGraph, RsdoctorModuleGraph, RsdoctorModuleIdsPatch,
@@ -12,10 +14,16 @@ define_hook!(RsdoctorPluginModuleSources: SeriesBail(data: &mut RsdoctorModuleSo
 define_hook!(RsdoctorPluginAssets: SeriesBail(data: &mut RsdoctorAssetPatch) -> bool);
 
 #[derive(Debug, Default)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct RsdoctorPluginHooks {
+  #[cfg_attr(allocative, allocative(skip))]
   pub module_graph: RsdoctorPluginModuleGraphHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub chunk_graph: RsdoctorPluginChunkGraphHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub module_ids: RsdoctorPluginModuleIdsHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub module_sources: RsdoctorPluginModuleSourcesHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub assets: RsdoctorPluginAssetsHook,
 }

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -16,6 +16,8 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_devtool::{
   SourceMapDevToolModuleOptionsPlugin, SourceMapDevToolModuleOptionsPluginOptions,
 };
+#[cfg(allocative)]
+use rspack_util::allocative;
 use rspack_util::fx_hash::FxDashMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -47,11 +49,15 @@ pub type SendModuleSources =
 /// We should make sure that there's no read-write and write-write conflicts for each hook instance by looking up [RsdoctorPlugin::get_compilation_hooks_mut]
 type ArcRsdoctorPluginHooks = Arc<AtomicRefCell<RsdoctorPluginHooks>>;
 
+#[cfg_attr(allocative, allocative::root)]
 static COMPILATION_HOOKS_MAP: LazyLock<FxDashMap<CompilationId, ArcRsdoctorPluginHooks>> =
   LazyLock::new(Default::default);
 
+#[cfg_attr(allocative, allocative::root)]
 static MODULE_UKEY_MAP: LazyLock<FxDashMap<CompilationId, HashMap<Identifier, ModuleUkey>>> =
   LazyLock::new(FxDashMap::default);
+
+#[cfg_attr(allocative, allocative::root)]
 static ENTRYPOINT_UKEY_MAP: LazyLock<
   FxDashMap<CompilationId, HashMap<ChunkGroupUkey, EntrypointUkey>>,
 > = LazyLock::new(FxDashMap::default);

--- a/crates/rspack_plugin_runtime/Cargo.toml
+++ b/crates/rspack_plugin_runtime/Cargo.toml
@@ -31,3 +31,7 @@ tracing    = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing", "tokio"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_plugin_runtime/src/drive.rs
+++ b/crates/rspack_plugin_runtime/src/drive.rs
@@ -2,6 +2,8 @@ use std::ptr::NonNull;
 
 use rspack_core::{ChunkUkey, Compilation, CompilationId};
 use rspack_hook::define_hook;
+#[cfg(allocative)]
+use rspack_util::allocative;
 
 #[derive(Debug, Clone)]
 pub struct CreateScriptData {
@@ -35,8 +37,12 @@ define_hook!(RuntimePluginLinkPreload: SeriesWaterfall(data: LinkPreloadData) ->
 define_hook!(RuntimePluginLinkPrefetch: SeriesWaterfall(data: LinkPrefetchData) -> LinkPrefetchData);
 
 #[derive(Debug, Default)]
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct RuntimePluginHooks {
+  #[cfg_attr(allocative, allocative(skip))]
   pub create_script: RuntimePluginCreateScriptHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub link_preload: RuntimePluginLinkPreloadHook,
+  #[cfg_attr(allocative, allocative(skip))]
   pub link_prefetch: RuntimePluginLinkPrefetchHook,
 }

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -15,6 +15,8 @@ use rspack_error::Result;
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{JavascriptModulesChunkHash, JsPlugin};
+#[cfg(allocative)]
+use rspack_util::allocative;
 use rspack_util::fx_hash::FxDashMap;
 
 use crate::{
@@ -41,6 +43,7 @@ use crate::{
 /// We should make sure that there's no read-write and write-write conflicts for each hook instance by looking up [RuntimePlugin::get_compilation_hooks_mut]
 type ArcRuntimePluginHooks = Arc<AtomicRefCell<RuntimePluginHooks>>;
 
+#[cfg_attr(allocative, allocative::root)]
 static COMPILATION_HOOKS_MAP: LazyLock<FxDashMap<CompilationId, ArcRuntimePluginHooks>> =
   LazyLock::new(Default::default);
 

--- a/crates/rspack_plugin_sri/Cargo.toml
+++ b/crates/rspack_plugin_sri/Cargo.toml
@@ -37,3 +37,7 @@ urlencoding                     = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing", "async-trait", "rspack_hash", "tokio"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_plugin_sri/src/config.rs
+++ b/crates/rspack_plugin_sri/src/config.rs
@@ -6,6 +6,8 @@ use rspack_core::CrossOriginLoading;
 use rspack_error::Result;
 use rspack_fs::WritableFileSystem;
 use rspack_paths::Utf8PathBuf;
+#[cfg(allocative)]
+use rspack_util::allocative;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::integrity::SubresourceIntegrityHashFunction;
@@ -40,7 +42,10 @@ pub struct SubresourceIntegrityPluginOptions {
 }
 
 pub type ArcFs = Arc<dyn WritableFileSystem + Send + Sync>;
+
+#[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct SRICompilationContext {
+  #[cfg_attr(allocative, allocative(skip))]
   pub fs: ArcFs,
   pub output_path: Utf8PathBuf,
   pub cross_origin_loading: CrossOriginLoading,

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -24,6 +24,8 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_html::HtmlRspackPlugin;
 use rspack_plugin_real_content_hash::RealContentHashPlugin;
 use rspack_plugin_runtime::RuntimePlugin;
+#[cfg(allocative)]
+use rspack_util::allocative;
 use rspack_util::fx_hash::FxDashMap;
 use runtime::{create_script, handle_runtime, link_preload};
 use rustc_hash::FxHashMap as HashMap;
@@ -32,7 +34,9 @@ use tokio::sync::RwLock;
 type CompilationIntegrityMap =
   LazyLock<FxDashMap<CompilationId, Arc<RwLock<HashMap<String, String>>>>>;
 
+#[cfg_attr(allocative, allocative::root)]
 static COMPILATION_INTEGRITY_MAP: CompilationIntegrityMap = LazyLock::new(Default::default);
+#[cfg_attr(allocative, allocative::root)]
 static COMPILATION_CONTEXT_MAP: LazyLock<FxDashMap<CompilationId, Arc<SRICompilationContext>>> =
   LazyLock::new(Default::default);
 

--- a/crates/rspack_tracing/Cargo.toml
+++ b/crates/rspack_tracing/Cargo.toml
@@ -7,7 +7,6 @@ repository        = "https://github.com/web-infra-dev/rspack"
 version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[features]
 [dependencies]
 rspack_tracing_perfetto = { workspace = true }
 tracing-subscriber      = { workspace = true, features = ["env-filter", "json"] }

--- a/crates/rspack_tracing_perfetto/Cargo.toml
+++ b/crates/rspack_tracing_perfetto/Cargo.toml
@@ -16,5 +16,7 @@ micromegas-perfetto = { workspace = true }
 prost               = { workspace = true }
 tracing             = { workspace = true }
 tracing-subscriber  = { workspace = true }
+allocative          = { workspace = true, optional = true }
+
 [lints]
 workspace = true

--- a/crates/rspack_tracing_perfetto/src/idl_helpers.rs
+++ b/crates/rspack_tracing_perfetto/src/idl_helpers.rs
@@ -8,6 +8,7 @@ use std::{
 
 use micromegas_perfetto::protos::{self as idl, TracePacket};
 
+#[cfg_attr(allocative, allocative::root)]
 static CUSTOM_SCOPE_NAMES: LazyLock<Mutex<HashMap<String, u64>>> =
   LazyLock::new(|| Mutex::new(HashMap::new()));
 

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+allocative       = { workspace = true, optional = true }
 base64-simd      = { workspace = true }
 bitflags         = { workspace = true }
 concat-string    = { workspace = true }
@@ -43,3 +44,7 @@ signal-hook  = { workspace = true, optional = true }
 [features]
 debug_tool = ["signal-hook"]                                                         # only used for local debug and  should not be enabled in production release
 plugin     = ["anyhow", "once_cell", "wasmtime", "wasi-common", "swc_plugin_runner"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(allocative)']

--- a/crates/rspack_util/src/lib.rs
+++ b/crates/rspack_util/src/lib.rs
@@ -26,6 +26,8 @@ pub mod tracing_preset;
 
 use std::future::Future;
 
+#[cfg(allocative)]
+pub use allocative;
 pub use merge::{MergeFrom, merge_from_optional_with};
 pub use span::SpanExt;
 

--- a/deny.toml
+++ b/deny.toml
@@ -252,6 +252,7 @@ skip = [
 
     { crate = "winnow", reason = "external dependency"},
     { crate = "heck", reason = "external dependency"},
+    { crate = "ctor", reason = "external dependency"},
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This introduces `allocative` to debug memory leaks caused by global variables. when enabled, a global variable memory snapshot will be generated each rebuild.

This requires enable the feature at build time using env `ALLOCATIVE=1` and specify the output directory at runtime use env `RSPACK_ALLOCATIVE_DIR="$DIR"`.

The output can then be visualized as svg.

to svg: `cat allocative.0.flamegraph | inferno-flamegraph > 0.svg`
diff: `inferno-diff-folded allocative.0.flamegraph allocative.1.flamegraph | inferno-flamegraph > diff0v1.svg`

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
