### PR TITLE
feat(react-refresh-loader): generate more compact runtime code

### DIFF
--- a/crates/rspack_loader_react_refresh/src/lib.rs
+++ b/crates/rspack_loader_react_refresh/src/lib.rs
@@ -40,18 +40,28 @@ impl Loader<RunnerContext> for ReactRefreshLoader {
     let Some(content) = loader_context.take_content() else {
       return Ok(());
     };
+    let supports_arrow_function = loader_context
+      .context
+      .options
+      .output
+      .environment
+      .supports_arrow_function();
+
     let mut source = content.try_into_string()?;
-    source += r#"
-function $RefreshSig$() {
-  return $ReactRefreshRuntime$.createSignatureFunctionForTransform();
-}
-function $RefreshReg$(type, id) {
-  $ReactRefreshRuntime$.register(type, __webpack_module__.id + "_" + id);
-}
-Promise.resolve().then(function() {
-  $ReactRefreshRuntime$.refresh(__webpack_module__.id, __webpack_module__.hot);
-});
+
+    if supports_arrow_function {
+      source += r#"
+function $RefreshSig$() { return $ReactRefreshRuntime$.createSignatureFunctionForTransform() }
+function $RefreshReg$(type, id) { $ReactRefreshRuntime$.register(type, __webpack_module__.id + "_" + id) }
+Promise.resolve().then(() => { $ReactRefreshRuntime$.refresh(__webpack_module__.id, __webpack_module__.hot) });
 "#;
+    } else {
+      source += r#"
+function $RefreshSig$() { return $ReactRefreshRuntime$.createSignatureFunctionForTransform() }
+function $RefreshReg$(type, id) { $ReactRefreshRuntime$.register(type, __webpack_module__.id + "_" + id) }
+Promise.resolve().then(function() { $ReactRefreshRuntime$.refresh(__webpack_module__.id, __webpack_module__.hot) });
+"#;
+    }
     let sm = loader_context.take_source_map();
     loader_context.finish_with((source, sm));
     Ok(())


### PR DESCRIPTION
## Summary

The React Refresh runtime helpers are inserted into every React component, and keeping it compact helps keep the output code clear.

## Related links

- Vite: https://github.com/vitejs/vite-plugin-react/blob/67427fc46e4e8235208e20e454557ddc9aa94c27/packages/common/refresh-utils.ts#L60
- Turbopack: https://github.com/vercel/next.js/blob/473ae4b70dd781cc8b2620c95766f827296e689a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs#L187-L192

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
