### PR TITLE
refactor: change dependencies_diagnostics_artifact to use atomic_refcell

### DIFF
--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -250,7 +250,7 @@ pub struct Compilation {
   // artifact for infer_async_modules_plugin
   pub async_modules_artifact: Arc<AtomicRefCell<AsyncModulesArtifact>>,
   // artifact for collect_dependencies_diagnostics
-  pub dependencies_diagnostics_artifact: DerefOption<DependenciesDiagnosticsArtifact>,
+  pub dependencies_diagnostics_artifact: Arc<AtomicRefCell<DependenciesDiagnosticsArtifact>>,
   // artifact for side_effects_flag_plugin
   pub side_effects_optimize_artifact: DerefOption<SideEffectsOptimizeArtifact>,
   // artifact for module_ids
@@ -389,9 +389,9 @@ impl Compilation {
 
       async_modules_artifact: Arc::new(AtomicRefCell::new(AsyncModulesArtifact::default())),
       imported_by_defer_modules_artifact: Default::default(),
-      dependencies_diagnostics_artifact: DerefOption::new(
+      dependencies_diagnostics_artifact: Arc::new(AtomicRefCell::new(
         DependenciesDiagnosticsArtifact::default(),
-      ),
+      )),
       side_effects_optimize_artifact: DerefOption::new(Default::default()),
       module_ids_artifact: Default::default(),
       named_chunk_ids_artifact: Default::default(),

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -1,8 +1,5 @@
 mod rebuild;
-use std::{
-  mem,
-  sync::{Arc, atomic::AtomicU32},
-};
+use std::sync::{Arc, atomic::AtomicU32};
 
 use futures::future::join_all;
 use rspack_error::Result;
@@ -323,18 +320,17 @@ impl Compiler {
       wait_for_signal("seal compilation");
     }
     self.build_module_graph().await?;
-    let mut dependencies_diagnostics_artifact =
-      mem::take(&mut self.compilation.dependencies_diagnostics_artifact);
+    let dependencies_diagnostics_artifact =
+      self.compilation.dependencies_diagnostics_artifact.clone();
     let async_modules_artifact = self.compilation.async_modules_artifact.clone();
     let diagnostics = self
       .compilation
       .collect_build_module_graph_effects(
-        &mut dependencies_diagnostics_artifact,
+        &mut dependencies_diagnostics_artifact.borrow_mut(),
         &mut async_modules_artifact.borrow_mut(),
       )
       .await?;
     self.compilation.extend_diagnostics(diagnostics);
-    self.compilation.dependencies_diagnostics_artifact = dependencies_diagnostics_artifact;
     self.compilation.seal(self.plugin_driver.clone()).await?;
     logger.time_end(start);
 


### PR DESCRIPTION
## Summary

Refactors `Compilation.dependencies_diagnostics_artifact` to `Arc<AtomicRefCell<DependenciesDiagnosticsArtifact>>`. This change aligns its sharing pattern with other compilation artifacts, allowing for mutable borrowing without moving the artifact and better supporting rebuild transfers. It also simplifies the usage in `Compiler::build` by removing the `mem::take` pattern.

## Related links

- Similar refactor: https://github.com/web-infra-dev/rspack/pull/12408

## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).

---
<a href="https://cursor.com/background-agent?bcId=bc-03733694-08a2-4621-a5a4-358b8a771004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03733694-08a2-4621-a5a4-358b8a771004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

