### PR TITLE
fix: type definitions for devtool module filename templates

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -1808,7 +1808,7 @@ type DevToolDebugIds = "-debugids" | "";
 export type DevtoolFallbackModuleFilenameTemplate = DevtoolModuleFilenameTemplate;
 
 // @public
-export type DevtoolModuleFilenameTemplate = string | ((info: any) => any);
+export type DevtoolModuleFilenameTemplate = string | ((context: ModuleFilenameTemplateContext) => string);
 
 // @public
 export type DevtoolNamespace = string;
@@ -4745,6 +4745,21 @@ declare namespace ModuleFilenameHelpers {
 export { ModuleFilenameHelpers }
 
 // @public (undocumented)
+export interface ModuleFilenameTemplateContext {
+    absoluteResourcePath: string;
+    allLoaders: string;
+    hash: string;
+    identifier: string;
+    loaders: string;
+    moduleId: string;
+    namespace: string;
+    query: string;
+    resource: string;
+    resourcePath: string;
+    shortIdentifier: string;
+}
+
+// @public (undocumented)
 type ModuleFilterItemTypes = RegExp | string | ((name: string, module: any, type: any) => boolean);
 
 // @public (undocumented)
@@ -6556,6 +6571,7 @@ declare namespace rspackExports {
         HashSalt,
         SourceMapFilename,
         DevtoolNamespace,
+        ModuleFilenameTemplateContext,
         DevtoolModuleFilenameTemplate,
         DevtoolFallbackModuleFilenameTemplate,
         Environment,

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -355,8 +355,35 @@ export type SourceMapFilename = string;
 /** This option determines the module's namespace */
 export type DevtoolNamespace = string;
 
+export interface ModuleFilenameTemplateContext {
+	/** The identifier of the module */
+	identifier: string;
+	/** The shortened identifier of the module */
+	shortIdentifier: string;
+	/** The resource of the module request */
+	resource: string;
+	/** The resource path of the module request */
+	resourcePath: string;
+	/** The absolute resource path of the module request */
+	absoluteResourcePath: string;
+	/** The loaders of the module request */
+	loaders: string;
+	/** All loaders of the module request */
+	allLoaders: string;
+	/** The query of the module identifier */
+	query: string;
+	/** The module id of the module */
+	moduleId: string;
+	/** The hash of the module identifier */
+	hash: string;
+	/** The module namespace */
+	namespace: string;
+}
+
 /** This option is only used when devtool uses an option that requires module names. */
-export type DevtoolModuleFilenameTemplate = string | ((info: any) => any);
+export type DevtoolModuleFilenameTemplate =
+	| string
+	| ((context: ModuleFilenameTemplateContext) => string);
 
 /** A fallback is used when the template string or function above yields duplicates. */
 export type DevtoolFallbackModuleFilenameTemplate =

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -266,7 +266,14 @@ You **must not** specify an absolute path here. However, feel free to include fo
 
 ## output.devtoolFallbackModuleFilenameTemplate
 
-- **Type:** `string` | `function (info)`
+- **Type:**
+
+```ts
+type DevtoolFallbackModuleFilenameTemplate =
+  | string
+  | ((context: ModuleFilenameTemplateContext) => string);
+```
+
 - **Default:** `undefined`
 
 A fallback is used when the template string or function above yields duplicates.
@@ -275,8 +282,15 @@ See [`output.devtoolModuleFilenameTemplate`](/config/output#outputdevtoolmodulef
 
 ## output.devtoolModuleFilenameTemplate
 
-- **Type:** `string = 'webpack://[namespace]/[resource-path]?[loaders]'` | `function (info) => string`
-- **Default:** `undefined`
+- **Type:**
+
+```ts
+type DevtoolModuleFilenameTemplate =
+  | string
+  | ((context: ModuleFilenameTemplateContext) => string);
+```
+
+- **Default:** `webpack://[namespace]/[resource-path]?[loaders]'`
 
 This option is only used when [`devtool`](/config/devtool.html) uses an option that requires module names.
 

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -262,7 +262,14 @@ export default {
 
 ## output.devtoolFallbackModuleFilenameTemplate
 
-- **类型：** `string` | `function (info)`
+- **类型：**
+
+```ts
+type DevtoolFallbackModuleFilenameTemplate =
+  | string
+  | ((context: ModuleFilenameTemplateContext) => string);
+```
+
 - **默认值：** `undefined`
 
 当模板字符串或函数产生重复时使用的备用内容。
@@ -271,8 +278,15 @@ export default {
 
 ## output.devtoolModuleFilenameTemplate
 
-- **类型：** `string = 'webpack://[namespace]/[resource-path]?[loaders]'` | `function (info) => string`
-- **默认值：** `undefined`
+- **类型：**
+
+```ts
+type DevtoolModuleFilenameTemplate =
+  | string
+  | ((context: ModuleFilenameTemplateContext) => string);
+```
+
+- **默认值：** `webpack://[namespace]/[resource-path]?[loaders]'`
 
 此选项仅在 [`devtool`](/config/devtool.html) 使用了需要模块名称的选项时使用。
 


### PR DESCRIPTION
## Summary

- Update type definitions to provide clearer type information for `output.devtoolModuleFilenameTemplate`.
- Add `ModuleFilenameTemplateContext` interface, 

## Related links

- Align with webpack: https://github.com/webpack/webpack/blob/5f898719ae47b89bee3c126bf5d2e0081ea8c91f/lib/ModuleFilenameHelpers.js#L120

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
