### PR TITLE
fix: triple with windows-msvc doesn't support -Cforce-unwind-tables=no

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -87,7 +87,9 @@ async function build() {
 		}
 		if (values.profile === "release") {
 			features.push("info-level");
-			rustflags.push("-Cforce-unwind-tables=no");
+			if (process.env.RUST_TARGET && !process.env.RUST_TARGET.startsWith("windows-msvc")) {
+				rustflags.push("-Cforce-unwind-tables=no");
+			}
 		}
 		if (features.length) {
 			args.push("--features " + features.join(","));


### PR DESCRIPTION
## Summary

Triple with windows-msvc doesn't support -Cforce-unwind-tables=no, need not use this rust flag in these triples


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
