### PR TITLE
test: enable passing normalCases tests and document failures

### DIFF
--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
@@ -1,5 +1,5 @@
 use rspack_util::SpanExt;
-use swc_core::ecma::ast::NewExpr;
+use swc_core::{atoms::Atom, ecma::ast::NewExpr};
 
 use super::BasicEvaluatedExpression;
 use crate::{utils::eval, visitors::JavascriptParser};
@@ -14,7 +14,9 @@ pub fn eval_new_expression<'a>(
     // FIXME: call hooks
     return None;
   }
-  // FIXME: should detect RegExpr variable info
+  if scanner.get_variable_info(&Atom::from("RegExp")).is_some() {
+    return None;
+  }
   let Some(args) = &expr.args else {
     let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
     res.set_regexp(String::new(), String::new());

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/test.filter.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/test.filter.js
@@ -1,4 +1,0 @@
-module.exports = function (config) {
-  // This test can't run in development mode
-  return config.mode !== "development";
-};

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-then-destructuring/test.filter.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-then-destructuring/test.filter.js
@@ -1,6 +1,0 @@
-"use strict";
-
-module.exports = function filter(config) {
-	// This test can't run in development mode
-	return config.mode !== "development";
-};

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-then/test.filter.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-then/test.filter.js
@@ -1,6 +1,0 @@
-"use strict";
-
-module.exports = function filter(config) {
-	// This test can't run in development mode
-	return config.mode !== "development";
-};

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import/test.filter.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import/test.filter.js
@@ -1,6 +1,0 @@
-"use strict";
-
-module.exports = function filter(config) {
-	// This test can't run in development mode
-	return config.mode !== "development";
-};

--- a/tests/rspack-test/normalCases/errors/load-module-error/test.filter.js
+++ b/tests/rspack-test/normalCases/errors/load-module-error/test.filter.js
@@ -1,3 +1,7 @@
+/*
+ * Test fails: this.loadModule is not a function
+ * The loader API this.loadModule is not implemented yet
+ */
 
 module.exports = () => "TODO: https://github.com/web-infra-dev/rspack/issues/3738"
 

--- a/tests/rspack-test/normalCases/loaders/emit-file/test.filter.js
+++ b/tests/rspack-test/normalCases/loaders/emit-file/test.filter.js
@@ -1,3 +1,0 @@
-module.exports = function (config) {
-	return !config.module;
-};

--- a/tests/rspack-test/normalCases/loaders/issue-4959/test.filter.js
+++ b/tests/rspack-test/normalCases/loaders/issue-4959/test.filter.js
@@ -1,3 +1,7 @@
+/*
+ * Test fails: this.loadModule is not a function
+ * The loader API this.loadModule is not implemented yet
+ */
 
 module.exports = () => "TODO: blocked by this.loadModule https://github.com/web-infra-dev/rspack/issues/3738"
 

--- a/tests/rspack-test/normalCases/mjs/namespace-object-lazy/test.filter.js
+++ b/tests/rspack-test/normalCases/mjs/namespace-object-lazy/test.filter.js
@@ -1,3 +1,0 @@
-module.exports = function(config) {
-	return !config.minimize;
-};

--- a/tests/rspack-test/normalCases/mjs/non-mjs-namespace-object-lazy/test.filter.js
+++ b/tests/rspack-test/normalCases/mjs/non-mjs-namespace-object-lazy/test.filter.js
@@ -1,3 +1,0 @@
-module.exports = function(config) {
-	return !config.minimize;
-};

--- a/tests/rspack-test/normalCases/optimize/side-effects-simple-unused/test.filter.js
+++ b/tests/rspack-test/normalCases/optimize/side-effects-simple-unused/test.filter.js
@@ -1,5 +1,0 @@
-
-module.exports = function(config) {
-	return config.mode !== "development";
-};
-

--- a/tests/rspack-test/normalCases/parsing/harmony-destructuring-assignment/test.filter.js
+++ b/tests/rspack-test/normalCases/parsing/harmony-destructuring-assignment/test.filter.js
@@ -1,5 +1,0 @@
-module.exports = function (config) {
-  // This test can't run in development mode
-  return config.mode !== "development";
-};
-

--- a/tests/rspack-test/normalCases/parsing/issue-758/test.filter.js
+++ b/tests/rspack-test/normalCases/parsing/issue-758/test.filter.js
@@ -1,3 +1,9 @@
+/*
+ * Test fails with error:
+ * Warnings while compiling:
+ * Module not found: Can't resolve './missingModule'
+ * The test expects warnings about missing modules but they cause test failure
+ */
 
 module.exports = () => "TODO: https://github.com/web-infra-dev/rspack/issues/4313"
 

--- a/tests/rspack-test/normalCases/parsing/precreated-ast/test.filter.js
+++ b/tests/rspack-test/normalCases/parsing/precreated-ast/test.filter.js
@@ -1,3 +1,9 @@
+/*
+ * Test fails: AST from loader not processed correctly
+ * Expected: 'ok'
+ * Got: 'wrong'
+ * The loader-provided AST is not being used properly
+ */
 
 module.exports = () => "TODO: https://github.com/web-infra-dev/rspack/issues/4442"
 

--- a/tests/rspack-test/normalCases/parsing/rspack-issue-4816/test.filter.js
+++ b/tests/rspack-test/normalCases/parsing/rspack-issue-4816/test.filter.js
@@ -1,2 +1,0 @@
-// Blocked by https://github.com/web-infra-dev/rspack/pull/5764
-module.exports = () => false

--- a/tests/rspack-test/normalCases/resolving/issue-2986/test.filter.js
+++ b/tests/rspack-test/normalCases/resolving/issue-2986/test.filter.js
@@ -1,1 +1,7 @@
+/*
+ * Test fails: Error message mismatch
+ * Expected: /Can't resolve 'any' in/
+ * Got: Unable to resolve loader other
+ */
 module.exports = () => "TODO: https://github.com/web-infra-dev/rspack/issues/4348"
+


### PR DESCRIPTION
## Summary

This PR systematically reviews and processes normalCases test filters without support-related checks:

### Enabled Tests (10 test.filter.js removed)
Successfully removed filters for tests that now pass:
- All 4 statical-dynamic-import related tests in chunks/
- mjs namespace-object-lazy tests  
- loaders/emit-file test
- optimize/side-effects-simple-unused test
- parsing/harmony-destructuring-assignment test
- parsing/rspack-issue-4816 test (with RegExp variable detection fix)

### Documented Failures (5 test.filter.js updated)
Added error documentation for tests that still fail:
- parsing/issue-758: Missing module warnings cause test failure
- parsing/precreated-ast: Loader-provided AST not processed correctly
- resolving/issue-2986: Error message format mismatch
- loaders/issue-4959: `this.loadModule` API not implemented
- errors/load-module-error: `this.loadModule` API not implemented

### Additional Fix
Fixed RegExp variable detection in `eval_new_expr.rs` to properly handle RegExp shadowing.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).