### PR TITLE
fix: concatenate module should use importer's 'strict' for interop

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2920,10 +2920,7 @@ impl ConcatenatedModule {
           crate::FindTargetResult::ValidTarget(reexport) => {
             if let Some(ref_info) = module_to_info_map.get(&reexport.module) {
               // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L457
-              let build_meta = mg
-                .module_by_identifier(&ref_info.id())
-                .expect("should have module")
-                .build_meta();
+
               return Self::get_final_binding(
                 mg,
                 mg_cache,
@@ -2937,7 +2934,7 @@ impl ConcatenatedModule {
                 runtime,
                 as_call,
                 reexport.defer,
-                build_meta.strict_esm_module,
+                module.build_meta().strict_esm_module,
                 asi_safe,
                 already_visited,
               );

--- a/tests/rspack-test/configCases/concatenate-modules/interop/index.js
+++ b/tests/rspack-test/configCases/concatenate-modules/interop/index.js
@@ -1,0 +1,7 @@
+import { value as value1 } from './module.js'
+import { value as value2 } from './module.mjs'
+
+it('should have correct interop', () => {
+  expect(value1()).toBe(24)
+  expect(value2()).toBe(42)
+})

--- a/tests/rspack-test/configCases/concatenate-modules/interop/module-normal.cjs
+++ b/tests/rspack-test/configCases/concatenate-modules/interop/module-normal.cjs
@@ -1,0 +1,8 @@
+function exportValue(exports) {
+  module.exports = function () { return 42 }
+
+  module.exports.__esModule = true
+  module.exports.default = () => { return 24 }
+}
+
+exportValue(exports)

--- a/tests/rspack-test/configCases/concatenate-modules/interop/module.js
+++ b/tests/rspack-test/configCases/concatenate-modules/interop/module.js
@@ -1,0 +1,1 @@
+export { default as value } from './module-normal.cjs'

--- a/tests/rspack-test/configCases/concatenate-modules/interop/module.mjs
+++ b/tests/rspack-test/configCases/concatenate-modules/interop/module.mjs
@@ -1,0 +1,1 @@
+export { default as value } from './module-normal.cjs'

--- a/tests/rspack-test/configCases/concatenate-modules/interop/rspack.config.js
+++ b/tests/rspack-test/configCases/concatenate-modules/interop/rspack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  entry: './index.js',
+  optimization: {
+    concatenateModules: true,
+  }
+}


### PR DESCRIPTION
## Summary

Concatenated module get_binding should use import module's `buildMeta.strictEsm` to get export, to make interop correct, the behavior should be the same as which not concatenateed

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
