### PR TITLE
chore:  rspack-resolver bump to 0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4926,9 +4926,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8680fe2525e9823c41cd53103aa27a2d1a22f412ea00913a91d5dd300a2d767"
+checksum = "54a76f6f4e9c5d27222f2f7f5c71c0475059207fc7042313c5b8f5c70b264850"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ regex               = { version = "1.11.1", default-features = false }
 regex-syntax        = { version = "0.8.5", default-features = false, features = ["std"] }
 regress             = { version = "0.10.4", default-features = false, features = ["pattern"] }
 ropey               = { version = "1.6.1", default-features = false }
-rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.3", default-features = false }
+rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.4", default-features = false }
 rspack_sources      = { version = "=0.4.11", default-features = false }
 rustc-hash          = { version = "2.1.0", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }


### PR DESCRIPTION
## Summary
In rspack-resolver@0.6.4
1. [windows] Fix the bad path format in the resolve context's file dependencies; close https://github.com/web-infra-dev/rspack/issues/11891
2. Add the resolved path's real path to resolve the context's file dependencies; Align to enhanced-resolve.



<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
