### PR TITLE
feat: supports async modules for EsmLibraryPlugin

### DIFF
--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -672,6 +672,7 @@ impl EsmLibraryPlugin {
       source: final_source,
     }))
   }
+
   pub async fn render_runtime(
     chunk_ukey: &ChunkUkey,
     compilation: &Compilation,

--- a/tests/rspack-test/esmOutputCases/basic/async-modules/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/async-modules/__snapshots__/esm.snap.txt
@@ -1,0 +1,214 @@
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+__webpack_require__.add({
+"./index.js"
+/*!******************!*\
+  !*** ./index.js ***!
+  \******************/
+(module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.a(module, async function (__webpack_handle_async_dependencies__, __webpack_async_result__) { try {
+__webpack_require__.d(__webpack_exports__, {
+  q: () => (demo)
+});
+/* import */ var _lib_defer_js__rspack_import_0 = __webpack_require__(/*! ./lib-defer.js */ "./lib-defer.js");
+/* import */ var _lib_js__rspack_import_1 = __webpack_require__(/*! ./lib.js */ "./lib.js");
+var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_lib_js__rspack_import_1, _lib_defer_js__rspack_import_0]);
+([_lib_js__rspack_import_1, _lib_defer_js__rspack_import_0] = __webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__); // this is a defer module
+ // this has tla
+
+it('should has correct exec order and export value', async () => {
+	const { demo } = await import(/*webpackIgnore: true*/ './main.mjs')
+	expect(demo).toBe(84)
+})
+
+const demo = _lib_js__rspack_import_1/* .lib */.c + _lib_defer_js__rspack_import_0.v
+
+
+__webpack_async_result__();
+} catch(e) { __webpack_async_result__(e); } });
+
+},
+"./lib-defer.js"
+/*!**********************!*\
+  !*** ./lib-defer.js ***!
+  \**********************/
+(module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.a(module, async function (__webpack_handle_async_dependencies__, __webpack_async_result__) { try {
+__webpack_require__.d(__webpack_exports__, {
+  v: () => (v)
+});
+const v = await (() => 42)()
+
+
+
+__webpack_async_result__();
+} catch(e) { __webpack_async_result__(e); } }, 1);
+
+},
+"./lib.js"
+/*!****************!*\
+  !*** ./lib.js ***!
+  \****************/
+(module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.a(module, async function (__webpack_handle_async_dependencies__, __webpack_async_result__) { try {
+__webpack_require__.d(__webpack_exports__, {
+  c: () => (lib)
+});
+await 42
+const lib = 42
+
+
+__webpack_async_result__();
+} catch(e) { __webpack_async_result__(e); } }, 1);
+
+},
+});
+const index = await __webpack_require__("./index.js");
+var q = index.q;
+
+export { q as demo };
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// esm library register module runtime
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/async_module
+(() => {
+var hasSymbol = typeof Symbol === "function";
+var webpackQueues = hasSymbol ? Symbol("webpack queues") : "__webpack_queues__";
+var webpackExports = __webpack_require__.aE = hasSymbol ? Symbol("webpack exports") : "__webpack_exports__";
+var webpackError = hasSymbol ? Symbol("webpack error") : "__webpack_error__";
+var webpackDone = hasSymbol ? Symbol("webpack done") : "__webpack_done__";
+var webpackDefer = __webpack_require__.zS = hasSymbol ? Symbol("webpack defer") : "__webpack_defer__";
+var resolveQueue = (queue) => {
+  if (queue && queue.d < 1) {
+    queue.d = 1;
+    queue.forEach((fn) => (fn.r--));
+		queue.forEach((fn) => (fn.r-- ? fn.r++ : fn()));
+	}
+}
+var wrapDeps = (deps) => {
+	return deps.map((dep) => {
+		if (dep !== null && typeof dep === "object") {
+			if(!dep[webpackQueues] && dep[webpackDefer]) {
+				var asyncDeps = dep[webpackDefer];
+				var hasUnresolvedAsyncSubgraph = asyncDeps.some((id) => {
+					var cache = __webpack_module_cache__[id];
+					return !cache || cache[webpackDone] === false;
+				});
+				if (hasUnresolvedAsyncSubgraph) {
+					var d = dep;
+					dep = {
+						then(callback) {
+							Promise.all(asyncDeps.map(__webpack_require__)).then(() => (callback(d)))
+						}
+					};
+				} else return dep;
+			}
+			if (dep[webpackQueues]) return dep;
+			if (dep.then) {
+				var queue = [];
+				queue.d = 0;
+				dep.then((r) => {
+					obj[webpackExports] = r;
+					resolveQueue(queue);
+				},(e) => {
+					obj[webpackError] = e;
+					resolveQueue(queue);
+				});
+				var obj = {};
+				obj[webpackDefer] = false;
+				obj[webpackQueues] = (fn) => (fn(queue));
+				return obj;
+			}
+		}
+		var ret = {};
+		ret[webpackQueues] = () => {};
+		ret[webpackExports] = dep;
+		return ret;
+	});
+};
+__webpack_require__.a = (module, body, hasAwait) => {
+	var queue;
+	hasAwait && ((queue = []).d = -1);
+	var depQueues = new Set();
+	var exports = module.exports;
+	var currentDeps;
+	var outerResolve;
+	var reject;
+	var promise = new Promise((resolve, rej) => {
+		reject = rej;
+		outerResolve = resolve;
+	});
+	promise[webpackExports] = exports;
+	promise[webpackQueues] = (fn) => { queue && fn(queue), depQueues.forEach(fn), promise["catch"](() => {}); };
+	module.exports = promise;
+	var handle = (deps) => {
+		currentDeps = wrapDeps(deps);
+		var fn;
+		var getResult = () => {
+			return currentDeps.map((d) => {
+				if(d[webpackDefer]) return d;
+				if (d[webpackError]) throw d[webpackError];
+				return d[webpackExports];
+			});
+		}
+		var promise = new Promise((resolve) => {
+			fn = () => (resolve(getResult));
+			fn.r = 0;
+			var fnQueue = (q) => (q !== queue && !depQueues.has(q) && (depQueues.add(q), q && !q.d && (fn.r++, q.push(fn))));
+			currentDeps.map((dep) => (dep[webpackDefer] || dep[webpackQueues](fnQueue)));
+		});
+		return fn.r ? promise : getResult();
+	};
+	var done = (err) => ((err ? reject(promise[webpackError] = err) : outerResolve(exports)), resolveQueue(queue), promise[webpackDone] = true);
+	body(handle, done);
+	queue && queue.d < 0 && (queue.d = 0);
+};
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, definition) => {
+	for(var key in definition) {
+        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+        }
+    }
+};
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/basic/async-modules/index.js
+++ b/tests/rspack-test/esmOutputCases/basic/async-modules/index.js
@@ -1,0 +1,10 @@
+import defer * as ns from './lib-defer.js' // this is a defer module
+import { lib } from './lib.js' // this has tla
+
+it('should has correct exec order and export value', async () => {
+	const { demo } = await import(/*webpackIgnore: true*/ './main.mjs')
+	expect(demo).toBe(84)
+})
+
+const demo = lib + ns.v
+export { demo }

--- a/tests/rspack-test/esmOutputCases/basic/async-modules/lib-defer.js
+++ b/tests/rspack-test/esmOutputCases/basic/async-modules/lib-defer.js
@@ -1,0 +1,3 @@
+const v = await (() => 42)()
+
+export { v }

--- a/tests/rspack-test/esmOutputCases/basic/async-modules/lib.js
+++ b/tests/rspack-test/esmOutputCases/basic/async-modules/lib.js
@@ -1,0 +1,3 @@
+await 42
+const lib = 42
+export { lib }


### PR DESCRIPTION
## Summary

When render require for async modules, use top level await to render them, this can make whole program works.

Current solution is not perfect, async modules are still wrapped in runtime execution context. We'll improve it to make async modules can be scope hoisted

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
