### PR TITLE
chore(workflow): update node version to 22 in ci and nvm configuration

### DIFF
--- a/.github/actions/pnpm/setup/action.yml
+++ b/.github/actions/pnpm/setup/action.yml
@@ -4,7 +4,7 @@ description: Install Node.js with pnpm global cache
 
 inputs:
   node-version:
-    default: "20"
+    default: "22"
     required: false
     type: string
 
@@ -17,7 +17,6 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Enable corepack
-      if: ${{ inputs.node-version != '16' }}
       shell: bash
       run: |
         if [[ "${{runner.os}}" == "Windows" ]]; then
@@ -28,13 +27,3 @@ runs:
         npm install -g corepack@0.31.0 --force
         echo "Corepack version: $(corepack --version)"
         corepack enable
-
-    # https://pnpm.io/continuous-integration#github-actions
-    # Uses `packageManagement` field from package.json
-    - name: Install pnpm
-      if: ${{ inputs.node-version == '16' }}
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-      with:
-        dest: ${{ runner.tool_cache }}/pnpm
-        # Use `@pnpm/exe` for Node 16
-        standalone: true

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -38,7 +38,7 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/pnpm/setup
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Pnpm Install
         uses: ./.github/actions/pnpm/install-dependencies
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false # wait for all test to finish for determining if it's node version based problem or general problem
       matrix:
         node: ${{ fromJSON(
-          inputs.target == 'wasm32-wasip1-threads'&& '[20]'
+          inputs.target == 'wasm32-wasip1-threads'&& '[22]'
           || contains(inputs.target, 'linux') && '[18, 20, 22]'
           || '[22]') }}
     name: Test Node ${{ matrix.node }}

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/iron
+lts/jod


### PR DESCRIPTION
## Summary

Node.js v22 enters long term support since Nov 2024. This PR updated our workflow:

- Update .nvmrc and github workflows to use Node.js 22 by default instead of 20
- Remove legacy Node.js 16 specific setup since it's no longer needed

## Related links

- https://nodejs.org/en/about/previous-releases

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
