### PR TITLE
refactor: refine exports info for CJS and ESM interop

### DIFF
--- a/crates/rspack_binding_api/src/exports_info.rs
+++ b/crates/rspack_binding_api/src/exports_info.rs
@@ -51,7 +51,6 @@ impl JsExportsInfo {
       &self.exports_info,
       module_graph,
       runtime.as_ref(),
-      false,
     );
     Ok(exports_info.is_used())
   }
@@ -67,7 +66,6 @@ impl JsExportsInfo {
       &self.exports_info,
       module_graph,
       runtime.as_ref(),
-      false,
     );
     Ok(exports_info.is_module_used())
   }

--- a/crates/rspack_core/src/exports/export_info_getter.rs
+++ b/crates/rspack_core/src/exports/export_info_getter.rs
@@ -40,6 +40,23 @@ impl ExportInfoData {
     }
   }
 
+  pub fn is_used(&self, runtime: Option<&RuntimeSpec>) -> bool {
+    if !self.has_use_in_runtime_info() {
+      return true;
+    }
+    if let Some(global_used) = self.global_used() {
+      return global_used != UsageState::Unused;
+    }
+    let Some(used_in_runtime) = self.used_in_runtime() else {
+      return false;
+    };
+    let Some(runtime) = runtime else {
+      return !used_in_runtime.is_empty();
+    };
+
+    runtime.iter().any(|r| used_in_runtime.contains_key(r))
+  }
+
   pub fn get_used(&self, runtime: Option<&RuntimeSpec>) -> UsageState {
     if !self.has_use_in_runtime_info() {
       return UsageState::NoInfo;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -458,8 +458,9 @@ fn get_exports_type_impl(
                 return ExportsType::Dynamic;
               };
               match target_exports_type {
-                BuildMetaExportsType::Flagged => ExportsType::Namespace,
-                BuildMetaExportsType::Namespace => ExportsType::Namespace,
+                BuildMetaExportsType::Flagged | BuildMetaExportsType::Namespace => {
+                  ExportsType::Namespace
+                }
                 BuildMetaExportsType::Default => handle_default(default_object),
                 _ => ExportsType::Dynamic,
               }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -452,7 +452,6 @@ impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
         &mg.get_exports_info(&module.identifier()),
         mg,
         *runtime,
-        false,
       );
       ExportsInfoGetter::get_used_name(
         GetUsedNameParam::WithoutNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -173,7 +173,6 @@ impl DependencyTemplate for CommonJsExportsDependencyTemplate {
         &module_graph.get_exports_info(&module.identifier()),
         module_graph,
         *runtime,
-        false,
       );
       ExportsInfoGetter::get_used_name(
         GetUsedNameParam::WithoutNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -174,7 +174,6 @@ impl DependencyTemplate for CommonJsFullRequireDependencyTemplate {
             &module_graph.get_exports_info(&imported_module.module_identifier),
             module_graph,
             *runtime,
-            false,
           );
           ExportsInfoGetter::get_used_name(
             GetUsedNameParam::WithoutNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -148,7 +148,6 @@ impl DependencyTemplate for CommonJsSelfReferenceDependencyTemplate {
           &module_graph.get_exports_info(&module.identifier()),
           module_graph,
           *runtime,
-          false,
         );
         ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithoutNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -168,100 +168,89 @@ impl ESMExportImportedSpecifierDependency {
     let parent_module = module_graph
       .get_parent_module(id)
       .expect("should have parent module");
-    let exports_info = module_graph.get_exports_info(parent_module);
-    let exports_info_data = ExportsInfoGetter::prefetch(
-      &exports_info,
-      module_graph,
-      PrefetchExportsInfoMode::Default,
-    );
 
-    let is_name_unused = if let Some(ref name) = name {
-      exports_info_data.get_used(std::slice::from_ref(name), runtime) == UsageState::Unused
-    } else {
-      !ExportsInfoGetter::prefetch_used_info_without_name(
-        &exports_info,
-        module_graph,
-        runtime,
-        false,
-      )
-      .is_used()
-    };
-    if is_name_unused {
-      return ExportMode::Unused(ExportModeUnused { name: "*".into() });
-    }
-    let imported_exports_type =
-      get_exports_type(module_graph, module_graph_cache, id, parent_module);
-    let ids = self.get_ids(module_graph);
-
-    // Special handling for reexporting the default export
-    // from non-namespace modules
-    if let Some(name) = name.as_ref()
-      && ids.first().map(|item| item.as_ref()) == Some("default")
-    {
-      match imported_exports_type {
-        ExportsType::Dynamic => {
-          return ExportMode::ReexportDynamicDefault(ExportModeReexportDynamicDefault {
-            name: name.clone(),
-          });
-        }
-        ExportsType::DefaultOnly | ExportsType::DefaultWithNamed => {
-          return ExportMode::ReexportNamedDefault(ExportModeReexportNamedDefault {
-            name: name.clone(),
-            partial_namespace_export_info: exports_info_data.get_read_only_export_info(name).id(),
-          });
-        }
-        _ => {}
-      }
-    }
-
-    // reexporting with a fixed name
     if let Some(name) = name {
-      let export_info = exports_info_data.get_read_only_export_info(&name).id();
-      if !ids.is_empty() {
-        // export { name as name }
+      let exports_info =
+        module_graph.get_prefetched_exports_info(parent_module, PrefetchExportsInfoMode::Default);
+      if !exports_info
+        .get_read_only_export_info(&name)
+        .is_used(runtime)
+      {
+        return ExportMode::Unused(ExportModeUnused { name: "*".into() });
+      }
+
+      let imported_exports_type =
+        get_exports_type(module_graph, module_graph_cache, id, parent_module);
+      let ids = self.get_ids(module_graph);
+
+      // Special handling for reexporting the default export
+      // from non-namespace modules
+      if ids.first().map(|item| item.as_ref()) == Some("default") {
         match imported_exports_type {
-          ExportsType::DefaultOnly => {
-            return ExportMode::ReexportUndefined(ExportModeReexportUndefined { name });
+          ExportsType::Dynamic => {
+            return ExportMode::ReexportDynamicDefault(ExportModeReexportDynamicDefault { name });
           }
-          _ => {
-            return ExportMode::NormalReexport(ExportModeNormalReexport {
-              items: vec![NormalReexportItem {
-                name,
-                ids: ids.to_vec(),
-                hidden: false,
-                checked: false,
-                export_info,
-              }],
+          ExportsType::DefaultOnly | ExportsType::DefaultWithNamed => {
+            return ExportMode::ReexportNamedDefault(ExportModeReexportNamedDefault {
+              partial_namespace_export_info: exports_info.get_read_only_export_info(&name).id(),
+              name,
             });
           }
+          _ => {}
         }
-      } else {
+      }
+
+      // reexporting with a fixed name
+      let export_info = exports_info.get_read_only_export_info(&name).id();
+      let res = if ids.is_empty() {
         // export * as name
         match imported_exports_type {
           ExportsType::DefaultOnly => {
-            return ExportMode::ReexportFakeNamespaceObject(ExportModeFakeNamespaceObject {
+            ExportMode::ReexportFakeNamespaceObject(ExportModeFakeNamespaceObject {
               name,
               partial_namespace_export_info: export_info,
               fake_type: 0,
-            });
+            })
           }
           ExportsType::DefaultWithNamed => {
-            return ExportMode::ReexportFakeNamespaceObject(ExportModeFakeNamespaceObject {
+            ExportMode::ReexportFakeNamespaceObject(ExportModeFakeNamespaceObject {
               name,
               partial_namespace_export_info: export_info,
               fake_type: 2,
-            });
+            })
           }
-          _ => {
-            return ExportMode::ReexportNamespaceObject(ExportModeReexportNamespaceObject {
-              name,
-              partial_namespace_export_info: export_info,
-            });
-          }
+          _ => ExportMode::ReexportNamespaceObject(ExportModeReexportNamespaceObject {
+            name,
+            partial_namespace_export_info: export_info,
+          }),
         }
-      }
+      } else {
+        // export { name as name }
+        match imported_exports_type {
+          ExportsType::DefaultOnly => {
+            ExportMode::ReexportUndefined(ExportModeReexportUndefined { name })
+          }
+          _ => ExportMode::NormalReexport(ExportModeNormalReexport {
+            items: vec![NormalReexportItem {
+              name,
+              ids: ids.to_vec(),
+              hidden: false,
+              checked: false,
+              export_info,
+            }],
+          }),
+        }
+      };
+      return res;
     }
 
+    let exports_info =
+      module_graph.get_prefetched_exports_info(parent_module, PrefetchExportsInfoMode::Default);
+    if !exports_info.is_used(runtime) {
+      return ExportMode::Unused(ExportModeUnused { name: "*".into() });
+    }
+
+    // export * from
     let StarReexportsInfo {
       exports,
       checked,
@@ -271,54 +260,48 @@ impl ESMExportImportedSpecifierDependency {
       module_graph,
       module_graph_cache,
       runtime,
-      &exports_info_data,
+      &exports_info,
       imported_module_identifier,
     );
 
-    if let Some(exports) = exports {
-      if exports.is_empty() {
-        return ExportMode::EmptyStar(ExportModeEmptyStar { hidden });
-      }
-
-      let exports_info_data =
-        module_graph.get_prefetched_exports_info(parent_module, PrefetchExportsInfoMode::Default);
-
-      let mut items = exports
-        .iter()
-        .map(|export_name| NormalReexportItem {
-          name: export_name.clone(),
-          ids: vec![export_name.clone()],
-          hidden: false,
-          checked: checked
-            .as_ref()
-            .map(|c| c.contains(export_name))
-            .unwrap_or_default(),
-          export_info: exports_info_data
-            .get_read_only_export_info(export_name)
-            .id(),
-        })
-        .collect::<Vec<_>>();
-
-      if let Some(hidden) = &hidden {
-        for export_name in hidden.iter() {
-          items.push(NormalReexportItem {
-            name: export_name.clone(),
-            ids: vec![export_name.clone()],
-            hidden: true,
-            checked: false,
-            export_info: exports_info_data
-              .get_read_only_export_info(export_name)
-              .id(),
-          });
-        }
-      }
-      ExportMode::NormalReexport(ExportModeNormalReexport { items })
-    } else {
-      ExportMode::DynamicReexport(Box::new(ExportModeDynamicReexport {
+    let Some(exports) = exports else {
+      return ExportMode::DynamicReexport(Box::new(ExportModeDynamicReexport {
         ignored: ignored_exports,
         hidden,
-      }))
+      }));
+    };
+
+    if exports.is_empty() {
+      return ExportMode::EmptyStar(ExportModeEmptyStar { hidden });
     }
+
+    let mut items = exports
+      .iter()
+      .map(|export_name| NormalReexportItem {
+        name: export_name.clone(),
+        ids: vec![export_name.clone()],
+        hidden: false,
+        checked: checked
+          .as_ref()
+          .map(|c| c.contains(export_name))
+          .unwrap_or_default(),
+        export_info: exports_info.get_read_only_export_info(export_name).id(),
+      })
+      .collect::<Vec<_>>();
+
+    if let Some(hidden) = &hidden {
+      for export_name in hidden.iter() {
+        items.push(NormalReexportItem {
+          name: export_name.clone(),
+          ids: vec![export_name.clone()],
+          hidden: true,
+          checked: false,
+          export_info: exports_info.get_read_only_export_info(export_name).id(),
+        });
+      }
+    }
+
+    ExportMode::NormalReexport(ExportModeNormalReexport { items })
   }
 
   pub fn get_star_reexports(
@@ -357,6 +340,7 @@ impl ESMExportImportedSpecifierDependency {
           .filter(|name| !ignored_exports.contains(name))
           .collect::<HashSet<_>>()
       });
+
     if !no_extra_exports && !no_extra_imports {
       return StarReexportsInfo {
         ignored_exports,
@@ -375,14 +359,12 @@ impl ESMExportImportedSpecifierDependency {
 
     if no_extra_imports {
       for (_name, export_info) in exports_info.exports() {
-        let export_name = export_info.name().cloned().unwrap_or_default();
-        if ignored_exports.contains(&export_name)
-          || matches!(export_info.get_used(runtime), UsageState::Unused)
-        {
+        let export_name = export_info.name().expect("should have export name");
+        if ignored_exports.contains(export_name) || !export_info.is_used(runtime) {
           continue;
         }
 
-        let imported_export_info = imported_exports_info.get_read_only_export_info(&export_name);
+        let imported_export_info = imported_exports_info.get_read_only_export_info(export_name);
         if matches!(
           imported_export_info.provided(),
           Some(ExportProvided::NotProvided)
@@ -392,8 +374,7 @@ impl ESMExportImportedSpecifierDependency {
 
         if hidden_exports
           .as_ref()
-          .map(|hidden_exports| hidden_exports.contains(&export_name))
-          == Some(true)
+          .is_some_and(|hidden_exports| hidden_exports.contains(export_name))
         {
           hidden.as_mut().expect("According previous condition if hidden_exports is `Some`, hidden must be `Some(HashSet)").insert(export_name.clone());
           continue;
@@ -406,12 +387,14 @@ impl ESMExportImportedSpecifierDependency {
         ) {
           continue;
         }
-        checked.insert(export_name);
+        checked.insert(export_name.clone());
       }
     } else if no_extra_exports {
       for (_name, imported_export_info) in imported_exports_info.exports() {
-        let imported_export_info_name = imported_export_info.name().cloned().unwrap_or_default();
-        if ignored_exports.contains(&imported_export_info_name)
+        let imported_export_info_name = imported_export_info
+          .name()
+          .expect("should have export name");
+        if ignored_exports.contains(imported_export_info_name)
           || matches!(
             imported_export_info.provided(),
             Some(ExportProvided::NotProvided)
@@ -419,15 +402,16 @@ impl ESMExportImportedSpecifierDependency {
         {
           continue;
         }
-        let export_info = exports_info.get_read_only_export_info(&imported_export_info_name);
-        if matches!(export_info.get_used(runtime), UsageState::Unused) {
+        if !exports_info
+          .get_read_only_export_info(imported_export_info_name)
+          .is_used(runtime)
+        {
           continue;
         }
         if let Some(hidden) = hidden.as_mut()
           && hidden_exports
             .as_ref()
-            .map(|hidden_exports| hidden_exports.contains(&imported_export_info_name))
-            == Some(true)
+            .is_some_and(|hidden_exports| hidden_exports.contains(imported_export_info_name))
         {
           hidden.insert(imported_export_info_name.clone());
           continue;
@@ -440,7 +424,7 @@ impl ESMExportImportedSpecifierDependency {
         ) {
           continue;
         }
-        checked.insert(imported_export_info_name);
+        checked.insert(imported_export_info_name.clone());
       }
     }
 
@@ -740,7 +724,7 @@ impl ESMExportImportedSpecifierDependency {
             let exports_info = mg.get_exports_info(imported_module);
             let used_name = if ids.is_empty() {
               let exports_info =
-                ExportsInfoGetter::prefetch_used_info_without_name(&exports_info, mg, None, false);
+                ExportsInfoGetter::prefetch_used_info_without_name(&exports_info, mg, None);
               ExportsInfoGetter::get_used_name(
                 GetUsedNameParam::WithoutNames(&exports_info),
                 None,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -176,7 +176,6 @@ impl DependencyTemplate for ProvideDependencyTemplate {
         &module_graph.get_exports_info(con.module_identifier()),
         module_graph,
         *runtime,
-        false,
       );
       ExportsInfoGetter::get_used_name(
         GetUsedNameParam::WithoutNames(&exports_info),

--- a/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
@@ -27,12 +27,8 @@ pub fn is_export_inlined(
   runtime: Option<&RuntimeSpec>,
 ) -> bool {
   let used_name = if ids.is_empty() {
-    let exports_info = ExportsInfoGetter::prefetch_used_info_without_name(
-      &mg.get_exports_info(module),
-      mg,
-      runtime,
-      false,
-    );
+    let exports_info =
+      ExportsInfoGetter::prefetch_used_info_without_name(&mg.get_exports_info(module), mg, runtime);
     ExportsInfoGetter::get_used_name(GetUsedNameParam::WithoutNames(&exports_info), runtime, ids)
   } else {
     let exports_info = mg.get_prefetched_exports_info(module, PrefetchExportsInfoMode::Nested(ids));


### PR DESCRIPTION
## Summary

Refine exports info handling for CommonJS and ES module interop so that inline exports and imported specifiers are tracked more accurately, improving tree-shaking and correctness of generated bundles.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

