### PR TITLE
chore: add RSPACK_DEBUG_MEMORY env to support debug allocator stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,6 +3504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c741844b1fbe0cfbae8dfeb73b5e5fdc95daf7be58bdd72afb3fd85c86bccdb"
 dependencies = [
  "cc",
+ "cty",
  "libc",
 ]
 
@@ -3506,6 +3513,7 @@ name = "rspack_allocator"
 version = "0.6.1"
 dependencies = [
  "mimalloc-rspack",
+ "rspack-libmimalloc-sys",
  "sftrace-setup",
  "tracy-client",
  "tracy-client-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ itertools = { version = "0.14.0", default-features = false, features = ["use_std
 itoa = { version = "1.0.14", default-features = false }
 json = { version = "0.12.4", default-features = false }
 jsonc-parser = { version = "0.26.2", default-features = false, features = ["serde"] }
-libmimalloc-sys = { version = "*", default-features = false, features = [
+libmimalloc-sys = { version = "0.2.4", default-features = false, features = [
   "extended",
   "v3",
 ], package = "rspack-libmimalloc-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,103 +16,107 @@ version       = "0.6.1"
 [workspace.metadata.cargo-shear]
 ignored = ["swc", "rspack"]
 [workspace.dependencies]
-aho-corasick        = { version = "1.1.3", default-features = false }
-anyhow              = { version = "1.0.95", default-features = false, features = ["backtrace", "std"] }
-anymap              = { package = "anymap3", version = "1.0.1", default-features = false, features = ["std"] }
-async-recursion     = { version = "1.1.1", default-features = false }
-async-trait         = { version = "0.1.84", default-features = false }
-atomic_refcell      = { version = "0.1.13", default-features = false }
-base64              = { version = "0.22.1", default-features = false }
-base64-simd         = { version = "0.8.0", default-features = false, features = ["alloc"] }
-bitflags            = { version = "2.9.1", default-features = false }
-browserslist-rs     = { version = "0.19.0", default-features = false }
-bytes               = { version = "1.10.0", default-features = false }
-camino              = { version = "1.2.1", default-features = false }
-cargo_toml          = { version = "0.21.0", default-features = false }
-cfg-if              = { version = "1.0.1", default-features = false }
-clap                = { version = "4.5.41", default-features = false }
-color-backtrace     = { version = "0.7.0", default-features = false, features = ["use-backtrace-crate"] }
-concat-string       = { version = "1.0.1", default-features = false }
-cow-utils           = { version = "0.1.3", default-features = false }
-criterion2          = { default-features = false, version = "2.0.0", features = ["async_tokio"] }
-css-module-lexer    = { version = "0.0.15", default-features = false }
-dashmap             = { version = "6.1.0", default-features = false }
-derive_more         = { version = "2.0.1", default-features = false }
-dunce               = { version = "1.0.5", default-features = false }
-dyn-clone           = { version = "1.0.17", default-features = false }
-either              = { version = "1.15.0", default-features = false }
-enum-tag            = { version = "0.3.0", default-features = false }
-fast-glob           = { version = "0.4.4", default-features = false }
-futures             = { version = "0.3.31", default-features = false, features = ["std"] }
-glob                = { version = "0.3.2", default-features = false }
-hashlink            = { version = "0.10.0", default-features = false }
-heck                = { version = "0.5.0", default-features = false }
-hex                 = { version = "0.4.3", default-features = false, features = ["std"] }
-indexmap            = { version = "2.7.0", default-features = false }
-indicatif           = { version = "0.17.9", default-features = false }
-indoc               = { version = "2.0.5", default-features = false }
-insta               = { version = "1.42.0", default-features = false }
-itertools           = { version = "0.14.0", default-features = false, features = ["use_std"] }
-itoa                = { version = "1.0.14", default-features = false }
-json                = { version = "0.12.4", default-features = false }
-jsonc-parser        = { version = "0.26.2", default-features = false, features = ["serde"] }
-lightningcss        = { version = "1.0.0-alpha.68", default-features = false, features = ["serde"] }
-linked_hash_set     = { version = "0.1.5", default-features = false }
-md4                 = { version = "0.10.2", default-features = false }
-memchr              = { version = "2.7.5", default-features = false }
+aho-corasick = { version = "1.1.3", default-features = false }
+anyhow = { version = "1.0.95", default-features = false, features = ["backtrace", "std"] }
+anymap = { package = "anymap3", version = "1.0.1", default-features = false, features = ["std"] }
+async-recursion = { version = "1.1.1", default-features = false }
+async-trait = { version = "0.1.84", default-features = false }
+atomic_refcell = { version = "0.1.13", default-features = false }
+base64 = { version = "0.22.1", default-features = false }
+base64-simd = { version = "0.8.0", default-features = false, features = ["alloc"] }
+bitflags = { version = "2.9.1", default-features = false }
+browserslist-rs = { version = "0.19.0", default-features = false }
+bytes = { version = "1.10.0", default-features = false }
+camino = { version = "1.2.1", default-features = false }
+cargo_toml = { version = "0.21.0", default-features = false }
+cfg-if = { version = "1.0.1", default-features = false }
+clap = { version = "4.5.41", default-features = false }
+color-backtrace = { version = "0.7.0", default-features = false, features = ["use-backtrace-crate"] }
+concat-string = { version = "1.0.1", default-features = false }
+cow-utils = { version = "0.1.3", default-features = false }
+criterion2 = { default-features = false, version = "2.0.0", features = ["async_tokio"] }
+css-module-lexer = { version = "0.0.15", default-features = false }
+dashmap = { version = "6.1.0", default-features = false }
+derive_more = { version = "2.0.1", default-features = false }
+dunce = { version = "1.0.5", default-features = false }
+dyn-clone = { version = "1.0.17", default-features = false }
+either = { version = "1.15.0", default-features = false }
+enum-tag = { version = "0.3.0", default-features = false }
+fast-glob = { version = "0.4.4", default-features = false }
+futures = { version = "0.3.31", default-features = false, features = ["std"] }
+glob = { version = "0.3.2", default-features = false }
+hashlink = { version = "0.10.0", default-features = false }
+heck = { version = "0.5.0", default-features = false }
+hex = { version = "0.4.3", default-features = false, features = ["std"] }
+indexmap = { version = "2.7.0", default-features = false }
+indicatif = { version = "0.17.9", default-features = false }
+indoc = { version = "2.0.5", default-features = false }
+insta = { version = "1.42.0", default-features = false }
+itertools = { version = "0.14.0", default-features = false, features = ["use_std"] }
+itoa = { version = "1.0.14", default-features = false }
+json = { version = "0.12.4", default-features = false }
+jsonc-parser = { version = "0.26.2", default-features = false, features = ["serde"] }
+libmimalloc-sys = { version = "*", default-features = false, features = [
+  "extended",
+  "v3",
+], package = "rspack-libmimalloc-sys" }
+lightningcss = { version = "1.0.0-alpha.68", default-features = false, features = ["serde"] }
+linked_hash_set = { version = "0.1.5", default-features = false }
+md4 = { version = "0.10.2", default-features = false }
+memchr = { version = "2.7.5", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
-miette              = { version = "7.5.0", default-features = false }
-mimalloc            = { version = "0.2.4", package = "mimalloc-rspack", default-features = false }
-mime_guess          = { version = "2.0.5", default-features = false, features = ["rev-mappings"] }
-notify              = { version = "8.2.0", default-features = false }
-num-bigint          = { version = "0.4.6", default-features = false }
-once_cell           = { version = "1.20.2", default-features = false }
-oneshot             = { version = "0.1.8", default-features = false, features = ["std", "async"] }
-owo-colors          = { version = "4.0.0", default-features = false }
-parcel_sourcemap    = { version = "2.1.1", default-features = false }
-paste               = { version = "1.0.15", default-features = false }
-path-clean          = { version = "1.0.1", default-features = false }
-pathdiff            = { version = "0.2.3", default-features = false }
-pretty_assertions   = { version = "1.4.1", default-features = false, features = ["std"] }
-proc-macro2         = { version = "1.0.92", default-features = false }
-prost               = { version = "0.13", default-features = false }
-quote               = { version = "1.0.38", default-features = false }
-rayon               = { version = "1.10.0", default-features = false }
-regex               = { version = "1.12.2", default-features = false }
-regex-syntax        = { version = "0.8.5", default-features = false, features = ["std"] }
-regress             = { version = "0.10.4", default-features = false, features = ["pattern"] }
-ropey               = { version = "1.6.1", default-features = false }
-rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.4", default-features = false }
-rspack_sources      = { version = "=0.4.15", default-features = false }
-rustc-hash          = { version = "2.1.0", default-features = false }
-ryu-js              = { version = "1.0.2", default-features = false }
-scopeguard          = { version = "1.2.0", default-features = false }
-serde               = { version = "1.0.225", default-features = false, features = ["derive"] }
-serde_json          = { version = "1.0.145", default-features = false, features = ["std"] }
-sftrace-setup       = { version = "0.1.0", default-features = false }
-sha2                = { version = "0.10.8", default-features = false }
-signal-hook         = { version = "0.3.18", default-features = false, features = ["iterator"] }
-simd-json           = { version = "0.14.3", default-features = false }
-smol_str            = { version = "0.3.0", default-features = false }
-stacker             = { version = "0.1.17", default-features = false }
-sugar_path          = { version = "1.2.0", default-features = false, features = ["cached_current_dir"] }
-syn                 = { version = "2.0.95", default-features = false }
-termcolor           = { version = "1.4.1", default-features = false }
-textwrap            = { version = "0.16.1", default-features = false }
-thread_local        = { version = "1.1.9", default-features = false }
-tokio               = { version = "1.48.0", default-features = false, features = ["rt", "rt-multi-thread"] }
-toml                = { version = "0.8.19", default-features = false, features = ["parse", "display"] }
-tracing             = { version = "0.1.41", default-features = false, features = ["max_level_trace", "release_max_level_trace"] }
-tracing-subscriber  = { version = "0.3.19", default-features = false, features = ["fmt", "registry"] }
-trybuild            = { version = "1.0.101", default-features = false, features = ["diff"] }
-unicase             = { version = "2.8.1", default-features = false }
-unicode-width       = { version = "0.2.0", default-features = false }
-url                 = { version = "2.5.4", default-features = false }
-urlencoding         = { version = "2.1.3", default-features = false }
-ustr                = { package = "ustr-fxhash", version = "1.0.1", default-features = false }
-wasmparser          = { version = "0.222.0", default-features = false }
-winnow              = { version = "0.7.12", default-features = false, features = ["std", "simd"] }
-xxhash-rust         = { version = "0.8.14", default-features = false }
+miette = { version = "7.5.0", default-features = false }
+mimalloc = { version = "0.2.4", package = "mimalloc-rspack", default-features = false }
+mime_guess = { version = "2.0.5", default-features = false, features = ["rev-mappings"] }
+notify = { version = "8.2.0", default-features = false }
+num-bigint = { version = "0.4.6", default-features = false }
+once_cell = { version = "1.20.2", default-features = false }
+oneshot = { version = "0.1.8", default-features = false, features = ["std", "async"] }
+owo-colors = { version = "4.0.0", default-features = false }
+parcel_sourcemap = { version = "2.1.1", default-features = false }
+paste = { version = "1.0.15", default-features = false }
+path-clean = { version = "1.0.1", default-features = false }
+pathdiff = { version = "0.2.3", default-features = false }
+pretty_assertions = { version = "1.4.1", default-features = false, features = ["std"] }
+proc-macro2 = { version = "1.0.92", default-features = false }
+prost = { version = "0.13", default-features = false }
+quote = { version = "1.0.38", default-features = false }
+rayon = { version = "1.10.0", default-features = false }
+regex = { version = "1.12.2", default-features = false }
+regex-syntax = { version = "0.8.5", default-features = false, features = ["std"] }
+regress = { version = "0.10.4", default-features = false, features = ["pattern"] }
+ropey = { version = "1.6.1", default-features = false }
+rspack_resolver = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.4", default-features = false }
+rspack_sources = { version = "=0.4.15", default-features = false }
+rustc-hash = { version = "2.1.0", default-features = false }
+ryu-js = { version = "1.0.2", default-features = false }
+scopeguard = { version = "1.2.0", default-features = false }
+serde = { version = "1.0.225", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.145", default-features = false, features = ["std"] }
+sftrace-setup = { version = "0.1.0", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
+signal-hook = { version = "0.3.18", default-features = false, features = ["iterator"] }
+simd-json = { version = "0.14.3", default-features = false }
+smol_str = { version = "0.3.0", default-features = false }
+stacker = { version = "0.1.17", default-features = false }
+sugar_path = { version = "1.2.0", default-features = false, features = ["cached_current_dir"] }
+syn = { version = "2.0.95", default-features = false }
+termcolor = { version = "1.4.1", default-features = false }
+textwrap = { version = "0.16.1", default-features = false }
+thread_local = { version = "1.1.9", default-features = false }
+tokio = { version = "1.48.0", default-features = false, features = ["rt", "rt-multi-thread"] }
+toml = { version = "0.8.19", default-features = false, features = ["parse", "display"] }
+tracing = { version = "0.1.41", default-features = false, features = ["max_level_trace", "release_max_level_trace"] }
+tracing-subscriber = { version = "0.3.19", default-features = false, features = ["fmt", "registry"] }
+trybuild = { version = "1.0.101", default-features = false, features = ["diff"] }
+unicase = { version = "2.8.1", default-features = false }
+unicode-width = { version = "0.2.0", default-features = false }
+url = { version = "2.5.4", default-features = false }
+urlencoding = { version = "2.1.3", default-features = false }
+ustr = { package = "ustr-fxhash", version = "1.0.1", default-features = false }
+wasmparser = { version = "0.222.0", default-features = false }
+winnow = { version = "0.7.12", default-features = false, features = ["std", "simd"] }
+xxhash-rust = { version = "0.8.14", default-features = false }
 
 allocative = { package = "rspack-allocative", version = "0.3.5", default-features = false, features = [
   "camino",

--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -15,13 +15,17 @@ tracy-client-sys = { version = "=0.26.0" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Turned on `local_dynamic_tls` to avoid issue: https://github.com/microsoft/mimalloc/issues/147
-mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
+libmimalloc-sys = { workspace = true, features = ["extended"] }
+mimalloc        = { workspace = true, features = ["local_dynamic_tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+libmimalloc-sys = { workspace = true, features = ["extended"] }
+mimalloc        = { workspace = true, features = ["v3"] }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
 mimalloc = { workspace = true }
 
 [package.metadata.cargo-shear]
-ignored = ["tracy-client-sys"]
+ignored         = ["tracy-client-sys"]
+libmimalloc-sys = { workspace = true, features = ["extended"] }
+mimalloc        = { workspace = true }

--- a/crates/rspack_allocator/src/lib.rs
+++ b/crates/rspack_allocator/src/lib.rs
@@ -14,3 +14,10 @@ static GLOBAL: sftrace_setup::SftraceAllocator<mimalloc::MiMalloc> =
 #[cfg(all(feature = "tracy-client", not(feature = "sftrace-setup")))]
 static GLOBAL: tracy_client::ProfiledAllocator<std::alloc::System> =
   tracy_client::ProfiledAllocator::new(std::alloc::System, 10); // adjust callstack_depth if needed with performance cost
+pub fn print_memory_stats() {
+  #[cfg(not(any(miri, target_family = "wasm")))]
+  #[cfg(not(feature = "sftrace-setup"))]
+  unsafe {
+    libmimalloc_sys::mi_stats_print(std::ptr::null_mut());
+  }
+}

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -62,13 +62,14 @@ napi-derive = { workspace = true, features = ["compat-mode"] }
 
 color-backtrace = { workspace = true, optional = true }
 
-derive_more                            = { workspace = true, features = ["debug"] }
-futures                                = { workspace = true }
-glob                                   = { workspace = true }
-heck                                   = { workspace = true }
-once_cell                              = { workspace = true }
-rayon                                  = { workspace = true }
-regex                                  = { workspace = true }
+derive_more = { workspace = true, features = ["debug"] }
+futures     = { workspace = true }
+glob        = { workspace = true }
+heck        = { workspace = true }
+once_cell   = { workspace = true }
+rayon       = { workspace = true }
+regex       = { workspace = true }
+
 rspack_browser                         = { workspace = true, optional = true }
 rspack_cacheable                       = { workspace = true }
 rspack_ids                             = { workspace = true }
@@ -127,7 +128,6 @@ serde_json                             = { workspace = true }
 swc_core                               = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
 tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot"] }
 ustr                                   = { workspace = true }
-
 [package.metadata.cargo-shear]
 ignored = ["parking_lot", "rspack_tracing_perfetto"]
 

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -114,6 +114,7 @@ use rspack_core::{
 use rspack_error::Diagnostic;
 use rspack_fs::{IntermediateFileSystem, NativeFileSystem, ReadableFileSystem};
 use rspack_tasks::{CURRENT_COMPILER_CONTEXT, CompilerContext, within_compiler_context_sync};
+use rspack_util::env::should_debug_memory;
 use rustc_hash::FxHashMap;
 use swc_core::common::util::take::Take;
 
@@ -345,6 +346,10 @@ impl JsCompiler {
             compiler.build().await.to_napi_result_with_message(|e| {
               print_error_diagnostic(e, compiler.options.stats.colors)
             })?;
+            if (should_debug_memory()) {
+              rspack_allocator::print_memory_stats();
+            }
+
             tracing::debug!("build ok");
             Ok(())
           },
@@ -381,6 +386,9 @@ impl JsCompiler {
               .to_napi_result_with_message(|e| {
                 print_error_diagnostic(e, compiler.options.stats.colors)
               })?;
+            if (should_debug_memory()) {
+              rspack_allocator::print_memory_stats();
+            }
             tracing::debug!("rebuild ok");
             Ok(())
           },

--- a/crates/rspack_util/src/env.rs
+++ b/crates/rspack_util/src/env.rs
@@ -7,3 +7,11 @@ static RSPACK_QUERY: LazyLock<Option<String>> =
 pub fn has_query() -> bool {
   RSPACK_QUERY.is_some()
 }
+
+// debug memory statistics
+static RSPACK_DEBUG_MEMORY: LazyLock<Option<String>> =
+  LazyLock::new(|| std::env::var("RSPACK_DEBUG_MEMORY").ok());
+
+pub fn should_debug_memory() -> bool {
+  RSPACK_DEBUG_MEMORY.is_some()
+}


### PR DESCRIPTION
## Summary
support debug mimalloc stats by RSPACK_DEBUG_MEMORY env
<img width="1658" height="974" alt="image" src="https://github.com/user-attachments/assets/034e6205-ef6f-4df9-ad12-b6db413ac3bd" />

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
