### PR TITLE
fix: check unused class names should check all conventions

### DIFF
--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -189,45 +189,52 @@ pub fn stringified_exports<'a>(
   for (key, elements) in exports {
     let content = elements
       .iter()
-      .map(|CssExport { ident, from, id: _ }| match from {
-        None => json_stringify(&ident),
-        Some(from_name) => {
-          let from = module
-            .get_dependencies()
-            .iter()
-            .find_map(|id| {
-              let dependency = module_graph.dependency_by_id(id);
-              let request = if let Some(d) = dependency.and_then(|d| d.as_module_dependency()) {
-                Some(d.request())
-              } else {
-                dependency
-                  .and_then(|d| d.as_context_dependency())
-                  .map(|d| d.request())
-              };
-              if let Some(request) = request
-                && request == from_name
-              {
-                return module_graph.module_graph_module_by_dependency_id(id);
-              }
-              None
-            })
-            .expect("should have css from module");
+      .map(
+        |CssExport {
+           ident,
+           from,
+           id: _,
+           orig_name: _,
+         }| match from {
+          None => json_stringify(&ident),
+          Some(from_name) => {
+            let from = module
+              .get_dependencies()
+              .iter()
+              .find_map(|id| {
+                let dependency = module_graph.dependency_by_id(id);
+                let request = if let Some(d) = dependency.and_then(|d| d.as_module_dependency()) {
+                  Some(d.request())
+                } else {
+                  dependency
+                    .and_then(|d| d.as_context_dependency())
+                    .map(|d| d.request())
+                };
+                if let Some(request) = request
+                  && request == from_name
+                {
+                  return module_graph.module_graph_module_by_dependency_id(id);
+                }
+                None
+              })
+              .expect("should have css from module");
 
-          let from = serde_json::to_string(
-            ChunkGraph::get_module_id(&compilation.module_ids_artifact, from.module_identifier)
-              .expect("should have module"),
-          )
-          .expect("should json stringify module id");
-          runtime_requirements.insert(RuntimeGlobals::REQUIRE);
-          format!(
-            "{}({from})[{}]",
-            compilation
-              .runtime_template
-              .render_runtime_globals(&RuntimeGlobals::REQUIRE),
-            json_stringify(&unescape(ident))
-          )
-        }
-      })
+            let from = serde_json::to_string(
+              ChunkGraph::get_module_id(&compilation.module_ids_artifact, from.module_identifier)
+                .expect("should have module"),
+            )
+            .expect("should json stringify module id");
+            runtime_requirements.insert(RuntimeGlobals::REQUIRE);
+            format!(
+              "{}({from})[{}]",
+              compilation
+                .runtime_template
+                .render_runtime_globals(&RuntimeGlobals::REQUIRE),
+              json_stringify(&unescape(ident))
+            )
+          }
+        },
+      )
       .collect::<Vec<_>>()
       .join(" + \" \" + ");
     writeln!(
@@ -265,44 +272,51 @@ pub fn css_modules_exports_to_concatenate_module_string<'a>(
   for (key, elements) in exports {
     let content = elements
       .iter()
-      .map(|CssExport { ident, from, id: _ }| match from {
-        None => json_stringify(&ident),
-        Some(from_name) => {
-          let from = module
-            .get_dependencies()
-            .iter()
-            .find_map(|id| {
-              let dependency = module_graph.dependency_by_id(id);
-              let request = if let Some(d) = dependency.and_then(|d| d.as_module_dependency()) {
-                Some(d.request())
-              } else {
-                dependency
-                  .and_then(|d| d.as_context_dependency())
-                  .map(|d| d.request())
-              };
-              if let Some(request) = request
-                && request == from_name
-              {
-                return module_graph.module_graph_module_by_dependency_id(id);
-              }
-              None
-            })
-            .expect("should have css from module");
+      .map(
+        |CssExport {
+           ident,
+           from,
+           id: _,
+           orig_name: _,
+         }| match from {
+          None => json_stringify(&ident),
+          Some(from_name) => {
+            let from = module
+              .get_dependencies()
+              .iter()
+              .find_map(|id| {
+                let dependency = module_graph.dependency_by_id(id);
+                let request = if let Some(d) = dependency.and_then(|d| d.as_module_dependency()) {
+                  Some(d.request())
+                } else {
+                  dependency
+                    .and_then(|d| d.as_context_dependency())
+                    .map(|d| d.request())
+                };
+                if let Some(request) = request
+                  && request == from_name
+                {
+                  return module_graph.module_graph_module_by_dependency_id(id);
+                }
+                None
+              })
+              .expect("should have css from module");
 
-          let from = serde_json::to_string(
-            ChunkGraph::get_module_id(&compilation.module_ids_artifact, from.module_identifier)
-              .expect("should have module"),
-          )
-          .expect("should json stringify module id");
-          format!(
-            "{}({from})[{}]",
-            compilation
-              .runtime_template
-              .render_runtime_globals(&RuntimeGlobals::REQUIRE),
-            json_stringify(&ident)
-          )
-        }
-      })
+            let from = serde_json::to_string(
+              ChunkGraph::get_module_id(&compilation.module_ids_artifact, from.module_identifier)
+                .expect("should have module"),
+            )
+            .expect("should json stringify module id");
+            format!(
+              "{}({from})[{}]",
+              compilation
+                .runtime_template
+                .render_runtime_globals(&RuntimeGlobals::REQUIRE),
+              json_stringify(&ident)
+            )
+          }
+        },
+      )
       .collect::<Vec<_>>()
       .join(" + \" \" + ");
     let mut identifier = to_identifier(key);

--- a/tests/rspack-test/configCases/css/minify-lightning-css-remove-unused-local-idents/index.js
+++ b/tests/rspack-test/configCases/css/minify-lightning-css-remove-unused-local-idents/index.js
@@ -6,6 +6,7 @@ it("should remove unused local idents", async () => {
 	expect(styles.a).toBe("./style.module-a");
 	expect(styles["local/used"]).toBe("./style.module-local/used");
 	expect(styles["composed-local"]).toBe("./style.module-composed-local");
+	expect(styles.camelCase).toBe("./style.module-camel-case");
 
 	if (!EXPORTS_ONLY) {
 		const css = await fs.promises.readFile(path.resolve(__dirname, "./bundle0.css"), "utf-8");
@@ -13,5 +14,6 @@ it("should remove unused local idents", async () => {
 		expect(css).toContain("local\\/used")
 		expect(css).not.toContain("local\\/unused")
 		expect(css).toContain("composed-local")
+		expect(css).toContain("camel-case")
 	}
 })

--- a/tests/rspack-test/configCases/css/minify-lightning-css-remove-unused-local-idents/rspack.config.js
+++ b/tests/rspack-test/configCases/css/minify-lightning-css-remove-unused-local-idents/rspack.config.js
@@ -11,7 +11,8 @@ const common = {
 		generator: {
 			"css/auto": {
 				localIdentName: "[path][name]-[local]",
-				exportsOnly: false
+				exportsOnly: false,
+				exportsConvention: 'camel-case',
 			}
 		}
 	},
@@ -44,7 +45,8 @@ module.exports = [
 			generator: {
 				"css/auto": {
 					localIdentName: "[path][name]-[local]",
-					exportsOnly: true
+					exportsOnly: true,
+					exportsConvention: 'camel-case',
 				}
 			}
 		},

--- a/tests/rspack-test/configCases/css/minify-lightning-css-remove-unused-local-idents/style.module.css
+++ b/tests/rspack-test/configCases/css/minify-lightning-css-remove-unused-local-idents/style.module.css
@@ -21,3 +21,7 @@
 .composed-local {
   background-color: green;
 }
+
+.camel-case {
+  color: yellow;
+}


### PR DESCRIPTION
## Summary

fix #11832

Should check all convention export names when checking whether a css ident is used. If any convention is used, should not remove it

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
