### PR TITLE
test: bump rstest to show relevant running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "cross-env": "^10.1.0",
     "husky": "^9.1.7",
     "is-ci": "4.1.0",
-    "@rstest/core": "^0.6.6",
+    "@rstest/core": "^0.6.8",
     "lint-staged": "^16.2.7",
     "prettier": "3.6.2",
     "prettier-2": "npm:prettier@2.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: workspace:*
         version: link:packages/rspack-cli
       '@rstest/core':
-        specifier: ^0.6.6
-        version: 0.6.6(jsdom@26.1.0)
+        specifier: ^0.6.8
+        version: 0.6.8(jsdom@26.1.0)
       '@taplo/cli':
         specifier: ^0.7.0
         version: 0.7.0
@@ -681,8 +681,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack-test-tools
       '@rstest/core':
-        specifier: ^0.6.6
-        version: 0.6.6(jsdom@26.1.0)
+        specifier: ^0.6.8
+        version: 0.6.8(jsdom@26.1.0)
       '@swc/helpers':
         specifier: 0.5.17
         version: 0.5.17
@@ -3283,8 +3283,8 @@ packages:
   '@rstack-dev/doc-ui@1.12.0':
     resolution: {integrity: sha512-YYnJ/8oCUuNMLxBXVFydmEfNOmELR7/Ee8Xcwh4Vt+sGhddf7GFFWFHD9c3fVy/IjdLL+rEIAj1i5nGQxsjwOA==}
 
-  '@rstest/core@0.6.6':
-    resolution: {integrity: sha512-dY7V+E1woLXxMF20lH6zq+aDViOEJ/0TfB6tfbwamLcfpVrYGK8aYLYe+Te0k4RsqR3Jhmwsd++JKx2fvrex4w==}
+  '@rstest/core@0.6.8':
+    resolution: {integrity: sha512-rWn3HzcOx1QY/F+Qu/5HpLM9k0f2I0Svvi08vGGB8p9TN9u2wD2/AY+Rh9ao+90wxX5GiN2RVlI//4G7lHYJBg==}
     engines: {node: '>=18.12.0'}
     hasBin: true
     peerDependencies:
@@ -10792,7 +10792,7 @@ snapshots:
       - react
       - react-dom
 
-  '@rstest/core@0.6.6(jsdom@26.1.0)':
+  '@rstest/core@0.6.8(jsdom@26.1.0)':
     dependencies:
       '@rsbuild/core': 1.6.0-beta.1
       '@types/chai': 5.2.3

--- a/tests/rspack-test/package.json
+++ b/tests/rspack-test/package.json
@@ -19,7 +19,7 @@
     "@rspack/plugin-preact-refresh": "1.1.4",
     "@rspack/plugin-react-refresh": "^1.5.3",
     "@rspack/test-tools": "workspace:*",
-    "@rstest/core": "^0.6.6",
+    "@rstest/core": "^0.6.8",
     "@swc/helpers": "0.5.17",
     "@swc/plugin-remove-console": "^10.0.0",
     "@types/babel__generator": "7.27.0",


### PR DESCRIPTION
## Summary

bump rstest to support show relevant running tests when worker unexpectedly exited. https://github.com/web-infra-dev/rstest/pull/722

before:
<img width="1608" height="660" alt="image" src="https://github.com/user-attachments/assets/2d455d03-851c-4041-a55f-4c9be24dcde5" />


after:
<img width="1914" height="572" alt="image" src="https://github.com/user-attachments/assets/25e30226-642e-4156-b8f2-13941f1f217e" />



<!-- Describe what this PR does and why. -->


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
