### PR TITLE
feat: export ErrorData from rspack_error crate

### DIFF
--- a/crates/rspack_error/src/lib.rs
+++ b/crates/rspack_error/src/lib.rs
@@ -16,7 +16,7 @@ pub use self::{
   diagnostic::Diagnostic,
   diagnostic_array::{IntoTWithDiagnosticArray, TWithDiagnosticArray},
   displayer::{Display, Renderer, StdioDisplayer, StringDisplayer},
-  error::{Error, Label, Severity},
+  error::{Error, ErrorData, Label, Severity},
 };
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
Add ErrorData to the public exports to allow external access to error data structures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

Need to display multiple labels and custom names. I believe this is the least disruptive change to the future planning of rspack.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
