### PR TITLE
fix: re-validate HttpUriPlugin redirects against allowedUris and enforce http(s) and max redirects

### DIFF
--- a/tests/rspack-test/configCases/asset-modules/http-redirect-security/errors.js
+++ b/tests/rspack-test/configCases/asset-modules/http-redirect-security/errors.js
@@ -1,0 +1,5 @@
+module.exports = [
+  /Too many redirects/,
+  /Redirected URL uses disallowed protocol: /,
+  /doesn't match the allowedUris policy after redirect/
+]

--- a/tests/rspack-test/configCases/asset-modules/http-redirect-security/index.js
+++ b/tests/rspack-test/configCases/asset-modules/http-redirect-security/index.js
@@ -1,0 +1,13 @@
+// the whole file is not gonna run, as the compilation should fail
+// import "http://localhost:9991/redirect-to-allowed"
+
+// Test disallowed redirect (should fail)
+import "http://localhost:9991/redirect-to-disallowed"
+
+// Test non-HTTP protocol redirect (should fail)
+import "http://localhost:9991/redirect-to-non-http"
+
+// Test too many redirects (should fail)
+import "http://localhost:9991/redirect-chain"
+
+throw new Error('should not reach here')

--- a/tests/rspack-test/configCases/asset-modules/http-redirect-security/rspack.config.js
+++ b/tests/rspack-test/configCases/asset-modules/http-redirect-security/rspack.config.js
@@ -1,0 +1,23 @@
+const ServerPlugin = require("./server");
+
+const serverPlugin = new ServerPlugin(9991);
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  entry: './index.js',
+  optimization: {
+    moduleIds: 'named'
+  },
+  plugins: [
+    serverPlugin,
+  ],
+  experiments: {
+    buildHttp: {
+      frozen: false,
+      allowedUris: [
+        "http://localhost:9991/"
+      ],
+    }
+  }
+};

--- a/tests/rspack-test/configCases/asset-modules/http-redirect-security/server/index.js
+++ b/tests/rspack-test/configCases/asset-modules/http-redirect-security/server/index.js
@@ -1,0 +1,109 @@
+const http = require("http");
+/**
+ * @returns {import("http").Server} server instance
+ */
+function createServer() {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (url.pathname === "/redirect-to-disallowed") {
+      res.writeHead(302, { "Location": "https://evil.com/malicious.js" });
+      res.end();
+      return;
+    }
+
+    if (url.pathname === "/redirect-to-non-http") {
+      res.writeHead(302, { "Location": "ftp://example.com/file.js" });
+      res.end();
+      return;
+    }
+
+    if (url.pathname === "/redirect-chain") {
+      res.writeHead(302, { "Location": "/redirect-chain-1" });
+      res.end();
+      return;
+    }
+
+    if (url.pathname === "/redirect-chain-1") {
+      res.writeHead(302, { "Location": "/redirect-chain-2" });
+      res.end();
+      return;
+    }
+
+    if (url.pathname === "/redirect-chain-2") {
+      res.writeHead(302, { "Location": "/redirect-chain-3" });
+      res.end();
+      return;
+    }
+
+    if (url.pathname === "/redirect-chain-3") {
+      res.writeHead(302, { "Location": "/redirect-chain-4" });
+      res.end();
+      return;
+    }
+
+    if (url.pathname === "/redirect-chain-4") {
+      res.writeHead(302, { "Location": "/redirect-chain-5" });
+      res.end();
+      return;
+    }
+
+    if (url.pathname === "/redirect-chain-5") {
+      res.writeHead(302, { "Location": "/redirect-chain-6" });
+      res.end();
+      return;
+    }
+
+    res.writeHead(404);
+    res.end("Not found");
+  });
+  server.unref();
+  return server;
+}
+
+class ServerPlugin {
+  /**
+   * @param {number} port
+   */
+  constructor(port) {
+    this.port = port;
+    this.refs = 0;
+    this.server = undefined;
+  }
+
+  /**
+   * @param {import("@rspack/core").Compiler} compiler
+   */
+  apply(compiler) {
+    compiler.hooks.beforeRun.tapPromise(
+      "ServerPlugin",
+      () => {
+        this.refs++;
+        if (!this.server) {
+          this.server = createServer();
+          return new Promise((resolve, reject) => {
+            this.server.listen(this.port, err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+          });
+        }
+      }
+    );
+
+    compiler.hooks.done.tap("ServerPlugin", (stats, callback) => {
+      const s = this.server;
+      if (s && --this.refs === 0) {
+        this.server = undefined;
+        s.close(callback);
+      } else {
+        callback();
+      }
+    });
+  }
+}
+
+module.exports = ServerPlugin;


### PR DESCRIPTION
- Re-validate HttpUriPlugin redirects against allowedUris
- Restrict redirects to http(s) protocols only
- Add a conservative redirect limit (5) to prevent SSRF and untrusted content inclusion
- Redirects failing policy are rejected before caching/lockfile writes

This addresses the same security vulnerability that was fixed in webpack commit https://github.com/webpack/webpack/pull/20230

## Summary

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
