### PR TITLE
docs: fix childAssets typo in ChunkGroup object

### DIFF
--- a/website/docs/en/api/javascript-api/stats-json.mdx
+++ b/website/docs/en/api/javascript-api/stats-json.mdx
@@ -296,7 +296,7 @@ type StatsChunkGroup = {
     prefetch?: Array<StatsChunkGroup>;
   };
   // Assets of ordered children chunk groups, order by preload/prefetch
-  children?: {
+  childAssets?: {
     // preload assets
     preload?: Array<string>;
     // prefetch assets

--- a/website/docs/zh/api/javascript-api/stats-json.mdx
+++ b/website/docs/zh/api/javascript-api/stats-json.mdx
@@ -298,7 +298,7 @@ type StatsChunkGroup = {
     prefetch?: Array<StatsChunkGroup>;
   };
   // 子 chunk group 加载文件顺序，按照优先级排序
-  children?: {
+  childAssets?: {
     // 需 preload 的资源文件
     preload?: Array<string>;
     // 需 prefetch 的资源文件


### PR DESCRIPTION
## Summary

I noticed the `StatsChunkGroup.children` prop is duplicated in the docs. It turns out that the second one should be `childAssets`

https://github.com/web-infra-dev/rspack/blob/0da65999fca4986897b134c2a9a472e0f555e78e/packages/rspack/src/stats/statsFactoryUtils.ts#L18-L25

Thanks!

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
