### PR TITLE
fix: support `import.meta.url` as the only param of `new Worker()`

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -20,6 +20,7 @@ pub struct WorkerDependency {
   range: DependencyRange,
   range_path: DependencyRange,
   factorize_info: FactorizeInfo,
+  need_new_url: bool,
 }
 
 impl WorkerDependency {
@@ -28,6 +29,7 @@ impl WorkerDependency {
     public_path: String,
     range: DependencyRange,
     range_path: DependencyRange,
+    need_new_url: bool,
   ) -> Self {
     Self {
       id: DependencyId::new(),
@@ -36,6 +38,7 @@ impl WorkerDependency {
       range,
       range_path,
       factorize_info: Default::default(),
+      need_new_url,
     }
   }
 }
@@ -158,17 +161,22 @@ impl DependencyTemplate for WorkerDependencyTemplate {
     runtime_requirements.insert(RuntimeGlobals::BASE_URI);
     runtime_requirements.insert(RuntimeGlobals::GET_CHUNK_SCRIPT_FILENAME);
 
+    let mut worker_import_str = format!(
+      "/* worker import */{} + {}({}), {}",
+      worker_import_base_url,
+      RuntimeGlobals::GET_CHUNK_SCRIPT_FILENAME,
+      chunk_id,
+      RuntimeGlobals::BASE_URI
+    );
+
+    if dep.need_new_url {
+      worker_import_str = format!("new URL({worker_import_str})");
+    }
+
     source.replace(
       dep.range_path.start,
       dep.range_path.end,
-      format!(
-        "/* worker import */{} + {}({}), {}",
-        worker_import_base_url,
-        RuntimeGlobals::GET_CHUNK_SCRIPT_FILENAME,
-        chunk_id,
-        RuntimeGlobals::BASE_URI
-      )
-      .as_str(),
+      worker_import_str.as_str(),
       None,
     );
   }

--- a/tests/rspack-test/configCases/url/dynamic-template-literals-expr/test.filter.js
+++ b/tests/rspack-test/configCases/url/dynamic-template-literals-expr/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => "TODO: support context module of new URL";
+module.exports = () => "TODO: support webpackComments of new URL in new Worker";

--- a/tests/rspack-test/configCases/worker/ignore/test.filter.js
+++ b/tests/rspack-test/configCases/worker/ignore/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "FIXME: Can't resolve './worker.mjs'";

--- a/tests/rspack-test/configCases/worker/node-worker-esm/rspack.config.js
+++ b/tests/rspack-test/configCases/worker/node-worker-esm/rspack.config.js
@@ -2,10 +2,10 @@
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	target: "node14",
+	target: "node",
 	entry: "./index.js",
 	optimization: {
-		chunkIds: "named"
+		chunkIds: "named",
 	},
 	output: {
 		module: true,

--- a/tests/rspack-test/configCases/worker/node-worker-esm/test.filter.js
+++ b/tests/rspack-test/configCases/worker/node-worker-esm/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "FIXME: import() was not found in the worker code for loading async chunks";

--- a/tests/rspack-test/configCases/worker/self-import/index.js
+++ b/tests/rspack-test/configCases/worker/self-import/index.js
@@ -2,7 +2,9 @@ const isMain = typeof window !== "undefined";
 
 if (isMain) {
 	it("should allow to import itself", async () => {
-		const worker = new Worker(import.meta.url);
+		const worker = new Worker(import.meta.url, {
+			type: MODULE_FLAG
+		});
 		worker.postMessage("ok");
 		const result = await new Promise(resolve => {
 			worker.onmessage = event => {
@@ -14,7 +16,9 @@ if (isMain) {
 	});
 
 	it("should allow to import itself", async () => {
-		const worker = new Worker(new URL(import.meta.url));
+		const worker = new Worker(new URL(import.meta.url), {
+			type: MODULE_FLAG
+		});
 		worker.postMessage("ok");
 		const result = await new Promise(resolve => {
 			worker.onmessage = event => {

--- a/tests/rspack-test/configCases/worker/self-import/rspack.config.js
+++ b/tests/rspack-test/configCases/worker/self-import/rspack.config.js
@@ -1,7 +1,15 @@
+const { DefinePlugin } = require("@rspack/core");
+
 /** @type {import("@rspack/core").Configuration[]} */
 module.exports = [
 	{
-		target: "web"
+		target: "web",
+		plugins: [
+			// TODO: support type: "module" injection
+			new DefinePlugin({
+				MODULE_FLAG: "undefined"
+			})
+		]
 	},
 	{
 		output: {
@@ -10,13 +18,25 @@ module.exports = [
 		target: "web",
 		optimization: {
 			runtimeChunk: "single"
-		}
+		},
+		plugins: [
+			// TODO: support type: "module" injection
+			new DefinePlugin({
+				MODULE_FLAG: "undefined"
+			})
+		]
 	},
 	{
 		target: "web",
 		experiments: {
 			outputModule: true
-		}
+		},
+		plugins: [
+			// TODO: support type: "module" injection
+			new DefinePlugin({
+				MODULE_FLAG: "\"module\""
+			})
+		]
 	},
 	{
 		target: "web",
@@ -28,6 +48,12 @@ module.exports = [
 		},
 		experiments: {
 			outputModule: true
-		}
+		},
+		plugins: [
+			// TODO: support type: "module" injection
+			new DefinePlugin({
+				MODULE_FLAG: "\"module\""
+			})
+		]
 	}
 ];

--- a/tests/rspack-test/configCases/worker/self-import/test.filter.js
+++ b/tests/rspack-test/configCases/worker/self-import/test.filter.js
@@ -1,2 +1,0 @@
-// Missing warning `This prevents using hashes of each other and should be avoided`
-module.exports = () => "FIXME: missing warning"


### PR DESCRIPTION
## Summary

support `new Worker(new URL(import.meta.url))` and `new Worker(import.meta.url)`

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
