### PR TITLE
feat: handle renamed webpack_require by compatibility plugin

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -14,11 +14,11 @@ use crate::{
   visitors::{JavascriptParser, Statement, TagInfoData, VariableDeclaration, expr_name},
 };
 
-const NESTED_WEBPACK_IDENTIFIER_TAG: &str = "_identifier__nested_webpack_identifier__";
+pub const NESTED_WEBPACK_IDENTIFIER_TAG: &str = "_identifier__nested_webpack_identifier__";
 
 #[derive(Debug, Clone)]
-struct NestedRequireData {
-  name: String,
+pub struct NestedRequireData {
+  pub name: String,
   update: bool,
   loc: DependencyRange,
   in_short_hand: bool,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -18,6 +18,7 @@ use crate::{
     ESMExportImportedSpecifierDependency, ESMExportSpecifierDependency,
     ESMImportSideEffectDependency,
   },
+  parser_plugin::compatibility_plugin::{NESTED_WEBPACK_IDENTIFIER_TAG, NestedRequireData},
   utils::object_properties::get_attributes,
   visitors::{
     ExportDefaultDeclaration, ExportDefaultExpression, ExportImport, ExportLocal, JavascriptParser,
@@ -135,9 +136,16 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
       if enum_value.is_some() && !parser.compiler_options.experiments.inline_enum {
         parser.add_error(rspack_error::error!("inlineEnum is still an experimental feature. To continue using it, please enable 'experiments.inlineEnum'.").into());
       }
+      let variable = parser.get_tag_data(local_id, NESTED_WEBPACK_IDENTIFIER_TAG);
+
       Box::new(ESMExportSpecifierDependency::new(
         export_name.clone(),
-        local_id.clone(),
+        if let Some(variable) = variable {
+          let data = NestedRequireData::downcast(variable);
+          data.name.clone().into()
+        } else {
+          local_id.clone()
+        },
         inlinable,
         enum_value,
         statement.span().into(),

--- a/tests/rspack-test/configCases/module/consume-webpack-runtime/index.js
+++ b/tests/rspack-test/configCases/module/consume-webpack-runtime/index.js
@@ -1,0 +1,21 @@
+import { __webpack_require__ as namedUse } from './runtime-export-named'
+import defaultUse from './runtime-export-default'
+
+it("should compile and run", () => {
+	expect(namedUse()).toBe(42);
+	expect(defaultUse()).toBe(42);
+
+	const path = __non_webpack_require__('path')
+	const fs = __non_webpack_require__('fs')
+	{
+		const content = fs.readFileSync(path.resolve(__dirname, './bundle0.js'), 'utf-8')
+		const NESTED_RE = /__nested_webpack_require_(.+)__/
+		expect(content.match(NESTED_RE)[1].length).toBeGreaterThan(0)
+	}
+
+	{
+		const content = fs.readFileSync(path.resolve(__dirname, './bundle1.js'), 'utf-8')
+		const NESTED_RE = /__nested_webpack_require_(.+)__/
+		expect(content.match(NESTED_RE)[1].length).toBeGreaterThan(0)
+	}
+});

--- a/tests/rspack-test/configCases/module/consume-webpack-runtime/rspack.config.js
+++ b/tests/rspack-test/configCases/module/consume-webpack-runtime/rspack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = [
+	{
+		node: false,
+		mode: "production",
+		devtool: false,
+		optimization: {
+			concatenateModules: true
+		}
+	},
+	{
+		node: false,
+		mode: "production",
+		devtool: false,
+		optimization: {
+			concatenateModules: false
+		}
+	}
+];

--- a/tests/rspack-test/configCases/module/consume-webpack-runtime/runtime-export-default.js
+++ b/tests/rspack-test/configCases/module/consume-webpack-runtime/runtime-export-default.js
@@ -1,0 +1,3 @@
+function __webpack_require__() {return 42}
+__webpack_require__.m = () => {}
+export default __webpack_require__

--- a/tests/rspack-test/configCases/module/consume-webpack-runtime/runtime-export-named.js
+++ b/tests/rspack-test/configCases/module/consume-webpack-runtime/runtime-export-named.js
@@ -1,0 +1,4 @@
+
+function __webpack_require__() {return 42}
+__webpack_require__.m = () => {}
+export {__webpack_require__}


### PR DESCRIPTION
## Summary

`__webpack_require__` is renamed by CompatibilityPlugin, which doesn't rename the exported specifier, causing the output be like this:

```js
defineProperoty(__webpack_exports__, { __webpack_require__: __webpack_require__})

function __nested_webpack_require__() {}
```

You can see the exported __webpack_require__ is undefined.

Considering we'd better not to mutate the AST, just hack on HarmonyExportsParserPlugin, every time we find the exported specifier, check if it's a variable that has been tagged by CompatibilityPlugin, if so change the id to the real renamed symbol

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
