### PR TITLE
fix: SRI plugin runtime module check for Module Federation

### DIFF
--- a/crates/rspack_plugin_sri/src/runtime.rs
+++ b/crates/rspack_plugin_sri/src/runtime.rs
@@ -111,9 +111,7 @@ impl RuntimeModule for SRIHashVariableRuntimeModule {
           .get_chunk_modules(c, &module_graph)
           .iter()
           .any(|m| {
-            let result = compilation
-              .code_generation_results
-              .get(&m.identifier(), None);
+            let result = compilation.code_generation_results.get_one(&m.identifier());
             result.inner.values().any(|v| v.size() != 0)
           })
       })

--- a/tests/rspack-test/configCases/sri/issue-12467/index.js
+++ b/tests/rspack-test/configCases/sri/issue-12467/index.js
@@ -1,0 +1,3 @@
+import { mime } from "./mf-expose";
+
+export { mime };

--- a/tests/rspack-test/configCases/sri/issue-12467/mf-expose.js
+++ b/tests/rspack-test/configCases/sri/issue-12467/mf-expose.js
@@ -1,0 +1,5 @@
+import { lookup } from "mime-types";
+
+export function mime() {
+  return lookup("file.png");
+}

--- a/tests/rspack-test/configCases/sri/issue-12467/rspack.config.js
+++ b/tests/rspack-test/configCases/sri/issue-12467/rspack.config.js
@@ -1,0 +1,38 @@
+const { SubresourceIntegrityPlugin, container } = require("@rspack/core");
+
+module.exports = {
+  mode: 'production',
+  target: ["web", "es2017"],
+  output: {
+    filename: '[name].[contenthash:8].js',
+    chunkFilename: '[name].[contenthash:8].js',
+    assetModuleFilename: '[name].[contenthash:8][ext]',
+    uniqueName: 'main_app',
+    crossOriginLoading: "anonymous"
+  },
+  resolve: {
+    alias: {
+      path: false,
+      "node:path": false
+    }
+  },
+  optimization: {
+    minimize: false,
+    splitChunks: {
+      chunks: 'all',
+    },
+  },
+  performance: false,
+  plugins: [
+    new SubresourceIntegrityPlugin(),
+    new container.ModuleFederationPlugin({
+      name: "main_app",
+      exposes: {
+        "./mf": {
+          import: ["./mf-expose"],
+          name: '__federation_expose_mf'
+        },
+      },
+    })
+  ],
+};

--- a/tests/rspack-test/configCases/sri/issue-12467/test.config.js
+++ b/tests/rspack-test/configCases/sri/issue-12467/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return [];
+	}
+};


### PR DESCRIPTION
## Summary

fix #12467

This PR fixes an issue with the Subresource Integrity (SRI) plugin when used with Module Federation. The plugin was using an incorrect API method (`get()` instead of `get_one()`) to check runtime modules, which could cause incorrect behavior in Module Federation scenarios.

The fix updates the SRI plugin's runtime module check to use the correct `get_one()` method, ensuring proper SRI hash generation for Module Federation chunks.



## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

