### PR TITLE
perf: EsmLibraryPlugin uses par_iter to deconflict symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,7 @@ name = "rspack_plugin_esm_library"
 version = "0.6.0"
 dependencies = [
  "async-trait",
+ "dashmap 6.1.0",
  "rayon",
  "regex",
  "rspack_cacheable",

--- a/crates/rspack_plugin_esm_library/Cargo.toml
+++ b/crates/rspack_plugin_esm_library/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace       = true
 
 [dependencies]
 async-trait                = { workspace = true }
+dashmap                    = { workspace = true }
 rayon                      = { workspace = true }
 regex                      = { workspace = true }
 rspack_cacheable           = { workspace = true }


### PR DESCRIPTION
## Summary

Use par_iter for deconflict symbols in different chunks

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
