### PR TITLE
chore(ci): update windows zstd version

### DIFF
--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           curl -L https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-v1.5.7-win64.zip --output zstd.zip
           unzip zstd.zip
-          mv zstd-v1.5.5-win64/zstd.exe C:/Windows/System32/
+          mv zstd-v1.5.7-win64/zstd.exe C:/Windows/System32/
           # Verify installation
           zstd --version
 


### PR DESCRIPTION
## Summary

This PR introduces performance improvements to the CI cargo cache for storing and restoring using ztsd. More details can be found in the [release notes](https://github.com/facebook/zstd/releases/tag/v1.5.7).

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
