### PR TITLE
refactor: make compilation readonly for  optimize tree hooks

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1254,7 +1254,7 @@ impl CompilationAfterOptimizeModules for CompilationAfterOptimizeModulesTap {
 
 #[async_trait]
 impl CompilationOptimizeTree for CompilationOptimizeTreeTap {
-  async fn run(&self, _compilation: &mut Compilation) -> rspack_error::Result<()> {
+  async fn run(&self, _compilation: &Compilation) -> rspack_error::Result<()> {
     self.function.call_with_promise(()).await
   }
 

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -82,7 +82,7 @@ define_hook!(CompilationOptimizeDependencies: SeriesBail(compilation: &Compilati
 define_hook!(CompilationOptimizeModules: SeriesBail(compilation: &Compilation, diagnostics: &mut Vec<Diagnostic>) -> bool);
 define_hook!(CompilationAfterOptimizeModules: Series(compilation: &mut Compilation));
 define_hook!(CompilationOptimizeChunks: SeriesBail(compilation: &mut Compilation) -> bool);
-define_hook!(CompilationOptimizeTree: Series(compilation: &mut Compilation));
+define_hook!(CompilationOptimizeTree: Series(compilation: &Compilation));
 define_hook!(CompilationOptimizeChunkModules: SeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationModuleIds: Series(compilation: &mut Compilation));
 define_hook!(CompilationChunkIds: Series(compilation: &mut Compilation));

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -473,7 +473,7 @@ async fn optimize_chunks(&self, _compilation: &mut Compilation) -> Result<Option
 }
 
 #[plugin_hook(CompilationOptimizeTree for ProgressPlugin)]
-async fn optimize_tree(&self, _compilation: &mut Compilation) -> Result<()> {
+async fn optimize_tree(&self, _compilation: &Compilation) -> Result<()> {
   self
     .sealing_hooks_report("module and chunk tree optimization", 11)
     .await


### PR DESCRIPTION
## Summary
- use an immutable compilation reference for the optimize_tree hook definition
- align plugin implementations and JS hook adapters with the new signature

## Related links
- n/a

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ad7e38348331895e79af2b322dd1)