### PR TITLE
refactor: merge rspack_cacheable SerializeError and DeserializeError

### DIFF
--- a/crates/rspack_cacheable/src/deserialize.rs
+++ b/crates/rspack_cacheable/src/deserialize.rs
@@ -5,73 +5,23 @@ use rkyv::{
   api::{deserialize_using, high::HighValidator},
   bytecheck::CheckBytes,
   de::Pool,
-  rancor::{BoxedError, Source, Strategy, Trace},
+  rancor::Strategy,
   util::AlignedVec,
 };
 
-use crate::context::ContextGuard;
+use crate::{
+  context::ContextGuard,
+  error::{Error, Result},
+};
 
-#[derive(Debug)]
-pub enum DeserializeError {
-  BoxedError(BoxedError),
-  MessageError(&'static str),
-  DynCheckBytesNotRegister,
-  NoContext,
-  UnsupportedField,
-}
-
-impl std::fmt::Display for DeserializeError {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match self {
-      Self::BoxedError(error) => error.fmt(f),
-      Self::MessageError(msg) => {
-        write!(f, "{msg}")
-      }
-      Self::DynCheckBytesNotRegister => {
-        write!(f, "cacheable_dyn check bytes not register")
-      }
-      Self::NoContext => {
-        write!(f, "no context")
-      }
-      Self::UnsupportedField => {
-        write!(f, "unsupported field")
-      }
-    }
-  }
-}
-
-impl std::error::Error for DeserializeError {
-  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-    match self {
-      Self::BoxedError(error) => error.source(),
-      _ => None,
-    }
-  }
-}
-
-impl Trace for DeserializeError {
-  fn trace<R>(self, trace: R) -> Self
-  where
-    R: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static,
-  {
-    Self::BoxedError(BoxedError::trace(BoxedError::new(self), trace))
-  }
-}
-
-impl Source for DeserializeError {
-  fn new<T: std::error::Error + Send + Sync + 'static>(source: T) -> Self {
-    Self::BoxedError(BoxedError::new(source))
-  }
-}
-
-pub type Validator<'a> = HighValidator<'a, DeserializeError>;
-pub type Deserializer = Strategy<Pool, DeserializeError>;
+pub type Validator<'a> = HighValidator<'a, Error>;
+pub type Deserializer = Strategy<Pool, Error>;
 
 /// Transform bytes to struct
 ///
 /// This function implementation refers to rkyv::from_bytes and
 /// add custom error and context support
-pub fn from_bytes<T, C: Any>(bytes: &[u8], context: &C) -> Result<T, DeserializeError>
+pub fn from_bytes<T, C: Any>(bytes: &[u8], context: &C) -> Result<T>
 where
   T: Archive,
   T::Archived: for<'a> CheckBytes<Validator<'a>> + Deserialize<T, Deserializer>,
@@ -85,7 +35,7 @@ where
   let mut aligned_vec = AlignedVec::<16>::new();
   aligned_vec.extend_from_slice(bytes);
   deserialize_using(
-    access::<T::Archived, DeserializeError>(&aligned_vec)?,
+    access::<T::Archived, Error>(&aligned_vec)?,
     &mut deserializer,
   )
 }

--- a/crates/rspack_cacheable/src/dyn/mod.rs
+++ b/crates/rspack_cacheable/src/dyn/mod.rs
@@ -18,19 +18,19 @@ mod vtable_ptr;
 
 pub use vtable_ptr::VTablePtr;
 
-use crate::{DeserializeError, Deserializer, SerializeError, Serializer};
+use crate::{Deserializer, Result, Serializer};
 
 /// A trait object that can be archived.
 pub trait SerializeDyn {
   /// Writes the value to the serializer and returns the position it was written to.
-  fn serialize_dyn(&self, serializer: &mut Serializer) -> Result<usize, SerializeError>;
+  fn serialize_dyn(&self, serializer: &mut Serializer) -> Result<usize>;
 }
 
 impl<T> SerializeDyn for T
 where
   T: for<'a> SerializeUnsized<Serializer<'a>>,
 {
-  fn serialize_dyn(&self, serializer: &mut Serializer) -> Result<usize, SerializeError> {
+  fn serialize_dyn(&self, serializer: &mut Serializer) -> Result<usize> {
     self.serialize_unsized(serializer)
   }
 }
@@ -40,11 +40,7 @@ where
 /// See [`SerializeDyn`] for more information.
 pub trait DeserializeDyn<T: Pointee + ?Sized> {
   /// Deserializes this value into the given out pointer.
-  fn deserialize_dyn(
-    &self,
-    deserializer: &mut Deserializer,
-    out: *mut T,
-  ) -> Result<(), DeserializeError>;
+  fn deserialize_dyn(&self, deserializer: &mut Deserializer, out: *mut T) -> Result<()>;
 
   /// Returns the pointer metadata for the deserialized form of this type.
   fn deserialized_pointer_metadata(&self) -> DynMetadata<T>;

--- a/crates/rspack_cacheable/src/dyn/validation.rs
+++ b/crates/rspack_cacheable/src/dyn/validation.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use rkyv::bytecheck::CheckBytes;
 
 use super::VTablePtr;
-use crate::{DeserializeError, Validator};
+use crate::{Result, Validator};
 
-type CheckBytesDyn = unsafe fn(*const u8, &mut Validator<'_>) -> Result<(), DeserializeError>;
+type CheckBytesDyn = unsafe fn(*const u8, &mut Validator<'_>) -> Result<()>;
 
 /// # Safety
 ///
@@ -13,7 +13,7 @@ type CheckBytesDyn = unsafe fn(*const u8, &mut Validator<'_>) -> Result<(), Dese
 pub unsafe fn default_check_bytes_dyn<T>(
   bytes: *const u8,
   context: &mut Validator<'_>,
-) -> Result<(), DeserializeError>
+) -> Result<()>
 where
   T: for<'a> CheckBytes<Validator<'a>>,
 {

--- a/crates/rspack_cacheable/src/error.rs
+++ b/crates/rspack_cacheable/src/error.rs
@@ -1,0 +1,56 @@
+use rkyv::rancor::{BoxedError, Source, Trace};
+
+#[derive(Debug)]
+pub enum Error {
+  BoxedError(BoxedError),
+  MessageError(&'static str),
+  DynCheckBytesNotRegister,
+  NoContext,
+  UnsupportedField,
+}
+
+impl std::fmt::Display for Error {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::BoxedError(error) => error.fmt(f),
+      Self::MessageError(msg) => {
+        write!(f, "{msg}")
+      }
+      Self::DynCheckBytesNotRegister => {
+        write!(f, "cacheable_dyn check bytes not register")
+      }
+      Self::NoContext => {
+        write!(f, "no context")
+      }
+      Self::UnsupportedField => {
+        write!(f, "unsupported field")
+      }
+    }
+  }
+}
+
+impl std::error::Error for Error {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    match self {
+      Self::BoxedError(error) => error.source(),
+      _ => None,
+    }
+  }
+}
+
+impl Trace for Error {
+  fn trace<R>(self, trace: R) -> Self
+  where
+    R: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static,
+  {
+    Self::BoxedError(BoxedError::trace(BoxedError::new(self), trace))
+  }
+}
+
+impl Source for Error {
+  fn new<T: std::error::Error + Send + Sync + 'static>(source: T) -> Self {
+    Self::BoxedError(BoxedError::new(source))
+  }
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/rspack_cacheable/src/lib.rs
+++ b/crates/rspack_cacheable/src/lib.rs
@@ -15,6 +15,7 @@ pub mod with;
 
 mod context;
 mod deserialize;
+mod error;
 mod serialize;
 
 #[doc(hidden)]
@@ -28,7 +29,7 @@ pub mod __private {
 #[cfg(not(feature = "noop"))]
 pub use deserialize::from_bytes;
 #[cfg(feature = "noop")]
-pub fn from_bytes<T, C: std::any::Any>(_bytes: &[u8], _context: &C) -> Result<T, DeserializeError> {
+pub fn from_bytes<T, C: std::any::Any>(_bytes: &[u8], _context: &C) -> Result<T> {
   let _ = deserialize::from_bytes::<u8, u8>;
   panic!("Cannot use from_bytes when noop feature is enabled")
 }
@@ -36,11 +37,12 @@ pub fn from_bytes<T, C: std::any::Any>(_bytes: &[u8], _context: &C) -> Result<T,
 #[cfg(not(feature = "noop"))]
 pub use serialize::to_bytes;
 #[cfg(feature = "noop")]
-pub fn to_bytes<T, C: std::any::Any>(_value: &T, _ctx: &C) -> Result<Vec<u8>, SerializeError> {
+pub fn to_bytes<T, C: std::any::Any>(_value: &T, _ctx: &C) -> Result<Vec<u8>> {
   let _ = serialize::to_bytes::<u8, u8>;
   panic!("Cannot use to_bytes when noop feature is enabled")
 }
 
-pub use deserialize::{DeserializeError, Deserializer, Validator};
-pub use serialize::{SerializeError, Serializer};
+pub use deserialize::{Deserializer, Validator};
+pub use error::{Error, Result};
+pub use serialize::Serializer;
 pub use xxhash_rust;

--- a/crates/rspack_cacheable/src/serialize.rs
+++ b/crates/rspack_cacheable/src/serialize.rs
@@ -3,7 +3,6 @@ use std::any::Any;
 use rkyv::{
   Serialize,
   api::{high::HighSerializer, serialize_using},
-  rancor::{BoxedError, Source, Trace},
   ser::{
     Serializer as RkyvSerializer,
     allocator::{Arena, ArenaHandle},
@@ -12,64 +11,18 @@ use rkyv::{
   util::AlignedVec,
 };
 
-use crate::context::ContextGuard;
+use crate::{
+  context::ContextGuard,
+  error::{Error, Result},
+};
 
-#[derive(Debug)]
-pub enum SerializeError {
-  BoxedError(BoxedError),
-  MessageError(&'static str),
-  NoContext,
-  UnsupportedField,
-}
-
-impl std::fmt::Display for SerializeError {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match self {
-      Self::BoxedError(error) => error.fmt(f),
-      Self::MessageError(msg) => {
-        write!(f, "{msg}")
-      }
-      Self::NoContext => {
-        write!(f, "no context")
-      }
-      Self::UnsupportedField => {
-        write!(f, "unsupported field")
-      }
-    }
-  }
-}
-
-impl std::error::Error for SerializeError {
-  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-    match self {
-      Self::BoxedError(error) => error.source(),
-      _ => None,
-    }
-  }
-}
-
-impl Trace for SerializeError {
-  fn trace<R>(self, trace: R) -> Self
-  where
-    R: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static,
-  {
-    Self::BoxedError(BoxedError::trace(BoxedError::new(self), trace))
-  }
-}
-
-impl Source for SerializeError {
-  fn new<T: std::error::Error + Send + Sync + 'static>(source: T) -> Self {
-    Self::BoxedError(BoxedError::new(source))
-  }
-}
-
-pub type Serializer<'a> = HighSerializer<AlignedVec, ArenaHandle<'a>, SerializeError>;
+pub type Serializer<'a> = HighSerializer<AlignedVec, ArenaHandle<'a>, Error>;
 
 /// Transform struct to bytes
 ///
 /// This function implementation refers to rkyv::to_bytes and
 /// add custom error and context support
-pub fn to_bytes<T, C: Any>(value: &T, ctx: &C) -> Result<Vec<u8>, SerializeError>
+pub fn to_bytes<T, C: Any>(value: &T, ctx: &C) -> Result<Vec<u8>>
 where
   T: for<'a> Serialize<Serializer<'a>>,
 {

--- a/crates/rspack_cacheable/src/with/as.rs
+++ b/crates/rspack_cacheable/src/with/as.rs
@@ -8,13 +8,13 @@ use rkyv::{
   with::{ArchiveWith, DeserializeWith, SerializeWith},
 };
 
-use crate::{DeserializeError, SerializeError, context::ContextGuard};
+use crate::{Error, Result, context::ContextGuard};
 
 pub trait AsConverter<T> {
-  fn serialize(data: &T, ctx: &dyn Any) -> Result<Self, SerializeError>
+  fn serialize(data: &T, ctx: &dyn Any) -> Result<Self>
   where
     Self: Sized;
-  fn deserialize(self, ctx: &dyn Any) -> Result<T, DeserializeError>;
+  fn deserialize(self, ctx: &dyn Any) -> Result<T>;
 }
 
 pub struct As<A> {
@@ -43,10 +43,10 @@ where
 impl<T, A, S> SerializeWith<T, S> for As<A>
 where
   A: AsConverter<T> + Archive + Serialize<S>,
-  S: Fallible<Error = SerializeError> + Sharing + ?Sized,
+  S: Fallible<Error = Error> + Sharing + ?Sized,
 {
   #[inline]
-  fn serialize_with(field: &T, serializer: &mut S) -> Result<Self::Resolver, SerializeError> {
+  fn serialize_with(field: &T, serializer: &mut S) -> Result<Self::Resolver> {
     let ctx = ContextGuard::sharing_context(serializer)?;
     let value = <A as AsConverter<T>>::serialize(field, ctx)?;
     Ok(AsResolver {
@@ -60,10 +60,10 @@ impl<T, A, D> DeserializeWith<Archived<A>, T, D> for As<A>
 where
   A: AsConverter<T> + Archive,
   A::Archived: Deserialize<A, D>,
-  D: Fallible<Error = DeserializeError> + Pooling + ?Sized,
+  D: Fallible<Error = Error> + Pooling + ?Sized,
 {
   #[inline]
-  fn deserialize_with(field: &Archived<A>, de: &mut D) -> Result<T, DeserializeError> {
+  fn deserialize_with(field: &Archived<A>, de: &mut D) -> Result<T> {
     let field = A::Archived::deserialize(field, de)?;
     let ctx = ContextGuard::pooling_context(de)?;
     field.deserialize(ctx)

--- a/crates/rspack_cacheable/src/with/as_preset/json.rs
+++ b/crates/rspack_cacheable/src/with/as_preset/json.rs
@@ -8,7 +8,7 @@ use rkyv::{
 };
 
 use super::AsPreset;
-use crate::{DeserializeError, SerializeError};
+use crate::{Error, Result};
 
 pub struct JsonResolver {
   inner: StringResolver,
@@ -28,13 +28,10 @@ impl ArchiveWith<JsonValue> for AsPreset {
 
 impl<S> SerializeWith<JsonValue, S> for AsPreset
 where
-  S: Fallible<Error = SerializeError> + Writer,
+  S: Fallible<Error = Error> + Writer,
 {
   #[inline]
-  fn serialize_with(
-    field: &JsonValue,
-    serializer: &mut S,
-  ) -> Result<Self::Resolver, SerializeError> {
+  fn serialize_with(field: &JsonValue, serializer: &mut S) -> Result<Self::Resolver> {
     let value = json::stringify(field.clone());
     let inner = ArchivedString::serialize_from_str(&value, serializer)?;
     Ok(JsonResolver { value, inner })
@@ -43,10 +40,10 @@ where
 
 impl<D> DeserializeWith<ArchivedString, JsonValue, D> for AsPreset
 where
-  D: Fallible<Error = DeserializeError>,
+  D: Fallible<Error = Error>,
 {
   #[inline]
-  fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<JsonValue, DeserializeError> {
-    json::parse(field).map_err(|_| DeserializeError::MessageError("deserialize json value failed"))
+  fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<JsonValue> {
+    json::parse(field).map_err(|_| Error::MessageError("deserialize json value failed"))
   }
 }

--- a/crates/rspack_cacheable/src/with/as_preset/lightningcss.rs
+++ b/crates/rspack_cacheable/src/with/as_preset/lightningcss.rs
@@ -8,7 +8,7 @@ use rkyv::{
 };
 
 use super::AsPreset;
-use crate::{DeserializeError, SerializeError};
+use crate::{Error, Result};
 
 pub struct BrowsersResolver {
   inner: StringResolver,
@@ -28,15 +28,12 @@ impl ArchiveWith<Browsers> for AsPreset {
 
 impl<S> SerializeWith<Browsers, S> for AsPreset
 where
-  S: Fallible<Error = SerializeError> + Writer,
+  S: Fallible<Error = Error> + Writer,
 {
   #[inline]
-  fn serialize_with(
-    field: &Browsers,
-    serializer: &mut S,
-  ) -> Result<Self::Resolver, SerializeError> {
+  fn serialize_with(field: &Browsers, serializer: &mut S) -> Result<Self::Resolver> {
     let value = serde_json::to_string(field)
-      .map_err(|_| SerializeError::MessageError("serialize serde_json value failed"))?;
+      .map_err(|_| Error::MessageError("serialize serde_json value failed"))?;
     let inner = ArchivedString::serialize_from_str(&value, serializer)?;
     Ok(BrowsersResolver { value, inner })
   }
@@ -44,13 +41,10 @@ where
 
 impl<D> DeserializeWith<ArchivedString, Browsers, D> for AsPreset
 where
-  D: Fallible<Error = DeserializeError>,
+  D: Fallible<Error = Error>,
 {
-  fn deserialize_with(
-    field: &ArchivedString,
-    _deserializer: &mut D,
-  ) -> Result<Browsers, DeserializeError> {
+  fn deserialize_with(field: &ArchivedString, _deserializer: &mut D) -> Result<Browsers> {
     serde_json::from_str(field.as_str())
-      .map_err(|_| DeserializeError::MessageError("deserialize serde_json value failed"))
+      .map_err(|_| Error::MessageError("deserialize serde_json value failed"))
   }
 }

--- a/crates/rspack_cacheable/src/with/as_preset/serde_json.rs
+++ b/crates/rspack_cacheable/src/with/as_preset/serde_json.rs
@@ -8,7 +8,7 @@ use rkyv::{
 use serde_json::{Map, Value};
 
 use super::AsPreset;
-use crate::{DeserializeError, SerializeError};
+use crate::{Error, Result};
 
 pub struct SerdeJsonResolver {
   inner: StringResolver,
@@ -29,12 +29,12 @@ impl ArchiveWith<Value> for AsPreset {
 
 impl<S> SerializeWith<Value, S> for AsPreset
 where
-  S: Fallible<Error = SerializeError> + Writer,
+  S: Fallible<Error = Error> + Writer,
 {
   #[inline]
-  fn serialize_with(field: &Value, serializer: &mut S) -> Result<Self::Resolver, SerializeError> {
+  fn serialize_with(field: &Value, serializer: &mut S) -> Result<Self::Resolver> {
     let value = serde_json::to_string(field)
-      .map_err(|_| SerializeError::MessageError("serialize serde_json value failed"))?;
+      .map_err(|_| Error::MessageError("serialize serde_json value failed"))?;
     let inner = ArchivedString::serialize_from_str(&value, serializer)?;
     Ok(SerdeJsonResolver { value, inner })
   }
@@ -42,12 +42,12 @@ where
 
 impl<D> DeserializeWith<ArchivedString, Value, D> for AsPreset
 where
-  D: Fallible<Error = DeserializeError>,
+  D: Fallible<Error = Error>,
 {
   #[inline]
-  fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<Value, DeserializeError> {
+  fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<Value> {
     serde_json::from_str(field)
-      .map_err(|_| DeserializeError::MessageError("deserialize serde_json value failed"))
+      .map_err(|_| Error::MessageError("deserialize serde_json value failed"))
   }
 }
 
@@ -69,15 +69,12 @@ impl ArchiveWith<Map<String, Value>> for AsPreset {
 
 impl<S> SerializeWith<Map<String, Value>, S> for AsPreset
 where
-  S: Fallible<Error = SerializeError> + Writer,
+  S: Fallible<Error = Error> + Writer,
 {
   #[inline]
-  fn serialize_with(
-    field: &Map<String, Value>,
-    serializer: &mut S,
-  ) -> Result<Self::Resolver, SerializeError> {
+  fn serialize_with(field: &Map<String, Value>, serializer: &mut S) -> Result<Self::Resolver> {
     let value = serde_json::to_string(field)
-      .map_err(|_| SerializeError::MessageError("serialize serde_json value failed"))?;
+      .map_err(|_| Error::MessageError("serialize serde_json value failed"))?;
     let inner = ArchivedString::serialize_from_str(&value, serializer)?;
     Ok(SerdeJsonResolver { value, inner })
   }
@@ -85,14 +82,11 @@ where
 
 impl<D> DeserializeWith<ArchivedString, Map<String, Value>, D> for AsPreset
 where
-  D: Fallible<Error = DeserializeError>,
+  D: Fallible<Error = Error>,
 {
   #[inline]
-  fn deserialize_with(
-    field: &ArchivedString,
-    _: &mut D,
-  ) -> Result<Map<String, Value>, DeserializeError> {
+  fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<Map<String, Value>> {
     serde_json::from_str(field)
-      .map_err(|_| DeserializeError::MessageError("deserialize serde_json value failed"))
+      .map_err(|_| Error::MessageError("deserialize serde_json value failed"))
   }
 }

--- a/crates/rspack_cacheable/src/with/as_string.rs
+++ b/crates/rspack_cacheable/src/with/as_string.rs
@@ -6,13 +6,13 @@ use rkyv::{
   with::{ArchiveWith, DeserializeWith, SerializeWith},
 };
 
-use crate::{DeserializeError, SerializeError};
+use crate::{Error, Result};
 
 pub struct AsString;
 
 pub trait AsStringConverter {
-  fn to_string(&self) -> Result<String, SerializeError>;
-  fn from_str(s: &str) -> Result<Self, DeserializeError>
+  fn to_string(&self) -> Result<String>;
+  fn from_str(s: &str) -> Result<Self>
   where
     Self: Sized;
 }
@@ -39,10 +39,10 @@ where
 impl<T, S> SerializeWith<T, S> for AsString
 where
   T: AsStringConverter,
-  S: Fallible<Error = SerializeError> + Writer + ?Sized,
+  S: Fallible<Error = Error> + Writer + ?Sized,
 {
   #[inline]
-  fn serialize_with(field: &T, serializer: &mut S) -> Result<Self::Resolver, SerializeError> {
+  fn serialize_with(field: &T, serializer: &mut S) -> Result<Self::Resolver> {
     let value = field.to_string()?;
     let inner = ArchivedString::serialize_from_str(&value, serializer)?;
     Ok(AsStringResolver { value, inner })
@@ -52,10 +52,10 @@ where
 impl<T, D> DeserializeWith<ArchivedString, T, D> for AsString
 where
   T: AsStringConverter,
-  D: Fallible<Error = DeserializeError> + ?Sized,
+  D: Fallible<Error = Error> + ?Sized,
 {
   #[inline]
-  fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<T, DeserializeError> {
+  fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<T> {
     AsStringConverter::from_str(field.as_str())
   }
 }
@@ -63,10 +63,10 @@ where
 // for pathbuf
 use std::path::PathBuf;
 impl AsStringConverter for PathBuf {
-  fn to_string(&self) -> Result<String, SerializeError> {
+  fn to_string(&self) -> Result<String> {
     Ok(self.to_string_lossy().to_string())
   }
-  fn from_str(s: &str) -> Result<Self, DeserializeError>
+  fn from_str(s: &str) -> Result<Self>
   where
     Self: Sized,
   {

--- a/crates/rspack_cacheable/src/with/unsupported.rs
+++ b/crates/rspack_cacheable/src/with/unsupported.rs
@@ -4,7 +4,7 @@ use rkyv::{
   with::{ArchiveWith, DeserializeWith, SerializeWith},
 };
 
-use crate::{DeserializeError, SerializeError};
+use crate::{Error, Result};
 
 pub struct Unsupported;
 
@@ -17,18 +17,18 @@ impl<F> ArchiveWith<F> for Unsupported {
 
 impl<F, S> SerializeWith<F, S> for Unsupported
 where
-  S: Fallible<Error = SerializeError> + ?Sized,
+  S: Fallible<Error = Error> + ?Sized,
 {
-  fn serialize_with(_: &F, _: &mut S) -> Result<(), SerializeError> {
-    Err(SerializeError::UnsupportedField)
+  fn serialize_with(_: &F, _: &mut S) -> Result<()> {
+    Err(Error::UnsupportedField)
   }
 }
 
 impl<F, D> DeserializeWith<(), F, D> for Unsupported
 where
-  D: Fallible<Error = DeserializeError> + ?Sized,
+  D: Fallible<Error = Error> + ?Sized,
 {
-  fn deserialize_with(_: &(), _: &mut D) -> Result<F, DeserializeError> {
-    Err(DeserializeError::UnsupportedField)
+  fn deserialize_with(_: &(), _: &mut D) -> Result<F> {
+    Err(Error::UnsupportedField)
   }
 }

--- a/crates/rspack_cacheable_macros/src/cacheable/impl.rs
+++ b/crates/rspack_cacheable_macros/src/cacheable/impl.rs
@@ -63,14 +63,14 @@ pub fn impl_cacheable(tokens: TokenStream, args: CacheableArgs) -> TokenStream {
   let bounds = if visitor.omit_bounds {
     quote! {
         #[rkyv(serialize_bounds(
-            __S: #crate_path::__private::rkyv::ser::Writer + #crate_path::__private::rkyv::ser::Allocator + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::SerializeError>,
+            __S: #crate_path::__private::rkyv::ser::Writer + #crate_path::__private::rkyv::ser::Allocator + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::Error>,
         ))]
         #[rkyv(deserialize_bounds(
-            __D: #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::DeserializeError>
+            __D: #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::Error>
         ))]
         #[rkyv(bytecheck(
             bounds(
-                __C: #crate_path::__private::rkyv::validation::ArchiveContext + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::DeserializeError>,
+                __C: #crate_path::__private::rkyv::validation::ArchiveContext + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::Error>,
             )
         ))]
     }

--- a/crates/rspack_cacheable_macros/src/cacheable_dyn.rs
+++ b/crates/rspack_cacheable_macros/src/cacheable_dyn.rs
@@ -43,7 +43,7 @@ pub fn impl_trait(mut input: ItemTrait) -> TokenStream {
             };
             use rspack_cacheable::{
                 r#dyn::{validation::CHECK_BYTES_REGISTRY, ArchivedDynMetadata, DeserializeDyn, VTablePtr},
-                DeserializeError, Deserializer, SerializeError, Serializer, Validator,
+                Error, Deserializer, Serializer, Validator,
             };
 
             unsafe impl #impl_generics ptr_meta::Pointee for dyn #trait_ident #ty_generics #where_clause {
@@ -70,7 +70,7 @@ pub fn impl_trait(mut input: ItemTrait) -> TokenStream {
                 fn serialize_unsized(
                     &self,
                     serializer: &mut Serializer
-                ) -> Result<usize, SerializeError> {
+                ) -> Result<usize, Error> {
                     self.serialize_dyn(serializer)
                 }
             }
@@ -98,7 +98,7 @@ pub fn impl_trait(mut input: ItemTrait) -> TokenStream {
                     &self,
                     deserializer: &mut Deserializer,
                     out: *mut dyn #trait_ident #ty_generics
-                ) -> Result<(), DeserializeError> {
+                ) -> Result<(), Error> {
                     self.deserialize_dyn(deserializer, out)
                 }
 
@@ -121,13 +121,13 @@ pub fn impl_trait(mut input: ItemTrait) -> TokenStream {
                 unsafe fn check_bytes(
                     value: *const Self,
                     context: &mut Validator,
-                ) -> Result<(), DeserializeError> {
+                ) -> Result<(), Error> {
                     let vtable = VTablePtr::new(ptr_meta::metadata(value));
                     if let Some(check_bytes_dyn) = CHECK_BYTES_REGISTRY.get(&vtable) {
                         check_bytes_dyn(value.cast(), context)?;
                         Ok(())
                     } else {
-                        Err(DeserializeError::DynCheckBytesNotRegister)
+                        Err(Error::DynCheckBytesNotRegister)
                     }
                 }
             }
@@ -200,7 +200,7 @@ pub fn impl_impl(mut input: ItemImpl) -> TokenStream {
                   validation::{default_check_bytes_dyn, CheckBytesEntry},
                   DeserializeDyn, DynEntry, VTablePtr,
               },
-              DeserializeError, Deserializer,
+              Error, Deserializer,
           };
 
           const fn get_vtable() -> VTablePtr {
@@ -219,7 +219,7 @@ pub fn impl_impl(mut input: ItemImpl) -> TokenStream {
                   &self,
                   deserializer: &mut Deserializer,
                   out: *mut dyn #trait_ident
-              ) -> Result<(), DeserializeError> {
+              ) -> Result<(), Error> {
                   unsafe {
                       <Self as DeserializeUnsized<#target_ident, _>>::deserialize_unsized(self, deserializer, out.cast())
                   }

--- a/crates/rspack_cacheable_test/tests/context.rs
+++ b/crates/rspack_cacheable_test/tests/context.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, sync::Arc};
 
 use rspack_cacheable::{
-  DeserializeError, SerializeError, enable_cacheable as cacheable, from_bytes, to_bytes,
+  Error, enable_cacheable as cacheable, from_bytes, to_bytes,
   with::{As, AsConverter},
 };
 
@@ -19,12 +19,12 @@ struct Context {
 struct FromContext;
 
 impl AsConverter<Arc<CompilerOptions>> for FromContext {
-  fn serialize(_data: &Arc<CompilerOptions>, _ctx: &dyn Any) -> Result<Self, SerializeError> {
+  fn serialize(_data: &Arc<CompilerOptions>, _ctx: &dyn Any) -> Result<Self, Error> {
     Ok(FromContext)
   }
-  fn deserialize(self, ctx: &dyn Any) -> Result<Arc<CompilerOptions>, DeserializeError> {
+  fn deserialize(self, ctx: &dyn Any) -> Result<Arc<CompilerOptions>, Error> {
     let Some(ctx) = ctx.downcast_ref::<Context>() else {
-      return Err(DeserializeError::MessageError("context not match"));
+      return Err(Error::MessageError("context not match"));
     };
     Ok(ctx.option.clone())
   }
@@ -52,7 +52,7 @@ fn test_context() {
 
   assert!(matches!(
     from_bytes::<Module, ()>(&bytes, &()),
-    Err(DeserializeError::MessageError("context not match"))
+    Err(Error::MessageError("context not match"))
   ));
   let new_module: Module = from_bytes(&bytes, &context).unwrap();
   assert_eq!(module, new_module);

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable/omit_bounds.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable/omit_bounds.rs
@@ -9,14 +9,14 @@ use rspack_cacheable::{from_bytes, to_bytes, with::AsMap};
 )]
 #[rkyv(crate=rspack_cacheable::__private::rkyv)]
 #[rkyv(serialize_bounds(
-    __S: rspack_cacheable::__private::rkyv::ser::Writer + rspack_cacheable::__private::rkyv::ser::Allocator + rspack_cacheable::__private::rkyv::rancor::Fallible<Error = rspack_cacheable::SerializeError>,
+    __S: rspack_cacheable::__private::rkyv::ser::Writer + rspack_cacheable::__private::rkyv::ser::Allocator + rspack_cacheable::__private::rkyv::rancor::Fallible<Error = rspack_cacheable::Error>,
   ))]
 #[rkyv(deserialize_bounds(
-      __D: rspack_cacheable::__private::rkyv::rancor::Fallible<Error = rspack_cacheable::DeserializeError>
+      __D: rspack_cacheable::__private::rkyv::rancor::Fallible<Error = rspack_cacheable::Error>
     ))]
 #[rkyv(bytecheck(
     bounds(
-        __C: rspack_cacheable::__private::rkyv::validation::ArchiveContext + rspack_cacheable::__private::rkyv::rancor::Fallible<Error = rspack_cacheable::DeserializeError>,
+        __C: rspack_cacheable::__private::rkyv::validation::ArchiveContext + rspack_cacheable::__private::rkyv::rancor::Fallible<Error = rspack_cacheable::Error>,
     )
   ))]
 #[derive(Debug, Clone)]

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
@@ -23,7 +23,7 @@ fn test_manual_cacheable_dyn_macro() {
         ptr_meta,
         traits::{ArchivePointee, LayoutRaw},
       },
-      DeserializeError, Deserializer, SerializeError, Serializer, Validator,
+      Deserializer, Error, Serializer, Validator,
       r#dyn::{ArchivedDynMetadata, DeserializeDyn, validation::CHECK_BYTES_REGISTRY},
     };
 
@@ -48,7 +48,7 @@ fn test_manual_cacheable_dyn_macro() {
     }
 
     impl SerializeUnsized<Serializer<'_>> for dyn Animal {
-      fn serialize_unsized(&self, serializer: &mut Serializer) -> Result<usize, SerializeError> {
+      fn serialize_unsized(&self, serializer: &mut Serializer) -> Result<usize, Error> {
         self.serialize_dyn(serializer)
       }
     }
@@ -75,7 +75,7 @@ fn test_manual_cacheable_dyn_macro() {
         &self,
         deserializer: &mut Deserializer,
         out: *mut dyn Animal,
-      ) -> Result<(), DeserializeError> {
+      ) -> Result<(), Error> {
         self.deserialize_dyn(deserializer, out)
       }
 
@@ -95,16 +95,13 @@ fn test_manual_cacheable_dyn_macro() {
     // CheckBytes
     unsafe impl CheckBytes<Validator<'_>> for dyn DeserializeAnimal {
       #[inline]
-      unsafe fn check_bytes(
-        value: *const Self,
-        context: &mut Validator,
-      ) -> Result<(), DeserializeError> {
+      unsafe fn check_bytes(value: *const Self, context: &mut Validator) -> Result<(), Error> {
         let vtable = VTablePtr::new(ptr_meta::metadata(value));
         if let Some(check_bytes_dyn) = CHECK_BYTES_REGISTRY.get(&vtable) {
           unsafe { check_bytes_dyn(value.cast(), context)? };
           Ok(())
         } else {
-          Err(DeserializeError::DynCheckBytesNotRegister)
+          Err(Error::DynCheckBytesNotRegister)
         }
       }
     }
@@ -137,7 +134,7 @@ fn test_manual_cacheable_dyn_macro() {
         inventory,
         rkyv::{ArchiveUnsized, Archived, Deserialize, DeserializeUnsized, ptr_meta},
       },
-      DeserializeError, Deserializer,
+      Deserializer, Error,
       r#dyn::{
         DeserializeDyn, DynEntry,
         validation::{CheckBytesEntry, default_check_bytes_dyn},
@@ -160,7 +157,7 @@ fn test_manual_cacheable_dyn_macro() {
         &self,
         deserializer: &mut Deserializer,
         out: *mut dyn Animal,
-      ) -> Result<(), DeserializeError> {
+      ) -> Result<(), Error> {
         unsafe {
           <Self as DeserializeUnsized<Dog, _>>::deserialize_unsized(self, deserializer, out.cast())
         }
@@ -199,7 +196,7 @@ fn test_manual_cacheable_dyn_macro() {
         inventory,
         rkyv::{ArchiveUnsized, Archived, Deserialize, DeserializeUnsized, ptr_meta},
       },
-      DeserializeError, Deserializer,
+      Deserializer, Error,
       r#dyn::{
         DeserializeDyn, DynEntry,
         validation::{CheckBytesEntry, default_check_bytes_dyn},
@@ -222,7 +219,7 @@ fn test_manual_cacheable_dyn_macro() {
         &self,
         deserializer: &mut Deserializer,
         out: *mut dyn Animal,
-      ) -> Result<(), DeserializeError> {
+      ) -> Result<(), Error> {
         unsafe {
           <Self as DeserializeUnsized<Cat, _>>::deserialize_unsized(self, deserializer, out.cast())
         }

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
@@ -23,7 +23,7 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
         ptr_meta,
         traits::{ArchivePointee, LayoutRaw},
       },
-      DeserializeError, Deserializer, SerializeError, Serializer, Validator,
+      Deserializer, Error, Serializer, Validator,
       r#dyn::{ArchivedDynMetadata, DeserializeDyn, validation::CHECK_BYTES_REGISTRY},
     };
 
@@ -48,7 +48,7 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
     }
 
     impl<T> SerializeUnsized<Serializer<'_>> for dyn Animal<T> {
-      fn serialize_unsized(&self, serializer: &mut Serializer) -> Result<usize, SerializeError> {
+      fn serialize_unsized(&self, serializer: &mut Serializer) -> Result<usize, Error> {
         self.serialize_dyn(serializer)
       }
     }
@@ -75,7 +75,7 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
         &self,
         deserializer: &mut Deserializer,
         out: *mut dyn Animal<T>,
-      ) -> Result<(), DeserializeError> {
+      ) -> Result<(), Error> {
         self.deserialize_dyn(deserializer, out)
       }
 
@@ -95,16 +95,13 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
     // CheckBytes
     unsafe impl<T> CheckBytes<Validator<'_>> for dyn DeserializeAnimal<T> {
       #[inline]
-      unsafe fn check_bytes(
-        value: *const Self,
-        context: &mut Validator,
-      ) -> Result<(), DeserializeError> {
+      unsafe fn check_bytes(value: *const Self, context: &mut Validator) -> Result<(), Error> {
         let vtable = VTablePtr::new(ptr_meta::metadata(value));
         if let Some(check_bytes_dyn) = CHECK_BYTES_REGISTRY.get(&vtable) {
           unsafe { check_bytes_dyn(value.cast(), context)? };
           Ok(())
         } else {
-          Err(DeserializeError::DynCheckBytesNotRegister)
+          Err(Error::DynCheckBytesNotRegister)
         }
       }
     }
@@ -136,7 +133,7 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
         inventory,
         rkyv::{ArchiveUnsized, Archived, Deserialize, DeserializeUnsized, ptr_meta},
       },
-      DeserializeError, Deserializer,
+      Deserializer, Error,
       r#dyn::{
         DeserializeDyn, DynEntry,
         validation::{CheckBytesEntry, default_check_bytes_dyn},
@@ -158,7 +155,7 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
         &self,
         deserializer: &mut Deserializer,
         out: *mut dyn Animal<&'static str>,
-      ) -> Result<(), DeserializeError> {
+      ) -> Result<(), Error> {
         unsafe {
           <Self as DeserializeUnsized<Dog, _>>::deserialize_unsized(self, deserializer, out.cast())
         }
@@ -196,7 +193,7 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
         inventory,
         rkyv::{ArchiveUnsized, Archived, Deserialize, DeserializeUnsized, ptr_meta},
       },
-      DeserializeError, Deserializer,
+      Deserializer, Error,
       r#dyn::{
         DeserializeDyn, DynEntry,
         validation::{CheckBytesEntry, default_check_bytes_dyn},
@@ -218,7 +215,7 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
         &self,
         deserializer: &mut Deserializer,
         out: *mut dyn Animal<String>,
-      ) -> Result<(), DeserializeError> {
+      ) -> Result<(), Error> {
         unsafe {
           <Self as DeserializeUnsized<Cat, _>>::deserialize_unsized(self, deserializer, out.cast())
         }

--- a/crates/rspack_cacheable_test/tests/with/as.rs
+++ b/crates/rspack_cacheable_test/tests/with/as.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, path::PathBuf};
 
 use rspack_cacheable::{
-  DeserializeError, SerializeError, enable_cacheable as cacheable,
+  Error, enable_cacheable as cacheable,
   with::{As, AsConverter},
 };
 
@@ -12,10 +12,10 @@ struct UnCacheableData(PathBuf);
 struct CacheableData(String);
 
 impl AsConverter<UnCacheableData> for CacheableData {
-  fn serialize(data: &UnCacheableData, _ctx: &dyn Any) -> Result<Self, SerializeError> {
+  fn serialize(data: &UnCacheableData, _ctx: &dyn Any) -> Result<Self, Error> {
     Ok(Self(data.0.to_string_lossy().to_string()))
   }
-  fn deserialize(self, _ctx: &dyn Any) -> Result<UnCacheableData, DeserializeError> {
+  fn deserialize(self, _ctx: &dyn Any) -> Result<UnCacheableData, Error> {
     Ok(UnCacheableData(PathBuf::from(&self.0)))
   }
 }

--- a/crates/rspack_cacheable_test/tests/with/as_string.rs
+++ b/crates/rspack_cacheable_test/tests/with/as_string.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use rspack_cacheable::{
-  DeserializeError, SerializeError, enable_cacheable as cacheable,
+  Error, enable_cacheable as cacheable,
   with::{AsString, AsStringConverter},
 };
 
@@ -12,10 +12,10 @@ struct Regex {
   flags: String,
 }
 impl AsStringConverter for Regex {
-  fn to_string(&self) -> Result<String, SerializeError> {
+  fn to_string(&self) -> Result<String, Error> {
     Ok(format!("{}#{}", self.flags, self.source))
   }
-  fn from_str(s: &str) -> Result<Self, DeserializeError>
+  fn from_str(s: &str) -> Result<Self, Error>
   where
     Self: Sized,
   {

--- a/crates/rspack_cacheable_test/tests/with/custom.rs
+++ b/crates/rspack_cacheable_test/tests/with/custom.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, path::PathBuf};
 
 use rspack_cacheable::{
-  DeserializeError, SerializeError, enable_cacheable as cacheable,
+  Error, enable_cacheable as cacheable,
   with::{Custom, CustomConverter},
 };
 
@@ -11,10 +11,10 @@ struct Data(PathBuf);
 
 impl CustomConverter for Data {
   type Target = String;
-  fn serialize(&self, _ctx: &dyn Any) -> Result<Self::Target, SerializeError> {
+  fn serialize(&self, _ctx: &dyn Any) -> Result<Self::Target, Error> {
     Ok(self.0.to_string_lossy().to_string())
   }
-  fn deserialize(data: Self::Target, _ctx: &dyn Any) -> Result<Self, DeserializeError> {
+  fn deserialize(data: Self::Target, _ctx: &dyn Any) -> Result<Self, Error> {
     Ok(Data(PathBuf::from(&data)))
   }
 }

--- a/crates/rspack_cacheable_test/tests/with/unsupported.rs
+++ b/crates/rspack_cacheable_test/tests/with/unsupported.rs
@@ -1,4 +1,4 @@
-use rspack_cacheable::{SerializeError, enable_cacheable as cacheable, with::Unsupported};
+use rspack_cacheable::{Error, enable_cacheable as cacheable, with::Unsupported};
 
 struct UnCacheable;
 
@@ -14,6 +14,6 @@ fn test_unsupport() {
 
   assert!(matches!(
     rspack_cacheable::to_bytes(&app, &()),
-    Err(SerializeError::UnsupportedField)
+    Err(Error::UnsupportedField)
   ));
 }

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use rayon::prelude::*;
-use rspack_cacheable::{SerializeError, cacheable, from_bytes, to_bytes, utils::OwnedOrRef};
+use rspack_cacheable::{
+  Error as CacheableError, cacheable, from_bytes, to_bytes, utils::OwnedOrRef,
+};
 use rspack_collections::IdentifierSet;
 use rspack_error::Result;
 use rustc_hash::FxHashSet as HashSet;
@@ -97,7 +99,7 @@ pub fn save_module_graph(
       };
       match to_bytes(&node, context) {
         Ok(bytes) => (identifier.as_bytes().to_vec(), bytes),
-        Err(err @ SerializeError::UnsupportedField) => {
+        Err(err @ CacheableError::UnsupportedField) => {
           tracing::warn!("to bytes failed {:?}", err);
           // try use alternatives
           node.module = TempModule::transform_from(node.module);

--- a/crates/rspack_core/src/module_profile.rs
+++ b/crates/rspack_core/src/module_profile.rs
@@ -17,16 +17,13 @@ enum ProfileState {
 
 impl CustomConverter for ProfileState {
   type Target = Option<u64>;
-  fn serialize(
-    &self,
-    _ctx: &dyn std::any::Any,
-  ) -> Result<Self::Target, rspack_cacheable::SerializeError> {
+  fn serialize(&self, _ctx: &dyn std::any::Any) -> Result<Self::Target, rspack_cacheable::Error> {
     Ok(self.duration())
   }
   fn deserialize(
     data: Self::Target,
     _ctx: &dyn std::any::Any,
-  ) -> Result<Self, rspack_cacheable::DeserializeError> {
+  ) -> Result<Self, rspack_cacheable::Error> {
     if let Some(time) = data {
       Ok(ProfileState::Finish(time))
     } else {

--- a/crates/rspack_regex/src/lib.rs
+++ b/crates/rspack_regex/src/lib.rs
@@ -124,10 +124,10 @@ impl TryFrom<SwcRegex> for RspackRegex {
 }
 
 impl AsStringConverter for RspackRegex {
-  fn to_string(&self) -> Result<String, rspack_cacheable::SerializeError> {
+  fn to_string(&self) -> Result<String, rspack_cacheable::Error> {
     Ok(format!("{}#{}", self.flags, self.source))
   }
-  fn from_str(s: &str) -> Result<Self, rspack_cacheable::DeserializeError>
+  fn from_str(s: &str) -> Result<Self, rspack_cacheable::Error>
   where
     Self: Sized,
   {


### PR DESCRIPTION
## Summary

Rspack_cacheable merge SerializeError and DeserializeError into Error enum. It helps to encapsulate some utility methods used in the serialization and deserialization processes.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
