### PR TITLE
ci(ecosystem): do not need to clone ecosystem ci repo to sub folder

### DIFF
--- a/.github/workflows/ecosystem-ci-rstack.yml
+++ b/.github/workflows/ecosystem-ci-rstack.yml
@@ -315,7 +315,6 @@ jobs:
         with:
           repository: rspack-contrib/rstack-ecosystem-ci
           ref: main
-          path: ecosystem-ci-repo
           fetch-depth: 1
           token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
 
@@ -339,7 +338,7 @@ jobs:
           SOURCE_REPO: ${{ github.repository }}
           SOURCE_COMMIT: ${{ github.sha }}
         run: |
-          node "$GITHUB_WORKSPACE/ecosystem-ci-repo/scripts/update-ecosystem-history.mjs"
+          node scripts/update-ecosystem-history.mjs
 
       - name: Publish History
         if: ${{ success() }}


### PR DESCRIPTION
## Summary

do not need to clone into a subfolder as it's in a separated job, which will raise `fatal: not in a git directory` https://github.com/web-infra-dev/rspack/actions/runs/19815883425/job/56767477433 issue.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
