### PR TITLE
chore: skip diff CI for doc-only changes

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -11,6 +11,10 @@ on:
   push:
     branches:
       - main
+    # Ignore md files in push to skip workflow when only documentation changes
+    paths-ignore:
+      - "**/*.md"
+      - "website/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
In the push stage, you still need to execute the diff workflow to upload this baseline. Pull_request can not execute diff workflow.


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
