### PR TITLE
refactor: remove redirect_to in exports info

### DIFF
--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -41,9 +41,6 @@ impl ExportsInfo {
       .side_effects_only_info_mut()
       .reset_provide_info();
     exports_info.other_exports_info_mut().reset_provide_info();
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      redirect_to.reset_provide_info(mg);
-    }
   }
 
   /// # Panic
@@ -59,16 +56,12 @@ impl ExportsInfo {
         export_info.set_can_mangle_provide(Some(true));
       }
     }
-    if let Some(redirect) = exports_info.redirect_to() {
-      redirect.set_has_provide_info(mg);
-    } else {
-      let other_exports_info = exports_info.other_exports_info_mut();
-      if other_exports_info.provided().is_none() {
-        other_exports_info.set_provided(Some(ExportProvided::NotProvided));
-      }
-      if other_exports_info.can_mangle_provide().is_none() {
-        other_exports_info.set_can_mangle_provide(Some(true));
-      }
+    let other_exports_info = exports_info.other_exports_info_mut();
+    if other_exports_info.provided().is_none() {
+      other_exports_info.set_provided(Some(ExportProvided::NotProvided));
+    }
+    if other_exports_info.can_mangle_provide().is_none() {
+      other_exports_info.set_can_mangle_provide(Some(true));
     }
   }
 
@@ -116,34 +109,24 @@ impl ExportsInfo {
       }
     }
 
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      changed |= redirect_to.set_unknown_exports_provided(
-        mg,
-        can_mangle,
-        exclude_exports,
-        target_key,
-        target_module,
-        priority,
-      );
-    } else {
-      let other_exports_info_data = exports_info.other_exports_info_mut();
-      if !matches!(
-        other_exports_info_data.provided(),
-        Some(ExportProvided::Provided | ExportProvided::Unknown)
-      ) {
-        other_exports_info_data.set_provided(Some(ExportProvided::Unknown));
-        changed = true;
-      }
-
-      if let Some(target_key) = target_key {
-        other_exports_info_data.set_target(Some(target_key), target_module, None, priority);
-      }
-
-      if !can_mangle && other_exports_info_data.can_mangle_provide() != Some(false) {
-        other_exports_info_data.set_can_mangle_provide(Some(false));
-        changed = true;
-      }
+    let other_exports_info_data = exports_info.other_exports_info_mut();
+    if !matches!(
+      other_exports_info_data.provided(),
+      Some(ExportProvided::Provided | ExportProvided::Unknown)
+    ) {
+      other_exports_info_data.set_provided(Some(ExportProvided::Unknown));
+      changed = true;
     }
+
+    if let Some(target_key) = target_key {
+      other_exports_info_data.set_target(Some(target_key), target_module, None, priority);
+    }
+
+    if !can_mangle && other_exports_info_data.can_mangle_provide() != Some(false) {
+      other_exports_info_data.set_can_mangle_provide(Some(false));
+      changed = true;
+    }
+
     changed
   }
 
@@ -151,9 +134,6 @@ impl ExportsInfo {
     let exports_info = self.as_data_mut(mg);
     if let Some(export_info) = exports_info.named_exports(name) {
       return export_info.id();
-    }
-    if let Some(redirect) = exports_info.redirect_to() {
-      return redirect.get_export_info(mg, name);
     }
 
     let other_export_info = exports_info.other_exports_info();
@@ -170,22 +150,19 @@ impl ExportsInfo {
       let flag = export_info.set_used_without_info(runtime);
       changed |= flag;
     }
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      let flag = redirect_to.set_used_without_info(mg, runtime);
-      changed |= flag;
-    } else {
-      let other_exports_info = exports_info.other_exports_info_mut();
-      let flag = other_exports_info.set_used(UsageState::NoInfo, None);
-      changed |= flag;
-      if other_exports_info.can_mangle_use() != Some(false) {
-        other_exports_info.set_can_mangle_use(Some(false));
-        changed = true;
-      }
-      if other_exports_info.can_inline_use() != Some(CanInlineUse::No) {
-        other_exports_info.set_can_inline_use(Some(CanInlineUse::No));
-        changed = true;
-      }
+
+    let other_exports_info = exports_info.other_exports_info_mut();
+    let flag = other_exports_info.set_used(UsageState::NoInfo, None);
+    changed |= flag;
+    if other_exports_info.can_mangle_use() != Some(false) {
+      other_exports_info.set_can_mangle_use(Some(false));
+      changed = true;
     }
+    if other_exports_info.can_inline_use() != Some(CanInlineUse::No) {
+      other_exports_info.set_can_inline_use(Some(CanInlineUse::No));
+      changed = true;
+    }
+
     changed
   }
 
@@ -201,28 +178,24 @@ impl ExportsInfo {
         changed = true;
       }
     }
-    if let Some(redirect_to) = exports_info.redirect_to() {
-      if redirect_to.set_used_in_unknown_way(mg, runtime) {
-        changed = true;
-      }
-    } else {
-      let other_exports_info = exports_info.other_exports_info_mut();
-      if other_exports_info.set_used_conditionally(
-        Box::new(|value| value < &UsageState::Unknown),
-        UsageState::Unknown,
-        runtime,
-      ) {
-        changed = true;
-      }
-      if other_exports_info.can_mangle_use() != Some(false) {
-        other_exports_info.set_can_mangle_use(Some(false));
-        changed = true;
-      }
-      if other_exports_info.can_inline_use() != Some(CanInlineUse::No) {
-        other_exports_info.set_can_inline_use(Some(CanInlineUse::No));
-        changed = true;
-      }
+
+    let other_exports_info = exports_info.other_exports_info_mut();
+    if other_exports_info.set_used_conditionally(
+      Box::new(|value| value < &UsageState::Unknown),
+      UsageState::Unknown,
+      runtime,
+    ) {
+      changed = true;
     }
+    if other_exports_info.can_mangle_use() != Some(false) {
+      other_exports_info.set_can_mangle_use(Some(false));
+      changed = true;
+    }
+    if other_exports_info.can_inline_use() != Some(CanInlineUse::No) {
+      other_exports_info.set_can_inline_use(Some(CanInlineUse::No));
+      changed = true;
+    }
+
     changed
   }
 }
@@ -241,7 +214,6 @@ pub struct ExportsInfoData {
   other_exports_info: ExportInfoData,
 
   side_effects_only_info: ExportInfoData,
-  redirect_to: Option<ExportsInfo>,
   id: ExportsInfo,
 }
 
@@ -252,7 +224,6 @@ impl Default for ExportsInfoData {
       exports: BTreeMap::default(),
       other_exports_info: ExportInfoData::new(id, None, None),
       side_effects_only_info: ExportInfoData::new(id, Some("*side effects only*".into()), None),
-      redirect_to: None,
       id,
     }
   }
@@ -266,10 +237,6 @@ impl ExportsInfoData {
   }
   pub fn id(&self) -> ExportsInfo {
     self.id
-  }
-
-  pub fn redirect_to(&self) -> Option<ExportsInfo> {
-    self.redirect_to
   }
 
   pub fn other_exports_info(&self) -> &ExportInfoData {
@@ -302,9 +269,5 @@ impl ExportsInfoData {
 
   pub fn exports_mut(&mut self) -> &mut BTreeMap<Atom, ExportInfoData> {
     &mut self.exports
-  }
-
-  pub fn set_redirect_to(&mut self, id: Option<ExportsInfo>) {
-    self.redirect_to = id;
   }
 }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -78,18 +78,11 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   pub fn other_exports_info(&self) -> &ExportInfoData {
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(&self.entry) {
-      return self.get_other_in_exports_info(&redirect);
-    }
     self.get_other_in_exports_info(&self.entry)
   }
 
   pub fn side_effects_only_info(&self) -> &ExportInfoData {
     self.get_side_effects_in_exports_info(&self.entry)
-  }
-
-  pub fn redirect_to(&self) -> Option<ExportsInfo> {
-    self.get_redirect_to_in_exports_info(&self.entry)
   }
 
   pub fn exports(&self) -> impl Iterator<Item = (&Atom, &ExportInfoData)> {
@@ -110,14 +103,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
       .get(exports_info)
       .expect("should have nested exports info");
     data.side_effects_only_info()
-  }
-
-  fn get_redirect_to_in_exports_info(&self, exports_info: &ExportsInfo) -> Option<ExportsInfo> {
-    let data = self
-      .exports
-      .get(exports_info)
-      .expect("should have nested exports info");
-    data.redirect_to()
   }
 
   fn get_exports_in_exports_info(
@@ -154,9 +139,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   ) -> &ExportInfoData {
     if let Some(export_info) = self.get_named_export_in_exports_info(exports_info, name) {
       return export_info;
-    }
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(exports_info) {
-      return self.get_read_only_export_info_impl(&redirect, name);
     }
     self.get_other_in_exports_info(exports_info)
   }
@@ -228,17 +210,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
       }
       list.push(export_info);
     }
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(exports_info) {
-      for export_info in self.get_relevant_exports_impl(&redirect, runtime) {
-        let name = export_info.name();
-        if self
-          .get_named_export_in_exports_info(exports_info, name.unwrap_or(&"".into()))
-          .is_none()
-        {
-          list.push(export_info);
-        }
-      }
-    }
 
     let other_export_info = self.get_other_in_exports_info(exports_info);
     if !matches!(
@@ -260,17 +231,15 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     exports_info: &ExportsInfo,
     runtime: Option<&RuntimeSpec>,
   ) -> UsedExports {
-    if self.get_redirect_to_in_exports_info(exports_info).is_none() {
-      match self
-        .get_other_in_exports_info(exports_info)
-        .get_used(runtime)
-      {
-        UsageState::NoInfo => return UsedExports::Unknown,
-        UsageState::Unknown | UsageState::OnlyPropertiesUsed | UsageState::Used => {
-          return UsedExports::UsedNamespace(true);
-        }
-        _ => (),
+    match self
+      .get_other_in_exports_info(exports_info)
+      .get_used(runtime)
+    {
+      UsageState::NoInfo => return UsedExports::Unknown,
+      UsageState::Unknown | UsageState::OnlyPropertiesUsed | UsageState::Used => {
+        return UsedExports::UsedNamespace(true);
       }
+      _ => (),
     }
 
     let mut res = vec![];
@@ -284,15 +253,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
             res.push(name);
           }
         }
-        _ => (),
-      }
-    }
-
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(exports_info) {
-      let inner = self.get_used_exports_impl(&redirect, runtime);
-      match inner {
-        UsedExports::UsedNames(v) => res.extend(v),
-        UsedExports::Unknown | UsedExports::UsedNamespace(true) => return inner,
         _ => (),
       }
     }
@@ -316,20 +276,19 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   fn get_provided_exports_impl(&self, exports_info: &ExportsInfo) -> ProvidedExports {
-    if self.get_redirect_to_in_exports_info(exports_info).is_none() {
-      match self.get_other_in_exports_info(exports_info).provided() {
-        Some(ExportProvided::Unknown) => {
-          return ProvidedExports::ProvidedAll;
-        }
-        Some(ExportProvided::Provided) => {
-          return ProvidedExports::ProvidedAll;
-        }
-        None => {
-          return ProvidedExports::Unknown;
-        }
-        _ => {}
+    match self.get_other_in_exports_info(exports_info).provided() {
+      Some(ExportProvided::Unknown) => {
+        return ProvidedExports::ProvidedAll;
       }
+      Some(ExportProvided::Provided) => {
+        return ProvidedExports::ProvidedAll;
+      }
+      None => {
+        return ProvidedExports::Unknown;
+      }
+      _ => {}
     }
+
     let mut ret = vec![];
     for (_, export_info) in self.get_exports_in_exports_info(exports_info) {
       match export_info.provided() {
@@ -337,19 +296,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
           ret.push(export_info.name().cloned().unwrap_or("".into()));
         }
         _ => {}
-      }
-    }
-    if let Some(exports_info) = self.get_redirect_to_in_exports_info(exports_info) {
-      let provided_exports = self.get_provided_exports_impl(&exports_info);
-      let inner = match provided_exports {
-        ProvidedExports::Unknown => return ProvidedExports::Unknown,
-        ProvidedExports::ProvidedAll => return ProvidedExports::ProvidedAll,
-        ProvidedExports::ProvidedNames(arr) => arr,
-      };
-      for item in inner {
-        if !ret.contains(&item) {
-          ret.push(item);
-        }
       }
     }
     ProvidedExports::ProvidedNames(ret)
@@ -372,9 +318,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   ) -> MaybeDynamicTargetExportInfo<'_> {
     if let Some(export_info) = self.get_named_export_in_exports_info(exports_info, name) {
       return MaybeDynamicTargetExportInfo::Static(export_info);
-    }
-    if let Some(redirect) = self.get_redirect_to_in_exports_info(exports_info) {
-      return self.get_export_info_without_mut_module_graph_impl(&redirect, name);
     }
 
     MaybeDynamicTargetExportInfo::Dynamic {
@@ -439,12 +382,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   pub fn is_used(&self, runtime: Option<&RuntimeSpec>) -> bool {
-    if let Some(redirect) = self.redirect_to() {
-      let redirected = self.redirect(redirect, false);
-      if redirected.is_used(runtime) {
-        return true;
-      }
-    } else if self.other_exports_info().is_used(runtime) {
+    if self.other_exports_info().is_used(runtime) {
       return true;
     }
 
@@ -503,13 +441,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     // only expand capacity when this has redirect_to
     let mut key = UsageKey(Vec::with_capacity(self.exports().count() + 2));
 
-    if let Some(redirect_to) = self.redirect_to() {
-      let redirected = self.redirect(redirect_to, false);
-      key.add(Either::Left(Box::new(redirected.get_usage_key(runtime))));
-    } else {
-      key.add(Either::Right(self.other_exports_info().get_used(runtime)));
-    };
-
+    key.add(Either::Right(self.other_exports_info().get_used(runtime)));
     key.add(Either::Right(
       self.side_effects_only_info().get_used(runtime),
     ));
@@ -605,10 +537,6 @@ impl ExportsInfoGetter {
         nested_exports.push((side_exports, PrefetchExportsInfoMode::Default));
       }
 
-      if let Some(redirect_to) = exports_info.redirect_to() {
-        nested_exports.push((redirect_to, mode.clone()));
-      }
-
       res.insert(*id, exports_info);
 
       for (nested_exports_info, nested_mode) in nested_exports {
@@ -636,11 +564,7 @@ impl ExportsInfoGetter {
       mg: &ModuleGraph,
     ) -> bool {
       let exports_info = info.as_data(mg);
-      if let Some(redirect) = exports_info.redirect_to() {
-        if is_exports_info_used(&redirect, runtime, mg) {
-          return true;
-        }
-      } else if exports_info.other_exports_info().is_used(runtime) {
+      if exports_info.other_exports_info().is_used(runtime) {
         return true;
       }
       exports_info

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -2,19 +2,11 @@ use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet;
 
 use crate::{
-  CanInlineUse, DependencyId, ExportInfoData, ExportProvided, ExportsInfo, ExportsInfoData,
-  Nullable, RuntimeSpec, UsageState,
+  CanInlineUse, DependencyId, ExportInfoData, ExportProvided, ExportsInfoData, Nullable,
+  RuntimeSpec, UsageState,
 };
 
 impl ExportsInfoData {
-  pub fn set_redirect_name_to(&mut self, id: Option<ExportsInfo>) -> bool {
-    if self.redirect_to() == id {
-      return false;
-    }
-    self.set_redirect_to(id);
-    true
-  }
-
   pub fn set_used_for_side_effects_only(&mut self, runtime: Option<&RuntimeSpec>) -> bool {
     self.side_effects_only_info_mut().set_used_conditionally(
       Box::new(|value| value == &UsageState::Unused),

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -84,17 +84,8 @@ impl<'a> FlagDependencyExportsState<'a> {
       // 2. exports from an esm reexport and the target is a commonjs module which should create a interop `default` export
       let (non_nested_specs, has_nested_specs): (Vec<_>, Vec<_>) = module_exports_specs
         .into_iter()
-        .partition(|(mid, (_, has_nested_exports))| {
+        .partition(|(_mid, (_, has_nested_exports))| {
           if *has_nested_exports {
-            return false;
-          }
-          if self
-            .mg
-            .get_exports_info(mid)
-            .as_data(self.mg)
-            .redirect_to()
-            .is_some()
-          {
             return false;
           }
           true
@@ -569,12 +560,12 @@ pub fn merge_exports(
     dependencies.extend(target_dependencies);
 
     let export_info_data = export_info.as_data_mut(mg);
-    if export_info_data.exports_info_owned() {
-      changed |= export_info_data
-        .exports_info()
-        .expect("should have exports_info when exports_info_owned is true")
-        .as_data_mut(mg)
-        .set_redirect_name_to(target_exports_info);
+    if export_info_data.exports_info_owned()
+      && export_info_data.exports_info() != target_exports_info
+      && let Some(target_exports_info) = target_exports_info
+    {
+      export_info_data.set_exports_info(Some(target_exports_info));
+      changed = true;
     }
   }
   (changed, dependencies)
@@ -633,7 +624,6 @@ fn merge_nested_exports(
       .expect("should have exports_info when exports_info is true")
   } else {
     let export_info = export_info.as_data_mut(mg);
-    let old_exports_info = export_info.exports_info();
     let new_exports_info = ExportsInfoData::default();
     let new_exports_info_id = new_exports_info.id();
     export_info.set_exports_info(Some(new_exports_info_id));
@@ -641,11 +631,6 @@ fn merge_nested_exports(
     mg.set_exports_info(new_exports_info_id, new_exports_info);
 
     new_exports_info_id.set_has_provide_info(mg);
-    if let Some(exports_info) = old_exports_info {
-      exports_info
-        .as_data_mut(mg)
-        .set_redirect_name_to(Some(new_exports_info_id));
-    }
     new_exports_info_id
   };
 

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -129,11 +129,10 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
               let mut non_nested_tasks = vec![];
               for (module_id, exports) in referenced_exports {
                 let exports_info = mg.get_exports_info(&module_id).as_data(mg);
-                let has_nested = exports_info.redirect_to().is_some()
-                  || exports.iter().any(|e| match e {
-                    ExtendedReferencedExport::Array(arr) => arr.len() > 1,
-                    ExtendedReferencedExport::Export(export) => export.name.len() > 1,
-                  });
+                let has_nested = exports.iter().any(|e| match e {
+                  ExtendedReferencedExport::Array(arr) => arr.len() > 1,
+                  ExtendedReferencedExport::Export(export) => export.name.len() > 1,
+                });
                 if has_nested {
                   nested_tasks.push((
                     runtime.clone(),

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -158,15 +158,9 @@ fn is_equally_used(
   b: &RuntimeSpec,
 ) -> bool {
   let info = exports_info.as_data(mg);
-  if let Some(redirect_to) = &info.redirect_to() {
-    if is_equally_used(redirect_to, mg, a, b) {
-      return false;
-    }
-  } else {
-    let other_exports_info = info.other_exports_info();
-    if other_exports_info.get_used(Some(a)) != other_exports_info.get_used(Some(b)) {
-      return false;
-    }
+  let other_exports_info = info.other_exports_info();
+  if other_exports_info.get_used(Some(a)) != other_exports_info.get_used(Some(b)) {
+    return false;
   }
   let side_effects_only_info = info.side_effects_only_info();
   if side_effects_only_info.get_used(Some(a)) != side_effects_only_info.get_used(Some(b)) {

--- a/tests/rspack-test/normalCases/parsing/esm-commonjs-interop/index.js
+++ b/tests/rspack-test/normalCases/parsing/esm-commonjs-interop/index.js
@@ -1,0 +1,28 @@
+import * as reexport from "./reexport.js"
+
+it("should handle cjs reexport default from fake namespace", () => {
+  expect(reexport.lib.default).toEqual({
+    a: 1,
+    b: 2,
+    "default": 3,
+  });
+  expect(reexport.lib.default.a).toEqual(1);
+  expect(reexport.lib.default.b).toEqual(2);
+  expect(reexport.lib.default.default).toEqual(3);
+  expect(reexport.lib.default.c).toBeUndefined();
+});
+
+it("should handle cjs reexport from fake namespace", () => {
+  expect(reexport.lib).toMatchObject({
+    a: 1,
+    b: 2,
+    "default": {
+      a: 1,
+      b: 2,
+      "default": 3
+    }
+  });
+  expect(reexport.lib.a).toEqual(1);
+  expect(reexport.lib.b).toEqual(2);
+  expect(reexport.lib.c).toBeUndefined();
+});

--- a/tests/rspack-test/normalCases/parsing/esm-commonjs-interop/lib.js
+++ b/tests/rspack-test/normalCases/parsing/esm-commonjs-interop/lib.js
@@ -1,0 +1,3 @@
+exports.a = 1
+exports.b = 2
+exports.default = 3;

--- a/tests/rspack-test/normalCases/parsing/esm-commonjs-interop/reexport.js
+++ b/tests/rspack-test/normalCases/parsing/esm-commonjs-interop/reexport.js
@@ -1,0 +1,1 @@
+export * as lib from "./lib.js"

--- a/tests/rspack-test/normalCases/parsing/esm-commonjs-interop/warnings.js
+++ b/tests/rspack-test/normalCases/parsing/esm-commonjs-interop/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+  [/ESModulesLinkingWarning: export 'lib'\.'c' \(imported as 'reexport'\) was not found in '\.\/reexport\.js' \(possible exports: a, b, default\)/]
+];

--- a/tests/rspack-test/normalCases/parsing/missing-export-warning-nested/warnings.js
+++ b/tests/rspack-test/normalCases/parsing/missing-export-warning-nested/warnings.js
@@ -9,10 +9,10 @@ module.exports = [
 		/export 'x'.'y'.'C' \(imported as 'm'\) was not found in '.\/a' \(possible exports: Z, c, z\)/
 	],
 	[
-		/export 'x'.'y'.'z'.'D' \(imported as 'm'\) was not found in '.\/a' \(possible exports: default, d\)/
+		/export 'x'.'y'.'z'.'D' \(imported as 'm'\) was not found in '.\/a' \(possible exports: d, default\)/
 	],
 	[
-		/export 'x'.'y'.'z'.'v' \(imported as 'm'\) was not found in '.\/a' \(possible exports: default, d\)/
+		/export 'x'.'y'.'z'.'v' \(imported as 'm'\) was not found in '.\/a' \(possible exports: d, default\)/
 	],
 	[
 		/export 'p' \(imported as 'm'\) was not found in '.\/a' \(possible exports: a, x\)/


### PR DESCRIPTION
## Summary

This pull request improves the handling of exports when ESM modules re-export CommonJS modules. The changes refactor the exports_info implementation to simplify the codebase and fix issues with nested exports warnings.

The main improvements include:
- Refactored exports_info code to reduce complexity and improve maintainability (net reduction of ~108 lines)
- Added comprehensive test cases for ESM reexporting CommonJS modules with default exports
- Fixed missing export warnings for nested exports in ESM-CommonJS interop scenarios

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).