### PR TITLE
test: share webpackChunk of chunk loading across esm and jsdom

### DIFF
--- a/packages/rspack-test-tools/src/runner/web/index.ts
+++ b/packages/rspack-test-tools/src/runner/web/index.ts
@@ -279,11 +279,17 @@ export class WebRunner extends NodeRunner {
 				  if (prop === "__HMR_UPDATED_RUNTIME__") {
 					  return window["__GLOBAL_SHARED__"]["__HMR_UPDATED_RUNTIME__"];
 					}
+					if (prop === "webpackChunk") {
+						return window["__GLOBAL_SHARED__"]["webpackChunk"];
+					}
 					return Reflect.get(target, prop, receiver);
 				},
 				set(target, prop, value, receiver) {
 					if (prop === "__HMR_UPDATED_RUNTIME__") {
 						window["__GLOBAL_SHARED__"]["__HMR_UPDATED_RUNTIME__"] = value;
+					}
+					if (prop === "webpackChunk") {
+						window["__GLOBAL_SHARED__"]["webpackChunk"] = value;
 					}
 					return Reflect.set(target, prop, value, receiver);
 				}

--- a/tests/rspack-test/configCases/web/prefetch-preload-module-jsonp/test.filter.js
+++ b/tests/rspack-test/configCases/web/prefetch-preload-module-jsonp/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "FIXME: jsdom does not work well with prefetch/preload"


### PR DESCRIPTION
## Summary

The esm and jsdom has different context and `self["webpackChunk"]` will be different instances that leads to chunk loading failure. So just share an array between these two vm context to make sure the loaded chunk can be found.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
