### PR TITLE
chore(workflow): run diff CI on push events

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
chore: change the diff ci yaml

**Workflow trigger improvements:**

* The CI workflow now also runs on `push` events to the `main` branch, in addition to pull request events (`opened`, `synchronize`, and `reopened`). This ensures that changes pushed directly to `main` are also checked by the workflow.
* The workflow trigger for pull requests now uses `reopened` instead of `closed`, so the workflow is triggered when a pull request is reopened rather than when it is closed.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
