### PR TITLE
fix: align webpack behavior of removing empty entry chunk

### DIFF
--- a/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
+++ b/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
@@ -22,9 +22,6 @@ impl RemoveEmptyChunksPlugin {
         chunk_graph.get_number_of_chunk_modules(&chunk.ukey()) == 0
           && !chunk.has_runtime(&compilation.chunk_group_by_ukey)
           && chunk_graph.get_number_of_entry_modules(&chunk.ukey()) == 0
-          && chunk
-            .get_entry_options(&compilation.chunk_group_by_ukey)
-            .is_none()
       })
       .map(|chunk| chunk.ukey())
       .collect::<Vec<_>>();

--- a/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
@@ -9,6 +9,9 @@ function applyLimits(options: RspackOptionsNormalized, logger: Logger) {
 	// concatenateModules is not supported in ESM library mode, it has its own scope hoist algorithm
 	options.optimization.concatenateModules = false;
 
+	// esm library won't have useless empty chunk, the empty chunk for esm lib is to re-exports
+	options.optimization.removeEmptyChunks = false;
+
 	// chunk rendering is handled by EsmLibraryPlugin
 	options.output.chunkFormat = false;
 

--- a/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/rspack.config.js
@@ -1,0 +1,58 @@
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+/**
+ * @type {import('@rspack/core').Configuration}
+ */
+const config = {
+  mode: "development",
+  target: "web",
+  devtool: false,
+  entry: {
+    app: "./src/app",
+    app2: "./src/app2",
+  },
+  node: false,
+  plugins: [{
+    apply(compiler) {
+      compiler.hooks.done.tapAsync('TestPlugin', ({ compilation }, callback) => {
+        const chunks = [];
+
+        Array.from(compilation.entrypoints.values()).forEach((entrypoint) => {
+          entrypoint.chunks.forEach(chunk => {
+            // Simulate some processing on each chunk
+            chunks.push(`${chunk.name}, ${Array.from(chunk.files).join(', ')}, ${Array.from(chunk.auxiliaryFiles).join(', ')}`);
+          });
+        });
+
+        fs.writeFileSync(path.join(compiler.outputPath, 'chunks-summary.txt'), chunks.join(os.EOL), 'utf-8');
+        callback()
+      });
+    }
+  }],
+  optimization: {
+    runtimeChunk: true,
+    chunkIds: 'named',
+    moduleIds: 'named',
+    splitChunks: {
+      name(module, chunks) {
+        return chunks.map((item) => item.name).join('~');
+      },
+      minSize: 0,
+      chunks: 'all',
+    },
+  },
+  externals: {
+    underscore: {
+      root: "fs",
+    },
+    jquery: {
+      root: "fs",
+    }
+  },
+  output: {
+    filename: "[name].js",
+  },
+};
+
+module.exports = config;

--- a/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/app.js
+++ b/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/app.js
@@ -1,0 +1,17 @@
+import _ from 'underscore';
+
+it('should remove empty chunks', async () => {
+  const [asyncBar, asyncFoo] = await Promise.all([
+    import(/* webpackChunkName: "async-bar" */ './async-bar.js').then(m => m.default),
+    import(/* webpackChunkName: "async-foo" */ './async-foo.js').then(m => m.default),
+  ]);
+
+  expect(asyncBar).toBe('async-bar');
+  expect(asyncFoo).toBe('foo');
+
+  const path = __non_webpack_require__('path')
+  const fs = __non_webpack_require__('fs')
+
+  const summary = fs.readFileSync(path.join(__dirname, 'chunks-summary.txt'), 'utf-8');
+  expect(summary).not.toContain('app~app2');
+})

--- a/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/app2.js
+++ b/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/app2.js
@@ -1,0 +1,5 @@
+import _ from 'underscore';
+
+import(/* webpackChunkName: "async-bar" */ './async-bar.js').then((x) => {
+  console.log.bind(x);
+});

--- a/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-async-async-bar.js
+++ b/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-async-async-bar.js
@@ -1,0 +1,4 @@
+import $ from 'jquery';
+import _ from 'underscore';
+
+export default 'async-async-async-bar';

--- a/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-async-bar-two.js
+++ b/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-async-bar-two.js
@@ -1,0 +1,1 @@
+export default 'async-async-bar-two';

--- a/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-async-bar.js
+++ b/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-async-bar.js
@@ -1,0 +1,6 @@
+import $ from 'jquery';
+import _ from 'underscore';
+
+export default () => {
+  import(/* webpackChunkName: "async-async-async-bar" */ './async-async-async-bar.js');
+};

--- a/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-bar.js
+++ b/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-bar.js
@@ -1,0 +1,9 @@
+import $ from 'jquery';
+import _ from 'underscore';
+
+export default 'async-bar';
+
+export const asyncBar = () => {
+  import(/* webpackChunkName: "async-async-bar" */ './async-async-bar.js');
+  import(/* webpackChunkName: "async-async-bar-two" */ './async-async-bar-two.js');
+};

--- a/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-foo.js
+++ b/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/src/async-foo.js
@@ -1,0 +1,2 @@
+export default 'foo';
+import _ from 'underscore';

--- a/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/rspack-issue-12400/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  findBundle() {
+    return ['runtime~app.js', 'app.js']
+  }
+}


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

fix #12400 

Align webpack's behavior of removing empty entry chunk. 

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
