### PR TITLE
feat: if no commonjs specific syntax detected, treat module as esm

### DIFF
--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -140,8 +140,9 @@ impl InitFragmentKey {
       | InitFragmentKey::ModuleExternal(_)
       | InitFragmentKey::ModuleDecorator(_)
       | InitFragmentKey::CommonJsExports(_)
+      | InitFragmentKey::ESMCompatibility
       | InitFragmentKey::Const(_) => first(fragments),
-      InitFragmentKey::ESMCompatibility | InitFragmentKey::Unique(_) => {
+      InitFragmentKey::Unique(_) => {
         debug_assert!(fragments.len() == 1, "fragment = {self:?}");
         first(fragments)
       }

--- a/crates/rspack_plugin_esm_library/src/esm_lib_parser_plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/esm_lib_parser_plugin.rs
@@ -1,0 +1,32 @@
+use rspack_core::DependencyType;
+use rspack_plugin_javascript::{
+  JavascriptParserPlugin, dependency::ESMCompatibilityDependency, visitors::JavascriptParser,
+};
+pub struct EsmLibParserPlugin;
+
+impl JavascriptParserPlugin for EsmLibParserPlugin {
+  fn finish(&self, parser: &mut JavascriptParser) -> Option<bool> {
+    if parser.module_type.is_js_auto()
+      && matches!(
+        parser.build_meta.exports_type,
+        rspack_core::BuildMetaExportsType::Unset
+      )
+      && !parser.get_dependencies().iter().any(|dep| {
+        matches!(
+          dep.dependency_type(),
+          DependencyType::CjsExportRequire
+            | DependencyType::CjsExports
+            | DependencyType::CjsFullRequire
+            | DependencyType::CjsRequire
+            | DependencyType::CjsSelfReference
+            | DependencyType::CommonJSRequireContext
+        )
+      })
+    {
+      parser.build_meta.exports_type = rspack_core::BuildMetaExportsType::Namespace;
+      parser.add_presentational_dependency(Box::new(ESMCompatibilityDependency));
+    }
+
+    None
+  }
+}

--- a/crates/rspack_plugin_esm_library/src/lib.rs
+++ b/crates/rspack_plugin_esm_library/src/lib.rs
@@ -1,5 +1,6 @@
 mod chunk_link;
 mod dependency;
+mod esm_lib_parser_plugin;
 mod link;
 mod plugin;
 mod preserve_modules;

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1724,10 +1724,6 @@ impl EsmLibraryPlugin {
             continue;
           };
 
-          if !matches!(dep.dependency_type(), DependencyType::EsmImport) {
-            continue;
-          }
-
           let Some(conn) = module_graph.connection_by_dependency_id(dep_id) else {
             continue;
           };
@@ -1743,6 +1739,10 @@ impl EsmLibraryPlugin {
           let ref_module = *conn.module_identifier();
           //ensure chunk
           chunk_imports.entry(ref_module).or_default();
+
+          if !matches!(dep.dependency_type(), DependencyType::EsmImport) {
+            continue;
+          }
 
           if outgoing_module_info.is_external() {
             if ChunkGraph::get_module_id(&compilation.module_ids_artifact, ref_module).is_none() {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -326,7 +326,7 @@ pub struct JavascriptParser<'parser> {
   pub resource_data: &'parser ResourceData,
   pub(crate) compiler_options: &'parser CompilerOptions,
   pub(crate) javascript_options: &'parser JavascriptParserOptions,
-  pub(crate) module_type: &'parser ModuleType,
+  pub module_type: &'parser ModuleType,
   pub(crate) module_layer: Option<&'parser ModuleLayer>,
   pub module_identifier: &'parser ModuleIdentifier,
   pub(crate) plugin_drive: Rc<JavaScriptParserPluginDrive>,
@@ -564,6 +564,10 @@ impl<'parser> JavascriptParser<'parser> {
 
   pub fn next_dependency_idx(&self) -> usize {
     self.dependencies.len()
+  }
+
+  pub fn get_dependencies(&self) -> &[BoxDependency] {
+    &self.dependencies
   }
 
   pub fn get_dependency_mut(&mut self, idx: usize) -> Option<&mut BoxDependency> {

--- a/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
@@ -1,89 +1,18 @@
 ```mjs title=dynamic_js.mjs
-import { __webpack_require__ } from "./runtime.mjs";
-__webpack_require__.add({
-"./dynamic.js": 
-/*!********************!*\
-  !*** ./dynamic.js ***!
-  \********************/
-(function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
-});
-/* ESM default export */ const __WEBPACK_DEFAULT_EXPORT__ = (42);
+// ./dynamic.js
+/* ESM default export */ const dynamic = (42);
 
-
-}),
-});
+export { dynamic };
 
 ```
 
 ```mjs title=main.mjs
-import { __webpack_require__ } from "./runtime.mjs";
-__webpack_require__.add({
-"./index.js": 
-/*!******************!*\
-  !*** ./index.js ***!
-  \******************/
-(function (__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
+// ./index.js
 it('should support dynamic import', async () => {
-	const value = await import("./dynamic_js.mjs").then(__webpack_require__.bind(__webpack_require__, /*! ./dynamic */ "./dynamic.js"))
+	const value = await import("./dynamic_js.mjs").then((mod) => ({ default: mod.dynamic }))
 	expect(value.default).toBe(42)
 })
 
 
-
-}),
-});
-const index = __webpack_require__("./index.js");
-
-
-```
-
-```mjs title=runtime.mjs
-
-var __webpack_modules__ = {};
-// The module cache
-var __webpack_module_cache__ = {};
-// The require function
-function __webpack_require__(moduleId) {
-// Check if module is in cache
-var cachedModule = __webpack_module_cache__[moduleId];
-if (cachedModule !== undefined) {
-return cachedModule.exports;
-}
-// Create a new module (and put it into the cache)
-var module = (__webpack_module_cache__[moduleId] = {
-exports: {}
-});
-// Execute the module function
-__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-
-// Return the exports of the module
-return module.exports;
-}
-// expose the modules object (__webpack_modules__)
-__webpack_require__.m = __webpack_modules__;
-
-// esm library register module runtime
-(() => {
-__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
-
-})();
-// webpack/runtime/define_property_getters
-(() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
-};
-})();
-// webpack/runtime/has_own_property
-(() => {
-__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
-})();
-
-export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/interop/raw-import/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/raw-import/__snapshots__/esm.snap.txt
@@ -1,28 +1,11 @@
 ```mjs title=main.mjs
-import { __webpack_require__ } from "./runtime.mjs";
-__webpack_require__.add({
-"./bar.js": 
-/*!****************!*\
-  !*** ./bar.js ***!
-  \****************/
-(function () {
+// ./bar.js
 globalThis.bar = 'bar';
 
-
-}),
-"./foo.js": 
-/*!****************!*\
-  !*** ./foo.js ***!
-  \****************/
-(function () {
+// ./foo.js
 globalThis.foo = 'foo';
 
-
-}),
-});
 // ./index.js
-__webpack_require__("./bar.js");
-__webpack_require__("./foo.js");
 
 
 
@@ -31,40 +14,5 @@ it('should have correct import', () => {
 	expect(globalThis.foo).toBe('foo');
 })
 
-
-```
-
-```mjs title=runtime.mjs
-
-var __webpack_modules__ = {};
-// The module cache
-var __webpack_module_cache__ = {};
-// The require function
-function __webpack_require__(moduleId) {
-// Check if module is in cache
-var cachedModule = __webpack_module_cache__[moduleId];
-if (cachedModule !== undefined) {
-return cachedModule.exports;
-}
-// Create a new module (and put it into the cache)
-var module = (__webpack_module_cache__[moduleId] = {
-exports: {}
-});
-// Execute the module function
-__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-
-// Return the exports of the module
-return module.exports;
-}
-// expose the modules object (__webpack_modules__)
-__webpack_require__.m = __webpack_modules__;
-
-// esm library register module runtime
-(() => {
-__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
-
-})();
-
-export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/new-url/keep-new-url/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/new-url/keep-new-url/__snapshots__/esm.snap.txt
@@ -5,19 +5,6 @@
 ```mjs title=main.mjs
 import { __webpack_require__ } from "./runtime.mjs";
 __webpack_require__.add({
-"./index.js": 
-/*!******************!*\
-  !*** ./index.js ***!
-  \******************/
-(function (__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
-
-function neverUse() {
-	new URL("./ef46db3751d8e999.js", import.meta.url)(function foo() {})();
-}
-neverUse.bind(neverUse)
-
-
-}),
 "./asset.js": 
 /*!******************!*\
   !*** ./asset.js ***!
@@ -27,7 +14,12 @@ module.exports = __webpack_require__.p + "ef46db3751d8e999.js";
 
 }),
 });
-const index = __webpack_require__("./index.js");
+// ./index.js
+
+function neverUse() {
+	new URL("./ef46db3751d8e999.js", import.meta.url)(function foo() {})();
+}
+neverUse.bind(neverUse)
 
 
 ```

--- a/tests/rspack-test/esmOutputCases/preserve-modules/basic/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/basic/__snapshots__/esm.snap.txt
@@ -1,9 +1,7 @@
 ```mjs title=demo/index.mjs
-import { __webpack_require__ } from "../runtime.mjs";
 import "../main.mjs";
 
 // ./src/demo/index.js
-__webpack_require__("./other2/index.js");
 const demo = () => 'demo'
 ;
 /* ESM default export */ const src_demo = (demo);
@@ -13,12 +11,10 @@ export default src_demo;
 ```
 
 ```mjs title=index.mjs
-import { __webpack_require__ } from "./runtime.mjs";
-import "./main.mjs";
 import { default as src_demo } from "./demo/index.mjs";
+import "./main.mjs";
 
 // ./src/index.js
-__webpack_require__("./other1/index.js");
 
 
 
@@ -30,63 +26,13 @@ it('should preserve modules', () => {
 ```
 
 ```mjs title=main.mjs
-import { __webpack_require__ } from "./runtime.mjs";
-__webpack_require__.add({
-"./other1/index.js": 
-/*!*************************!*\
-  !*** ./other1/index.js ***!
-  \*************************/
-(function () {
-// other1
-console.log.bind(console)
-
-
-}),
-"./other2/index.js": 
-/*!*************************!*\
-  !*** ./other2/index.js ***!
-  \*************************/
-(function () {
+// ./other2/index.js
 // other2
 console.log.bind(console)
 
+// ./other1/index.js
+// other1
+console.log.bind(console)
 
-}),
-});
-
-```
-
-```mjs title=runtime.mjs
-
-var __webpack_modules__ = {};
-// The module cache
-var __webpack_module_cache__ = {};
-// The require function
-function __webpack_require__(moduleId) {
-// Check if module is in cache
-var cachedModule = __webpack_module_cache__[moduleId];
-if (cachedModule !== undefined) {
-return cachedModule.exports;
-}
-// Create a new module (and put it into the cache)
-var module = (__webpack_module_cache__[moduleId] = {
-exports: {}
-});
-// Execute the module function
-__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-
-// Return the exports of the module
-return module.exports;
-}
-// expose the modules object (__webpack_modules__)
-__webpack_require__.m = __webpack_modules__;
-
-// esm library register module runtime
-(() => {
-__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
-
-})();
-
-export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/split-chunks/move-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/split-chunks/move-entry/__snapshots__/esm.snap.txt
@@ -1,70 +1,20 @@
 ```mjs title=lib.mjs
-import "./lib_js.mjs";
-
 
 ```
 
 ```mjs title=lib_js.mjs
-import { __webpack_require__ } from "./runtime.mjs";
-__webpack_require__.add({
-"./lib.js": 
-/*!****************!*\
-  !*** ./lib.js ***!
-  \****************/
-(function () {
+// ./lib.js
 // side effect
 console.log.bind(console)
-
-
-}),
-});
-const lib = __webpack_require__("./lib.js");
 
 
 ```
 
 ```mjs title=main.mjs
-import { __webpack_require__ } from "./runtime.mjs";
 import "./lib_js.mjs";
 
 // ./index.js
-__webpack_require__("./lib.js");
 
 
-
-```
-
-```mjs title=runtime.mjs
-
-var __webpack_modules__ = {};
-// The module cache
-var __webpack_module_cache__ = {};
-// The require function
-function __webpack_require__(moduleId) {
-// Check if module is in cache
-var cachedModule = __webpack_module_cache__[moduleId];
-if (cachedModule !== undefined) {
-return cachedModule.exports;
-}
-// Create a new module (and put it into the cache)
-var module = (__webpack_module_cache__[moduleId] = {
-exports: {}
-});
-// Execute the module function
-__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-
-// Return the exports of the module
-return module.exports;
-}
-// expose the modules object (__webpack_modules__)
-__webpack_require__.m = __webpack_modules__;
-
-// esm library register module runtime
-(() => {
-__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
-
-})();
-
-export { __webpack_require__ };
 
 ```


### PR DESCRIPTION
## Summary

If there is no module syntax (export or import statemen), and there is no commonjs specific symbols (module require and exports), we can give it a default namespace exportsType, so it can be possible to be scope hoisted

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
