### PR TITLE
fix(diagnostic): avoid emitting dim-only indent lines

### DIFF
--- a/crates/rspack_error/src/displayer/renderer/graphical.rs
+++ b/crates/rspack_error/src/displayer/renderer/graphical.rs
@@ -244,15 +244,13 @@ impl GraphicalReportHandler {
           char, self.theme.characters.hbar, self.theme.characters.rarrow
         ))
         .to_string();
-        let rest_indent = dim(&format!(
-          "  {}   ",
-          if is_last {
-            ' '
-          } else {
-            self.theme.characters.vbar
-          }
-        ))
-        .to_string();
+
+        let rest_indent = if is_last {
+          "      ".to_string()
+        } else {
+          dim(&format!("  {}   ", self.theme.characters.vbar)).to_string()
+        };
+
         let opts = textwrap::Options::new(width)
           .initial_indent(&initial_indent)
           .subsequent_indent(&rest_indent);


### PR DESCRIPTION
## Summary

This change avoids emitting ANSI dim escape sequences that contain only whitespace in error output.

Previously, the formatter could produce dimmed indentation without any visible content  (`\u001b[2m      \u001b[0m`). This update ensures that dim is only applied when there is meaningful visible content.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
