### PR TITLE
docs: correct markdown link in infrastructure logging

### DIFF
--- a/website/docs/en/config/infrastructure-logging.mdx
+++ b/website/docs/en/config/infrastructure-logging.mdx
@@ -89,7 +89,7 @@ export default {
 - **Type:** `'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose'`
 - **Default:** `'info'`
 
-Enable infrastructure logging output. Similar to (stats.logging)[/config/stats#statslogging] option but for infrastructure. Defaults to `'info'`.
+Enable infrastructure logging output. Similar to [stats.logging](/config/stats#statslogging) option but for infrastructure. Defaults to `'info'`.
 
 Possible values:
 


### PR DESCRIPTION
## Summary

Fixed the markdown link for `stats.logging` to use proper bracket syntax.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
