### PR TITLE
docs(quick-start): update non-interactive mode section

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -102,7 +102,8 @@ Update your build scripts to use Rspack CLI:
 {
   "scripts": {
     "dev": "rspack dev",
-    "build": "rspack build"
+    "build": "rspack build",
+    "preview": "rspack preview"
   }
 }
 ```

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -100,7 +100,8 @@ npm init -y
 {
   "scripts": {
     "dev": "rspack dev",
-    "build": "rspack build"
+    "build": "rspack build",
+    "preview": "rspack preview"
   }
 }
 ```


### PR DESCRIPTION
## Summary

- Update the quick start documentation to clarify non-interactive mode usage of `create-rspack`.
- Add `-y` flag to npx commands for automatic yes responses

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
