### PR TITLE
test: add retry configuration for CI to reduce flakes

### DIFF
--- a/tests/rspack-test/rstest.config.ts
+++ b/tests/rspack-test/rstest.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
 	],
 	slowTestThreshold: 5000,
   // Retry on CI to reduce flakes
-  retry: process.env.CI ? 3 : 0,
+	retry: process.env.CI ? 3 : 0,
 	resolve: {
 		alias: {
 			// Fixed jest-serialize-path not working when non-ascii code contains.


### PR DESCRIPTION
## Summary

- Add `retry` configuration for CI to reduce flakes
- Remove duplicated `testTimeout` config

## Related links

- https://rstest.rs/config/test/retry#retry

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
