### PR TITLE
fix: should set interop2_used to true if namespace import default-only

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -223,12 +223,6 @@ impl ConcatenatedModuleInfo {
       return self.internal_names.get(&*DEFAULT_EXPORT_ATOM);
     }
 
-    if let Some(name) = &self.namespace_export_symbol
-      && name == atom
-    {
-      return Some(name);
-    }
-
     if let Some(name) = &self.namespace_object_name
       && name == atom
     {

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -2173,6 +2173,7 @@ impl EsmLibraryPlugin {
     if export_name.is_empty() {
       match exports_type {
         ExportsType::DefaultOnly => {
+          info.set_interop_namespace_object2_used(true);
           let symbol = match info {
             ModuleInfo::External(info) => {
               let required_info = Self::add_require(

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -319,7 +319,7 @@ impl EsmLibraryPlugin {
 
       if info.interop_namespace_object_used {
         render_source.add(RawStringSource::from(format!(
-          "\nvar {} = /*#__PURE__*/{}({}, 2);",
+          "var {} = /*#__PURE__*/{}({}, 2);\n",
           info
             .interop_namespace_object_name
             .clone()
@@ -336,7 +336,7 @@ impl EsmLibraryPlugin {
 
       if info.interop_namespace_object2_used {
         render_source.add(RawStringSource::from(format!(
-          "\nvar {} = /*#__PURE__*/{}({});",
+          "var {} = /*#__PURE__*/{}({});\n",
           info
             .interop_namespace_object2_name
             .clone()

--- a/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/__snapshots__/esm.snap.txt
@@ -1,0 +1,102 @@
+```mjs title=407a5f26e1107499.mjs
+export default 42
+```
+
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+// ./foo.mjs
+import foo_namespaceObject from "./407a5f26e1107499.mjs";
+var foo_namespaceObject2 = /*#__PURE__*/__webpack_require__.t(foo_namespaceObject);
+// ./index.js
+
+
+it('should have ns', () => {
+	expect(foo_namespaceObject2).toBeDefined()
+})
+
+
+```
+
+```mjs title=runtime.mjs
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+
+// esm library register module runtime
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/create_fake_namespace_object
+(() => {
+var getProto = Object.getPrototypeOf ? (obj) => (Object.getPrototypeOf(obj)) : (obj) => (obj.__proto__);
+var leafPrototypes;
+// create a fake namespace object
+// mode & 1: value is a module id, require it
+// mode & 2: merge all properties of value into the ns
+// mode & 4: return value when already ns object
+// mode & 16: return value when it's Promise-like
+// mode & 8|1: behave like require
+__webpack_require__.t = function(value, mode) {
+	if(mode & 1) value = this(value);
+	if(mode & 8) return value;
+	if(typeof value === 'object' && value) {
+		if((mode & 4) && value.__esModule) return value;
+		if((mode & 16) && typeof value.then === 'function') return value;
+	}
+	var ns = Object.create(null);
+  __webpack_require__.r(ns);
+	var def = {};
+	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
+	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
+		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+	}
+	def['default'] = () => (value);
+	__webpack_require__.d(ns, def);
+	return ns;
+};
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, definition) => {
+	for(var key in definition) {
+        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+        }
+    }
+};
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/foo.mjs
+++ b/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/foo.mjs
@@ -1,0 +1,1 @@
+export default 42

--- a/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/index.js
+++ b/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/index.js
@@ -1,0 +1,5 @@
+import * as ns from './foo.mjs'
+
+it('should have ns', () => {
+	expect(ns).toBeDefined()
+})

--- a/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/rspack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /foo\.mjs$/,
+				type: 'asset/resource',
+				generator: {
+					importMode: "preserve",
+				},
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

Should set `interop2_used` flag if needs interop2 mode 

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
