### PR TITLE
chore(ci): support force use github artifacts

### DIFF
--- a/.github/actions/artifact/download/action.yml
+++ b/.github/actions/artifact/download/action.yml
@@ -19,12 +19,12 @@ runs:
   steps:
     - name: Download artifact from github
       uses: actions/download-artifact@v4.1.7
-      if: ${{ runner.environment == 'github-hosted' }}
+      if: ${{ runner.environment == 'github-hosted' || inputs.force-use-github == 'true' }}
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
     - name: Download artifact from local
-      if: ${{ runner.environment == 'self-hosted' }}
+      if: ${{ runner.environment == 'self-hosted' && inputs.force-use-github != 'true' }}
       uses: lynx-infra/download-artifact@79d9914484f933089c2840552cf439bac85debad # https://github.com/lynx-infra/download-artifact/tree/dev
       with:
         name: ${{ inputs.name }}


### PR DESCRIPTION
## Summary
In some cases (e.g. ecosystem bench ), we need to force the use of GitHub artifacts for better speed.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
