### PR TITLE
feat!: remove `experiments.parallelLoader`

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2451,7 +2451,6 @@ export type Experiments = {
     incremental?: IncrementalPresets | Incremental;
     futureDefaults?: boolean;
     buildHttp?: HttpUriOptions;
-    parallelLoader?: boolean;
     useInputFileSystem?: UseInputFileSystem;
     nativeWatcher?: boolean;
     inlineConst?: boolean;
@@ -2535,8 +2534,6 @@ export interface ExperimentsNormalized {
     nativeWatcher?: boolean;
     // (undocumented)
     outputModule?: boolean;
-    // (undocumented)
-    parallelLoader?: boolean;
     // (undocumented)
     topLevelAwait?: boolean;
     // (undocumented)

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -259,9 +259,6 @@ const applyExperimentsDefaults = (
     D(experiments.incremental, 'emitAssets', true);
   }
 
-  // IGNORE(experiments.parallelLoader): Rspack specific configuration for parallel loader execution
-  D(experiments, 'parallelLoader', false);
-
   // IGNORE(experiments.useInputFileSystem): Rspack specific configuration
   // Enable `useInputFileSystem` will introduce much more fs overheads,  So disable by default.
   D(experiments, 'useInputFileSystem', false);

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -422,7 +422,6 @@ export const getNormalizedRspackOptions = (
           getNormalizedIncrementalOptions(options),
         ),
         buildHttp: experiments.buildHttp,
-        parallelLoader: experiments.parallelLoader,
         useInputFileSystem: experiments.useInputFileSystem,
       };
     }),
@@ -704,7 +703,6 @@ export interface ExperimentsNormalized {
   incremental?: false | Incremental;
   futureDefaults?: boolean;
   buildHttp?: HttpUriPluginOptions;
-  parallelLoader?: boolean;
   useInputFileSystem?: false | RegExp[];
   /**
    * @deprecated This option is deprecated, it's already stable and enabled by default, Rspack will remove this option in future version

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2827,11 +2827,6 @@ export type Experiments = {
    */
   buildHttp?: HttpUriOptions;
   /**
-   * Enable parallel loader
-   * @default false
-   */
-  parallelLoader?: boolean;
-  /**
    * Enable Node.js input file system
    * @default false
    */

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -964,10 +964,7 @@ export async function runLoaders(
   };
 
   const enableParallelism = (currentLoaderObject: any) => {
-    return (
-      compiler.options.experiments.parallelLoader &&
-      currentLoaderObject?.parallel
-    );
+    return currentLoaderObject?.parallel;
   };
 
   const isomorphoicRun = async (fn: Function, args: any[]) => {

--- a/tests/rspack-test/configCases/loader-parallel-import-module/codegen-cache/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel-import-module/codegen-cache/rspack.config.js
@@ -18,7 +18,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel-import-module/css/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel-import-module/css/rspack.config.js
@@ -79,7 +79,4 @@ module.exports = {
 				}
 			})
 	],
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel-import-module/execute-failed/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel-import-module/execute-failed/rspack.config.js
@@ -12,7 +12,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel-import-module/nul-byte/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel-import-module/nul-byte/rspack.config.js
@@ -18,7 +18,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel-import-module/recursive-import-module/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel-import-module/recursive-import-module/rspack.config.js
@@ -18,7 +18,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel-import-module/with-layer/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel-import-module/with-layer/rspack.config.js
@@ -16,7 +16,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/additional-data-no-passthrough/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/additional-data-no-passthrough/rspack.config.js
@@ -21,7 +21,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/additional-data-passthrough/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/additional-data-passthrough/rspack.config.js
@@ -21,7 +21,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/additional-data/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/additional-data/rspack.config.js
@@ -16,7 +16,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/async/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/async/rspack.config.js
@@ -58,7 +58,4 @@ module.exports = {
 			createRule(10, [syncLoader, syncLoader, syncLoader])
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/binary-with-source-map/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/binary-with-source-map/rspack.config.js
@@ -15,7 +15,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/issue-webpack-9053/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/issue-webpack-9053/rspack.config.js
@@ -12,7 +12,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/loader-error-async/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/loader-error-async/rspack.config.js
@@ -32,7 +32,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/loader-raw-string/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/loader-raw-string/rspack.config.js
@@ -19,7 +19,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/loader-raw/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/loader-raw/rspack.config.js
@@ -10,7 +10,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/loader-string/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/loader-string/rspack.config.js
@@ -17,7 +17,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/options/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/options/rspack.config.js
@@ -115,7 +115,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/parallel-object/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/parallel-object/rspack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 					{
 						loader: "./unclonable.js",
 						options: {
-							notclonable() {}
+							notclonable() { }
 						}
 					},
 					{
@@ -20,7 +20,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/parallel-option/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/parallel-option/rspack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 					{
 						loader: "./unclonable.js",
 						options: {
-							notclonable() {}
+							notclonable() { }
 						}
 					},
 					{
@@ -20,7 +20,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/pitching-mixed/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/pitching-mixed/rspack.config.js
@@ -21,9 +21,6 @@ module.exports = [
 				CONTEXT: JSON.stringify(__dirname)
 			})
 		],
-		experiments: {
-			parallelLoader: true
-		}
 	},
 	{
 		module: {
@@ -47,9 +44,6 @@ module.exports = [
 				CONTEXT: JSON.stringify(__dirname)
 			})
 		],
-		experiments: {
-			parallelLoader: true
-		}
 	},
 	{
 		module: {
@@ -73,9 +67,6 @@ module.exports = [
 				CONTEXT: JSON.stringify(__dirname)
 			})
 		],
-		experiments: {
-			parallelLoader: true
-		}
 	},
 	{
 		module: {
@@ -95,8 +86,5 @@ module.exports = [
 				CONTEXT: JSON.stringify(__dirname)
 			})
 		],
-		experiments: {
-			parallelLoader: true
-		}
 	}
 ];

--- a/tests/rspack-test/configCases/loader-parallel/pitching/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/pitching/rspack.config.js
@@ -21,9 +21,6 @@ module.exports = [
 				CONTEXT: JSON.stringify(__dirname)
 			})
 		],
-		experiments: {
-			parallelLoader: true
-		}
 	},
 	{
 		module: {
@@ -47,9 +44,6 @@ module.exports = [
 				CONTEXT: JSON.stringify(__dirname)
 			})
 		],
-		experiments: {
-			parallelLoader: true
-		}
 	},
 	{
 		module: {
@@ -73,9 +67,6 @@ module.exports = [
 				CONTEXT: JSON.stringify(__dirname)
 			})
 		],
-		experiments: {
-			parallelLoader: true
-		}
 	},
 	{
 		module: {
@@ -99,8 +90,5 @@ module.exports = [
 				CONTEXT: JSON.stringify(__dirname)
 			})
 		],
-		experiments: {
-			parallelLoader: true
-		}
 	}
 ];

--- a/tests/rspack-test/configCases/loader-parallel/pre-post-loader/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/pre-post-loader/rspack.config.js
@@ -24,7 +24,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/source-map/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/source-map/rspack.config.js
@@ -16,7 +16,4 @@ module.exports = {
 			}
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/configCases/loader-parallel/sync/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/sync/rspack.config.js
@@ -36,7 +36,4 @@ module.exports = {
 			createRule(10, [syncLoader, syncLoader, syncLoader])
 		]
 	},
-	experiments: {
-		parallelLoader: true
-	}
 };

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -48,7 +48,6 @@ module.exports = {
 			    inlineEnum: false,
 			    lazyBarrel: true,
 			    lazyCompilation: false,
-			    parallelLoader: false,
 			    topLevelAwait: true,
 			    typeReexportsPresence: false,
 			    useInputFileSystem: false,

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -148,39 +148,6 @@ The table below shows the results of incremental in different scenarios:
 
 Starting from v1.4.0, Rspack enables incremental builds for all phases by default using `'advance-silent'` mode. In previous versions, it only activated incremental builds for the `make` and `emitAssets` phases by default with `'safe'` mode.
 
-## experiments.parallelLoader
-
-<ApiMeta addedVersion="1.3.1" />
-
-- **Type**: `boolean`
-- **Default:** `false`
-
-Enable parallel loader execution. You need to manually enable parallel mode for each loader using [`rules[].use.parallel`](/config/module-rules#rulesuseparallel). When enabled, the corresponding loaders will be executed in worker threads.
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    rules: [
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: 'less-loader',
-            parallel: true,
-            options: {
-              // loader options
-            },
-          },
-        ],
-      },
-    ],
-  },
-  experiments: {
-    parallelLoader: true,
-  },
-};
-```
-
 ## experiments.cache
 
 <ApiMeta addedVersion="1.2.0-alpha.0" />

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -764,9 +764,6 @@ export default {
       },
     ],
   },
-  experiments: {
-    parallelLoader: true,
-  },
 };
 ```
 
@@ -774,7 +771,6 @@ When multiple loaders within the same rule have `parallel` enabled, Rspack execu
 
 :::tip
 
-- This feature is experimental. It only takes effect when [experiments.parallelLoader](/config/experiments#experimentsparallelloader) is enabled.
 - The loader options must comply with the [HTML structured clone algorithm](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist), otherwise transmission will fail.
 - In worker mode, most methods on `LoaderContext._compilation`, `LoaderContext._compiler`, `LoaderContext._module` are not supported.
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -149,39 +149,6 @@ export default {
 
 Rspack 在 v1.4.0 后默认使用 `'advance-silent'` 开启所有阶段的增量构建；之前的版本默认使用 `'safe'` 仅开启 `make` 和 `emitAssets` 阶段的增量。
 
-## experiments.parallelLoader
-
-<ApiMeta addedVersion="1.3.1" />
-
-- **类型**: `boolean`
-- **默认值:** `false`
-
-开启并行 loader，你需要使用 [`rules[].use.parallel`](/config/module-rules#rulesuseparallel) 手动为各个 loader 分别开启并行模式。开启后，对应的 loader 会被发送到 worker threads 执行。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    rules: [
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: 'less-loader',
-            parallel: true,
-            options: {
-              // loader options
-            },
-          },
-        ],
-      },
-    ],
-  },
-  experiments: {
-    parallelLoader: true,
-  },
-};
-```
-
 ## experiments.cache
 
 <ApiMeta addedVersion="1.2.0-alpha.0" />

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -764,9 +764,6 @@ export default {
       },
     ],
   },
-  experiments: {
-    parallelLoader: true,
-  },
 };
 ```
 
@@ -774,7 +771,6 @@ export default {
 
 :::tip
 
-- 由于当前功能是实验性特性，只有开启 [experiments.parallelLoader](/config/experiments#experimentsparallelloader) 时该配置才会生效。
 - loader 的选项需要满足 [HTML structured clone algorithm](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist)，否则会发送失败。
 - 目前 loader 在 worker 中不支持 `LoaderContext._compilation`, `LoaderContext._compiler`, `LoaderContext._module` 上的大多数方法。
 


### PR DESCRIPTION
## Summary

The `experiments.parallelLoader` is stable now, just remove it. You still need to use `loader.use.parallel` to enable this feature.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
