### PR TITLE
fix: generate CSS file for universal target

### DIFF
--- a/packages/rspack-test-tools/src/case/runner.ts
+++ b/packages/rspack-test-tools/src/case/runner.ts
@@ -3,6 +3,14 @@ import { NodeRunner, WebRunner } from '../runner';
 import { DEBUG_SCOPES } from '../test/debug';
 import type { ITestContext, ITestEnv, ITestRunner } from '../type';
 
+const isWebTarget = (compilerOptions: RspackOptions): boolean => {
+  const target = compilerOptions.target;
+  if (Array.isArray(target)) {
+    return target.some((t) => t === 'web' || t === 'webworker');
+  }
+  return target === 'web' || target === 'webworker';
+};
+
 export type THotStepRuntimeLangData = {
   outdatedModules: string[];
   outdatedDependencies: Record<string, string[]>;
@@ -60,10 +68,8 @@ export function createRunner(
     dist: context.getDist(),
     compilerOptions,
   };
-  if (
-    compilerOptions.target === 'web' ||
-    compilerOptions.target === 'webworker'
-  ) {
+  const isWeb = isWebTarget(compilerOptions);
+  if (isWeb) {
     return new WebRunner({
       ...runnerOptions,
       runInNewContext: true,
@@ -144,10 +150,8 @@ export function createMultiCompilerRunner(
     logs,
     errors,
   };
-  if (
-    compilerOptions.target === 'web' ||
-    compilerOptions.target === 'webworker'
-  ) {
+  const isWeb = isWebTarget(compilerOptions);
+  if (isWeb) {
     runner = new WebRunner({
       ...runnerOptions,
       runInNewContext: true,

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -29,9 +29,11 @@ import {
   getDefaultTarget,
   getTargetProperties,
   getTargetsProperties,
+  type TargetProperties,
 } from './target';
 import type {
   Context,
+  CssGeneratorOptions,
   ExternalsPresets,
   InfrastructureLogging,
   JavascriptParserOptions,
@@ -343,6 +345,18 @@ const applyJavascriptParserOptionsDefaults = (
   D(parserOptions, 'deferImport', deferImport);
 };
 
+const applyCssGeneratorOptionsDefaults = (
+  generatorOptions: CssGeneratorOptions,
+  { targetProperties }: { targetProperties: TargetProperties | false },
+) => {
+  D(
+    generatorOptions,
+    'exportsOnly',
+    !targetProperties || targetProperties.document === false,
+  );
+  D(generatorOptions, 'esModule', true);
+};
+
 const applyJsonGeneratorOptionsDefaults = (
   generatorOptions: JsonGeneratorOptions,
 ) => {
@@ -424,20 +438,15 @@ const applyModuleDefaults = (
     // IGNORE(module.generator): already check to align in 2024.6.27
     F(module.generator, 'css', () => ({}));
     assertNotNill(module.generator.css);
-    D(
-      module.generator.css,
-      'exportsOnly',
-      !targetProperties || !targetProperties.document,
-    );
-    D(module.generator.css, 'esModule', true);
+    applyCssGeneratorOptionsDefaults(module.generator.css, {
+      targetProperties,
+    });
 
     F(module.generator, 'css/auto', () => ({}));
     assertNotNill(module.generator['css/auto']);
-    D(
-      module.generator['css/auto'],
-      'exportsOnly',
-      !targetProperties || !targetProperties.document,
-    );
+    applyCssGeneratorOptionsDefaults(module.generator['css/auto'], {
+      targetProperties,
+    });
     D(module.generator['css/auto'], 'exportsConvention', 'as-is');
     const localIdentName =
       mode === 'development'
@@ -446,18 +455,14 @@ const applyModuleDefaults = (
           : '[id]-[local]'
         : '[fullhash]';
     D(module.generator['css/auto'], 'localIdentName', localIdentName);
-    D(module.generator['css/auto'], 'esModule', true);
 
     F(module.generator, 'css/module', () => ({}));
     assertNotNill(module.generator['css/module']);
-    D(
-      module.generator['css/module'],
-      'exportsOnly',
-      !targetProperties || !targetProperties.document,
-    );
+    applyCssGeneratorOptionsDefaults(module.generator['css/module'], {
+      targetProperties,
+    });
     D(module.generator['css/module'], 'exportsConvention', 'as-is');
     D(module.generator['css/module'], 'localIdentName', localIdentName);
-    D(module.generator['css/module'], 'esModule', true);
   }
 
   // IGNORE(module.defaultRules): Rspack does not support `rule.assert`

--- a/packages/rspack/src/config/target.ts
+++ b/packages/rspack/src/config/target.ts
@@ -109,7 +109,7 @@ export type EcmaTargetProperties = {
 type Never<T> = { [P in keyof T]?: never };
 type Mix<A, B> = (A & Never<B>) | (Never<A> & B) | (A & B);
 
-type TargetProperties = Mix<
+export type TargetProperties = Mix<
   Mix<PlatformTargetProperties, ElectronContextTargetProperties>,
   Mix<ApiTargetProperties, EcmaTargetProperties>
 >;

--- a/tests/rspack-test/configCases/asset-modules/bytes/test.config.js
+++ b/tests/rspack-test/configCases/asset-modules/bytes/test.config.js
@@ -10,7 +10,7 @@ module.exports = {
 
 		const link = scope.window.document.createElement("link");
 		link.rel = "stylesheet";
-		link.href = `bundle0.css`;
+		link.href = `bundle${run === 0 ? "0" : "2"}.css`;
 		scope.window.document.head.appendChild(link);
 
 		run++;

--- a/tests/rspack-test/configCases/css/universal/rspack.config.js
+++ b/tests/rspack-test/configCases/css/universal/rspack.config.js
@@ -1,8 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	// DIFF: no css file is generated in node target
-	// target: ["web", "node"],
-	target: "web",
+	target: ["web", "node"],
 	mode: "development",
 	experiments: {
 		css: true,

--- a/tests/rspack-test/configCases/css/universal/test.config.js
+++ b/tests/rspack-test/configCases/css/universal/test.config.js
@@ -1,8 +1,8 @@
 module.exports = {
 	moduleScope(scope) {
-		// const link = scope.window.document.createElement("link");
-		// link.rel = "stylesheet";
-		// link.href = "bundle0.css";
-		// scope.window.document.head.appendChild(link);
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "bundle0.css";
+		scope.window.document.head.appendChild(link);
 	}
 };


### PR DESCRIPTION
## Summary
Generate css file for universal target and update test cases.

## Related

- https://github.com/webpack/webpack/blob/6fe040f0362befb8679ca666ac31f27e2c459c06/lib/config/defaults.js#L589-L599

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
