### PR TITLE
chore: temporarily disable wasm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,16 +87,16 @@ jobs:
       runner: ${{ vars.MAC_SELF_HOSTED_RUNNER_LABELS || '"macos-latest"' }}
       test: true
 
-  test-wasm:
-    name: Test WASM
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      target: wasm32-wasip1-threads
-      profile: "ci"
-      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
-      test: true
+  # test-wasm:
+  #   name: Test WASM
+  #   needs: [check-changed]
+  #   if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   with:
+  #     target: wasm32-wasip1-threads
+  #     profile: "ci"
+  #     runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+  #     test: true
 
   check-codspeed:
     name: Check Bench Result


### PR DESCRIPTION
## Summary

I'd like to enable wasm ci again after migrating it to rstest in https://github.com/web-infra-dev/rspack/pull/11990.

And I will fix the problems as many as possible.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
