### PR TITLE
test: rename `toMatchFileSnapshot` to `toMatchFileSnapshotSync`

### DIFF
--- a/packages/rspack-test-tools/jest.d.ts
+++ b/packages/rspack-test-tools/jest.d.ts
@@ -9,14 +9,14 @@ declare interface FileMatcherOptions {
 declare global {
 	namespace jest {
 		interface Matchers<R, T> {
-			toMatchFileSnapshot: (
+			toMatchFileSnapshotSync: (
 				filename?: string,
 				options?: FileMatcherOptions
 			) => void;
 		}
 
 		interface Expect {
-			toMatchFileSnapshot: (
+			toMatchFileSnapshotSync: (
 				filename?: string,
 				options?: FileMatcherOptions
 			) => void;

--- a/packages/rspack-test-tools/src/case/common.ts
+++ b/packages/rspack-test-tools/src/case/common.ts
@@ -267,7 +267,7 @@ export async function checkSnapshot(
 					path.join("__snapshots__", `${snapshot}${total > 1 ? `-${i}` : ""}`)
 				);
 
-		env.expect(content).toMatchFileSnapshot(snapshotPath);
+		env.expect(content).toMatchFileSnapshotSync(snapshotPath);
 	}
 }
 

--- a/packages/rspack-test-tools/src/case/diagnostic.ts
+++ b/packages/rspack-test-tools/src/case/diagnostic.ts
@@ -157,7 +157,7 @@ async function check(
 	const warningStatsOutputPath = path.resolve(
 		context.getSource(options.snapshotWarning)
 	);
-	env.expect(output).toMatchFileSnapshot(errorOutputPath);
-	env.expect(errors).toMatchFileSnapshot(errorStatsOutputPath);
-	env.expect(warnings).toMatchFileSnapshot(warningStatsOutputPath);
+	env.expect(output).toMatchFileSnapshotSync(errorOutputPath);
+	env.expect(errors).toMatchFileSnapshotSync(errorStatsOutputPath);
+	env.expect(warnings).toMatchFileSnapshotSync(warningStatsOutputPath);
 }

--- a/packages/rspack-test-tools/src/case/hook.ts
+++ b/packages/rspack-test-tools/src/case/hook.ts
@@ -239,7 +239,7 @@ export class HookCasesContext extends TestContext {
 		}, "");
 		env
 			.expect(snapshots)
-			.toMatchFileSnapshot(path.join(this.src, "hooks.snap.txt"), options);
+			.toMatchFileSnapshotSync(path.join(this.src, "hooks.snap.txt"), options);
 	}
 }
 

--- a/packages/rspack-test-tools/src/case/hot-step.ts
+++ b/packages/rspack-test-tools/src/case/hot-step.ts
@@ -311,7 +311,7 @@ ${runtime.javascript.disposedModules.map(i => `- ${i}`).join("\n")}
 			})
 			.trim();
 
-		env.expect(content).toMatchFileSnapshot(snapshotPath);
+		env.expect(content).toMatchFileSnapshotSync(snapshotPath);
 	}
 
 	const originRun = processor.run;

--- a/packages/rspack-test-tools/src/case/stats-output.ts
+++ b/packages/rspack-test-tools/src/case/stats-output.ts
@@ -214,7 +214,7 @@ async function check(
 		? snapshot
 		: path.resolve(context.getSource(), `./__snapshots__/${snapshot}`);
 
-	env.expect(new RspackStats(actual)).toMatchFileSnapshot(snapshotPath);
+	env.expect(new RspackStats(actual)).toMatchFileSnapshotSync(snapshotPath);
 
 	const testConfig = context.getTestConfig();
 	if (typeof testConfig?.validate === "function") {

--- a/packages/rspack-test-tools/src/helper/expect/to-match-file-snapshot.ts
+++ b/packages/rspack-test-tools/src/helper/expect/to-match-file-snapshot.ts
@@ -31,7 +31,7 @@ const isEqual = (a: string | Buffer, b: string | Buffer): boolean => {
  * @param filepath Path to the file to match against
  * @param options Additional options for matching
  */
-export function toMatchFileSnapshot(
+export function toMatchFileSnapshotSync(
 	this: {
 		testPath: string;
 		currentTestName: string;

--- a/packages/rspack-test-tools/src/helper/setup-expect.ts
+++ b/packages/rspack-test-tools/src/helper/setup-expect.ts
@@ -1,12 +1,12 @@
 import { toBeTypeOf } from "./expect/to-be-typeof";
 import { toEndWith } from "./expect/to-end-with";
-import { toMatchFileSnapshot } from "./expect/to-match-file-snapshot";
+import { toMatchFileSnapshotSync } from "./expect/to-match-file-snapshot";
 import { serializers } from "./serializers";
 
 expect.extend({
 	// CHANGE: new test matcher for `rspack-test-tools`
 	// @ts-expect-error
-	toMatchFileSnapshot,
+	toMatchFileSnapshotSync,
 	toBeTypeOf,
 	toEndWith
 });

--- a/packages/rspack-test-tools/src/helper/setup-wasm.ts
+++ b/packages/rspack-test-tools/src/helper/setup-wasm.ts
@@ -10,12 +10,12 @@ function toMatchInlineSnapshot() {
 	return { pass: true, message: () => "" };
 }
 
-function toMatchFileSnapshot() {
+function toMatchFileSnapshotSync() {
 	return { pass: true, message: () => "" };
 }
 
 expect.extend({
 	toMatchSnapshot,
 	toMatchInlineSnapshot,
-	toMatchFileSnapshot
+	toMatchFileSnapshotSync
 });

--- a/tests/rspack-test/configCases/build-http/css/index.js
+++ b/tests/rspack-test/configCases/build-http/css/index.js
@@ -10,5 +10,5 @@ it(`should work with URLs in CSS`, async () => {
 		css.push(getLinkSheet(link));
 	}
 
-	expect(css).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/basic-include/index.js
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/basic-include/index.js
@@ -7,5 +7,5 @@ it("should transform css correct", () => {
 	expect(styles).toHaveProperty('used');
 	expect('unused' in styles).toBeFalsy();
 
-	expect(fs.readFileSync(path.resolve(__dirname, './bundle0.css')).toString()).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'bundle0.css.txt'))
+	expect(fs.readFileSync(path.resolve(__dirname, './bundle0.css')).toString()).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'bundle0.css.txt'))
 });

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/minify/index.js
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/minify/index.js
@@ -9,5 +9,5 @@ it("css content minifyed", () => {
 		"utf-8"
 	);
 
-	expect(css.toString()).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'bundle0.css.txt'))
+	expect(css.toString()).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'bundle0.css.txt'))
 });

--- a/tests/rspack-test/configCases/builtins/css-auto/index.js
+++ b/tests/rspack-test/configCases/builtins/css-auto/index.js
@@ -3,7 +3,7 @@ const path = __non_webpack_require__("path");
 
 it("css/auto can handle css module correctly", () => {
 	const style = require("./index.module.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.module.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.module.css.txt'));
 });
 
 it("css/auto can handle css correctly", () => {

--- a/tests/rspack-test/configCases/builtins/css-modules-composes-preprocessers/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-composes-preprocessers/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules with css preprocessers", () => {
 	const style = require("./index.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-composes-sass/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-composes-sass/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules in scss", () => {
 	const style = require("./index.scss");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.scss.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.scss.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-composes/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-composes/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules composes", () => {
 	const style = require("./index.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-dedupe/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-dedupe/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules dedupe", () => {
 	const style = require("./source.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'source.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'source.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-exports-only/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-exports-only/index.js
@@ -4,5 +4,5 @@ const path = require("path");
 it("css modules exportsOnly", () => {
 	const style = require("./index.css");
 	expect(fs.existsSync(path.resolve(__dirname, "./main.css"))).toBe(false);
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-local-ident-name-hash/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-local-ident-name-hash/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules localIdentName with hash", () => {
 	const style = require("./index.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-local-ident-name-path/src/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-local-ident-name-path/src/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules localIdentName with path", () => {
 	const style = require("./index.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-locals-convention-camelCase/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-locals-convention-camelCase/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules localsConvention with camelCase", () => {
 	const style = require("./index.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-locals-convention-camelCaseOnly/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-locals-convention-camelCaseOnly/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules localsConvention with camelCaseOnly", () => {
 	const style = require("./index.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-locals-convention-dashes/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-locals-convention-dashes/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules localsConvention with dashes", () => {
 	const style = require("./index.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-pseudo/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-pseudo/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules pseudo syntax", () => {
 	const style = require("./index.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.css.txt'));
 });

--- a/tests/rspack-test/configCases/builtins/css-modules-simple/index.js
+++ b/tests/rspack-test/configCases/builtins/css-modules-simple/index.js
@@ -2,5 +2,5 @@ const path = __non_webpack_require__("path");
 
 it("css modules simple test", () => {
 	const style = require("./index.module.css");
-	expect(style).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'index.module.css.txt'));
+	expect(style).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'index.module.css.txt'));
 });

--- a/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/index.js
+++ b/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/index.js
@@ -15,5 +15,5 @@ it("should have stable chunkIds and chunk content", async () => {
 		snapshot += `${key}\n\n::\n\n${content}\n`;
 		snapshot += '==============================================================\n';
 	}
-	expect(snapshot).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'snapshot.txt'));
+	expect(snapshot).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'snapshot.txt'));
 })

--- a/tests/rspack-test/configCases/chunk-index/available-modules-order-index/main.js
+++ b/tests/rspack-test/configCases/chunk-index/available-modules-order-index/main.js
@@ -11,5 +11,5 @@ it("should compile", async () => {
 
 	expect(
 		fs.readFileSync(path.resolve(__dirname, "./shared.css")).toString()
-	).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'shared.css.txt'));
+	).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'shared.css.txt'));
 });

--- a/tests/rspack-test/configCases/css/at-import-in-the-top/index.js
+++ b/tests/rspack-test/configCases/css/at-import-in-the-top/index.js
@@ -9,5 +9,5 @@ it("at-import-in-the-top", async () => {
 		"utf-8"
 	);
 
-	expect(css).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
 });

--- a/tests/rspack-test/configCases/css/at-import/index.js
+++ b/tests/rspack-test/configCases/css/at-import/index.js
@@ -8,5 +8,5 @@ it("at-import-in-the-top", async () => {
 		"utf-8"
 	);
 
-	expect(css).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
 });

--- a/tests/rspack-test/configCases/css/css-modules-no-space/index.js
+++ b/tests/rspack-test/configCases/css/css-modules-no-space/index.js
@@ -10,7 +10,7 @@ it("should allow to create css modules", () => new Promise((resolve, reject) => 
 			const fs = __non_webpack_require__("fs");
 			const path = __non_webpack_require__("path");
 
-			expect(x).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'x.txt'));
+			expect(x).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'x.txt'));
 
 			const cssOutputFilename = "use-style_js.bundle0.css";
 
@@ -18,7 +18,7 @@ it("should allow to create css modules", () => new Promise((resolve, reject) => 
 				path.join(__dirname, cssOutputFilename),
 				"utf-8"
 			);
-			expect(cssContent).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'cssContent.txt'));
+			expect(cssContent).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'cssContent.txt'));
 		} catch (e) {
 			return done(e);
 		}

--- a/tests/rspack-test/configCases/css/css-order-concatenate-modules/index.js
+++ b/tests/rspack-test/configCases/css/css-order-concatenate-modules/index.js
@@ -8,7 +8,7 @@ it("keep consistent css order", function () {
 	const fs = __non_webpack_require__("fs");
 	const path = __non_webpack_require__("path");
 	let source = fs.readFileSync(__dirname + "/main.css", "utf-8");
-	expect(removeComments(source)).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'main.css.txt'))
+	expect(removeComments(source)).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'main.css.txt'))
 });
 
 function removeComments(source) {

--- a/tests/rspack-test/configCases/css/css-order-reexport/index.js
+++ b/tests/rspack-test/configCases/css/css-order-reexport/index.js
@@ -7,7 +7,7 @@ it("keep consistent css order", function () {
 	const fs = __non_webpack_require__("fs");
 	const path = __non_webpack_require__("path");
 	let source = fs.readFileSync(__dirname + "/main.css", "utf-8");
-	expect(removeComments(source)).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'main.css.txt'))
+	expect(removeComments(source)).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'main.css.txt'))
 });
 
 function removeComments(source) {

--- a/tests/rspack-test/configCases/css/css-order/index.js
+++ b/tests/rspack-test/configCases/css/css-order/index.js
@@ -8,7 +8,7 @@ it("keep consistent css order", function () {
 	const fs = __non_webpack_require__("fs");
 	const path = __non_webpack_require__("path");
 	let source = fs.readFileSync(__dirname + "/main.css", "utf-8");
-	expect(removeComments(source)).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'main.css.txt'))
+	expect(removeComments(source)).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'main.css.txt'))
 });
 
 function removeComments(source) {

--- a/tests/rspack-test/configCases/css/css-order2/index.js
+++ b/tests/rspack-test/configCases/css/css-order2/index.js
@@ -7,7 +7,7 @@ it("keep consistent css order", function () {
 	const fs = __non_webpack_require__("fs");
 	const path = __non_webpack_require__("path");
 	let source = fs.readFileSync(__dirname + "/main.css", "utf-8");
-	expect(removeComments(source)).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'main.css.txt'))
+	expect(removeComments(source)).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'main.css.txt'))
 });
 
 function removeComments(source) {

--- a/tests/rspack-test/configCases/css/css-order3/index.js
+++ b/tests/rspack-test/configCases/css/css-order3/index.js
@@ -7,7 +7,7 @@ it("keep consistent css order", function () {
 	const fs = __non_webpack_require__("fs");
 	const path = __non_webpack_require__("path");
 	let source = fs.readFileSync(__dirname + "/main.css", "utf-8");
-	expect(removeComments(source)).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'main.css.txt'))
+	expect(removeComments(source)).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'main.css.txt'))
 });
 
 function removeComments(source) {

--- a/tests/rspack-test/configCases/css/escape-unescape/index.js
+++ b/tests/rspack-test/configCases/css/escape-unescape/index.js
@@ -10,6 +10,6 @@ it(`should work with URLs in CSS`, () => {
 		css.push(getLinkSheet(link));
 	}
 
-	expect(css).toMatchFileSnapshot(path.join(__SNAPSHOT__, `css.${__STATS_I__}.txt`));
-	expect(styles).toMatchFileSnapshot(path.join(__SNAPSHOT__, `styles.${__STATS_I__}.txt`));
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, `css.${__STATS_I__}.txt`));
+	expect(styles).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, `styles.${__STATS_I__}.txt`));
 });

--- a/tests/rspack-test/configCases/css/export-selector/index.js
+++ b/tests/rspack-test/configCases/css/export-selector/index.js
@@ -3,7 +3,7 @@ const path = __non_webpack_require__('path')
 
 it('should have correct css result', async () => {
 	const css = await fs.promises.readFile(path.resolve(eval('__dirname'), './imported_js.bundle0.css'))
-	expect(css.toString()).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'imported_js.bundle0.css.txt'));
+	expect(css.toString()).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'imported_js.bundle0.css.txt'));
 })
 
 it("should allow to dynamic import a css module", async () => {

--- a/tests/rspack-test/configCases/css/import/index.js
+++ b/tests/rspack-test/configCases/css/import/index.js
@@ -10,5 +10,5 @@ it("should compile", () => {
 		css.push(getLinkSheet(link));
 	}
 
-	expect(css).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
 });

--- a/tests/rspack-test/configCases/css/no-extra-runtime-in-js/index.js
+++ b/tests/rspack-test/configCases/css/no-extra-runtime-in-js/index.js
@@ -10,7 +10,7 @@ it("should compile", () => {
 		css.push(getLinkSheet(link));
 	}
 
-	expect(css).toMatchFileSnapshot(path.join(__SNAPSHOT__, `css.txt`));
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, `css.txt`));
 	expect(Object.keys(__webpack_modules__).length).toBe(7);
 	expect(__webpack_modules__['./index.js']).toBeDefined();
 	expect(__webpack_modules__['./shared-external.png']).toBeDefined();

--- a/tests/rspack-test/configCases/css/pseudo-import/index.js
+++ b/tests/rspack-test/configCases/css/pseudo-import/index.js
@@ -10,7 +10,7 @@ it("should compile", () => {
 		css.push(getLinkSheet(link));
 	}
 
-	expect(css).toMatchFileSnapshot(path.join(__SNAPSHOT__, `css.txt`));
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, `css.txt`));
 });
 
 it("should re-export", async () => {

--- a/tests/rspack-test/configCases/css/pure-css/index.js
+++ b/tests/rspack-test/configCases/css/pure-css/index.js
@@ -10,5 +10,5 @@ it("should compile", () => {
 		css.push(getLinkSheet(link));
 	}
 
-	expect(css).toMatchFileSnapshot(path.join(__SNAPSHOT__, `css.txt`));
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, `css.txt`));
 });

--- a/tests/rspack-test/configCases/css/rewrite-url-css-variables/index.js
+++ b/tests/rspack-test/configCases/css/rewrite-url-css-variables/index.js
@@ -8,12 +8,12 @@ it("should rewrite the css url() in css variables", function () {
 	expect(a.startsWith("./")).toBe(false);
 	expect(a.includes("./logo.png")).toBe(false);
 	expect(a.endsWith(".png")).toBe(true);
-	expect(a).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'a.txt'));
+	expect(a).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'a.txt'));
 	const b = /--b: url\((.*)\);/.exec(css)[1];
 	expect(b.startsWith("./")).toBe(false);
 	expect(b.includes("./logo.png")).toBe(false);
 	expect(b.endsWith(".png")).toBe(true);
-	expect(b).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'b.txt'));
+	expect(b).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'b.txt'));
 	const c = /--c: (.*?);/.exec(css)[1];
 	expect(c).toBe(JSON.stringify(""));
 });

--- a/tests/rspack-test/configCases/css/rewrite-url-with-css-filename/index.js
+++ b/tests/rspack-test/configCases/css/rewrite-url-with-css-filename/index.js
@@ -9,7 +9,7 @@ it("should rewrite the css url() with publicPath when output.cssFilename is set"
 	expect(a.includes("./logo.png")).toBe(false);
 	expect(a.endsWith(".png")).toBe(true);
 	expect(a.startsWith("/")).toBe(true);
-	expect(a).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'a.txt'));
+	expect(a).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'a.txt'));
 });
 
 it("should rewrite the css url() with publicPath and ~@ prefix", function () {
@@ -19,5 +19,5 @@ it("should rewrite the css url() with publicPath and ~@ prefix", function () {
 	expect(b.includes("./logo.png")).toBe(false);
 	expect(b.endsWith(".png")).toBe(true);
 	expect(b.startsWith("/")).toBe(true);
-	expect(b).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'b.txt'));
+	expect(b).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'b.txt'));
 });

--- a/tests/rspack-test/configCases/css/rewrite-url/index.js
+++ b/tests/rspack-test/configCases/css/rewrite-url/index.js
@@ -8,9 +8,9 @@ it("should rewrite the css url()", function () {
 	expect(a.startsWith("./")).toBe(false);
 	expect(a.includes("./logo.png")).toBe(false);
 	expect(a.endsWith(".png")).toBe(true);
-	expect(a).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'a.txt'));
+	expect(a).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'a.txt'));
 	const b = /b: url\((.*)\);/.exec(css)[1];
-	expect(b).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'b.txt'));
+	expect(b).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'b.txt'));
 	const c = /c: url\((.*)\);/.exec(css)[1];
 	expect(c).toBe("#ccc");
 	const d = /d: url\((.*)\);/.exec(css)[1];

--- a/tests/rspack-test/configCases/css/urls/index.js
+++ b/tests/rspack-test/configCases/css/urls/index.js
@@ -7,5 +7,5 @@ it("css urls should works", async () => {
 		path.resolve(__dirname, "bundle.css"),
 		"utf-8"
 	);
-	expect(css).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'bundle.css.txt'));
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'bundle.css.txt'));
 });

--- a/tests/rspack-test/configCases/externals/reexport-star/index.js
+++ b/tests/rspack-test/configCases/externals/reexport-star/index.js
@@ -3,10 +3,10 @@ const path = require("path");
 const readCase = (name) => fs.readFileSync(path.resolve(__dirname, `${name}.mjs`), "utf-8");
 
 it("reexport star from external module", function () {
-	expect(readCase("case1")).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'case1.txt'));
-	expect(readCase("case2")).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'case2.txt'));
-	expect(readCase("case3")).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'case3.txt'));
-	expect(readCase("case4")).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'case4.txt'));
-	expect(readCase("case5")).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'case5.txt'));
-	expect(readCase("case6")).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'case6.txt'));
+	expect(readCase("case1")).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'case1.txt'));
+	expect(readCase("case2")).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'case2.txt'));
+	expect(readCase("case3")).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'case3.txt'));
+	expect(readCase("case4")).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'case4.txt'));
+	expect(readCase("case5")).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'case5.txt'));
+	expect(readCase("case6")).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'case6.txt'));
 });

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/rspack.config.js
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/rspack.config.js
@@ -46,31 +46,31 @@ module.exports = {
 			 */
 			const handler = compilation => {
 				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
-					expect(assets["a.js"]._value).toMatchFileSnapshot(
+					expect(assets["a.js"]._value).toMatchFileSnapshotSync(
 						path.join(__dirname, "__snapshot__", "a.js.txt"),
 						"ESM export should concat"
 					);
-					expect(assets["b.js"]._value).toMatchFileSnapshot(
+					expect(assets["b.js"]._value).toMatchFileSnapshotSync(
 						path.join(__dirname, "__snapshot__", "b.js.txt"),
 						".cjs should bail out"
 					);
-					expect(assets["c.js"]._value).toMatchFileSnapshot(
+					expect(assets["c.js"]._value).toMatchFileSnapshotSync(
 						path.join(__dirname, "__snapshot__", "c.js.txt"),
 						"unambiguous should bail out"
 					);
-					expect(assets["d.js"]._value).toMatchFileSnapshot(
+					expect(assets["d.js"]._value).toMatchFileSnapshotSync(
 						path.join(__dirname, "__snapshot__", "d.js.txt"),
 						".mjs should concat"
 					);
-					expect(assets["e.js"]._value).toMatchFileSnapshot(
+					expect(assets["e.js"]._value).toMatchFileSnapshotSync(
 						path.join(__dirname, "__snapshot__", "e.js.txt"),
 						".cjs should bail out when bundling"
 					);
-					expect(assets["f.js"]._value).toMatchFileSnapshot(
+					expect(assets["f.js"]._value).toMatchFileSnapshotSync(
 						path.join(__dirname, "__snapshot__", "f.js.txt"),
 						"external module should bail out when bundling"
 					);
-					expect(assets["g.js"]._value).toMatchFileSnapshot(
+					expect(assets["g.js"]._value).toMatchFileSnapshotSync(
 						path.join(__dirname, "__snapshot__", "g.js.txt"),
 						"harmony export should concat, even with bailout reason"
 					);

--- a/tests/rspack-test/configCases/library/render-order-issue/rspack.config.js
+++ b/tests/rspack-test/configCases/library/render-order-issue/rspack.config.js
@@ -49,7 +49,7 @@ module.exports = {
 							/** @type {Record<string, import("webpack-sources").Source>} */ assets
 						) => {
 							const source = assets["entry.mjs"].source();
-							expect(source).toMatchFileSnapshot(path.join(__dirname, "__snapshots__", `entry.mjs.txt`));
+							expect(source).toMatchFileSnapshotSync(path.join(__dirname, "__snapshots__", `entry.mjs.txt`));
 						}
 					);
 				}

--- a/tests/rspack-test/configCases/optimization/minimizer-esm-asset/index.js
+++ b/tests/rspack-test/configCases/optimization/minimizer-esm-asset/index.js
@@ -5,5 +5,5 @@ import path from "node:path";
 it("minimizing an asset file of esm type should success", () => {
 	const worker = new URL("./pkg/pkg.js", import.meta.url);
 	const minifiedContent = readFileSync(fileURLToPath(worker), "utf-8");
-	expect(minifiedContent).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'pkg.js.txt'));
+	expect(minifiedContent).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'pkg.js.txt'));
 });

--- a/tests/rspack-test/configCases/optimization/minimizer-swc-extract-comments/index.js
+++ b/tests/rspack-test/configCases/optimization/minimizer-swc-extract-comments/index.js
@@ -5,5 +5,5 @@ it("should keep the extracted license file stable", () => {
 	require("bar")
 	require("baz")
 	require("./relative")
-	expect(fs.readFileSync(path.join(__dirname, "bundle0.js.LICENSE.txt"), "utf8")).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'bundle0.js.LICENSE.txt.txt'))
+	expect(fs.readFileSync(path.join(__dirname, "bundle0.js.LICENSE.txt"), "utf8")).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'bundle0.js.LICENSE.txt.txt'))
 })

--- a/tests/rspack-test/configCases/parsing/jsx-enabled/test.js
+++ b/tests/rspack-test/configCases/parsing/jsx-enabled/test.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 it("should keep jsx in output when parser jsx is enabled", () => {
   const bundle = fs.readFileSync(path.join(__dirname, "bundle0.jsx"), "utf-8");
-  expect(bundle).toMatchFileSnapshot(
+  expect(bundle).toMatchFileSnapshotSync(
     path.join(__SNAPSHOT__, "bundle0.jsx.txt")
   );
 });

--- a/tests/rspack-test/configCases/plugins/chunk-modules/index.js
+++ b/tests/rspack-test/configCases/plugins/chunk-modules/index.js
@@ -7,5 +7,5 @@ it("chunk-modules", async () => {
 	const data = JSON.parse(
 		await fs.promises.readFile(path.join(__dirname, "data.json"), "utf-8")
 	);
-	expect(data).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'data.json.txt'));
+	expect(data).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'data.json.txt'));
 });

--- a/tests/rspack-test/configCases/plugins/mini-css-extract-plugin/a.js
+++ b/tests/rspack-test/configCases/plugins/mini-css-extract-plugin/a.js
@@ -27,16 +27,16 @@ it("a should load a chunk with css", () => {
 			"utf-8"
 		)
 		.trim();
-	expect(css).toMatchFileSnapshot(path.resolve(__SNAPSHOT__, `${__STATS_I__}/a.0.css`));
+	expect(css).toMatchFileSnapshotSync(path.resolve(__SNAPSHOT__, `${__STATS_I__}/a.0.css`));
 	return promise;
 });
 
 it("a should generate correct css", () => {
 	const css = fs.readFileSync(path.resolve(__dirname, "a.css"), "utf-8").trim();
-	expect(css).toMatchFileSnapshot(path.resolve(__SNAPSHOT__, `${__STATS_I__}/a.1.css`));
+	expect(css).toMatchFileSnapshotSync(path.resolve(__SNAPSHOT__, `${__STATS_I__}/a.1.css`));
 });
 
 it("c should generate correct css", () => {
 	const css = fs.readFileSync(path.resolve(__dirname, "c.css"), "utf-8").trim();
-	expect(css).toMatchFileSnapshot(path.resolve(__SNAPSHOT__, `${__STATS_I__}/a.2.css`));
+	expect(css).toMatchFileSnapshotSync(path.resolve(__SNAPSHOT__, `${__STATS_I__}/a.2.css`));
 });

--- a/tests/rspack-test/configCases/plugins/mini-css-extract-plugin/b.js
+++ b/tests/rspack-test/configCases/plugins/mini-css-extract-plugin/b.js
@@ -45,12 +45,12 @@ it("b should load a css chunk", () => {
 			"utf-8"
 		)
 		.trim();
-	expect(css).toMatchFileSnapshot(path.resolve(__SNAPSHOT__, `${__STATS_I__}/b.0.css`));
+	expect(css).toMatchFileSnapshotSync(path.resolve(__SNAPSHOT__, `${__STATS_I__}/b.0.css`));
 
 	return promise;
 });
 
 it("b should generate correct css", () => {
 	const css = fs.readFileSync(path.resolve(__dirname, "b.css"), "utf-8").trim();
-	expect(css).toMatchFileSnapshot(path.resolve(__SNAPSHOT__, `${__STATS_I__}/b.1.css`));
+	expect(css).toMatchFileSnapshotSync(path.resolve(__SNAPSHOT__, `${__STATS_I__}/b.1.css`));
 });

--- a/tests/rspack-test/configCases/schemes/data-imports/index.js
+++ b/tests/rspack-test/configCases/schemes/data-imports/index.js
@@ -21,7 +21,7 @@ it("data imports", async () => {
 
 	expect(
 		fs.readFileSync(path.resolve(__dirname, "bundle0.css"), "utf-8")
-	).toMatchFileSnapshot(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
+	).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, 'bundle0.css.txt'));
 	expect(inlineSvg).toBe(
 		'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>'
 	);

--- a/tests/rspack-test/jest.d.ts
+++ b/tests/rspack-test/jest.d.ts
@@ -9,14 +9,14 @@ declare interface FileMatcherOptions {
 declare global {
 	namespace jest {
 		interface Matchers<R, T> {
-			toMatchFileSnapshot: (
+			toMatchFileSnapshotSync: (
 				filename?: string,
 				options?: FileMatcherOptions
 			) => void;
 		}
 
 		interface Expect {
-			toMatchFileSnapshot: (
+			toMatchFileSnapshotSync: (
 				filename?: string,
 				options?: FileMatcherOptions
 			) => void;

--- a/tests/rspack-test/serialCases/css/build-http/index.js
+++ b/tests/rspack-test/serialCases/css/build-http/index.js
@@ -9,6 +9,6 @@ it(`should work with URLs in CSS`, () => new Promise(done => {
 		css.push(link.sheet.css);
 	}
 
-	expect(css).toMatchFileSnapshot(`${__SNAPSHOT__}/css.txt`);
+	expect(css).toMatchFileSnapshotSync(`${__SNAPSHOT__}/css.txt`);
 	done();
 }));

--- a/tests/rspack-test/serialCases/css/css-modules-no-space/index.js
+++ b/tests/rspack-test/serialCases/css/css-modules-no-space/index.js
@@ -5,7 +5,7 @@ it("should allow to create css modules", () => new Promise((resolve, reject) => 
 	__non_webpack_require__("./use-style_js.bundle0.js");
 	import("./use-style.js").then(({ default: x }) => {
 		try {
-			expect(x).toMatchFileSnapshot(`${__SNAPSHOT__}/x.txt`);
+			expect(x).toMatchFileSnapshotSync(`${__SNAPSHOT__}/x.txt`);
 
 			const fs = __non_webpack_require__("fs");
 			const path = __non_webpack_require__("path");
@@ -15,7 +15,7 @@ it("should allow to create css modules", () => new Promise((resolve, reject) => 
 				path.join(__dirname, cssOutputFilename),
 				"utf-8"
 			);
-			expect(cssContent).toMatchFileSnapshot(`${__SNAPSHOT__}/cssContent.txt`);
+			expect(cssContent).toMatchFileSnapshotSync(`${__SNAPSHOT__}/cssContent.txt`);
 		} catch (e) {
 			return done(e);
 		}

--- a/tests/rspack-test/serialCases/css/exports-convention/index.js
+++ b/tests/rspack-test/serialCases/css/exports-convention/index.js
@@ -40,12 +40,12 @@ it("should have correct convention for css exports name", () => new Promise((res
 		import("./style.module.css?dashes-only"),
 		import("./style.module.css?upper"),
 	]).then(([asIs, camelCase, camelCaseOnly, dashes, dashesOnly, upper]) => {
-		expect(asIs).toMatchFileSnapshot(`${__SNAPSHOT__}/as-is.txt`);
-		expect(camelCase).toMatchFileSnapshot(`${__SNAPSHOT__}/camel-case.txt`);
-		expect(camelCaseOnly).toMatchFileSnapshot(`${__SNAPSHOT__}/camel-case-only.txt`);
-		expect(dashes).toMatchFileSnapshot(`${__SNAPSHOT__}/dashes.txt`);
-		expect(dashesOnly).toMatchFileSnapshot(`${__SNAPSHOT__}/dashes-only.txt`);
-		expect(upper).toMatchFileSnapshot(`${__SNAPSHOT__}/upper.txt`);
+		expect(asIs).toMatchFileSnapshotSync(`${__SNAPSHOT__}/as-is.txt`);
+		expect(camelCase).toMatchFileSnapshotSync(`${__SNAPSHOT__}/camel-case.txt`);
+		expect(camelCaseOnly).toMatchFileSnapshotSync(`${__SNAPSHOT__}/camel-case-only.txt`);
+		expect(dashes).toMatchFileSnapshotSync(`${__SNAPSHOT__}/dashes.txt`);
+		expect(dashesOnly).toMatchFileSnapshotSync(`${__SNAPSHOT__}/dashes-only.txt`);
+		expect(upper).toMatchFileSnapshotSync(`${__SNAPSHOT__}/upper.txt`);
 		done()
 	}).catch(done)
 }));

--- a/tests/rspack-test/serialCases/css/large/index.js
+++ b/tests/rspack-test/serialCases/css/large/index.js
@@ -7,7 +7,7 @@ it("should allow to create css modules", () => new Promise((resolve, reject) => 
 		: __non_webpack_require__("./use-style_js.bundle0.js");
 	import("./use-style.js").then(({ default: x }) => {
 		try {
-			expect(x).toMatchFileSnapshot(`${__SNAPSHOT__}/${__STATS_I__}_${prod ? "prod" : "dev"}.txt`);
+			expect(x).toMatchFileSnapshotSync(`${__SNAPSHOT__}/${__STATS_I__}_${prod ? "prod" : "dev"}.txt`);
 		} catch (e) {
 			return done(e);
 		}

--- a/tests/rspack-test/serialCases/css/webpack-ignore/index.js
+++ b/tests/rspack-test/serialCases/css/webpack-ignore/index.js
@@ -4,5 +4,5 @@ it("should compile", () => {
 	const links = document.getElementsByTagName("link");
 	const css = links[1].sheet.css;
 
-	expect(css).toMatchFileSnapshot(`${__SNAPSHOT__}/css.txt`);
+	expect(css).toMatchFileSnapshotSync(`${__SNAPSHOT__}/css.txt`);
 });

--- a/tests/rspack-test/serialCases/custom-modules/json-custom/index.js
+++ b/tests/rspack-test/serialCases/custom-modules/json-custom/index.js
@@ -1,5 +1,5 @@
 import toml from "../_files/data.toml";
 
 it("should transform toml to json", () => {
-	expect(toml).toMatchFileSnapshot(`${__SNAPSHOT__}/toml.txt`);
+	expect(toml).toMatchFileSnapshotSync(`${__SNAPSHOT__}/toml.txt`);
 });


### PR DESCRIPTION
## Summary


The `toMatchFileSnapshot` API in rspack is a custom synchronous implementation, unlike the asynchronous API built into rstest.
In order to distinguish between the two, rename `toMatchFileSnapshot` API in rspack to `toMatchFileSnapshotSync`.


The  `toMatchFileSnapshot` API in rspack:
```ts
type toMatchFileSnapshotSync = (filename?: string, options?: FileMatcherOptions ) => void;
```

The  `toMatchFileSnapshot` API in rstest builtin:
```ts
type toMatchFileSnapshot = (filepath: string, message?: string) => Promise<void>;

```


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
