### PR TITLE
fix: make splitChunks more stable

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1429,6 +1429,14 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       }
 
       cgi.ukey
+    } else if !item_chunk_group_info.async_chunks || !item_chunk_group_info.chunk_loading {
+      self.queue.push(QueueAction::ProcessBlock(ProcessBlock {
+        block: block_id.into(),
+        module: module_id,
+        chunk_group_info: item_chunk_group_info.ukey,
+        chunk: item_chunk_ukey,
+      }));
+      return;
     } else {
       let chunk_ukey = if let Some(chunk_name) = compilation
         .get_module_graph()
@@ -1549,14 +1557,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
             chunk: chunk_ukey,
           }));
         cgi.ukey
-      } else if !item_chunk_group_info.async_chunks || !item_chunk_group_info.chunk_loading {
-        self.queue.push(QueueAction::ProcessBlock(ProcessBlock {
-          block: block_id.into(),
-          module: module_id,
-          chunk_group_info: item_chunk_group_info.ukey,
-          chunk: item_chunk_ukey,
-        }));
-        return;
       } else {
         let cgi = if let Some(chunk_name) = chunk_name
           && let Some(cgi) = self.named_chunk_groups.get(chunk_name)

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -110,7 +110,11 @@ fn assign_named_chunk_ids(
 
   let mut ordered_chunk_modules_cache = Default::default();
 
-  for (name, mut items) in name_to_items {
+  // Sort by name to ensure deterministic processing order
+  let mut name_to_items_sorted: Vec<_> = name_to_items.into_iter().collect();
+  name_to_items_sorted.sort_by(|a, b| a.0.cmp(&b.0));
+
+  for (name, mut items) in name_to_items_sorted {
     if name.is_empty() {
       for item in items {
         unnamed_items.push(item)

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -140,9 +140,8 @@ impl SplitChunksPlugin {
         compilation.chunk_graph.add_chunk(new_chunk.ukey());
         new_chunk.ukey()
       }
-    } else if let Some(reusable_chunk) =
-      self.find_the_best_reusable_chunk(compilation, module_group)
-      && module_group.cache_group_reuse_existing_chunk
+    } else if module_group.cache_group_reuse_existing_chunk
+      && let Some(reusable_chunk) = self.find_the_best_reusable_chunk(compilation, module_group)
     {
       *is_reuse_existing_chunk = true;
       *is_reuse_existing_chunk_with_all_modules = true;

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -128,7 +128,7 @@ impl SplitChunksPlugin {
         "ModuleGroup({}) is removed. Reason: empty modules cause by `minSize` checking",
         key,
       );
-      module_group_map.remove(&key);
+      module_group_map.swap_remove(&key);
     });
   }
 


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

I found some potential vulnerabilities of `SplitChunksPlugin`, this can make output inconsistent during incremental rebuild.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
