### PR TITLE
chore(ci): set timeout for  pnpm setup action

### DIFF
--- a/.github/actions/pnpm/setup/action.yml
+++ b/.github/actions/pnpm/setup/action.yml
@@ -15,7 +15,6 @@ runs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.node-version }}
-        mirror: ${{ runner.environment == 'self-hosted' && runner.os == 'macOS' && 'https://npmmirror.com/mirrors/node' || '' }}
 
     - name: Enable corepack
       if: ${{ inputs.node-version != '16' }}

--- a/.github/workflows/reusable-build-bench.yml
+++ b/.github/workflows/reusable-build-bench.yml
@@ -67,6 +67,7 @@ jobs:
           chmod +x  target/codspeed/instrumentation/rspack_benchmark/benches
 
       - name: Pnpm Setup
+        timeout-minutes: 5
         uses: ./.github/actions/pnpm/setup
 
       - name: Pnpm Install

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -41,6 +41,7 @@ jobs:
           clean: ${{ runner.environment == 'github-hosted' }}
 
       - name: Pnpm Setup
+        timeout-minutes: 5
         uses: ./.github/actions/pnpm/setup
 
       - name: Install Binding Dependencies

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -97,6 +97,7 @@ jobs:
         run: ls -lah crates/node_binding/
 
       - name: Setup Pnpm
+        timeout-minutes: 5
         uses: ./.github/actions/pnpm/setup
         with:
           node-version: ${{ matrix.node }}


### PR DESCRIPTION
## Summary
Make the pnpm setup freezing problem in macOS failing fast

<img width="2264" height="546" alt="image" src="https://github.com/user-attachments/assets/2cc5f626-5f81-415e-bd6b-2901934fe90f" />

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
