### PR TITLE
fix: include import attributes in context module identifier

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1217,6 +1217,10 @@ fn create_identifier(options: &ContextModuleOptions, resource: Option<&str>) -> 
     ContextNameSpaceObject::Bool(true) => "|namespace object",
     _ => "",
   };
+  if let Some(attributes) = &options.context_options.attributes {
+    id += "|importAttributes: ";
+    id += &serde_json::to_string(attributes).expect("json stringify failed");
+  }
   if let Some(layer) = &options.layer {
     id += "|layer: ";
     id += layer;

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -32,13 +32,18 @@ impl ImportContextDependency {
     value_range: DependencyRange,
     optional: bool,
   ) -> Self {
-    let resource_identifier = create_resource_identifier_for_context_dependency(None, &options);
+    let mut resource_identifier =
+      create_resource_identifier_for_context_dependency(None, &options).to_string();
+    if let Some(attributes) = &options.attributes {
+      resource_identifier
+        .push_str(&serde_json::to_string(attributes).expect("json stringify failed"));
+    }
     Self {
       options,
       range,
       value_range,
       id: DependencyId::new(),
-      resource_identifier,
+      resource_identifier: resource_identifier.into(),
       optional,
       critical: None,
       factorize_info: Default::default(),

--- a/tests/rspack-test/configCases/context-modules/import-attributes/test.filter.js
+++ b/tests/rspack-test/configCases/context-modules/import-attributes/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "TODO: support import with type bytes";


### PR DESCRIPTION
## Summary

This pull request fixes an issue where import attributes were not included in the context module identifier, which could lead to incorrect module resolution and caching behavior. When context modules use import attributes (e.g., `import('./module.json', { with: { type: 'json' } })`), these attributes should be part of the module identifier to ensure different attribute configurations are treated as separate modules.

The fix ensures that import attributes are properly serialized and included in both the context module identifier and the import context dependency resource identifier, allowing rspack to correctly distinguish between context modules with different import attribute configurations.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).