### PR TITLE
docs: add test/include/exclude options for eval source map devtool

### DIFF
--- a/website/docs/en/plugins/webpack/eval-source-map-dev-tool-plugin.mdx
+++ b/website/docs/en/plugins/webpack/eval-source-map-dev-tool-plugin.mdx
@@ -12,6 +12,24 @@ new webpack.EvalSourceMapDevToolPlugin(options);
 
 ## Options
 
+### test
+
+- **Type:** `string` `RegExp` `[string, RegExp]`
+
+Include source maps for modules based on their extension (defaults to `.js`, `.mjs`, and `.css`).
+
+### include
+
+- **Type:** `string` `RegExp` `[string, RegExp]`
+
+Include source maps for module paths that match the given value.
+
+### exclude
+
+- **Type:** `string` `RegExp` `[string, RegExp]`
+
+Exclude modules that match the given value from source map generation.
+
 ### append
 
 - **Type:** `string | function`

--- a/website/docs/zh/plugins/webpack/eval-source-map-dev-tool-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/eval-source-map-dev-tool-plugin.mdx
@@ -12,6 +12,24 @@ new webpack.EvalSourceMapDevToolPlugin(options);
 
 ## 选项
 
+### test
+
+- **类型：** `string` `RegExp` `[string, RegExp]`
+
+根据模块扩展名，匹配的生成 source map（默认是 `.js`、`.mjs` 和 `.css`）。
+
+### include
+
+- **类型：** `string` `RegExp` `[string, RegExp]`
+
+使路径与该值匹配的模块生成 source map。
+
+### exclude
+
+- **类型：** `string` `RegExp` `[string, RegExp]`
+
+使匹配该值的模块不生成 source map。
+
 ### append
 
 - **类型：** `string | function`


### PR DESCRIPTION
## Summary

This PR updates the English and Chinese EvalSourceMapDevToolPlugin docs to document the `test`, `include`, and `exclude` options, keeping them consistent with the SourceMapDevToolPlugin documentation. This makes it clearer how to filter which modules generate source maps when using the eval-based devtool variant.

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).

