### PR TITLE
fix: make after optimize modules hook immutable

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1243,7 +1243,7 @@ impl CompilationOptimizeModules for CompilationOptimizeModulesTap {
 
 #[async_trait]
 impl CompilationAfterOptimizeModules for CompilationAfterOptimizeModulesTap {
-  async fn run(&self, _compilation: &mut Compilation) -> rspack_error::Result<()> {
+  async fn run(&self, _compilation: &Compilation) -> rspack_error::Result<()> {
     self.function.call_with_sync(()).await
   }
 

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -80,7 +80,7 @@ define_hook!(CompilationConcatenationScope: SeriesBail(compilation: &Compilation
 define_hook!(CompilationOptimizeDependencies: SeriesBail(compilation: &Compilation, side_effects_optimize_artifact: &mut SideEffectsOptimizeArtifact,  build_module_graph_artifact: &mut BuildModuleGraphArtifact,
  diagnostics: &mut Vec<Diagnostic>) -> bool);
 define_hook!(CompilationOptimizeModules: SeriesBail(compilation: &Compilation, diagnostics: &mut Vec<Diagnostic>) -> bool);
-define_hook!(CompilationAfterOptimizeModules: Series(compilation: &mut Compilation));
+define_hook!(CompilationAfterOptimizeModules: Series(compilation: &Compilation));
 define_hook!(CompilationOptimizeChunks: SeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationOptimizeTree: Series(compilation: &mut Compilation));
 define_hook!(CompilationOptimizeChunkModules: SeriesBail(compilation: &mut Compilation) -> bool);

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -460,7 +460,7 @@ async fn optimize_modules(
 }
 
 #[plugin_hook(CompilationAfterOptimizeModules for ProgressPlugin)]
-async fn after_optimize_modules(&self, _compilation: &mut Compilation) -> Result<()> {
+async fn after_optimize_modules(&self, _compilation: &Compilation) -> Result<()> {
   self
     .sealing_hooks_report("after module optimization", 8)
     .await


### PR DESCRIPTION
## Summary

- change `after_optimize_modules` hook to accept an immutable `Compilation` reference and update plugin bindings accordingly

## Related links

- N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ad26068c83319083e63584cf74d3)