### PR TITLE
fix: parsing arrow function IIFE 

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1070,6 +1070,11 @@ impl JavascriptParser<'_> {
         } else if let Expr::Fn(fn_expr) = &**callee
           && is_simple_function(&fn_expr.function.params)
         {
+          // ((…) => { }(…))
+          self._walk_iife(callee, expr.args.iter().map(|arg| &*arg.expr), None)
+        } else if let Expr::Arrow(arrow_expr) = &**callee
+          && arrow_expr.params.iter().all(|p| p.as_ident().is_some())
+        {
           // (function(…) { }(…))
           self._walk_iife(callee, expr.args.iter().map(|arg| &*arg.expr), None)
         } else {

--- a/tests/rspack-test/configCases/asset-url/target-node3/test.filter.js
+++ b/tests/rspack-test/configCases/asset-url/target-node3/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "TODO: parser walk IIFE not supported" 


### PR DESCRIPTION
## Summary

This PR adds support for parsing arrow function IIFE (Immediately Invoked Function Expression) patterns like `((…) => { }(…))`. Previously, this pattern was not properly handled by the JavaScript parser, causing related tests to be skipped.

The implementation adds a new condition to handle arrow function expressions as IIFE callers when all parameters are simple identifiers, similar to how regular function IIFEs are handled.

Additionally, the test filter that was skipping the `asset-url/target-node3` test case has been removed, as the functionality is now supported.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).