### PR TITLE
fix: should use sourceOrder to sort module outgoing in buildChunkGraph

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -2047,14 +2047,19 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         let mut connection_map =
           IndexMap::<(DependenciesBlockIdentifier, ModuleIdentifier), Vec<DependencyId>>::default();
 
-        for dep_id in mg.get_outgoing_deps_in_order(module) {
-          let dep = mg.dependency_by_id(dep_id).expect("should have dep");
-          if dep.as_module_dependency().is_none() && dep.as_context_dependency().is_none() {
-            continue;
-          }
-          if matches!(dep.as_module_dependency().map(|d| d.weak()), Some(true)) {
-            continue;
-          }
+        let mut deps = mg
+          .get_outgoing_deps_in_order(module)
+          .filter_map(|dep_id| mg.dependency_by_id(dep_id))
+          .filter(|dep| {
+            dep.as_module_dependency().is_some() || dep.as_context_dependency().is_some()
+          })
+          .filter(|dep| !matches!(dep.as_module_dependency().map(|d| d.weak()), Some(true)))
+          .collect::<Vec<_>>();
+        deps.sort_by_key(|a| a.source_order());
+
+        for dep in deps {
+          let dep_id = dep.id();
+
           // Dependency created but no module is available.
           // This could happen when module factorization is failed, but `options.bail` set to `false`
           let Some(module_identifier) = mg.module_identifier_by_dependency_id(dep_id) else {
@@ -2065,6 +2070,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           } else {
             (*module).into()
           };
+
           connection_map
             .entry((block_id, *module_identifier))
             .and_modify(|e| e.push(*dep_id))

--- a/tests/rspack-test/configCases/css/css-order/__snapshot__/main.css.txt
+++ b/tests/rspack-test/configCases/css/css-order/__snapshot__/main.css.txt
@@ -1,1 +1,1 @@
-.teaser-module {  padding: 20px;  border: 1px solid #ddd;  border-radius: 8px;  margin: 16px;}.teaser-module {  background-color: orange;}.button-module {  padding: 8px 16px;  background-color: #007bff;  color: white;  border: none;  border-radius: 4px;}
+.button-module {  padding: 8px 16px;  background-color: #007bff;  color: white;  border: none;  border-radius: 4px;}.teaser-module {  padding: 20px;  border: 1px solid #ddd;  border-radius: 8px;  margin: 16px;}.teaser-module {  background-color: orange;}


### PR DESCRIPTION
## Summary

Fix #11148

Should use `sourceOrder` to sort module.dependencies when calculating chunk graph. This can keep the import order right.

```js
import {a} from './a'
import './b'
access(a); 
```

The order should be `a` then `b`

The order after side effect optimization would be:

```js
import './b'
access(a);
```

The order becomes `b` then `a`.

So use `sourceOrder` to sort all dependencies to make sure the first import statement be the first in the preOrderIndex

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
