### PR TITLE
fix(context-replacement): only apply changes when regex matches

### DIFF
--- a/crates/rspack_plugin_module_replacement/src/context_replacement.rs
+++ b/crates/rspack_plugin_module_replacement/src/context_replacement.rs
@@ -43,10 +43,10 @@ impl ContextReplacementPlugin {
 
 #[plugin_hook(ContextModuleFactoryBeforeResolve for ContextReplacementPlugin)]
 async fn cmf_before_resolve(&self, mut result: BeforeResolveResult) -> Result<BeforeResolveResult> {
-  if let BeforeResolveResult::Data(data) = &mut result {
-    if self.resource_reg_exp.test(&data.request)
-      && let Some(new_content_resource) = &self.new_content_resource
-    {
+  if let BeforeResolveResult::Data(data) = &mut result
+    && self.resource_reg_exp.test(&data.request)
+  {
+    if let Some(new_content_resource) = &self.new_content_resource {
       data.request = new_content_resource.clone();
     }
     if let Some(new_content_recursive) = self.new_content_recursive {

--- a/tests/rspack-test/configCases/context-replacement/non-matching-regex/assets/file1.js
+++ b/tests/rspack-test/configCases/context-replacement/non-matching-regex/assets/file1.js
@@ -1,0 +1,1 @@
+module.exports = "asset1";

--- a/tests/rspack-test/configCases/context-replacement/non-matching-regex/assets/file2.js
+++ b/tests/rspack-test/configCases/context-replacement/non-matching-regex/assets/file2.js
@@ -1,0 +1,1 @@
+module.exports = "asset2";

--- a/tests/rspack-test/configCases/context-replacement/non-matching-regex/index.js
+++ b/tests/rspack-test/configCases/context-replacement/non-matching-regex/index.js
@@ -1,0 +1,14 @@
+it("should not affect contexts that don't match the regex", function () {
+	// This context does NOT match /components$/ so should not be affected
+	var assetsContext = require.context("./assets", false, /\.js$/);
+	var assetKeys = assetsContext.keys();
+
+	// Should find the asset files since the plugin shouldn't affect this context
+	expect(assetKeys.length).toBe(2);
+	expect(assetKeys).toContain("./file1.js");
+	expect(assetKeys).toContain("./file2.js");
+
+	// Verify we can actually load the files
+	expect(assetsContext("./file1.js")).toBe("asset1");
+	expect(assetsContext("./file2.js")).toBe("asset2");
+});

--- a/tests/rspack-test/configCases/context-replacement/non-matching-regex/rspack.config.js
+++ b/tests/rspack-test/configCases/context-replacement/non-matching-regex/rspack.config.js
@@ -1,0 +1,15 @@
+var webpack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	plugins: [
+		// This plugin should only affect contexts matching /components$/
+		// and should NOT affect the "assets" context
+		new webpack.ContextReplacementPlugin(
+			/components$/,
+			"./replaced-components",
+			true,
+			/^replaced$/
+		)
+	]
+};


### PR DESCRIPTION
## Summary
- Fixed bug where `ContextReplacementPlugin` applied transformations to all `require.context()` calls regardless of regex match
- The regex check was incorrectly placed inside the `new_content_resource` conditional, causing `recursive`, `regExp`, and `critical` modifications to apply to non-matching contexts
- Now all transformations only apply when the configured regex successfully matches the request

## Test plan
- Added test case `context-replacement/non-matching-regex` that verifies non-matching contexts are not affected
- Existing context-replacement tests should continue to pass

Closes #12656