### PR TITLE
fix: inline enum module should populate its collected_typescript_info

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -692,6 +692,16 @@ impl Module for ConcatenatedModule {
       .iter()
       .map(|item| Some(&item.id))
       .collect::<HashSet<_>>();
+
+    let root_module = module_graph
+      .module_by_identifier(&self.root_module_ctxt.id)
+      .expect("should have root module");
+
+    // populate root collected_typescript_info
+    if let Some(collected_typescript_info) = &root_module.build_info().collected_typescript_info {
+      self.build_info.collected_typescript_info = Some(collected_typescript_info.clone());
+    }
+
     for m in self.modules.iter() {
       let module = module_graph
         .module_by_identifier(&m.id)

--- a/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/foo.js
+++ b/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/foo.js
@@ -1,0 +1,2 @@
+console.log()
+export const foo = 1

--- a/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/index.js
+++ b/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/index.js
@@ -1,0 +1,10 @@
+import { INLINE } from "./lib.ts";
+
+it("should work", () => {
+	expect(INLINE.Foo).toBe(0);
+});
+
+import "./foo?a";
+
+import("./module.js");
+

--- a/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/lib.ts
+++ b/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/lib.ts
@@ -1,0 +1,9 @@
+import './foo?1'
+
+export enum INLINE {
+  Foo,
+  Bar,
+}
+
+export const NO_INLINE = () => 42
+module;

--- a/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/module.js
+++ b/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/module.js
@@ -1,0 +1,5 @@
+import { NO_INLINE } from "./lib.ts";
+
+import "./foo?22";
+
+console.log(NO_INLINE);

--- a/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/rspack.config.js
+++ b/tests/rspack-test/configCases/inline-enum/enum-module-in-concate-root/rspack.config.js
@@ -1,0 +1,41 @@
+module.exports = {
+	entry: {
+		main: './index.js',
+	},
+	module: {
+    parser: {
+      javascript: {
+        inlineEnum: true,
+      },
+    },
+    rules: [
+      {
+        test: /\.ts/,
+        sideEffects: false,
+        use: [
+          {
+            loader: "builtin:swc-loader",
+            options: {
+              jsc: {
+                parser: {
+                  syntax: "typescript",
+                }
+              },
+              rspackExperiments: {
+                collectTypeScriptInfo: {
+                  exportedEnum: true,
+                },
+              },
+            },
+          },
+        ],
+      },
+    ],
+	},
+	optimization: {
+		concatenateModules: true,
+	},
+	experiments: {
+		inlineEnum: true,
+	}
+}


### PR DESCRIPTION
## Summary

When inlined enum as concatenated module's root module, the concatenated module should keep the `collected_typescript_info` in build_info, to make sure the result of `connection.is_target_active` stays the same after concatenation

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
