### PR TITLE
fix(esm_lib_plugin): should set original module for get_binding

### DIFF
--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -311,7 +311,7 @@ pub struct ChunkLinkContext {
   pub raw_import_stmts: FxIndexMap<(String, Option<String>), ImportSpec>,
 
   /**
-  const symbol = __webpack_require__(module_id)
+  `const symbol = __webpack_require__(module_id)`
   */
   pub required: IdentifierIndexMap<ExternalInterop>,
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1849,7 +1849,7 @@ var {} = {{}};
             info.module,
             Self::add_require(
               *info_id,
-              None,
+              from,
               Some(info.name.clone().expect("should have symbol")),
               all_used_names,
               required,
@@ -2062,7 +2062,7 @@ var {} = {{}};
               info.module,
               Self::add_require(
                 *info_id,
-                None,
+                from,
                 Some(info.name.clone().expect("should have symbol")),
                 all_used_names,
                 required,

--- a/tests/rspack-test/esmOutputCases/interop/contains-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/contains-cjs/__snapshots__/esm.snap.txt
@@ -22,7 +22,7 @@ exports["default"] = 'esm'
 
 },
 });
-// ./index.js
+// ./lib.js
 const foo = __webpack_require__("./foo.cjs");
 const from_esm = __webpack_require__("./from-esm.cjs");
 
@@ -39,6 +39,8 @@ it('should have correct import', () => {
 	expect(foo.foo).toBe(42)
 	expect(/* inlined export .value */("value")).toBe('value')
 })
+
+// ./index.js
 
 
 ```

--- a/tests/rspack-test/esmOutputCases/interop/contains-cjs/index.js
+++ b/tests/rspack-test/esmOutputCases/interop/contains-cjs/index.js
@@ -1,14 +1,1 @@
-import { foo } from './foo.cjs'
-import v1 from './foo.cjs'
-import v2 from './from-esm.cjs'
-import { value } from './foo.js'
-
-it('should have correct import', () => {
-	expect(v1).toHaveProperty('foo')
-	expect(v1.foo).toBe(42)
-
-	expect(v2).toBe('esm')
-
-	expect(foo).toBe(42)
-	expect(value).toBe('value')
-})
+import './lib'

--- a/tests/rspack-test/esmOutputCases/interop/contains-cjs/lib.js
+++ b/tests/rspack-test/esmOutputCases/interop/contains-cjs/lib.js
@@ -1,0 +1,14 @@
+import { foo } from './foo.cjs'
+import v1 from './foo.cjs'
+import v2 from './from-esm.cjs'
+import { value } from './foo.js'
+
+it('should have correct import', () => {
+	expect(v1).toHaveProperty('foo')
+	expect(v1.foo).toBe(42)
+
+	expect(v2).toBe('esm')
+
+	expect(foo).toBe(42)
+	expect(value).toBe('value')
+})


### PR DESCRIPTION
## Summary

Should set correct original module for required module, so that required module will render before access

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
