### PR TITLE
chore(release):  fix debug package release failure

### DIFF
--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -42,7 +42,7 @@ export function getNextName(name, scopePostfix = "canary") {
 		return name;
 	}
 	if (name === "create-rspack") {
-		return "create-rspack-canary";
+		return `create-rspack-${scopePostfix}`;
 	}
 	return name.replace(/^@rspack/, `@rspack-${scopePostfix}`);
 }


### PR DESCRIPTION
## Summary
Rename `create-rspack-canary` to `create-rspack-debug` for the release debug workflow to work successfully.

Both the release debug and the release canary workflows are verified.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
