### PR TITLE
test: fix rstest tests not found in windows

### DIFF
--- a/tests/rspack-test/rstest.config.ts
+++ b/tests/rspack-test/rstest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 	setupFiles: setupFilesAfterEnv,
 	testTimeout: process.env.CI ? 60000 : 30000,
 	include: process.env.WASM ? [] : [
-		"<rootDir>/*.test.js",
+		"*.test.js",
 	],
 	exclude: ["Cache.test.js", "Incremental-*.test.js", "Hot*.test.js", "Serial.test.js", "NativeWatcher*.test.js", "Diagnostics.test.js", "EsmOutput.test.js"],
 	slowTestThreshold: 5000,


### PR DESCRIPTION
## Summary

fix rstest `tests not found` in windows

before:
<img width="1159" height="203" alt="image" src="https://github.com/user-attachments/assets/2949b5c0-0dbd-47a8-a6b4-3d399090cabc" />

after:
<img width="1025" height="227" alt="image" src="https://github.com/user-attachments/assets/c578a2a2-a0c8-4a62-b1b1-a9ec6b59dcd8" />

https://github.com/web-infra-dev/rspack/actions/runs/18772103400/job/53559042781?pr=11995

<!-- Describe what this PR does and why. -->

## Related links

https://github.com/web-infra-dev/rstest/pull/645
<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
