### PR TITLE
fix(rstest): always hoist @rstest/core init fragment

### DIFF
--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -121,10 +121,8 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
       Self::add_placeholder_fragment(init_fragments, flag, request);
     }
 
-    // Step 2: Hoist @rstest/core import for rs.hoisted() to ensure it appears before the placeholder
-    if dep.method == MockMethod::Hoisted {
-      Self::hoist_rstest_core_import(init_fragments);
-    }
+    // Step 2: Hoist @rstest/core import to ensure it comes before all hoisted code
+    Self::hoist_rstest_core_import(init_fragments);
 
     // Step 3: Transform the source code
     Self::transform_source(source, dep, &require_name, mock_method, hoist_flag, request);


### PR DESCRIPTION
## Summary

currently, following code will raise an error `Cannot read properties of undefined (reading 'rs')`. since using `rs` function is a common pattern, so we hoist it anyway.

```js
import { foo } from '../src/foo';
import { expect, it, rs } from '@rstest/core';

rs.mock('../src/foo', () => {
  return {
    foo: rs.fn(),
  };
});
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
