### PR TITLE
chore: use Node 24 for WASM tests

### DIFF
--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false # wait for all test to finish for determining if it's node version based problem or general problem
       matrix:
         node: ${{ fromJSON(
-          inputs.target == 'wasm32-wasip1-threads'&& '[22]'
+          inputs.target == 'wasm32-wasip1-threads'&& '[24]'
           || contains(inputs.target, 'linux') && '[18, 20, 22]'
           || '[22]') }}
     name: Test Node ${{ matrix.node }}


### PR DESCRIPTION
## Summary

This PR updates the CI environment to use Node.js 24 for wasm32-wasip1-threads targets. This change is necessary to avoid a stable Undefined Behavior (UB) in V8's WASM SIMD implementation found in earlier Node.js versions.

**Problem & Investigation**
We identified a consistent JSON parsing error (UB) when running simdjson in Node.js versions prior to 24 on Ubuntu systems.

**Key findings from the investigation:**

- **Environment:** The issue is reproducible in Node.js < 24 (which uses an older version of V8). Node.js 24 upgraded V8, which effectively resolves the bug.
- **Root Cause:** The behavior is likely a V8 bug related to the wasm-simd128 feature.
- **Reproduction:** A minimal reproduction using Rust and simdjson ([node-wasm-simd-bug](https://github.com/CPunisher/node-wasm-simd-bug)) confirms that the same WASM binary runs correctly in wasmer but fails in older Node.js environments.
- **Workaround context:** Interestingly, the bug does not manifest in release builds that have been processed with wasm-opt, but it remains a blocker for debug/test environments using standard WASM SIMD.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
