### PR TITLE
perf: lazy load node:worker_threads to improve startup time

### DIFF
--- a/packages/rspack/src/loader-runner/service.ts
+++ b/packages/rspack/src/loader-runner/service.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { MessageChannel } from "node:worker_threads";
 // biome-ignore syntax/correctness/noTypeOnlyImportAttributes: Biome does not support this
 import type { Tinypool } from "tinypool" with { "resolution-mode": "import" };
 
@@ -203,6 +202,7 @@ export const run = async (
 	}
 ) =>
 	ensureLoaderWorkerPool().then(async pool => {
+		const { MessageChannel } = await import("node:worker_threads");
 		const { port1: mainPort, port2: workerPort } = new MessageChannel();
 		// Create message channel for processing sync API requests from worker
 		// threads.


### PR DESCRIPTION
## Summary

Move `node:worker_threads` import inside the async function to defer loading until needed, improving startup performance.

<img width="1270" height="324" alt="image" src="https://github.com/user-attachments/assets/81136e7a-40a2-42cf-8bce-1bdec29be09e" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
