### PR TITLE
fix: should only top-level require wrapped modules for import side-effect specifier

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -10,8 +10,8 @@ use rspack_collections::{
 };
 use rspack_core::{
   BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkUkey,
-  CodeGenerationPublicPathAutoReplace, Compilation, ConcatenatedModuleIdent, ExportMode,
-  ExportProvided, ExportsInfoGetter, ExportsType, FindTargetResult, GetUsedNameParam,
+  CodeGenerationPublicPathAutoReplace, Compilation, ConcatenatedModuleIdent, DependencyType,
+  ExportMode, ExportProvided, ExportsInfoGetter, ExportsType, FindTargetResult, GetUsedNameParam,
   IdentCollector, InitFragmentKey, InitFragmentStage, MaybeDynamicTargetExportInfoHashKey,
   ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT,
   NormalInitFragment, PathData, PrefetchExportsInfoMode, RuntimeGlobals, SourceType, URLStaticMode,
@@ -1711,15 +1711,22 @@ impl EsmLibraryPlugin {
           .module_by_identifier(&m)
           .expect("should have module");
 
-        // make sure all outgoing modules are rendered
+        // make sure all side-effect modules are rendered
         // eg.
         // import './foo.cjs'
         // should be rendered as __webpack_require__('./foo.cjs')
-        for dep in module.get_dependencies() {
-          let Some(conn) = module_graph.connection_by_dependency_id(dep) else {
+        for dep_id in module.get_dependencies() {
+          let Some(dep) = module_graph.dependency_by_id(dep_id) else {
             continue;
           };
 
+          if !matches!(dep.dependency_type(), DependencyType::EsmImport) {
+            continue;
+          }
+
+          let Some(conn) = module_graph.connection_by_dependency_id(dep_id) else {
+            continue;
+          };
           if !conn.is_target_active(
             &module_graph,
             None,
@@ -1732,6 +1739,7 @@ impl EsmLibraryPlugin {
           let ref_module = *conn.module_identifier();
           //ensure chunk
           chunk_imports.entry(ref_module).or_default();
+
           if outgoing_module_info.is_external() {
             if ChunkGraph::get_module_id(&compilation.module_ids_artifact, ref_module).is_none() {
               // if module don't contains id, it no need to be required

--- a/tests/rspack-test/esmOutputCases/interop/type-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/type-module/__snapshots__/esm.snap.txt
@@ -22,12 +22,6 @@ exports.foo = () => 'foo'
 }),
 });
 // ./index.js
-const cjs = __webpack_require__("./cjs.cjs");
-var foo_1 = cjs.foo;
-const cjs_unknown = __webpack_require__("./cjs-unknown.cjs");
-var cjs_unknown_default = /*#__PURE__*/__webpack_require__.n(cjs_unknown);
-var cjs_unknown_default_0 = cjs_unknown_default();
-var bar_1 = cjs_unknown.bar;
 
 
 
@@ -38,6 +32,14 @@ it('should have correct re-export', async () => {
 	expect(bar()).toBe('bar')
 	expect(defaultV.bar()).toBe('bar')
 })
+
+const cjs = __webpack_require__("./cjs.cjs");
+var foo_1 = cjs.foo;
+
+const cjs_unknown = __webpack_require__("./cjs-unknown.cjs");
+var cjs_unknown_default = /*#__PURE__*/__webpack_require__.n(cjs_unknown);
+var cjs_unknown_default_0 = cjs_unknown_default();
+var bar_1 = cjs_unknown.bar;
 
 export { bar_1 as bar, foo_1 as foo };
 export default cjs_unknown_default_0;

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-wrapped/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-wrapped/__snapshots__/esm.snap.txt
@@ -50,8 +50,6 @@ const lib3 = 42
 }),
 });
 // ./index.js
-const lib_0 = __webpack_require__("./lib.js");
-var cR = lib_0.cR;
 
 
 it('should re-export esm correctly', async () => {
@@ -66,6 +64,9 @@ var u = lib2_0.u;
 
 const lib3_0 = __webpack_require__("./lib3.js");
 var B = lib3_0.B;
+
+const lib_0 = __webpack_require__("./lib.js");
+var cR = lib_0.cR;
 
 export { B as lib3, cR as lib, u as lib2 };
 

--- a/tests/rspack-test/esmOutputCases/re-exports/entry-re-exports/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/entry-re-exports/__snapshots__/esm.snap.txt
@@ -12,8 +12,6 @@ exports.bar = 2
 }),
 });
 // ./foo.js
-const bar_0 = __webpack_require__("./bar.js");
-var bar_2 = bar_0.bar;
 const foo_foo = 1
 
 
@@ -25,6 +23,9 @@ it('should have correct output for entry re-exports', async () => {
 	expect(foo).toBe(1);
 	expect(bar).toBe(2);
 })
+
+const bar_0 = __webpack_require__("./bar.js");
+var bar_2 = bar_0.bar;
 
 export { bar_2 as bar, foo_foo as foo };
 

--- a/tests/rspack-test/esmOutputCases/side-effect-only-connections/index.js
+++ b/tests/rspack-test/esmOutputCases/side-effect-only-connections/index.js
@@ -1,0 +1,4 @@
+it('should has connection to lib only in closure', () => {
+	const { foo } = require('./lib')
+	expect(foo()).toBe(42)
+})

--- a/tests/rspack-test/esmOutputCases/side-effect-only-connections/lib.js
+++ b/tests/rspack-test/esmOutputCases/side-effect-only-connections/lib.js
@@ -1,0 +1,1 @@
+exports.foo = () => 42


### PR DESCRIPTION


## Summary

There is a condition that we're likely to ignore the connection, which is the side effect import to a wrapped module

```js
import './foo.cjs'
```

We link modules through the specifier connections, we should make sure the imported wrapped module is imported. But before we process all kinds of connections includes CommonjsRequire dependency, that will causing duplicated require in below cases

```js
function Main() { require('./other') }
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
