### PR TITLE
fix: reexports in arrow-only environments without const

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -795,7 +795,9 @@ impl ESMExportImportedSpecifierDependency {
         }
         content += "__rspack_reexport[__rspack_import_key] =";
 
-        if supports_arrow_function {
+        // Arrow getters capture the loop variable by reference.
+        // They are only correct when the loop binding is block-scoped (const/let), not var.
+        if supports_arrow_function && supports_const {
           content += &format!("() => {import_var}[__rspack_import_key]");
         } else {
           content +=


### PR DESCRIPTION
## Summary

When generating re-exports runtime code, arrow function getters were previously emitted based on `supports_arrow_function`.

In environments that support arrow functions but not block-scoped bindings like `const` (for example iOS 10), this causes all reexport getters to capture the same loop variable and produce incorrect exports.

This change ensures arrow getters are only generated when `const` is also supported. Otherwise, it falls back to a function-based getter that safely captures the key per iteration.

## Related links

- https://github.com/web-infra-dev/rspack/pull/12268

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
