### PR TITLE
feat!: remove `experiments.SubResourceIntegrityPlugin`

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2488,8 +2488,6 @@ interface Experiments_2 {
     RslibPlugin: typeof RslibPlugin;
     // (undocumented)
     RstestPlugin: typeof RstestPlugin;
-    // @deprecated (undocumented)
-    SubresourceIntegrityPlugin: typeof SubresourceIntegrityPlugin;
     // (undocumented)
     swc: {
         transform: typeof transform;

--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -75,7 +75,7 @@ export type HtmlRspackPluginOptions = {
 
   /**
    * Configure the SRI hash algorithm, which is disabled by default.
-   * @deprecated Use `experiments.SubresourceIntegrityPlugin` instead.
+   * @deprecated Use `SubresourceIntegrityPlugin` instead.
    */
   sri?: 'sha256' | 'sha384' | 'sha512';
 

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -377,10 +377,6 @@ interface Experiments {
     cleanup: () => Promise<void>;
   };
   RemoveDuplicateModulesPlugin: typeof RemoveDuplicateModulesPlugin;
-  /**
-   * @deprecated Use `rspack.SubresourceIntegrityPlugin` instead
-   */
-  SubresourceIntegrityPlugin: typeof SubresourceIntegrityPlugin;
   EsmLibraryPlugin: typeof EsmLibraryPlugin;
   RsdoctorPlugin: typeof RsdoctorPlugin;
   RstestPlugin: typeof RstestPlugin;
@@ -421,7 +417,6 @@ export const experiments: Experiments = {
     },
   },
   RemoveDuplicateModulesPlugin,
-  SubresourceIntegrityPlugin,
   EsmLibraryPlugin,
   /**
    * Note: This plugin is unstable yet


### PR DESCRIPTION
## Summary

Remove `rspack.experiments.SubResourceIntegrityPlugin`, use `rspack.SubResourceIntegrityPlugin` instead.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
