### PR TITLE
chore: improve struct type and remove some useless fields

### DIFF
--- a/crates/rspack_core/src/loader/rspack_loader.rs
+++ b/crates/rspack_core/src/loader/rspack_loader.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use rspack_error::{Diagnostic, Result};
 use rspack_fs::ReadableFileSystem;
@@ -10,7 +10,6 @@ use crate::{RunnerContext, SharedPluginDriver, utils::extract_source_map};
 
 pub struct RspackLoaderRunnerPlugin {
   pub plugin_driver: SharedPluginDriver,
-  pub current_loader: Mutex<Option<String>>,
   pub extract_source_map: Option<bool>,
 }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -447,7 +447,6 @@ impl Module for NormalModule {
 
     let plugin = Arc::new(RspackLoaderRunnerPlugin {
       plugin_driver: build_context.plugin_driver.clone(),
-      current_loader: Default::default(),
       extract_source_map: self.inner().extract_source_map,
     });
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -153,12 +153,10 @@ impl EsmLibraryPlugin {
     // codegen uses self.concatenated_modules_map_for_codegen which has hold another Arc, so
     // it's safe to access concate_modules_map lock
     let mut concate_modules_map = self.concatenated_modules_map.write().await;
-    let concate_modules_map = Arc::get_mut(&mut concate_modules_map)
-      .expect("should have unique access to concatenated modules map");
 
     // analyze every modules and collect identifiers to concate_modules_map
     self
-      .analyze_module(compilation, concate_modules_map)
+      .analyze_module(compilation, &mut concate_modules_map)
       .await?;
 
     // initialize data for link chunks
@@ -250,7 +248,7 @@ impl EsmLibraryPlugin {
     for chunk_link in link.values_mut() {
       self.deconflict_symbols(
         compilation,
-        concate_modules_map,
+        &mut concate_modules_map,
         chunk_link,
         &escaped_names,
         &escaped_identifiers,
@@ -262,7 +260,7 @@ impl EsmLibraryPlugin {
     compilation.extend_diagnostics(self.link_imports_and_exports(
       compilation,
       &mut link,
-      concate_modules_map,
+      &mut concate_modules_map,
       &mut needed_namespace_objects_by_ukey,
       &escaped_identifiers,
     ));
@@ -327,7 +325,7 @@ impl EsmLibraryPlugin {
                 &compilation.module_graph_cache_artifact,
                 module_info_id,
                 vec![export_info.name().cloned().unwrap_or("".into())],
-                concate_modules_map,
+                &mut concate_modules_map,
                 &mut needed_namespace_objects,
                 false,
                 false,


### PR DESCRIPTION
## Summary

Remove the `sync::Arc` inside `RwLock`, remove useless fields in loader

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
