### PR TITLE
refactor: move code splitting cache into artifact

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
@@ -16,7 +16,12 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
     .incremental
     .mutations_readable(IncrementalPasses::BUILD_CHUNK_GRAPH);
   let mut splitter = if enable_incremental {
-    std::mem::take(&mut compilation.code_splitting_cache.code_splitter)
+    std::mem::take(
+      &mut compilation
+        .build_chunk_graph_artifact
+        .code_splitting_cache
+        .code_splitter,
+    )
   } else {
     Default::default()
   };
@@ -47,7 +52,10 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
     compilation.chunk_graph.add_module(module_identifier)
   }
 
-  compilation.code_splitting_cache.code_splitter = splitter;
+  compilation
+    .build_chunk_graph_artifact
+    .code_splitting_cache
+    .code_splitter = splitter;
 
   Ok(())
 }

--- a/crates/rspack_core/src/compilation/build_chunk_graph/new_code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/new_code_splitter.rs
@@ -1809,6 +1809,7 @@ pub fn code_split(compilation: &mut Compilation) -> Result<()> {
   let module_graph: &ModuleGraph<'_> = &compilation.get_module_graph();
 
   let mut splitter = if !compilation
+    .build_chunk_graph_artifact
     .code_splitting_cache
     .new_code_splitter
     .module_ordinal
@@ -1823,7 +1824,12 @@ pub fn code_split(compilation: &mut Compilation) -> Result<()> {
     affected.extend(removed);
 
     // reuse data from last computation
-    let mut splitter = std::mem::take(&mut compilation.code_splitting_cache.new_code_splitter);
+    let mut splitter = std::mem::take(
+      &mut compilation
+        .build_chunk_graph_artifact
+        .code_splitting_cache
+        .new_code_splitter,
+    );
     splitter.invalidate(affected.into_iter());
     splitter
   } else {
@@ -1833,7 +1839,10 @@ pub fn code_split(compilation: &mut Compilation) -> Result<()> {
   // fill chunks with its modules
   splitter.create_chunks(compilation, &outgoings)?;
 
-  compilation.code_splitting_cache.new_code_splitter = splitter;
+  compilation
+    .build_chunk_graph_artifact
+    .code_splitting_cache
+    .new_code_splitter = splitter;
 
   Ok(())
 }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -11,8 +11,7 @@ use std::{
 };
 
 use build_chunk_graph::{
-  artifact::{CodeSplittingCache, use_code_splitting_cache},
-  build_chunk_graph, build_chunk_graph_new,
+  artifact::use_code_splitting_cache, build_chunk_graph, build_chunk_graph_new,
 };
 use dashmap::DashSet;
 use futures::future::BoxFuture;
@@ -53,6 +52,7 @@ use crate::{
   ModuleStaticCacheArtifact, PathData, ResolverFactory, RuntimeGlobals, RuntimeKeyMap, RuntimeMode,
   RuntimeModule, RuntimeSpec, RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver,
   SideEffectsOptimizeArtifact, SourceType, Stats, ValueCacheVersions,
+  build_chunk_graph::artifact::BuildChunkGraphArtifact,
   compilation::make::{
     MakeArtifact, ModuleExecutor, UpdateParam, finish_make, make, update_module_graph,
   },
@@ -274,7 +274,7 @@ pub struct Compilation {
   pub code_generated_modules: IdentifierSet,
   pub build_time_executed_modules: IdentifierSet,
   pub old_cache: Arc<OldCache>,
-  pub code_splitting_cache: CodeSplittingCache,
+  pub build_chunk_graph_artifact: BuildChunkGraphArtifact,
   pub incremental: Incremental,
 
   pub hash: Option<RspackHashDigest>,
@@ -405,7 +405,7 @@ impl Compilation {
       build_time_executed_modules: Default::default(),
       old_cache,
       incremental,
-      code_splitting_cache: Default::default(),
+      build_chunk_graph_artifact: Default::default(),
 
       hash: None,
 

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -89,8 +89,8 @@ impl Compiler {
           .swap_make_artifact_with_compilation(&mut new_compilation);
 
         // seal stage used
-        new_compilation.code_splitting_cache =
-          std::mem::take(&mut self.compilation.code_splitting_cache);
+        new_compilation.build_chunk_graph_artifact =
+          std::mem::take(&mut self.compilation.build_chunk_graph_artifact);
 
         // reuse module executor
         new_compilation.module_executor = std::mem::take(&mut self.compilation.module_executor);


### PR DESCRIPTION
## Summary
move code splitting cache into build_chunk_graph_artifact
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
