### PR TITLE
docs: fix benchmark repo links

### DIFF
--- a/website/docs/en/blog/announcing-0-2.mdx
+++ b/website/docs/en/blog/announcing-0-2.mdx
@@ -202,15 +202,6 @@ With the help of the [Valor](https://valor-software.com/) team, Rspack has compl
 
 With the help of [Rosa](https://rosa.be/), [Nx](https://nx.dev/), and [Valor](https://valor-software.com/), Rspack has completed the compilation support for [NestJS](https://nestjs.com/). You can use Rspack to package NestJS applications, and in actual projects, tests have shown that Rspack has a 5-10 times build performance improvement compared to the webpack version.
 
-## Benchmark
-
-Added a benchmark comparison with esbuild. Please refer to the following link for more details: https://github.com/web-infra-dev/performance-compare
-
-<img
-  src="https://raw.githubusercontent.com/web-infra-dev/performance-compare/main/assets/benchmark.png"
-  alt="benchmark"
-></img>
-
 ## Dev guide
 
 The Rspack team cherishes the valuable contributions made by the open source community and wants to actively fosters collaboration. We are committed to maintaining an open approach, striving to engage and involve the community at every step.

--- a/website/docs/en/blog/announcing-1-0.mdx
+++ b/website/docs/en/blog/announcing-1-0.mdx
@@ -41,7 +41,7 @@ Since the release of 0.1, Rspack has introduced numerous important features and 
 
 As a Rust-based bundler, performance has always been a core focus for Rspack. Since the release of Rspack 0.1, we have made numerous performance improvements, optimized its performance for different scenarios, and added key features such as [lazy compilation](/config/experiments#experimentslazycompilation) to ensure better performance in large projects.
 
-Here is a comparison of build performance between Rspack 0.1 and Rspack 1.0 from the [benchmark](https://github.com/rstackjs/performance-compare). Rspack has significantly improved build performance while also adding many new features:
+Here is a comparison of build performance between Rspack 0.1 and Rspack 1.0 from the [benchmark](https://github.com/rstackjs/build-tools-performance). Rspack has significantly improved build performance while also adding many new features:
 
 ![Rspack benchmark](https://assets.rspack.rs/rspack/assets/rspack-v1-0-benchmark.png)
 

--- a/website/docs/zh/blog/announcing-0-2.mdx
+++ b/website/docs/zh/blog/announcing-0-2.mdx
@@ -199,15 +199,6 @@ Rspack 0.2 已经完成了对 vue-loader 的兼容。对于 Vue 3 项目，你�
 
 在 Rosa、Nx 和 Valor 的帮助下，Rspack 完成了对 NestJS 的编译支持，你可以使用 Rspack 打包 NestJS 应用，在实际项目中进行测试，Rspack 相比 webpack 版本有 5-10 倍的构建性能提升。
 
-## Benchmark
-
-添加与 esbuild 对比的 benchmark https://github.com/web-infra-dev/performance-compare
-
-<img
-  src="https://raw.githubusercontent.com/web-infra-dev/performance-compare/main/assets/benchmark.png"
-  alt="benchmark"
-></img>
-
 ## 开发指南
 
 Rspack 团队非常重视开源社区做出的宝贵贡献。我们致力于保持开放的态度，努力在每一步都让开源社区参与进来。

--- a/website/docs/zh/blog/announcing-1-0.mdx
+++ b/website/docs/zh/blog/announcing-1-0.mdx
@@ -41,7 +41,7 @@ Rspack 是基于 Rust 编写的下一代 JavaScript 打包工具， 兼容 webpa
 
 作为基于 Rust 实现的 Bundler，性能始终是 Rspack 的一个核心指标。从 Rspack 0.1 发布以来，我们对 Rspack 做了大量的性能改进，优化各个场景下的性能表现，并支持了 [lazy compilation](/config/experiments#experimentslazycompilation) 等核心功能，以保障 Rspack 在大型项目中有更佳的性能。
 
-下图是 Rspack 0.1 与 Rspack 1.0 在 [benchmark](https://github.com/rstackjs/performance-compare) 中的 build 性能对比。可以看到，Rspack 在实现大量新特性的同时，也显著提升了构建性能：
+下图是 Rspack 0.1 与 Rspack 1.0 在 [benchmark](https://github.com/rstackjs/build-tools-performance) 中的 build 性能对比。可以看到，Rspack 在实现大量新特性的同时，也显著提升了构建性能：
 
 ![Rspack benchmark](https://assets.rspack.rs/rspack/assets/rspack-v1-0-benchmark.png)
 

--- a/website/theme/components/Landingpage/Benchmark/index.tsx
+++ b/website/theme/components/Landingpage/Benchmark/index.tsx
@@ -15,7 +15,7 @@ import styles from './index.module.scss';
 
 // Benchmark data for different cases
 // Unit: second
-// From: https://github.com/rstackjs/performance-compare
+// From: https://github.com/rstackjs/build-tools-performance
 const BENCHMARK_DATA: BenchmarkData = {
   rspack: {
     label: 'Rspack',
@@ -99,7 +99,7 @@ export const Benchmark = memo(() => {
         <BaseBenchmark data={BENCHMARK_DATA} />
         <div className="flex flex-col items-center self-stretch">
           <a
-            href="https://github.com/rstackjs/performance-compare"
+            href="https://github.com/rstackjs/build-tools-performance"
             target="_blank"
             className={styles.button}
             rel="noreferrer"


### PR DESCRIPTION
## Summary

Fix benchmark repo links in documentation.

The latest benchmark repo is https://github.com/rstackjs/build-tools-performance

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
