### PR TITLE
fix: rayon iterator.consume will block in WASM

### DIFF
--- a/crates/rspack_core/src/utils/iterator_consumer/rayon.rs
+++ b/crates/rspack_core/src/utils/iterator_consumer/rayon.rs
@@ -17,6 +17,8 @@ where
   I: Send,
 {
   type Item = I;
+
+  #[cfg(not(target_family = "wasm"))]
   fn consume(self, mut func: impl FnMut(Self::Item)) {
     let (tx, rx) = channel::<Self::Item>();
     std::thread::scope(|s| {
@@ -28,6 +30,14 @@ where
         func(data);
       }
     });
+  }
+
+  #[cfg(target_family = "wasm")]
+  fn consume(self, mut func: impl FnMut(Self::Item)) {
+    let items: Vec<Self::Item> = self.collect();
+    for item in items {
+      func(item)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

The iterator.consume will block in WASM target, rewrite it to synchronous implementation.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
