### PR TITLE
ci: check formats for doc-only changes

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -94,6 +94,9 @@ jobs:
       - name: Pnpm Install
         uses: ./.github/actions/pnpm/install-dependencies
 
+      - name: Prettier
+        run: pnpm run format-ci:js
+
       - name: Run
         run: |
           cd website


### PR DESCRIPTION
## Summary

Starting from PR https://github.com/web-infra-dev/rspack/pull/12075, the entire repository uses a single shared format command.

As a result, we need to run the formatting check even in doc-only PRs to ensure the documentation formatting is correct.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
