### PR TITLE
feat!: remove `output.charset`

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2634,7 +2634,6 @@ export interface RawOutputOptions {
   module: boolean
   chunkLoading: string | false
   chunkLoadTimeout: number
-  charset: boolean
   enabledChunkLoadingTypes?: Array<string>
   trustedTypes?: RawTrustedTypes
   sourceMapFilename: string

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -2161,8 +2161,6 @@ pub struct OutputOptionsBuilder {
   chunk_load_timeout: Option<u32>,
   /// Set the chunk format.
   chunk_format: Option<String>,
-  /// Set the charset.
-  charset: Option<bool>,
   /// Set the filename.
   filename: Option<Filename>,
   /// Set the chunk filename.
@@ -2248,7 +2246,6 @@ impl From<OutputOptions> for OutputOptionsBuilder {
       chunk_loading_global: Some(value.chunk_loading_global),
       chunk_load_timeout: Some(value.chunk_load_timeout),
       chunk_format: None,
-      charset: Some(value.charset),
       filename: Some(value.filename),
       chunk_filename: Some(value.chunk_filename),
       cross_origin_loading: Some(value.cross_origin_loading),
@@ -2302,7 +2299,6 @@ impl From<&mut OutputOptionsBuilder> for OutputOptionsBuilder {
       chunk_loading_global: value.chunk_loading_global.take(),
       chunk_load_timeout: value.chunk_load_timeout.take(),
       chunk_format: value.chunk_format.take(),
-      charset: value.charset.take(),
       filename: value.filename.take(),
       chunk_filename: value.chunk_filename.take(),
       cross_origin_loading: value.cross_origin_loading.take(),
@@ -2434,14 +2430,6 @@ impl OutputOptionsBuilder {
   /// The format of chunks (formats included by default are 'array-push' (web/webworker), 'commonjs' (node.js), 'module' (ESM).
   pub fn chunk_format(&mut self, chunk_format: String) -> &mut Self {
     self.chunk_format = Some(chunk_format);
-    self
-  }
-
-  /// Add charset="utf-8" to the HTML <script> tag.
-  ///
-  /// Default set to `true`.
-  pub fn charset(&mut self, charset: bool) -> &mut Self {
-    self.charset = Some(charset);
     self
   }
 
@@ -2828,8 +2816,6 @@ impl OutputOptionsBuilder {
 
     let chunk_load_timeout = d!(self.chunk_load_timeout.take(), 120_000);
 
-    let charset = d!(self.charset.take(), true);
-
     let hot_update_global = f!(self.hot_update_global.take(), || {
       format!(
         "webpackHotUpdate{}",
@@ -3146,7 +3132,6 @@ impl OutputOptionsBuilder {
       chunk_loading,
       chunk_loading_global,
       chunk_load_timeout,
-      charset,
       filename,
       chunk_filename,
       cross_origin_loading,
@@ -3863,7 +3848,7 @@ mod test {
   fn mutable_builder_into_owned_builder() {
     let _ = CompilerOptions::builder()
       .optimization(OptimizationOptionsBuilder::default().node_env("development".to_string()))
-      .output(OutputOptionsBuilder::default().charset(true))
+      .output(OutputOptionsBuilder::default())
       .experiments(ExperimentsBuilder::default().future_defaults(true))
       .module(ModuleOptionsBuilder::default().no_parse(ModuleNoParseRules::Rules(vec![])))
       .node(NodeOptionBuilder::default().dirname(NodeDirnameOption::EvalOnly))

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -33,7 +33,6 @@ CompilerOptions {
         ),
         chunk_loading_global: "webpackChunk",
         chunk_load_timeout: 120000,
-        charset: true,
         filename: Filename(
             Template(
                 "[name].js",

--- a/crates/rspack_binding_api/src/raw_options/raw_output.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_output.rs
@@ -120,7 +120,6 @@ pub struct RawOutputOptions {
   #[napi(ts_type = "string | false")]
   pub chunk_loading: RawChunkLoading,
   pub chunk_load_timeout: u32,
-  pub charset: bool,
   pub enabled_chunk_loading_types: Option<Vec<String>>,
   pub trusted_types: Option<RawTrustedTypes>,
   pub source_map_filename: String,
@@ -217,7 +216,6 @@ impl TryFrom<RawOutputOptions> for OutputOptions {
         WithFalse::True(s) => s,
       },
       environment: value.environment.into(),
-      charset: value.charset,
       chunk_load_timeout: value.chunk_load_timeout,
       compare_before_emit: value.compare_before_emit,
     })

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -41,7 +41,6 @@ pub struct OutputOptions {
   pub chunk_loading: ChunkLoading,
   pub chunk_loading_global: String,
   pub chunk_load_timeout: u32,
-  pub charset: bool,
   pub filename: Filename,
   pub chunk_filename: Filename,
   pub cross_origin_loading: CrossOriginLoading,

--- a/crates/rspack_plugin_css/src/runtime/css_loading_create_link.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_create_link.ejs
@@ -1,7 +1,4 @@
 link = document.createElement("link");
-<% if (_charset) { %>
-link.charset = 'utf-8';
-<% } %>
 if (<%- SCRIPT_NONCE %>) {
   link.setAttribute("nonce", <%- SCRIPT_NONCE %>);
 }

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_prefetch_link.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_prefetch_link.ejs
@@ -1,7 +1,4 @@
 var link = document.createElement('link');
-<% if (_charset) { %>
-link.charset = 'utf-8';
-<% } %>
 <% if (_cross_origin != "") { %>
 link.crossOrigin = '<%- _cross_origin %>';
 <% } %>

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_preload_link.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_preload_link.ejs
@@ -1,7 +1,4 @@
 var link = document.createElement('link');
-<% if (_charset) { %>
-link.charset = 'utf-8';
-<% } %>
 if (<%- SCRIPT_NONCE %>) {
   link.setAttribute("nonce", <%- SCRIPT_NONCE %>);
 }

--- a/crates/rspack_plugin_css/src/runtime/mod.rs
+++ b/crates/rspack_plugin_css/src/runtime/mod.rs
@@ -171,7 +171,6 @@ impl RuntimeModule for CssLoadingRuntimeModule {
         &self.template_id(TemplateId::CreateLink),
         Some(serde_json::json!({
           "_with_fetch_priority": with_fetch_priority,
-          "_charset": compilation.options.output.charset,
           "_cross_origin": match &compilation.options.output.cross_origin_loading {
             CrossOriginLoading::Disable => "".to_string(),
             CrossOriginLoading::Enable(cross_origin) => cross_origin.to_string(),
@@ -276,7 +275,6 @@ installedChunks[chunkId] = 0;
         let link_prefetch_raw = compilation.runtime_template.render(
           &self.template_id(TemplateId::WithPrefetchLink),
           Some(serde_json::json!({
-            "_charset": compilation.options.output.charset,
             "_cross_origin": compilation.options.output.cross_origin_loading.to_string(),
           })),
         )?;
@@ -309,7 +307,6 @@ installedChunks[chunkId] = 0;
         let link_preload_raw = compilation.runtime_template.render(
           &self.template_id(TemplateId::WithPreloadLink),
           Some(serde_json::json!({
-            "_charset": compilation.options.output.charset,
             "_cross_origin": compilation.options.output.cross_origin_loading.to_string(),
           })),
         )?;

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -163,7 +163,6 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
     let with_fetch_priority = runtime_requirements.contains(RuntimeGlobals::HAS_FETCH_PRIORITY);
     let cross_origin_loading = &compilation.options.output.cross_origin_loading;
     let script_type = &compilation.options.output.script_type;
-    let charset = compilation.options.output.charset;
 
     let hooks = RuntimePlugin::get_compilation_hooks(compilation.id());
 
@@ -242,7 +241,6 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       let link_prefetch_code = compilation.runtime_template.render(
         &self.template_id(TemplateId::WithPrefetchLink),
         Some(serde_json::json!({
-          "_charset": charset,
           "_cross_origin": cross_origin_loading.to_string(),
         })),
       )?;
@@ -276,7 +274,6 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       let link_preload_code = compilation.runtime_template.render(
         &self.template_id(TemplateId::WithPreloadLink),
         Some(serde_json::json!({
-          "_charset": charset,
           "_script_type": script_type.as_str(),
           "_cross_origin": cross_origin_loading.to_string(),
         })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
@@ -79,7 +79,6 @@ impl RuntimeModule for LoadScriptRuntimeModule {
       &self.template_id(TemplateId::CreateScript),
       Some(serde_json::json!({
         "_script_type": &compilation.options.output.script_type,
-        "_charset": compilation.options.output.charset,
         "_unique_prefix": unique_prefix.is_some(),
         "_with_fetch_priority": with_fetch_priority,
         "_with_create_script_url": self.with_create_script_url,

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -262,13 +262,11 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
 
     if !matches!(has_js_matcher, BooleanMatcher::Condition(false)) {
       let js_matcher = has_js_matcher.render("chunkId");
-      let charset = compilation.options.output.charset;
       let cross_origin_loading = &compilation.options.output.cross_origin_loading;
       if with_prefetch {
         let link_prefetch_code = compilation.runtime_template.render(
           &self.template(TemplateId::WithPrefetchLink),
           Some(serde_json::json!({
-            "_charset": charset,
             "_cross_origin": cross_origin_loading.to_string(),
           })),
         )?;
@@ -302,7 +300,6 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
         let link_preload_code = compilation.runtime_template.render(
           &self.template(TemplateId::WithPreloadLink),
           Some(serde_json::json!({
-            "_charset": charset,
             "_cross_origin": cross_origin_loading.to_string(),
           })),
         )?;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_prefetch_link.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_prefetch_link.ejs
@@ -1,7 +1,4 @@
 var link = document.createElement('link');
-<% if (_charset) { %>
-link.charset = 'utf-8';
-<% } %>
 <% if (_cross_origin != "") { %>
 link.crossOrigin = '<%- _cross_origin %>';
 <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_preload_link.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_preload_link.ejs
@@ -1,7 +1,4 @@
 var link = document.createElement('link');
-<% if (_charset) { %>
-link.charset = 'utf-8';
-<% } %>
 <% if (_script_type != "false" && _script_type != "module") { %>
 link.type = "<%- _script_type %>";
 <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/load_script_create_script.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/load_script_create_script.ejs
@@ -2,9 +2,6 @@ script = document.createElement('script');
 <% if (_script_type != "false") { %>
 script.type = '<%- _script_type %>';
 <% } %>
-<% if (_charset) { %>
-script.charset = 'utf-8';
-<% } %>
 script.timeout = <%- _chunk_load_timeout %>;
 if (<%- SCRIPT_NONCE %>) {
   script.setAttribute("nonce", <%- SCRIPT_NONCE %>);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_prefetch_link.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_prefetch_link.ejs
@@ -1,7 +1,4 @@
 var link = document.createElement('link');
-<% if (_charset) { %>
-link.charset = 'utf-8';
-<% } %>
 <% if (_cross_origin != "") { %>
 link.crossOrigin = '<%- _cross_origin %>';
 <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_preload_link.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_preload_link.ejs
@@ -1,7 +1,4 @@
 var link = document.createElement('link');
-<% if (_charset) { %>
-link.charset = 'utf-8';
-<% } %>
 if (<%- SCRIPT_NONCE %>) {
   link.setAttribute("nonce", <%- SCRIPT_NONCE %>);
 }

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -5616,7 +5616,6 @@ export type Output = {
     devtoolModuleFilenameTemplate?: DevtoolModuleFilenameTemplate;
     devtoolFallbackModuleFilenameTemplate?: DevtoolFallbackModuleFilenameTemplate;
     chunkLoadTimeout?: number;
-    charset?: boolean;
     environment?: Environment;
     compareBeforeEmit?: boolean;
     bundlerInfo?: BundlerInfoOptions;
@@ -5669,8 +5668,6 @@ export interface OutputNormalized {
     asyncChunks?: boolean;
     // (undocumented)
     bundlerInfo?: BundlerInfoOptions;
-    // (undocumented)
-    charset?: boolean;
     // (undocumented)
     chunkFilename?: ChunkFilename;
     // (undocumented)

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -833,8 +833,6 @@ const applyOutputDefaults = (
   D(output, 'workerPublicPath', '');
   D(output, 'sourceMapFilename', '[file].map[query]');
   F(output, 'scriptType', () => (output.module ? 'module' : false));
-  // IGNORE(output.charset): `output.charset` has already been deprecated for a long time
-  D(output, 'charset', false);
   D(output, 'chunkLoadTimeout', 120000);
 
   const { trustedTypes } = output;

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -252,7 +252,6 @@ export const getNormalizedRspackOptions = (
         devtoolFallbackModuleFilenameTemplate:
           output.devtoolFallbackModuleFilenameTemplate,
         chunkLoadTimeout: output.chunkLoadTimeout,
-        charset: output.charset,
         environment: cloneObject(output.environment),
         compareBeforeEmit: output.compareBeforeEmit,
         bundlerInfo: output.bundlerInfo,
@@ -649,7 +648,6 @@ export interface OutputNormalized {
   devtoolModuleFilenameTemplate?: DevtoolModuleFilenameTemplate;
   devtoolFallbackModuleFilenameTemplate?: DevtoolFallbackModuleFilenameTemplate;
   environment?: Environment;
-  charset?: boolean;
   chunkLoadTimeout?: number;
   compareBeforeEmit?: boolean;
   bundlerInfo?: BundlerInfoOptions;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -699,12 +699,6 @@ export type Output = {
    * */
   chunkLoadTimeout?: number;
 
-  /**
-   * Add charset="utf-8" to the HTML <script> tag.
-   * @default true
-   * */
-  charset?: boolean;
-
   /** Tell Rspack what kind of ES-features may be used in the generated runtime-code. */
   environment?: Environment;
 

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -300,7 +300,6 @@ module.exports = {
 			      force: true,
 			      version: $version$,
 			    },
-			    charset: false,
 			    chunkFilename: [name].js,
 			    chunkFormat: array-push,
 			    chunkLoadTimeout: 120000,

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset 6954a74052160253.js xx KiB [emitted] [immutable] (name: main)
+asset 4ac18e26791e9447.js xx KiB [emitted] [immutable] (name: main)
 asset ce122906ee13f376.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -20,10 +20,10 @@ Rspack x.x.x compiled successfully in X s
 assets by chunk xx bytes (id hint: all)
   asset c-all-b_js-113206d7531c234d.js xx bytes [emitted] [immutable] (id hint: all)
   asset c-all-c_js-9f8c7c16580d157a.js xx bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-f25a17b47b43aefb.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset c-runtime~main-4af3a6192ba7ffaf.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-831261ae36cba529.js xx bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-01281488ed24fc05.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-f25a17b47b43aefb.js xx KiB c-all-c_js-9f8c7c16580d157a.js xx bytes c-main-831261ae36cba529.js xx bytes
+Entrypoint main xx KiB = c-runtime~main-4af3a6192ba7ffaf.js xx KiB c-all-c_js-9f8c7c16580d157a.js xx bytes c-main-831261ae36cba529.js xx bytes
 runtime modules xx KiB 14 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -83,13 +83,6 @@ export default {
 };
 ```
 
-## output.charset
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Add [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#Charset) `charset="utf-8"` attribute to the HTML `<script>` tag.
-
 ## output.chunkFilename
 
 - **Type:** `string | (pathData: PathData, assetInfo?: AssetInfo) => string`

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -83,13 +83,6 @@ export default {
 };
 ```
 
-## output.charset
-
-- **类型：** `boolean`
-- **默认值：** `false`
-
-为 `<script>` 标签添加已被标记为[已废弃的](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/script#Charset) `charset="utf-8"` 属性。
-
 ## output.chunkFilename
 
 - **类型：** `string | (pathData: PathData, assetInfo?: AssetInfo) => string`


### PR DESCRIPTION
## Summary

All major browsers (Chrome, Firefox, Safari, Edge, and IE9+) ignore `<script charset>` since scripts are always parsed as UTF-8 or according to HTTP headers. See https://github.com/web-infra-dev/rspack/discussions/11594#discussioncomment-14411740

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
