### PR TITLE
refactor: use atomic_refcell for async_module_artifact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3793,6 +3793,7 @@ dependencies = [
  "anymap3",
  "async-recursion",
  "async-trait",
+ "atomic_refcell",
  "bitflags 2.9.1",
  "cow-utils",
  "dashmap 6.1.0",

--- a/crates/rspack_binding_api/src/module_graph.rs
+++ b/crates/rspack_binding_api/src/module_graph.rs
@@ -258,7 +258,7 @@ impl JsModuleGraph {
   pub fn is_async(&self, module: ModuleObjectRef) -> napi::Result<bool> {
     let (compilation, _) = self.as_ref()?;
     Ok(ModuleGraph::is_async(
-      &compilation.async_modules_artifact,
+      &compilation.async_modules_artifact.borrow(),
       &module.identifier,
     ))
   }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 anymap = { workspace = true }
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
+atomic_refcell = { workspace = true }
 bitflags = { workspace = true }
 cow-utils = { workspace = true }
 dashmap = { workspace = true, features = ["rayon"] }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -383,8 +383,11 @@ impl ChunkGraph {
           .hash(&mut hasher);
         module.source_types(&mg).dyn_hash(&mut hasher);
 
-        ModuleGraph::is_async(&compilation.async_modules_artifact, &module_identifier)
-          .dyn_hash(&mut hasher);
+        ModuleGraph::is_async(
+          &compilation.async_modules_artifact.borrow(),
+          &module_identifier,
+        )
+        .dyn_hash(&mut hasher);
         let exports_info =
           mg.get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Full);
         let (entry, exports) = exports_info.meta();

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -11,6 +11,7 @@ use std::{
   },
 };
 
+use atomic_refcell::AtomicRefCell;
 use build_chunk_graph::{
   artifact::use_code_splitting_cache, build_chunk_graph, build_chunk_graph_new,
 };
@@ -247,7 +248,7 @@ pub struct Compilation {
   pub runtime_template: RuntimeTemplate,
 
   // artifact for infer_async_modules_plugin
-  pub async_modules_artifact: DerefOption<AsyncModulesArtifact>,
+  pub async_modules_artifact: Arc<AtomicRefCell<AsyncModulesArtifact>>,
   // artifact for collect_dependencies_diagnostics
   pub dependencies_diagnostics_artifact: DerefOption<DependenciesDiagnosticsArtifact>,
   // artifact for side_effects_flag_plugin
@@ -386,7 +387,7 @@ impl Compilation {
       named_chunks: Default::default(),
       named_chunk_groups: Default::default(),
 
-      async_modules_artifact: DerefOption::new(AsyncModulesArtifact::default()),
+      async_modules_artifact: Arc::new(AtomicRefCell::new(AsyncModulesArtifact::default())),
       imported_by_defer_modules_artifact: Default::default(),
       dependencies_diagnostics_artifact: DerefOption::new(
         DependenciesDiagnosticsArtifact::default(),

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -325,17 +325,16 @@ impl Compiler {
     self.build_module_graph().await?;
     let mut dependencies_diagnostics_artifact =
       mem::take(&mut self.compilation.dependencies_diagnostics_artifact);
-    let mut async_modules_artifact = mem::take(&mut self.compilation.async_modules_artifact);
+    let async_modules_artifact = self.compilation.async_modules_artifact.clone();
     let diagnostics = self
       .compilation
       .collect_build_module_graph_effects(
         &mut dependencies_diagnostics_artifact,
-        &mut async_modules_artifact,
+        &mut async_modules_artifact.borrow_mut(),
       )
       .await?;
     self.compilation.extend_diagnostics(diagnostics);
     self.compilation.dependencies_diagnostics_artifact = dependencies_diagnostics_artifact;
-    self.compilation.async_modules_artifact = async_modules_artifact;
     self.compilation.seal(self.plugin_driver.clone()).await?;
     logger.time_end(start);
 

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1,6 +1,5 @@
 use std::{
   collections::hash_map::Entry,
-  mem,
   ops::{Deref, DerefMut},
 };
 
@@ -445,10 +444,10 @@ impl<'a> ModuleGraph<'a> {
     new_mgm.depth = assign_tuple.2;
     new_mgm.exports = assign_tuple.3;
 
-    let is_async = ModuleGraph::is_async(&compilation.async_modules_artifact, source_module);
-    let mut async_modules_artifact = mem::take(&mut compilation.async_modules_artifact);
+    let is_async =
+      ModuleGraph::is_async(&compilation.async_modules_artifact.borrow(), source_module);
+    let mut async_modules_artifact = compilation.async_modules_artifact.borrow_mut();
     ModuleGraph::set_async(&mut async_modules_artifact, *target_module, is_async);
-    compilation.async_modules_artifact = async_modules_artifact;
   }
 
   pub fn move_module_connections(

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -930,7 +930,7 @@ impl RuntimeTemplate {
         }
         runtime_requirements.insert(RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT);
         if ModuleGraph::is_async(
-          &compilation.async_modules_artifact,
+          &compilation.async_modules_artifact.borrow(),
           compilation
             .get_module_graph()
             .module_identifier_by_dependency_id(dep_id)
@@ -1356,7 +1356,10 @@ fn get_outgoing_async_modules(
     visited: &mut HashSet<ModuleIdentifier>,
   ) {
     let module_identifier = module.identifier();
-    if !ModuleGraph::is_async(&compilation.async_modules_artifact, &module_identifier) {
+    if !ModuleGraph::is_async(
+      &compilation.async_modules_artifact.borrow(),
+      &module_identifier,
+    ) {
       return;
     }
     if !visited.insert(module_identifier) {

--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -184,7 +184,8 @@ impl ExternalInterop {
     let mut source = ConcatSource::default();
     let name = self.required_symbol.as_ref();
 
-    let is_async = ModuleGraph::is_async(&compilation.async_modules_artifact, &self.module);
+    let is_async =
+      ModuleGraph::is_async(&compilation.async_modules_artifact.borrow(), &self.module);
 
     if let Some(name) = name {
       source.add(RawStringSource::from(format!(

--- a/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
+++ b/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
@@ -68,7 +68,7 @@ fn then_expr(
       }
       runtime_requirements.insert(RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT);
       if ModuleGraph::is_async(
-        &compilation.async_modules_artifact,
+        &compilation.async_modules_artifact.borrow(),
         compilation
           .get_module_graph()
           .module_identifier_by_dependency_id(dep_id)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -78,7 +78,10 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
       )));
     }
 
-    if ModuleGraph::is_async(&compilation.async_modules_artifact, &module.identifier()) {
+    if ModuleGraph::is_async(
+      &compilation.async_modules_artifact.borrow(),
+      &module.identifier(),
+    ) {
       runtime_requirements.insert(RuntimeGlobals::MODULE);
       runtime_requirements.insert(RuntimeGlobals::ASYNC_MODULE);
       init_fragments.push(Box::new(NormalInitFragment::new(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -718,8 +718,10 @@ impl ESMExportImportedSpecifierDependency {
               ids[0].clone(),
               ValueKey::UsedName(UsedName::Normal(ids)),
             );
-            let is_async =
-              ModuleGraph::is_async(&compilation.async_modules_artifact, &module_identifier);
+            let is_async = ModuleGraph::is_async(
+              &compilation.async_modules_artifact.borrow(),
+              &module_identifier,
+            );
             ctxt
               .init_fragments
               .push(Box::new(ConditionalInitFragment::new(
@@ -807,8 +809,10 @@ impl ESMExportImportedSpecifierDependency {
           .module_by_identifier(&module.identifier())
           .expect("should have module graph module");
         let exports_name = module.get_exports_argument();
-        let is_async =
-          ModuleGraph::is_async(&compilation.async_modules_artifact, &module.identifier());
+        let is_async = ModuleGraph::is_async(
+          &compilation.async_modules_artifact.borrow(),
+          &module.identifier(),
+        );
         ctxt.init_fragments.push(
           NormalInitFragment::new(
             format!(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -230,7 +230,7 @@ pub fn esm_import_dependency_apply<T: ModuleDependency>(
     emitted_modules.insert(target_module, merged_runtime_condition);
   }
 
-  let is_async_module = matches!(target_module, Some(target_module) if ModuleGraph::is_async(&compilation.async_modules_artifact, &target_module.identifier()));
+  let is_async_module = matches!(target_module, Some(target_module) if ModuleGraph::is_async(&compilation.async_modules_artifact.borrow(), &target_module.identifier()));
   if is_async_module {
     init_fragments.push(Box::new(ConditionalInitFragment::new(
       content.0,

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -889,7 +889,7 @@ impl ModuleConcatenationPlugin {
           return (false, false, module_id, bailout_reason);
         }
 
-        if ModuleGraph::is_async(&compilation.async_modules_artifact, &module_id) {
+        if ModuleGraph::is_async(&compilation.async_modules_artifact.borrow(), &module_id) {
           bailout_reason.push("Module is async".into());
           return (false, false, module_id, bailout_reason);
         }

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -75,7 +75,7 @@ async fn render_startup(
     .runtime_template
     .render_runtime_variable(&RuntimeVariable::Exports);
   let mut source = ConcatSource::default();
-  let is_async = ModuleGraph::is_async(&compilation.async_modules_artifact, module);
+  let is_async = ModuleGraph::is_async(&compilation.async_modules_artifact.borrow(), module);
   let module_graph = compilation.get_module_graph();
   source.add(render_source.source.clone());
   // export { local as exported }

--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -184,7 +184,7 @@ fn module_namespace_promise_rstest(
       }
       runtime_requirements.insert(RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT);
       if ModuleGraph::is_async(
-        &compilation.async_modules_artifact,
+        &compilation.async_modules_artifact.borrow(),
         compilation
           .get_module_graph()
           .module_identifier_by_dependency_id(dep_id)

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -194,7 +194,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
                 let len_str = len_buffer.format(len);
                 let import_var = format!("rspack_import_{}", len_str);
                 if ModuleGraph::is_async(
-                  &compilation.async_modules_artifact,
+                  &compilation.async_modules_artifact.borrow(),
                   &mgm.module_identifier,
                 ) {
                   promises.push(import_var.clone());


### PR DESCRIPTION
## Summary
use atomic_refcell for artifact so we can still safely access artifact from js side
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
