### PR TITLE
fix: should add file dependencies in `loaderContext.resolve`

### DIFF
--- a/crates/rspack_binding_api/src/resolver.rs
+++ b/crates/rspack_binding_api/src/resolver.rs
@@ -5,7 +5,7 @@ use napi::{
   bindgen_prelude::{Function, block_on},
 };
 use napi_derive::napi;
-use rspack_core::Resolver;
+use rspack_core::{ResolveContext, Resolver};
 use serde::Serialize;
 
 use crate::{error::ErrorCode, utils::callbackify};
@@ -18,6 +18,8 @@ pub struct ResolveRequest {
   pub fragment: String,
   pub description_file_data: Option<serde_json::Value>,
   pub description_file_path: Option<String>,
+  pub file_dependencies: Vec<String>,
+  pub missing_dependencies: Vec<String>,
 }
 
 impl From<rspack_core::Resource> for ResolveRequest {
@@ -30,6 +32,8 @@ impl From<rspack_core::Resource> for ResolveRequest {
       fragment: value.fragment,
       description_file_data: description_file_data.map(std::sync::Arc::unwrap_or_clone),
       description_file_path: description_file_path.map(|path| path.to_string_lossy().into_owned()),
+      file_dependencies: vec![],
+      missing_dependencies: vec![],
     }
   }
 }
@@ -71,9 +75,23 @@ impl JsResolver {
     callbackify(
       f,
       async move {
-        match resolver.resolve(Path::new(&path), &request).await {
+        let mut resolve_context = ResolveContext::default();
+        match resolver
+          .resolve_with_context(Path::new(&path), &request, &mut resolve_context)
+          .await
+        {
           Ok(rspack_core::ResolveResult::Resource(resource)) => {
-            let resolve_request = ResolveRequest::from(resource);
+            let mut resolve_request = ResolveRequest::from(resource);
+            resolve_request.file_dependencies = resolve_context
+              .file_dependencies
+              .drain()
+              .map(|path| path.to_string_lossy().into_owned())
+              .collect();
+            resolve_request.missing_dependencies = resolve_context
+              .missing_dependencies
+              .drain()
+              .map(|path| path.to_string_lossy().into_owned())
+              .collect();
             Ok(match serde_json::to_string(&resolve_request) {
               Ok(json) => Either::<String, ()>::A(json),
               Err(_) => Either::B(()),

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -19,7 +19,7 @@ use sugar_path::SugarPath;
 
 pub use self::{
   factory::{ResolveOptionsWithDependencyType, ResolverFactory},
-  resolver_impl::{ResolveInnerError, ResolveInnerOptions, Resolver},
+  resolver_impl::{ResolveContext, ResolveInnerError, ResolveInnerOptions, Resolver},
 };
 use crate::{
   Context, DependencyCategory, DependencyRange, DependencyType, ModuleIdentifier, Resolve,

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -6092,7 +6092,17 @@ export type ResolveAlias = {
 type ResolveCallback = (err: null | ErrorWithDetails, res?: string | false, req?: ResolveRequest) => void;
 
 // @public (undocumented)
-type ResolveContext = {};
+type ResolveContext = {
+    contextDependencies?: {
+        add: (context: string) => void;
+    };
+    missingDependencies?: {
+        add: (dependency: string) => void;
+    };
+    fileDependencies?: {
+        add: (dependency: string) => void;
+    };
+};
 
 // @public (undocumented)
 export type ResolveData = binding.JsResolveData;
@@ -6141,11 +6151,17 @@ class Resolver {
 // @public (undocumented)
 interface ResolveRequest {
     // (undocumented)
+    contextDependencies?: string[];
+    // (undocumented)
     descriptionFileData?: string;
     // (undocumented)
     descriptionFilePath?: string;
     // (undocumented)
+    fileDependencies?: string[];
+    // (undocumented)
     fragment: string;
+    // (undocumented)
+    missingDependencies?: string[];
     // (undocumented)
     path: string;
     // (undocumented)

--- a/packages/rspack/src/Resolver.ts
+++ b/packages/rspack/src/Resolver.ts
@@ -1,7 +1,17 @@
 import type binding from "@rspack/binding";
 import type { ResolveCallback } from "./config/adapterRuleUse";
 
-type ResolveContext = {};
+export type ResolveContext = {
+	contextDependencies?: {
+		add: (context: string) => void;
+	};
+	missingDependencies?: {
+		add: (dependency: string) => void;
+	};
+	fileDependencies?: {
+		add: (dependency: string) => void;
+	};
+};
 
 export type ResourceData = binding.JsResourceData;
 
@@ -30,6 +40,9 @@ export interface ResolveRequest {
 	fragment: string;
 	descriptionFileData?: string;
 	descriptionFilePath?: string;
+	fileDependencies?: string[];
+	missingDependencies?: string[];
+	contextDependencies?: string[];
 }
 
 export class Resolver {
@@ -56,6 +69,19 @@ export class Resolver {
 				return;
 			}
 			const req = text ? (JSON.parse(text) as ResolveRequest) : undefined;
+
+			if (req?.fileDependencies) {
+				req.fileDependencies.forEach(file => {
+					resolveContext.fileDependencies?.add(file);
+				});
+			}
+
+			if (req?.missingDependencies) {
+				req.missingDependencies.forEach(missing => {
+					resolveContext.missingDependencies?.add(missing);
+				});
+			}
+
 			callback(
 				error,
 				req

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -33,6 +33,7 @@ import {
 	type LoaderContext
 } from "../config/adapterRuleUse";
 import { NormalModule } from "../NormalModule";
+import type { ResolveContext } from "../Resolver";
 import { NonErrorEmittedError, type RspackError } from "../RspackError";
 import { JavaScriptTracer } from "../trace";
 import {
@@ -518,24 +519,21 @@ export async function runLoaders(
 	const getResolveContext = () => {
 		return {
 			fileDependencies: {
-				// @ts-expect-error: Mocking insert-only `Set<T>`
 				add: d => {
 					loaderContext.addDependency(d);
 				}
 			},
 			contextDependencies: {
-				// @ts-expect-error: Mocking insert-only `Set<T>`
 				add: d => {
 					loaderContext.addContextDependency(d);
 				}
 			},
 			missingDependencies: {
-				// @ts-expect-error: Mocking insert-only `Set<T>`
 				add: d => {
 					loaderContext.addMissingDependency(d);
 				}
 			}
-		};
+		} as ResolveContext;
 	};
 
 	const getResolver = memoize(() => {

--- a/tests/rspack-test/watchCases/resolve/in-loader/0/loader.js
+++ b/tests/rspack-test/watchCases/resolve/in-loader/0/loader.js
@@ -4,15 +4,11 @@ module.exports = function () {
 	this.resolve(this.context, "./file", (err, file) => {
 		if (err) return callback(err);
 		if (!file) return callback(new Error("Resolving failed"));
-		// TODO: add dependencies in loaderContext.resolve
-		this.addDependency(file);
-		this.addMissingDependency(file.replace(".js", ""));
 
 		this.fs.readFile(file, (err, result) => {
 			if (err) return callback(err);
 			callback(
 				null,
-				// `export default ${JSON.stringify(result.toString("utf-8").trim())};`
 				`export default ${JSON.stringify(result.toString("utf-8").trim())};`
 			);
 		});


### PR DESCRIPTION
## Summary

Should add file dependencies and missing dependencies when calling `loaderContext.resolve` in loaders. Otherwise the resolved file will not be watched and can not trigger rebuild.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
