### PR TITLE
fix(test): flaky test due to calling toJSON while hot updating

### DIFF
--- a/tests/e2e/cases/make/remove-dynamic-entry-with-loader/index.test.ts
+++ b/tests/e2e/cases/make/remove-dynamic-entry-with-loader/index.test.ts
@@ -19,10 +19,7 @@ test('should compile', async ({ page, fileAction, rspack }) => {
     ),
   );
 
-  await expect(async () => {
-    await page.reload();
-    expect(await page.locator('#index1').innerText()).toBe('index1 updated');
-  }).toPass();
+  await expect(page.locator('#index1')).toContainText('index1 updated');
 
   await expect(page.locator('#index2')).toHaveCount(0);
   await expect(page.locator('#webpack-dev-server-client-overlay')).toHaveCount(

--- a/tests/e2e/cases/make/remove-dynamic-entry-with-loader/rspack.config.js
+++ b/tests/e2e/cases/make/remove-dynamic-entry-with-loader/rspack.config.js
@@ -26,6 +26,9 @@ module.exports = {
   },
   context: __dirname,
   mode: 'development',
+  optimization: {
+    runtimeChunk: 'single',
+  },
   plugins: [
     new rspack.HtmlRspackPlugin(),
     function (compiler) {


### PR DESCRIPTION
## Problem 

[remove-dynamic-entry-with-loader](https://github.com/web-infra-dev/rspack/tree/6ee0d4b1f096707d99174bf38af4396f4840fcde/tests/e2e/cases/make/remove-dynamic-entry-with-loader) 

Panic during E2E testing
```
Message: should set in compilation first
Location: crates/rspack_core/src/utils/deref_option.rs:52
```

## Root Cause Analysis

The problem occurs as follows:

0. The compiler completes the first compilation.
1. The test case asserts successfully, then modifies the file's content, triggering a `page.reload`.
2. This modification triggers a new compilation while the `DerefOption<build_module_graph_artifact>` is being executed.
3. The `page.reload` initiates a new HMR (Hot Module Replacement) connection to the development server. The server sends stats to the new HMR client, which triggers a [stats.toJson()](https://github.com/webpack/webpack-dev-server/blob/195a7e6f7102e48725b1b1fbc3bb80c5df0efedf/lib/Server.js#L2760) call that requires the module graph.
4. A panic occurs because the module graph is taken away.

## Solution

1. Configure a `single` runtime chunk to use HMR for reloading the page once the compilation is completed.
2. Remove the `page.reload` in the test to avoid race conditions.

## Related Links


## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).


