### PR TITLE
chore: run ci/eco-ci/eco-benchmark on v2 branch

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - v2
     # Ignore md files in push to skip workflow when only documentation changes
     paths-ignore:
       - '**/*.md'

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - v2
     paths-ignore:
       - '**/*.md'
       - 'website/**'

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - v2
     paths:
       - '.github/workflows/**'
       - 'crates/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
       - main
+      - v2
     paths-ignore:
       - '**/*.md'
       - 'website/**'
@@ -23,7 +24,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'v2' }}
 
 permissions:
   # Allow commenting on issues for `reusable-build.yml`

--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - v2
     paths-ignore:
       - '**/*.md'
       - 'website/**'

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -33,6 +33,7 @@ on:
   push:
     branches:
       - main
+      - v2
     paths-ignore:
       - '**/*.md'
       - 'website/**'


### PR DESCRIPTION
## Summary

The v2 branch should also trigger ci, eco-ci and eco-benchmark

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
