### PR TITLE
fix(lint): enable @typescript-eslint/return-await rule

### DIFF
--- a/packages/rspack/src/FileSystem.ts
+++ b/packages/rspack/src/FileSystem.ts
@@ -242,7 +242,7 @@ class ThreadsafeIntermediateNodeFS extends ThreadsafeOutputNodeFS {
     this.write = memoizeFn(() => {
       const writeFn = util.promisify(fs.write.bind(fs));
       return async (fd: number, content: Buffer, position: number) => {
-        return await writeFn(fd, content, {
+        return writeFn(fd, content, {
           position,
         });
       };
@@ -250,7 +250,7 @@ class ThreadsafeIntermediateNodeFS extends ThreadsafeOutputNodeFS {
     this.writeAll = memoizeFn(() => {
       const writeFn = util.promisify(fs.writeFile.bind(fs));
       return async (fd: number, content: Buffer) => {
-        return await writeFn(fd, content);
+        return writeFn(fd, content);
       };
     });
     this.read = memoizeFn(() => {

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -70,7 +70,7 @@ export class ExternalsPlugin extends RspackBuiltinPlugin {
       const processResolveResult = this.#processResolveResult;
 
       return async (ctx: RawExternalItemFnCtx) => {
-        return await new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
           const data = ctx.data();
           const promise = item(
             {

--- a/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
@@ -161,7 +161,7 @@ export const createRsdoctorPluginHooksRegisters: CreatePartialRegisters<
       },
       function (queried) {
         return async function (data: JsRsdoctorModuleGraph) {
-          return await queried.promise(data);
+          return queried.promise(data);
         };
       },
     ),
@@ -174,7 +174,7 @@ export const createRsdoctorPluginHooksRegisters: CreatePartialRegisters<
       },
       function (queried) {
         return async function (data: JsRsdoctorChunkGraph) {
-          return await queried.promise(data);
+          return queried.promise(data);
         };
       },
     ),
@@ -187,7 +187,7 @@ export const createRsdoctorPluginHooksRegisters: CreatePartialRegisters<
       },
       function (queried) {
         return async function (data: JsRsdoctorModuleIdsPatch) {
-          return await queried.promise(data);
+          return queried.promise(data);
         };
       },
     ),
@@ -200,7 +200,7 @@ export const createRsdoctorPluginHooksRegisters: CreatePartialRegisters<
       },
       function (queried) {
         return async function (data: JsRsdoctorModuleSourcesPatch) {
-          return await queried.promise(data);
+          return queried.promise(data);
         };
       },
     ),
@@ -213,7 +213,7 @@ export const createRsdoctorPluginHooksRegisters: CreatePartialRegisters<
       },
       function (queried) {
         return async function (data: JsRsdoctorAssetPatch) {
-          return await queried.promise(data);
+          return queried.promise(data);
         };
       },
     ),

--- a/packages/rspack/src/taps/compilation.ts
+++ b/packages/rspack/src/taps/compilation.ts
@@ -282,7 +282,7 @@ export const createCompilationHooksRegisters: CreatePartialRegisters<
 
       function (queried) {
         return async function () {
-          return await queried.promise(
+          return queried.promise(
             getCompiler().__internal__get_compilation()!.modules,
           );
         };
@@ -329,7 +329,7 @@ export const createCompilationHooksRegisters: CreatePartialRegisters<
 
       function (queried) {
         return async function () {
-          return await queried.promise(
+          return queried.promise(
             getCompiler().__internal__get_compilation()!.chunks,
             getCompiler().__internal__get_compilation()!.modules,
           );
@@ -346,7 +346,7 @@ export const createCompilationHooksRegisters: CreatePartialRegisters<
 
       function (queried) {
         return async function () {
-          return await queried.promise(
+          return queried.promise(
             getCompiler().__internal__get_compilation()!.chunks,
             getCompiler().__internal__get_compilation()!.modules,
           );
@@ -403,7 +403,7 @@ export const createCompilationHooksRegisters: CreatePartialRegisters<
 
       function (queried) {
         return async function () {
-          return await queried.promise(
+          return queried.promise(
             getCompiler().__internal__get_compilation()!.assets,
           );
         };
@@ -447,7 +447,7 @@ export const createCompilationHooksRegisters: CreatePartialRegisters<
 
       function (queried) {
         return async function () {
-          return await queried.promise();
+          return queried.promise();
         };
       },
     ),

--- a/packages/rspack/src/taps/compiler.ts
+++ b/packages/rspack/src/taps/compiler.ts
@@ -47,9 +47,7 @@ export const createCompilerHooksRegisters: CreatePartialRegisters<
 
       function (queried) {
         return async function () {
-          return await queried.promise(
-            getCompiler().__internal__get_compilation()!,
-          );
+          return queried.promise(getCompiler().__internal__get_compilation()!);
         };
       },
     ),
@@ -62,9 +60,7 @@ export const createCompilerHooksRegisters: CreatePartialRegisters<
 
       function (queried) {
         return async function () {
-          return await queried.promise(
-            getCompiler().__internal__get_compilation()!,
-          );
+          return queried.promise(getCompiler().__internal__get_compilation()!);
         };
       },
     ),
@@ -90,9 +86,7 @@ export const createCompilerHooksRegisters: CreatePartialRegisters<
 
       function (queried) {
         return async function () {
-          return await queried.promise(
-            getCompiler().__internal__get_compilation()!,
-          );
+          return queried.promise(getCompiler().__internal__get_compilation()!);
         };
       },
     ),
@@ -105,9 +99,7 @@ export const createCompilerHooksRegisters: CreatePartialRegisters<
 
       function (queried) {
         return async function () {
-          return await queried.promise(
-            getCompiler().__internal__get_compilation()!,
-          );
+          return queried.promise(getCompiler().__internal__get_compilation()!);
         };
       },
     ),

--- a/rslint.json
+++ b/rslint.json
@@ -27,7 +27,7 @@
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
       "@typescript-eslint/require-await": "error",
       "@typescript-eslint/switch-exhaustiveness-check": "off",
-      "@typescript-eslint/return-await": "off",
+      "@typescript-eslint/return-await": "error",
       "@typescript-eslint/non-nullable-type-assertion-style": "off",
       "@typescript-eslint/no-misused-spread": "off",
       "@typescript-eslint/unbound-method": "off",


### PR DESCRIPTION
## Summary

Enables `@typescript-eslint/return-await` rule and fixes all 17 violations across 6 files.

Related to #11761

### Changes

This rule disallows unnecessary `return await` in `async` functions (outside `try/catch/finally`, where `return await` can preserve error handling semantics).

- `rslint.json`: Enable the rule (`off` → `error`)
- `packages/rspack/src/FileSystem.ts`: 2 fixes
- `packages/rspack/src/taps/compilation.ts`: 5 fixes
- `packages/rspack/src/taps/compiler.ts`: 4 fixes
- `packages/rspack/src/builtin-plugin/ExternalsPlugin.ts`: 1 fix
- `packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts`: 5 fixes

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
