### PR TITLE
feat(@rspack-cli): make @rspack/dev-server and webpack-bundle-analyzer peer dependencies

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -34,13 +34,12 @@
   },
   "dependencies": {
     "@discoveryjs/json-ext": "^0.5.7",
-    "@rspack/dev-server": "~1.1.5",
-    "exit-hook": "^4.0.0",
-    "webpack-bundle-analyzer": "4.10.2"
+    "exit-hook": "^4.0.0"
   },
   "devDependencies": {
     "@rslib/core": "0.19.1",
     "@rspack/core": "workspace:*",
+    "@rspack/dev-server": "~1.1.5",
     "@rspack/test-tools": "workspace:*",
     "@types/webpack-bundle-analyzer": "^4.7.0",
     "cac": "^6.7.14",
@@ -50,10 +49,24 @@
     "picocolors": "^1.1.1",
     "pirates": "^4.0.7",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "webpack-bundle-analyzer": "4.10.2"
   },
   "peerDependencies": {
-    "@rspack/core": "^1.0.0-alpha || ^1.x"
+    "@rspack/core": "^1.0.0-alpha || ^1.x",
+    "@rspack/dev-server": "~1.1.5",
+    "webpack-bundle-analyzer": "4.10.2"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": false
+    },
+    "@rspack/dev-server": {
+      "optional": true
+    },
+    "webpack-bundle-analyzer": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/rspack-cli/src/commands/preview.ts
+++ b/packages/rspack-cli/src/commands/preview.ts
@@ -40,6 +40,18 @@ export class PreviewCommand implements RspackCommand {
       setDefaultNodeEnv(options, 'production');
       normalizeCommonOptions(options, 'preview');
 
+      const packageName = '@rspack/dev-server';
+      try {
+        require.resolve(packageName);
+      } catch {
+        const logger = cli.getLogger();
+        logger.warn(
+          `Package "${packageName}" is not installed. Please install it before using "rspack preview" command.`,
+        );
+        process.exit(2);
+      }
+
+      // Lazy import @rspack/dev-server to avoid loading it on build mode
       const { RspackDevServer } = await import('@rspack/dev-server');
 
       let { config } = await cli.loadConfig(options);

--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -48,6 +48,17 @@ export class ServeCommand implements RspackCommand {
       normalizeCommonOptions(cliOptions, 'serve');
       cliOptions.hot = normalizeHotOption(cliOptions.hot);
 
+      const packageName = '@rspack/dev-server';
+      try {
+        require.resolve(packageName);
+      } catch {
+        const logger = cli.getLogger();
+        logger.warn(
+          `Package "${packageName}" is not installed. Please install it before using "rspack serve" command.`,
+        );
+        process.exit(2);
+      }
+
       // Lazy import @rspack/dev-server to avoid loading it on build mode
       const { RspackDevServer } = await import('@rspack/dev-server');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,15 +438,9 @@ importers:
       '@discoveryjs/json-ext':
         specifier: ^0.5.7
         version: 0.5.7
-      '@rspack/dev-server':
-        specifier: ~1.1.5
-        version: 1.1.5(@rspack/core@packages+rspack)(@types/express@4.17.23)(webpack@5.99.9)
       exit-hook:
         specifier: ^4.0.0
         version: 4.0.0
-      webpack-bundle-analyzer:
-        specifier: 4.10.2
-        version: 4.10.2
     devDependencies:
       '@rslib/core':
         specifier: 0.19.1
@@ -454,6 +448,9 @@ importers:
       '@rspack/core':
         specifier: workspace:*
         version: link:../rspack
+      '@rspack/dev-server':
+        specifier: ~1.1.5
+        version: 1.1.5(@rspack/core@packages+rspack)(@types/express@4.17.23)(webpack@5.99.9)
       '@rspack/test-tools':
         specifier: workspace:*
         version: link:../rspack-test-tools
@@ -484,6 +481,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      webpack-bundle-analyzer:
+        specifier: 4.10.2
+        version: 4.10.2
 
   packages/rspack-test-tools:
     dependencies:


### PR DESCRIPTION
## Summary

Hi! 👋
This is my first PR here, do not hesitate to tell me if I didn't something wrong, thanks!

We are considering possibly replacing webpack by rspack in [Webpack Encore](https://github.com/symfony/webpack-encore)
(a wrapper for webpack to make it easier to use in Symfony projects, existing for ~10 years now).

In Webpack Encore, we _recently_ made `webpack-dev-server` an optional dependency (https://github.com/symfony/webpack-encore/pull/1336), getting inspiration from [e18e initiative](https://e18e.dev/). It allowed us to remove a tons of sub-dependencies and reduce the package size when not using some features.

But, when looking at [@rspack/cli's npmgraph](https://npmgraph.js.org/?q=%40rspack%2Fcli), I see it force to install **~225 dependencies** (that's a lot!):
- `@rspack/dev-server` is only useful when running `rspack serve`, and not all projects need it. Based on [@rspack/dev-server's npmgraph](https://npmgraph.js.org/?q=%40rspack%2Fdev-server%401.1.5), it brings **~207 dependencies**,
- `webpack-bundle-analyzer` is only useful when running `rspack analyze`, and not all projects need it. Based on [webpack-bundle-analyzer's npmgraph](https://npmgraph.js.org/?q=webpack-bundle-analyzer%404.10.2), it brings **~16 dependencies**

By making these two dependencies optional, we could reduce the number of dependencies to **2** (`@discoveryjs/json-ext` and `webpack-bundle-analyzer`).

It may be considered a breaking change, but it will only impact local development (not production builds), and only for people using `rspack serve` or `rspack analyze`.

WDYT? Thanks!

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- ~~[ ] Tests updated (or not required).~~
- [ ] Documentation updated (or not required).
