### PR TITLE
refactor: recalculate all chunk ids with cache

### DIFF
--- a/crates/rspack_binding_api/src/chunk.rs
+++ b/crates/rspack_binding_api/src/chunk.rs
@@ -45,7 +45,7 @@ impl Chunk {
   #[napi(getter)]
   pub fn id(&self) -> napi::Result<Either<&str, ()>> {
     let (compilation, chunk) = self.as_ref()?;
-    Ok(match chunk.id(&compilation.chunk_ids_artifact) {
+    Ok(match chunk.id() {
       Some(id) => Either::A(id.as_str()),
       None => Either::B(()),
     })
@@ -54,12 +54,7 @@ impl Chunk {
   #[napi(getter)]
   pub fn ids(&self) -> napi::Result<Vec<&str>> {
     let (compilation, chunk) = self.as_ref()?;
-    Ok(
-      chunk
-        .id(&compilation.chunk_ids_artifact)
-        .map(|id| vec![id.as_str()])
-        .unwrap_or_default(),
-    )
+    Ok(chunk.id().map(|id| vec![id.as_str()]).unwrap_or_default())
   }
 
   #[napi(getter)]

--- a/crates/rspack_core/src/artifacts/chunk_ids_artifact.rs
+++ b/crates/rspack_core/src/artifacts/chunk_ids_artifact.rs
@@ -1,0 +1,33 @@
+use rspack_collections::UkeyMap;
+
+use crate::{ChunkUkey, chunk_graph_chunk::ChunkId};
+
+#[derive(Debug, Default)]
+pub struct ChunkNamedIdArtifact {
+  pub chunk_short_names: UkeyMap<ChunkUkey, String>,
+  pub chunk_long_names: UkeyMap<ChunkUkey, String>,
+  pub chunk_ids: UkeyMap<ChunkUkey, ChunkId>,
+}
+
+impl ChunkNamedIdArtifact {
+  pub fn clear(&mut self) {
+    self.chunk_short_names.clear();
+    self.chunk_long_names.clear();
+    self.chunk_ids.clear();
+  }
+
+  pub fn retain<F>(&mut self, mut f: F)
+  where
+    F: FnMut(&ChunkUkey) -> bool,
+  {
+    self.chunk_short_names.retain(|chunk, _| f(chunk));
+    self.chunk_long_names.retain(|chunk, _| f(chunk));
+    self.chunk_ids.retain(|chunk, _| f(chunk));
+  }
+
+  pub fn remove(&mut self, chunk: &ChunkUkey) {
+    self.chunk_short_names.remove(chunk);
+    self.chunk_long_names.remove(chunk);
+    self.chunk_ids.remove(chunk);
+  }
+}

--- a/crates/rspack_core/src/artifacts/mod.rs
+++ b/crates/rspack_core/src/artifacts/mod.rs
@@ -1,11 +1,12 @@
 use rspack_collections::{IdentifierMap, IdentifierSet, UkeyMap};
 use rspack_error::Diagnostic;
 
-use crate::{ChunkRenderResult, ChunkUkey, ModuleId, RuntimeGlobals, chunk_graph_chunk::ChunkId};
+use crate::{ChunkRenderResult, ChunkUkey, ModuleId, RuntimeGlobals};
 
 mod cgm_hash_artifact;
 mod cgm_runtime_requirement_artifact;
 mod chunk_hashes_artifact;
+mod chunk_ids_artifact;
 mod chunk_render_cache_artifact;
 mod code_generation_results;
 mod module_graph_cache_artifact;
@@ -15,6 +16,7 @@ mod side_effects_do_optimize_artifact;
 pub use cgm_hash_artifact::*;
 pub use cgm_runtime_requirement_artifact::*;
 pub use chunk_hashes_artifact::*;
+pub use chunk_ids_artifact::*;
 pub use chunk_render_cache_artifact::ChunkRenderCacheArtifact;
 pub use code_generation_results::*;
 pub use module_graph_cache_artifact::*;
@@ -25,6 +27,5 @@ pub type AsyncModulesArtifact = IdentifierSet;
 pub type ImportedByDeferModulesArtifact = IdentifierSet;
 pub type DependenciesDiagnosticsArtifact = IdentifierMap<Vec<Diagnostic>>;
 pub type ModuleIdsArtifact = IdentifierMap<ModuleId>;
-pub type ChunkIdsArtifact = UkeyMap<ChunkUkey, ChunkId>;
 pub type CgcRuntimeRequirementsArtifact = UkeyMap<ChunkUkey, RuntimeGlobals>;
 pub type ChunkRenderArtifact = UkeyMap<ChunkUkey, ChunkRenderResult>;

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -13,10 +13,9 @@ use rspack_hash::{RspackHash, RspackHashDigest};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 
 use crate::{
-  ChunkGraph, ChunkGroupByUkey, ChunkGroupOrderKey, ChunkGroupUkey, ChunkHashesArtifact,
-  ChunkIdsArtifact, ChunkUkey, Compilation, EntryOptions, Filename, ModuleGraph,
-  RenderManifestEntry, RuntimeSpec, SourceType, chunk_graph_chunk::ChunkId, compare_chunk_group,
-  sort_group_by_index,
+  ChunkGraph, ChunkGroupByUkey, ChunkGroupOrderKey, ChunkGroupUkey, ChunkHashesArtifact, ChunkUkey,
+  Compilation, EntryOptions, Filename, ModuleGraph, RenderManifestEntry, RuntimeSpec, SourceType,
+  chunk_graph_chunk::ChunkId, compare_chunk_group, sort_group_by_index,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,6 +56,7 @@ pub struct ChunkRenderResult {
 pub struct Chunk {
   ukey: ChunkUkey,
   kind: ChunkKind,
+  id: Option<ChunkId>,
   // - If the chunk is create by entry config, the name is the entry name
   // - The name of chunks create by dynamic import is `None` unless users use
   // magic comment like `import(/* webpackChunkName: "someChunk" * / './someModule.js')` to specify it.
@@ -110,19 +110,24 @@ impl Chunk {
     self.css_filename_template = filename_template;
   }
 
-  pub fn id<'a>(&self, chunk_ids: &'a ChunkIdsArtifact) -> Option<&'a ChunkId> {
-    ChunkGraph::get_chunk_id(chunk_ids, &self.ukey)
+  pub fn id(&self) -> Option<&ChunkId> {
+    self.id.as_ref()
   }
 
-  pub fn expect_id<'a>(&self, chunk_ids: &'a ChunkIdsArtifact) -> &'a ChunkId {
-    self
-      .id(chunk_ids)
-      .expect("Should set id before calling expect_id")
+  pub fn expect_id(&self) -> &ChunkId {
+    self.id().expect("Should set id before calling expect_id")
   }
 
-  pub fn set_id(&self, chunk_ids: &mut ChunkIdsArtifact, id: impl Into<ChunkId>) -> bool {
-    let id = id.into();
-    ChunkGraph::set_chunk_id(chunk_ids, self.ukey, id)
+  pub fn set_id(&mut self, id: impl Into<ChunkId>) -> bool {
+    let id: ChunkId = id.into();
+    if let Some(prev_id) = &self.id
+      && prev_id == &id
+    {
+      return false;
+    }
+
+    self.id = Some(id);
+    true
   }
 
   pub fn prevent_integration(&self) -> bool {
@@ -280,6 +285,7 @@ impl Chunk {
       filename_template: None,
       css_filename_template: None,
       ukey: ChunkUkey::new(),
+      id: None,
       id_name_hints: Default::default(),
       prevent_integration: false,
       files: Default::default(),
@@ -667,14 +673,11 @@ impl Chunk {
     chunks
   }
 
-  pub fn name_for_filename_template<'a>(
-    &'a self,
-    chunk_ids: &'a ChunkIdsArtifact,
-  ) -> Option<&'a str> {
+  pub fn name_for_filename_template(&self) -> Option<&str> {
     if self.name.is_some() {
       self.name.as_deref()
     } else {
-      self.id(chunk_ids).map(|id| id.as_str())
+      self.id().map(|id| id.as_str())
     }
   }
 
@@ -687,7 +690,7 @@ impl Chunk {
   }
 
   pub fn update_hash(&self, hasher: &mut RspackHash, compilation: &Compilation) {
-    self.id(&compilation.chunk_ids_artifact).hash(hasher);
+    self.id().hash(hasher);
     let runtime_modules = compilation
       .chunk_graph
       .get_chunk_runtime_modules_iterable(&self.ukey)
@@ -853,7 +856,7 @@ impl Chunk {
           && let Some(chunk_id) = compilation
             .chunk_by_ukey
             .expect_get(chunk_ukey)
-            .id(&compilation.chunk_ids_artifact)
+            .id()
             .cloned()
         {
           chunk_ids.push(chunk_id);
@@ -883,7 +886,7 @@ impl Chunk {
     ) -> Option<(ChunkId, Vec<ChunkId>)> {
       let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
       if let (Some(chunk_id), Some(child_chunk_ids)) = (
-        chunk.id(&compilation.chunk_ids_artifact).cloned(),
+        chunk.id().cloned(),
         chunk.get_child_ids_by_order(order, compilation, filter_fn),
       ) {
         return Some((chunk_id, child_chunk_ids));

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -12,8 +12,8 @@ use serde::{Serialize, Serializer};
 
 use crate::{
   BoxModule, Chunk, ChunkByUkey, ChunkGraph, ChunkGraphModule, ChunkGroupByUkey, ChunkGroupUkey,
-  ChunkIdsArtifact, ChunkUkey, Compilation, Module, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleIdentifier, RuntimeGlobals, RuntimeModule, SourceType, find_graph_roots, merge_runtime,
+  ChunkUkey, Compilation, Module, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
+  RuntimeGlobals, RuntimeModule, SourceType, find_graph_roots, merge_runtime,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -719,10 +719,7 @@ impl ChunkGraph {
       .iter()
     {
       let chunk = compilation.chunk_by_ukey.expect_get(c);
-      map.insert(
-        chunk.expect_id(&compilation.chunk_ids_artifact).to_string(),
-        filter(c, compilation),
-      );
+      map.insert(chunk.expect_id().to_string(), filter(c, compilation));
     }
 
     map
@@ -1153,24 +1150,5 @@ impl ChunkGraph {
         None
       })
       .unwrap_or(module.source_types(module_graph).iter().copied().collect())
-  }
-
-  pub fn get_chunk_id<'a>(
-    chunk_ids: &'a ChunkIdsArtifact,
-    chunk_ukey: &ChunkUkey,
-  ) -> Option<&'a ChunkId> {
-    chunk_ids.get(chunk_ukey)
-  }
-
-  pub fn set_chunk_id(
-    chunk_ids: &mut ChunkIdsArtifact,
-    chunk_ukey: ChunkUkey,
-    id: ChunkId,
-  ) -> bool {
-    if let Some(old_id) = chunk_ids.insert(chunk_ukey, id.clone()) {
-      old_id != id
-    } else {
-      true
-    }
   }
 }

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -285,7 +285,7 @@ impl ChunkGroup {
         compilation
           .chunk_by_ukey
           .get(chunk)
-          .and_then(|item| item.id(&compilation.chunk_ids_artifact))
+          .and_then(|item| item.id())
       })
       .join("+")
   }

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
@@ -224,7 +224,8 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
     let mut chunk = Chunk::new(Some("build time chunk".into()), ChunkKind::Normal);
 
     if let Some(name) = chunk.name() {
-      chunk.set_id(&mut compilation.chunk_ids_artifact, name);
+      let name = name.to_string();
+      chunk.set_id(name);
     }
     let runtime: RuntimeSpec = once("build time".into()).collect();
 

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -44,17 +44,17 @@ use crate::{
   AsyncModulesArtifact, BindingCell, BoxDependency, BoxModule, CacheCount, CacheOptions,
   CgcRuntimeRequirementsArtifact, CgmHashArtifact, CgmRuntimeRequirementsArtifact, Chunk,
   ChunkByUkey, ChunkContentHash, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkHashesArtifact,
-  ChunkIdsArtifact, ChunkKind, ChunkRenderArtifact, ChunkRenderCacheArtifact, ChunkRenderResult,
-  ChunkUkey, CodeGenerationJob, CodeGenerationResult, CodeGenerationResults, CompilationLogger,
-  CompilationLogging, CompilerOptions, ConcatenationScope, DependenciesDiagnosticsArtifact,
-  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, DependencyType,
-  DerefOption, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId, Filename,
-  ImportPhase, ImportVarMap, ImportedByDeferModulesArtifact, Logger, MemoryGCStorage,
-  ModuleFactory, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphMut, ModuleGraphPartial,
-  ModuleGraphRef, ModuleIdentifier, ModuleIdsArtifact, ModuleStaticCacheArtifact, PathData,
-  ResolverFactory, RuntimeGlobals, RuntimeKeyMap, RuntimeMode, RuntimeModule, RuntimeSpec,
-  RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact, SourceType,
-  Stats, ValueCacheVersions,
+  ChunkKind, ChunkNamedIdArtifact, ChunkRenderArtifact, ChunkRenderCacheArtifact,
+  ChunkRenderResult, ChunkUkey, CodeGenerationJob, CodeGenerationResult, CodeGenerationResults,
+  CompilationLogger, CompilationLogging, CompilerOptions, ConcatenationScope,
+  DependenciesDiagnosticsArtifact, DependencyCodeGeneration, DependencyTemplate,
+  DependencyTemplateType, DependencyType, DerefOption, Entry, EntryData, EntryOptions,
+  EntryRuntime, Entrypoint, ExecuteModuleId, Filename, ImportPhase, ImportVarMap,
+  ImportedByDeferModulesArtifact, Logger, MemoryGCStorage, ModuleFactory, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleGraphMut, ModuleGraphPartial, ModuleGraphRef, ModuleIdentifier,
+  ModuleIdsArtifact, ModuleStaticCacheArtifact, PathData, ResolverFactory, RuntimeGlobals,
+  RuntimeKeyMap, RuntimeMode, RuntimeModule, RuntimeSpec, RuntimeSpecMap, RuntimeTemplate,
+  SharedPluginDriver, SideEffectsOptimizeArtifact, SourceType, Stats, ValueCacheVersions,
   build_chunk_graph::artifact::BuildChunkGraphArtifact,
   compilation::build_module_graph::{
     BuildModuleGraphArtifact, ModuleExecutor, UpdateParam, build_module_graph,
@@ -254,8 +254,8 @@ pub struct Compilation {
   pub side_effects_optimize_artifact: SideEffectsOptimizeArtifact,
   // artifact for module_ids
   pub module_ids_artifact: ModuleIdsArtifact,
-  // artifact for chunk_ids
-  pub chunk_ids_artifact: ChunkIdsArtifact,
+  // artifact for named_chunk_ids
+  pub named_chunk_ids_artifact: ChunkNamedIdArtifact,
   // artifact for code_generation
   pub code_generation_results: BindingCell<CodeGenerationResults>,
   // artifact for create_module_hashes
@@ -393,7 +393,7 @@ impl Compilation {
       ),
       side_effects_optimize_artifact: Default::default(),
       module_ids_artifact: Default::default(),
-      chunk_ids_artifact: Default::default(),
+      named_chunk_ids_artifact: Default::default(),
       code_generation_results: Default::default(),
       cgm_hash_artifact: Default::default(),
       cgm_runtime_requirements_artifact: Default::default(),
@@ -2006,7 +2006,6 @@ impl Compilation {
       entrypoint_ukey: &ChunkGroupUkey,
       chunk_group_by_ukey: &ChunkGroupByUkey,
       chunk_by_ukey: &ChunkByUkey,
-      chunk_ids: &ChunkIdsArtifact,
       chunk_graph: &mut ChunkGraph,
     ) {
       let entrypoint = chunk_group_by_ukey.expect_get(entrypoint_ukey);
@@ -2022,7 +2021,7 @@ impl Compilation {
         runtime,
         chunk_by_ukey.get(&entrypoint.get_runtime_chunk(chunk_group_by_ukey)),
       ) {
-        chunk_graph.set_runtime_id(runtime, chunk.id(chunk_ids).map(|id| id.to_string()));
+        chunk_graph.set_runtime_id(runtime, chunk.id().map(|id| id.to_string()));
       }
     }
     for i in self.entrypoints.iter() {
@@ -2030,7 +2029,6 @@ impl Compilation {
         i.1,
         &self.chunk_group_by_ukey,
         &self.chunk_by_ukey,
-        &self.chunk_ids_artifact,
         &mut self.chunk_graph,
       )
     }
@@ -2039,7 +2037,6 @@ impl Compilation {
         i,
         &self.chunk_group_by_ukey,
         &self.chunk_by_ukey,
-        &self.chunk_ids_artifact,
         &mut self.chunk_graph,
       )
     }
@@ -2525,17 +2522,14 @@ impl Compilation {
         .filter(|(_, (_, remaining))| *remaining != 0)
         .map(|(chunk_ukey, _)| self.chunk_by_ukey.expect_get(chunk_ukey))
         .collect();
-      circular.sort_unstable_by(|a, b| {
-        a.id(&self.chunk_ids_artifact)
-          .cmp(&b.id(&self.chunk_ids_artifact))
-      });
+      circular.sort_unstable_by(|a, b| a.id().cmp(&b.id()));
       runtime_chunks.extend(circular.iter().map(|chunk| chunk.ukey()));
       let circular_names = circular
         .iter()
         .map(|chunk| {
           chunk
             .name()
-            .or(chunk.id(&self.chunk_ids_artifact).map(|id| id.as_str()))
+            .or(chunk.id().map(|id| id.as_str()))
             .unwrap_or("no id chunk")
         })
         .join(", ");

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -127,8 +127,8 @@ impl Compiler {
         .incremental
         .mutations_readable(IncrementalPasses::CHUNK_IDS)
       {
-        new_compilation.chunk_ids_artifact =
-          std::mem::take(&mut self.compilation.chunk_ids_artifact);
+        new_compilation.named_chunk_ids_artifact =
+          std::mem::take(&mut self.compilation.named_chunk_ids_artifact);
       }
       if new_compilation
         .incremental
@@ -234,10 +234,7 @@ impl CompilationRecords {
         let mut hashes = FxHashMap::default();
         for chunk in compilation.chunk_graph.get_module_chunks(*identifier) {
           let chunk = compilation.chunk_by_ukey.expect_get(chunk);
-          let chunk_id = chunk
-            .id(&compilation.chunk_ids_artifact)
-            .expect("should have chunk_id")
-            .clone();
+          let chunk_id = chunk.id().expect("should have chunk_id").clone();
           let hash = compilation
             .code_generation_results
             .get_hash(identifier, Some(chunk.runtime()))
@@ -282,7 +279,7 @@ impl CompilationRecords {
       .values()
       .filter(|chunk| chunk.kind() != ChunkKind::HotUpdate)
       .map(|chunk| {
-        let chunk_id = chunk.expect_id(&compilation.chunk_ids_artifact).clone();
+        let chunk_id = chunk.expect_id().clone();
         let chunk_runtime = chunk.runtime().clone();
         let chunk_modules: FxHashSet<ModuleId> = compilation
           .chunk_graph

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -507,7 +507,7 @@ impl ContextModule {
               let chunk_id = compilation
                 .chunk_by_ukey
                 .expect_get(c)
-                .id(&compilation.chunk_ids_artifact)
+                .id()
                 .expect("should have chunk id in code generation");
               serde_json::json!(chunk_id)
             }))

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -1010,19 +1010,12 @@ impl RuntimeTemplate {
       .chunks
       .iter()
       .map(|c| compilation.chunk_by_ukey.expect_get(c))
-      .filter(|c| {
-        !c.has_runtime(&compilation.chunk_group_by_ukey)
-          && c.id(&compilation.chunk_ids_artifact).is_some()
-      })
+      .filter(|c| !c.has_runtime(&compilation.chunk_group_by_ukey) && c.id().is_some())
       .collect::<Vec<_>>();
 
     if chunks.len() == 1 {
-      let chunk_id = serde_json::to_string(
-        chunks[0]
-          .id(&compilation.chunk_ids_artifact)
-          .expect("should have chunk.id"),
-      )
-      .expect("should able to json stringify");
+      let chunk_id = serde_json::to_string(chunks[0].id().expect("should have chunk.id"))
+        .expect("should able to json stringify");
       runtime_requirements.insert(RuntimeGlobals::ENSURE_CHUNK);
 
       let fetch_priority = chunk_group
@@ -1062,11 +1055,8 @@ impl RuntimeTemplate {
           .map(|c| format!(
             "{}({}{})",
             self.render_runtime_globals(&RuntimeGlobals::ENSURE_CHUNK),
-            serde_json::to_string(
-              c.id(&compilation.chunk_ids_artifact)
-                .expect("should have chunk.id")
-            )
-            .expect("should able to json stringify"),
+            serde_json::to_string(c.id().expect("should have chunk.id"))
+              .expect("should able to json stringify"),
             fetch_priority
               .map(|x| format!(r#", "{x}""#))
               .unwrap_or_default()

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -132,11 +132,7 @@ impl Stats<'_> {
       if let Some(chunks) = compilation_file_to_chunks.get(name) {
         asset.chunks = chunks
           .par_iter()
-          .map(|chunk| {
-            chunk
-              .id(&self.compilation.chunk_ids_artifact)
-              .map(|id| id.as_str())
-          })
+          .map(|chunk| chunk.id().map(|id| id.as_str()))
           .collect();
         asset.chunks.sort_unstable();
         asset.chunk_names = chunks
@@ -160,11 +156,7 @@ impl Stats<'_> {
       if let Some(auxiliary_chunks) = compilation_file_to_auxiliary_chunks.get(name) {
         asset.auxiliary_chunks = auxiliary_chunks
           .par_iter()
-          .map(|chunk| {
-            chunk
-              .id(&self.compilation.chunk_ids_artifact)
-              .map(|id| id.as_str())
-          })
+          .map(|chunk| chunk.id().map(|id| id.as_str()))
           .collect();
         asset.auxiliary_chunks.sort_unstable();
         asset.auxiliary_chunk_names = auxiliary_chunks
@@ -436,9 +428,7 @@ impl Stats<'_> {
           r#type: "chunk",
           files,
           auxiliary_files,
-          id: c
-            .id(&self.compilation.chunk_ids_artifact)
-            .map(|id| id.as_str()),
+          id: c.id().map(|id| id.as_str()),
           id_hints,
           names: c.name().map(|n| vec![n]).unwrap_or_default(),
           entry: c.has_entry_module(chunk_graph),
@@ -491,7 +481,7 @@ impl Stats<'_> {
           .compilation
           .chunk_by_ukey
           .expect_get(c)
-          .id(&self.compilation.chunk_ids_artifact)
+          .id()
           .map(|id| id.as_str())
       })
       .collect();
@@ -662,10 +652,7 @@ impl Stats<'_> {
           chunk_name: chunk.and_then(|c| c.name()),
           chunk_entry: chunk.map(|c| c.has_runtime(&self.compilation.chunk_group_by_ukey)),
           chunk_initial: chunk.map(|c| c.can_be_initial(&self.compilation.chunk_group_by_ukey)),
-          chunk_id: chunk.and_then(|c| {
-            c.id(&self.compilation.chunk_ids_artifact)
-              .map(|id| id.as_str())
-          }),
+          chunk_id: chunk.and_then(|c| c.id().map(|id| id.as_str())),
           details: d.details.clone(),
           stack: d.stack.clone(),
           module_trace,
@@ -725,10 +712,7 @@ impl Stats<'_> {
           chunk_name: chunk.and_then(|c| c.name()),
           chunk_entry: chunk.map(|c| c.has_runtime(&self.compilation.chunk_group_by_ukey)),
           chunk_initial: chunk.map(|c| c.can_be_initial(&self.compilation.chunk_group_by_ukey)),
-          chunk_id: chunk.and_then(|c| {
-            c.id(&self.compilation.chunk_ids_artifact)
-              .map(|id| id.as_str())
-          }),
+          chunk_id: chunk.and_then(|c| c.id().map(|id| id.as_str())),
           details: d.details.clone(),
           stack: d.stack.clone(),
           module_trace,
@@ -959,7 +943,7 @@ impl Stats<'_> {
                   .compilation
                   .chunk_by_ukey
                   .expect_get(k)
-                  .id(&self.compilation.chunk_ids_artifact)
+                  .id()
                   .map(|id| id.as_str())
               })
               .collect::<Vec<_>>()
@@ -1254,7 +1238,7 @@ impl Stats<'_> {
           .compilation
           .chunk_by_ukey
           .expect_get(k)
-          .id(&self.compilation.chunk_ids_artifact)
+          .id()
           .map(|id| id.as_str())
       })
       .collect();
@@ -1408,7 +1392,7 @@ pub fn create_stats_errors<'a>(
         chunk_name: chunk.and_then(|c| c.name()),
         chunk_entry: chunk.map(|c| c.has_runtime(&compilation.chunk_group_by_ukey)),
         chunk_initial: chunk.map(|c| c.can_be_initial(&compilation.chunk_group_by_ukey)),
-        chunk_id: chunk.and_then(|c| c.id(&compilation.chunk_ids_artifact).map(|id| id.as_str())),
+        chunk_id: chunk.and_then(|c| c.id().map(|id| id.as_str())),
         details: d.details.clone(),
         stack: d.stack.clone(),
         module_trace,

--- a/crates/rspack_core/src/stats/utils.rs
+++ b/crates/rspack_core/src/stats/utils.rs
@@ -115,7 +115,7 @@ pub fn get_chunk_relations<'a>(
         if let Some(pg) = compilation.chunk_group_by_ukey.get(p) {
           for c in &pg.chunks {
             if let Some(c) = compilation.chunk_by_ukey.get(c)
-              && let Some(id) = c.id(&compilation.chunk_ids_artifact)
+              && let Some(id) = c.id()
             {
               parents.insert(id.as_str());
             }
@@ -127,7 +127,7 @@ pub fn get_chunk_relations<'a>(
         if let Some(pg) = compilation.chunk_group_by_ukey.get(p) {
           for c in &pg.chunks {
             if let Some(c) = compilation.chunk_by_ukey.get(c)
-              && let Some(id) = c.id(&compilation.chunk_ids_artifact)
+              && let Some(id) = c.id()
             {
               children.insert(id.as_str());
             }
@@ -137,8 +137,8 @@ pub fn get_chunk_relations<'a>(
 
       for c in &cg.chunks {
         if let Some(c) = compilation.chunk_by_ukey.get(c)
-          && c.id(&compilation.chunk_ids_artifact) != chunk.id(&compilation.chunk_ids_artifact)
-          && let Some(id) = c.id(&compilation.chunk_ids_artifact)
+          && c.id() != chunk.id()
+          && let Some(id) = c.id()
         {
           siblings.insert(id.as_str());
         }

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -28,11 +28,9 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     IncrementalPasses::CHUNK_IDS,
     "DeterministicChunkIdsPlugin (optimization.chunkIds = \"deterministic\")",
     "it requires calculating the id of all the chunks, which is a global effect",
-  ) {
-    if let Some(diagnostic) = diagnostic {
-      compilation.push_diagnostic(diagnostic);
-    }
-    compilation.chunk_ids_artifact.clear();
+  ) && let Some(diagnostic) = diagnostic
+  {
+    compilation.push_diagnostic(diagnostic);
   }
 
   let mut used_ids = get_used_chunk_ids(compilation);
@@ -53,7 +51,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
   let chunks = compilation
     .chunk_by_ukey
     .values()
-    .filter(|chunk| chunk.id(&compilation.chunk_ids_artifact).is_none())
+    .filter(|chunk| chunk.id().is_none())
     .collect::<Vec<_>>();
   let mut chunk_key_to_id =
     FxHashMap::with_capacity_and_hasher(chunks.len(), FxBuildHasher::default());
@@ -112,7 +110,7 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
 
   chunk_key_to_id.into_iter().for_each(|(chunk_ukey, id)| {
     let chunk = compilation.chunk_by_ukey.expect_get_mut(&chunk_ukey);
-    chunk.set_id(&mut compilation.chunk_ids_artifact, id.to_string());
+    chunk.set_id(id.to_string());
   });
 
   Ok(())

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -1,7 +1,7 @@
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 use rspack_collections::{DatabaseItem, UkeyIndexSet, UkeySet};
 use rspack_core::{
-  ChunkGraph, ChunkIdsArtifact, ChunkUkey, Compilation, CompilationChunkIds, Logger, Plugin,
+  ChunkNamedIdArtifact, ChunkUkey, Compilation, CompilationChunkIds, Logger, Plugin,
   chunk_graph_chunk::ChunkId,
   incremental::{self, IncrementalPasses, Mutation, Mutations},
 };
@@ -14,10 +14,10 @@ use crate::id_helpers::{compare_chunks_natural, get_long_chunk_name, get_short_c
 #[tracing::instrument(skip_all)]
 fn assign_named_chunk_ids(
   chunks: UkeySet<ChunkUkey>,
-  compilation: &Compilation,
+  compilation: &mut Compilation,
   delimiter: &str,
   used_ids: &mut FxHashMap<ChunkId, ChunkUkey>,
-  chunk_ids: &mut ChunkIdsArtifact,
+  named_chunk_ids_artifact: &mut ChunkNamedIdArtifact,
   mutations: &mut Option<Mutations>,
 ) -> Vec<ChunkUkey> {
   let context: &str = compilation.options.context.as_ref();
@@ -36,6 +36,7 @@ fn assign_named_chunk_ids(
         delimiter,
         &module_graph,
         module_graph_cache,
+        named_chunk_ids_artifact,
       );
       (item, name)
     })
@@ -43,6 +44,10 @@ fn assign_named_chunk_ids(
   let mut name_to_items: FxHashMap<String, UkeyIndexSet<ChunkUkey>> = FxHashMap::default();
   let mut invalid_and_repeat_names: FxHashSet<String> = std::iter::once(String::new()).collect();
   for (item, name) in item_name_pair {
+    named_chunk_ids_artifact
+      .chunk_short_names
+      .insert(item, name.clone());
+
     let items = name_to_items.entry(name.clone()).or_default();
     items.insert(item);
     // If the short chunk id is conflict, then we need to rename all the conflicting chunks to long module id
@@ -59,7 +64,7 @@ fn assign_named_chunk_ids(
     }
   }
 
-  let item_name_pair: Vec<_> = invalid_and_repeat_names
+  let item_name_pair: Vec<(ChunkUkey, String)> = invalid_and_repeat_names
     .iter()
     .flat_map(|name| {
       let mut res = vec![];
@@ -78,11 +83,17 @@ fn assign_named_chunk_ids(
         delimiter,
         &module_graph,
         module_graph_cache,
+        named_chunk_ids_artifact,
       );
       (item, long_name)
     })
     .collect();
+
   for (item, name) in item_name_pair {
+    named_chunk_ids_artifact
+      .chunk_long_names
+      .insert(item, name.clone());
+
     let items = name_to_items.entry(name.clone()).or_default();
     items.insert(item);
     // Also rename the conflicting chunks in used_ids
@@ -107,7 +118,8 @@ fn assign_named_chunk_ids(
     } else if items.len() == 1 && !used_ids.contains_key(name.as_str()) {
       let item = items[0];
       let name: ChunkId = name.into();
-      if ChunkGraph::set_chunk_id(chunk_ids, item, name.clone())
+      let chunk = compilation.chunk_by_ukey.expect_get_mut(&item);
+      if chunk.set_id(name.clone())
         && let Some(mutations) = mutations
       {
         mutations.add(Mutation::ChunkSetId { chunk: item });
@@ -138,7 +150,8 @@ fn assign_named_chunk_ids(
           formatted_name = format!("{name}{}", i_buffer.format(i));
         }
         let name: ChunkId = formatted_name.into();
-        if ChunkGraph::set_chunk_id(chunk_ids, item, name.clone())
+        let chunk = compilation.chunk_by_ukey.expect_get_mut(&item);
+        if chunk.set_id(name.clone())
           && let Some(mutations) = mutations
         {
           mutations.add(Mutation::ChunkSetId { chunk: item });
@@ -178,7 +191,7 @@ impl NamedChunkIdsPlugin {
 
 #[plugin_hook(CompilationChunkIds for NamedChunkIdsPlugin)]
 async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
-  let more_chunks = if let Some(mutations) = compilation
+  if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::CHUNK_IDS)
   {
@@ -187,29 +200,34 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     for mutation in mutations.iter() {
       match mutation {
         Mutation::ChunkRemove { chunk } => {
-          compilation.chunk_ids_artifact.remove(chunk);
+          compilation.named_chunk_ids_artifact.remove(chunk);
         }
         Mutation::ModuleSetId { module } => {
-          affected_chunks.extend(compilation.chunk_graph.get_module_chunks(*module));
+          let chunks = compilation.chunk_graph.get_module_chunks(*module);
+          affected_chunks.extend(chunks.iter().copied());
         }
         _ => {}
       }
     }
-    compilation
-      .chunk_ids_artifact
-      .retain(|chunk, _| compilation.chunk_by_ukey.contains(chunk));
-    affected_chunks
-  } else {
-    UkeySet::default()
-  };
+
+    compilation.named_chunk_ids_artifact.retain(|chunk| {
+      compilation.chunk_by_ukey.contains(chunk) && !affected_chunks.contains(chunk)
+    });
+  }
+
+  let mut named_chunk_ids_artifact = std::mem::take(&mut compilation.named_chunk_ids_artifact);
 
   let mut chunks: UkeySet<ChunkUkey> = compilation
     .chunk_by_ukey
-    .values()
-    .filter(|chunk| chunk.id(&compilation.chunk_ids_artifact).is_none())
-    .map(|chunk| chunk.ukey())
+    .values_mut()
+    .map(|chunk| {
+      if let Some(id) = named_chunk_ids_artifact.chunk_ids.get(&chunk.ukey()) {
+        chunk.set_id(id.clone());
+      }
+      chunk.ukey()
+    })
     .collect();
-  chunks.extend(more_chunks);
+
   let chunks_len = chunks.len();
 
   let mut mutations = compilation
@@ -217,15 +235,16 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     .mutations_writeable()
     .then(Mutations::default);
 
+  let mut used_ids: FxHashMap<ChunkId, ChunkUkey> = Default::default();
+
   // Use chunk name as default chunk id
   chunks.retain(|chunk_ukey| {
-    let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
+    let chunk = compilation.chunk_by_ukey.expect_get_mut(chunk_ukey);
     if let Some(chunk_name) = chunk.name() {
-      if ChunkGraph::set_chunk_id(
-        &mut compilation.chunk_ids_artifact,
-        *chunk_ukey,
-        chunk_name.into(),
-      ) && let Some(mutations) = &mut mutations
+      let name = chunk_name.to_string();
+      used_ids.insert(name.clone().into(), *chunk_ukey);
+      if chunk.set_id(name)
+        && let Some(mutations) = &mut mutations
       {
         mutations.add(Mutation::ChunkSetId { chunk: *chunk_ukey });
       }
@@ -235,18 +254,12 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
   });
   let named_chunks_len = chunks_len - chunks.len();
 
-  let mut chunk_ids = std::mem::take(&mut compilation.chunk_ids_artifact);
-  let mut used_ids: FxHashMap<ChunkId, ChunkUkey> = chunk_ids
-    .iter()
-    .map(|(&chunk, id)| (id.clone(), chunk))
-    .collect();
-
   let unnamed_chunks = assign_named_chunk_ids(
     chunks,
     compilation,
     &self.delimiter,
     &mut used_ids,
-    &mut chunk_ids,
+    &mut named_chunk_ids_artifact,
     &mut mutations,
   );
 
@@ -259,7 +272,9 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
         next_id += 1;
         id = next_id.to_string();
       }
-      if chunk.set_id(&mut chunk_ids, id)
+
+      used_ids.insert(id.clone().into(), *chunk_ukey);
+      if chunk.set_id(id)
         && let Some(mutations) = &mut mutations
       {
         mutations.add(Mutation::ChunkSetId { chunk: *chunk_ukey });
@@ -275,11 +290,6 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
   {
     let logger = compilation.get_logger("rspack.incremental.chunkIds");
     logger.log(format!(
-      "{} chunks are affected, {} in total",
-      chunks_len,
-      compilation.chunk_by_ukey.len(),
-    ));
-    logger.log(format!(
       "{} chunks are updated by set_chunk_id, with {} chunks using name as id, and {} unnamed chunks",
       mutations.len(),
       named_chunks_len,
@@ -293,7 +303,14 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     compilation_mutations.extend(mutations);
   }
 
-  compilation.chunk_ids_artifact = chunk_ids;
+  // store chunk id map to the artifact
+  compilation.chunk_by_ukey.values().for_each(|chunk| {
+    named_chunk_ids_artifact
+      .chunk_ids
+      .insert(chunk.ukey(), chunk.expect_id().clone());
+  });
+  compilation.named_chunk_ids_artifact = named_chunk_ids_artifact;
+
   Ok(())
 }
 

--- a/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
@@ -15,11 +15,9 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_
     IncrementalPasses::CHUNK_IDS,
     "NaturalChunkIdsPlugin (optimization.chunkIds = \"natural\")",
     "it requires calculating the id of all the chunks, which is a global effect",
-  ) {
-    if let Some(diagnostic) = diagnostic {
-      compilation.push_diagnostic(diagnostic);
-    }
-    compilation.chunk_ids_artifact.clear();
+  ) && let Some(diagnostic) = diagnostic
+  {
+    compilation.push_diagnostic(diagnostic);
   }
 
   let module_ids = &compilation.module_ids_artifact;

--- a/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
@@ -31,11 +31,9 @@ async fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<
     IncrementalPasses::CHUNK_IDS,
     "OccurrenceChunkIdsPlugin (optimization.chunkIds = \"size\")",
     "it requires calculating the id of all the chunks, which is a global effect",
-  ) {
-    if let Some(diagnostic) = diagnostic {
-      compilation.push_diagnostic(diagnostic);
-    }
-    compilation.chunk_ids_artifact.clear();
+  ) && let Some(diagnostic) = diagnostic
+  {
+    compilation.push_diagnostic(diagnostic);
   }
 
   let chunk_graph = &compilation.chunk_graph;

--- a/crates/rspack_plugin_banner/src/lib.rs
+++ b/crates/rspack_plugin_banner/src/lib.rs
@@ -191,12 +191,8 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
               &compilation.chunk_hashes_artifact,
               compilation.options.output.hash_digest_length,
             ))
-            .chunk_id_optional(
-              chunk
-                .id(&compilation.chunk_ids_artifact)
-                .map(|id| id.as_str()),
-            )
-            .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+            .chunk_id_optional(chunk.id().map(|id| id.as_str()))
+            .chunk_name_optional(chunk.name_for_filename_template())
             .hash(&hash)
             .filename(file),
         )

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -134,12 +134,9 @@ impl CssPlugin {
           "Conflicting order".into(),
           format!(
             "chunk {}\nConflicting order between {} and {}",
-            chunk.name().unwrap_or(
-              chunk
-                .id(&compilation.chunk_ids_artifact)
-                .expect("should have chunk id")
-                .as_str()
-            ),
+            chunk
+              .name()
+              .unwrap_or(chunk.id().expect("should have chunk id").as_str()),
             failed_module.readable_identifier(&compilation.options.context),
             selected_module.readable_identifier(&compilation.options.context)
           ),
@@ -422,16 +419,12 @@ async fn render_manifest(
     .get_path_with_info(
       filename_template,
       PathData::default()
-        .chunk_id_optional(
-          chunk
-            .id(&compilation.chunk_ids_artifact)
-            .map(|id| id.as_str()),
-        )
+        .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,
           compilation.options.output.hash_digest_length,
         ))
-        .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+        .chunk_name_optional(chunk.name_for_filename_template())
         .content_hash_optional(chunk.rendered_content_hash_by_source_type(
           &compilation.chunk_hashes_artifact,
           &SourceType::Css,

--- a/crates/rspack_plugin_css/src/runtime/mod.rs
+++ b/crates/rspack_plugin_css/src/runtime/mod.rs
@@ -121,7 +121,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
         let id = compilation
           .chunk_by_ukey
           .expect_get(chunk_ukey)
-          .expect_id(&compilation.chunk_ids_artifact)
+          .expect_id()
           .clone();
         if chunk_has_css(chunk_ukey, compilation) {
           initial_chunk_ids.insert(id);

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -105,9 +105,7 @@ async fn eval_devtool_plugin_render_module_content(
 
   let chunk = compilation.chunk_by_ukey.get(chunk_ukey);
   let path_data = PathData::default()
-    .chunk_id_optional(
-      chunk.and_then(|c| c.id(&compilation.chunk_ids_artifact).map(|id| id.as_str())),
-    )
+    .chunk_id_optional(chunk.and_then(|c| c.id().map(|id| id.as_str())))
     .chunk_name_optional(chunk.and_then(|c| c.name()))
     .chunk_hash_optional(chunk.and_then(|c| {
       c.rendered_hash(

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -130,11 +130,7 @@ async fn eval_source_map_devtool_plugin_render_module_content(
           }
         });
         let path_data = PathData::default()
-          .chunk_id_optional(
-            chunk
-              .id(&compilation.chunk_ids_artifact)
-              .map(|id| id.as_str()),
-          )
+          .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_name_optional(chunk.name())
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -286,7 +286,7 @@ impl SourceMapDevToolPlugin {
                   let path_data = PathData::default()
                     .chunk_id_optional(
                       chunk
-                        .and_then(|c| c.id(&compilation.chunk_ids_artifact).map(|id| id.as_str())),
+                        .and_then(|c| c.id().map(|id| id.as_str())),
                     )
                     .chunk_name_optional(chunk.and_then(|c| c.name()))
                     .chunk_hash_optional(chunk.and_then(|c| {
@@ -542,7 +542,7 @@ impl SourceMapDevToolPlugin {
                   Some(chunk) => data
                     .chunk_id_optional(
                       chunk
-                        .id(&compilation.chunk_ids_artifact)
+                        .id()
                         .map(|id| id.as_str()),
                     )
                     .chunk_hash_optional(chunk.rendered_hash(
@@ -550,7 +550,7 @@ impl SourceMapDevToolPlugin {
                       compilation.options.output.hash_digest_length,
                     ))
                     .chunk_name_optional(
-                      chunk.name_for_filename_template(&compilation.chunk_ids_artifact),
+                      chunk.name_for_filename_template(),
                     )
                     .content_hash_optional(Some(digest.encoded())),
                   None => data,

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -67,16 +67,12 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
       .get_path(
         &self.options.path,
         PathData::default()
-          .chunk_id_optional(
-            chunk
-              .id(&compilation.chunk_ids_artifact)
-              .map(|id| id.as_str()),
-          )
+          .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,
             compilation.options.output.hash_digest_length,
           ))
-          .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact)),
+          .chunk_name_optional(chunk.name_for_filename_template()),
       )
       .await?;
 
@@ -90,18 +86,12 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
           .get_path(
             name,
             PathData::default()
-              .chunk_id_optional(
-                chunk
-                  .id(&compilation.chunk_ids_artifact)
-                  .map(|id| id.as_str()),
-              )
+              .chunk_id_optional(chunk.id().map(|id| id.as_str()))
               .chunk_hash_optional(chunk.rendered_hash(
                 &compilation.chunk_hashes_artifact,
                 compilation.options.output.hash_digest_length,
               ))
-              .chunk_name_optional(
-                chunk.name_for_filename_template(&compilation.chunk_ids_artifact),
-              )
+              .chunk_name_optional(chunk.name_for_filename_template())
               .content_hash_optional(chunk.rendered_content_hash_by_source_type(
                 &compilation.chunk_hashes_artifact,
                 &SourceType::JavaScript,

--- a/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
+++ b/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use rspack_core::{
-  ChunkGraph, Dependency, DependencyId, DependencyTemplate, ExportsType, ExtendedReferencedExport,
+  Dependency, DependencyId, DependencyTemplate, ExportsType, ExtendedReferencedExport,
   FakeNamespaceObjectMode, ModuleGraph, RuntimeGlobals, TemplateContext, UsageState,
   get_exports_type,
 };
@@ -179,16 +179,16 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
         const { a, b } = await import('./ref-chunk').then(() => __webpack_require__(./refModule));
     */
     let already_in_chunk = ref_chunk == orig_chunk;
+    let ref_chunk = code_generatable_context
+      .compilation
+      .chunk_by_ukey
+      .expect_get(&ref_chunk);
     let import_promise = if already_in_chunk {
       Cow::Borrowed("Promise.resolve()")
     } else {
       Cow::Owned(format!(
         "import(\"__RSPACK_ESM_CHUNK_{}\")",
-        ChunkGraph::get_chunk_id(
-          &code_generatable_context.compilation.chunk_ids_artifact,
-          &ref_chunk
-        )
-        .expect("should have id")
+        ref_chunk.expect_id().as_str()
       ))
     };
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -690,12 +690,8 @@ impl EsmLibraryPlugin {
               &compilation.chunk_hashes_artifact,
               compilation.options.output.hash_digest_length,
             ))
-            .chunk_id_optional(
-              chunk
-                .id(&compilation.chunk_ids_artifact)
-                .map(|id| id.as_str()),
-            )
-            .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+            .chunk_id_optional(chunk.id().map(|id| id.as_str()))
+            .chunk_name_optional(chunk.name_for_filename_template())
             .content_hash_optional(chunk.rendered_content_hash_by_source_type(
               &compilation.chunk_hashes_artifact,
               &SourceType::JavaScript,

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -7,7 +7,7 @@ use atomic_refcell::AtomicRefCell;
 use regex::Regex;
 use rspack_collections::{IdentifierIndexMap, IdentifierSet, UkeyMap};
 use rspack_core::{
-  ApplyContext, AssetInfo, AsyncModulesArtifact, ChunkGraph, ChunkUkey, Compilation,
+  ApplyContext, AssetInfo, AsyncModulesArtifact, ChunkUkey, Compilation,
   CompilationAdditionalChunkRuntimeRequirements, CompilationAdditionalTreeRuntimeRequirements,
   CompilationAfterCodeGeneration, CompilationConcatenationScope, CompilationFinishModules,
   CompilationOptimizeChunks, CompilationParams, CompilationProcessAssets,
@@ -298,8 +298,9 @@ async fn after_code_generation(&self, compilation: &mut Compilation) -> Result<(
   let mut chunk_ids_to_ukey = FxHashMap::default();
 
   for chunk_ukey in compilation.chunk_by_ukey.keys() {
-    let id = ChunkGraph::get_chunk_id(&compilation.chunk_ids_artifact, chunk_ukey);
-    if let Some(id) = id {
+    let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
+
+    if let Some(id) = chunk.id() {
       chunk_ids_to_ukey.insert(id.as_str().to_string(), *chunk_ukey);
     }
   }
@@ -440,9 +441,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             .unwrap_or_else(|| {
               panic!(
                 "at least one path for chunk: {:?}",
-                chunk
-                  .id(&compilation.chunk_ids_artifact)
-                  .map(|id| { id.as_str() })
+                chunk.id().map(|id| { id.as_str() })
               )
             })
             .as_str(),

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -151,12 +151,8 @@ impl EsmLibraryPlugin {
             &compilation.chunk_hashes_artifact,
             compilation.options.output.hash_digest_length,
           ))
-          .chunk_id_optional(
-            chunk
-              .id(&compilation.chunk_ids_artifact)
-              .map(|id| id.as_str()),
-          )
-          .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+          .chunk_id_optional(chunk.id().map(|id| id.as_str()))
+          .chunk_name_optional(chunk.name_for_filename_template())
           .content_hash_optional(chunk.rendered_content_hash_by_source_type(
             &compilation.chunk_hashes_artifact,
             &SourceType::JavaScript,
@@ -391,14 +387,14 @@ impl EsmLibraryPlugin {
     if !runtime_requirements.is_empty() {
       let runtime_chunk = Self::get_runtime_chunk(*chunk_ukey, compilation);
       if &runtime_chunk != chunk_ukey && runtime_requirements.contains(RuntimeGlobals::REQUIRE) {
+        let runtime_chunk = compilation.chunk_by_ukey.expect_get(&runtime_chunk);
+
         final_source.add(RawStringSource::from(format!(
           "import {{ {} }} from \"__RSPACK_ESM_CHUNK_{}\";\n",
           compilation
             .runtime_template
             .render_runtime_globals(&RuntimeGlobals::REQUIRE),
-          ChunkGraph::get_chunk_id(&compilation.chunk_ids_artifact, &runtime_chunk)
-            .expect("should have id for chunk")
-            .as_str()
+          runtime_chunk.expect_id().as_str()
         )));
       }
     }
@@ -469,6 +465,7 @@ impl EsmLibraryPlugin {
       {
         continue;
       }
+      let chunk = compilation.chunk_by_ukey.expect_get(chunk);
 
       final_source.add(RawStringSource::from(format!(
         "import {}\"__RSPACK_ESM_CHUNK_{}\";\n",
@@ -490,9 +487,7 @@ impl EsmLibraryPlugin {
               .join(", ")
           )
         },
-        ChunkGraph::get_chunk_id(&compilation.chunk_ids_artifact, chunk)
-          .expect("should have chunk id")
-          .as_str()
+        chunk.expect_id().as_str()
       )));
     }
 
@@ -588,12 +583,8 @@ impl EsmLibraryPlugin {
           .join(", "),
         match re_export_from {
           crate::chunk_link::ReExportFrom::Chunk(chunk_ukey) => {
-            Cow::Owned(format!(
-              "__RSPACK_ESM_CHUNK_{}",
-              ChunkGraph::get_chunk_id(&compilation.chunk_ids_artifact, chunk_ukey)
-                .expect("should have chunk id")
-                .as_str()
-            ))
+            let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
+            Cow::Owned(format!("__RSPACK_ESM_CHUNK_{}", chunk.expect_id().as_str()))
           }
           crate::chunk_link::ReExportFrom::Request(request) => {
             Cow::Borrowed(request)

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -341,9 +341,7 @@ despite it was not able to fulfill desired ordering with these modules:
 {}"#,
             chunk
               .name()
-              .or_else(|| chunk
-                .id(&compilation.chunk_ids_artifact)
-                .map(|id| id.as_str()))
+              .or_else(|| chunk.id().map(|id| id.as_str()))
               .unwrap_or_default(),
             fallback_module.readable_identifier(&compilation.options.context),
             conflict
@@ -655,16 +653,12 @@ async fn render_manifest(
     .get_path_with_info(
       filename_template,
       PathData::default()
-        .chunk_id_optional(
-          chunk
-            .id(&compilation.chunk_ids_artifact)
-            .map(|id| id.as_str()),
-        )
+        .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,
           compilation.options.output.hash_digest_length,
         ))
-        .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+        .chunk_name_optional(chunk.name_for_filename_template())
         .content_hash_optional(chunk.rendered_content_hash_by_source_type(
           &compilation.chunk_hashes_artifact,
           &SOURCE_TYPE[0],

--- a/crates/rspack_plugin_extract_css/src/runtime.rs
+++ b/crates/rspack_plugin_extract_css/src/runtime.rs
@@ -206,7 +206,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
           Some(serde_json::json!({
             "_installed_chunks": format!(
               "{}: 0,\n",
-              serde_json::to_string(chunk.expect_id(&compilation.chunk_ids_artifact))
+              serde_json::to_string(chunk.expect_id())
                 .expect("json stringify failed")
             ),
             "_css_chunks": format!(
@@ -216,7 +216,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
                 .filter_map(|id| {
                   let chunk = compilation.chunk_by_ukey.expect_get(id);
 
-                  chunk.id(&compilation.chunk_ids_artifact).map(|id| {
+                  chunk.id().map(|id| {
                     format!(
                       "{}: 1,\n",
                       serde_json::to_string(id).expect("json stringify failed")

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -126,11 +126,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     let current_chunk = compilation
       .chunk_by_ukey
       .iter()
-      .find(|(_, chunk)| {
-        chunk
-          .expect_id(&compilation.chunk_ids_artifact)
-          .eq(&chunk_id)
-      })
+      .find(|(_, chunk)| chunk.expect_id().eq(&chunk_id))
       .map(|(_, chunk)| chunk);
     let current_chunk_ukey = current_chunk.map(|c| c.ukey());
 
@@ -218,7 +214,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 
     if !new_modules.is_empty() || !new_runtime_modules.is_empty() {
       let mut hot_update_chunk = Chunk::new(None, ChunkKind::HotUpdate);
-      hot_update_chunk.set_id(&mut compilation.chunk_ids_artifact, chunk_id.clone());
+      hot_update_chunk.set_id(chunk_id.clone());
       hot_update_chunk.set_runtime(if let Some(current_chunk) = current_chunk {
         current_chunk.runtime().clone()
       } else {
@@ -293,14 +289,8 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             .get_path(
               &compilation.options.output.hot_update_chunk_filename,
               PathData::default()
-                .chunk_id_optional(
-                  hot_update_chunk
-                    .id(&compilation.chunk_ids_artifact)
-                    .map(|id| id.as_str()),
-                )
-                .chunk_name_optional(
-                  hot_update_chunk.name_for_filename_template(&compilation.chunk_ids_artifact),
-                )
+                .chunk_id_optional(hot_update_chunk.id().map(|id| id.as_str()))
+                .chunk_name_optional(hot_update_chunk.name_for_filename_template())
                 .hash_optional(
                   old_hash
                     .as_ref()

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -148,7 +148,7 @@ impl DependencyTemplate for WorkerDependencyTemplate {
       })
       .map(|entrypoint| entrypoint.get_entrypoint_chunk())
       .and_then(|ukey| compilation.chunk_by_ukey.get(&ukey))
-      .and_then(|chunk| chunk.id(&compilation.chunk_ids_artifact))
+      .and_then(|chunk| chunk.id())
       .and_then(|chunk_id| serde_json::to_string(chunk_id).ok())
       .expect("failed to get json stringified chunk id");
     let worker_import_base_url = if !dep.public_path.is_empty() {

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -433,7 +433,7 @@ async fn content_hash(
     .or_insert_with(|| RspackHash::from(&compilation.options.output));
 
   if !chunk.has_runtime(&compilation.chunk_group_by_ukey) {
-    chunk.id(&compilation.chunk_ids_artifact).hash(&mut hasher);
+    chunk.id().hash(&mut hasher);
   }
 
   let module_graph = compilation.get_module_graph();
@@ -528,12 +528,8 @@ async fn render_manifest(
           &compilation.chunk_hashes_artifact,
           compilation.options.output.hash_digest_length,
         ))
-        .chunk_id_optional(
-          chunk
-            .id(&compilation.chunk_ids_artifact)
-            .map(|id| id.as_str()),
-        )
-        .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+        .chunk_id_optional(chunk.id().map(|id| id.as_str()))
+        .chunk_name_optional(chunk.name_for_filename_template())
         .content_hash_optional(chunk.rendered_content_hash_by_source_type(
           &compilation.chunk_hashes_artifact,
           &SourceType::JavaScript,

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -388,7 +388,7 @@ var module = ({}[moduleId] = {{"#,
               compilation
                 .chunk_by_ukey
                 .expect_get(chunk_ukey)
-                .expect_id(&compilation.chunk_ids_artifact)
+                .expect_id()
                 .to_string()
             })
             .collect::<Vec<_>>();

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1410,7 +1410,7 @@ async fn optimize_chunk_modules(&self, compilation: &mut Compilation) -> Result<
     }
     compilation.cgm_hash_artifact.clear();
     compilation.module_ids_artifact.clear();
-    compilation.chunk_ids_artifact.clear();
+    compilation.named_chunk_ids_artifact.clear();
     compilation.cgc_runtime_requirements_artifact.clear();
     compilation.chunk_hashes_artifact.clear();
   }

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -132,16 +132,12 @@ async fn render(
       .get_path(
         &Filename::from(name),
         PathData::default()
-          .chunk_id_optional(
-            chunk
-              .id(&compilation.chunk_ids_artifact)
-              .map(|id| id.as_str()),
-          )
+          .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,
             compilation.options.output.hash_digest_length,
           ))
-          .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+          .chunk_name_optional(chunk.name_for_filename_template())
           .content_hash_optional(chunk.rendered_content_hash_by_source_type(
             &compilation.chunk_hashes_artifact,
             &SourceType::JavaScript,

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -156,18 +156,12 @@ impl AssignLibraryPlugin {
           .get_path(
             &Filename::from(v),
             PathData::default()
-              .chunk_id_optional(
-                chunk
-                  .id(&compilation.chunk_ids_artifact)
-                  .map(|id| id.as_str()),
-              )
+              .chunk_id_optional(chunk.id().map(|id| id.as_str()))
               .chunk_hash_optional(chunk.rendered_hash(
                 &compilation.chunk_hashes_artifact,
                 compilation.options.output.hash_digest_length,
               ))
-              .chunk_name_optional(
-                chunk.name_for_filename_template(&compilation.chunk_ids_artifact),
-              )
+              .chunk_name_optional(chunk.name_for_filename_template())
               .content_hash_optional(chunk.rendered_content_hash_by_source_type(
                 &compilation.chunk_hashes_artifact,
                 &SourceType::JavaScript,

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -93,9 +93,7 @@ async fn render(
     let chunk = compilation.chunk_by_ukey.get(chunk_ukey);
     let filename = Filename::from(name);
     let path_data = PathData::default()
-      .chunk_id_optional(
-        chunk.and_then(|c| c.id(&compilation.chunk_ids_artifact).map(|id| id.as_str())),
-      )
+      .chunk_id_optional(chunk.and_then(|c| c.id().map(|id| id.as_str())))
       .chunk_name_optional(chunk.and_then(|c| c.name()))
       .chunk_hash_optional(chunk.and_then(|c| {
         c.rendered_hash(

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -326,16 +326,12 @@ async fn replace_keys(v: String, chunk: &Chunk, compilation: &Compilation) -> Re
     .get_path(
       &Filename::from(v),
       PathData::default()
-        .chunk_id_optional(
-          chunk
-            .id(&compilation.chunk_ids_artifact)
-            .map(|id| id.as_str()),
-        )
+        .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,
           compilation.options.output.hash_digest_length,
         ))
-        .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+        .chunk_name_optional(chunk.name_for_filename_template())
         .content_hash_optional(chunk.rendered_content_hash_by_source_type(
           &compilation.chunk_hashes_artifact,
           &SourceType::JavaScript,

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -93,7 +93,7 @@ impl RuntimeModule for RemoteRuntimeModule {
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk);
       chunk_to_remotes_mapping.insert(
         chunk
-          .id(&compilation.chunk_ids_artifact)
+          .id()
           .expect("should have chunkId at <RemoteRuntimeModule as RuntimeModule>::generate"),
         remotes,
       );

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
@@ -116,7 +116,7 @@ impl RuntimeModule for ConsumeSharedRuntimeModule {
       }
       chunk_to_module_mapping.insert(
         chunk
-          .id(&compilation.chunk_ids_artifact)
+          .id()
           .map(ToOwned::to_owned)
           .expect("should have chunkId at <ConsumeSharedRuntimeModule as RuntimeModule>::generate"),
         ids,

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -113,7 +113,7 @@ async fn render_chunk(
       "{}[{}]({}, ",
       global_object,
       serde_json::to_string(hot_update_global).to_rspack_result()?,
-      json_stringify(chunk.expect_id(&compilation.chunk_ids_artifact))
+      json_stringify(chunk.expect_id())
     )));
     source.add(render_source.source.clone());
     if has_runtime_modules {
@@ -130,8 +130,7 @@ async fn render_chunk(
       chunk_loading_global,
       global_object,
       chunk_loading_global,
-      serde_json::to_string(chunk.expect_id(&compilation.chunk_ids_artifact))
-        .expect("json stringify failed"),
+      serde_json::to_string(chunk.expect_id()).expect("json stringify failed"),
     )));
     source.add(render_source.source.clone());
     let has_entry = chunk.has_entry_module(&compilation.chunk_graph);

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -118,7 +118,7 @@ async fn render_chunk(
   let mut sources = ConcatSource::default();
   sources.add(RawStringSource::from(format!(
     "exports.ids = [{}];\n",
-    json_stringify(chunk.expect_id(&compilation.chunk_ids_artifact))
+    json_stringify(chunk.expect_id())
   )));
   sources.add(RawStringSource::from_static("exports.modules = "));
   sources.add(render_source.source.clone());

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -40,7 +40,7 @@ pub fn update_hash_for_entry_startup(
         &compilation.chunk_group_by_ukey,
       ) {
         if let Some(chunk) = compilation.chunk_by_ukey.get(&chunk_ukey) {
-          chunk.id(&compilation.chunk_ids_artifact).hash(hasher);
+          chunk.id().hash(hasher);
         }
       }
     }
@@ -221,7 +221,7 @@ pub fn generate_entry_startup(
           .iter()
           .map(|chunk_ukey| {
             let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
-            chunk.expect_id(&compilation.chunk_ids_artifact).clone()
+            chunk.expect_id().clone()
           })
           .collect::<HashSet<_>>(),
       );
@@ -333,16 +333,12 @@ pub async fn get_chunk_output_name(chunk: &Chunk, compilation: &Compilation) -> 
     .get_path(
       &filename,
       PathData::default()
-        .chunk_id_optional(
-          chunk
-            .id(&compilation.chunk_ids_artifact)
-            .map(|id| id.as_str()),
-        )
+        .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,
           compilation.options.output.hash_digest_length,
         ))
-        .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+        .chunk_name_optional(chunk.name_for_filename_template())
         .content_hash_optional(chunk.rendered_content_hash_by_source_type(
           &compilation.chunk_hashes_artifact,
           &SourceType::JavaScript,

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -127,7 +127,7 @@ async fn render_chunk(
   let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
   let base_chunk_output_name = get_chunk_output_name(chunk, compilation).await?;
 
-  let chunk_id_json_string = json_stringify(chunk.expect_id(&compilation.chunk_ids_artifact));
+  let chunk_id_json_string = json_stringify(chunk.expect_id());
 
   let mut sources = ConcatSource::default();
   sources.add(RawStringSource::from(format!(

--- a/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
@@ -50,16 +50,12 @@ impl RuntimeModule for AutoPublicPathRuntimeModule {
       .get_path(
         &filename,
         PathData::default()
-          .chunk_id_optional(
-            chunk
-              .id(&compilation.chunk_ids_artifact)
-              .map(|id| id.as_str()),
-          )
+          .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,
             compilation.options.output.hash_digest_length,
           ))
-          .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+          .chunk_name_optional(chunk.name_for_filename_template())
           .content_hash_optional(chunk.rendered_content_hash_by_source_type(
             &compilation.chunk_hashes_artifact,
             &SourceType::JavaScript,

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
@@ -51,7 +51,7 @@ impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
               compilation
                 .chunk_by_ukey
                 .expect_get(c)
-                .id(&compilation.chunk_ids_artifact)
+                .id()
             } else {
               None
             }
@@ -64,7 +64,7 @@ impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
             compilation
               .chunk_by_ukey
               .expect_get(c)
-              .id(&compilation.chunk_ids_artifact)
+              .id()
           })
           .collect_vec();
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -185,13 +185,9 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
 
       let chunk_id = "\" + chunkId + \"";
       let chunk_name = stringify_dynamic_chunk_map(
-        |c| {
-          c.name_for_filename_template(&compilation.chunk_ids_artifact)
-            .map(|s| s.to_string())
-        },
+        |c| c.name_for_filename_template().map(|s| s.to_string()),
         &chunks,
         &chunk_map,
-        compilation,
       );
       let chunk_runtime = stringify_dynamic_chunk_map(
         |c| {
@@ -200,7 +196,6 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
         },
         &chunks,
         &chunk_map,
-        compilation,
       );
       let chunk_hash = stringify_dynamic_chunk_map(
         |c| {
@@ -217,7 +212,6 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
         },
         &chunks,
         &chunk_map,
-        compilation,
       );
       let content_hash = stringify_dynamic_chunk_map(
         |c| {
@@ -233,7 +227,6 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
         },
         &chunks,
         &chunk_map,
-        compilation,
       );
       let full_hash = match hash_len_map
         .get("[fullhash]")
@@ -291,15 +284,12 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
         let (fake_filename, hash_len_map) = get_filename_without_hash_length(filename_template);
 
         let chunk_id = chunk
-          .id(&compilation.chunk_ids_artifact)
+          .id()
           .map(|chunk_id| unquoted_stringify(Some(chunk_id), chunk_id.as_str()));
         let chunk_name = match chunk.name() {
-          Some(chunk_name) => Some(unquoted_stringify(
-            chunk.id(&compilation.chunk_ids_artifact),
-            chunk_name,
-          )),
+          Some(chunk_name) => Some(unquoted_stringify(chunk.id(), chunk_name)),
           None => chunk
-            .id(&compilation.chunk_ids_artifact)
+            .id()
             .map(|chunk_id| unquoted_stringify(Some(chunk_id), chunk_id.as_str())),
         };
         let chunk_hash = chunk
@@ -308,7 +298,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
             compilation.options.output.hash_digest_length,
           )
           .map(|chunk_hash| {
-            let hash = unquoted_stringify(chunk.id(&compilation.chunk_ids_artifact), chunk_hash);
+            let hash = unquoted_stringify(chunk.id(), chunk_hash);
             match hash_len_map.get("[chunkhash]") {
               Some(hash_len) => hash[..*hash_len].to_string(),
               None => hash,
@@ -319,7 +309,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
           .and_then(|content_hash| content_hash.get(&self.source_type))
           .map(|i| {
             let hash = unquoted_stringify(
-              chunk.id(&compilation.chunk_ids_artifact),
+              chunk.id(),
               i.rendered(compilation.options.output.hash_digest_length),
             );
             match hash_len_map.get("[contenthash]") {
@@ -363,11 +353,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
                   .render(
                     PathData::default()
                       .chunk_name_optional(chunk.name())
-                      .chunk_id_optional(
-                        chunk
-                          .id(&compilation.chunk_ids_artifact)
-                          .map(|id| id.as_str()),
-                      ),
+                      .chunk_id_optional(chunk.id().map(|id| id.as_str())),
                     None,
                   )
                   .await?
@@ -385,7 +371,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
           )
           .await?;
 
-        if let Some(chunk_id) = chunk.id(&compilation.chunk_ids_artifact) {
+        if let Some(chunk_id) = chunk.id() {
           static_urls
             .entry(filename)
             .or_insert(Vec::new())

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
@@ -44,7 +44,7 @@ impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
               &compilation.chunk_hashes_artifact,
               compilation.options.output.hash_digest_length,
             ))
-            .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+            .chunk_name_optional(chunk.name_for_filename_template())
             .content_hash_optional(chunk.rendered_content_hash_by_source_type(
               &compilation.chunk_hashes_artifact,
               &SourceType::JavaScript,

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -37,16 +37,12 @@ impl RuntimeModule for GetMainFilenameRuntimeModule {
         .get_path(
           &self.filename,
           PathData::default()
-            .chunk_id_optional(
-              chunk
-                .id(&compilation.chunk_ids_artifact)
-                .map(|id| id.as_str()),
-            )
+            .chunk_id_optional(chunk.id().map(|id| id.as_str()))
             .chunk_hash_optional(chunk.rendered_hash(
               &compilation.chunk_hashes_artifact,
               compilation.options.output.hash_digest_length,
             ))
-            .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+            .chunk_name_optional(chunk.name_for_filename_template())
             .content_hash_optional(chunk.rendered_content_hash_by_source_type(
               &compilation.chunk_hashes_artifact,
               &SourceType::JavaScript,

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
@@ -48,7 +48,7 @@ impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
           compilation
             .chunk_by_ukey
             .expect_get(&chunk_ukey)
-            .expect_id(&compilation.chunk_ids_artifact)
+            .expect_id()
             .to_string()
         })
         .collect::<Vec<_>>();

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -22,10 +22,10 @@ pub fn get_initial_chunk_ids(
           .filter(|key| !(chunk_ukey.eq(key) || filter_fn(key, compilation)))
           .map(|chunk_ukey| {
             let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
-            chunk.expect_id(&compilation.chunk_ids_artifact).clone()
+            chunk.expect_id().clone()
           })
           .collect::<HashSet<_>>();
-        js_chunks.insert(chunk.expect_id(&compilation.chunk_ids_artifact).clone());
+        js_chunks.insert(chunk.expect_id().clone());
         js_chunks
       }
       None => HashSet::default(),
@@ -89,16 +89,12 @@ pub async fn get_output_dir(
     .get_path(
       &filename,
       PathData::default()
-        .chunk_id_optional(
-          chunk
-            .id(&compilation.chunk_ids_artifact)
-            .map(|id| id.as_str()),
-        )
+        .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,
           compilation.options.output.hash_digest_length,
         ))
-        .chunk_name_optional(chunk.name_for_filename_template(&compilation.chunk_ids_artifact))
+        .chunk_name_optional(chunk.name_for_filename_template())
         .content_hash_optional(chunk.rendered_content_hash_by_source_type(
           &compilation.chunk_hashes_artifact,
           &SourceType::JavaScript,
@@ -142,7 +138,6 @@ pub fn stringify_dynamic_chunk_map<F>(
   f: F,
   chunks: &UkeyIndexSet<ChunkUkey>,
   chunk_map: &UkeyIndexMap<ChunkUkey, &Chunk>,
-  compilation: &Compilation,
 ) -> String
 where
   F: Fn(&Chunk) -> Option<String>,
@@ -154,7 +149,7 @@ where
 
   for chunk_ukey in chunks.iter() {
     if let Some(chunk) = chunk_map.get(chunk_ukey)
-      && let Some(chunk_id) = chunk.id(&compilation.chunk_ids_artifact)
+      && let Some(chunk_id) = chunk.id()
       && let Some(value) = f(chunk)
     {
       if value.as_str() == chunk_id.as_str() {

--- a/crates/rspack_plugin_sri/src/asset.rs
+++ b/crates/rspack_plugin_sri/src/asset.rs
@@ -60,11 +60,7 @@ See https://w3c.github.io/webappsec-subresource-integrity/#cross-origin-data-lea
     let results = chunks
       .into_par_iter()
       .flat_map(|c| {
-        let mut files = c
-          .files()
-          .iter()
-          .map(|f| (c.id(&compilation.chunk_ids_artifact), f))
-          .collect::<Vec<_>>();
+        let mut files = c.files().iter().map(|f| (c.id(), f)).collect::<Vec<_>>();
         files.sort_by(|a, b| {
           let a_file = a.1.split("?").next().expect("should have a file name");
           let b_file = b.1.split("?").next().expect("should have a file name");

--- a/crates/rspack_plugin_sri/src/runtime.rs
+++ b/crates/rspack_plugin_sri/src/runtime.rs
@@ -65,7 +65,7 @@ impl RuntimeModule for SRIHashVariableRuntimeModule {
       .iter()
       .filter_map(|c| {
         let chunk = compilation.chunk_by_ukey.get(c)?;
-        let id = chunk.id(&compilation.chunk_ids_artifact)?;
+        let id = chunk.id()?;
         let rendered_hash = chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,
           compilation.options.output.hash_digest_length,
@@ -120,12 +120,7 @@ impl RuntimeModule for SRIHashVariableRuntimeModule {
             .chunk_graph
             .has_chunk_module_by_source_type(c, source_type, &module_graph)
         })
-        .map(|c| {
-          compilation
-            .chunk_ids_artifact
-            .get(c)
-            .expect("should have chunk id in code generation")
-        })
+        .map(|c| compilation.chunk_by_ukey.expect_get(c).expect_id())
         .filter(|c| include_chunks.contains_key(c))
         .collect::<Vec<_>>();
 

--- a/tests/rspack-test/watchCases/chunk-ids/id-equals-name/0/index.js
+++ b/tests/rspack-test/watchCases/chunk-ids/id-equals-name/0/index.js
@@ -17,7 +17,6 @@ it("should have correct log when incremental enabled", async () => {
   const incrementalLog = /LOG from rspack\.incremental\.chunkIds[\s\S]*?LOG/.exec(statsString);
   if (incrementalLog) {
     const content = incrementalLog[0];
-    expect(content.includes("3 chunks are affected, 3 in total")).toBe(true);
     expect(content.includes("3 chunks are updated by set_chunk_id, with 2 chunks using name as id, and 0 unnamed chunks")).toBe(true);
   }
 });

--- a/tests/rspack-test/watchCases/chunk-ids/id-equals-name/1/index.js
+++ b/tests/rspack-test/watchCases/chunk-ids/id-equals-name/1/index.js
@@ -17,7 +17,6 @@ it("should have correct log when incremental enabled", async () => {
   const incrementalLog = /LOG from rspack\.incremental\.chunkIds[\s\S]*?LOG/.exec(statsString);
   if (incrementalLog) {
     const content = incrementalLog[0];
-    expect(content.includes("3 chunks are affected, 3 in total")).toBe(true);
     expect(content.includes("3 chunks are updated by set_chunk_id, with 2 chunks using name as id, and 0 unnamed chunks")).toBe(true);
   }
 });

--- a/tests/rspack-test/watchCases/chunk-ids/update-module/0/index.js
+++ b/tests/rspack-test/watchCases/chunk-ids/update-module/0/index.js
@@ -23,12 +23,10 @@ it("should have correct log when incremental enabled", async () => {
     const content = incrementalLog[0];
     switch (WATCH_STEP) {
       case "0":
-        expect(content.includes("6 chunks are affected, 6 in total")).toBe(true);
-        expect(content.includes("6 chunks are updated by set_chunk_id, with 1 chunks using name as id, and 0 unnamed chunks")).toBe(true);
+        expect(content).toContain("6 chunks are updated by set_chunk_id, with 1 chunks using name as id, and 0 unnamed chunks");
         break;
       case "1":
-        expect(content.includes("2 chunks are affected, 6 in total")).toBe(true);
-        expect(content.includes("2 chunks are updated by set_chunk_id, with 0 chunks using name as id, and 0 unnamed chunks")).toBe(true);
+        expect(content).toContain("2 chunks are updated by set_chunk_id, with 1 chunks using name as id, and 0 unnamed chunks");
         break;
     }
   }


### PR DESCRIPTION
## Summary

We cannot rely on patch algorithm to update chunk id. The chunk id is order-related, you can see from this image

![img_v3_02sk_17a139a4-508e-42a6-8779-0d568fa6971g](https://github.com/user-attachments/assets/c29012a4-b698-40ed-be99-98e216a6a75e)

Even if chunk has nothing change, no content changes, no module changes, it still can be different chunk id.

We have to full recalculate all chunk ids per compilation. But we can cache the chunk long name and chunk short name to improve re-calculation performance.

And we still need to remember the previous chunk id, to make next stage know that some chunk has no id changes

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
