### PR TITLE
refactor: rename webpack default export var to rspack format

### DIFF
--- a/crates/rspack_core/src/reserved_names.rs
+++ b/crates/rspack_core/src/reserved_names.rs
@@ -1,5 +1,5 @@
 pub const RESERVED_NAMES: [&str; 188] = [
-  "__WEBPACK_DEFAULT_EXPORT__",
+  "__rspack_default_export",
   "__WEBPACK_NAMESPACE_OBJECT__",
   "abstract",
   "arguments",

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -14,10 +14,9 @@ use crate::{
   concatenated_module::{ConcatenatedModuleInfo, ModuleInfo},
 };
 
-pub static DEFAULT_EXPORT_ATOM: LazyLock<Atom> =
-  LazyLock::new(|| "__WEBPACK_DEFAULT_EXPORT__".into());
+pub static DEFAULT_EXPORT_ATOM: LazyLock<Atom> = LazyLock::new(|| "__rspack_default_export".into());
 pub const NAMESPACE_OBJECT_EXPORT: &str = "__WEBPACK_NAMESPACE_OBJECT__";
-pub const DEFAULT_EXPORT: &str = "__WEBPACK_DEFAULT_EXPORT__";
+pub const DEFAULT_EXPORT: &str = "__rspack_default_export";
 
 static MODULE_REFERENCE_REGEXP: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(

--- a/tests/rspack-test/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
@@ -198,11 +198,11 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   DO_NOT_CONVERTED7: () => (DO_NOT_CONVERTED7),
   DO_NOT_CONVERTED9: () => (DO_NOT_CONVERTED9),
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 const DO_NOT_CONVERTED7 = 402;
 const DO_NOT_CONVERTED9 = 403;
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (401); // DO_NOT_CONVERTED8
+/* export default */ const __rspack_default_export = (401); // DO_NOT_CONVERTED8
 
 
 

--- a/tests/rspack-test/builtinCases/plugin-javascript/provide/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-javascript/provide/__snapshots__/output.snap.txt
@@ -22,7 +22,7 @@ function a() {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 const lib = {
 	get: () => {
@@ -30,7 +30,7 @@ const lib = {
 	}
 };
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (lib);
+/* export default */ const __rspack_default_export = (lib);
 
 
 }),

--- a/tests/rspack-test/configCases/parsing/default-export-const/supports-const.js
+++ b/tests/rspack-test/configCases/parsing/default-export-const/supports-const.js
@@ -4,7 +4,7 @@ try {
   d
 } catch (e) {
   it('should have TDZ error', () => {
-    expect(e.message).toBe("Cannot access '__WEBPACK_DEFAULT_EXPORT__' before initialization");
+    expect(e.message).toBe("Cannot access '__rspack_default_export' before initialization");
   })
 }
 

--- a/tests/rspack-test/configCases/parsing/harmony-export-comment/index.js
+++ b/tests/rspack-test/configCases/parsing/harmony-export-comment/index.js
@@ -11,6 +11,6 @@ it("should keep pure comment of unused export default", () => {
 });
 
 it("should keep pure comment of used export default", () => {
-  const methodName = "function __WEBPACK_DEFAULT_EXPORT__()";
+  const methodName = "function __rspack_default_export()";
   expect(content).toContain(`${pureComment}${methodName}`)
 });

--- a/tests/rspack-test/diagnosticsCases/module-parse-failed/concatenate_parse_module/stats.err
+++ b/tests/rspack-test/diagnosticsCases/module-parse-failed/concatenate_parse_module/stats.err
@@ -4,5 +4,5 @@ ERROR in ./index.js + 1 modules
    ╭─[1:14]
  1 │ console.log(1 2 3)
    ·               ─
- 2 │ /* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+ 2 │ /* export default */ const __rspack_default_export = (1);
    ╰────

--- a/tests/rspack-test/hotCases/asset/parser-and-generator-states/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/asset/parser-and-generator-states/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 2830
+- Update: main.LAST_HASH.hot-update.js, size: 2824
 
 ## Manifest
 
@@ -41,12 +41,12 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _logo_svg__rspack_import_0 = __webpack_require__(/*! ./logo.svg */ "./logo.svg");
 
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ((typeof _logo_svg__rspack_import_0) + ' result');
+/* export default */ const __rspack_default_export = ((typeof _logo_svg__rspack_import_0) + ' result');
 
 }),
 "./logo.svg": 

--- a/tests/rspack-test/hotCases/child-compiler/issue-9706/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/child-compiler/issue-9706/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: test.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 736
+- Update: main.LAST_HASH.hot-update.js, size: 730
 
 ## Manifest
 
@@ -41,10 +41,10 @@ self["webpackHotUpdate"]("main", {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   assets: () => (assets),
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 const assets = ["test.js"];
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
@@ -12,7 +12,7 @@
 - Manifest: runtime~main.LAST_HASH.hot-update.json, size: 76
 - Update: main.LAST_HASH.hot-update.js, size: 686
 - Update: runtime~main.LAST_HASH.hot-update.js, size: 19042
-- Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 509
+- Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 503
 
 ## Manifest
 
@@ -742,9 +742,9 @@ self["webpackHotUpdate"]("vendors-node_modules_vendor_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/code-generation/this-in-accept-webpackhot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/code-generation/this-in-accept-webpackhot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 566
+- Update: main.LAST_HASH.hot-update.js, size: 560
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("ok2");
+/* export default */ const __rspack_default_export = ("ok2");
 
 
 }),

--- a/tests/rspack-test/hotCases/code-generation/this-in-accept/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/code-generation/this-in-accept/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 566
+- Update: main.LAST_HASH.hot-update.js, size: 560
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("ok2");
+/* export default */ const __rspack_default_export = ("ok2");
 
 
 }),

--- a/tests/rspack-test/hotCases/concat/reload-compat-flag/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/concat/reload-compat-flag/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 27
-- Update: 889.LAST_HASH.hot-update.js, size: 492
+- Update: 889.LAST_HASH.hot-update.js, size: 486
 
 ## Manifest
 
@@ -35,11 +35,11 @@ self["webpackHotUpdate"]("889", {
 "./module.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("ok2");
+/* export default */ const __rspack_default_export = ("ok2");
 
 
 }),

--- a/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 27
-- Update: 889.LAST_HASH.hot-update.js, size: 481
+- Update: 889.LAST_HASH.hot-update.js, size: 475
 
 ## Manifest
 
@@ -36,9 +36,9 @@ self["webpackHotUpdate"]("889", {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 27
-- Update: 889.LAST_HASH.hot-update.js, size: 482
+- Update: 889.LAST_HASH.hot-update.js, size: 476
 
 ## Manifest
 
@@ -36,9 +36,9 @@ self["webpackHotUpdate"]("889", {
 "./b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (20);
+/* export default */ const __rspack_default_export = (20);
 
 
 }),

--- a/tests/rspack-test/hotCases/conditional-runtime/accept-conditional/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/conditional-runtime/accept-conditional/__snapshots__/web/1.snap.txt
@@ -10,8 +10,8 @@
 - Bundle: shared.chunk.CURRENT_HASH.js
 - Manifest: [runtime of dep1_js-dep2_js-worker_js].LAST_HASH.hot-update.json, size: 49
 - Manifest: main.LAST_HASH.hot-update.json, size: 48
-- Update: dep1_js-dep2_js-worker_js.LAST_HASH.hot-update.js, size: 576
-- Update: dep1_js-module_js.LAST_HASH.hot-update.js, size: 437
+- Update: dep1_js-dep2_js-worker_js.LAST_HASH.hot-update.js, size: 570
+- Update: dep1_js-module_js.LAST_HASH.hot-update.js, size: 431
 - Update: main.LAST_HASH.hot-update.js, size: 182
 
 ## Manifest
@@ -53,9 +53,9 @@ self["webpackHotUpdate"]("dep1_js-dep2_js-worker_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (43);
+/* export default */ const __rspack_default_export = (43);
 
 
 }),
@@ -91,9 +91,9 @@ self["webpackHotUpdate"]("dep1_js-module_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (43);
+/* export default */ const __rspack_default_export = (43);
 
 
 }),

--- a/tests/rspack-test/hotCases/css/css-extract/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/css/css-extract/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1211
+- Update: main.LAST_HASH.hot-update.js, size: 1199
 
 ## Manifest
 
@@ -40,13 +40,13 @@ self["webpackHotUpdate"]("main", {
 (function (module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _index_module_css__rspack_import_0 = __webpack_require__(/*! ./index.module.css */ "./index.module.css");
 
 module.hot.accept();
 // modify
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (_index_module_css__rspack_import_0["default"]);
+/* export default */ const __rspack_default_export = (_index_module_css__rspack_import_0["default"]);
 
 
 }),
@@ -57,10 +57,10 @@ module.hot.accept();
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 // extracted by css-extract-rspack-plugin
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ({"bar":"gVlquue4Gts5AqVo"});
+/* export default */ const __rspack_default_export = ({"bar":"gVlquue4Gts5AqVo"});
 
 }),
 

--- a/tests/rspack-test/hotCases/define/issue-6962/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/define/issue-6962/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 590
+- Update: main.LAST_HASH.hot-update.js, size: 584
 
 ## Manifest
 
@@ -39,10 +39,10 @@ self["webpackHotUpdate"]("main", {
 (function (module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 if (module.hot.data && module.hot.data.crash) throw new Error();
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/determinism/issue-10174/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/determinism/issue-10174/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 550
+- Update: main.LAST_HASH.hot-update.js, size: 544
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
@@ -8,7 +8,7 @@
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Manifest: [runtime of chunk2_js].LAST_HASH.hot-update.json, size: 60
 - Manifest: main.LAST_HASH.hot-update.json, size: 41
-- Update: main.LAST_HASH.hot-update.js, size: 18536
+- Update: main.LAST_HASH.hot-update.js, size: 18530
 
 ## Manifest
 
@@ -50,9 +50,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (42);
+/* export default */ const __rspack_default_export = (42);
 
 
 }),

--- a/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 52
-- Update: main.LAST_HASH.hot-update.js, size: 563
+- Update: main.LAST_HASH.hot-update.js, size: 557
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (42);
+/* export default */ const __rspack_default_export = (42);
 
 
 }),

--- a/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
-- Update: main.LAST_HASH.hot-update.js, size: 18536
+- Update: main.LAST_HASH.hot-update.js, size: 18530
 
 ## Manifest
 
@@ -34,9 +34,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (42);
+/* export default */ const __rspack_default_export = (42);
 
 
 }),

--- a/tests/rspack-test/hotCases/errors/decline-webpackhot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/decline-webpackhot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 542
+- Update: main.LAST_HASH.hot-update.js, size: 536
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/errors/decline/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/decline/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 542
+- Update: main.LAST_HASH.hot-update.js, size: 536
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/errors/events/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/events/__snapshots__/web/1.snap.txt
@@ -12,7 +12,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 2837
+- Update: main.LAST_HASH.hot-update.js, size: 2795
 
 ## Manifest
 
@@ -51,9 +51,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),
@@ -64,9 +64,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),
@@ -77,9 +77,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),
@@ -90,9 +90,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),
@@ -103,9 +103,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 throw new Error("Error while loading module i");
 
 
@@ -117,9 +117,9 @@ throw new Error("Error while loading module i");
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 throw new Error("Error while loading module j");
 
 
@@ -131,9 +131,9 @@ throw new Error("Error while loading module j");
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 throw new Error("Error while loading module l");
 
 

--- a/tests/rspack-test/hotCases/errors/self-decline/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/self-decline/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 542
+- Update: main.LAST_HASH.hot-update.js, size: 536
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 542
+- Update: main.LAST_HASH.hot-update.js, size: 536
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),

--- a/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 542
+- Update: main.LAST_HASH.hot-update.js, size: 536
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/3.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 900
+- Update: main.LAST_HASH.hot-update.js, size: 888
 
 ## Manifest
 
@@ -41,9 +41,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 
 
 }),
@@ -54,9 +54,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),

--- a/tests/rspack-test/hotCases/errors/unaccepted/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 542
+- Update: main.LAST_HASH.hot-update.js, size: 536
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/harmony/cjs-analyze-changed/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/harmony/cjs-analyze-changed/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 917
+- Update: main.LAST_HASH.hot-update.js, size: 911
 
 ## Manifest
 
@@ -50,11 +50,11 @@ exports["default"] = 1;
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _file__rspack_import_0 = __webpack_require__(/*! ./file */ "./file.js");
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (_file__rspack_import_0["default"]);
+/* export default */ const __rspack_default_export = (_file__rspack_import_0["default"]);
 
 
 

--- a/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 554
+- Update: main.LAST_HASH.hot-update.js, size: 548
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 554
+- Update: main.LAST_HASH.hot-update.js, size: 548
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),

--- a/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 553
+- Update: main.LAST_HASH.hot-update.js, size: 547
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 }),
 

--- a/tests/rspack-test/hotCases/hashing/exports-info-influence/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hashing/exports-info-influence/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1388
+- Update: main.LAST_HASH.hot-update.js, size: 1382
 
 ## Manifest
 
@@ -40,7 +40,7 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _module__rspack_import_0 = __webpack_require__(/*! ./module */ "./module.js");
 /* import */var _module__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(_module__rspack_import_0);
@@ -48,7 +48,7 @@ __webpack_require__.d(__webpack_exports__, {
 /* import */var external__rspack_import_1_default = /*#__PURE__*/__webpack_require__.n(external__rspack_import_1);
 
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (`${_module__rspack_import_0.test} ${external__rspack_import_1.test}`);
+/* export default */ const __rspack_default_export = (`${_module__rspack_import_0.test} ${external__rspack_import_1.test}`);
 
 
 }),

--- a/tests/rspack-test/hotCases/hashing/full-hash-main/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hashing/full-hash-main/__snapshots__/web/1.snap.txt
@@ -8,7 +8,7 @@
 - Bundle: thing_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 39
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: thing_js.LAST_HASH.hot-update.js, size: 431
+- Update: thing_js.LAST_HASH.hot-update.js, size: 425
 
 ## Manifest
 
@@ -64,9 +64,9 @@ self["webpackHotUpdate"]("thing_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: modules_demo_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 69
-- Update: main.LAST_HASH.hot-update.js, size: 578
+- Update: main.LAST_HASH.hot-update.js, size: 572
 - Update: modules_demo_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1481
 
 ## Manifest
@@ -43,9 +43,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
@@ -10,7 +10,7 @@
 - Bundle: modules_module_js.chunk.CURRENT_HASH.js
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 71
-- Update: main.LAST_HASH.hot-update.js, size: 578
+- Update: main.LAST_HASH.hot-update.js, size: 572
 - Update: modules_module_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1501
 
 ## Manifest
@@ -44,9 +44,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),

--- a/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: lazy_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 563
+- Update: main.LAST_HASH.hot-update.js, size: 557
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (43);
+/* export default */ const __rspack_default_export = (43);
 
 
 }),

--- a/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: lazy_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 563
+- Update: main.LAST_HASH.hot-update.js, size: 557
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (44);
+/* export default */ const __rspack_default_export = (44);
 
 
 }),

--- a/tests/rspack-test/hotCases/loader/import-module-1/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/loader/import-module-1/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 590
+- Update: main.LAST_HASH.hot-update.js, size: 584
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 656
+- Update: main.LAST_HASH.hot-update.js, size: 650
 
 ## Manifest
 
@@ -39,11 +39,11 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _cycle2_a__rspack_import_0 = __webpack_require__(/*! ./cycle2/a */ "./cycle2/a.js");
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 650
+- Update: main.LAST_HASH.hot-update.js, size: 644
 
 ## Manifest
 
@@ -39,11 +39,11 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _common__rspack_import_0 = __webpack_require__(/*! ./common */ "./common.js");
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),

--- a/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 189
-- Update: main.LAST_HASH.hot-update.js, size: 554
+- Update: main.LAST_HASH.hot-update.js, size: 548
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 
 
 }),

--- a/tests/rspack-test/hotCases/make/clean-isolated-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-module/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 45
-- Update: main.LAST_HASH.hot-update.js, size: 544
+- Update: main.LAST_HASH.hot-update.js, size: 538
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("a");
+/* export default */ const __rspack_default_export = ("a");
 
 
 }),

--- a/tests/rspack-test/hotCases/make/fix-issuer/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/fix-issuer/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 56
-- Update: main.LAST_HASH.hot-update.js, size: 554
+- Update: main.LAST_HASH.hot-update.js, size: 548
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/make/issue-10915/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/issue-10915/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 63
-- Update: main.LAST_HASH.hot-update.js, size: 559
+- Update: main.LAST_HASH.hot-update.js, size: 553
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("file");
+/* export default */ const __rspack_default_export = ("file");
 
 
 }),

--- a/tests/rspack-test/hotCases/make/rebuild-abnormal-module/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/make/rebuild-abnormal-module/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 962
+- Update: main.LAST_HASH.hot-update.js, size: 950
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),
@@ -53,9 +53,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("a");
+/* export default */ const __rspack_default_export = ("a");
 
 
 }),

--- a/tests/rspack-test/hotCases/module/build-info/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/module/build-info/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 590
+- Update: main.LAST_HASH.hot-update.js, size: 584
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/newTreeshaking/re-export-optimization/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/newTreeshaking/re-export-optimization/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1197
+- Update: main.LAST_HASH.hot-update.js, size: 1185
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ('bar');
+/* export default */ const __rspack_default_export = ('bar');
 
 
 }),
@@ -53,12 +53,12 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _reexport__rspack_import_0 = __webpack_require__(/*! ./reexport */ "./foo.js");
 /* import */var _reexport__rspack_import_1 = __webpack_require__(/*! ./reexport */ "./bar.js");
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (_reexport__rspack_import_0["default"] + _reexport__rspack_import_1["default"]);
+/* export default */ const __rspack_default_export = (_reexport__rspack_import_0["default"] + _reexport__rspack_import_1["default"]);
 
 
 }),

--- a/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 51
 - Update: 1e1.LAST_HASH.hot-update.js, size: 353
-- Update: main.LAST_HASH.hot-update.js, size: 698
+- Update: main.LAST_HASH.hot-update.js, size: 692
 
 ## Manifest
 
@@ -73,9 +73,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (() => __webpack_require__.e(/*! import() | 10 */ "10").then(__webpack_require__.bind(__webpack_require__, /*! ./chunk2 */ "./chunk2.js")));
+/* export default */ const __rspack_default_export = (() => __webpack_require__.e(/*! import() | 10 */ "10").then(__webpack_require__.bind(__webpack_require__, /*! ./chunk2 */ "./chunk2.js")));
 
 
 }),

--- a/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/2.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 50
 - Update: 10.LAST_HASH.hot-update.js, size: 350
-- Update: main.LAST_HASH.hot-update.js, size: 698
+- Update: main.LAST_HASH.hot-update.js, size: 692
 
 ## Manifest
 
@@ -73,9 +73,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (() => __webpack_require__.e(/*! import() | 1e1 */ "1e1").then(__webpack_require__.bind(__webpack_require__, /*! ./chunk */ "./chunk.js")));
+/* export default */ const __rspack_default_export = (() => __webpack_require__.e(/*! import() | 1e1 */ "1e1").then(__webpack_require__.bind(__webpack_require__, /*! ./chunk */ "./chunk.js")));
 
 
 }),

--- a/tests/rspack-test/hotCases/parsing/hot-api-optional-chaining/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/parsing/hot-api-optional-chaining/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 542
+- Update: main.LAST_HASH.hot-update.js, size: 536
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 569
+- Update: main.LAST_HASH.hot-update.js, size: 563
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 throw new Error("Failed");
 
 

--- a/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 542
+- Update: main.LAST_HASH.hot-update.js, size: 536
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),

--- a/tests/rspack-test/hotCases/recover/recover-after-loader-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-loader-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1029
+- Update: main.LAST_HASH.hot-update.js, size: 1023
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),

--- a/tests/rspack-test/hotCases/recover/recover-after-parsing-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-parsing-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 981
+- Update: main.LAST_HASH.hot-update.js, size: 975
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),

--- a/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 40
-- Update: main.LAST_HASH.hot-update.js, size: 566
+- Update: main.LAST_HASH.hot-update.js, size: 560
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("ok2");
+/* export default */ const __rspack_default_export = ("ok2");
 
 
 }),

--- a/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1083
+- Update: main.LAST_HASH.hot-update.js, size: 1071
 
 ## Manifest
 
@@ -40,11 +40,11 @@ self["webpackHotUpdate"]("main", {
 (function (module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 module.hot.accept();
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("-inner");
+/* export default */ const __rspack_default_export = ("-inner");
 
 
 }),
@@ -55,12 +55,12 @@ module.hot.accept();
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _inner__rspack_import_0 = __webpack_require__(/*! ./inner */ "./inner.js");
 
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("ok3" + _inner__rspack_import_0["default"]);
+/* export default */ const __rspack_default_export = ("ok3" + _inner__rspack_import_0["default"]);
 
 
 }),

--- a/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 802
+- Update: main.LAST_HASH.hot-update.js, size: 796
 
 ## Manifest
 
@@ -39,13 +39,13 @@ self["webpackHotUpdate"]("main", {
 (function (module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__),
+  "default": () => (__rspack_default_export),
   getError: () => (getError),
   id: () => (id)
 });
 module.hot.data.store.error = false;
 module.hot.data.store.value = 2;
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (() => { throw new Error("should not happen") });
+/* export default */ const __rspack_default_export = (() => { throw new Error("should not happen") });
 const getError = () => { throw new Error("should not happen") };
 const id = module.id;
 throw new Error("Failed");

--- a/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1214
+- Update: main.LAST_HASH.hot-update.js, size: 1208
 
 ## Manifest
 
@@ -40,13 +40,13 @@ self["webpackHotUpdate"]("main", {
 (function (module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__),
+  "default": () => (__rspack_default_export),
   getError: () => (getError),
   id: () => (id)
 });
 module.hot.data.store.error = false;
 module.hot.data.store.value = 4;
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (() => { throw new Error("should not happen") });
+/* export default */ const __rspack_default_export = (() => { throw new Error("should not happen") });
 const getError = () => { throw new Error("should not happen") };
 const id = module.id;
 

--- a/tests/rspack-test/hotCases/runtime/circular/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/circular/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1064
+- Update: main.LAST_HASH.hot-update.js, size: 1052
 
 ## Manifest
 
@@ -41,13 +41,13 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var ___rspack_import_0 = __webpack_require__(/*! ./ */ "./index.js");
 /* import */var _b__rspack_import_1 = __webpack_require__(/*! ./b */ "./b.js");
 
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),
@@ -58,9 +58,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: b_js.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 42
-- Update: main.LAST_HASH.hot-update.js, size: 679
+- Update: main.LAST_HASH.hot-update.js, size: 673
 
 ## Manifest
 
@@ -42,9 +42,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (__webpack_require__.e(/*! import() */ "b_js").then(__webpack_require__.bind(__webpack_require__, /*! ./b */ "./b.js")));
+/* export default */ const __rspack_default_export = (__webpack_require__.e(/*! import() */ "b_js").then(__webpack_require__.bind(__webpack_require__, /*! ./b */ "./b.js")));
 
 
 }),

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/2.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: b_js.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 35
-- Update: b_js.LAST_HASH.hot-update.js, size: 422
+- Update: b_js.LAST_HASH.hot-update.js, size: 416
 - Update: main.LAST_HASH.hot-update.js, size: 182
 
 ## Manifest
@@ -43,9 +43,9 @@ self["webpackHotUpdate"]("b_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("version b2");
+/* export default */ const __rspack_default_export = ("version b2");
 
 
 }),

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/3.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: a_js.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 42
-- Update: main.LAST_HASH.hot-update.js, size: 679
+- Update: main.LAST_HASH.hot-update.js, size: 673
 
 ## Manifest
 
@@ -42,9 +42,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (__webpack_require__.e(/*! import() */ "a_js").then(__webpack_require__.bind(__webpack_require__, /*! ./a */ "./a.js")));
+/* export default */ const __rspack_default_export = (__webpack_require__.e(/*! import() */ "a_js").then(__webpack_require__.bind(__webpack_require__, /*! ./a */ "./a.js")));
 
 
 }),

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 36
-- Update: main.LAST_HASH.hot-update.js, size: 842
+- Update: main.LAST_HASH.hot-update.js, size: 836
 
 ## Manifest
 
@@ -41,9 +41,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 }),
 "./module.js": 

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 36
-- Update: main.LAST_HASH.hot-update.js, size: 953
+- Update: main.LAST_HASH.hot-update.js, size: 947
 
 ## Manifest
 
@@ -41,9 +41,9 @@ self["webpackHotUpdate"]("main", {
 (function (module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (module.id);
+/* export default */ const __rspack_default_export = (module.id);
 
 }),
 "./module.js": 

--- a/tests/rspack-test/hotCases/runtime/hmr-circular/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/hmr-circular/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 45
-- Update: main.LAST_HASH.hot-update.js, size: 571
+- Update: main.LAST_HASH.hot-update.js, size: 565
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("new_entry.js");
+/* export default */ const __rspack_default_export = ("new_entry.js");
 
 
 }),

--- a/tests/rspack-test/hotCases/runtime/import-after-download/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/import-after-download/__snapshots__/web/1.snap.txt
@@ -9,8 +9,8 @@
 - Bundle: chunk_js.CURRENT_HASH.js
 - Bundle: unaffected-chunk_js.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 39
-- Update: chunk_js.LAST_HASH.hot-update.js, size: 432
-- Update: main.LAST_HASH.hot-update.js, size: 554
+- Update: chunk_js.LAST_HASH.hot-update.js, size: 426
+- Update: main.LAST_HASH.hot-update.js, size: 548
 
 ## Manifest
 
@@ -43,9 +43,9 @@ self["webpackHotUpdate"]("chunk_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (20);
+/* export default */ const __rspack_default_export = (20);
 
 
 }),
@@ -74,9 +74,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/runtime/replace-runtime-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/replace-runtime-module/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: b.chunk.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 39
-- Update: main.LAST_HASH.hot-update.js, size: 680
+- Update: main.LAST_HASH.hot-update.js, size: 674
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (__webpack_require__.e(/*! import() | b */ "b").then(__webpack_require__.bind(__webpack_require__, /*! ./b */ "./b.js")));
+/* export default */ const __rspack_default_export = (__webpack_require__.e(/*! import() | b */ "b").then(__webpack_require__.bind(__webpack_require__, /*! ./b */ "./b.js")));
 
 
 }),

--- a/tests/rspack-test/hotCases/runtime/require-disposed-module-warning/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/require-disposed-module-warning/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 36
-- Update: main.LAST_HASH.hot-update.js, size: 773
+- Update: main.LAST_HASH.hot-update.js, size: 767
 
 ## Manifest
 
@@ -40,9 +40,9 @@ self["webpackHotUpdate"]("main", {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("b");
+/* export default */ const __rspack_default_export = ("b");
 
 
 }),

--- a/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 554
+- Update: main.LAST_HASH.hot-update.js, size: 548
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 554
+- Update: main.LAST_HASH.hot-update.js, size: 548
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),

--- a/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 553
+- Update: main.LAST_HASH.hot-update.js, size: 547
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 }),
 

--- a/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 608
+- Update: main.LAST_HASH.hot-update.js, size: 602
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 608
+- Update: main.LAST_HASH.hot-update.js, size: 602
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),

--- a/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 607
+- Update: main.LAST_HASH.hot-update.js, size: 601
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 }),
 

--- a/tests/rspack-test/hotCases/stats/chunks/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/stats/chunks/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 553
+- Update: main.LAST_HASH.hot-update.js, size: 547
 
 ## Manifest
 
@@ -39,9 +39,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 }),
 

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/1.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 827
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 815
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -90,9 +90,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),
@@ -103,9 +103,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),
@@ -134,9 +134,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),
@@ -172,9 +172,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/2.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 827
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 815
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -90,9 +90,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),
@@ -103,9 +103,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),
@@ -134,9 +134,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),
@@ -172,9 +172,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/3.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 827
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 815
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -90,9 +90,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),
@@ -103,9 +103,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),
@@ -134,9 +134,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),
@@ -172,9 +172,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/4.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/4.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 827
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 815
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -90,9 +90,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 
 
 }),
@@ -103,9 +103,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 
 
 }),
@@ -134,9 +134,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 
 
 }),
@@ -172,9 +172,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/5.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/5.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 827
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 815
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -90,9 +90,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (5);
+/* export default */ const __rspack_default_export = (5);
 
 
 }),
@@ -103,9 +103,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (5);
+/* export default */ const __rspack_default_export = (5);
 
 
 }),
@@ -134,9 +134,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (5);
+/* export default */ const __rspack_default_export = (5);
 
 
 }),
@@ -172,9 +172,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (5);
+/* export default */ const __rspack_default_export = (5);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/6.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/6.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 827
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 815
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -90,9 +90,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (6);
+/* export default */ const __rspack_default_export = (6);
 
 
 }),
@@ -103,9 +103,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (6);
+/* export default */ const __rspack_default_export = (6);
 
 
 }),
@@ -134,9 +134,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (6);
+/* export default */ const __rspack_default_export = (6);
 
 
 }),
@@ -172,9 +172,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (6);
+/* export default */ const __rspack_default_export = (6);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/7.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/7.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 827
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 815
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -90,9 +90,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (7);
+/* export default */ const __rspack_default_export = (7);
 
 
 }),
@@ -103,9 +103,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (7);
+/* export default */ const __rspack_default_export = (7);
 
 
 }),
@@ -134,9 +134,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (7);
+/* export default */ const __rspack_default_export = (7);
 
 
 }),
@@ -172,9 +172,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (7);
+/* export default */ const __rspack_default_export = (7);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/1.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 1316
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 1053
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 1298
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 1041
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -91,10 +91,10 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _moduleS__rspack_import_0 = __webpack_require__(/*! ./moduleS */ "./moduleS.js");
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 
@@ -106,9 +106,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),
@@ -119,9 +119,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("moduleS");
+/* export default */ const __rspack_default_export = ("moduleS");
 
 
 }),
@@ -151,9 +151,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("module");
+/* export default */ const __rspack_default_export = ("module");
 
 
 }),
@@ -164,10 +164,10 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _module__rspack_import_0 = __webpack_require__(/*! ./module */ "./module.js");
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 
@@ -204,9 +204,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/2.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 1025
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 668
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 1053
+- Update: shared.LAST_HASH.hot-update.js, size: 1013
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 662
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 1041
 
 ## Manifest
 
@@ -90,10 +90,10 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _moduleS__rspack_import_0 = __webpack_require__(/*! ./moduleS */ "./moduleS.js");
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 
@@ -105,10 +105,10 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _moduleS__rspack_import_0 = __webpack_require__(/*! ./moduleS */ "./moduleS.js");
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 
@@ -138,10 +138,10 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _module__rspack_import_0 = __webpack_require__(/*! ./module */ "./module.js");
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 
@@ -179,9 +179,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("module");
+/* export default */ const __rspack_default_export = ("module");
 
 
 }),
@@ -192,10 +192,10 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _module__rspack_import_0 = __webpack_require__(/*! ./module */ "./module.js");
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/3.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 926
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 668
+- Update: shared.LAST_HASH.hot-update.js, size: 914
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 662
 
 ## Manifest
 
@@ -90,9 +90,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),
@@ -103,10 +103,10 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _moduleS__rspack_import_0 = __webpack_require__(/*! ./moduleS */ "./moduleS.js");
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 
@@ -136,9 +136,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),
@@ -174,10 +174,10 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _module__rspack_import_0 = __webpack_require__(/*! ./module */ "./module.js");
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/4.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/4.snap.txt
@@ -17,9 +17,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 71
 - Manifest: main.LAST_HASH.hot-update.json, size: 56
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 985
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 727
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 973
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 721
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -92,9 +92,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, /*! ./chunkS */ "./chunkS.js"));
 
 
@@ -106,9 +106,9 @@ if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunkS_js").then(_
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 
 
 }),
@@ -137,9 +137,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, /*! ./chunk */ "./chunk.js"));
 
 
@@ -176,9 +176,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (4);
+/* export default */ const __rspack_default_export = (4);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/5.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/5.snap.txt
@@ -17,9 +17,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 1143
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 727
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 727
+- Update: shared.LAST_HASH.hot-update.js, size: 1131
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 721
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 721
 
 ## Manifest
 
@@ -92,9 +92,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (5);
+/* export default */ const __rspack_default_export = (5);
 if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, /*! ./chunkS */ "./chunkS.js"));
 
 
@@ -106,9 +106,9 @@ if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunkS_js").then(_
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (5);
+/* export default */ const __rspack_default_export = (5);
 if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, /*! ./chunkS */ "./chunkS.js"));
 
 
@@ -138,9 +138,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (5);
+/* export default */ const __rspack_default_export = (5);
 if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, /*! ./chunk */ "./chunk.js"));
 
 
@@ -177,9 +177,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (5);
+/* export default */ const __rspack_default_export = (5);
 if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, /*! ./chunk */ "./chunk.js"));
 
 

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/6.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/6.snap.txt
@@ -17,9 +17,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 985
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 727
+- Update: shared.LAST_HASH.hot-update.js, size: 973
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 721
 
 ## Manifest
 
@@ -92,9 +92,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (6);
+/* export default */ const __rspack_default_export = (6);
 
 
 }),
@@ -105,9 +105,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (6);
+/* export default */ const __rspack_default_export = (6);
 if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, /*! ./chunkS */ "./chunkS.js"));
 
 
@@ -137,9 +137,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (6);
+/* export default */ const __rspack_default_export = (6);
 
 
 }),
@@ -175,9 +175,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (6);
+/* export default */ const __rspack_default_export = (6);
 if (Math.random() < 0) __webpack_require__.e(/*! import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, /*! ./chunk */ "./chunk.js"));
 
 

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/7.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/7.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 91
 - Manifest: main.LAST_HASH.hot-update.json, size: 54
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: shared.LAST_HASH.hot-update.js, size: 827
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 572
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 572
+- Update: shared.LAST_HASH.hot-update.js, size: 815
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 566
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 566
 
 ## Manifest
 
@@ -90,9 +90,9 @@ self["webpackHotUpdate"]("shared", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (7);
+/* export default */ const __rspack_default_export = (7);
 
 
 }),
@@ -103,9 +103,9 @@ __webpack_require__.d(__webpack_exports__, {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (7);
+/* export default */ const __rspack_default_export = (7);
 
 
 }),
@@ -134,9 +134,9 @@ self["webpackHotUpdate"]("workerA_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (7);
+/* export default */ const __rspack_default_export = (7);
 
 
 }),
@@ -172,9 +172,9 @@ self["webpackHotUpdate"]("workerB_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (7);
+/* export default */ const __rspack_default_export = (7);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/1.snap.txt
@@ -41,9 +41,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* ESM default export */ const __WEBPACK_DEFAULT_EXPORT__ = (async () => {
+/* ESM default export */ const __rspack_default_export = (async () => {
 	const worker = new Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("worker_js"), __webpack_require__.b));
 	const result = await new Promise((resolve, reject) => {
 		worker.onmessage = ({ data }) => {

--- a/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/2.snap.txt
@@ -49,9 +49,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* ESM default export */ const __WEBPACK_DEFAULT_EXPORT__ = (() => Promise.resolve(42));
+/* ESM default export */ const __rspack_default_export = (() => Promise.resolve(42));
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/3.snap.txt
@@ -41,9 +41,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* ESM default export */ const __WEBPACK_DEFAULT_EXPORT__ = (async () => {
+/* ESM default export */ const __rspack_default_export = (async () => {
 	const worker = new Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("worker_js"), __webpack_require__.b));
 	const result = await new Promise((resolve, reject) => {
 		worker.onmessage = ({ data }) => {

--- a/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/4.snap.txt
+++ b/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/4.snap.txt
@@ -50,12 +50,12 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 if(Math.random() < 0) {
 	new Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("worker_js_1"), __webpack_require__.b));
 }
-/* ESM default export */ const __WEBPACK_DEFAULT_EXPORT__ = (async () => {
+/* ESM default export */ const __rspack_default_export = (async () => {
 	const worker = new Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("worker_js"), __webpack_require__.b));
 	const result = await new Promise((resolve, reject) => {
 		worker.onmessage = ({ data }) => {

--- a/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/5.snap.txt
+++ b/tests/rspack-test/hotCases/worker/remove-add-worker/__snapshots__/web/5.snap.txt
@@ -59,9 +59,9 @@ self["webpackHotUpdate"]("main", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* ESM default export */ const __WEBPACK_DEFAULT_EXPORT__ = (async () => {
+/* ESM default export */ const __rspack_default_export = (async () => {
 	const worker = new Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("worker_js"), __webpack_require__.b));
 	const result = await new Promise((resolve, reject) => {
 		worker.onmessage = ({ data }) => {

--- a/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Manifest: [runtime of worker_js].LAST_HASH.hot-update.json, size: 33
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: worker_js.LAST_HASH.hot-update.js, size: 567
+- Update: worker_js.LAST_HASH.hot-update.js, size: 561
 
 ## Manifest
 
@@ -73,9 +73,9 @@ self["webpackHotUpdate"]("worker_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+/* export default */ const __rspack_default_export = (2);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/2.snap.txt
@@ -9,7 +9,7 @@
 - Manifest: [runtime of worker_js].LAST_HASH.hot-update.json, size: 33
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: worker_js.LAST_HASH.hot-update.js, size: 567
+- Update: worker_js.LAST_HASH.hot-update.js, size: 561
 
 ## Manifest
 
@@ -73,9 +73,9 @@ self["webpackHotUpdate"]("worker_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (3);
+/* export default */ const __rspack_default_export = (3);
 
 
 }),

--- a/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/3.snap.txt
@@ -9,7 +9,7 @@
 - Manifest: [runtime of worker_js].LAST_HASH.hot-update.json, size: 33
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 182
-- Update: worker_js.LAST_HASH.hot-update.js, size: 568
+- Update: worker_js.LAST_HASH.hot-update.js, size: 562
 
 ## Manifest
 
@@ -73,9 +73,9 @@ self["webpackHotUpdate"]("worker_js", {
 (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (42);
+/* export default */ const __rspack_default_export = (42);
 
 
 }),

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -71,7 +71,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: ebb4200b82e431d1,
+			      hash: 2a4fcd21c37fffc7,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -459,7 +459,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 4eef549f69015bed,
+			  hash: 4114978a03e09ff7,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsOutputCases/import-context-filter/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/import-context-filter/__snapshots__/stats.txt
@@ -1,7 +1,7 @@
 asset entry.js xx KiB [emitted] (name: entry)
-asset 870.js 401 bytes [emitted]
-asset 897.js 401 bytes [emitted]
-asset 985.js 399 bytes [emitted]
+asset 870.js 395 bytes [emitted]
+asset 897.js 395 bytes [emitted]
+asset 985.js 393 bytes [emitted]
 runtime modules xx KiB 11 modules
 cacheable modules 724 bytes
   modules by path ./templates/*.js 114 bytes

--- a/tests/rspack-test/statsOutputCases/split-chunks-cache-group-filename/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/split-chunks-cache-group-filename/__snapshots__/stats.txt
@@ -1,4 +1,4 @@
-Entrypoint main xx KiB = 256.vendors.js 331 bytes 955.vendors.js 331 bytes 38.vendors.js 330 bytes main.js xx KiB
+Entrypoint main xx KiB = 256.vendors.js 325 bytes 955.vendors.js 325 bytes 38.vendors.js 324 bytes main.js xx KiB
 chunk (runtime: main) 256.vendors.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
   ./node_modules/a.js 20 bytes [built] [code generated]
 chunk (runtime: main) 38.vendors.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)

--- a/tests/rspack-test/statsOutputCases/split-chunks/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/split-chunks/__snapshots__/stats.txt
@@ -56,9 +56,9 @@ default:
 
 all-chunks:
   Entrypoint main xx KiB = all-chunks/main.js
-  Entrypoint a xx KiB = all-chunks/773.js 331 bytes all-chunks/192.js 331 bytes all-chunks/266.js 331 bytes all-chunks/327.js 331 bytes all-chunks/a.js xx KiB
-  Entrypoint b xx KiB = all-chunks/773.js 331 bytes all-chunks/192.js 331 bytes all-chunks/266.js 331 bytes all-chunks/828.js 331 bytes all-chunks/b.js xx KiB
-  Entrypoint c xx KiB = all-chunks/773.js 331 bytes all-chunks/859.js 331 bytes all-chunks/266.js 331 bytes all-chunks/828.js 331 bytes all-chunks/c.js xx KiB
+  Entrypoint a xx KiB = all-chunks/773.js 325 bytes all-chunks/192.js 325 bytes all-chunks/266.js 325 bytes all-chunks/327.js 325 bytes all-chunks/a.js xx KiB
+  Entrypoint b xx KiB = all-chunks/773.js 325 bytes all-chunks/192.js 325 bytes all-chunks/266.js 325 bytes all-chunks/828.js 325 bytes all-chunks/b.js xx KiB
+  Entrypoint c xx KiB = all-chunks/773.js 325 bytes all-chunks/859.js 325 bytes all-chunks/266.js 325 bytes all-chunks/828.js 325 bytes all-chunks/c.js xx KiB
   chunk (runtime: a, main) all-chunks/async-g.js (async-g) 45 bytes <{192}> <{266}> <{327}> <{341}> <{724}> <{773}> ={828}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
@@ -124,9 +124,9 @@ all-chunks:
 
 manual:
   Entrypoint main xx KiB = manual/main.js
-  Entrypoint a xx KiB = manual/vendors.js 817 bytes manual/a.js xx KiB
-  Entrypoint b xx KiB = manual/vendors.js 817 bytes manual/b.js xx KiB
-  Entrypoint c xx KiB = manual/vendors.js 817 bytes manual/c.js xx KiB
+  Entrypoint a xx KiB = manual/vendors.js 799 bytes manual/a.js xx KiB
+  Entrypoint b xx KiB = manual/vendors.js 799 bytes manual/b.js xx KiB
+  Entrypoint c xx KiB = manual/vendors.js 799 bytes manual/c.js xx KiB
   chunk (runtime: a, main) manual/async-g.js (async-g) 65 bytes <{341}> <{545}> <{724}> [rendered]
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
@@ -190,9 +190,9 @@ manual:
 
 name-too-long:
   Entrypoint main xx KiB = name-too-long/main.js
-  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa xx KiB = name-too-long/773.js 331 bytes name-too-long/192.js 331 bytes name-too-long/266.js 331 bytes name-too-long/327.js 331 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js xx KiB
-  Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb xx KiB = name-too-long/773.js 331 bytes name-too-long/192.js 331 bytes name-too-long/266.js 331 bytes name-too-long/828.js 331 bytes name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js xx KiB
-  Entrypoint cccccccccccccccccccccccccccccc xx KiB = name-too-long/773.js 331 bytes name-too-long/859.js 331 bytes name-too-long/266.js 331 bytes name-too-long/828.js 331 bytes name-too-long/cccccccccccccccccccccccccccccc.js xx KiB
+  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa xx KiB = name-too-long/773.js 325 bytes name-too-long/192.js 325 bytes name-too-long/266.js 325 bytes name-too-long/327.js 325 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js xx KiB
+  Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb xx KiB = name-too-long/773.js 325 bytes name-too-long/192.js 325 bytes name-too-long/266.js 325 bytes name-too-long/828.js 325 bytes name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js xx KiB
+  Entrypoint cccccccccccccccccccccccccccccc xx KiB = name-too-long/773.js 325 bytes name-too-long/859.js 325 bytes name-too-long/266.js 325 bytes name-too-long/828.js 325 bytes name-too-long/cccccccccccccccccccccccccccccc.js xx KiB
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/async-g.js (async-g) 45 bytes <{192}> <{266}> <{327}> <{706}> <{724}> <{773}> ={828}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
@@ -259,8 +259,8 @@ name-too-long:
 custom-chunks-filter:
   Entrypoint main xx KiB = custom-chunks-filter/main.js
   Entrypoint a xx KiB = custom-chunks-filter/a.js
-  Entrypoint b xx KiB = custom-chunks-filter/773.js 331 bytes custom-chunks-filter/192.js 331 bytes custom-chunks-filter/828.js 331 bytes custom-chunks-filter/266.js 331 bytes custom-chunks-filter/b.js xx KiB
-  Entrypoint c xx KiB = custom-chunks-filter/773.js 331 bytes custom-chunks-filter/859.js 331 bytes custom-chunks-filter/828.js 331 bytes custom-chunks-filter/266.js 331 bytes custom-chunks-filter/c.js xx KiB
+  Entrypoint b xx KiB = custom-chunks-filter/773.js 325 bytes custom-chunks-filter/192.js 325 bytes custom-chunks-filter/828.js 325 bytes custom-chunks-filter/266.js 325 bytes custom-chunks-filter/b.js xx KiB
+  Entrypoint c xx KiB = custom-chunks-filter/773.js 325 bytes custom-chunks-filter/859.js 325 bytes custom-chunks-filter/828.js 325 bytes custom-chunks-filter/266.js 325 bytes custom-chunks-filter/c.js xx KiB
   chunk (runtime: a, main) custom-chunks-filter/async-g.js (async-g) 45 bytes <{192}> <{266}> <{341}> <{724}> <{773}> ={828}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
@@ -320,9 +320,9 @@ custom-chunks-filter:
 
 custom-chunks-filter-in-cache-groups:
   Entrypoint main 9 KiB = custom-chunks-filter-in-cache-groups/main.js
-  Entrypoint a xx KiB = custom-chunks-filter-in-cache-groups/70.js 667 bytes custom-chunks-filter-in-cache-groups/a.js xx KiB
-  Entrypoint b xx KiB = custom-chunks-filter-in-cache-groups/vendors.js 817 bytes custom-chunks-filter-in-cache-groups/b.js xx KiB
-  Entrypoint c xx KiB = custom-chunks-filter-in-cache-groups/vendors.js 817 bytes custom-chunks-filter-in-cache-groups/c.js xx KiB
+  Entrypoint a xx KiB = custom-chunks-filter-in-cache-groups/70.js 652 bytes custom-chunks-filter-in-cache-groups/a.js xx KiB
+  Entrypoint b xx KiB = custom-chunks-filter-in-cache-groups/vendors.js 799 bytes custom-chunks-filter-in-cache-groups/b.js xx KiB
+  Entrypoint c xx KiB = custom-chunks-filter-in-cache-groups/vendors.js 799 bytes custom-chunks-filter-in-cache-groups/c.js xx KiB
   chunk (runtime: a, main) custom-chunks-filter-in-cache-groups/async-g.js (async-g) 65 bytes <{341}> <{545}> <{70}> <{724}> [rendered]
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module

--- a/tests/rspack-test/treeShakingCases/cjs-export-computed-property/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/cjs-export-computed-property/__snapshots__/treeshaking.snap.txt
@@ -26,12 +26,12 @@ function test() {}
 }),
 "./locale_zh.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _zh_locale__rspack_import_0 = __webpack_require__("./zh_locale.js");
 
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (_zh_locale__rspack_import_0["default"]);
+/* export default */ const __rspack_default_export = (_zh_locale__rspack_import_0["default"]);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/cyclic-reference-export-all/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/cyclic-reference-export-all/__snapshots__/treeshaking.snap.txt
@@ -3,7 +3,7 @@
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["main"], {
 "./src/App.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _containers__rspack_import_0 = __webpack_require__("./src/containers/containers.js");
 
@@ -14,7 +14,7 @@ const Index = () => {
 	return "something";
 };
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (Index);
+/* export default */ const __rspack_default_export = (Index);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/import-as-default/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-as-default/__snapshots__/treeshaking.snap.txt
@@ -3,10 +3,10 @@
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 var a = 1;
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (a);
+/* export default */ const __rspack_default_export = (a);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/issue-4637/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/issue-4637/__snapshots__/treeshaking.snap.txt
@@ -60,7 +60,7 @@ ConsoleExporterWeb = (function () {
 	return ConsoleExporterWeb;
 })();
 
-/* unused export default */ var __WEBPACK_DEFAULT_EXPORT__ = ((/* unused pure expression or super */ null && (ConsoleExporterWeb)));
+/* unused export default */ var __rspack_default_export = ((/* unused pure expression or super */ null && (ConsoleExporterWeb)));
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/prune-bailout-module/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/prune-bailout-module/__snapshots__/treeshaking.snap.txt
@@ -3,9 +3,9 @@
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (300);
+/* export default */ const __rspack_default_export = (300);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/pure_comments_magic_comments/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/pure_comments_magic_comments/__snapshots__/treeshaking.snap.txt
@@ -10,7 +10,7 @@ function res() {
 	answer;
 }
 const a = 3;
-/* unused export default */ var __WEBPACK_DEFAULT_EXPORT__ = (/*#__PURE__*/(/* unused pure expression or super */ null && (res())));
+/* unused export default */ var __rspack_default_export = (/*#__PURE__*/(/* unused pure expression or super */ null && (res())));
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/react-redux-like/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/react-redux-like/__snapshots__/treeshaking.snap.txt
@@ -12,11 +12,11 @@ _foo__rspack_import_1["default"];
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 function Provider() {}
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (Provider);
+/* export default */ const __rspack_default_export = (Provider);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/reexport_entry_elimination/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/reexport_entry_elimination/__snapshots__/treeshaking.snap.txt
@@ -3,19 +3,19 @@
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["main"], {
 "./b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _c_js__rspack_import_0 = __webpack_require__("./c.js");
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (2000 + _c_js__rspack_import_0["default"]);
+/* export default */ const __rspack_default_export = (2000 + _c_js__rspack_import_0["default"]);
 
 
 }),
 "./c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (10);
+/* export default */ const __rspack_default_export = (10);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports-function-argument/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports-function-argument/__snapshots__/treeshaking.snap.txt
@@ -4,13 +4,13 @@
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
   bar: () => (bar),
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 var foo = function () {
 	return 42;
 };
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (foo);
+/* export default */ const __rspack_default_export = (foo);
 
 function bar() {
 	return contrivedExample(foo);

--- a/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports/__snapshots__/treeshaking.snap.txt
@@ -3,14 +3,14 @@
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["main"], {
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 var Foo = function () {
 	console.log("side effect");
 	this.isFoo = true;
 };
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (Foo);
+/* export default */ const __rspack_default_export = (Foo);
 
 Foo.prototype = {
 	answer: function () {

--- a/tests/rspack-test/treeShakingCases/rollup-unused-called-import/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-called-import/__snapshots__/treeshaking.snap.txt
@@ -2,7 +2,7 @@
 "use strict";
 (self["webpackChunkwebpack"] = self["webpackChunkwebpack"] || []).push([["main"], {
 "./dead.js": (function () {
-/* export default */ function __WEBPACK_DEFAULT_EXPORT__() {
+/* export default */ function __rspack_default_export() {
 	return "dead";
 }
 
@@ -10,12 +10,12 @@
 }),
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* export default binding */ __WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (/* export default binding */ __rspack_default_export)
 });
 /* import */var _dead__rspack_import_0 = __webpack_require__("./dead.js");
 
 
-/* export default */ function __WEBPACK_DEFAULT_EXPORT__() {
+/* export default */ function __rspack_default_export() {
 	return "foo";
 }
 

--- a/tests/rspack-test/treeShakingCases/rollup-unused-default-exports/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-default-exports/__snapshots__/treeshaking.snap.txt
@@ -12,7 +12,7 @@ function mutate(obj) {
 	return obj;
 }
 
-/* unused export default */ var __WEBPACK_DEFAULT_EXPORT__ = (mutate(foo));
+/* unused export default */ var __rspack_default_export = (mutate(foo));
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/side-effects-analyzed/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-analyzed/__snapshots__/treeshaking.snap.txt
@@ -11,12 +11,12 @@
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* export default binding */ __WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (/* export default binding */ __rspack_default_export)
 });
 const secret = "888";
 const result = 20000;
 const something = function () {};
-/* export default */ function __WEBPACK_DEFAULT_EXPORT__() {}
+/* export default */ function __rspack_default_export() {}
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/side-effects-export-default-expr/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-export-default-expr/__snapshots__/treeshaking.snap.txt
@@ -7,7 +7,7 @@ __webpack_require__.d(__webpack_exports__, {
 });
 
 
-/* unused export default */ var __WEBPACK_DEFAULT_EXPORT__ = ((/* unused pure expression or super */ null && (a)));
+/* unused export default */ var __rspack_default_export = ((/* unused pure expression or super */ null && (a)));
 
 const b = 1;
 

--- a/tests/rspack-test/treeShakingCases/side-effects-flagged-only/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-flagged-only/__snapshots__/treeshaking.snap.txt
@@ -22,17 +22,17 @@ __webpack_require__.d(__webpack_exports__, {
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* export default binding */ __WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (/* export default binding */ __rspack_default_export)
 });
 const secret = "888";
 const result = 20000;
 const something = function () {};
-/* export default */ function __WEBPACK_DEFAULT_EXPORT__() {}
+/* export default */ function __rspack_default_export() {}
 
 
 }),
 "./src/a.js": (function () {
-/* unused export default */ var __WEBPACK_DEFAULT_EXPORT__ = (() => {
+/* unused export default */ var __rspack_default_export = (() => {
 	console.log("");
 });
 

--- a/tests/rspack-test/treeShakingCases/side-effects-two/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-two/__snapshots__/treeshaking.snap.txt
@@ -11,12 +11,12 @@
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* export default binding */ __WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (/* export default binding */ __rspack_default_export)
 });
 const secret = "888";
 const result = 20000;
 const something = function () {};
-/* export default */ function __WEBPACK_DEFAULT_EXPORT__() {}
+/* export default */ function __rspack_default_export() {}
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/tree-shaking-lazy-import/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/tree-shaking-lazy-import/__snapshots__/treeshaking.snap.txt
@@ -4,7 +4,7 @@
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _test__rspack_import_0 = __webpack_require__("./test.js");
 
@@ -12,17 +12,17 @@ function myanswer() {
 	_test__rspack_import_0["default"];
 }
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (myanswer);
+/* export default */ const __rspack_default_export = (myanswer);
 
 
 }),
 "./test.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 function test() {}
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (test);
+/* export default */ const __rspack_default_export = (test);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/webpack-inner-graph-export-default-named/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-inner-graph-export-default-named/__snapshots__/treeshaking.snap.txt
@@ -53,65 +53,65 @@ class def {
 }),
 "./dep.js?a": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__),
+  "default": () => (__rspack_default_export),
   x: () => (x)
 });
 const x = "x";
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (true);
+/* export default */ const __rspack_default_export = (true);
 
 
 }),
 "./dep.js?b": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 const x = "x";
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (false);
+/* export default */ const __rspack_default_export = (false);
 
 
 }),
 "./dep.js?c": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__),
+  "default": () => (__rspack_default_export),
   x: () => (x)
 });
 const x = "x";
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (true);
+/* export default */ const __rspack_default_export = (true);
 
 
 }),
 "./dep.js?d": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__),
+  "default": () => (__rspack_default_export),
   x: () => (x)
 });
 const x = "x";
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (true);
+/* export default */ const __rspack_default_export = (true);
 
 
 }),
 "./dep.js?e": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 const x = "x";
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (false);
+/* export default */ const __rspack_default_export = (false);
 
 
 }),
 "./dep.js?f": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__),
+  "default": () => (__rspack_default_export),
   x: () => (x)
 });
 const x = "x";
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (true);
+/* export default */ const __rspack_default_export = (true);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/webpack-inner-graph-switch/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-inner-graph-switch/__snapshots__/treeshaking.snap.txt
@@ -40,7 +40,7 @@ it("should generate correct code when pure expressions are in dead branches", ()
 "./module.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _some_module__rspack_import_0 = __webpack_require__("./some-module.js");
 
@@ -83,7 +83,7 @@ function useDocument(obj) {
 }
 
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (doSomething);
+/* export default */ const __rspack_default_export = (doSomething);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/webpack-innergraph-no-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-innergraph-no-side-effects/__snapshots__/treeshaking.snap.txt
@@ -11,13 +11,13 @@ it("should be able to load package without side effects where modules are unused
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__),
+  "default": () => (__rspack_default_export),
   test: () => (test)
 });
 /* import */var _package__rspack_import_0 = __webpack_require__("./package/index.js");
 
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (_package__rspack_import_0.a);
+/* export default */ const __rspack_default_export = (_package__rspack_import_0.a);
 
 function test() {}
 

--- a/tests/rspack-test/treeShakingCases/webpack-reexport-namespace-and-default/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-reexport-namespace-and-default/__snapshots__/treeshaking.snap.txt
@@ -46,7 +46,7 @@ __webpack_require__.d(__webpack_exports__, {
 });
 /* import */var _script1__rspack_import_0 = __webpack_require__("./package1/script1.js");
 
-/* unused export default */ var __WEBPACK_DEFAULT_EXPORT__ = ((/* unused pure expression or super */ null && (mod)));
+/* unused export default */ var __rspack_default_export = ((/* unused pure expression or super */ null && (mod)));
 
 
 const exportDefaultUsed = false;
@@ -56,7 +56,7 @@ const exportDefaultUsed = false;
 "./package1/script1.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 /* import */var _script2__rspack_import_0 = __webpack_require__("./package1/script2.js");
 
-/* unused export default */ var __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* unused export default */ var __rspack_default_export = (1);
 
 
 }),
@@ -65,7 +65,7 @@ __webpack_require__.d(__webpack_exports__, {
   exportDefaultUsed: () => (exportDefaultUsed)
 });
 
-/* export default */ function __WEBPACK_DEFAULT_EXPORT__() {
+/* export default */ function __rspack_default_export() {
 	return mod;
 }
 
@@ -76,12 +76,12 @@ const exportDefaultUsed = false;
 }),
 "./package2/script.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__),
+  "default": () => (__rspack_default_export),
   exportDefaultUsed: () => (exportDefaultUsed)
 });
 /* import */var _script1__rspack_import_0 = __webpack_require__("./package2/script1.js");
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (_script1__rspack_import_0["default"]);
+/* export default */ const __rspack_default_export = (_script1__rspack_import_0["default"]);
 
 
 const exportDefaultUsed = true;
@@ -90,9 +90,9 @@ const exportDefaultUsed = true;
 }),
 "./package2/script1.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+/* export default */ const __rspack_default_export = (1);
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/webpack-side-effects-all-used/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-side-effects-all-used/__snapshots__/treeshaking.snap.txt
@@ -49,7 +49,7 @@ var z = "z";
 }),
 "../node_modules/pmodule/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 
@@ -58,7 +58,7 @@ __webpack_require__.d(__webpack_exports__, {
 
 (0,_tracker__rspack_import_0.track)("index.js");
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("def");
+/* export default */ const __rspack_default_export = ("def");
 
 
 }),

--- a/tests/rspack-test/treeShakingCases/webpack-side-effects-simple-unused/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-side-effects-simple-unused/__snapshots__/treeshaking.snap.txt
@@ -33,7 +33,7 @@ var z = "z";
 }),
 "../node_modules/pmodule/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+  "default": () => (__rspack_default_export)
 });
 /* import */var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 
@@ -42,7 +42,7 @@ __webpack_require__.d(__webpack_exports__, {
 
 (0,_tracker__rspack_import_0.track)("index.js");
 
-/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = ("def");
+/* export default */ const __rspack_default_export = ("def");
 
 
 }),


### PR DESCRIPTION
## Summary

Update default export variable naming convention from `__WEBPACK_DEFAULT_EXPORT__` to `__rspack_default_export`. 

See https://github.com/web-infra-dev/rspack/discussions/12244 for more details.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
