### PR TITLE
test: `maxConcurrency` and `testTimeout` should be configurable via cli options

### DIFF
--- a/packages/rspack-test-tools/src/test/creator.ts
+++ b/packages/rspack-test-tools/src/test/creator.ts
@@ -44,7 +44,9 @@ export interface IBasicCaseCreatorOptions {
 	[key: string]: unknown;
 }
 
-const DEFAULT_MAX_CONCURRENT = process.env.WASM ? 1 : 5;
+const DEFAULT_MAX_CONCURRENT = process.env.WASM
+	? 1
+	: Number(process.env.DEFAULT_MAX_CONCURRENT) || 5;
 
 export class BasicCaseCreator {
 	protected currentConcurrent = 0;
@@ -170,7 +172,7 @@ export class BasicCaseCreator {
 						throw e;
 					}
 				},
-				options.timeout || 300000
+				options.timeout
 			);
 
 			chain = chain.then(

--- a/tests/rspack-test/rstest.config.ts
+++ b/tests/rspack-test/rstest.config.ts
@@ -86,12 +86,18 @@ export default defineConfig({
 		__TEST_FIXTURES_PATH__: path.resolve(__dirname, "fixtures"),
 		__TEST_DIST_PATH__: path.resolve(__dirname, "js"),
 		__ROOT_PATH__: root,
+		DEFAULT_MAX_CONCURRENT: process.argv.includes("--maxConcurrency")
+				? process.argv[
+				process.argv.indexOf("--maxConcurrency") + 1
+				]
+				: undefined,
 		__RSPACK_PATH__: path.resolve(root, "packages/rspack"),
 		__RSPACK_TEST_TOOLS_PATH__: path.resolve(root, "packages/rspack-test-tools"),
 		__DEBUG__: process.env.DEBUG === "test" ? 'true' : 'false',
 	},
 	hideSkippedTests: true,
 	reporters: ['default'],
+	testTimeout: 300000,
 	...(wasmConfig || {}),
 });
 


### PR DESCRIPTION
## Summary

test  `maxConcurrency` and `testTimeout` configurations should be configurable via cli options

<img width="1102" height="195" alt="image" src="https://github.com/user-attachments/assets/b2b70be2-513d-435d-8c34-1f4a1af8d05d" />


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
