### PR TITLE
fix: should not panic when SRI options is invalid

### DIFF
--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -92,7 +92,7 @@ use rspack_plugin_runtime::{
 use rspack_plugin_runtime_chunk::RuntimeChunkPlugin;
 use rspack_plugin_schemes::{DataUriPlugin, FileUriPlugin};
 use rspack_plugin_size_limits::SizeLimitsPlugin;
-use rspack_plugin_sri::SubresourceIntegrityPlugin;
+use rspack_plugin_sri::{SubresourceIntegrityPlugin, SubresourceIntegrityPluginOptions};
 use rspack_plugin_swc_js_minimizer::SwcJsMinimizerRspackPlugin;
 use rspack_plugin_warn_sensitive_module::WarnCaseSensitiveModulesPlugin;
 use rspack_plugin_wasm::{
@@ -819,9 +819,15 @@ impl<'a> BuiltinPlugin<'a> {
       }
       BuiltinPluginName::SubresourceIntegrityPlugin => {
         let raw_options = downcast_into::<RawSubresourceIntegrityPluginOptions>(self.options)
-          .map_err(|report| napi::Error::from_reason(report.to_string()))?;
-        let options = raw_options.into();
-        plugins.push(SubresourceIntegrityPlugin::new(options).boxed());
+          .and_then(SubresourceIntegrityPluginOptions::try_from);
+        match raw_options {
+          Ok(options) => {
+            plugins.push(SubresourceIntegrityPlugin::new(options, None).boxed());
+          }
+          Err(error) => {
+            plugins.push(SubresourceIntegrityPlugin::new(Default::default(), Some(error)).boxed());
+          }
+        }
       }
       BuiltinPluginName::ModuleInfoHeaderPlugin => {
         let verbose = downcast_into::<bool>(self.options)

--- a/crates/rspack_plugin_sri/src/config.rs
+++ b/crates/rspack_plugin_sri/src/config.rs
@@ -15,25 +15,30 @@ use crate::integrity::SubresourceIntegrityHashFunction;
 pub type IntegrityCallbackFn =
   Arc<dyn Fn(IntegrityCallbackData) -> BoxFuture<'static, Result<()>> + Send + Sync>;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum IntegrityHtmlPlugin {
   NativePlugin,
   JavaScriptPlugin,
+  #[default]
   Disabled,
 }
 
-impl From<String> for IntegrityHtmlPlugin {
-  fn from(value: String) -> Self {
+impl TryFrom<String> for IntegrityHtmlPlugin {
+  type Error = rspack_error::Error;
+
+  fn try_from(value: String) -> Result<Self, rspack_error::Error> {
     match value.as_str() {
-      "JavaScript" => Self::JavaScriptPlugin,
-      "Native" => Self::NativePlugin,
-      "Disabled" => Self::Disabled,
-      _ => panic!("Invalid integrity html plugin: {value}"),
+      "JavaScript" => Ok(Self::JavaScriptPlugin),
+      "Native" => Ok(Self::NativePlugin),
+      "Disabled" => Ok(Self::Disabled),
+      _ => Err(rspack_error::Error::error(format!(
+        "Invalid integrity html plugin: {value}"
+      ))),
     }
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SubresourceIntegrityPluginOptions {
   pub hash_func_names: Vec<SubresourceIntegrityHashFunction>,
   pub html_plugin: IntegrityHtmlPlugin,

--- a/crates/rspack_plugin_sri/src/integrity.rs
+++ b/crates/rspack_plugin_sri/src/integrity.rs
@@ -11,16 +11,17 @@ pub enum SubresourceIntegrityHashFunction {
   Sha512,
 }
 
-impl From<String> for SubresourceIntegrityHashFunction {
-  fn from(s: String) -> Self {
-    match s.as_str() {
-      "sha256" => Self::Sha256,
-      "sha384" => Self::Sha384,
-      "sha512" => Self::Sha512,
-      _ => panic!(
-        "sri hash function only support 'sha256', 'sha384' or 'sha512', but got '{}'.",
-        s
-      ),
+impl TryFrom<String> for SubresourceIntegrityHashFunction {
+  type Error = rspack_error::Error;
+
+  fn try_from(value: String) -> Result<Self, rspack_error::Error> {
+    match value.as_str() {
+      "sha256" => Ok(Self::Sha256),
+      "sha384" => Ok(Self::Sha384),
+      "sha512" => Ok(Self::Sha512),
+      _ => Err(rspack_error::Error::error(format!(
+        "Expect SRI hash function to be 'sha256', 'sha384' or 'sha512', but got '{value}'."
+      ))),
     }
   }
 }


### PR DESCRIPTION
## Summary

The zod is removed, so the validation will be processed by the rust plugin. Currently, most configurations are type-checked through `napi`. After passing the check, an attempt is made to perform data conversion through the `From` trait. At this point, if the conversion fails, it will cause a panic.

The behavior of the SRI plugin is to add an error to the compilation diagnostics when the validation fails. Therefore, the validation method needs to be modified so that a validation failure no longer causes a panic.

The test cases is in https://github.com/rspack-contrib/rspack-plugin-ci/pull/12

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
