### PR TITLE
fix: compilation.*_dep.added should not contains updated files

### DIFF
--- a/crates/rspack_core/src/utils/file_counter/mod.rs
+++ b/crates/rspack_core/src/utils/file_counter/mod.rs
@@ -73,11 +73,7 @@ impl FileCounter {
 
   /// Added files compared to the `files()` when call reset_incremental_info
   pub fn added_files(&self) -> impl Iterator<Item = &ArcPath> {
-    self
-      .incremental_info
-      .added()
-      .iter()
-      .chain(self.incremental_info.updated())
+    self.incremental_info.added().iter()
   }
 
   /// Removed files compared to the `files()` when call reset_incremental_info
@@ -172,6 +168,18 @@ mod test {
 
     counter.add_files(&resource_1, &file_list_a);
     assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 1);
+    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+
+    counter.reset_incremental_info();
+    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+
+    counter.remove_files(&resource_1, &file_list_a);
+    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 1);
+
+    counter.add_files(&resource_1, &file_list_a);
+    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
     assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
 
     counter.reset_incremental_info();


### PR DESCRIPTION
## Summary

Compilation.*_dependencies.added should contains added files only.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
