### PR TITLE
test: split Config, Watch and NativeWatcher tests into 3 parts for better parallelization

### DIFF
--- a/packages/rspack-test-tools/src/helper/directory.ts
+++ b/packages/rspack-test-tools/src/helper/directory.ts
@@ -24,7 +24,7 @@ export function describeByWalk(
 	const describeFn = options.describe || describe;
 	const testBasename = path
 		.basename(testFile)
-		.replace(/\.(diff|hot)?test\.(j|t)s/, "");
+		.replace(/(\.part\d+)?\.(diff|hot)?test\.(j|t)s/, "");
 	const testId = testBasename.charAt(0).toLowerCase() + testBasename.slice(1);
 	const sourceBase =
 		options.source || path.join(path.dirname(testFile), `${testId}Cases`);

--- a/tests/rspack-test/Config.part1.test.js
+++ b/tests/rspack-test/Config.part1.test.js
@@ -1,0 +1,19 @@
+const path = require("path");
+const { describeByWalk, createConfigCase } = require("@rspack/test-tools");
+
+// Part 1: Test cases starting with a-d (49 dirs, 36.0%)
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createConfigCase(name, src, dist);
+	},
+	{
+		source: require("path").join(__dirname, "configCases"),
+		dist: path.resolve(__dirname, `./js/config`),
+		exclude: [
+			// Exclude e-z and non-ascii
+			/^[e-z]/,
+			/^[^a-d]/
+		]
+	}
+);

--- a/tests/rspack-test/Config.part2.test.js
+++ b/tests/rspack-test/Config.part2.test.js
@@ -1,0 +1,21 @@
+const path = require("path");
+const { describeByWalk, createConfigCase } = require("@rspack/test-tools");
+
+// Part 2: Test cases starting with e-o (43 dirs, 31.6%)
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createConfigCase(name, src, dist);
+	},
+	{
+		source: require("path").join(__dirname, "configCases"),
+		dist: path.resolve(__dirname, `./js/config`),
+		exclude: [
+			// Exclude a-d
+			/^[a-d]/,
+			// Exclude p-z and non-ascii
+			/^[p-z]/,
+			/^[^a-o]/
+		]
+	}
+);

--- a/tests/rspack-test/Config.part3.test.js
+++ b/tests/rspack-test/Config.part3.test.js
@@ -1,0 +1,18 @@
+const path = require("path");
+const { describeByWalk, createConfigCase } = require("@rspack/test-tools");
+
+// Part 3: Test cases starting with p-z and others (44 dirs, 32.4%)
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createConfigCase(name, src, dist);
+	},
+	{
+		source: require("path").join(__dirname, "configCases"),
+		dist: path.resolve(__dirname, `./js/config`),
+		exclude: [
+			// Exclude a-o
+			/^[a-o]/
+		]
+	}
+);

--- a/tests/rspack-test/Config.test.js
+++ b/tests/rspack-test/Config.test.js
@@ -1,5 +1,0 @@
-const { describeByWalk, createConfigCase } = require("@rspack/test-tools");
-
-describeByWalk(__filename, (name, src, dist) => {
-	createConfigCase(name, src, dist);
-});

--- a/tests/rspack-test/NativeWatcher.part1.test.js
+++ b/tests/rspack-test/NativeWatcher.part1.test.js
@@ -1,0 +1,20 @@
+const path = require("path");
+const { describeByWalk, createNativeWatcher } = require("@rspack/test-tools");
+const tempDir = path.resolve(__dirname, `./js/temp`);
+
+// Part 1: Test cases starting with a-co (12 dirs, 37.5%)
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createNativeWatcher(name, src, dist, path.join(tempDir, name));
+	},
+	{
+		source: path.join(__dirname, `./watchCases`),
+		dist: path.resolve(__dirname, `./js/native-watcher/watch`),
+		exclude: [
+			// Exclude cp-z
+			/^c[p-z]/,
+			/^[d-z]/
+		]
+	}
+);

--- a/tests/rspack-test/NativeWatcher.part2.test.js
+++ b/tests/rspack-test/NativeWatcher.part2.test.js
@@ -1,0 +1,22 @@
+const path = require("path");
+const { describeByWalk, createNativeWatcher } = require("@rspack/test-tools");
+const tempDir = path.resolve(__dirname, `./js/temp`);
+
+// Part 2: Test cases starting with cp-p (9 dirs, 28.1%)
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createNativeWatcher(name, src, dist, path.join(tempDir, name));
+	},
+	{
+		source: path.join(__dirname, `./watchCases`),
+		dist: path.resolve(__dirname, `./js/native-watcher/watch`),
+		exclude: [
+			// Exclude a-co
+			/^[a-c][a-o]/,
+			/^[ab]/,
+			// Exclude r-z
+			/^[r-z]/
+		]
+	}
+);

--- a/tests/rspack-test/NativeWatcher.part3.test.js
+++ b/tests/rspack-test/NativeWatcher.part3.test.js
@@ -2,6 +2,7 @@ const path = require("path");
 const { describeByWalk, createNativeWatcher } = require("@rspack/test-tools");
 const tempDir = path.resolve(__dirname, `./js/temp`);
 
+// Part 3: Test cases starting with r-z (11 dirs, 34.4%)
 describeByWalk(
 	__filename,
 	(name, src, dist) => {
@@ -9,6 +10,10 @@ describeByWalk(
 	},
 	{
 		source: path.join(__dirname, `./watchCases`),
-		dist: path.resolve(__dirname, `./js/native-watcher/watch`)
+		dist: path.resolve(__dirname, `./js/native-watcher/watch`),
+		exclude: [
+			// Exclude a-p
+			/^[a-p]/
+		]
 	}
 );

--- a/tests/rspack-test/Watch.part1.test.js
+++ b/tests/rspack-test/Watch.part1.test.js
@@ -1,0 +1,20 @@
+const path = require("path");
+const { describeByWalk, createWatchCase } = require("@rspack/test-tools");
+const tempDir = path.resolve(__dirname, `./js/temp`);
+
+// Part 1: Test cases starting with a-co (12 dirs, 37.5%)
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createWatchCase(name, src, dist, path.join(tempDir, name));
+	},
+	{
+		source: require("path").join(__dirname, "watchCases"),
+		dist: path.resolve(__dirname, `./js/watch`),
+		exclude: [
+			// Exclude cp-z
+			/^c[p-z]/,
+			/^[d-z]/
+		]
+	}
+);

--- a/tests/rspack-test/Watch.part2.test.js
+++ b/tests/rspack-test/Watch.part2.test.js
@@ -1,0 +1,22 @@
+const path = require("path");
+const { describeByWalk, createWatchCase } = require("@rspack/test-tools");
+const tempDir = path.resolve(__dirname, `./js/temp`);
+
+// Part 2: Test cases starting with cp-p (9 dirs, 28.1%)
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createWatchCase(name, src, dist, path.join(tempDir, name));
+	},
+	{
+		source: require("path").join(__dirname, "watchCases"),
+		dist: path.resolve(__dirname, `./js/watch`),
+		exclude: [
+			// Exclude a-co
+			/^[a-c][a-o]/,
+			/^[ab]/,
+			// Exclude r-z
+			/^[r-z]/
+		]
+	}
+);

--- a/tests/rspack-test/Watch.part3.test.js
+++ b/tests/rspack-test/Watch.part3.test.js
@@ -1,0 +1,19 @@
+const path = require("path");
+const { describeByWalk, createWatchCase } = require("@rspack/test-tools");
+const tempDir = path.resolve(__dirname, `./js/temp`);
+
+// Part 3: Test cases starting with r-z (11 dirs, 34.4%)
+describeByWalk(
+	__filename,
+	(name, src, dist) => {
+		createWatchCase(name, src, dist, path.join(tempDir, name));
+	},
+	{
+		source: require("path").join(__dirname, "watchCases"),
+		dist: path.resolve(__dirname, `./js/watch`),
+		exclude: [
+			// Exclude a-p
+			/^[a-p]/
+		]
+	}
+);

--- a/tests/rspack-test/Watch.test.js
+++ b/tests/rspack-test/Watch.test.js
@@ -1,7 +1,0 @@
-const path = require("path");
-const { describeByWalk, createWatchCase } = require("@rspack/test-tools");
-const tempDir = path.resolve(__dirname, `./js/temp`);
-
-describeByWalk(__filename, (name, src, dist) => {
-	createWatchCase(name, src, dist, path.join(tempDir, name));
-});


### PR DESCRIPTION
## Summary

This commit splits the following test files into 3 parts each:
- Config.test.js → Config.part1/2/3.test.js (136 dirs: 49/44/43)
- Watch.test.js → Watch.part1/2/3.test.js (32 dirs: 12/9/11)
- NativeWatcher.test.js → NativeWatcher.part1/2/3.test.js (32 dirs: 12/9/11)

The split is based on alphabetical ranges for easy maintenance:
- Part 1: a-d (or a-co for Watch/NativeWatcher)
- Part 2: e-o (or cp-p for Watch/NativeWatcher)
- Part 3: p-z (or r-z for Watch/NativeWatcher)

Benefits:
- Better parallelization across test workers
- More balanced load distribution
- Easy to maintain with simple regex patterns

🤖 This PR was generated by AI 

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
