### PR TITLE
chore(ci): run Mac CI test on github hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       target: aarch64-apple-darwin
       profile: "ci"
       runner: ${{ vars.MAC_SELF_HOSTED_RUNNER_LABELS || '"macos-latest"' }}
+      test-runner: ${{ '"macos-latest"' }}
       test: true
 
   test-wasm:


### PR DESCRIPTION
## Summary
NativeWatch fails more frequently on self hosted runner.
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
