### PR TITLE
refactor: replace UsageCallback closure with InnerGraphUsageOperation enum

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -10,6 +10,7 @@ use swc_core::{
 use super::{InnerGraphPlugin, JavascriptParserPlugin};
 use crate::{
   dependency::{ESMImportSideEffectDependency, ESMImportSpecifierDependency},
+  parser_plugin::inner_graph::state::InnerGraphUsageOperation,
   utils::object_properties::get_attributes,
   visitors::{
     AllowedMemberTypes, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo, TagInfoData,
@@ -158,13 +159,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
 
     InnerGraphPlugin::on_usage(
       parser,
-      Box::new(move |parser, used_by_exports| {
-        if let Some(dep) = parser.get_dependency_mut(dep_idx)
-          && let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>()
-        {
-          dep.set_used_by_exports(used_by_exports);
-        }
-      }),
+      InnerGraphUsageOperation::ESMImportSpecifier(dep_idx),
     );
 
     Some(true)
@@ -226,13 +221,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
 
     InnerGraphPlugin::on_usage(
       parser,
-      Box::new(move |parser, used_by_exports| {
-        if let Some(dep) = parser.get_dependency_mut(dep_idx)
-          && let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>()
-        {
-          dep.set_used_by_exports(used_by_exports);
-        }
-      }),
+      InnerGraphUsageOperation::ESMImportSpecifier(dep_idx),
     );
 
     Some(true)
@@ -294,13 +283,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
 
     InnerGraphPlugin::on_usage(
       parser,
-      Box::new(move |parser, used_by_exports| {
-        if let Some(dep) = parser.get_dependency_mut(dep_idx)
-          && let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>()
-        {
-          dep.set_used_by_exports(used_by_exports);
-        }
-      }),
+      InnerGraphUsageOperation::ESMImportSpecifier(dep_idx),
     );
 
     parser.walk_expr_or_spread(&call_expr.args);
@@ -361,13 +344,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
 
     InnerGraphPlugin::on_usage(
       parser,
-      Box::new(move |parser, used_by_exports| {
-        if let Some(dep) = parser.get_dependency_mut(dep_idx)
-          && let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>()
-        {
-          dep.set_used_by_exports(used_by_exports);
-        }
-      }),
+      InnerGraphUsageOperation::ESMImportSpecifier(dep_idx),
     );
 
     Some(true)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -14,9 +14,10 @@ use url::Url;
 
 use super::JavascriptParserPlugin;
 use crate::{
+  InnerGraphPlugin,
   dependency::{URLContextDependency, URLDependency},
   magic_comment::try_extract_magic_comment,
-  parser_plugin::inner_graph::plugin::InnerGraphPlugin,
+  parser_plugin::inner_graph::state::InnerGraphUsageOperation,
   visitors::{ExprRef, JavascriptParser, context_reg_exp, create_context_dependency},
 };
 
@@ -166,16 +167,7 @@ impl JavascriptParserPlugin for URLPlugin {
       );
       let dep_idx = parser.next_dependency_idx();
       parser.add_dependency(Box::new(dep));
-      InnerGraphPlugin::on_usage(
-        parser,
-        Box::new(move |parser, used_by_exports| {
-          if let Some(dep) = parser.get_dependency_mut(dep_idx)
-            && let Some(dep) = dep.downcast_mut::<URLDependency>()
-          {
-            dep.set_used_by_exports(used_by_exports);
-          }
-        }),
-      );
+      InnerGraphPlugin::on_usage(parser, InnerGraphUsageOperation::URLDependency(dep_idx));
       return Some(true);
     }
 


### PR DESCRIPTION

## Summary

Replace the closure-based UsageCallback pattern in InnerGraphPlugin::on_usage with an InnerGraphUsageOperation enum for better performance and code clarity.

Changes:
- Add InnerGraphUsageOperation enum with three variants:
  - PureExpression(DependencyRange)
  - ESMImportSpecifier(usize)
  - URLDependency(usize)
- Update on_usage to accept enum instead of closure
- Update infer_dependency_usage to match on enum variants
- Update 11 call sites across plugin.rs, esm_import_dependency_parser_plugin.rs, and url_plugin.rs

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
