### PR TITLE
chore: remove injected test code in diff test cases

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -41,9 +41,9 @@ use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_hook::plugin;
 use rspack_javascript_compiler::ast::Ast;
+use rspack_util::SpanExt;
 #[cfg(allocative)]
 use rspack_util::allocative;
-use rspack_util::{SpanExt, diff_mode};
 use rustc_hash::FxHashMap;
 pub use side_effects_flag_plugin::*;
 use swc_core::{
@@ -399,10 +399,6 @@ impl JsPlugin {
             .await?;
           if allow_inline_startup && let Some(bailout) = bailout {
             buf2.push(format!("// This entry module can't be inlined because {bailout}").into());
-            allow_inline_startup = false;
-          }
-          if allow_inline_startup && diff_mode::is_diff_mode() {
-            buf2.push("// This entry module can't be inlined in diff mode".into());
             allow_inline_startup = false;
           }
           let entry_runtime_requirements =

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -5,10 +5,8 @@ use rspack_core::{
   chunk_graph_chunk::ChunkId,
   get_undo_path,
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
-  to_normal_comment,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_util::diff_mode::is_diff_mode;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{JavascriptModulesPluginHooks, RenderSource};
@@ -177,13 +175,6 @@ pub async fn render_module(
     ));
     sources.add(RawStringSource::from_static(": "));
 
-    if is_diff_mode() {
-      sources.add(RawStringSource::from(format!(
-        "\n{}\n",
-        to_normal_comment(&format!("start::{}", module.identifier()))
-      )));
-    }
-
     let mut post_module_container = {
       let runtime_requirements = ChunkGraph::get_module_runtime_requirements(
         compilation,
@@ -221,14 +212,6 @@ pub async fn render_module(
 
       let mut container_sources = ConcatSource::default();
 
-      // TODO: put this in a plugin via render_module_{container,package} hook
-      if is_diff_mode() {
-        container_sources.add(RawStringSource::from(format!(
-          "\n{}\n",
-          to_normal_comment(&format!("start::{}", module.identifier()))
-        )));
-      }
-
       container_sources.add(RawStringSource::from(format!(
         "(function ({}) {{\n",
         args.join(", ")
@@ -238,13 +221,6 @@ pub async fn render_module(
       }
       container_sources.add(render_source.source);
       container_sources.add(RawStringSource::from_static("\n\n})"));
-
-      if is_diff_mode() {
-        container_sources.add(RawStringSource::from(format!(
-          "\n{}\n",
-          to_normal_comment(&format!("end::{}", module.identifier()))
-        )));
-      }
       container_sources.add(RawStringSource::from_static(",\n"));
 
       RenderSource {
@@ -344,17 +320,10 @@ pub async fn render_runtime_modules(
           if source.size() == 0 {
             return Ok(sources);
           }
-          if is_diff_mode() {
-            sources.add(RawStringSource::from(format!(
-              "/* start::{} */\n",
-              module.identifier()
-            )));
-          } else {
-            sources.add(RawStringSource::from(format!(
-              "// {}\n",
-              module.identifier()
-            )));
-          }
+          sources.add(RawStringSource::from(format!(
+            "// {}\n",
+            module.identifier()
+          )));
           let supports_arrow_function = compilation
             .options
             .output
@@ -381,12 +350,6 @@ pub async fn render_runtime_modules(
             } else {
               "\n}();\n"
             }));
-          }
-          if is_diff_mode() {
-            sources.add(RawStringSource::from(format!(
-              "/* end::{} */\n",
-              module.identifier()
-            )));
           }
           Ok(sources)
         });

--- a/crates/rspack_util/src/diff_mode.rs
+++ b/crates/rspack_util/src/diff_mode.rs
@@ -1,8 +1,0 @@
-use std::sync::LazyLock;
-
-static IS_DIFF_MODE: LazyLock<bool> =
-  LazyLock::new(|| std::env::var("RSPACK_DIFF").ok().as_deref() == Some("true"));
-
-pub fn is_diff_mode() -> bool {
-  *IS_DIFF_MODE
-}

--- a/crates/rspack_util/src/lib.rs
+++ b/crates/rspack_util/src/lib.rs
@@ -6,7 +6,6 @@ pub mod base64;
 pub mod comparators;
 #[cfg(feature = "debug_tool")]
 pub mod debug_tool;
-pub mod diff_mode;
 pub mod env;
 pub mod ext;
 pub mod fx_hash;


### PR DESCRIPTION
## Summary

The diff test cases had been removed. So there is no need to inject these codes that are used to split codes of modules.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
