### PR TITLE
fix(mf): supplement remotes in manifest and stats

### DIFF
--- a/tests/rspack-test/configCases/container-1-5/manifest/index.js
+++ b/tests/rspack-test/configCases/container-1-5/manifest/index.js
@@ -77,11 +77,41 @@ it("should record remote usage", () => {
 				consumingFederationContainerName: "container",
 				federationContainerName: "remote",
 				moduleName: ".",
-				usedIn: expect.arrayContaining([
+				usedIn: [
 					"module.js"
-				]),
+				],
 				entry: 'http://localhost:8000/remoteEntry.js'
-			})
+			}),
+			expect.objectContaining({
+				alias: "@remote/alias",
+				consumingFederationContainerName: "container",
+				federationContainerName: "remote",
+				moduleName: "List",
+				usedIn: [
+					"module.js"
+				],
+				entry: 'http://localhost:8000/remoteEntry.js'
+			}),
+			expect.objectContaining({
+				alias: "@dynamic-remote/alias",
+				consumingFederationContainerName: "container",
+				federationContainerName: "dynamic_remote",
+				moduleName: "UNKNOWN",
+				usedIn: [
+					"UNKNOWN"
+				],
+				entry: 'http://localhost:8001/remoteEntry.js'
+			}),
+				expect.objectContaining({
+				alias: "@scope-scope/ui",
+				consumingFederationContainerName: "container",
+				federationContainerName: "ui",
+				moduleName: "Button",
+				usedIn: [
+					"module.js"
+				],
+				entry: 'http://localhost:8002/remoteEntry.js'
+			}),
 		])
 	);
 });
@@ -92,7 +122,26 @@ it("should persist remote metadata in manifest", () => {
 			expect.objectContaining({
 				alias: "@remote/alias",
 				federationContainerName: "remote",
-				moduleName: "."
+				moduleName: ".",
+				entry: "http://localhost:8000/remoteEntry.js"
+			}),
+			expect.objectContaining({
+				alias: "@remote/alias",
+				federationContainerName: "remote",
+				moduleName: "List",
+				entry: "http://localhost:8000/remoteEntry.js"
+			}),
+			expect.objectContaining({
+				alias: "@dynamic-remote/alias",
+				federationContainerName: "dynamic_remote",
+				moduleName: "UNKNOWN",
+				entry: "http://localhost:8001/remoteEntry.js"
+			}),
+			expect.objectContaining({
+				alias: "@scope-scope/ui",
+				federationContainerName: "ui",
+				moduleName: "Button",
+				entry: "http://localhost:8002/remoteEntry.js"
 			})
 		])
 	);

--- a/tests/rspack-test/configCases/container-1-5/manifest/module.js
+++ b/tests/rspack-test/configCases/container-1-5/manifest/module.js
@@ -1,8 +1,14 @@
 import react from 'react';
+import { loadRemote } from 'mf';
 import remote from '@remote/alias';
+import List from '@remote/alias/List';
+import Button from '@scope-scope/ui/Button';
 
 global.react = react;
 global.remote = remote;
+global.dynamicRemote = loadRemote('@dynamic-remote/alias');
+global.Button = Button;
+global.List = List
 
 import('./lazy-module').then(r=>{
 	console.log('lazy module: ',r)

--- a/tests/rspack-test/configCases/container-1-5/manifest/node_modules/mf.js
+++ b/tests/rspack-test/configCases/container-1-5/manifest/node_modules/mf.js
@@ -1,0 +1,3 @@
+export const loadRemote = async (name) => {
+		return name;
+}

--- a/tests/rspack-test/configCases/container-1-5/manifest/rspack.config.js
+++ b/tests/rspack-test/configCases/container-1-5/manifest/rspack.config.js
@@ -23,7 +23,9 @@ module.exports = {
 			},
 			remoteType:'script',
 			remotes: {
-				'@remote/alias': 'remote@http://localhost:8000/remoteEntry.js'
+				'@remote/alias': 'remote@http://localhost:8000/remoteEntry.js',
+				'@dynamic-remote/alias': 'dynamic_remote@http://localhost:8001/remoteEntry.js',
+				'@scope-scope/ui': 'ui@http://localhost:8002/remoteEntry.js'
 			},
 			shared: {
 				react: {}


### PR DESCRIPTION
## Summary

Summary

- Completes configured remotes in Manifest and Stats even when not compiled (e.g., loadRemote usage).
- Derives moduleName from alias/internal_request (supports scoped names and subpaths).
- Normalizes usedIn entries to file names only.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
