### PR TITLE
docs(split-chunks): update module federation compatibility note

### DIFF
--- a/website/docs/en/plugins/webpack/split-chunks-plugin.mdx
+++ b/website/docs/en/plugins/webpack/split-chunks-plugin.mdx
@@ -129,7 +129,11 @@ export default {
 ```
 
 :::tip
-When using [Module Federation](/guide/features/module-federation), if the application uses `exposes` to expose remote modules, `chunks: 'all'` cannot be used as it would break the remote module splitting.
+
+Before Rspack v1.6.2, projects using [Module Federation](/guide/features/module-federation) with exposes could not enable `chunks: 'all'`, as it would break remote module splitting.
+
+Starting from v1.6.2, Module Federation works seamlessly with `chunks: 'all'`.
+
 :::
 
 The `chunks` option can be set to a regular expression, which is a shorthand for `(chunk) => typeof chunk.name === "string" && regex.test(chunk.name)`.

--- a/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
@@ -127,7 +127,11 @@ export default {
 ```
 
 :::tip
-在使用 [模块联邦](/guide/features/module-federation) 时，如果应用使用了 `exposes` 来暴露出远程模块，则无法使用 `chunks: 'all'`，因为这会破坏远程模块的拆分。
+
+在 Rspack v1.6.2 之前，使用 [模块联邦](/guide/features/module-federation) 并配置 `exposes` 时无法开启 `chunks: 'all'`，否则会破坏远程模块拆分。
+
+从 v1.6.2 起，可以同时使用模块联邦和 `chunks: 'all'`。
+
 :::
 
 `chunks` 选项可以设置为正则表达式，它是 `(chunk) => typeof chunk.name === "string" && regex.test(chunk.name)` 的缩写。


### PR DESCRIPTION
## Summary

Update module federation compatibility note, clarify that `chunks: 'all'` is now compatible with module federation `exposes` starting from v1.6.2.

## Related links

- https://github.com/web-infra-dev/rspack/pull/12142

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
