### PR TITLE
fix: use default runtime to export default interop and keep empty import for externals

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1064,6 +1064,10 @@ var {} = {{}};
 
               let export_name = if let Some(id) = symbol_binding.ids.first() {
                 required_info.property_access(id, &mut chunk_link.used_names)
+              } else if let Some(default_access) = &required_info.default_access
+                && default_access == &symbol_binding.symbol
+              {
+                required_info.default_exported(&mut chunk_link.used_names)
               } else {
                 symbol_binding.symbol
               };
@@ -1590,6 +1594,11 @@ var {} = {{}};
 
       let mut removed_import_stmts = vec![];
       for (key, specifiers) in &chunk_link.raw_import_stmts {
+        if specifiers.atoms.is_empty() && specifiers.default_import.is_none() {
+          // import 'externals'
+          continue;
+        }
+
         if key.1.is_some() {
           // TODO: optimize import attributes
           continue;

--- a/tests/rspack-test/esmOutputCases/externals/empty-import/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/empty-import/__snapshots__/esm.snap.txt
@@ -1,0 +1,9 @@
+```mjs title=main.mjs
+import "fs";
+
+// fs
+
+// ./index.js
+
+
+```

--- a/tests/rspack-test/esmOutputCases/externals/empty-import/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/empty-import/index.js
@@ -1,0 +1,1 @@
+import 'fs'

--- a/tests/rspack-test/esmOutputCases/externals/empty-import/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/empty-import/rspack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  externals: {
+    fs: "module fs",
+  },
+
+}

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default-type-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default-type-module/__snapshots__/esm.snap.txt
@@ -1,0 +1,81 @@
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+__webpack_require__.add({
+"./foo.cjs"
+/*!*****************!*\
+  !*** ./foo.cjs ***!
+  \*****************/
+(module, __unused_rspack_exports, __webpack_require__) {
+/* module decorator */ module = __webpack_require__.nmd(module);
+function defExports(m) {
+  m.exports = 42
+}
+
+defExports(module)
+
+},
+});
+// ./index.js
+// import default from cjs
+// js/esm: the default is module.exports of cjs
+// js/auto: check __esModule in runtime
+//        if so, module.exports.default, otherwise module.exports
+//        otherwise, module.exports
+
+
+it('should have correct interop for cjs', async () => {
+  const { value } = await import(/*webpackIgnore: true*/ './main.mjs')
+  expect(value).toBe(42)
+})
+const foo = __webpack_require__("./foo.cjs");
+
+export { foo as value };
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+id: moduleId,
+loaded: false,
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Flag the module as loaded
+module.loaded = true;
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// esm library register module runtime
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/node_module_decorator
+(() => {
+__webpack_require__.nmd = (module) => {
+  module.paths = [];
+  if (!module.children) module.children = [];
+  return module;
+};
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default-type-module/foo.cjs
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default-type-module/foo.cjs
@@ -1,0 +1,5 @@
+function defExports(m) {
+  m.exports = 42
+}
+
+defExports(module)

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default-type-module/index.js
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default-type-module/index.js
@@ -1,0 +1,11 @@
+// import default from cjs
+// js/esm: the default is module.exports of cjs
+// js/auto: check __esModule in runtime
+//        if so, module.exports.default, otherwise module.exports
+//        otherwise, module.exports
+export { default as value } from './foo.cjs'
+
+it('should have correct interop for cjs', async () => {
+  const { value } = await import(/*webpackIgnore: true*/ './main.mjs')
+  expect(value).toBe(42)
+})

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default-type-module/package.json
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default-type-module/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default/__snapshots__/esm.snap.txt
@@ -1,0 +1,109 @@
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+__webpack_require__.add({
+"./foo.cjs"
+/*!*****************!*\
+  !*** ./foo.cjs ***!
+  \*****************/
+(module, __unused_rspack_exports, __webpack_require__) {
+/* module decorator */ module = __webpack_require__.nmd(module);
+function defExports(m) {
+  m.exports = 42
+}
+
+defExports(module)
+
+},
+});
+// ./index.js
+// import default from cjs
+// js/esm: the default is module.exports of cjs
+// js/auto: check __esModule in runtime
+//        if so, module.exports.default, otherwise module.exports
+//        otherwise, module.exports
+
+
+it('should have correct interop for cjs', async () => {
+  const { value } = await import(/*webpackIgnore: true*/ './main.mjs')
+  expect(value).toBe(42)
+})
+const foo = __webpack_require__("./foo.cjs");
+var foo_default = /*#__PURE__*/__webpack_require__.n(foo);
+var foo_default_0 = foo_default();
+
+export { foo_default_0 as value };
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+id: moduleId,
+loaded: false,
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Flag the module as loaded
+module.loaded = true;
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// esm library register module runtime
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-ESM modules
+__webpack_require__.n = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, definition) => {
+	for(var key in definition) {
+        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+        }
+    }
+};
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/node_module_decorator
+(() => {
+__webpack_require__.nmd = (module) => {
+  module.paths = [];
+  if (!module.children) module.children = [];
+  return module;
+};
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default/foo.cjs
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default/foo.cjs
@@ -1,0 +1,5 @@
+function defExports(m) {
+  m.exports = 42
+}
+
+defExports(module)

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default/index.js
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default/index.js
@@ -1,0 +1,11 @@
+// import default from cjs
+// js/esm: the default is module.exports of cjs
+// js/auto: check __esModule in runtime
+//        if so, module.exports.default, otherwise module.exports
+//        otherwise, module.exports
+export { default as value } from './foo.cjs'
+
+it('should have correct interop for cjs', async () => {
+  const { value } = await import(/*webpackIgnore: true*/ './main.mjs')
+  expect(value).toBe(42)
+})


### PR DESCRIPTION
## Summary

When export interop default, should invoke the default access runtime.

Keep empty external import

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
