### PR TITLE
refactor: afterCodeGeneration hook use read only compilation ref

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -139,7 +139,11 @@ impl EsmLibraryPlugin {
     }
   }
 
-  pub(crate) async fn link(&self, compilation: &mut Compilation) -> Result<()> {
+  pub(crate) async fn link(
+    &self,
+    compilation: &Compilation,
+    diagnostics: &mut Vec<Diagnostic>,
+  ) -> Result<()> {
     let module_graph = compilation.get_module_graph();
 
     // codegen uses self.concatenated_modules_map_for_codegen which has hold another Arc, so
@@ -247,7 +251,7 @@ impl EsmLibraryPlugin {
 
     // link imported specifier with exported symbol
     let mut needed_namespace_objects_by_ukey = UkeyMap::default();
-    compilation.extend_diagnostics(self.link_imports_and_exports(
+    diagnostics.extend(self.link_imports_and_exports(
       compilation,
       &mut link,
       &mut concate_modules_map,

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -18,7 +18,7 @@ use rspack_core::{
   ParserOptions, Plugin, PrefetchExportsInfoMode, RuntimeGlobals, get_target, is_esm_dep_like,
   rspack_sources::{ReplaceSource, Source},
 };
-use rspack_error::Result;
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesRenderChunkContent, JsPlugin, RenderSource,
@@ -303,7 +303,11 @@ async fn concatenation_scope(
 }
 
 #[plugin_hook(CompilationAfterCodeGeneration for EsmLibraryPlugin)]
-async fn after_code_generation(&self, compilation: &mut Compilation) -> Result<()> {
+async fn after_code_generation(
+  &self,
+  compilation: &Compilation,
+  diagnostics: &mut Vec<Diagnostic>,
+) -> Result<()> {
   let mut chunk_ids_to_ukey = FxHashMap::default();
 
   for chunk_ukey in compilation.chunk_by_ukey.keys() {
@@ -316,7 +320,7 @@ async fn after_code_generation(&self, compilation: &mut Compilation) -> Result<(
 
   *self.chunk_ids_to_ukey.borrow_mut() = chunk_ids_to_ukey;
 
-  self.link(compilation).await?;
+  self.link(compilation, diagnostics).await?;
   Ok(())
 }
 

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -418,7 +418,11 @@ async fn module_ids(
 }
 
 #[plugin_hook(CompilationAfterCodeGeneration for RsdoctorPlugin, stage = 9999)]
-async fn after_code_generation(&self, compilation: &mut Compilation) -> Result<()> {
+async fn after_code_generation(
+  &self,
+  compilation: &Compilation,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<()> {
   if !self.has_module_graph_feature(RsdoctorPluginModuleGraphFeature::ModuleSources) {
     return Ok(());
   }


### PR DESCRIPTION
## Summary
Refactor `AfterCodeGeneration` hook to use read only `compilation` ref

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
