### PR TITLE
feat: add warning when requireAlias is disabled

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
@@ -184,7 +184,12 @@ impl JavascriptParserPlugin for AMDParserPlugin {
     None
   }
 
-  fn can_rename(&self, _parser: &mut JavascriptParser, for_name: &str) -> Option<bool> {
+  fn can_rename(
+    &self,
+    _parser: &mut JavascriptParser,
+    _expr: &Expr,
+    for_name: &str,
+  ) -> Option<bool> {
     if for_name == DEFINE {
       return Some(true);
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -402,9 +402,21 @@ impl CommonJsImportsParserPlugin {
 }
 
 impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
-  fn can_rename(&self, parser: &mut JavascriptParser, for_name: &str) -> Option<bool> {
+  fn can_rename(&self, parser: &mut JavascriptParser, expr: &Expr, for_name: &str) -> Option<bool> {
     if for_name == expr_name::REQUIRE {
-      Some(parser.javascript_options.require_alias.unwrap_or(true))
+      let require_alias = parser.javascript_options.require_alias.unwrap_or(true);
+      if !require_alias {
+        let mut warning = create_traceable_error(
+          "Critical dependency".into(),
+          "please enable 'module.parser.javascript.requireAlias' to analyze require alias"
+            .to_string(),
+          parser.source.to_owned(),
+          expr.span().into(),
+        );
+        warning.severity = Severity::Warning;
+        parser.add_warning(warning.into());
+      }
+      Some(require_alias)
     } else {
       None
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
@@ -52,7 +52,7 @@ impl DefineParserPlugin {
 }
 
 impl JavascriptParserPlugin for DefineParserPlugin {
-  fn can_rename(&self, parser: &mut JavascriptParser, str: &str) -> Option<bool> {
+  fn can_rename(&self, parser: &mut JavascriptParser, _expr: &Expr, str: &str) -> Option<bool> {
     if let Some(first_key) = self.walk_data.can_rename.get(str) {
       self.add_value_dependency(parser, str);
       if let Some(first_key) = first_key

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -579,9 +579,9 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     None
   }
 
-  fn can_rename(&self, parser: &mut JavascriptParser, str: &str) -> Option<bool> {
+  fn can_rename(&self, parser: &mut JavascriptParser, expr: &Expr, str: &str) -> Option<bool> {
     for plugin in &self.plugins {
-      let res = plugin.can_rename(parser, str);
+      let res = plugin.can_rename(parser, expr, str);
       // `SyncBailHook`
       if res.is_some() {
         return res;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin/parser.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin/parser.rs
@@ -4,7 +4,7 @@ use cow_utils::CowUtils;
 use itertools::Itertools;
 use rspack_core::DependencyRange;
 use rustc_hash::FxHashSet as HashSet;
-use swc_core::{atoms::Atom, common::Spanned};
+use swc_core::{atoms::Atom, common::Spanned, ecma::ast::Expr};
 
 use super::{super::JavascriptParserPlugin, ProvideValue, VALUE_DEP_PREFIX};
 use crate::{dependency::ProvideDependency, visitors::JavascriptParser};
@@ -62,7 +62,7 @@ impl ProvideParserPlugin {
 }
 
 impl JavascriptParserPlugin for ProvideParserPlugin {
-  fn can_rename(&self, _parser: &mut JavascriptParser, str: &str) -> Option<bool> {
+  fn can_rename(&self, _parser: &mut JavascriptParser, _expr: &Expr, str: &str) -> Option<bool> {
     self.names.contains(str).then_some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -38,7 +38,7 @@ pub trait JavascriptParserPlugin {
   /// The return value will have no effect.
   fn top_level_for_of_await_stmt(&self, _parser: &mut JavascriptParser, _stmt: &ForOfStmt) {}
 
-  fn can_rename(&self, _parser: &mut JavascriptParser, _str: &str) -> Option<bool> {
+  fn can_rename(&self, _parser: &mut JavascriptParser, _expr: &Expr, _str: &str) -> Option<bool> {
     None
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -104,7 +104,12 @@ pub struct URLPlugin {
 }
 
 impl JavascriptParserPlugin for URLPlugin {
-  fn can_rename(&self, _parser: &mut JavascriptParser, for_name: &str) -> Option<bool> {
+  fn can_rename(
+    &self,
+    _parser: &mut JavascriptParser,
+    _expr: &Expr,
+    for_name: &str,
+  ) -> Option<bool> {
     (for_name == "URL").then_some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -375,7 +375,7 @@ impl JavascriptParser<'_> {
       {
         let drive = self.plugin_drive.clone();
         if drive
-          .can_rename(self, &renamed_identifier)
+          .can_rename(self, init, &renamed_identifier)
           .unwrap_or_default()
         {
           if !drive
@@ -930,7 +930,9 @@ impl JavascriptParser<'_> {
       if let Some(rename_identifier) = parser.get_rename_identifier(expr)
         && let drive = parser.plugin_drive.clone()
         && rename_identifier
-          .call_hooks_name(parser, |this, for_name| drive.can_rename(this, for_name))
+          .call_hooks_name(parser, |this, for_name| {
+            drive.can_rename(this, expr, for_name)
+          })
           .unwrap_or_default()
         && !rename_identifier
           .call_hooks_name(parser, |this, for_name| drive.rename(this, expr, for_name))
@@ -1257,7 +1259,9 @@ impl JavascriptParser<'_> {
       if let Some(rename_identifier) = self.get_rename_identifier(&expr.right)
         && let drive = self.plugin_drive.clone()
         && rename_identifier
-          .call_hooks_name(self, |this, for_name| drive.can_rename(this, for_name))
+          .call_hooks_name(self, |this, for_name| {
+            drive.can_rename(this, &expr.right, for_name)
+          })
           .unwrap_or_default()
       {
         if !rename_identifier

--- a/tests/rspack-test/configCases/parsing/renaming-disabled/warnings.js
+++ b/tests/rspack-test/configCases/parsing/renaming-disabled/warnings.js
@@ -1,0 +1,4 @@
+module.exports = [
+  [/Critical dependency: please enable 'module.parser.javascript.requireAlias' to analyze require alias/],
+  [/Critical dependency: please enable 'module.parser.javascript.requireAlias' to analyze require alias/]
+]


### PR DESCRIPTION
## Summary

This PR adds a warning message when the `requireAlias` option is disabled in the parser configuration. The warning helps developers understand that they need to enable `module.parser.javascript.requireAlias` to properly analyze require aliases in their code.

## Changes

- Modified the `can_rename` method signature in `JavascriptParserPlugin` trait to accept an `Expr` parameter, allowing access to the expression's span information for better warning messages
- Added warning logic in `CommonJsImportsParserPlugin` when `requireAlias` is disabled
- Updated all call sites of `can_rename` to pass the expression parameter
- Added test case to verify the warning behavior

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).