### PR TITLE
docs: add link to pure annotation specification

### DIFF
--- a/website/docs/en/guide/optimization/tree-shaking.mdx
+++ b/website/docs/en/guide/optimization/tree-shaking.mdx
@@ -164,7 +164,7 @@ Since `value` is used, the `foo` it depends on is retained.
 
 ## Pure annotation
 
-Use the `/*#__PURE__*/` annotation to tell Rspack that a function call is side-effect-free (pure). Place it before function calls to mark them as having no side effects.
+Use the [`/*#__PURE__*/`](https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/pure-notation-spec.md) annotation to tell Rspack that a function call is side-effect-free (pure). Place it before function calls to mark them as having no side effects.
 
 When an unused variable's initial value is marked as side-effect-free (pure), it's treated as dead code and removed by the minimizer.
 

--- a/website/docs/zh/guide/optimization/tree-shaking.mdx
+++ b/website/docs/zh/guide/optimization/tree-shaking.mdx
@@ -168,7 +168,7 @@ export const foo = 42;
 
 ## Pure 注解
 
-通过 `/*#__PURE__*/` 注解可以告诉 Rspack 某个函数调用无副作用。它可以被放到函数调用之前，用来标记此函数调用是无副作用的。
+通过 [`/*#__PURE__*/`](https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/pure-notation-spec.md) 注解可以告诉 Rspack 某个函数调用无副作用。它可以被放到函数调用之前，用来标记此函数调用是无副作用的。
 
 如果一个没被使用的变量定义的初始值被认为是无副作用的，它会被标记为死代码，不会被执行且会被压缩工具清除掉。
 


### PR DESCRIPTION
## Summary

Added a link to the official `/*#__PURE__*/` annotation specification.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
