### PR TITLE
Refactor: introduce transformImport to replace swc-plugin-import

### DIFF
--- a/crates/rspack_loader_swc/src/options.rs
+++ b/crates/rspack_loader_swc/src/options.rs
@@ -2,7 +2,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsRefStr, AsRefStrConverter},
 };
-use rspack_swc_plugin_import::{ImportOptions, RawImportOptions};
+use rspack_swc_plugin_import::{ImportOptions, RawImportOptions, TransformImportOptions};
 use serde::Deserialize;
 use swc_config::{file_pattern::FilePattern, types::BoolConfig};
 use swc_core::base::config::{
@@ -14,6 +14,7 @@ use swc_core::base::config::{
 #[serde(rename_all = "camelCase", default)]
 pub struct RawRspackExperiments {
   pub import: Option<Vec<RawImportOptions>>,
+  pub transform_import: Option<Vec<TransformImportOptions>>,
 }
 
 #[derive(Default, Deserialize, Debug)]
@@ -26,6 +27,7 @@ pub struct RawCollectTypeScriptInfoOptions {
 #[derive(Default, Debug)]
 pub(crate) struct RspackExperiments {
   pub(crate) import: Option<Vec<ImportOptions>>,
+  pub(crate) transform_import: Option<Vec<TransformImportOptions>>,
 }
 
 #[derive(Default, Debug)]
@@ -47,6 +49,7 @@ impl From<RawRspackExperiments> for RspackExperiments {
       import: value
         .import
         .map(|i| i.into_iter().map(|v| v.into()).collect()),
+      transform_import: value.transform_import,
     }
   }
 }

--- a/crates/rspack_loader_swc/src/transformer.rs
+++ b/crates/rspack_loader_swc/src/transformer.rs
@@ -23,7 +23,14 @@ macro_rules! either {
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn transform(rspack_experiments: &RspackExperiments) -> impl Pass + '_ {
-  either!(rspack_experiments.import, |options| {
-    rspack_swc_plugin_import::plugin_import(options)
-  })
+  (
+    // Legacy import API (deprecated)
+    either!(rspack_experiments.import, |options| {
+      rspack_swc_plugin_import::plugin_import(options)
+    }),
+    // Modern transformImport API
+    either!(rspack_experiments.transform_import, |options| {
+      rspack_swc_plugin_import::transform_import(options)
+    }),
+  )
 }

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -521,13 +521,6 @@ type BufferEncodingOption = 'buffer' | {
     encoding: 'buffer';
 };
 
-// @public
-export type BundlerInfoOptions = {
-    version?: string;
-    bundler?: string;
-    force?: boolean | ('version' | 'uniqueId')[];
-};
-
 // @public (undocumented)
 type ByPass = (req: Request_2, res: Response_2, proxyConfig: ProxyConfigArrayItem) => any;
 
@@ -1619,6 +1612,7 @@ export type CssAutoGeneratorOptions = {
 export type CssAutoParserOptions = {
     namedExports?: CssParserNamedExports;
     url?: CssParserUrl;
+    resolveImport?: CssParserResolveImport;
 };
 
 // @public
@@ -1725,6 +1719,7 @@ export type CssModuleGeneratorOptions = CssAutoGeneratorOptions;
 export type CssModuleParserOptions = {
     namedExports?: CssParserNamedExports;
     url?: CssParserUrl;
+    resolveImport?: CssParserResolveImport;
 };
 
 // @public (undocumented)
@@ -1734,7 +1729,11 @@ export type CssParserNamedExports = boolean;
 export type CssParserOptions = {
     namedExports?: CssParserNamedExports;
     url?: CssParserUrl;
+    resolveImport?: CssParserResolveImport;
 };
+
+// @public (undocumented)
+export type CssParserResolveImport = boolean | ((url: string, media: string | undefined, resourcePath: string, supports: string | undefined, layer: string | undefined) => boolean);
 
 // @public (undocumented)
 export type CssParserUrl = boolean;
@@ -2450,7 +2449,9 @@ export type Experiments = {
     layers?: boolean;
     incremental?: IncrementalPresets | Incremental;
     futureDefaults?: boolean;
+    rspackFuture?: RspackFutureOptions;
     buildHttp?: HttpUriOptions;
+    parallelLoader?: boolean;
     useInputFileSystem?: UseInputFileSystem;
     nativeWatcher?: boolean;
     inlineConst?: boolean;
@@ -2493,6 +2494,8 @@ interface Experiments_2 {
     RslibPlugin: typeof RslibPlugin;
     // (undocumented)
     RstestPlugin: typeof RstestPlugin;
+    // @deprecated (undocumented)
+    SubresourceIntegrityPlugin: typeof SubresourceIntegrityPlugin;
     // (undocumented)
     swc: {
         transform: typeof transform;
@@ -2534,6 +2537,10 @@ export interface ExperimentsNormalized {
     nativeWatcher?: boolean;
     // (undocumented)
     outputModule?: boolean;
+    // (undocumented)
+    parallelLoader?: boolean;
+    // (undocumented)
+    rspackFuture?: RspackFutureOptions;
     // (undocumented)
     topLevelAwait?: boolean;
     // (undocumented)
@@ -3124,6 +3131,7 @@ export type HtmlRspackPluginOptions = {
     chunks?: string[];
     excludeChunks?: string[];
     chunksSortMode?: 'auto' | 'manual';
+    sri?: 'sha256' | 'sha384' | 'sha512';
     minify?: boolean;
     favicon?: string;
     meta?: Record<string, string | Record<string, string>>;
@@ -4201,6 +4209,7 @@ type KnownStatsModule = {
     failed?: boolean;
     errors?: number;
     warnings?: number;
+    profile?: StatsProfile;
     reasons?: StatsModuleReason[];
     usedExports?: boolean | string[] | null;
     providedExports?: string[] | null;
@@ -4262,6 +4271,13 @@ type KnownStatsPrinterContext = {
     formatFlag?: (flag: string) => string;
     formatTime?: (time: number, boldQuantity?: boolean) => string;
     chunkGroupKind?: string;
+};
+
+// @public (undocumented)
+type KnownStatsProfile = {
+    total: number;
+    resolving: number;
+    building: number;
 };
 
 // @public (undocumented)
@@ -5608,9 +5624,9 @@ export type Output = {
     devtoolModuleFilenameTemplate?: DevtoolModuleFilenameTemplate;
     devtoolFallbackModuleFilenameTemplate?: DevtoolFallbackModuleFilenameTemplate;
     chunkLoadTimeout?: number;
+    charset?: boolean;
     environment?: Environment;
     compareBeforeEmit?: boolean;
-    bundlerInfo?: BundlerInfoOptions;
 };
 
 // @public (undocumented)
@@ -5659,7 +5675,7 @@ export interface OutputNormalized {
     // (undocumented)
     asyncChunks?: boolean;
     // (undocumented)
-    bundlerInfo?: BundlerInfoOptions;
+    charset?: boolean;
     // (undocumented)
     chunkFilename?: ChunkFilename;
     // (undocumented)
@@ -5910,6 +5926,9 @@ interface PrivateProperty extends ClassPropertyBase {
     // (undocumented)
     type: "PrivateProperty";
 }
+
+// @public
+export type Profile = boolean;
 
 // @public (undocumented)
 type Program = Module_2 | Script;
@@ -6822,6 +6841,7 @@ declare namespace rspackExports {
         AssetParserOptions,
         CssParserNamedExports,
         CssParserUrl,
+        CssParserResolveImport,
         CssParserOptions,
         CssAutoParserOptions,
         CssModuleParserOptions,
@@ -6891,7 +6911,7 @@ declare namespace rspackExports {
         OptimizationSplitChunksOptions,
         Optimization,
         ExperimentCacheOptions,
-        BundlerInfoOptions,
+        RspackFutureOptions,
         LazyCompilationOptions,
         Incremental,
         IncrementalPresets,
@@ -6903,6 +6923,7 @@ declare namespace rspackExports {
         DevServer,
         DevServerMiddleware,
         IgnoreWarnings,
+        Profile,
         Amd,
         Bail,
         Performance_2 as Performance,
@@ -6910,6 +6931,15 @@ declare namespace rspackExports {
         Configuration
     }
 }
+
+// @public
+export type RspackFutureOptions = {
+    bundlerInfo?: {
+        version?: string;
+        bundler?: string;
+        force?: boolean | ('version' | 'uniqueId')[];
+    };
+};
 
 // @public (undocumented)
 export type RspackOptions = {
@@ -6941,6 +6971,7 @@ export type RspackOptions = {
     plugins?: Plugins;
     devServer?: DevServer;
     module?: ModuleOptions;
+    profile?: Profile;
     amd?: Amd;
     bail?: Bail;
     performance?: Performance_2;
@@ -7005,6 +7036,8 @@ export interface RspackOptionsNormalized {
     performance?: Performance_2;
     // (undocumented)
     plugins: Plugins;
+    // (undocumented)
+    profile?: Profile;
     // (undocumented)
     resolve: Resolve;
     // (undocumented)
@@ -7723,6 +7756,9 @@ class StatsPrinter {
 
 // @public (undocumented)
 type StatsPrinterContext = KnownStatsPrinterContext & Record<string, any>;
+
+// @public (undocumented)
+type StatsProfile = KnownStatsProfile & Record<string, any>;
 
 // @public
 export type StatsValue = boolean | StatsOptions | StatsPresets;

--- a/packages/rspack/src/builtin-loader/swc/index.ts
+++ b/packages/rspack/src/builtin-loader/swc/index.ts
@@ -2,6 +2,8 @@ export type { CollectTypeScriptInfoOptions } from './collectTypeScriptInfo';
 export { resolveCollectTypeScriptInfo } from './collectTypeScriptInfo';
 export type { PluginImportOptions } from './pluginImport';
 export { resolvePluginImport } from './pluginImport';
+export type { TransformImportOptions } from './transformImport';
+export { resolveTransformImport } from './transformImport';
 
 export type {
   SwcLoaderEnvConfig,

--- a/packages/rspack/src/builtin-loader/swc/transformImport.ts
+++ b/packages/rspack/src/builtin-loader/swc/transformImport.ts
@@ -1,0 +1,32 @@
+export type TransformImportConfig = {
+  source: string;
+  namedImport?: boolean;
+  output: string[];
+  exclude?: string[];
+};
+
+export type TransformImportOptions = TransformImportConfig[];
+
+type RawTransformImportConfig = {
+  source: string;
+  namedImport?: boolean;
+  output: string[];
+  exclude?: string[];
+};
+
+function resolveTransformImport(
+  transformImport: TransformImportOptions,
+): RawTransformImportConfig[] | undefined {
+  if (!transformImport) {
+    return undefined;
+  }
+
+  return transformImport.map((config) => ({
+    source: config.source,
+    namedImport: config.namedImport ?? true,
+    output: config.output,
+    exclude: config.exclude,
+  }));
+}
+
+export { resolveTransformImport };

--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -11,6 +11,7 @@ import type {
 } from '@swc/types';
 import type { CollectTypeScriptInfoOptions } from './collectTypeScriptInfo';
 import type { PluginImportOptions } from './pluginImport';
+import type { TransformImportOptions } from './transformImport';
 export type SwcLoaderEnvConfig = EnvConfig;
 export type SwcLoaderJscConfig = JscConfig;
 export type SwcLoaderModuleConfig = ModuleConfig;
@@ -30,6 +31,14 @@ export type SwcLoaderOptions = Config & {
    * @experimental
    */
   rspackExperiments?: {
+    /**
+     * Transform named imports from a library to individual module imports.
+     * This is a modern replacement for the deprecated `import` option.
+     */
+    transformImport?: TransformImportOptions;
+    /**
+     * @deprecated Use `transformImport` instead. This option will be removed in Rspack v2.0.
+     */
     import?: PluginImportOptions;
     /**
      * @deprecated Use top-level `collectTypeScriptInfo` instead.

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -2,6 +2,7 @@ import type { AssetInfo, RawModuleRuleUse, RawOptions } from '@rspack/binding';
 import {
   resolveCollectTypeScriptInfo,
   resolvePluginImport,
+  resolveTransformImport,
 } from '../builtin-loader';
 import {
   type FeatureOptions,
@@ -506,10 +507,21 @@ const getSwcLoaderOptions: GetLoaderOptions = (options, _) => {
       );
     }
 
-    // resolve `rspackExperiments.import` options
+    // resolve `rspackExperiments` options
     const { rspackExperiments } = options;
     if (rspackExperiments) {
+      // resolve `rspackExperiments.transformImport` options (new API)
+      if (rspackExperiments.transformImport) {
+        rspackExperiments.transformImport = resolveTransformImport(
+          rspackExperiments.transformImport,
+        );
+      }
+
+      // resolve `rspackExperiments.import` options (deprecated API)
       if (rspackExperiments.import || rspackExperiments.pluginImport) {
+        deprecate(
+          '`rspackExperiments.import` is deprecated and will be removed in Rspack v2.0. Use `rspackExperiments.transformImport` instead.',
+        );
         rspackExperiments.import = resolvePluginImport(
           rspackExperiments.import || rspackExperiments.pluginImport,
         );

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/basic.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/basic.js
@@ -1,0 +1,5 @@
+import { FooBar } from "./src/basic";
+
+it("basic transformImport", () => {
+	expect(FooBar).toBe("FooBar");
+});

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/default-import.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/default-import.js
@@ -1,0 +1,5 @@
+import { FooBar } from "./src/default-import";
+
+it("transformImport with namedImport: false (default import)", () => {
+	expect(FooBar).toBe("FooBar");
+});

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/exclude.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/exclude.js
@@ -1,0 +1,7 @@
+import { Included, Excluded } from "./src/exclude";
+
+it("transformImport with exclude", () => {
+	expect(Included).toBe("Included");
+	// Excluded should still work since it's not transformed but stays as named export from source
+	expect(Excluded).toBe("Excluded");
+});

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/helpers.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/helpers.js
@@ -1,0 +1,5 @@
+import { FooBar } from "./src/helpers";
+
+it("transformImport with various helpers (camelCase, snakeCase, upperCase, lowerCase)", () => {
+	expect(FooBar).toBe("FooBar");
+});

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/index.js
@@ -1,0 +1,6 @@
+import "./basic";
+import "./with-css";
+import "./named-import";
+import "./default-import";
+import "./exclude";
+import "./helpers";

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/named-import.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/named-import.js
@@ -1,0 +1,5 @@
+import { FooBar } from "./src/named-import";
+
+it("transformImport with namedImport: true", () => {
+	expect(FooBar).toBe("FooBar");
+});

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/rspack.config.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/rspack.config.js
@@ -1,0 +1,54 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	resolve: {},
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				type: "asset"
+			},
+			{
+				test: /\.js$/,
+				loader: "builtin:swc-loader",
+				options: {
+					rspackExperiments: {
+						transformImport: [
+							{
+								source: "./src/basic",
+								output: ["./src/basic/lib/{{ kebabCase filename }}"]
+							},
+							{
+								source: "./src/with-css",
+								output: [
+									"./src/with-css/es/{{ kebabCase filename }}.js",
+									"./src/with-css/css/{{ kebabCase filename }}.css"
+								]
+							},
+							{
+								source: "./src/named-import",
+								namedImport: true,
+								output: ["./src/named-import/lib/{{ filename }}"]
+							},
+							{
+								source: "./src/default-import",
+								namedImport: false,
+								output: ["./src/default-import/lib/{{ kebabCase filename }}"]
+							},
+							{
+								source: "./src/exclude",
+								output: ["./src/exclude/lib/{{ kebabCase filename }}"],
+								exclude: ["Excluded"]
+							},
+							{
+								source: "./src/helpers",
+								output: [
+									"./src/helpers/{{ camelCase filename }}/{{ snakeCase filename }}/{{ upperCase filename }}/{{ lowerCase filename }}"
+								]
+							}
+						]
+					}
+				}
+			}
+		]
+	}
+};

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/basic/lib/foo-bar/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/basic/lib/foo-bar/index.js
@@ -1,0 +1,1 @@
+export default "FooBar";

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/default-import/lib/foo-bar/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/default-import/lib/foo-bar/index.js
@@ -1,0 +1,1 @@
+export default "FooBar";

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/exclude/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/exclude/index.js
@@ -1,0 +1,3 @@
+// This is the main barrel file that exports both Included and Excluded
+// Excluded is not transformed due to the exclude config
+export const Excluded = "Excluded";

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/exclude/lib/included/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/exclude/lib/included/index.js
@@ -1,0 +1,1 @@
+export default "Included";

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/helpers/fooBar/foo_bar/FOOBAR/foobar/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/helpers/fooBar/foo_bar/FOOBAR/foobar/index.js
@@ -1,0 +1,1 @@
+export default "FooBar";

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/named-import/lib/FooBar/FooBar.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/named-import/lib/FooBar/FooBar.js
@@ -1,0 +1,1 @@
+export const FooBar = "FooBar";

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/named-import/lib/FooBar/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/named-import/lib/FooBar/index.js
@@ -1,0 +1,1 @@
+export { FooBar } from "./FooBar";

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/with-css/css/foo-bar.css
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/with-css/css/foo-bar.css
@@ -1,0 +1,3 @@
+.foo-bar {
+  color: red;
+}

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/with-css/es/foo-bar.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/src/with-css/es/foo-bar.js
@@ -1,0 +1,1 @@
+export default "FooBar";

--- a/tests/rspack-test/configCases/builtin-swc-loader/transform-import/with-css.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/transform-import/with-css.js
@@ -1,0 +1,5 @@
+import { FooBar } from "./src/with-css";
+
+it("transformImport with CSS side-effect", () => {
+	expect(FooBar).toBe("FooBar");
+});

--- a/website/docs/en/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/features/builtin-swc-loader.mdx
@@ -328,7 +328,11 @@ Experimental features provided by rspack.
 
 ### rspackExperiments.import
 
-<ApiMeta stability={Stability.Experimental} />
+<ApiMeta stability={Stability.Experimental} deprecated />
+
+:::warning Deprecated
+`rspackExperiments.import` has been deprecated. Please use [rspackExperiments.transformImport](#rspackexperimentstransformimport) instead, which provides the same functionality with a more advanced API design.
+:::
 
 Ported from [babel-plugin-import](https://github.com/umijs/babel-plugin-import), configurations are basically the same.
 
@@ -471,6 +475,96 @@ The above configuration will transform `import { Button } from 'antd';` to:
 import Button from 'antd/es/button';
 import 'antd/es/button/style';
 ```
+
+### rspackExperiments.transformImport
+
+<ApiMeta addedVersion="2.0.0" />
+
+`transformImport` is the successor to [`rspackExperiments.import`](#rspackexperimentsimport), providing the same functionality for transforming module imports with a more advanced API design. This is the recommended approach for new projects, and existing projects are encouraged to migrate from `import` to `transformImport`.
+
+The core concept is the same as `rspackExperiments.import` - transforming import specifiers from a source module into individual module imports, with optional additional outputs (e.g., styles).
+
+#### Configuration Options
+
+| Option        | Type       | Description                                                                                                                                                                |
+| ------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`      | `string`   | The source module to match, e.g., `'antd'` or `'./src/components'`                                                                                                         |
+| `output`      | `string[]` | Array of output templates for the transformed imports. Use `{{ filename }}` as placeholder for the import specifier, only the first output contains the imported specifier |
+| `namedImport` | `boolean`  | Whether to keep the import as a named import. Default: `false` (converts to default import)                                                                                |
+| `exclude`     | `string[]` | Array of import specifiers to exclude from transformation                                                                                                                  |
+
+#### Template Helpers
+
+The `output` templates support the following helpers:
+
+- `{{ filename }}` - The original import specifier
+- `{{ kebabCase filename }}` - Convert to kebab-case (e.g., `MyButton` → `my-button`)
+- `{{ camelCase filename }}` - Convert to camelCase
+- `{{ snakeCase filename }}` - Convert to snake_case
+- `{{ upperCase filename }}` - Convert to UPPERCASE
+- `{{ lowerCase filename }}` - Convert to lowercase
+
+#### Example
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        loader: 'builtin:swc-loader',
+        options: {
+          rspackExperiments: {
+            transformImport: [
+              {
+                source: './src/components',
+                output: [
+                  './src/components/lib/{{ kebabCase filename }}',
+                  './src/components/lib/{{ kebabCase filename }}/style.css',
+                ],
+              },
+              {
+                source: './src/ui',
+                output: [
+                  './src/ui/es/{{ kebabCase filename }}.js',
+                  './src/ui/css/{{ kebabCase filename }}.css',
+                ],
+              },
+              {
+                source: './src/utils',
+                namedImport: true,
+                output: ['./src/utils/lib/{{ filename }}'],
+              },
+              {
+                source: './src/exclude',
+                output: ['./src/exclude/lib/{{ kebabCase filename }}'],
+                exclude: ['Excluded'],
+              },
+            ],
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+With this configuration:
+
+```ts
+import { MyButton, MyInput } from './src/components';
+```
+
+Will be transformed to:
+
+```ts
+import MyButton from './src/components/lib/my-button';
+import './src/components/lib/my-button/style.css';
+import MyInput from './src/components/lib/my-input';
+import './src/components/lib/my-input/style.css';
+```
+
+For more examples, see the [test configuration](https://github.com/web-infra-dev/rspack/blob/main/tests/rspack-test/configCases/builtin-swc-loader/transform-import/rspack.config.js).
 
 ### collectTypeScriptInfo
 

--- a/website/docs/zh/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-swc-loader.mdx
@@ -328,7 +328,11 @@ Rspack 内置的实验性功能。
 
 ### rspackExperiments.import
 
-<ApiMeta stability={Stability.Experimental} />
+<ApiMeta stability={Stability.Experimental} deprecated />
+
+:::warning 已废弃
+`rspackExperiments.import` 已被废弃。请使用 [rspackExperiments.transformImport](#rspackexperimentstransformimport) 替代，它提供相同的功能并具有更先进的 API 设计。
+:::
 
 移植自 [babel-plugin-import](https://github.com/umijs/babel-plugin-import)，配置基本保持一致。
 
@@ -474,6 +478,96 @@ export default {
 import Button from 'antd/es/button';
 import 'antd/es/button/style';
 ```
+
+### rspackExperiments.transformImport
+
+<ApiMeta addedVersion="2.0.0" />
+
+`transformImport` 是 [`rspackExperiments.import`](#rspackexperimentsimport) 的后继版本，提供相同的模块导入转换功能，更现代易用的 API 设计。推荐新项目使用此配置，现有项目也建议从 `import` 迁移到 `transformImport`。
+
+核心概念与 `rspackExperiments.import` 相同——将源模块的导入转换为更加具体的模块导入，并可选地添加额外的输出（例如样式）。
+
+#### 配置选项
+
+| 选项          | 类型       | 描述                                                                                                   |
+| ------------- | ---------- | ------------------------------------------------------------------------------------------------------ |
+| `source`      | `string`   | 要匹配的源模块，例如 `'antd'` 或 `'./src/components'`                                                  |
+| `output`      | `string[]` | 转换后导入的输出模板数组。使用 `{{ filename }}` 作为导入说明符的占位符，只有第一个输出包含导入的说明符 |
+| `namedImport` | `boolean`  | 是否保持命名导入。默认：`false`（转换为默认导入）                                                      |
+| `exclude`     | `string[]` | 要排除转换的导入说明符数组                                                                             |
+
+#### 模板辅助函数
+
+`output` 模板支持以下辅助函数：
+
+- `{{ filename }}` - 原始导入说明符
+- `{{ kebabCase filename }}` - 转换为 kebab-case（例如 `MyButton` → `my-button`）
+- `{{ camelCase filename }}` - 转换为 camelCase
+- `{{ snakeCase filename }}` - 转换为 snake_case
+- `{{ upperCase filename }}` - 转换为大写
+- `{{ lowerCase filename }}` - 转换为小写
+
+#### 示例
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        loader: 'builtin:swc-loader',
+        options: {
+          rspackExperiments: {
+            transformImport: [
+              {
+                source: './src/components',
+                output: [
+                  './src/components/lib/{{ kebabCase filename }}',
+                  './src/components/lib/{{ kebabCase filename }}/style.css',
+                ],
+              },
+              {
+                source: './src/ui',
+                output: [
+                  './src/ui/es/{{ kebabCase filename }}.js',
+                  './src/ui/css/{{ kebabCase filename }}.css',
+                ],
+              },
+              {
+                source: './src/utils',
+                namedImport: true,
+                output: ['./src/utils/lib/{{ filename }}'],
+              },
+              {
+                source: './src/exclude',
+                output: ['./src/exclude/lib/{{ kebabCase filename }}'],
+                exclude: ['Excluded'],
+              },
+            ],
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+使用此配置：
+
+```ts
+import { MyButton, MyInput } from './src/components';
+```
+
+将被转换为：
+
+```ts
+import MyButton from './src/components/lib/my-button';
+import './src/components/lib/my-button/style.css';
+import MyInput from './src/components/lib/my-input';
+import './src/components/lib/my-input/style.css';
+```
+
+更多示例请参考 [测试配置](https://github.com/web-infra-dev/rspack/blob/main/tests/rspack-test/configCases/builtin-swc-loader/transform-import/rspack.config.js)。
 
 ### collectTypeScriptInfo
 


### PR DESCRIPTION
## Summary

Introduce `rspackExperiments.transformImport`, it has the same capability as `rspackExperiments.import`, but with more easy-to-use API.

See output here, only the first item has specifier, the rest items are just render as normal `import '{{source}}'`


```
import { specifier } from "{{output[0]}}"
import "{{output[1]}}"
```

Example:

```js title="rspack.config.mjs"
export default {
  module: {
    rules: [
      {
        test: /\.js$/,
        loader: 'builtin:swc-loader',
        options: {
          rspackExperiments: {
            transformImport: [
              {
                source: 'lib',
                namedImport: false,
                output: [
                  'lib/{{ kebabCase filename }}',
                  'lib/{{ kebabCase filename }}/style.css',
                ],
              },
            ],
          },
        },
      },
    ],
  },
};
```

```js
import { MyButton, MyInput } from 'lib';

// 👇

import MyButton from 'lib/my-button';
import 'lib/my-button/style.css';
import MyInput from 'lib/my-input';
import 'lib/my-input/style.css';
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
