### PR TITLE
fix(create-rspack): use current package manager in templates

### DIFF
--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -20,7 +20,7 @@
     "dev": "rslib build -w"
   },
   "dependencies": {
-    "create-rstack": "1.7.7"
+    "create-rstack": "1.7.8"
   },
   "devDependencies": {
     "@rslib/core": "0.17.1",

--- a/packages/create-rspack/template-common/AGENTS.md
+++ b/packages/create-rspack/template-common/AGENTS.md
@@ -4,9 +4,9 @@ You are an expert in JavaScript, Rspack, and web application development. You wr
 
 ## Commands
 
-- `npm run dev` - Start the dev server
-- `npm run build` - Build the app for production
-- `npm run preview` - Preview the production build locally
+- `{{ packageManager }} run dev` - Start the dev server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
 
 ## Docs
 

--- a/packages/create-rspack/template-common/README.md
+++ b/packages/create-rspack/template-common/README.md
@@ -5,7 +5,7 @@
 Install the dependencies:
 
 ```bash
-npm install
+{{ packageManager }} install
 ```
 
 ## Get started
@@ -13,19 +13,19 @@ npm install
 Start the dev server, and the app will be available at <http://localhost:8080>.
 
 ```bash
-npm run dev
+{{ packageManager }} run dev
 ```
 
 Build the app for production:
 
 ```bash
-npm run build
+{{ packageManager }} run build
 ```
 
 Preview the production build locally:
 
 ```bash
-npm run preview
+{{ packageManager }} run preview
 ```
 
 ## Learn more

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
   packages/create-rspack:
     dependencies:
       create-rstack:
-        specifier: 1.7.7
-        version: 1.7.7
+        specifier: 1.7.8
+        version: 1.7.8
     devDependencies:
       '@rslib/core':
         specifier: 0.17.1
@@ -4467,8 +4467,8 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  create-rstack@1.7.7:
-    resolution: {integrity: sha512-mZHKC+56IahOrz9FS21vhRayRjJkrfpN+emXVHczqUN3h8yJyOqu1JJkkYhQBd28rbZR1GjWD+Q0bE8MrcW1GQ==}
+  create-rstack@1.7.8:
+    resolution: {integrity: sha512-B8+cOGs0Gsk2i3ZVJweMsFFU50vXlNYzkWOiVQBoMs02Ui/6hQcqB4d+jmTEgwvdb5gJmX2Rcr9J6l+Ld1yCQQ==}
 
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
@@ -12156,7 +12156,7 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  create-rstack@1.7.7: {}
+  create-rstack@1.7.8: {}
 
   cross-env@10.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- update dependency `create-rstack` to v1.7.8
- replace hardcoded package manager commands with template variables in documentation files

## Related Links

- https://github.com/rspack-contrib/create-rstack/releases/tag/v1.7.8

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
