### PR TITLE
refactor: reuse artifact based on cache options

### DIFF
--- a/crates/rspack_core/src/cache/disable.rs
+++ b/crates/rspack_core/src/cache/disable.rs
@@ -9,7 +9,7 @@ pub struct DisableCache;
 
 #[async_trait::async_trait]
 impl Cache for DisableCache {
-  async fn before_build_module_graph(&mut self, make_artifact: &mut BuildModuleGraphArtifact) {
-    *make_artifact = Default::default();
+  async fn before_build_module_graph(&mut self, _make_artifact: &mut BuildModuleGraphArtifact) {
+     // do nothing just don't use any cache
   }
 }

--- a/crates/rspack_core/src/cache/disable.rs
+++ b/crates/rspack_core/src/cache/disable.rs
@@ -10,6 +10,6 @@ pub struct DisableCache;
 #[async_trait::async_trait]
 impl Cache for DisableCache {
   async fn before_build_module_graph(&mut self, _make_artifact: &mut BuildModuleGraphArtifact) {
-     // do nothing just don't use any cache
+    // do nothing just don't use any cache
   }
 }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -1548,6 +1548,14 @@ impl Compilation {
     &self,
     dependencies_diagnostics_artifact: &mut DependenciesDiagnosticsArtifact,
   ) -> Vec<Diagnostic> {
+    // Clear artifact when incremental is disabled for DEPENDENCIES_DIAGNOSTICS pass
+    if !self
+      .incremental
+      .passes_enabled(IncrementalPasses::DEPENDENCIES_DIAGNOSTICS)
+    {
+      dependencies_diagnostics_artifact.clear();
+    }
+
     // Compute modules while holding the lock, then release it
     let (modules, has_mutations) = {
       let mutations = self

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -8,7 +8,9 @@ use rspack_tasks::within_compiler_context;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-  CacheOptions, ChunkGraph, ChunkKind, Compilation, Compiler, DerefOption, RuntimeSpec, chunk_graph_chunk::ChunkId, chunk_graph_module::ModuleId, compilation::build_module_graph::ModuleExecutor, fast_set, incremental::Incremental
+  CacheOptions, ChunkGraph, ChunkKind, Compilation, Compiler, DerefOption, RuntimeSpec,
+  chunk_graph_chunk::ChunkId, chunk_graph_module::ModuleId,
+  compilation::build_module_graph::ModuleExecutor, fast_set, incremental::Incremental,
 };
 
 impl Compiler {

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -205,6 +205,14 @@ async fn chunk_ids(
   named_chunk_ids_artifact: &mut ChunkNamedIdArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> rspack_error::Result<()> {
+  // Clear artifact when incremental is disabled for CHUNK_IDS pass
+  if !compilation
+    .incremental
+    .passes_enabled(IncrementalPasses::CHUNK_IDS)
+  {
+    named_chunk_ids_artifact.clear();
+  }
+
   if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::CHUNK_IDS)

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -130,12 +130,21 @@ async fn module_ids(
   module_ids_artifact: &mut ModuleIdsArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<()> {
+  // Clear artifacts when incremental is disabled for MODULE_IDS pass
+  if !compilation
+    .incremental
+    .passes_enabled(IncrementalPasses::MODULE_IDS)
+  {
+    module_ids_artifact.clear();
+  }
+
   let mut module_ids = std::mem::take(module_ids_artifact);
   let mut used_ids: FxHashMap<ModuleId, ModuleIdentifier> = module_ids
     .iter()
     .map(|(&module, id)| (id.clone(), module))
     .collect();
   let module_graph = compilation.get_module_graph();
+
   if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::MODULE_IDS)

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -34,6 +34,9 @@ async fn finish_modules(
       .for_each(|module| {
         async_modules_artifact.remove(module);
       });
+  } else {
+    // Clear artifact when incremental is disabled for INFER_ASYNC_MODULES pass
+    async_modules_artifact.clear();
   }
 
   let module_graph = compilation.get_module_graph();

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -18,6 +18,14 @@ async fn finish_modules(
   compilation: &mut Compilation,
   async_modules_artifact: &mut AsyncModulesArtifact,
 ) -> Result<()> {
+  // Clear artifact when incremental is disabled for INFER_ASYNC_MODULES pass
+  if !compilation
+    .incremental
+    .passes_enabled(IncrementalPasses::INFER_ASYNC_MODULES)
+  {
+    async_modules_artifact.clear();
+  }
+
   if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::INFER_ASYNC_MODULES)
@@ -34,9 +42,6 @@ async fn finish_modules(
       .for_each(|module| {
         async_modules_artifact.remove(module);
       });
-  } else {
-    // Clear artifact when incremental is disabled for INFER_ASYNC_MODULES pass
-    async_modules_artifact.clear();
   }
 
   let module_graph = compilation.get_module_graph();

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -241,6 +241,8 @@ async fn optimize_dependencies(
 
     modules
   } else {
+    // Clear artifact when incremental is disabled for SIDE_EFFECTS pass
+    side_effects_optimize_artifact.clear();
     all_modules.keys().copied().collect()
   };
   logger.time_end(inner_start);

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -156,6 +156,14 @@ async fn optimize_dependencies(
   build_module_graph_artifact: &mut BuildModuleGraphArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
+  // Clear artifact when incremental is disabled for SIDE_EFFECTS pass
+  if !compilation
+    .incremental
+    .passes_enabled(IncrementalPasses::SIDE_EFFECTS)
+  {
+    side_effects_optimize_artifact.clear();
+  }
+
   let logger = compilation.get_logger("rspack.SideEffectsFlagPlugin");
   let start = logger.time("update connections");
 
@@ -179,6 +187,7 @@ async fn optimize_dependencies(
     .collect();
 
   let inner_start = logger.time("prepare connections");
+
   let modules: IdentifierSet = if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::SIDE_EFFECTS)
@@ -241,8 +250,6 @@ async fn optimize_dependencies(
 
     modules
   } else {
-    // Clear artifact when incremental is disabled for SIDE_EFFECTS pass
-    side_effects_optimize_artifact.clear();
     all_modules.keys().copied().collect()
   };
   logger.time_end(inner_start);


### PR DESCRIPTION
## Summary
make clear distinction about incremental and cache to controll artifact
* cache: to controll whether reuse artifacts from last compilation
* incremental: to controll whether clear artifact based on whether current incrementalPasses is enabled
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
