### PR TITLE
fix: improve type safety for MultiStats options

### DIFF
--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs";
-import type { MultiStats, Stats } from "@rspack/core";
+import type {
+	MultiStats,
+	MultiStatsOptions,
+	Stats,
+	StatsOptions
+} from "@rspack/core";
 import type { RspackCLI } from "../cli";
 import type { RspackCommand } from "../types";
 import {
@@ -43,13 +48,18 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
 			return;
 		}
 
-		const statsOptions = cli.isMultipleCompiler(compiler)
-			? {
+		const getStatsOptions = () => {
+			if (cli.isMultipleCompiler(compiler)) {
+				return {
 					children: compiler.compilers.map(item =>
 						item.options ? item.options.stats : undefined
 					)
-				}
-			: compiler.options?.stats;
+				} satisfies MultiStatsOptions;
+			}
+			return compiler.options?.stats;
+		};
+
+		const statsOptions = getStatsOptions() as StatsOptions;
 
 		if (options.json && createJsonStringifyStream) {
 			const handleWriteError = (error: Error) => {

--- a/packages/rspack-test-tools/src/case/example.ts
+++ b/packages/rspack-test-tools/src/case/example.ts
@@ -52,7 +52,7 @@ function createExampleProcessor(name: string): ITestProcessor {
 						all: false,
 						errors: true,
 						errorDetails: true,
-						errorStacks: true
+						errorStack: true
 					})
 				);
 			}

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4870,10 +4870,15 @@ export class MultiStats {
     // (undocumented)
     stats: Stats[];
     // (undocumented)
-    toJson(options: any): StatsCompilation;
+    toJson(options: boolean | StatsPresets | MultiStatsOptions): StatsCompilation;
     // (undocumented)
-    toString(options: any): string;
+    toString(options: boolean | StatsPresets | MultiStatsOptions): string;
 }
+
+// @public (undocumented)
+export type MultiStatsOptions = Omit<StatsOptions, "children"> & {
+    children?: StatsValue | (StatsValue | undefined)[];
+};
 
 // @public (undocumented)
 class MultiWatching {
@@ -6596,8 +6601,10 @@ declare namespace rspackExports {
         Loader,
         SnapshotOptions,
         CacheOptions,
+        StatsPresets,
         StatsColorOptions,
         StatsOptions,
+        MultiStatsOptions,
         StatsValue,
         RspackPluginInstance,
         RspackPluginFunction,
@@ -7451,7 +7458,7 @@ export type StatsOptions = {
     loggingDebug?: boolean | FilterTypes;
     loggingTrace?: boolean;
     runtimeModules?: boolean;
-    children?: boolean | StatsOptions | StatsPresets | StatsValue[];
+    children?: boolean;
     usedExports?: boolean;
     providedExports?: boolean;
     optimizationBailout?: boolean;
@@ -7504,7 +7511,7 @@ export type StatsOptions = {
 type StatsOrBigIntStatsCallback = (err: NodeJS.ErrnoException | null, stats?: IStats | IBigIntStats) => void;
 
 // @public (undocumented)
-type StatsPresets = "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary";
+export type StatsPresets = "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary";
 
 // @public (undocumented)
 class StatsPrinter {

--- a/packages/rspack/src/MultiStats.ts
+++ b/packages/rspack/src/MultiStats.ts
@@ -9,6 +9,7 @@
  */
 
 import type { KnownCreateStatsOptionsContext } from "./Compilation";
+import type { MultiStatsOptions, StatsPresets } from "./config";
 import type { Stats } from "./Stats";
 import type { StatsCompilation } from "./stats/statsFactoryUtils";
 import { indent } from "./util";
@@ -34,16 +35,19 @@ export default class MultiStats {
 	}
 
 	#createChildOptions(
-		options: { [x: string]: any; children?: any },
+		options: boolean | StatsPresets | MultiStatsOptions = {},
 		context: (KnownCreateStatsOptionsContext & Record<string, any>) | undefined
 	) {
 		const { children: childrenOptions = undefined, ...baseOptions } =
-			typeof options === "string" ? { preset: options } : options;
+			typeof options === "string" || typeof options === "boolean"
+				? { preset: options }
+				: options;
 
 		const children = this.stats.map((stat, idx) => {
 			const childOptions = Array.isArray(childrenOptions)
 				? childrenOptions[idx]
 				: childrenOptions;
+
 			return stat.compilation.createStatsOptions(
 				{
 					...baseOptions,
@@ -68,8 +72,8 @@ export default class MultiStats {
 		};
 	}
 
-	toJson(options: any) {
-		const childOptions = this.#createChildOptions(options || {}, {
+	toJson(options: boolean | StatsPresets | MultiStatsOptions) {
+		const childOptions = this.#createChildOptions(options, {
 			forToString: false
 		});
 
@@ -133,8 +137,8 @@ export default class MultiStats {
 		return obj;
 	}
 
-	toString(options: any) {
-		const childOptions = this.#createChildOptions(options || {}, {
+	toString(options: boolean | StatsPresets | MultiStatsOptions) {
+		const childOptions = this.#createChildOptions(options, {
 			forToString: true
 		});
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1742,7 +1742,7 @@ export type CacheOptions = boolean;
 
 //#region Stats
 
-type StatsPresets =
+export type StatsPresets =
 	| "normal"
 	| "none"
 	| "verbose"
@@ -1945,7 +1945,7 @@ export type StatsOptions = {
 	 * Enables or disables the display of children modules.
 	 * @default true
 	 */
-	children?: boolean | StatsOptions | StatsPresets | StatsValue[];
+	children?: boolean;
 	/**
 	 * Enables or disables the display of used exports.
 	 * @default false
@@ -2160,6 +2160,10 @@ export type StatsOptions = {
 	 * @default 5
 	 */
 	warningsSpace?: number;
+};
+
+export type MultiStatsOptions = Omit<StatsOptions, "children"> & {
+	children?: StatsValue | (StatsValue | undefined)[];
 };
 
 /**


### PR DESCRIPTION
## Summary

Improve type safety for MultiStats options:

- Add `MultiStatsOptions` type, align with webpack: https://github.com/webpack/webpack/blob/v5.102.1/types.d.ts#L11087-L11092
- Update `MultiStats` implementation to use new types
- Fix some related type issues

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
