### PR TITLE
refactor: remove get_make_module_graph_mut api

### DIFF
--- a/crates/rspack_binding_api/src/exports_info.rs
+++ b/crates/rspack_binding_api/src/exports_info.rs
@@ -32,8 +32,9 @@ impl JsExportsInfo {
 
   fn as_mut(&mut self) -> napi::Result<&'static mut ModuleGraph> {
     let compilation = unsafe { self.compilation.as_mut() };
-    let module_graph =
-      Compilation::get_make_module_graph_mut(&mut compilation.build_module_graph_artifact);
+    let module_graph = compilation
+      .build_module_graph_artifact
+      .get_module_graph_mut();
     Ok(module_graph)
   }
 }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -475,11 +475,6 @@ impl Compilation {
       .get_module_graph()
       .module_by_identifier(identifier)
   }
-  pub fn get_make_module_graph_mut(
-    build_module_graph_artifact: &mut BuildModuleGraphArtifact,
-  ) -> &mut ModuleGraph {
-    build_module_graph_artifact.get_module_graph_mut()
-  }
   pub fn get_module_graph_mut(&mut self) -> &mut ModuleGraph {
     self.build_module_graph_artifact.get_module_graph_mut()
   }
@@ -625,8 +620,10 @@ impl Compilation {
 
   pub async fn add_entry(&mut self, entry: BoxDependency, options: EntryOptions) -> Result<()> {
     let entry_id = *entry.id();
-    let entry_name = options.name.clone();
-    Compilation::get_make_module_graph_mut(&mut self.build_module_graph_artifact)
+    let entry_name: Option<String> = options.name.clone();
+    self
+      .build_module_graph_artifact
+      .get_module_graph_mut()
       .add_dependency(entry);
     if let Some(name) = &entry_name {
       if let Some(data) = self.entries.get_mut(name) {
@@ -687,7 +684,9 @@ impl Compilation {
 
     for (entry, options) in args {
       let entry_id = *entry.id();
-      Compilation::get_make_module_graph_mut(&mut self.build_module_graph_artifact)
+      self
+        .build_module_graph_artifact
+        .get_module_graph_mut()
         .add_dependency(entry);
       if let Some(name) = options.name.clone() {
         if let Some(data) = self.entries.get_mut(&name) {

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -258,8 +258,9 @@ async fn finish_modules(
     );
   }
 
-  let module_graph =
-    Compilation::get_make_module_graph_mut(&mut compilation.build_module_graph_artifact);
+  let module_graph = compilation
+    .build_module_graph_artifact
+    .get_module_graph_mut();
   for m in entry_modules {
     let exports_info = module_graph.get_exports_info(&m);
 

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -212,8 +212,9 @@ async fn finish_modules(
   };
   let module_graph_cache = compilation.module_graph_cache_artifact.clone();
 
-  let module_graph =
-    Compilation::get_make_module_graph_mut(&mut compilation.build_module_graph_artifact);
+  let module_graph = compilation
+    .build_module_graph_artifact
+    .get_module_graph_mut();
   FlagDependencyExportsState::new(module_graph, &module_graph_cache).apply(modules);
   Ok(())
 }

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -229,8 +229,9 @@ async fn normal_module_factory_module(
 #[plugin_hook(CompilerMake for LazyCompilationPlugin<T: Backend, F: LazyCompilationTestCheck>)]
 async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
   let active_modules = self.backend.lock().await.current_active_modules().await?;
-  let module_graph =
-    Compilation::get_make_module_graph_mut(&mut compilation.build_module_graph_artifact);
+  let module_graph = compilation
+    .build_module_graph_artifact
+    .get_module_graph_mut();
   let mut errors = vec![];
   for module_id in &active_modules {
     let Some(active_module) = module_graph.module_by_identifier_mut(module_id) else {

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -476,8 +476,9 @@ async fn finish_modules(
   }
 
   for (runtime, export, module_identifier) in runtime_info {
-    let module_graph =
-      Compilation::get_make_module_graph_mut(&mut compilation.build_module_graph_artifact);
+    let module_graph = compilation
+      .build_module_graph_artifact
+      .get_module_graph_mut();
     if let Some(export) = export {
       let export_info = module_graph
         .get_exports_info(&module_identifier)

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -153,8 +153,9 @@ async fn finish_modules(
   }
 
   for (runtime, export, module_identifier) in runtime_info {
-    let module_graph =
-      Compilation::get_make_module_graph_mut(&mut compilation.build_module_graph_artifact);
+    let module_graph = compilation
+      .build_module_graph_artifact
+      .get_module_graph_mut();
     if let Some(export) = export {
       let export_info = module_graph
         .get_exports_info(&module_identifier)

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -230,7 +230,9 @@ impl ModernModuleLibraryPlugin {
       }
     }
 
-    let mg = Compilation::get_make_module_graph_mut(&mut compilation.build_module_graph_artifact);
+    let mg = compilation
+      .build_module_graph_artifact
+      .get_module_graph_mut();
     for dep in deps_to_replace {
       let dep_id = dep.id();
       external_connections.remove(dep_id);

--- a/crates/rspack_plugin_rslib/src/import_external.rs
+++ b/crates/rspack_plugin_rslib/src/import_external.rs
@@ -51,7 +51,9 @@ pub fn replace_import_dependencies_for_external_modules(
     }
   }
 
-  let mg = Compilation::get_make_module_graph_mut(&mut compilation.build_module_graph_artifact);
+  let mg = compilation
+    .build_module_graph_artifact
+    .get_module_graph_mut();
   for dep in deps_to_replace {
     let dep_id = dep.id();
     // remove connection


### PR DESCRIPTION
## Summary
Compilation::get_make_module_graph_mut is no needed now since we can directly access build_module_graph_artifacts.module_graph
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
