### PR TITLE
test: disable iconv-lite decode warning in test tools

### DIFF
--- a/packages/rspack-test-tools/src/helper/disable-iconv-lite-warning.ts
+++ b/packages/rspack-test-tools/src/helper/disable-iconv-lite-warning.ts
@@ -1,0 +1,11 @@
+export function disableIconvLiteWarning() {
+	for (const [path, mod] of Object.entries(require.cache)) {
+		if (
+			path.includes("iconv-lite") &&
+			typeof mod?.exports === "object" &&
+			typeof mod.exports.decode === "function"
+		) {
+			mod.exports.skipDecodeWarning = true;
+		}
+	}
+}

--- a/packages/rspack-test-tools/src/index.ts
+++ b/packages/rspack-test-tools/src/index.ts
@@ -6,3 +6,5 @@ export * from "./test/context";
 export * from "./test/creator";
 export * from "./test/tester";
 export * from "./type";
+
+require("./helper/disable-iconv-lite-warning").disableIconvLiteWarning();


### PR DESCRIPTION
## Summary

Can not find a better way to prevent emitting warning in iconv-lite.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
