### PR TITLE
feat: RemoveDuplicatedModulesPlugin supports using existing chunk for spliting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4736,11 +4736,12 @@ dependencies = [
 name = "rspack_plugin_remove_duplicate_modules"
 version = "0.7.1"
 dependencies = [
+ "dashmap 6.1.0",
+ "rayon",
  "rspack_collections",
  "rspack_core",
  "rspack_error",
  "rspack_hook",
- "rustc-hash",
  "tracing",
 ]
 

--- a/crates/rspack_plugin_remove_duplicate_modules/Cargo.toml
+++ b/crates/rspack_plugin_remove_duplicate_modules/Cargo.toml
@@ -13,9 +13,11 @@ workspace = true
 ignored = ["tracing"]
 
 [dependencies]
+dashmap = { workspace = true }
+rayon   = { workspace = true }
+tracing = { workspace = true }
+
 rspack_collections = { workspace = true }
 rspack_core        = { workspace = true }
 rspack_error       = { workspace = true }
 rspack_hook        = { workspace = true }
-rustc-hash         = { workspace = true }
-tracing            = { workspace = true }

--- a/tests/rspack-test/esmOutputCases/basic/single-entry-split/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/single-entry-split/__snapshots__/esm.snap.txt
@@ -1,0 +1,42 @@
+```mjs title=bar.mjs
+
+export { v } from "./bar_js.mjs";
+
+```
+
+```mjs title=bar_js.mjs
+// ./bar.js
+const v = () => 42
+export { v };
+
+```
+
+```mjs title=foo.mjs
+
+export { value } from "./foo_js.mjs";
+
+```
+
+```mjs title=foo_js.mjs
+import { v } from "./bar_js.mjs";
+
+// ./foo.js
+
+
+const value = () => v()
+
+export { value };
+
+```
+
+```mjs title=main.mjs
+import { value } from "./foo_js.mjs";
+
+// ./index.js
+
+
+it('should have correct value', () => {
+  expect(value()).toBe(42)
+})
+
+```

--- a/tests/rspack-test/esmOutputCases/basic/single-entry-split/bar.js
+++ b/tests/rspack-test/esmOutputCases/basic/single-entry-split/bar.js
@@ -1,0 +1,1 @@
+export const v = () => 42

--- a/tests/rspack-test/esmOutputCases/basic/single-entry-split/foo.js
+++ b/tests/rspack-test/esmOutputCases/basic/single-entry-split/foo.js
@@ -1,0 +1,3 @@
+import { v } from './bar'
+
+export const value = () => v()

--- a/tests/rspack-test/esmOutputCases/basic/single-entry-split/index.js
+++ b/tests/rspack-test/esmOutputCases/basic/single-entry-split/index.js
@@ -1,0 +1,5 @@
+import {value} from './foo'
+
+it('should have correct value', () => {
+  expect(value()).toBe(42)
+})

--- a/tests/rspack-test/esmOutputCases/basic/single-entry-split/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/basic/single-entry-split/rspack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  entry: {
+    main: "./index.js",
+    foo: "./foo.js",
+    bar: "./bar.js",
+  }
+}

--- a/tests/rspack-test/esmOutputCases/re-exports/move-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/move-entry/__snapshots__/esm.snap.txt
@@ -1,11 +1,4 @@
 ```mjs title=lib.mjs
-import "./lib_js.mjs";
-
-export * from "fs";
-
-```
-
-```mjs title=lib_js.mjs
 import * as __rspack_external_fs from "fs";
 // fs
 
@@ -17,6 +10,7 @@ console.log.bind(console)
 // re-export star from unknown
 
 
+export * from "fs";
 
 ```
 
@@ -28,7 +22,7 @@ export { a, b } from "./proxy-main.mjs";
 ```
 
 ```mjs title=proxy-main.mjs
-import "./lib_js.mjs";
+import "./lib.mjs";
 
 // ./index.js
 // normal export


### PR DESCRIPTION
## Summary

`RemoveDuplicatedModulesPlugin` now supports using existing chunk as target splited chunk

Now you can use multiple single entry to hack `preserveModules` temporarily.


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
