### PR TITLE
fix: properties of build meta should be optional when sending to dll plugin from javascript

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -707,11 +707,11 @@ export interface JsBeforeEmitData {
 }
 
 export interface JsBuildMeta {
-  strictEsmModule: boolean
-  hasTopLevelAwait: boolean
-  esm: boolean
-  exportsType: 'unset' | 'default' | 'namespace' | 'flagged' | 'dynamic'
-  defaultObject: 'false' | 'redirect' | JsBuildMetaDefaultObjectRedirectWarn
+  strictEsmModule?: boolean
+  hasTopLevelAwait?: boolean
+  esm?: boolean
+  exportsType?: undefined | 'unset' | 'default' | 'namespace' | 'flagged' | 'dynamic'
+  defaultObject?: undefined | 'false' | 'redirect' | JsBuildMetaDefaultObjectRedirectWarn
   sideEffectFree?: boolean
   exportsFinalName?: Array<[string, string]> | undefined
 }

--- a/tests/rspack-test/configCases/parsing/optional/test.filter.js
+++ b/tests/rspack-test/configCases/parsing/optional/test.filter.js
@@ -1,2 +1,2 @@
 
-module.exports = () => "FIXME: should not bail for optional modules, can be fixed by https://github.com/web-infra-dev/rspack/pull/10351, but it is too dirty"
+module.exports = () => "TODO: should not bail for optional modules, can be fixed by https://github.com/web-infra-dev/rspack/pull/10351, but it is too dirty"

--- a/tests/rspack-test/configCases/require/module-require/index.js
+++ b/tests/rspack-test/configCases/require/module-require/index.js
@@ -3,17 +3,17 @@ import { createRequire as __createRequire, builtinModules } from "module";
 
 it("should evaluate require/createRequire", () => {
 	expect(
-		(function() { return typeof _createRequire; }).toString()
+		(function () { return typeof _createRequire; }).toString()
 	).toBe('function() { return "function"; }');
 	expect(
-		(function() { if (typeof _createRequire); }).toString()
+		(function () { if (typeof _createRequire); }).toString()
 	).toBe('function() { if (true); }');
 	const require = __createRequire(import.meta.url);
 	expect(
-		(function() { return typeof require; }).toString()
+		(function () { return typeof require; }).toString()
 	).toBe('function() { return "function"; }');
 	expect(
-		(function() { if (typeof require); }).toString()
+		(function () { if (typeof require); }).toString()
 	).toBe('function() { if (true); }');
 });
 

--- a/tests/rspack-test/configCases/require/module-require/test.filter.js
+++ b/tests/rspack-test/configCases/require/module-require/test.filter.js
@@ -1,2 +1,2 @@
 
-module.exports = () => "FIXME: missing warnings"
+module.exports = () => "TODO: support parsing createRequire in CommonJsImportsParserPlugin"

--- a/tests/rspack-test/configCases/resolve-merging/override/index.js
+++ b/tests/rspack-test/configCases/resolve-merging/override/index.js
@@ -35,8 +35,9 @@ it("should allow to override in loader", () => {
 });
 
 it("should allow to use custom dependencyType", () => {
-	expect(d).toBe("style");
-	expect(e).toBe("default");
+	// TODO: should support using custom dependencyType in loaderContext.getResolve
+	// expect(d).toBe("style");
+	// expect(e).toBe("default");
 });
 
 it("should allow to alias 'byDependency'", () => {

--- a/tests/rspack-test/configCases/resolve-merging/override/test.filter.js
+++ b/tests/rspack-test/configCases/resolve-merging/override/test.filter.js
@@ -1,2 +1,0 @@
-
-module.exports = () => "FIXME: expect 'required' to be 'style'"

--- a/tests/rspack-test/configCases/rule-set/compiler/test.filter.js
+++ b/tests/rspack-test/configCases/rule-set/compiler/test.filter.js
@@ -1,2 +1,2 @@
 
-module.exports = () => "FIXME: expect loader not matched"
+module.exports = () => "TODO: support rule match by compiler name"

--- a/tests/rspack-test/configCases/rule-set/custom/rspack.config.js
+++ b/tests/rspack-test/configCases/rule-set/custom/rspack.config.js
@@ -7,6 +7,8 @@ module.exports = {
 				use: function (data) {
 					return {
 						loader: "./loader",
+						// DIFF: need to use ident to identify the loader options
+						ident: data.resource,
 						options: {
 							resource: data.resource.replace(/^.*[\\/]/g, ""),
 							resourceQuery: data.resourceQuery,

--- a/tests/rspack-test/configCases/rule-set/custom/test.filter.js
+++ b/tests/rspack-test/configCases/rule-set/custom/test.filter.js
@@ -1,2 +1,0 @@
-
-module.exports = () => "FIXME: expect 'call-a.js' to be 'a.js'"

--- a/tests/rspack-test/configCases/rule-set/oneOf/rspack.config.js
+++ b/tests/rspack-test/configCases/rule-set/oneOf/rspack.config.js
@@ -4,6 +4,9 @@ module.exports = {
 	output: {
 		assetModuleFilename: "[name][ext]"
 	},
+	experiments: {
+		css: false
+	},
 	module: {
 		rules: [
 			{
@@ -14,7 +17,8 @@ module.exports = {
 						issuer: /\.(js)$/
 					},
 					{
-						type: "asset/resource",
+						// TODO: should not change source type when no pre/post loader
+						// type: "asset/resource",
 						issuer: /\.(css|scss|sass)$/
 					}
 				]

--- a/tests/rspack-test/configCases/rule-set/oneOf/test.filter.js
+++ b/tests/rspack-test/configCases/rule-set/oneOf/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "FIXME: oneOf rule not taken into account";

--- a/tests/rspack-test/configCases/rule-set/simple-use-fn-array/test.filter.js
+++ b/tests/rspack-test/configCases/rule-set/simple-use-fn-array/test.filter.js
@@ -1,2 +1,2 @@
 
-module.exports = () => "FIXME: Cannot read properties of undefined(reading 'startsWith')"
+module.exports = () => "TODO: support function array type of module.rules.use"

--- a/tests/rspack-test/configCases/scope-hoisting/dll-plugin/rspack.config.js
+++ b/tests/rspack-test/configCases/scope-hoisting/dll-plugin/rspack.config.js
@@ -1,12 +1,12 @@
-var webpack = require("@rspack/core");
+const { DllReferencePlugin } = require("@rspack/core");
+
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	// CHANGE: use optimization.concatenateModules instead of ModuleConcatenationPlugin
 	optimization: {
 		concatenateModules: true
 	},
 	plugins: [
-		new webpack.DllReferencePlugin({
+		new DllReferencePlugin({
 			name: "function(id) { return {default: 'ok'}; }",
 			scope: "dll",
 			content: {
@@ -19,6 +19,5 @@ module.exports = {
 				}
 			}
 		}),
-		// new webpack.optimize.ModuleConcatenationPlugin()
 	]
 };

--- a/tests/rspack-test/configCases/scope-hoisting/dll-plugin/test.filter.js
+++ b/tests/rspack-test/configCases/scope-hoisting/dll-plugin/test.filter.js
@@ -1,2 +1,0 @@
-
-module.exports = () => "FIXME: build timeout"


### PR DESCRIPTION
## Summary

Properties of build meta should be optional when sending to dll plugin from javascript

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
