### PR TITLE
refactor: DerefOpiton default to Some(T) when T impl Default trait

### DIFF
--- a/crates/rspack_core/src/utils/deref_option.rs
+++ b/crates/rspack_core/src/utils/deref_option.rs
@@ -3,8 +3,17 @@ use std::{
   ops::{Deref, DerefMut},
 };
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct DerefOption<T>(Option<T>);
+
+impl<T> Default for DerefOption<T>
+where
+  T: Default,
+{
+  fn default() -> Self {
+    Self(Some(T::default()))
+  }
+}
 
 impl<T> From<T> for DerefOption<T> {
   fn from(value: T) -> Self {
@@ -40,10 +49,7 @@ impl<T> Deref for DerefOption<T> {
       .unwrap_or_else(|| panic!("should set in compilation first"))
   }
 }
-impl<T> DerefMut for DerefOption<T>
-where
-  T: Debug,
-{
+impl<T> DerefMut for DerefOption<T> {
   fn deref_mut(&mut self) -> &mut Self::Target {
     self
       .0


### PR DESCRIPTION
## Why

Change DerefOption<T> to default to Some(T) when T implements the Default trait.

Currently, Artifacts implements Default and is initialized by calling Default::default(). If Artifacts is changed to DerefOption<Artifacts>, the existing behavior changes subtly: all fields are initialized to None instead of using Artifacts::default().

This difference in default initialization is easy to miss and can lead to subtle bugs. Defaulting DerefOption<T> to Some(T::default()) when T: Default preserves the original behavior and makes the change safer and more intuitive.




<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
