### PR TITLE
fix(mf): federation modules plugin hooks leak

### DIFF
--- a/crates/rspack_plugin_mf/src/container/federation_modules_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/federation_modules_plugin.rs
@@ -104,4 +104,12 @@ impl Plugin for FederationModulesPlugin {
     ctx.compiler_hooks.compilation.tap(compilation::new(self));
     Ok(())
   }
+
+  fn clear_cache(&self, id: CompilationId) {
+    if let Some(map) = FEDERATION_MODULES_PLUGIN_HOOKS_MAP.get()
+      && let Ok(mut map) = map.lock()
+    {
+      map.remove(&id);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Currently `FEDERATION_MODULES_PLUGIN_HOOKS_MAP` is not remove anywhere, I followed my previous attempt to remove it in `clear_cache`. but I am not sure if this behavior is correct.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
