### PR TITLE
chore(vscode): set defaultFormatter to prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,16 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json5]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "git.ignoreLimitWarning": true,
   "eslint.enable": false,
   "cSpell.allowCompoundWords": true,


### PR DESCRIPTION
## Summary

Set `editor.defaultFormatter` to `"esbenp.prettier-vscode"`.

For json files, need to specific configurations to overrides the json language server.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
