### PR TITLE
fix: use real resource when export from external

### DIFF
--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -294,6 +294,13 @@ impl ExternalModule {
     &self.external_type
   }
 
+  pub fn get_request(&self) -> &ExternalRequestValue {
+    match &self.request {
+      ExternalRequest::Single(request) => request,
+      ExternalRequest::Map(map) => &map[&self.external_type],
+    }
+  }
+
   fn get_request_and_external_type(&self) -> (Option<&ExternalRequestValue>, &ExternalType) {
     match &self.request {
       ExternalRequest::Single(request) => (Some(request), &self.external_type),

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1115,24 +1115,25 @@ impl EsmLibraryPlugin {
     current_chunk: ChunkUkey,
     mode: &ExportMode,
     link: &mut UkeyMap<ChunkUkey, ChunkLinkContext>,
-    export_dep: &ESMExportImportedSpecifierDependency,
   ) {
     match mode {
       // render export * from 'external module'
       ExportMode::DynamicReexport(_) | ExportMode::EmptyStar(_) => {
         let chunk_link = link.get_mut_unwrap(&current_chunk);
+
         chunk_link
           .raw_star_exports
-          .entry(export_dep.request.to_string())
+          .entry(module.get_request().primary().into())
           .or_default()
           .insert(START_EXPORTS.clone());
       }
 
       ExportMode::Unused(mode) if mode.name == "*" => {
         let chunk_link = link.get_mut_unwrap(&current_chunk);
+
         chunk_link
           .raw_star_exports
-          .entry(export_dep.request.to_string())
+          .entry(module.get_request().primary().into())
           .or_default()
           .insert(START_EXPORTS.clone());
       }
@@ -1145,7 +1146,7 @@ impl EsmLibraryPlugin {
       ExportMode::ReexportDynamicDefault(_) => {
         let chunk_link = link.get_mut_unwrap(&current_chunk);
         chunk_link.add_re_export_from_request(
-          module.user_request().to_string(),
+          module.get_request().primary().into(),
           JS_DEFAULT_KEYWORD.clone(),
           JS_DEFAULT_KEYWORD.clone(),
         );
@@ -1153,7 +1154,7 @@ impl EsmLibraryPlugin {
       ExportMode::ReexportNamedDefault(mode) => {
         let chunk_link = link.get_mut_unwrap(&current_chunk);
         chunk_link.add_re_export_from_request(
-          module.user_request().to_string(),
+          module.get_request().primary().into(),
           JS_DEFAULT_KEYWORD.clone(),
           mode.name.clone(),
         );
@@ -1162,7 +1163,7 @@ impl EsmLibraryPlugin {
         let chunk_link = link.get_mut_unwrap(&current_chunk);
         chunk_link
           .raw_star_exports
-          .entry(module.user_request().to_string())
+          .entry(module.get_request().primary().into())
           .or_default()
           .insert(mode.name.clone());
       }
@@ -1170,7 +1171,7 @@ impl EsmLibraryPlugin {
         let chunk_link = link.get_mut_unwrap(&current_chunk);
         chunk_link
           .raw_star_exports
-          .entry(module.user_request().to_string())
+          .entry(module.get_request().primary().into())
           .or_default()
           .insert(mode.name.clone());
       }
@@ -1178,7 +1179,7 @@ impl EsmLibraryPlugin {
         let chunk_link = link.get_mut_unwrap(&current_chunk);
         for item in &normal.items {
           chunk_link.add_re_export_from_request(
-            module.user_request().into(),
+            module.get_request().primary().into(),
             item.ids.first().unwrap_or(&item.name).clone(),
             item.name.clone(),
           );
@@ -1262,13 +1263,7 @@ impl EsmLibraryPlugin {
             "module-import" | "module"
           )
         {
-          Self::re_export_from_external_module(
-            external_module,
-            current_chunk,
-            &re_exports,
-            link,
-            export_dep,
-          );
+          Self::re_export_from_external_module(external_module, current_chunk, &re_exports, link);
           continue;
         }
 
@@ -1502,7 +1497,6 @@ impl EsmLibraryPlugin {
                   current_chunk,
                   &rspack_core::ExportMode::NormalReexport(mode.clone()),
                   link,
-                  export_dep,
                 );
                 continue;
               }

--- a/tests/rspack-test/esmOutputCases/externals/aliased/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/aliased/__snapshots__/esm.snap.txt
@@ -1,0 +1,18 @@
+```mjs title=main.mjs
+import { createRequire as __WEBPACK_EXTERNAL_createRequire } from "node:module";
+const __WEBPACK_EXTERNAL_createRequire_require = __WEBPACK_EXTERNAL_createRequire(import.meta.url);
+// external
+
+// ./index.js
+
+
+it('should have correct exports', async () => {
+  const { resolve } = await import(/*webpackIgnore: true*/'./main.mjs')
+
+	const { resolve: nodeResolve } = __WEBPACK_EXTERNAL_createRequire_require('path')
+	expect(resolve).toBe(nodeResolve)
+});
+
+export * from "path";
+
+```

--- a/tests/rspack-test/esmOutputCases/externals/aliased/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/aliased/index.js
@@ -1,0 +1,8 @@
+export * from 'external'
+
+it('should have correct exports', async () => {
+  const { resolve } = await import(/*webpackIgnore: true*/'./main.mjs')
+
+	const { resolve: nodeResolve } = __non_webpack_require__('path')
+	expect(resolve).toBe(nodeResolve)
+});

--- a/tests/rspack-test/esmOutputCases/externals/aliased/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/aliased/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	externals: {
+		'external': 'module path'
+	}
+}


### PR DESCRIPTION
## Summary

Use real resource when we are exporting from an external module instead of raw user request.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
