### PR TITLE
refactor: remove option in module_graph_module_by_identifier_mut

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -181,9 +181,7 @@ pub async fn recovery_module_graph(
     });
   // recovery incoming connections
   for (dep_id, module_identifier) in need_check_dep {
-    let mgm = mg
-      .module_graph_module_by_identifier_mut(&module_identifier)
-      .expect("should mgm exist");
+    let mgm = mg.module_graph_module_by_identifier_mut(&module_identifier);
     mgm.add_incoming_connection(dep_id);
   }
 

--- a/crates/rspack_core/src/compilation/build_chunk_graph/artifact.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/artifact.rs
@@ -200,10 +200,7 @@ where
       let module_idx = cache.module_idx.clone();
       let module_graph = compilation.get_module_graph_mut();
       for (m, (pre, post)) in module_idx {
-        let Some(mgm) = module_graph.module_graph_module_by_identifier_mut(&m) else {
-          continue;
-        };
-
+        let mgm = module_graph.module_graph_module_by_identifier_mut(&m);
         mgm.pre_order_index = Some(pre);
         mgm.post_order_index = Some(post);
       }

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1162,9 +1162,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
     {
       let module_graph = compilation.get_module_graph_mut();
-      let module = module_graph
-        .module_graph_module_by_identifier_mut(&item.module)
-        .unwrap_or_else(|| panic!("No module found {:?}", &item.module));
+      let module = module_graph.module_graph_module_by_identifier_mut(&item.module);
 
       if module.pre_order_index.is_none() {
         module.pre_order_index = Some(self.next_free_module_pre_order_index);
@@ -1207,9 +1205,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     }
 
     let module_graph = compilation.get_module_graph_mut();
-    let module = module_graph
-      .module_graph_module_by_identifier_mut(&item.module)
-      .unwrap_or_else(|| panic!("no module found: {:?}", &item.module));
+    let module = module_graph.module_graph_module_by_identifier_mut(&item.module);
 
     if module.post_order_index.is_none() {
       module.post_order_index = Some(self.next_free_module_post_order_index);

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -197,9 +197,7 @@ impl Task<TaskContext> for BuildResultTask {
     }
 
     {
-      let mgm = module_graph
-        .module_graph_module_by_identifier_mut(&module.identifier())
-        .expect("Failed to get mgm");
+      let mgm = module_graph.module_graph_module_by_identifier_mut(&module.identifier());
       mgm.all_dependencies = all_dependencies.clone();
       if let Some(current_profile) = current_profile {
         mgm.set_profile(current_profile);

--- a/crates/rspack_core/src/module_graph/internal.rs
+++ b/crates/rspack_core/src/module_graph/internal.rs
@@ -1,0 +1,33 @@
+/// Internal helpers for ModuleGraph that should only be used by specific modules.
+///
+/// **DO NOT USE THESE FUNCTIONS** unless you're in `compilation::build_module_graph`.
+///
+/// This module provides restricted access to potentially unsafe ModuleGraph operations
+/// that should only be used in specific contexts where modules may legitimately not exist.
+use crate::{ModuleGraph, ModuleGraphModule, ModuleIdentifier};
+
+/// Try to get a mutable module graph module by identifier, returning None if not found.
+///
+/// # Restricted Use - DO NOT USE
+///
+/// **WARNING**: This function should ONLY be used in `compilation::build_module_graph`
+/// for handling module removal during graph updates where modules may have been removed
+/// during incremental compilation.
+///
+/// **All other code must use `ModuleGraph::module_graph_module_by_identifier_mut()`**
+/// which enforces the invariant that the module exists with a clear panic message.
+///
+/// # When to Use (only in build_module_graph)
+///
+/// Only use when you have a legitimate reason to expect the module might not exist:
+/// - During incremental compilation where modules may have been removed
+/// - During graph cleanup operations where referenced modules may already be deleted
+///
+/// If you're unsure, use `module_graph_module_by_identifier_mut()` instead.
+#[inline]
+pub(crate) fn try_get_module_graph_module_mut_by_identifier<'a>(
+  module_graph: &'a mut ModuleGraph,
+  identifier: &ModuleIdentifier,
+) -> Option<&'a mut ModuleGraphModule> {
+  module_graph.inner.module_graph_modules.get_mut(identifier)
+}

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1,5 +1,5 @@
+pub(crate) mod internal;
 pub mod rollback;
-use std::collections::hash_map::Entry;
 
 use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
@@ -12,6 +12,7 @@ use crate::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, AsyncModulesArtifact, Compilation,
   DependenciesBlock, Dependency, ExportInfo, ExportName, ImportedByDeferModulesArtifact,
   ModuleGraphCacheArtifact, RuntimeSpec, UsedNameItem,
+  internal::try_get_module_graph_module_mut_by_identifier,
 };
 mod module;
 pub use module::*;
@@ -124,7 +125,7 @@ impl ModuleGraphData {
 
 #[derive(Debug, Default)]
 pub struct ModuleGraph {
-  inner: ModuleGraphData,
+  pub(super) inner: ModuleGraphData,
 }
 impl ModuleGraph {
   // checkpoint
@@ -213,14 +214,10 @@ impl ModuleGraph {
       let con = self
         .connection_by_dependency_id(dep_id)
         .expect("should have connection");
-      match map.entry(con.original_module_identifier) {
-        Entry::Occupied(mut occ) => {
-          occ.get_mut().push(con);
-        }
-        Entry::Vacant(vac) => {
-          vac.insert(vec![con]);
-        }
-      }
+      map
+        .entry(con.original_module_identifier)
+        .or_default()
+        .push(con);
     }
     map
   }
@@ -258,7 +255,8 @@ impl ModuleGraph {
 
     // remove outgoing from original module graph module
     if let Some(original_module_identifier) = &original_module_identifier
-      && let Some(mgm) = self.module_graph_module_by_identifier_mut(original_module_identifier)
+      && let Some(mgm) =
+        try_get_module_graph_module_mut_by_identifier(self, original_module_identifier)
     {
       mgm.remove_outgoing_connection(dep_id);
       if force {
@@ -267,7 +265,7 @@ impl ModuleGraph {
     }
     // remove incoming from module graph module
     if let Some(module_identifier) = &module_identifier
-      && let Some(mgm) = self.module_graph_module_by_identifier_mut(module_identifier)
+      && let Some(mgm) = try_get_module_graph_module_mut_by_identifier(self, module_identifier)
     {
       mgm.remove_incoming_connection(dep_id);
     }
@@ -333,9 +331,7 @@ impl ModuleGraph {
       old_mgm.depth,
       old_mgm.exports,
     );
-    let new_mgm = module_graph
-      .module_graph_module_by_identifier_mut(target_module)
-      .expect("should have mgm");
+    let new_mgm = module_graph.module_graph_module_by_identifier_mut(target_module);
     new_mgm.post_order_index = assign_tuple.0;
     new_mgm.pre_order_index = assign_tuple.1;
     new_mgm.depth = assign_tuple.2;
@@ -378,16 +374,12 @@ impl ModuleGraph {
       }
     }
 
-    let old_mgm = self
-      .module_graph_module_by_identifier_mut(old_module)
-      .expect("should have mgm");
+    let old_mgm = self.module_graph_module_by_identifier_mut(old_module);
     for dep_id in &affected_outgoing_connection {
       old_mgm.remove_outgoing_connection(dep_id);
     }
 
-    let new_mgm = self
-      .module_graph_module_by_identifier_mut(new_module)
-      .expect("should have mgm");
+    let new_mgm = self.module_graph_module_by_identifier_mut(new_module);
     for dep_id in affected_outgoing_connection {
       new_mgm.add_outgoing_connection(dep_id);
     }
@@ -413,16 +405,12 @@ impl ModuleGraph {
       }
     }
 
-    let old_mgm = self
-      .module_graph_module_by_identifier_mut(old_module)
-      .expect("should have mgm");
+    let old_mgm = self.module_graph_module_by_identifier_mut(old_module);
     for dep_id in &affected_incoming_connection {
       old_mgm.remove_incoming_connection(dep_id);
     }
 
-    let new_mgm = self
-      .module_graph_module_by_identifier_mut(new_module)
-      .expect("should have mgm");
+    let new_mgm = self.module_graph_module_by_identifier_mut(new_module);
     for dep_id in affected_incoming_connection {
       new_mgm.add_incoming_connection(dep_id);
     }
@@ -462,9 +450,7 @@ impl ModuleGraph {
       }
     }
 
-    let new_mgm = self
-      .module_graph_module_by_identifier_mut(new_module)
-      .expect("should have mgm");
+    let new_mgm = self.module_graph_module_by_identifier_mut(new_module);
     for dep_id in affected_outgoing_connections {
       new_mgm.add_outgoing_connection(dep_id);
     }
@@ -477,19 +463,14 @@ impl ModuleGraph {
   }
 
   pub fn set_depth_if_lower(&mut self, module_id: &ModuleIdentifier, depth: usize) -> bool {
-    let mgm = self
-      .module_graph_module_by_identifier_mut(module_id)
-      .expect("should have module graph module");
-    if let Some(ref mut cur_depth) = mgm.depth {
-      if *cur_depth > depth {
-        *cur_depth = depth;
-        return true;
+    let mgm = self.module_graph_module_by_identifier_mut(module_id);
+    match mgm.depth {
+      Some(cur_depth) if cur_depth <= depth => false,
+      _ => {
+        mgm.depth = Some(depth);
+        true
       }
-    } else {
-      mgm.depth = Some(depth);
-      return true;
     }
-    false
   }
 
   pub fn add_module(&mut self, module: BoxModule) {
@@ -538,7 +519,7 @@ impl ModuleGraph {
     &self,
     block_id: &AsyncDependenciesBlockIdentifier,
   ) -> Option<&AsyncDependenciesBlock> {
-    self.inner.blocks.get(block_id).map(|b| &**b)
+    self.inner.blocks.get(block_id).map(AsRef::as_ref)
   }
 
   pub fn block_by_id_expect(
@@ -636,11 +617,9 @@ impl ModuleGraph {
   }
 
   pub fn get_module_by_dependency_id(&self, dep_id: &DependencyId) -> Option<&BoxModule> {
-    if let Some(module_id) = self.module_identifier_by_dependency_id(dep_id) {
-      self.inner.modules.get(module_id)
-    } else {
-      None
-    }
+    self
+      .module_identifier_by_dependency_id(dep_id)
+      .and_then(|module_id| self.inner.modules.get(module_id))
   }
 
   fn add_connection(
@@ -674,22 +653,14 @@ impl ModuleGraph {
 
     // set to module incoming connection
     {
-      let mgm = self
-        .module_graph_module_by_identifier_mut(&module_id)
-        .unwrap_or_else(|| {
-          panic!(
-            "Failed to add connection: Module linked to module identifier {module_id} cannot be found"
-          )
-        });
+      let mgm = self.module_graph_module_by_identifier_mut(&module_id);
 
       mgm.add_incoming_connection(dependency_id);
     }
 
     // set to origin module outgoing connection
     if let Some(identifier) = origin_module_id {
-      let original_mgm = self
-        .module_graph_module_by_identifier_mut(&identifier)
-        .expect("should mgm exist");
+      let original_mgm = self.module_graph_module_by_identifier_mut(&identifier);
       original_mgm.add_outgoing_connection(dependency_id);
     };
   }
@@ -743,12 +714,21 @@ impl ModuleGraph {
     self.inner.module_graph_modules.get(identifier)
   }
 
-  /// Uniquely identify a module graph module by its module's identifier and return the exclusive reference
+  /// Get a mutable module graph module by identifier, panicking if not found.
+  ///
+  /// **PREFERRED METHOD**: Use this for all internal code where the module graph module
+  /// should exist. This enforces the invariant with a clear panic message if violated.
+  ///
+  /// Only use `try_module_graph_module_by_identifier_mut()` when you need to handle missing modules.
   pub fn module_graph_module_by_identifier_mut(
     &mut self,
     identifier: &ModuleIdentifier,
-  ) -> Option<&mut ModuleGraphModule> {
-    self.inner.module_graph_modules.get_mut(identifier)
+  ) -> &mut ModuleGraphModule {
+    self
+      .inner
+      .module_graph_modules
+      .get_mut(identifier)
+      .unwrap_or_else(|| panic!("ModuleGraphModule with identifier {identifier:?} not found"))
   }
 
   pub fn get_ordered_outgoing_connections(
@@ -935,22 +915,16 @@ impl ModuleGraph {
     connection.set_module_identifier(*module_id);
 
     // remove dep_id from old module mgm incoming connection
-    let old_mgm = self
-      .module_graph_module_by_identifier_mut(&old_module_identifier)
-      .expect("should exist mgm");
+    let old_mgm = self.module_graph_module_by_identifier_mut(&old_module_identifier);
     old_mgm.remove_incoming_connection(dep_id);
 
     // add dep_id to updated module mgm incoming connection
-    let new_mgm = self
-      .module_graph_module_by_identifier_mut(module_id)
-      .expect("should exist mgm");
+    let new_mgm = self.module_graph_module_by_identifier_mut(module_id);
     new_mgm.add_incoming_connection(*dep_id);
   }
 
   pub fn get_optimization_bailout_mut(&mut self, id: &ModuleIdentifier) -> &mut Vec<String> {
-    let mgm = self
-      .module_graph_module_by_identifier_mut(id)
-      .expect("should have module graph module");
+    let mgm = self.module_graph_module_by_identifier_mut(id);
     mgm.optimization_bailout_mut()
   }
 


### PR DESCRIPTION
## Summary
remove option in module_graph_module_by_identifier_{mut} api to avoid unnecessary expect. 
we need to ensure it shouldn't return None after module_graph is built.
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
