### PR TITLE
revert:  refactor: remove support for nested importModule usage (#12111)

### DIFF
--- a/crates/rspack_core/src/compilation/make/module_executor/entry.rs
+++ b/crates/rspack_core/src/compilation/make/module_executor/entry.rs
@@ -40,14 +40,6 @@ impl Task<ExecutorTaskContext> for EntryTask {
       executed_entry_deps,
     } = context;
 
-    if tracker.is_module_building(&meta.origin_module_identifier) {
-      execute_task.finish_with_error(rspack_error::error!(
-        "Nested calls to importModule are not supported. MetaInfo: {:?}",
-        meta
-      ));
-      return Ok(vec![]);
-    }
-
     let mut res = vec![];
     let (dep_id, is_new) = match entries.entry(meta.clone()) {
       Entry::Vacant(v) => {
@@ -98,7 +90,7 @@ impl Task<ExecutorTaskContext> for EntryTask {
     // mark as executed
     executed_entry_deps.insert(dep_id);
 
-    if tracker.is_entry_running(&dep_id) {
+    if tracker.is_running(&dep_id) {
       let mg = origin_context.artifact.get_module_graph();
       // the module in module executor need to check.
       if mg

--- a/crates/rspack_core/src/compilation/make/module_executor/module_tracker.rs
+++ b/crates/rspack_core/src/compilation/make/module_executor/module_tracker.rs
@@ -197,16 +197,8 @@ impl ModuleTracker {
     }
   }
 
-  /// Check if a entry dep_id is running
-  pub fn is_entry_running(&self, dep_id: &DependencyId) -> bool {
+  /// Check if a dep_id is running
+  pub fn is_running(&self, dep_id: &DependencyId) -> bool {
     self.entry_finish_tasks.contains_key(dep_id)
-  }
-
-  /// Check if a module is building
-  pub fn is_module_building(&self, mid: &ModuleIdentifier) -> bool {
-    let Some(child) = self.unfinished_module.get(mid) else {
-      return false;
-    };
-    child == &usize::MAX
   }
 }

--- a/tests/rspack-test/configCases/loader-import-module/recursive-import-module/errors.js
+++ b/tests/rspack-test/configCases/loader-import-module/recursive-import-module/errors.js
@@ -1,4 +1,0 @@
-module.exports = [
-	[/Nested calls to importModule are not supported/],
-	[/Module build failed/]
-];

--- a/tests/rspack-test/configCases/loader-parallel-import-module/recursive-import-module/errors.js
+++ b/tests/rspack-test/configCases/loader-parallel-import-module/recursive-import-module/errors.js
@@ -1,4 +1,0 @@
-module.exports = [
-	[/Nested calls to importModule are not supported/],
-	[/Module build failed/]
-];

--- a/tests/rspack-test/normalCases/errors/import-module-cycle-multiple/index.js
+++ b/tests/rspack-test/normalCases/errors/import-module-cycle-multiple/index.js
@@ -1,11 +1,11 @@
 it("should error importModule when a cycle with 2 modules is requested", () => {
 	expect(require("./loader!./2/a")).toEqual([
-		["./b.json", [["./a.json", "err"]]]
+		["./b.json", [["./a.json", [["./b.json", "err"]]]]]
 	]);
 });
 it("should error importModule when a cycle with 3 modules is requested", () => {
 	expect(require("./loader!./3/a")).toEqual([
-		["./b.json", [["./c.json", "err"]]]
+		["./b.json", [["./c.json", [["./a.json", [["./b.json", "err"]]]]]]]
 	]);
 });
 it("should error importModule when requesting itself", () => {
@@ -15,7 +15,7 @@ it("should error importModule when requesting itself", () => {
 });
 it("should not report a cycle when importModule is used twice", () => {
 	expect(require("./loader!./4/a")).toEqual([
-		["./b.json", [["./c.json", "err"]]],
-		["./b.json", [["./c.json", "err"]]]
+		["./b.json", [["./c.json", []]]],
+		["./b.json", [["./c.json", []]]]
 	]);
 });

--- a/tests/rspack-test/normalCases/errors/import-module-cycle/index.js
+++ b/tests/rspack-test/normalCases/errors/import-module-cycle/index.js
@@ -1,15 +1,9 @@
 it("should error importModule when a cycle with 2 modules is requested", () => {
-	expect(require("./loader!./2/a")).toMatch(
-		"Nested calls to importModule are not supported"
-	);
+	expect(require("./loader!./2/a")).toMatch("circular build dependency");
 });
 it("should error importModule when a cycle with 3 modules is requested", () => {
-	expect(require("./loader!./3/a")).toMatch(
-		"Nested calls to importModule are not supported"
-	);
+	expect(require("./loader!./3/a")).toMatch("circular build dependency");
 });
 it("should error importModule when requesting itself", () => {
-	expect(require("./loader!./1/a")).toMatch(
-		"Nested calls to importModule are not supported"
-	);
+	expect(require("./loader!./1/a")).toMatch("circular build dependency");
 });

--- a/tests/rspack-test/watchCases/cache/loader-import-module/0/a.generate-json.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/0/a.generate-json.js
@@ -1,0 +1,4 @@
+export const value = 42;
+export * from "./imported.js";
+export { default as nested } from "./b.generate-json.js";
+export const random = Math.random();

--- a/tests/rspack-test/watchCases/cache/loader-import-module/0/b.generate-json.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/0/b.generate-json.js
@@ -1,0 +1,2 @@
+export const value = 42;
+export * from "./imported.js";

--- a/tests/rspack-test/watchCases/cache/loader-import-module/0/imported.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/0/imported.js
@@ -1,0 +1,2 @@
+export const a = "a";
+export const b = "b";

--- a/tests/rspack-test/watchCases/cache/loader-import-module/0/index.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/0/index.js
@@ -1,0 +1,18 @@
+import a from "./a.generate-json.js";
+import { value as unrelated } from "./unrelated";
+
+it("should have to correct values and validate on change", () => {
+	const step = +WATCH_STEP;
+	expect(a.value).toBe(42);
+	expect(a.a).toBe("a");
+	expect(a.nested.value).toBe(step < 3 ? 42 : 24);
+	expect(a.nested.a).toBe(step < 3 ? "a" : undefined);
+	expect(a.b).toBe(step < 1 ? "b" : undefined);
+	expect(a.nested.b).toBe(step < 1 ? "b" : undefined);
+	expect(a.c).toBe(step < 1 ? undefined : "c");
+	expect(a.nested.c).toBe(step < 1 || step >= 3 ? undefined : "c");
+	if (step !== 0) {
+		expect(STATE.random === a.random).toBe(step === 2);
+	}
+	STATE.random = a.random;
+});

--- a/tests/rspack-test/watchCases/cache/loader-import-module/0/loader.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/0/loader.js
@@ -1,0 +1,7 @@
+/** @type {import("../../../../../").PitchLoaderDefinitionFunction} */
+exports.pitch = async function (remaining) {
+	const result = await this.importModule(
+		`${this.resourcePath}.webpack[javascript/auto]!=!${remaining}`
+	);
+	return JSON.stringify(result, null, 2);
+};

--- a/tests/rspack-test/watchCases/cache/loader-import-module/0/unrelated.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/0/unrelated.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/tests/rspack-test/watchCases/cache/loader-import-module/1/imported.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/1/imported.js
@@ -1,0 +1,2 @@
+export const a = "a";
+export const c = "c";

--- a/tests/rspack-test/watchCases/cache/loader-import-module/2/unrelated.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/2/unrelated.js
@@ -1,0 +1,1 @@
+export const value = 24;

--- a/tests/rspack-test/watchCases/cache/loader-import-module/3/b.generate-json.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/3/b.generate-json.js
@@ -1,0 +1,1 @@
+export const value = 24;

--- a/tests/rspack-test/watchCases/cache/loader-import-module/rspack.config.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/rspack.config.js
@@ -1,0 +1,12 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.generate-json\.js$/,
+				use: "./loader",
+				type: "json"
+			}
+		]
+	}
+};

--- a/tests/rspack-test/watchCases/cache/loader-import-module/test.filter.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module/test.filter.js
@@ -1,0 +1,2 @@
+
+module.exports = () => "FIXME: panic"


### PR DESCRIPTION
This reverts commit a2ba2958159d523c218e834383a3906d7ff1ca08.

## Summary

Fix the ecosystem CI: https://github.com/web-infra-dev/rspack/actions/runs/19288926831/job/55155671354

## Related links

- https://github.com/web-infra-dev/rsbuild/blob/main/e2e/cases/plugin-api/plugin-transform-import-module/myPlugin.ts

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
