### PR TITLE
fix(lint): enable @typescript-eslint/require-await rule

### DIFF
--- a/packages/rspack/src/FileSystem.ts
+++ b/packages/rspack/src/FileSystem.ts
@@ -255,8 +255,8 @@ class ThreadsafeIntermediateNodeFS extends ThreadsafeOutputNodeFS {
     });
     this.read = memoizeFn(() => {
       const readFn = fs.read.bind(fs);
-      return async (fd: number, length: number, position: number) => {
-        new Promise((resolve) => {
+      return (fd: number, length: number, position: number) => {
+        return new Promise((resolve, reject) => {
           readFn(
             fd,
             {
@@ -265,7 +265,7 @@ class ThreadsafeIntermediateNodeFS extends ThreadsafeOutputNodeFS {
             },
             (err, _bytesRead, buffer) => {
               if (err) {
-                resolve(err);
+                reject(err);
               } else {
                 resolve(buffer);
               }

--- a/packages/rspack/src/browser/service.ts
+++ b/packages/rspack/src/browser/service.ts
@@ -23,6 +23,6 @@ export enum RequestType {
   CompilationGetAssetPathWithInfo = 'CompilationGetAssetPathWithInfo',
 }
 
-export async function run() {
-  throw new Error('Not support browser');
+export function run(): Promise<never> {
+  return Promise.reject(new Error('Not support browser'));
 }

--- a/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SubresourceIntegrityPlugin.ts
@@ -286,9 +286,9 @@ export class SubresourceIntegrityPlugin extends NativeSubresourceIntegrityPlugin
             const hwpHooks = getHooks(compilation);
             hwpHooks.beforeAssetTagGeneration.tapPromise(
               PLUGIN_NAME,
-              async (data) => {
+              (data) => {
                 self.handleHwpPluginArgs(data);
-                return data;
+                return Promise.resolve(data);
               },
             );
 
@@ -297,13 +297,13 @@ export class SubresourceIntegrityPlugin extends NativeSubresourceIntegrityPlugin
                 name: PLUGIN_NAME,
                 stage: 10000,
               },
-              async (data) => {
+              (data) => {
                 self.handleHwpBodyTags(
                   data,
                   compiler.outputPath,
                   compiler.options.output.crossOriginLoading,
                 );
-                return data;
+                return Promise.resolve(data);
               },
             );
           });

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -648,10 +648,10 @@ function worker(workerOptions: WorkerOptions) {
   const waitFor = createWaitForPendingRequest(sendRequest);
 
   loaderImpl(workerOptions, sendRequest, waitFor)
-    .then(async (data) => {
+    .then((data) => {
       workerData.workerPort.postMessage({ type: 'done', data });
     })
-    .catch(async (err) => {
+    .catch((err) => {
       workerData.workerPort.postMessage({
         type: 'done-error',
         error: serializeError(err),

--- a/rslint.json
+++ b/rslint.json
@@ -25,7 +25,7 @@
       "@typescript-eslint/no-confusing-void-expression": "off",
       "@typescript-eslint/promise-function-async": "off",
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
-      "@typescript-eslint/require-await": "off",
+      "@typescript-eslint/require-await": "error",
       "@typescript-eslint/switch-exhaustiveness-check": "off",
       "@typescript-eslint/return-await": "off",
       "@typescript-eslint/non-nullable-type-assertion-style": "off",


### PR DESCRIPTION
## Summary

Enables `@typescript-eslint/require-await` rule and fixes the 6 violations found.

**Changes:**
- `rslint.json`: Changed `@typescript-eslint/require-await` from `off` to `error`
- `FileSystem.ts`: Fixed missing `return` for Promise, removed unnecessary `async`
- `SubresourceIntegrityPlugin.ts`: Changed `async` callbacks to use `Promise.resolve()` since no `await` is needed
- `browser/service.ts`: Removed `async` from function that only throws (added explicit `Promise<never>` return type)
- `loader-runner/worker.ts`: Removed `async` from `.then/.catch` callbacks

Related to #11761

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.