### PR TITLE
fix: typo in preload runtime of CssExtractPlugin

### DIFF
--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_prefetch.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_prefetch.ejs
@@ -1,5 +1,5 @@
 <%- PREFETCH_CHUNK_HANDLERS %>.miniCss = <%- basicFunction("chunkId") %> {
-  if ((!<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && <%- _css_matcher %>) {
+  if ((!<%- HAS_OWN_PROPERTY %>(installedCssChunks, chunkId) || installedCssChunks[chunkId] === undefined) && <%- _css_matcher %>) {
     installedCssChunks[chunkId] = null;
 
     <%- _create_prefetch_link %>

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_preload.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_preload.ejs
@@ -1,5 +1,5 @@
 <%- PRELOAD_CHUNK_HANDLERS %>.miniCss = <%- basicFunction("chunkId") %> {
-  if ((!<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && <%- _css_matcher %>) {
+  if ((!<%- HAS_OWN_PROPERTY %>(installedCssChunks, chunkId) || installedCssChunks[chunkId] === undefined) && <%- _css_matcher %>) {
     installedCssChunks[chunkId] = null;
 
     <%- _create_preload_link %>


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Fix the typo

```diff
- installedChunks
+ installedCssChunks
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
