### PR TITLE
fix: add test/include/exclude options to EvalSourceMapDevToolPlugin

### DIFF
--- a/tests/rspack-test/configCases/source-map/exclude-modules-source-map/test.filter.js
+++ b/tests/rspack-test/configCases/source-map/exclude-modules-source-map/test.filter.js
@@ -1,2 +1,0 @@
-
-module.exports = () => "TODO: support exclude of EvalSourceMapDevToolPlugin"


### PR DESCRIPTION
## Summary

This PR adds `test`, `include`, and `exclude` options to `EvalSourceMapDevToolPlugin`, allowing users to filter modules for which source maps should be generated based on module paths.

This feature aligns the plugin behavior with webpack's EvalSourceMapDevToolPlugin.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).


