### PR TITLE
fix: should rename global in node

### DIFF
--- a/tests/rspack-test/configCases/web/node-source-global/test.filter.js
+++ b/tests/rspack-test/configCases/web/node-source-global/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "FIXME: expect 'test' but got undefined"


### PR DESCRIPTION
## Summary

Should rename global variable to `__webpack_require__.g` in node. Align with [webapck](https://github.com/webpack/webpack/blob/main/lib/NodeStuffPlugin.js#L108-L113).

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
