### PR TITLE
feat: use __rspack_dev_server_uri to communicate to right dev server

### DIFF
--- a/packages/rspack/hot/lazy-compilation-web.js
+++ b/packages/rspack/hot/lazy-compilation-web.js
@@ -7,6 +7,7 @@ if (typeof EventSource !== "function") {
 var urlBase = decodeURIComponent(__resourceQuery.slice(1));
 if (
 	!urlBase.startsWith("http") &&
+	!urlBase.startsWith("//") &&
 	typeof __rspack_dev_server_uri !== "undefined"
 ) {
 	urlBase = __rspack_dev_server_uri + urlBase;


### PR DESCRIPTION
## Summary

This update depends on [Pull Request #53](https://github.com/web-infra-dev/rspack-dev-server/pull/53).

This change enhances the developer experience for users running the development server on a proxied site rather than on localhost.

For example, if the development server starts on a localhost **auto** port, and the user configures `lazyCompilation: true` (using the default settings), the development assets are proxied to a site like `https://a.com`.

### Before

With lazy compilation enabled, requests would be sent to `https://a.com/lazy-compilation-using-compilation-proxy....` These requests would fail, resulting in a blank page.

### After

Requests will now be sent to `http://127.0.0.1:8080/lazy-compilation-using-compilation-proxy....`, allowing lazy compilation to function as expected.

<!-- Describe what this PR does and why. -->

## Related Links

<!-- List any related issues or discussions. -->

## Checklist

<!-- Check and mark with an "x" where appropriate. -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).