### PR TITLE
refactor: wrap module trait objects in BoxModule newtype

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/make/alternatives/module.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/alternatives/module.rs
@@ -10,7 +10,8 @@ use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 use crate::{
   AsyncDependenciesBlockIdentifier, BoxModule, BuildInfo, BuildMeta, CodeGenerationResult,
   Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId, FactoryMeta, Module,
-  ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, ValueCacheVersions,
+  ModuleExt, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
+  ValueCacheVersions,
 };
 
 #[cacheable]
@@ -26,14 +27,17 @@ pub struct TempModule {
 impl TempModule {
   pub fn transform_from(module: OwnedOrRef<BoxModule>) -> OwnedOrRef<BoxModule> {
     let m = module.as_ref();
-    OwnedOrRef::Owned(Box::new(Self {
-      id: m.identifier(),
-      build_info: m.build_info().clone(),
-      build_meta: m.build_meta().clone(),
-      dependencies: m.get_dependencies().to_vec(),
-      // clean all of blocks
-      blocks: vec![],
-    }))
+    OwnedOrRef::Owned(
+      Self {
+        id: m.identifier(),
+        build_info: m.build_info().clone(),
+        build_meta: m.build_meta().clone(),
+        dependencies: m.get_dependencies().to_vec(),
+        // clean all of blocks
+        blocks: vec![],
+      }
+      .boxed(),
+    )
   }
 }
 

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/add.rs
@@ -2,7 +2,7 @@ use rspack_error::Result;
 
 use super::{TaskContext, build::BuildTask, lazy::ProcessUnlazyDependenciesTask};
 use crate::{
-  BoxDependency, Module, ModuleIdentifier, ModuleProfile,
+  BoxDependency, BoxModule, ModuleIdentifier, ModuleProfile,
   compilation::make::ForwardedIdSet,
   module_graph::{ModuleGraph, ModuleGraphModule},
   utils::task_loop::{Task, TaskResult, TaskType},
@@ -11,7 +11,7 @@ use crate::{
 #[derive(Debug)]
 pub struct AddTask {
   pub original_module_identifier: Option<ModuleIdentifier>,
-  pub module: Box<dyn Module>,
+  pub module: BoxModule,
   pub module_graph_module: Box<ModuleGraphModule>,
   pub dependencies: Vec<BoxDependency>,
   pub current_profile: Option<ModuleProfile>,

--- a/crates/rspack_core/src/compilation/make/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/make/graph_updater/repair/build.rs
@@ -7,8 +7,9 @@ use super::{
   TaskContext, lazy::ProcessUnlazyDependenciesTask, process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BuildContext, BuildResult, CompilationId, CompilerId,
-  CompilerOptions, DependencyParents, Module, ModuleProfile, ResolverFactory, SharedPluginDriver,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CompilationId,
+  CompilerId, CompilerOptions, DependencyParents, ModuleProfile, ResolverFactory,
+  SharedPluginDriver,
   compilation::make::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
   utils::{
     ResourceId,
@@ -20,7 +21,7 @@ use crate::{
 pub struct BuildTask {
   pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
-  pub module: Box<dyn Module>,
+  pub module: BoxModule,
   pub current_profile: Option<ModuleProfile>,
   pub resolver_factory: Arc<ResolverFactory>,
   pub compiler_options: Arc<CompilerOptions>,
@@ -88,7 +89,7 @@ impl Task<TaskContext> for BuildTask {
 
 #[derive(Debug)]
 struct BuildResultTask {
-  pub module: Box<dyn Module>,
+  pub module: BoxModule,
   pub build_result: Box<BuildResult>,
   pub plugin_driver: SharedPluginDriver,
   pub current_profile: Option<ModuleProfile>,

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -304,10 +304,7 @@ impl ContextModuleFactory {
           context_options: dependency.options().clone(),
           type_prefix: dependency.type_prefix(),
         };
-        let module = Box::new(ContextModule::new(
-          self.resolve_dependencies.clone(),
-          options.clone(),
-        ));
+        let module = ContextModule::new(self.resolve_dependencies.clone(), options.clone()).boxed();
         (module, Some(options))
       }
       Ok(ResolveResult::Ignored) => {
@@ -383,9 +380,10 @@ impl ContextModuleFactory {
         let module = ContextModule::new(
           after_resolve_data.resolve_dependencies,
           context_module_options.clone(),
-        );
+        )
+        .boxed();
 
-        Ok(Some(ModuleFactoryResult::new_with_module(Box::new(module))))
+        Ok(Some(ModuleFactoryResult::new_with_module(module)))
       }
     }
   }

--- a/crates/rspack_core/src/self_module_factory.rs
+++ b/crates/rspack_core/src/self_module_factory.rs
@@ -1,6 +1,6 @@
 use rspack_error::Result;
 
-use crate::{ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, SelfModule};
+use crate::{ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, SelfModule};
 
 #[derive(Debug)]
 pub struct SelfModuleFactory;
@@ -11,8 +11,8 @@ impl ModuleFactory for SelfModuleFactory {
     let issuer = data
       .issuer_identifier
       .expect("self module must have issuer");
-    Ok(ModuleFactoryResult::new_with_module(Box::new(
-      SelfModule::new(issuer),
-    )))
+    Ok(ModuleFactoryResult::new_with_module(
+      SelfModule::new(issuer).boxed(),
+    ))
   }
 }

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_module_options_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_module_options_plugin.rs
@@ -37,7 +37,8 @@ async fn build_module(
     module.set_source_map_kind(SourceMapKind::SimpleSourceMap);
   }
   if self.cheap {
-    module.set_source_map_kind(*module.get_source_map_kind() | SourceMapKind::Cheap)
+    let next_kind = *module.get_source_map_kind() | SourceMapKind::Cheap;
+    module.set_source_map_kind(next_kind)
   }
   Ok(())
 }
@@ -58,7 +59,8 @@ async fn runtime_module(
     module.set_source_map_kind(SourceMapKind::SimpleSourceMap);
   }
   if self.cheap {
-    module.set_source_map_kind(*module.get_source_map_kind() | SourceMapKind::Cheap)
+    let next_kind = *module.get_source_map_kind() | SourceMapKind::Cheap;
+    module.set_source_map_kind(next_kind)
   }
   Ok(())
 }

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module_factory.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module_factory.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use rspack_core::{ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult};
+use rspack_core::{ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult};
 use rspack_error::Result;
 
 use super::{dll_entry_dependency::DllEntryDependency, dll_module::DllModule};
@@ -16,7 +16,7 @@ impl ModuleFactory for DllModuleFactory {
       .expect("unreachable");
 
     Ok(ModuleFactoryResult {
-      module: Some(Box::new(DllModule::new(dll_entry_dependency))),
+      module: Some(DllModule::new(dll_entry_dependency).boxed()),
     })
   }
 }

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_plugin.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_plugin.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   BoxModule, Compilation, CompilationParams, CompilerCompilation, Context, DependencyType,
-  LibIdentOptions, ModuleFactoryCreateData, NormalModuleCreateData, NormalModuleFactoryFactorize,
-  NormalModuleFactoryModule, Plugin,
+  LibIdentOptions, ModuleExt, ModuleFactoryCreateData, NormalModuleCreateData,
+  NormalModuleFactoryFactorize, NormalModuleFactoryModule, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -87,26 +87,32 @@ async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<B
       );
 
       if let Some(resolved) = self.options.content.get(&inner_request) {
-        return Ok(Some(Box::new(DelegatedModule::new(
-          self.options.source.clone(),
-          resolved.clone(),
-          self.options.r#type.clone(),
-          inner_request,
-          Some(request.to_owned()),
-        ))));
+        return Ok(Some(
+          DelegatedModule::new(
+            self.options.source.clone(),
+            resolved.clone(),
+            self.options.r#type.clone(),
+            inner_request,
+            Some(request.to_owned()),
+          )
+          .boxed(),
+        ));
       }
 
       for extension in self.options.extensions.iter() {
         let request_plus_ext = format!("{inner_request}{extension}");
 
         if let Some(resolved) = self.options.content.get(&request_plus_ext) {
-          return Ok(Some(Box::new(DelegatedModule::new(
-            self.options.source.clone(),
-            resolved.clone(),
-            self.options.r#type.clone(),
-            request_plus_ext,
-            format!("{request}{extension}").into(),
-          ))));
+          return Ok(Some(
+            DelegatedModule::new(
+              self.options.source.clone(),
+              resolved.clone(),
+              self.options.r#type.clone(),
+              request_plus_ext,
+              format!("{request}{extension}").into(),
+            )
+            .boxed(),
+          ));
         }
       }
     }
@@ -132,13 +138,14 @@ async fn nmf_module(
       context: &self.options.compilation_context,
     });
 
-    *module = Box::new(DelegatedModule::new(
+    *module = DelegatedModule::new(
       self.options.source.clone(),
       resolved.clone(),
       self.options.r#type.clone(),
       request.to_string(),
       original_request.map(|request| request.to_string()),
-    ));
+    )
+    .boxed();
   };
 
   Ok(())

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -5,9 +5,9 @@ use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta, BuildResult,
   CodeGenerationResult, Compilation, CompilerOptions, ConcatenationScope, DependenciesBlock,
-  DependencyId, FactoryMeta, Module, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult,
-  ModuleGraph, ModuleLayer, RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config,
-  module_update_hash, rspack_sources::BoxSource,
+  DependencyId, FactoryMeta, Module, ModuleExt, ModuleFactory, ModuleFactoryCreateData,
+  ModuleFactoryResult, ModuleGraph, ModuleLayer, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -239,9 +239,9 @@ impl ModuleFactory for CssModuleFactory {
       .downcast_ref::<CssDependency>()
       .expect("unreachable");
 
-    Ok(ModuleFactoryResult::new_with_module(Box::new(
-      CssModule::new(css_dep.clone()),
-    )))
+    Ok(ModuleFactoryResult::new_with_module(
+      CssModule::new(css_dep.clone()).boxed(),
+    ))
   }
 }
 

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -6,7 +6,7 @@ use std::{
 use rspack_collections::IdentifierSet;
 use rspack_core::{
   BoxModule, Compilation, CompilationId, CompilationParams, CompilerCompilation, CompilerId,
-  CompilerMake, DependencyType, EntryDependency, LibIdentOptions, Module, ModuleFactory,
+  CompilerMake, DependencyType, EntryDependency, LibIdentOptions, Module, ModuleExt, ModuleFactory,
   ModuleFactoryCreateData, ModuleIdentifier, NormalModuleCreateData, NormalModuleFactoryModule,
   Plugin,
 };
@@ -212,7 +212,7 @@ async fn normal_module_factory_module(
     context: module_factory_create_data.options.context.as_str(),
   });
 
-  *module = Box::new(LazyCompilationProxyModule::new(
+  *module = LazyCompilationProxyModule::new(
     module_identifier,
     readable_identifier,
     lib_ident.map(|ident| ident.into_owned()),
@@ -220,7 +220,8 @@ async fn normal_module_factory_module(
     create_data.resource_resolve_data.resource().to_owned(),
     active,
     self.client.clone(),
-  ));
+  )
+  .boxed();
 
   Ok(())
 }

--- a/crates/rspack_plugin_mf/src/container/container_entry_module_factory.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module_factory.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use rspack_core::{ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult};
+use rspack_core::{ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult};
 use rspack_error::Result;
 
 use super::{
@@ -16,13 +16,14 @@ impl ModuleFactory for ContainerEntryModuleFactory {
     let dep = data.dependencies[0]
       .downcast_ref::<ContainerEntryDependency>()
       .expect("dependency of ContainerEntryModuleFactory should be ContainerEntryDependency");
-    Ok(ModuleFactoryResult::new_with_module(Box::new(
+    Ok(ModuleFactoryResult::new_with_module(
       ContainerEntryModule::new(
         dep.name.clone(),
         dep.exposes.clone(),
         dep.share_scope.clone(),
         dep.enhanced,
-      ),
-    )))
+      )
+      .boxed(),
+    ))
   }
 }

--- a/crates/rspack_plugin_mf/src/container/fallback_module_factory.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module_factory.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use rspack_core::{ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult};
+use rspack_core::{ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult};
 use rspack_error::Result;
 
 use super::{fallback_dependency::FallbackDependency, fallback_module::FallbackModule};
@@ -13,8 +13,8 @@ impl ModuleFactory for FallbackModuleFactory {
     let dep = data.dependencies[0]
       .downcast_ref::<FallbackDependency>()
       .expect("dependency of FallbackModuleFactory should be FallbackDependency");
-    Ok(ModuleFactoryResult::new_with_module(Box::new(
-      FallbackModule::new(dep.requests.clone()),
-    )))
+    Ok(ModuleFactoryResult::new_with_module(
+      FallbackModule::new(dep.requests.clone()).boxed(),
+    ))
   }
 }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module_factory.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module_factory.rs
@@ -1,7 +1,9 @@
 use std::borrow::Cow;
 
 use async_trait::async_trait;
-use rspack_core::{ModuleDependency, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult};
+use rspack_core::{
+  ModuleDependency, ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult,
+};
 use rspack_error::{Diagnosable, Diagnostic, Result};
 
 use super::{
@@ -19,7 +21,7 @@ impl ModuleFactory for ProvideSharedModuleFactory {
     let dep = data.dependencies[0]
       .downcast_ref::<ProvideSharedDependency>()
       .expect("dependency of ProvideSharedModuleFactory should be ProvideSharedDependency");
-    Ok(ModuleFactoryResult::new_with_module(Box::new(
+    Ok(ModuleFactoryResult::new_with_module(
       ProvideSharedModule::new(
         dep.share_scope.clone(),
         dep.name.clone(),
@@ -29,8 +31,9 @@ impl ModuleFactory for ProvideSharedModuleFactory {
         dep.singleton,
         dep.required_version.clone(),
         dep.strict_version,
-      ),
-    )))
+      )
+      .boxed(),
+    ))
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the `BoxModule` type alias with a tuple struct wrapper
- implement deref, conversions, and serialization support for `BoxModule`
- update module factories and related plugins to construct modules through the new wrapper API

## Testing
- cargo check -p rspack_core

------
https://chatgpt.com/codex/tasks/task_e_68f8fccbad94832d9d5613f591f56d12