### PR TITLE
fix: add Set methods to compilation dependencies

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -868,9 +868,14 @@ export class Compilation {
     // (undocumented)
     buildDependencies: {
         [Symbol.iterator](): Generator<string, void, unknown>;
-        has(dep: string): boolean;
+        has: (dep: string) => boolean;
         add: (dep: string) => void;
         addAll: (deps: Iterable<string>) => void;
+        delete: (dep: string) => boolean;
+        keys(): SetIterator<string>;
+        values(): SetIterator<string>;
+        entries(): SetIterator<[string, string]>;
+        readonly size: number;
     };
     // (undocumented)
     get builtModules(): ReadonlySet<Module>;
@@ -891,9 +896,14 @@ export class Compilation {
     // (undocumented)
     contextDependencies: {
         [Symbol.iterator](): Generator<string, void, unknown>;
-        has(dep: string): boolean;
+        has: (dep: string) => boolean;
         add: (dep: string) => void;
         addAll: (deps: Iterable<string>) => void;
+        delete: (dep: string) => boolean;
+        keys(): SetIterator<string>;
+        values(): SetIterator<string>;
+        entries(): SetIterator<[string, string]>;
+        readonly size: number;
     };
     // (undocumented)
     createChildCompiler(name: string, outputOptions: OutputNormalized, plugins: RspackPluginInstance[]): Compiler;
@@ -917,9 +927,14 @@ export class Compilation {
     // (undocumented)
     fileDependencies: {
         [Symbol.iterator](): Generator<string, void, unknown>;
-        has(dep: string): boolean;
+        has: (dep: string) => boolean;
         add: (dep: string) => void;
         addAll: (deps: Iterable<string>) => void;
+        delete: (dep: string) => boolean;
+        keys(): SetIterator<string>;
+        values(): SetIterator<string>;
+        entries(): SetIterator<[string, string]>;
+        readonly size: number;
     };
     // (undocumented)
     fileSystemInfo: {
@@ -1002,9 +1017,14 @@ export class Compilation {
     // (undocumented)
     missingDependencies: {
         [Symbol.iterator](): Generator<string, void, unknown>;
-        has(dep: string): boolean;
+        has: (dep: string) => boolean;
         add: (dep: string) => void;
         addAll: (deps: Iterable<string>) => void;
+        delete: (dep: string) => boolean;
+        keys(): SetIterator<string>;
+        values(): SetIterator<string>;
+        entries(): SetIterator<[string, string]>;
+        readonly size: number;
     };
     // (undocumented)
     moduleGraph: ModuleGraph;

--- a/packages/rspack/src/util/fake.ts
+++ b/packages/rspack/src/util/fake.ts
@@ -7,23 +7,59 @@ export function createFakeCompilationDependencies(
 	addDeps: (deps: string[]) => void
 ) {
 	const addDepsCaller = new MergeCaller(addDeps);
+	const deletedDeps = new Set<string>();
+
+	const hasDep = (dep: string): boolean => {
+		if (deletedDeps.has(dep)) {
+			return false;
+		}
+		return addDepsCaller.pendingData().includes(dep) || getDeps().includes(dep);
+	};
+
+	const getAllDeps = () => {
+		const deps = new Set([...getDeps(), ...addDepsCaller.pendingData()]);
+		for (const deleted of deletedDeps) {
+			deps.delete(deleted);
+		}
+		return deps;
+	};
+
 	return {
 		*[Symbol.iterator]() {
-			const deps = new Set([...getDeps(), ...addDepsCaller.pendingData()]);
+			const deps = getAllDeps();
 			for (const dep of deps) {
 				yield dep;
 			}
 		},
-		has(dep: string): boolean {
-			return (
-				addDepsCaller.pendingData().includes(dep) || getDeps().includes(dep)
-			);
-		},
+		has: hasDep,
 		add: (dep: string) => {
+			deletedDeps.delete(dep);
 			addDepsCaller.push(dep);
 		},
 		addAll: (deps: Iterable<string>) => {
+			for (const dep of deps) {
+				deletedDeps.delete(dep);
+			}
 			addDepsCaller.push(...deps);
+		},
+		delete: (dep: string) => {
+			const hadDep = hasDep(dep);
+			if (hadDep) {
+				deletedDeps.add(dep);
+			}
+			return hadDep;
+		},
+		keys() {
+			return getAllDeps().keys();
+		},
+		values() {
+			return getAllDeps().values();
+		},
+		entries() {
+			return getAllDeps().entries();
+		},
+		get size() {
+			return getAllDeps().size;
 		}
 	};
 }

--- a/tests/rspack-test/configCases/utils/lazy-set/test.filter.js
+++ b/tests/rspack-test/configCases/utils/lazy-set/test.filter.js
@@ -1,7 +1,0 @@
-/*
- * Test fails: compilation.fileDependencies is a proxy
- * LazySet implementation issue
- */
-
-module.exports = () => "TODO: compilation.fileDependencies is a proxy"
-


### PR DESCRIPTION
## Summary

This PR fixes a bug where `compilation.fileDependencies` and other compilation dependency objects were missing standard Set methods (`keys()`, `values()`, `entries()`, `delete()`, `size`). This caused the `utils/lazy-set` test case to fail with "keys is not a function" error.

The fix extends the `createFakeCompilationDependencies` function to implement these missing Set methods, making the compilation dependencies objects behave like a proper Set. This ensures compatibility with code that expects Set-like behavior.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).