### PR TITLE
fix(rstest): dedicated to hoist @rstest/core declaration

### DIFF
--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -498,6 +498,10 @@ impl ConditionalInitFragment {
     }
   }
 
+  pub fn content(&self) -> &str {
+    &self.content
+  }
+
   pub fn merge(
     one: Box<ConditionalInitFragment>,
     other: Box<ConditionalInitFragment>,

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -1,8 +1,9 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, DependencyCodeGeneration, DependencyRange,
-  DependencyTemplate, DependencyTemplateType, DependencyType, InitFragmentExt, InitFragmentKey,
-  InitFragmentStage, NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, AsModuleDependency, ConditionalInitFragment, DependencyCodeGeneration,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, InitFragmentExt,
+  InitFragmentKey, InitFragmentStage, NormalInitFragment, RuntimeCondition, RuntimeGlobals,
+  TemplateContext, TemplateReplaceSource,
 };
 use swc_core::common::Span;
 
@@ -13,6 +14,8 @@ pub struct MockMethodDependency {
   call_expr_span: Span,
   #[cacheable(with=Skip)]
   callee_span: Span,
+  #[cacheable(with=Skip)]
+  statement_span: Option<Span>,
   request: String,
   hoist: bool,
   method: MockMethod,
@@ -42,6 +45,25 @@ impl MockMethodDependency {
     Self {
       call_expr_span,
       callee_span,
+      statement_span: None,
+      request,
+      hoist,
+      method,
+    }
+  }
+
+  pub fn new_with_statement_span(
+    call_expr_span: Span,
+    callee_span: Span,
+    statement_span: Span,
+    request: String,
+    hoist: bool,
+    method: MockMethod,
+  ) -> Self {
+    Self {
+      call_expr_span,
+      callee_span,
+      statement_span: Some(statement_span),
       request,
       hoist,
       method,
@@ -84,20 +106,46 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
     let dep = dep
       .as_any()
       .downcast_ref::<MockMethodDependency>()
-      .expect("ModulePathNameDependencyTemplate can only be applied to ModulePathNameDependency");
+      .expect("MockMethodDependencyTemplate can only be applied to MockMethodDependency");
+
     let request = &dep.request;
+    let require_name = compilation
+      .runtime_template
+      .render_runtime_globals(&RuntimeGlobals::REQUIRE);
 
-    let hoist_flag = match dep.method {
-      MockMethod::Mock => "MOCK",
-      MockMethod::DoMock => "", // won't be used.
-      MockMethod::MockRequire => "MOCKREQUIRE",
-      MockMethod::DoMockRequire => "", // won't be used.
-      MockMethod::Unmock => "UNMOCK",
-      MockMethod::Hoisted => "HOISTED",
-      MockMethod::DoUnmock => "", // won't be used.
-    };
+    let hoist_flag = Self::get_hoist_flag(&dep.method);
+    let mock_method = Self::get_mock_method(&dep.method);
 
-    let mock_method = match dep.method {
+    // Step 1: Add placeholder init fragment for hoistable methods
+    if let Some(flag) = hoist_flag {
+      Self::add_placeholder_fragment(init_fragments, flag, request);
+    }
+
+    // Step 2: Hoist @rstest/core import for rs.hoisted() to ensure it appears before the placeholder
+    if dep.method == MockMethod::Hoisted {
+      Self::hoist_rstest_core_import(init_fragments);
+    }
+
+    // Step 3: Transform the source code
+    Self::transform_source(source, dep, &require_name, mock_method, hoist_flag, request);
+  }
+}
+
+impl MockMethodDependencyTemplate {
+  /// Get the hoist flag string for methods that need hoisting
+  fn get_hoist_flag(method: &MockMethod) -> Option<&'static str> {
+    match method {
+      MockMethod::Mock => Some("MOCK"),
+      MockMethod::MockRequire => Some("MOCKREQUIRE"),
+      MockMethod::Unmock => Some("UNMOCK"),
+      MockMethod::Hoisted => Some("HOISTED"),
+      MockMethod::DoMock | MockMethod::DoMockRequire | MockMethod::DoUnmock => None,
+    }
+  }
+
+  /// Get the runtime method name
+  fn get_mock_method(method: &MockMethod) -> &'static str {
+    match method {
       MockMethod::Mock => "rstest_mock",
       MockMethod::DoMock => "rstest_do_mock",
       MockMethod::MockRequire => "rstest_mock_require",
@@ -105,50 +153,197 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
       MockMethod::Unmock => "rstest_unmock",
       MockMethod::Hoisted => "rstest_hoisted",
       MockMethod::DoUnmock => "rstest_do_unmock",
+    }
+  }
+
+  /// Add a placeholder init fragment that marks where hoisted code should be inserted
+  fn add_placeholder_fragment(
+    init_fragments: &mut Vec<Box<dyn rspack_core::InitFragment<rspack_core::GenerateContext<'_>>>>,
+    flag: &str,
+    request: &str,
+  ) {
+    let init = NormalInitFragment::new(
+      format!("/* RSTEST:{flag}_PLACEHOLDER:{request} */;"),
+      InitFragmentStage::StageESMImports,
+      0,
+      InitFragmentKey::Const(format!("rstest mock_hoist {request}")),
+      None,
+    );
+    init_fragments.push(init.boxed());
+  }
+
+  /// Hoist @rstest/core import to the very top of the module.
+  ///
+  /// This ensures that `@rstest/core` is imported before the hoisted placeholder,
+  /// so that `rs.fn()` and other utilities are available inside `rs.hoisted()` callbacks.
+  ///
+  /// We achieve this by inserting a higher-priority fragment with the same key.
+  /// Since ESMImport's merge logic returns the first fragment when its runtime_condition is true,
+  /// our new fragment will take precedence and the original will be ignored.
+  fn hoist_rstest_core_import(
+    init_fragments: &mut Vec<Box<dyn rspack_core::InitFragment<rspack_core::GenerateContext<'_>>>>,
+  ) {
+    let target_key =
+      InitFragmentKey::ESMImport("ESM import external global \"@rstest/core\"".to_string());
+
+    // Find the original @rstest/core import fragment
+    let Some(fragment) = init_fragments.iter().find(|f| f.key() == &target_key) else {
+      return;
     };
 
-    // Hoist placeholder init fragment.
-    if !hoist_flag.is_empty() {
-      let init = NormalInitFragment::new(
-        format!("/* RSTEST:{hoist_flag}_PLACEHOLDER:{request} */;"),
-        InitFragmentStage::StageESMImports,
-        0,
-        InitFragmentKey::Const(format!("rstest mock_hoist {request}")),
-        None,
-      );
-      init_fragments.push(init.boxed());
-    }
+    // Clone and downcast to get the content
+    let cloned: Box<dyn rspack_core::InitFragment<_>> = fragment.clone();
+    let Ok(conditional_fragment) = cloned.into_any().downcast::<ConditionalInitFragment>() else {
+      return;
+    };
 
-    // Start before hoist.
+    // Create a new fragment with higher priority (position=-1) and insert at the beginning
+    let content = conditional_fragment.content().to_string();
+    let rstest_import = ConditionalInitFragment::new(
+      content,
+      InitFragmentStage::StageESMImports,
+      -1, // Higher priority than default (0)
+      target_key,
+      None,
+      RuntimeCondition::Boolean(true),
+    );
+    init_fragments.insert(0, rstest_import.boxed());
+  }
+
+  /// Transform the source code by:
+  /// 1. Adding hoist markers (HOIST_START/HOIST_END) around the code to be hoisted
+  /// 2. Replacing the original callee with the runtime method
+  fn transform_source(
+    source: &mut TemplateReplaceSource,
+    dep: &MockMethodDependency,
+    require_name: &str,
+    mock_method: &str,
+    hoist_flag: Option<&str>,
+    request: &str,
+  ) {
     let callee_range: DependencyRange = dep.callee_span.into();
-    let require_name = compilation
-      .runtime_template
-      .render_runtime_globals(&RuntimeGlobals::REQUIRE);
+    let should_hoist = hoist_flag.is_some() && dep.hoist;
+
+    if should_hoist && dep.statement_span.is_some() {
+      // Case 1: Variable declaration with hoisting (e.g., `const mocks = rs.hoisted(...)`)
+      // Wrap the entire statement with hoist markers
+      Self::transform_with_statement_hoist(
+        source,
+        dep,
+        require_name,
+        mock_method,
+        hoist_flag.expect("hoist_flag should be Some when should_hoist is true"),
+        request,
+        &callee_range,
+      );
+    } else if should_hoist {
+      // Case 2: Standalone call with hoisting (e.g., `rs.hoisted(...)` or `rs.mock(...)`)
+      // Wrap just the call expression with hoist markers
+      Self::transform_with_call_hoist(
+        source,
+        dep,
+        require_name,
+        mock_method,
+        hoist_flag.expect("hoist_flag should be Some when should_hoist is true"),
+        request,
+        &callee_range,
+      );
+    } else {
+      // Case 3: No hoisting needed (e.g., `rs.doMock(...)`)
+      // Just replace the callee
+      Self::transform_without_hoist(source, require_name, mock_method, &callee_range);
+    }
+  }
+
+  /// Transform for variable declarations that need hoisting.
+  /// Example: `const mocks = rs.hoisted(() => {...})`
+  /// Result: `/* HOIST_START */const mocks = __webpack_require__.rstest_hoisted(() => {...})/* HOIST_END */`
+  fn transform_with_statement_hoist(
+    source: &mut TemplateReplaceSource,
+    dep: &MockMethodDependency,
+    require_name: &str,
+    mock_method: &str,
+    flag: &str,
+    request: &str,
+    callee_range: &DependencyRange,
+  ) {
+    let stmt_range: DependencyRange = dep
+      .statement_span
+      .expect("statement_span should be Some when transform_with_statement_hoist is called")
+      .into();
+
+    // Insert HOIST_START before the statement
+    source.replace(
+      stmt_range.start,
+      stmt_range.start,
+      &format!("/* RSTEST:{flag}_HOIST_START:{request} */"),
+      None,
+    );
+
+    // Insert HOIST_END after the statement
+    source.replace(
+      stmt_range.end,
+      stmt_range.end,
+      &format!("\n/* RSTEST:{flag}_HOIST_END:{request} */"),
+      None,
+    );
+
+    // Comment out original callee and replace with runtime method
+    // `rs.hoisted` -> `/* rs.hoisted */ __webpack_require__.rstest_hoisted`
     source.replace(callee_range.start, callee_range.start, "/* ", None);
     source.replace(
       callee_range.end,
       callee_range.end,
-      // callee_range.end,
-      if dep.hoist {
-        format!(" */ /* RSTEST:{hoist_flag}_HOIST_START:{request} */{require_name}.{mock_method}")
-      } else {
-        format!(" */ {require_name}.{mock_method}")
-      }
-      .as_str(),
+      &format!(" */ {require_name}.{mock_method}"),
+      None,
+    );
+  }
+
+  /// Transform for standalone calls that need hoisting.
+  /// Example: `rs.mock('./foo', () => {...})`
+  /// Result: `/* rs.mock */ /* HOIST_START */__webpack_require__.rstest_mock('./foo', () => {...})/* HOIST_END */`
+  fn transform_with_call_hoist(
+    source: &mut TemplateReplaceSource,
+    dep: &MockMethodDependency,
+    require_name: &str,
+    mock_method: &str,
+    flag: &str,
+    request: &str,
+    callee_range: &DependencyRange,
+  ) {
+    // Comment out original callee and add HOIST_START + runtime method
+    source.replace(callee_range.start, callee_range.start, "/* ", None);
+    source.replace(
+      callee_range.end,
+      callee_range.end,
+      &format!(" */ /* RSTEST:{flag}_HOIST_START:{request} */{require_name}.{mock_method}"),
       None,
     );
 
-    // End before hoist.
-    let range: DependencyRange = dep.call_expr_span.into();
+    // Insert HOIST_END after the call expression
+    let call_range: DependencyRange = dep.call_expr_span.into();
     source.replace(
-      range.end, // count the trailing semicolon
-      range.end,
-      if dep.hoist {
-        format!("\n/* RSTEST:{hoist_flag}_HOIST_END:{request} */")
-      } else {
-        "".to_string()
-      }
-      .as_ref(),
+      call_range.end,
+      call_range.end,
+      &format!("\n/* RSTEST:{flag}_HOIST_END:{request} */"),
+      None,
+    );
+  }
+
+  /// Transform for calls without hoisting.
+  /// Example: `rs.doMock('./foo', () => {...})`
+  /// Result: `/* rs.doMock */ __webpack_require__.rstest_do_mock('./foo', () => {...})`
+  fn transform_without_hoist(
+    source: &mut TemplateReplaceSource,
+    require_name: &str,
+    mock_method: &str,
+    callee_range: &DependencyRange,
+  ) {
+    source.replace(callee_range.start, callee_range.start, "/* ", None);
+    source.replace(
+      callee_range.end,
+      callee_range.end,
+      &format!(" */ {require_name}.{mock_method}"),
       None,
     );
   }

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -372,16 +372,34 @@ impl RstestParserPlugin {
     }
   }
 
-  fn hoisted(&self, parser: &mut JavascriptParser, call_expr: &CallExpr) {
+  fn hoisted(
+    &self,
+    parser: &mut JavascriptParser,
+    call_expr: &CallExpr,
+    statement_span: Option<Span>,
+  ) -> Option<bool> {
     match call_expr.args.len() {
       1 => {
-        parser.add_presentational_dependency(Box::new(MockMethodDependency::new(
-          call_expr.span(),
-          call_expr.callee.span(),
-          call_expr.span().real_lo().to_string(),
-          true,
-          MockMethod::Hoisted,
-        )));
+        let dep = if let Some(stmt_span) = statement_span {
+          MockMethodDependency::new_with_statement_span(
+            call_expr.span(),
+            call_expr.callee.span(),
+            stmt_span,
+            call_expr.span().real_lo().to_string(),
+            true,
+            MockMethod::Hoisted,
+          )
+        } else {
+          MockMethodDependency::new(
+            call_expr.span(),
+            call_expr.callee.span(),
+            call_expr.span().real_lo().to_string(),
+            true,
+            MockMethod::Hoisted,
+          )
+        };
+        parser.add_presentational_dependency(Box::new(dep));
+        Some(false)
       }
       _ => {
         parser.add_error(
@@ -393,6 +411,7 @@ impl RstestParserPlugin {
           )
           .into(),
         );
+        Some(false)
       }
     }
   }
@@ -547,6 +566,7 @@ impl RstestParserPlugin {
     call_expr: &CallExpr,
     ident: &Ident,
     prop: &swc_core::ecma::ast::IdentName,
+    statement_span: Option<Span>,
   ) -> Option<bool> {
     match (ident.sym.as_str(), prop.sym.as_str()) {
       // rs.mock
@@ -602,10 +622,7 @@ impl RstestParserPlugin {
       // rs.resetModules
       ("rs", "resetModules") | ("rstest", "resetModules") => self.reset_modules(parser, call_expr),
       // rs.hoisted
-      ("rs", "hoisted") | ("rstest", "hoisted") => {
-        self.hoisted(parser, call_expr);
-        Some(true)
-      }
+      ("rs", "hoisted") | ("rstest", "hoisted") => self.hoisted(parser, call_expr, statement_span),
       _ => {
         // Not a mock module, continue.
         None
@@ -636,7 +653,13 @@ impl JavascriptParserPlugin for RstestParserPlugin {
           && let Some(obj_ident) = member_expr.obj.as_ident()
           && let Some(prop_ident) = member_expr.prop.as_ident()
         {
-          return self.handle_rstest_method_call(parser, call_expr, obj_ident, prop_ident);
+          return self.handle_rstest_method_call(
+            parser,
+            call_expr,
+            obj_ident,
+            prop_ident,
+            Some(stmt.span()),
+          );
         }
       }
     }
@@ -662,7 +685,7 @@ impl JavascriptParserPlugin for RstestParserPlugin {
       && let Some(obj_ident) = member_expr.obj.as_ident()
       && let Some(prop_ident) = member_expr.prop.as_ident()
     {
-      return self.handle_rstest_method_call(parser, call_expr, obj_ident, prop_ident);
+      return self.handle_rstest_method_call(parser, call_expr, obj_ident, prop_ident, None);
     }
 
     None

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -170,7 +170,7 @@ async fn mock_hoist_process_assets(&self, compilation: &mut Compilation) -> Resu
       files.push(file.clone());
     }
   }
-  let regex = regex::Regex::new(r"\/\* RSTEST:(MOCK|UNMOCK|MOCKREQUIRE)_(.*?):(.*?) \*\/")
+  let regex = regex::Regex::new(r"\/\* RSTEST:(MOCK|UNMOCK|MOCKREQUIRE|HOISTED)_(.*?):(.*?) \*\/")
     .expect("should initialize `Regex`");
 
   for file in files {

--- a/tests/rspack-test/configCases/rstest/mock/hoisted.js
+++ b/tests/rspack-test/configCases/rstest/mock/hoisted.js
@@ -1,0 +1,19 @@
+import { rs } from '@rstest/core';
+
+const mocks = rs.hoisted(() => {
+	globalThis.rstestCore = {
+  rs: {
+    fn: function() {
+      return function mockFn() {}
+    }
+  }
+};
+
+  return {
+    mockedFn: rs.fn()
+  }
+})
+
+it('rs.hoisted should work with rs.fn from @rstest/core', () => {
+  expect(typeof mocks.mockedFn).toBe('function')
+})

--- a/tests/rspack-test/configCases/rstest/mock/node_modules/@rstest/core/index.js
+++ b/tests/rspack-test/configCases/rstest/mock/node_modules/@rstest/core/index.js
@@ -1,0 +1,11 @@
+module.exports = {
+  rs: {
+    fn: function() {
+      return function mockFn() {}
+    },
+    hoisted: function(factory) {
+      return factory()
+    },
+    mock: function() {}
+  }
+}

--- a/tests/rspack-test/configCases/rstest/mock/node_modules/@rstest/core/package.json
+++ b/tests/rspack-test/configCases/rstest/mock/node_modules/@rstest/core/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@rstest/core",
+  "main": "index.js"
+}

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -111,6 +111,10 @@ __webpack_require__.rstest_do_mock = (id, modFactory) => {
     __webpack_module_cache__[id] = { exports, id, loaded: true };
   }
 };
+
+__webpack_require__.rstest_hoisted = (fn) => {
+  return fn();
+};
 `;
 			}
 		}
@@ -177,5 +181,11 @@ module.exports = [
 			mangleExports: false
 		}
 	},
-	rstestEntry("./mockFirstArgIsImport.js")
+	rstestEntry("./mockFirstArgIsImport.js"),
+	{
+		...rstestEntry("./hoisted.js"),
+		externals: {
+			"@rstest/core": "global @rstest/core"
+		}
+	}
 ];


### PR DESCRIPTION
## Summary

this PR mainly did two features:

1. `rs.hoisted`, will be hoisting to the top of the module. if there's a statement declaration, it will be hoisted alongside.

```js
// source
rs.hoisted(()=> {})
const a = rs.hoisted(()=> {})

// output
__webapack_require__.rstest_hoisted(()=> {}) // top of the module
const a = __webapack_require__.rstest_hoisted(()=> {}) // top of the module
```

2. dedicated hoisting `@rstest/core` to the top of the module, this is for the common use with `rs.hoisted`.
   the implementation is to find the `@rstest/core` ESM import init fragment. then, copy the content and insert the fragment with the same key at the beginning of the init fragments (-1 position), using the key deduplication principle of init fragments. this way, the init fragment corresponding to the `@rstest/core` ESM dependency will be placed before `rs.hoisted` (0 position).

it might be a bit hacky to find the target init fragment by key (although the key is consistent).

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
