### PR TITLE
refactor: make compilation readonly for  module ids hook 

### DIFF
--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -84,7 +84,7 @@ define_hook!(CompilationAfterOptimizeModules: Series(compilation: &mut Compilati
 define_hook!(CompilationOptimizeChunks: SeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationOptimizeTree: Series(compilation: &mut Compilation));
 define_hook!(CompilationOptimizeChunkModules: SeriesBail(compilation: &mut Compilation) -> bool);
-define_hook!(CompilationModuleIds: Series(compilation: &mut Compilation));
+define_hook!(CompilationModuleIds: Series(compilation: &Compilation, module_ids: &mut ModuleIdsArtifact, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationChunkIds: Series(compilation: &mut Compilation));
 define_hook!(CompilationRuntimeModule: Series(compilation: &mut Compilation, module: &ModuleIdentifier, chunk: &ChunkUkey));
 define_hook!(CompilationAdditionalModuleRuntimeRequirements: Series(compilation: &Compilation, module_identifier: &ModuleIdentifier, runtime_requirements: &mut RuntimeGlobals),tracing=false);
@@ -1726,12 +1726,16 @@ impl Compilation {
 
     let start = logger.time("module ids");
 
+    let mut diagnostics = vec![];
+    let mut module_ids_artifact = mem::take(&mut self.module_ids_artifact);
     plugin_driver
       .compilation_hooks
       .module_ids
-      .call(self)
+      .call(self, &mut module_ids_artifact, &mut diagnostics)
       .await
       .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.moduleIds"))?;
+    self.module_ids_artifact = module_ids_artifact;
+    self.extend_diagnostics(diagnostics);
     logger.time_end(start);
 
     let start = logger.time("chunk ids");

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -1,9 +1,10 @@
 use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
-  ChunkGraph, Compilation, CompilationModuleIds, Plugin, incremental::IncrementalPasses,
+  ChunkGraph, Compilation, CompilationModuleIds, ModuleIdsArtifact, Plugin,
+  incremental::IncrementalPasses,
 };
-use rspack_error::Result;
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 
 use crate::id_helpers::{
@@ -16,21 +17,26 @@ use crate::id_helpers::{
 pub struct DeterministicModuleIdsPlugin;
 
 #[plugin_hook(CompilationModuleIds for DeterministicModuleIdsPlugin)]
-async fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
+async fn module_ids(
+  &self,
+  compilation: &Compilation,
+  module_ids: &mut ModuleIdsArtifact,
+  diagnostics: &mut Vec<Diagnostic>,
+) -> Result<()> {
   if let Some(diagnostic) = compilation.incremental.disable_passes(
     IncrementalPasses::MODULE_IDS,
     "DeterministicModuleIdsPlugin (optimization.moduleIds = \"deterministic\")",
     "it requires calculating the id of all the modules, which is a global effect",
   ) {
     if let Some(diagnostic) = diagnostic {
-      compilation.push_diagnostic(diagnostic);
+      diagnostics.push(diagnostic);
     }
-    compilation.module_ids_artifact.clear();
+    module_ids.clear();
   }
 
   let (mut used_ids, modules) = get_used_module_ids_and_modules(compilation, None);
 
-  let mut module_ids = std::mem::take(&mut compilation.module_ids_artifact);
+  let mut module_ids_map = std::mem::take(module_ids);
   let context = compilation.options.context.as_ref();
   let max_length = 3;
   let fail_on_conflict = false;
@@ -70,7 +76,11 @@ async fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
         conflicts += 1;
         return false;
       }
-      ChunkGraph::set_module_id(&mut module_ids, module.identifier(), id.to_string().into());
+      ChunkGraph::set_module_id(
+        &mut module_ids_map,
+        module.identifier(),
+        id.to_string().into(),
+      );
       true
     },
     &[usize::pow(10, max_length)],
@@ -78,7 +88,7 @@ async fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
     used_ids_len,
     salt,
   );
-  compilation.module_ids_artifact = module_ids;
+  *module_ids = module_ids_map;
   if fail_on_conflict && conflicts > 0 {
     // TODO: better error msg
     panic!("Assigning deterministic module ids has lead to conflicts {conflicts}");

--- a/crates/rspack_ids/src/natural_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_module_ids_plugin.rs
@@ -1,5 +1,7 @@
-use rspack_core::{CompilationModuleIds, Plugin, incremental::IncrementalPasses};
-use rspack_error::Result;
+use rspack_core::{
+  Compilation, CompilationModuleIds, ModuleIdsArtifact, Plugin, incremental::IncrementalPasses,
+};
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 
 use crate::id_helpers::{
@@ -12,21 +14,26 @@ use crate::id_helpers::{
 pub struct NaturalModuleIdsPlugin;
 
 #[plugin_hook(CompilationModuleIds for NaturalModuleIdsPlugin)]
-async fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<()> {
+async fn module_ids(
+  &self,
+  compilation: &Compilation,
+  module_ids: &mut ModuleIdsArtifact,
+  diagnostics: &mut Vec<Diagnostic>,
+) -> Result<()> {
   if let Some(diagnostic) = compilation.incremental.disable_passes(
     IncrementalPasses::MODULE_IDS,
     "NaturalModuleIdsPlugin (optimization.moduleIds = \"natural\")",
     "it requires calculating the id of all the modules, which is a global effect",
   ) {
     if let Some(diagnostic) = diagnostic {
-      compilation.push_diagnostic(diagnostic);
+      diagnostics.push(diagnostic);
     }
-    compilation.module_ids_artifact.clear();
+    module_ids.clear();
   }
 
   let (used_ids, mut modules_in_natural_order) = get_used_module_ids_and_modules(compilation, None);
 
-  let mut module_ids = std::mem::take(&mut compilation.module_ids_artifact);
+  let mut module_ids_artifact = std::mem::take(module_ids);
   let module_graph = compilation.get_module_graph();
 
   modules_in_natural_order
@@ -37,9 +44,13 @@ async fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result
     .filter_map(|i| module_graph.module_by_identifier(&i))
     .collect::<Vec<_>>();
 
-  assign_ascending_module_ids(&used_ids, modules_in_natural_order, &mut module_ids);
+  assign_ascending_module_ids(
+    &used_ids,
+    modules_in_natural_order,
+    &mut module_ids_artifact,
+  );
 
-  compilation.module_ids_artifact = module_ids;
+  *module_ids = module_ids_artifact;
 
   Ok(())
 }

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -19,7 +19,7 @@ use rspack_core::{
   CompilationOptimizeModules, CompilationOptimizeTree, CompilationParams, CompilationProcessAssets,
   CompilationSeal, CompilationSucceedModule, CompilerAfterEmit, CompilerClose, CompilerCompilation,
   CompilerEmit, CompilerFinishMake, CompilerId, CompilerMake, CompilerThisCompilation,
-  ModuleIdentifier, Plugin, SideEffectsOptimizeArtifact,
+  ModuleIdentifier, ModuleIdsArtifact, Plugin, SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
 };
 use rspack_error::{Diagnostic, Result};
@@ -488,7 +488,12 @@ async fn optimize_chunk_modules(&self, _compilation: &mut Compilation) -> Result
 }
 
 #[plugin_hook(CompilationModuleIds for ProgressPlugin)]
-async fn module_ids(&self, _modules: &mut Compilation) -> Result<()> {
+async fn module_ids(
+  &self,
+  _compilation: &Compilation,
+  _module_ids: &mut ModuleIdsArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<()> {
   self.sealing_hooks_report("module ids", 16).await
 }
 

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -9,9 +9,9 @@ use rspack_collections::Identifier;
 use rspack_core::{
   ChunkGroupUkey, Compilation, CompilationAfterCodeGeneration, CompilationAfterProcessAssets,
   CompilationId, CompilationModuleIds, CompilationOptimizeChunkModules, CompilationOptimizeChunks,
-  CompilationParams, CompilerCompilation, Plugin,
+  CompilationParams, CompilerCompilation, ModuleIdsArtifact, Plugin,
 };
-use rspack_error::Result;
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_devtool::{
   SourceMapDevToolModuleOptionsPlugin, SourceMapDevToolModuleOptionsPluginOptions,
@@ -379,7 +379,12 @@ async fn optimize_chunk_modules(&self, compilation: &mut Compilation) -> Result<
 }
 
 #[plugin_hook(CompilationModuleIds for RsdoctorPlugin, stage = 9999)]
-async fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
+async fn module_ids(
+  &self,
+  compilation: &Compilation,
+  module_ids: &mut ModuleIdsArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<()> {
   if !self.has_module_graph_feature(RsdoctorPluginModuleGraphFeature::ModuleIds) {
     return Ok(());
   }
@@ -392,7 +397,7 @@ async fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
     &MODULE_UKEY_MAP
       .get(&compilation.id())
       .expect("should have module ukey map"),
-    &compilation.module_ids_artifact,
+    module_ids,
   );
 
   tokio::spawn(async move {


### PR DESCRIPTION
## Summary

- allow the `CompilationModuleIds` hook to take an immutable compilation alongside mutable module id artifacts and collected diagnostics, updating the call site accordingly.
- adjust module id plugins (deterministic, natural, named, progress, rsdoctor) to the new hook signature and diagnostic handling.

## Related links

- N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ad9b974c8331a6b25edbfe534046)