### PR TITLE
test: use rstest's default reporters in CI

### DIFF
--- a/tests/rspack-test/rstest.config.ts
+++ b/tests/rspack-test/rstest.config.ts
@@ -61,7 +61,7 @@ export default defineConfig({
 		__RSPACK_PATH__: path.resolve(root, "packages/rspack"),
 		__RSPACK_TEST_TOOLS_PATH__: path.resolve(root, "packages/rspack-test-tools"),
 	},
-	reporters: process.env.CI ?  undefined: ["verbose"],
+	reporters: process.env.CI ? undefined : ["verbose"],
 	hideSkippedTests: true,
 });
 


### PR DESCRIPTION
## Summary

use rstest's default reporters in CI, not output all case details.

<!-- Describe what this PR does and why. -->

## Related links

https://rstest.rs/config/test/reporters

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
