### PR TITLE
docs: fix rules[].use example

### DIFF
--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -718,16 +718,18 @@ export default {
       {
         test: /\.svg$/,
         type: 'asset',
-        use: info => ({
-          loader: 'svgo-loader',
-          options: {
-            plugins: [
-              {
-                cleanupIDs: { prefix: basename(info.resource) },
-              },
-            ],
+        use: info => [
+          {
+            loader: 'svgo-loader',
+            options: {
+              plugins: [
+                {
+                  cleanupIDs: { prefix: basename(info.resource) },
+                },
+              ],
+            },
           },
-        }),
+        ],
       },
     ],
   },

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -718,16 +718,18 @@ export default {
       {
         test: /\.svg$/,
         type: 'asset',
-        use: info => ({
-          loader: 'svgo-loader',
-          options: {
-            plugins: [
-              {
-                cleanupIDs: { prefix: basename(info.resource) },
-              },
-            ],
+        use: info => [
+          {
+            loader: 'svgo-loader',
+            options: {
+              plugins: [
+                {
+                  cleanupIDs: { prefix: basename(info.resource) },
+                },
+              ],
+            },
           },
-        }),
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Summary

```ts
  type RuleSetUse =
    | RuleSetUseItem[]
    | RuleSetUseItem
    | ((ctx: RawFuncUseCtx) => RuleSetUseItem[]);
```

When `use` is used as a function it should return `RuleSetUseItem[]` (an array), not a single `RuleSetUseItem`. My understanding, at least with webpack is that each item in the array is expected to have an `ident` set but even webpack does not document that well.

Thanks!

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
