### PR TITLE
test: can not handle `uncaughtException` correctly

### DIFF
--- a/packages/rspack-test-tools/src/helper/setup-env.ts
+++ b/packages/rspack-test-tools/src/helper/setup-env.ts
@@ -105,15 +105,24 @@ if (process.env.DEBUG_INFO) {
 	it = addDebugInfo(it);
 }
 
+const uncaughtExceptionListenersLength =
+	process.listeners("uncaughtException").length;
+const unhandledRejectionListenersLength =
+	process.listeners("unhandledRejection").length;
+
 // cspell:word wabt
 // Workaround for a memory leak in wabt
 // It leaks an Error object on construction
 // so it leaks the whole stack trace
 require("wast-loader");
 
-// remove the last uncaughtException / unhandledRejection listener added by wast
+// remove the last uncaughtException / unhandledRejection listener added by wast-loader
 const listeners = process.listeners("uncaughtException");
-process.off("uncaughtException", listeners[listeners.length - 1]);
+if (listeners.length > uncaughtExceptionListenersLength) {
+	process.off("uncaughtException", listeners[listeners.length - 1]);
+}
 
 const listeners1 = process.listeners("unhandledRejection");
-process.off("unhandledRejection", listeners1[listeners1.length - 1]);
+if (listeners1.length > unhandledRejectionListenersLength) {
+	process.off("unhandledRejection", listeners1[listeners1.length - 1]);
+}


### PR DESCRIPTION
## Summary

fix: `uncaughtException` was not being handled correctly in tests because all `uncaughtException` listeners were removed.

before:
![img_v3_02rv_de1c635f-2551-4f8c-a914-33e08cf074dg](https://github.com/user-attachments/assets/e9e21cf3-5617-44fe-a669-a33024b27960)

![img_v3_02rv_778bb80d-3bd3-4c02-9d85-cb526f84c3eg](https://github.com/user-attachments/assets/efc079de-09bc-4512-8f79-28e7cf15760b)

after:
![img_v3_02rv_2bfe2173-4a35-446b-b60e-9c053d587c4g](https://github.com/user-attachments/assets/17dd9feb-f828-4736-be45-1cb342cf17ed)


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
