### PR TITLE
test: migrate jest lazy tests to rstest

### DIFF
--- a/packages/rspack-test-tools/src/case/esm-output.ts
+++ b/packages/rspack-test-tools/src/case/esm-output.ts
@@ -93,7 +93,7 @@ const creator = new BasicCaseCreator({
 		key: getMultiCompilerRunnerKey,
 		runner: createMultiCompilerRunner
 	},
-	concurrent: false
+	concurrent: 1
 });
 
 const defaultOptions = (

--- a/packages/rspack-test-tools/src/case/serial.ts
+++ b/packages/rspack-test-tools/src/case/serial.ts
@@ -24,7 +24,7 @@ const creator = new BasicCaseCreator({
 		key: getMultiCompilerRunnerKey,
 		runner: createMultiCompilerRunner
 	},
-	concurrent: false
+	concurrent: 1
 });
 
 export function createSerialCase(name: string, src: string, dist: string) {

--- a/tests/rspack-test/jest.config.js
+++ b/tests/rspack-test/jest.config.js
@@ -53,10 +53,8 @@ const config = {
 	prettierPath: require.resolve("prettier-2"),
 	testMatch: process.env.WASM ? [
 		"<rootDir>/*.test.js",
-	] : [
-		"<rootDir>/Serial.test.js",
-		"<rootDir>/EsmOutput.test.js",
-	],
+	] : [],
+	testPathIgnorePatterns: ["<rootDir>"],
 	moduleNameMapper: {
 		// Fixed jest-serialize-path not working when non-ascii code contains.
 		slash: "@rspack/test-tools/jest/slash",

--- a/tests/rspack-test/rstest.config.ts
+++ b/tests/rspack-test/rstest.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
 	include: process.env.WASM ? [] : [
 		"*.test.js",
 	],
-	exclude: ["Serial.test.js", "EsmOutput.test.js"],
 	slowTestThreshold: 5000,
 	resolve: {
 		alias: {


### PR DESCRIPTION
## Summary

migrate jest lazy tests to rstest.
-  `<rootDir>/Serial.test.js`
- `<rootDir>/EsmOutput.test.js`

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
