### PR TITLE
chore(renovate): disable lockFileMaintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,9 +4,6 @@
 	extends: [":dependencyDashboard", "helpers:pinGitHubActionDigests"],
 	schedule: ["before 8am on wednesday"],
 	enabledManagers: ["github-actions", "cargo", "npm"],
-	lockFileMaintenance: {
-		enabled: true
-	},
 	ignorePaths: [
 		"**/fixtures/**",
 		"**/no-override-loaded/**",


### PR DESCRIPTION
## Summary

Disable Renovate's `lockFileMaintenance` feature.

It is too difficult to refresh the entire Cargo.toml file and pass the CI in a single pull request.

## Related links

For example: https://github.com/web-infra-dev/rspack/pull/12062

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
