### PR TITLE
fix: should disable default splitChunks rules for EsmLibraryPlugin

### DIFF
--- a/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
@@ -27,17 +27,19 @@ function applyLimits(options: RspackOptionsNormalized, logger: Logger) {
 		options.output.library = undefined;
 	}
 
-	const { splitChunks } = options.optimization;
+	let { splitChunks } = options.optimization;
+	if (splitChunks === undefined) {
+		splitChunks = options.optimization.splitChunks = {};
+	}
 
-	if (splitChunks) {
+	if (splitChunks !== false) {
 		splitChunks.chunks = "all";
 		splitChunks.minSize = 0;
 		splitChunks.maxAsyncRequests = Infinity;
 		splitChunks.maxInitialRequests = Infinity;
-		if (splitChunks.cacheGroups) {
-			splitChunks.cacheGroups.default = false;
-			splitChunks.cacheGroups.defaultVendors = false;
-		}
+		splitChunks.cacheGroups ??= {};
+		splitChunks.cacheGroups.default = false;
+		splitChunks.cacheGroups.defaultVendors = false;
 	}
 }
 


### PR DESCRIPTION
## Summary

EsmLibraryPlugin do no needs the default splitChunks rules

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
