### PR TITLE
test: add debug mode of test tools

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -105,6 +105,9 @@ export function createHotNormalCase(name: string, src: string, dist: string): vo
 export function createHotStepCase(name: string, src: string, dist: string, temp: string, target: RspackOptions["target"]): void;
 
 // @public (undocumented)
+export const createLocatedError: (collectedErrors: Error[], offset: number) => (e: Error, file: TRunnerFile) => Error;
+
+// @public (undocumented)
 export function createMultiCompilerCase(name: string, src: string, dist: string, testConfig: string): void;
 
 // @public (undocumented)
@@ -246,6 +249,10 @@ export interface INodeRunnerOptions {
     dist: string;
     // (undocumented)
     env: ITestEnv;
+    // (undocumented)
+    errors?: Error[];
+    // (undocumented)
+    logs?: string[];
     // (undocumented)
     name: string;
     // (undocumented)
@@ -481,6 +488,8 @@ export class NodeRunner implements ITestRunner {
     getRequire(): TRunnerRequirer;
     // (undocumented)
     protected globalContext: IGlobalContext | null;
+    // (undocumented)
+    protected log(message: string): void;
     // (undocumented)
     protected _options: INodeRunnerOptions;
     // (undocumented)
@@ -819,6 +828,8 @@ export class WebRunner extends NodeRunner {
     },
     string
     ];
+    // (undocumented)
+    protected log(message: string): void;
     // (undocumented)
     run(file: string): Promise<unknown>;
     // (undocumented)

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -51,6 +51,7 @@
     "filenamify": "4.3.0",
     "fs-extra": "^11.3.2",
     "iconv-lite": "^0.6.3",
+    "javascript-stringify": "^2.1.0",
     "jest-diff": "^29.7.0",
     "jest-snapshot": "29.7.0",
     "jest-environment-node": "29.7.0",

--- a/packages/rspack-test-tools/src/case/runner.ts
+++ b/packages/rspack-test-tools/src/case/runner.ts
@@ -1,5 +1,6 @@
 import type { RspackOptions, StatsCompilation } from "@rspack/core";
 import { NodeRunner, WebRunner } from "../runner";
+import { DEBUG_SCOPES } from "../test/debug";
 import type { ITestContext, ITestEnv, ITestRunner } from "../type";
 
 export type THotStepRuntimeLangData = {
@@ -118,6 +119,10 @@ export function createMultiCompilerRunner(
 		context.getValue("multiCompilerOptions") || [];
 	const [index] = getIndex();
 	const compilerOptions = multiCompilerOptions[index];
+	const logs = context.getValue(DEBUG_SCOPES.RunLogs) as string[] | undefined;
+	const errors = context.getValue(DEBUG_SCOPES.RunErrors) as
+		| Error[]
+		| undefined;
 	let runner;
 	const runnerOptions = {
 		runInNewContext: false,
@@ -135,7 +140,9 @@ export function createMultiCompilerRunner(
 		testConfig: context.getTestConfig(),
 		source: context.getSource(),
 		dist: context.getDist(),
-		compilerOptions
+		compilerOptions,
+		logs,
+		errors
 	};
 	if (
 		compilerOptions.target === "web" ||

--- a/packages/rspack-test-tools/src/compiler.ts
+++ b/packages/rspack-test-tools/src/compiler.ts
@@ -1,7 +1,8 @@
 import EventEmitter from "node:events";
-import type { Compiler, RspackOptions, Stats } from "@rspack/core";
+import { Compiler, type RspackOptions, type Stats } from "@rspack/core";
 import merge from "webpack-merge";
-import type { ITestCompilerManager } from "./type";
+import { DEBUG_SCOPES } from "./test/debug";
+import type { ITestCompilerManager, ITestContext } from "./type";
 
 export enum ECompilerEvent {
 	Build = "build",
@@ -16,7 +17,7 @@ export class TestCompilerManager implements ITestCompilerManager {
 	protected compilerStats: Stats | null = null;
 	protected emitter: EventEmitter = new EventEmitter();
 
-	constructor() {}
+	constructor(protected context: ITestContext) {}
 
 	getOptions(): RspackOptions {
 		return this.compilerOptions;
@@ -42,6 +43,39 @@ export class TestCompilerManager implements ITestCompilerManager {
 		this.compilerInstance = require("@rspack/core")(
 			this.compilerOptions
 		) as Compiler;
+		if (__DEBUG__) {
+			const context = this.context;
+			this.compilerInstance = new Proxy(this.compilerInstance, {
+				get(target, p, receiver) {
+					const value = Reflect.get(target, p, receiver);
+					if (
+						typeof value === "function" &&
+						Compiler.prototype.hasOwnProperty(p)
+					) {
+						return value.bind(target);
+					}
+					return value;
+				},
+				set(target, p, value, receiver) {
+					const debugSetProperties =
+						(context.getValue(
+							DEBUG_SCOPES.CreateCompilerSetProperties
+						) as string[]) || [];
+					debugSetProperties.push(
+						`${p as string} ${new Error().stack?.split("\n")[2]?.trim()}`
+					);
+					context.setValue(
+						DEBUG_SCOPES.CreateCompilerSetProperties,
+						debugSetProperties
+					);
+					return Reflect.set(target, p, value, receiver);
+				}
+			});
+			this.context.setValue(DEBUG_SCOPES.CreateCompilerInstance, {
+				path: require.resolve("@rspack/core"),
+				mode: "no-callback"
+			});
+		}
 		this.emitter.emit(ECompilerEvent.Create, this.compilerInstance);
 		return this.compilerInstance;
 	}
@@ -53,6 +87,39 @@ export class TestCompilerManager implements ITestCompilerManager {
 			this.compilerOptions,
 			callback
 		) as Compiler;
+		if (__DEBUG__) {
+			const context = this.context;
+			this.compilerInstance = new Proxy(this.compilerInstance, {
+				get(target, p, receiver) {
+					const value = Reflect.get(target, p, receiver);
+					if (
+						typeof value === "function" &&
+						Compiler.prototype.hasOwnProperty(p)
+					) {
+						return value.bind(target);
+					}
+					return value;
+				},
+				set(target, p, value, receiver) {
+					const debugSetProperties =
+						(context.getValue(
+							DEBUG_SCOPES.CreateCompilerSetProperties
+						) as string[]) || [];
+					debugSetProperties.push(
+						`${p as string} ${new Error().stack?.split("\n")[2]?.trim()}`
+					);
+					context.setValue(
+						DEBUG_SCOPES.CreateCompilerSetProperties,
+						debugSetProperties
+					);
+					return Reflect.set(target, p, value, receiver);
+				}
+			});
+			this.context.setValue(DEBUG_SCOPES.CreateCompilerInstance, {
+				path: require.resolve("@rspack/core"),
+				mode: "callback"
+			});
+		}
 		this.emitter.emit(ECompilerEvent.Create, this.compilerInstance);
 		return this.compilerInstance;
 	}
@@ -62,10 +129,44 @@ export class TestCompilerManager implements ITestCompilerManager {
 			throw new Error("Compiler should be created before build");
 		return new Promise<Stats>((resolve, reject) => {
 			try {
+				const context = this.context;
+				if (__DEBUG__) {
+					context.setValue(DEBUG_SCOPES.BuildMethod, {
+						method: "run"
+					});
+				}
 				this.compilerInstance!.run((error, newStats) => {
 					this.emitter.emit(ECompilerEvent.Build, error, newStats);
-					if (error) return reject(error);
+					if (error) {
+						if (__DEBUG__) {
+							context.setValue(DEBUG_SCOPES.BuildError, {
+								type: "fatal",
+								errors: [error]
+							});
+						}
+						return reject(error);
+					}
 					this.compilerStats = newStats as Stats;
+					if (__DEBUG__) {
+						if (newStats?.hasErrors()) {
+							context.setValue(DEBUG_SCOPES.BuildError, {
+								type: "stats",
+								errors:
+									newStats.toJson({
+										errors: true
+									}).errors || []
+							});
+						}
+						if (newStats?.hasWarnings()) {
+							context.setValue(
+								DEBUG_SCOPES.BuildWarning,
+								newStats.toJson({
+									warnings: true
+								}).warnings || []
+							);
+						}
+					}
+
 					resolve(newStats as Stats);
 				});
 			} catch (e) {
@@ -77,26 +178,60 @@ export class TestCompilerManager implements ITestCompilerManager {
 	watch(timeout = 1000) {
 		if (!this.compilerInstance)
 			throw new Error("Compiler should be created before watch");
-		this.compilerInstance!.watch(
-			{
-				// IMPORTANT:
-				// This is a workaround for the issue that watchpack cannot detect the file change in time
-				// so we set the poll to 300ms to make it more sensitive to the file change
-				poll: 300,
-				// Rspack ignored node_modules and .git by default for better performance, but for tests we
-				// want to watch all files, which aligns with webpack's default behavior
-				ignored: [],
-				aggregateTimeout: timeout
-			},
-			(error, newStats) => {
-				this.emitter.emit(ECompilerEvent.Build, error, newStats);
-				if (error) return error;
-				if (newStats) {
-					this.compilerStats = newStats as Stats;
+		const context = this.context;
+		const watchOptions = {
+			// IMPORTANT:
+			// This is a workaround for the issue that watchpack cannot detect the file change in time
+			// so we set the poll to 300ms to make it more sensitive to the file change
+			poll: 300,
+			// Rspack ignored node_modules and .git by default for better performance, but for tests we
+			// want to watch all files, which aligns with webpack's default behavior
+			ignored: [],
+			aggregateTimeout: timeout
+		};
+		if (__DEBUG__) {
+			context.setValue(DEBUG_SCOPES.BuildMethod, {
+				method: "watch",
+				options: watchOptions
+			});
+		}
+		this.compilerInstance!.watch(watchOptions, (error, newStats) => {
+			this.emitter.emit(ECompilerEvent.Build, error, newStats);
+			if (__DEBUG__) {
+				if (error) {
+					context.setValue(DEBUG_SCOPES.BuildError, {
+						type: "fatal",
+						errors: [error]
+					});
+					return error;
 				}
-				return newStats;
 			}
-		);
+
+			if (newStats) {
+				if (__DEBUG__) {
+					if (newStats.hasErrors()) {
+						context.setValue(DEBUG_SCOPES.BuildError, {
+							type: "stats",
+							errors:
+								newStats.toJson({
+									errors: true
+								}).errors || []
+						});
+					}
+					if (newStats.hasWarnings()) {
+						context.setValue(
+							DEBUG_SCOPES.BuildWarning,
+							newStats.toJson({
+								warnings: true
+							}).warnings || []
+						);
+					}
+				}
+
+				this.compilerStats = newStats as Stats;
+			}
+			return newStats;
+		});
 	}
 
 	getStats() {

--- a/packages/rspack-test-tools/src/helper/index.ts
+++ b/packages/rspack-test-tools/src/helper/index.ts
@@ -2,6 +2,7 @@ export * from "./directory";
 export * from "./is";
 export * from "./parse-modules";
 export * from "./read-config-file";
+export * from "./stringify-config";
 export * from "./update-snapshot";
 export * from "./util/checkStats";
 export * from "./win";

--- a/packages/rspack-test-tools/src/helper/read-config-file.ts
+++ b/packages/rspack-test-tools/src/helper/read-config-file.ts
@@ -1,5 +1,6 @@
 import type { RspackOptions } from "@rspack/core";
 import fs from "fs-extra";
+import { DEBUG_SCOPES } from "../test/debug";
 import type { ITestContext } from "../type";
 
 export function readConfigFile(
@@ -12,6 +13,7 @@ export function readConfigFile(
 ): RspackOptions[] {
 	const existsFile = files.find(i => fs.existsSync(i));
 	let fileConfig = existsFile ? require(existsFile) : {};
+
 	if (typeof fileConfig === "function") {
 		fileConfig = fileConfig(
 			{ config: prevOption },
@@ -19,5 +21,11 @@ export function readConfigFile(
 		);
 	}
 	const configArr = Array.isArray(fileConfig) ? fileConfig : [fileConfig];
+	if (existsFile) {
+		context.setValue(DEBUG_SCOPES.CompilerOptionsReadConfigFile, {
+			file: existsFile,
+			config: fileConfig
+		});
+	}
 	return functionApply ? functionApply(configArr) : configArr;
 }

--- a/packages/rspack-test-tools/src/helper/setup-env.ts
+++ b/packages/rspack-test-tools/src/helper/setup-env.ts
@@ -19,6 +19,7 @@ if (process.env.RSTEST) {
 	global.__ROOT_PATH__ ??= process.env.__ROOT_PATH__;
 	global.__RSPACK_PATH__ ??= process.env.__RSPACK_PATH__;
 	global.__RSPACK_TEST_TOOLS_PATH__ ??= process.env.__RSPACK_TEST_TOOLS_PATH__;
+	global.__DEBUG__ ??= process.env.DEBUG === "test";
 } else {
 	// Compatible with wasm tests (lazyTestEnv)
 	global.rstest = jest;

--- a/packages/rspack-test-tools/src/helper/stringify-config.ts
+++ b/packages/rspack-test-tools/src/helper/stringify-config.ts
@@ -1,0 +1,63 @@
+import type { RspackOptions } from "@rspack/core";
+import { stringify } from "javascript-stringify";
+
+export default function stringifyConfig(
+	config: RspackOptions,
+	verbose = false
+) {
+	return stringify(
+		config,
+		(value, indent, stringify) => {
+			// improve plugin output
+			if (value?.__pluginName) {
+				const prefix = `/* config.${value.__pluginType}('${value.__pluginName}') */\n`;
+				const constructorExpression = value.__pluginPath
+					? // The path is stringified to ensure special characters are escaped
+						// (such as the backslashes in Windows-style paths).
+						`(require(${stringify(value.__pluginPath)}))`
+					: value.__pluginConstructorName;
+
+				if (constructorExpression) {
+					// get correct indentation for args by stringifying the args array and
+					// discarding the square brackets.
+					const args = stringify(value.__pluginArgs)?.slice(1, -1);
+					return `${prefix}new ${constructorExpression}(${args})`;
+				}
+				return (
+					prefix +
+					stringify(
+						value.__pluginArgs?.length ? { args: value.__pluginArgs } : {}
+					)
+				);
+			}
+
+			// improve rule/use output
+			if (value?.__ruleNames) {
+				const ruleTypes = value.__ruleTypes;
+				const prefix = `/* config.module${value.__ruleNames
+					.map(
+						(r: string, index: number) =>
+							`.${ruleTypes ? ruleTypes[index] : "rule"}('${r}')`
+					)
+					.join("")}${
+					value.__useName ? `.use('${value.__useName}')` : ``
+				} */\n`;
+				return prefix + stringify(value);
+			}
+
+			if (value?.__expression) {
+				return value.__expression;
+			}
+
+			// shorten long functions
+			if (typeof value === "function") {
+				if (!verbose && value.toString().length > 100) {
+					return `function () { /* omitted long function */ }`;
+				}
+			}
+
+			return stringify(value);
+		},
+		2
+	);
+}

--- a/packages/rspack-test-tools/src/test/debug.ts
+++ b/packages/rspack-test-tools/src/test/debug.ts
@@ -1,0 +1,226 @@
+import path from "node:path";
+import type { RspackOptions } from "@rspack/core";
+import fs from "fs-extra";
+import { stringify } from "javascript-stringify";
+import stringifyConfig from "../helper/stringify-config";
+import type { ITestContext } from "../type";
+
+export function generateDebugReport(context: ITestContext) {
+	const report = `
+## Case Meta
+
+${generateCaseMetaPathReport(context)}
+
+${generateCaseMetaTestConfigReport(context)}
+
+## Compiler Options
+
+${generateReadConfigFileReport(context)}
+
+${generateFinalOptionsReport(context)}
+
+## Create Compiler
+
+${generateCreateCompilerInstanceReport(context)}
+
+${generateCreateCompilerSetPropertiesReport(context)}
+
+## Build
+
+${generateBuildMethodReport(context)}
+
+${generateBuildErrorReport(context)}
+
+${generateBuildWarningReport(context)}
+
+## Run
+
+${generateRunFindBundleReport(context)}
+
+${generateRunGetRunnerReport(context)}
+
+${generateRunLogsReport(context)}
+
+${generateRunErrorsReport(context)}
+
+  `;
+
+	const dist = context.getDist("debug.md");
+	fs.ensureDirSync(path.dirname(dist));
+	fs.writeFileSync(dist, report);
+}
+
+function generateCaseMetaPathReport(context: ITestContext) {
+	return `
+### Case Path
+
+- Source: ${context.getSource()}
+- Dist: ${context.getDist()}
+- Temp: ${context.getTemp()}
+  `;
+}
+
+function generateCaseMetaTestConfigReport(context: ITestContext) {
+	return `
+### Test Config
+
+\`\`\`js
+// ${path.resolve(context.getSource(), "./test.config.js")}
+${stringify(context.getTestConfig(), null, 2)}
+\`\`\`
+  `;
+}
+
+function generateReadConfigFileReport(context: ITestContext) {
+	const configFileInfo = context.getValue(
+		DEBUG_SCOPES.CompilerOptionsReadConfigFile
+	) as { file: string; config: RspackOptions };
+	if (!configFileInfo) return "";
+	return `
+### Read Config File
+
+\`\`\`js
+// ${configFileInfo.file}
+${stringifyConfig(configFileInfo.config)}
+\`\`\`
+  `;
+}
+
+function generateFinalOptionsReport(context: ITestContext) {
+	const finalOptions = context.getCompiler().getOptions();
+	return `
+### Final Options
+
+\`\`\`js
+${stringifyConfig(finalOptions)}
+\`\`\`
+`;
+}
+
+function generateCreateCompilerInstanceReport(context: ITestContext) {
+	const instanceInfo = context.getValue(
+		DEBUG_SCOPES.CreateCompilerInstance
+	) as { path: string; mode: string };
+	if (!instanceInfo) return "";
+	return `
+### Create Compiler Instance
+
+- Rspack Path: ${instanceInfo.path}
+- Callback Mode: ${instanceInfo.mode}
+`;
+}
+
+function generateCreateCompilerSetPropertiesReport(context: ITestContext) {
+	const setPropertiesInfo = context.getValue(
+		DEBUG_SCOPES.CreateCompilerSetProperties
+	) as string[];
+	if (!setPropertiesInfo || setPropertiesInfo.length === 0) return "";
+	return `
+### Set Properties
+
+${setPropertiesInfo.map(p => `- ${p}`).join("\n")}
+`;
+}
+
+function generateBuildMethodReport(context: ITestContext) {
+	const buildMethod = context.getValue(DEBUG_SCOPES.BuildMethod) as {
+		method: string;
+		options?: any;
+	};
+	if (!buildMethod) return "";
+	return `
+### Build Method
+
+- Method: \`compiler.${buildMethod.method}()\`
+${buildMethod.options ? `- Options:\n\`\`\`js\n${stringify(buildMethod.options, null, 2)}\n\`\`\`` : ""}
+`;
+}
+
+function generateBuildErrorReport(context: ITestContext) {
+	const buildError = context.getValue(DEBUG_SCOPES.BuildError) as {
+		type: "fatal" | "stats";
+		errors: Error[];
+	};
+	if (!buildError) return "";
+	return `
+### Build Error
+
+type: ${buildError.type}
+
+${buildError.errors.map(e => `\`\`\`\n// message:\n${e.message}\n// stack:\n${e.stack}\n\`\`\``).join("\n\n")}
+`;
+}
+
+function generateBuildWarningReport(context: ITestContext) {
+	const buildWarning = context.getValue(DEBUG_SCOPES.BuildWarning) as Error[];
+	if (!buildWarning) return "";
+	return `
+### Build Warning
+
+${buildWarning.map(w => `\`\`\`\n// message:\n${w.message}\n// stack:\n${w.stack}\n\`\`\``).join("\n\n")}
+`;
+}
+
+function generateRunFindBundleReport(context: ITestContext) {
+	const runFindBundle = context.getValue(
+		DEBUG_SCOPES.RunFindBundle
+	) as string[];
+	if (!runFindBundle) return "";
+	return `
+### Find Bundle
+
+${runFindBundle.map(b => `- ${context.getDist(b)}`).join("\n")}
+`;
+}
+
+function generateRunGetRunnerReport(context: ITestContext) {
+	const getRunnerInfo = context.getValue(DEBUG_SCOPES.RunGetRunner) as Record<
+		string,
+		{ runnerKey: string; reused: boolean; runnerType?: string }
+	>;
+	if (!getRunnerInfo) return "";
+	return `
+### Get Runner
+
+${Object.entries(getRunnerInfo)
+	.map(
+		([file, info]) =>
+			`- ${file}: ${info.runnerKey} (Reused: ${info.reused}, Type: \`${info.runnerType}\`)`
+	)
+	.join("\n")}
+`;
+}
+
+function generateRunLogsReport(context: ITestContext) {
+	const runLogs = context.getValue(DEBUG_SCOPES.RunLogs) as string[];
+	if (!runLogs) return "";
+	return `
+### Run Logs
+
+${runLogs.map(l => `- ${l}`).join("\n")}
+`;
+}
+
+function generateRunErrorsReport(context: ITestContext) {
+	const runErrors = context.getValue(DEBUG_SCOPES.RunErrors) as Error[];
+	if (!runErrors) return "";
+	return `
+### Run Errors
+
+${runErrors.map(e => `\`\`\`\n// message:\n${e.message}\n// stack:\n${e.stack}\n\`\`\``).join("\n\n")}
+`;
+}
+
+export const DEBUG_SCOPES = {
+	CompilerOptionsReadConfigFile: "compiler-options:read-config-file",
+	CompilerOptionsFinalOptions: "compiler-options:final-options",
+	CreateCompilerInstance: "create-compiler:instance",
+	CreateCompilerSetProperties: "create-compiler:set-properties",
+	BuildMethod: "build:method",
+	BuildError: "build:error",
+	BuildWarning: "build:warning",
+	RunFindBundle: "run:find-bundle",
+	RunGetRunner: "run:get-runner",
+	RunLogs: "run:logs",
+	RunErrors: "run:errors"
+};

--- a/packages/rspack-test-tools/src/test/tester.ts
+++ b/packages/rspack-test-tools/src/test/tester.ts
@@ -7,6 +7,7 @@ import type {
 	ITestProcessor
 } from "../type";
 import { TestContext } from "./context";
+import { generateDebugReport } from "./debug";
 
 export class Tester implements ITester {
 	private context: ITestContext;
@@ -95,6 +96,13 @@ export class Tester implements ITester {
 			console.warn(
 				`Error occured while closing compilers of '${this.config.name}':\n${e.stack}`
 			);
+		}
+		if (__DEBUG__) {
+			try {
+				generateDebugReport(this.context);
+			} catch (e) {
+				console.warn(`Generate debug report failed: ${(e as Error).message}`);
+			}
 		}
 	}
 

--- a/packages/rspack-test-tools/src/type.ts
+++ b/packages/rspack-test-tools/src/type.ts
@@ -265,6 +265,7 @@ export type TTestRunnerCreator = {
 };
 
 declare global {
+	var __DEBUG__: boolean;
 	var __TEST_PATH__: string;
 	var __TEST_FIXTURES_PATH__: string;
 	var __TEST_DIST_PATH__: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,9 @@ importers:
       iconv-lite:
         specifier: ^0.6.3
         version: 0.6.3
+      javascript-stringify:
+        specifier: ^2.1.0
+        version: 2.1.0
       jest-diff:
         specifier: ^29.7.0
         version: 29.7.0
@@ -5998,6 +6001,9 @@ packages:
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
+
+  javascript-stringify@2.1.0:
+    resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
 
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
@@ -14296,6 +14302,8 @@ snapshots:
   jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
+
+  javascript-stringify@2.1.0: {}
 
   jest-changed-files@29.7.0:
     dependencies:

--- a/tests/rspack-test/jest.config.js
+++ b/tests/rspack-test/jest.config.js
@@ -103,6 +103,7 @@ const config = {
 		__ROOT_PATH__: root,
 		__RSPACK_PATH__: path.resolve(root, "packages/rspack"),
 		__RSPACK_TEST_TOOLS_PATH__: path.resolve(root, "packages/rspack-test-tools"),
+		__DEBUG__: process.env.DEBUG === "test",
 	},
 	...(wasmConfig || {}),
 	verbose: true,

--- a/tests/rspack-test/rstest.config.ts
+++ b/tests/rspack-test/rstest.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
 		__ROOT_PATH__: root,
 		__RSPACK_PATH__: path.resolve(root, "packages/rspack"),
 		__RSPACK_TEST_TOOLS_PATH__: path.resolve(root, "packages/rspack-test-tools"),
+		__DEBUG__: process.env.DEBUG === "test" ? 'true' : 'false',
 	},
 	reporters: process.env.CI ? undefined : ["verbose"],
 	hideSkippedTests: true,

--- a/tests/rspack-test/watchCases/runtime/static-import/test.config.js
+++ b/tests/rspack-test/watchCases/runtime/static-import/test.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	bundlePath: [
+	findBundle: () => [
 		"./runtime~main.js",
 		"./main.js"
 	]


### PR DESCRIPTION
## Summary

Add debug mode of test tools. No you can use DEBUG=test pnpm run test:base to generate `debug.md` files in the dist `js` case directories to see the compiler options, running logs and more debug infos. Should add more debug infos in the future to helper developers to figure out why the error failed easily.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
