### PR TITLE
chore(ci): support collapsing the CI comment

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -89,7 +89,7 @@ jobs:
         run: RSDOCTOR=true CI=true pnpm run build:cases
 
       - name: Report Compressed Size
-        uses: web-infra-dev/rsdoctor-action@3576edf3ddc2c86c9651d4a916fad68013c4d6cd
+        uses: web-infra-dev/rsdoctor-action@4e57a095c40ff4409c2276a1eac05ec583d15561
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file_path: "../build-tools-performance/**/dist/rsdoctor-data.json"


### PR DESCRIPTION
## Summary
- chore(ci): support collapsing the CI comment
- chore(ci): support finding parent commits when the latest commit does not have a baseline
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
