### PR TITLE
fix(wasm): add another SharedArrayBuffer instance check

### DIFF
--- a/packages/rspack/src/loader-runner/utils.ts
+++ b/packages/rspack/src/loader-runner/utils.ts
@@ -16,7 +16,7 @@ function utf8BufferToString(buf: Uint8Array) {
 	// the `instanceof` check but they should be treated as of that type.
 	const isShared =
 		buf.buffer instanceof SharedArrayBuffer ||
-		buf.buffer.constructor.name === "SharedArrayBuffer";
+		buf.buffer.constructor?.name === "SharedArrayBuffer";
 
 	const str = decoder.decode(isShared ? Buffer.from(buf) : buf);
 	if (str.charCodeAt(0) === 0xfeff) {


### PR DESCRIPTION
## Summary

`buf.buffer instanceof SharedArrayBufer` could be `false` if `buf.buffer` is an instanceof `SharedArrayBuffer` from other js context.

Ref: https://github.com/feross/buffer/blob/d02bd0a30d9b0bbd0189d5a7c424b0ab165fe5ab/index.js#L2083

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
