### PR TITLE
chore: bump `swc_experimental` to fix parsing utf8 in template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6497,9 +6497,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ast_macros"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf71433ef7a565be74d5ebfccc03163fd8ba0de39dbf41807a6a1163bddc003"
+checksum = "1bbcb09c12c4f07c6d5c95f01f9ae2af44b4a76b249e3ade6fa50cfbfa82980c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6508,59 +6508,54 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_ast"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8d2d1395dee9633e93427f23df04c0dbd6648fe87d8fe8925a1093b5364343"
+checksum = "40116ae7186c3c5b7323beed636550abbde6019686815f405cd965b14a55065c"
 dependencies = [
  "num-bigint",
  "oxc_index",
- "swc_atoms",
- "swc_common",
+ "swc_core",
  "swc_experimental_ast_macros",
  "unicode-id-start",
 ]
 
 [[package]]
 name = "swc_experimental_ecma_parser"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28206a21db7bf7cd767cc10ca2726f20f8062b5aa70f1786c41398c86b17411"
+checksum = "1db388580236a7cb0b962a0407c137fc80229eec793ad35d17dcfb7019a27e7e"
 dependencies = [
  "bitflags 2.9.1",
  "either",
  "num-bigint",
- "oxc_index",
  "rustc-hash",
  "seq-macro",
  "smartstring",
- "stacker",
- "swc_atoms",
- "swc_common",
+ "swc_core",
  "swc_experimental_ecma_ast",
  "tracing",
 ]
 
 [[package]]
 name = "swc_experimental_ecma_semantic"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26a9fe675fe7c79b7eaccd52b8dcb9ff99505ecaae020a50e3843d861e4ddc9"
+checksum = "3964ab8ee3f832148d26c29a7033487c86f8e91ec1e9a724e6c3e03cf1bb8da3"
 dependencies = [
  "bitflags 2.9.1",
  "oxc_index",
  "rustc-hash",
- "swc_common",
+ "swc_core",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_visit",
 ]
 
 [[package]]
 name = "swc_experimental_ecma_visit"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f09d9eb1fe206b4813304f0145dab14ce39eda21b0a785a33d3106924a9570"
+checksum = "239be626f08b90bf8bc8647a52eff36a377137f419ffddfc6fae5c7b4a297fef"
 dependencies = [
- "swc_common",
  "swc_experimental_ecma_ast",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,9 +146,9 @@ swc_html_minifier   = { version = "35.0.0", default-features = false }
 swc_node_comments   = { version = "16.0.0", default-features = false }
 swc_plugin_runner   = { version = "21.0.0", default-features = false }
 
-swc_experimental_ecma_ast      = { version = "0.1.1", default-features = false }
-swc_experimental_ecma_parser   = { version = "0.1.1", default-features = false }
-swc_experimental_ecma_semantic = { version = "0.1.1", default-features = false }
+swc_experimental_ecma_ast      = { version = "0.3.1", default-features = false }
+swc_experimental_ecma_parser   = { version = "0.3.1", default-features = false }
+swc_experimental_ecma_semantic = { version = "0.3.1", default-features = false }
 
 rspack_dojang = { version = "0.1.11", default-features = false }
 tracy-client = { version = "=0.18.2", default-features = false, features = [


### PR DESCRIPTION
## Summary

See: https://github.com/CPunisher/swc-experimental/commit/be7913b7dab39a702199a86328980034e289953b

SWC doesn't add utf8 boundary check in `bump` function, although it still works in this cases. 
SWC-experimental add utf8 boundary check, thus panic here.

There are some other changes in this pr due to the breaking of SWC-experimental

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
