### PR TITLE
fix: extra runtime global bits are lost after js hook

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1286,7 +1286,11 @@ impl CompilationAdditionalTreeRuntimeRequirements
     };
     let result = self.function.call_with_sync(arg).await?;
     if let Some(result) = result {
-      let _ = std::mem::replace(runtime_requirements, result.as_runtime_globals());
+      runtime_requirements.insert(
+        result
+          .as_runtime_globals()
+          .difference(*runtime_requirements),
+      );
     }
     Ok(())
   }


### PR DESCRIPTION
## Summary

I'm building a _Rspack Custom Binding_ that uses some untaken `RuntimeGlobals` bits.

I noticed these extra bits are lost after the serialization&deserialization for JS `compilation.hooks.additionalTreeRuntimeRequirements`.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
