### PR TITLE
fix: should use exported name of the imported module

### DIFF
--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm/__snapshots__/esm.snap.txt
@@ -2,6 +2,10 @@
 // ./lib3.js
 const lib3_lib3 = 42
 
+const lib_local = 24
+
+
+
 // ./lib2.js
 
 
@@ -16,12 +20,13 @@ const lib_lib = 42
 
 
 it('should re-export esm correctly', async () => {
-	const { lib, lib2, lib3 } = await import(/* webpackIgnore: true */ './main.mjs')
+	const { lib, lib2, lib3, lib4 } = await import(/* webpackIgnore: true */ './main.mjs')
 	expect(lib).toBe(42)
 	expect(lib2).toBe(42)
 	expect(lib3).toBe(42)
+	expect(lib4).toBe(24)
 })
 
-export { lib2_lib2 as lib2, lib3_lib3 as lib3, lib_lib as lib };
+export { lib2_lib2 as lib2, lib3_lib3 as lib3, lib_lib as lib, lib_local as lib4 };
 
 ```

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm/index.js
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm/index.js
@@ -1,8 +1,9 @@
 export * from './lib'
 
 it('should re-export esm correctly', async () => {
-	const { lib, lib2, lib3 } = await import(/* webpackIgnore: true */ './main.mjs')
+	const { lib, lib2, lib3, lib4 } = await import(/* webpackIgnore: true */ './main.mjs')
 	expect(lib).toBe(42)
 	expect(lib2).toBe(42)
 	expect(lib3).toBe(42)
+	expect(lib4).toBe(24)
 })

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm/lib3.js
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm/lib3.js
@@ -1,1 +1,5 @@
 export const lib3 = 42
+
+const lib_local = 24
+
+export { lib_local as lib4 }


### PR DESCRIPTION
## Summary

related issue: https://github.com/web-infra-dev/rsbuild/pull/6746

Should first look into the `export_map` for concatenated modules, then find the internal name of it. Use export_info of ref module instead of current module

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve normal re-exports via the referenced module’s export info/export_map (including externals and concatenated modules), and add a test covering deep re-exports with a new lib4 export.
> 
> - **ESM linking**:
>   - **Normal re-exports**: Derive `export_name` from `get_target(item.export_info)` and use the referenced module’s exports info to compute the used name (instead of the current module).
>   - **External modules**: Pass the computed `export_name` as `ids` when re-exporting from external modules.
>   - **Concatenated modules**: Resolve `internal_name` by mapping `export_name` through `export_map` before lookup.
> - **Tests**:
>   - Update deep re-exports ESM case to re-export `lib4`, adjusting snapshot and assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35ac63886dab63b911847858c616f32ee890672b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->