### PR TITLE
feat!: remove `experiments.lazyCompilation`

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2437,7 +2437,6 @@ interface ExecuteModuleContext {
 
 // @public
 export type Experiments = {
-    lazyCompilation?: boolean | LazyCompilationOptions;
     asyncWebAssembly?: boolean;
     outputModule?: boolean;
     topLevelAwait?: boolean;
@@ -2521,8 +2520,6 @@ export interface ExperimentsNormalized {
     layers?: boolean;
     // @deprecated (undocumented)
     lazyBarrel?: boolean;
-    // @deprecated (undocumented)
-    lazyCompilation?: false | LazyCompilationOptions;
     // (undocumented)
     nativeWatcher?: boolean;
     // (undocumented)

--- a/packages/rspack/scripts/check-documentation-coverage.ts
+++ b/packages/rspack/scripts/check-documentation-coverage.ts
@@ -226,7 +226,6 @@ function checkConfigsDocumentationCoverage() {
 
   // const implementedConfigs = getImplementedConfigs().filter(config => {
   // 	return ![
-  // 		"experiments.lazyCompilation.backend",
   // 		"resolveLoader",
   // 		"module.parser",
   // 		"module.generator",

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -211,9 +211,6 @@ const applyInfrastructureLoggingDefaults = (
 
 const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
   D(experiments, 'futureDefaults', false);
-  // TODO: lazyCompilation is moving to Configuration top level, we can remove this in future.
-  // IGNORE(experiments.lazyCompilation): In webpack, lazyCompilation is undefined by default
-  D(experiments, 'lazyCompilation', false);
   D(experiments, 'asyncWebAssembly', experiments.futureDefaults);
   D(experiments, 'css', experiments.futureDefaults ? true : undefined);
   D(experiments, 'topLevelAwait', true);

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -406,10 +406,6 @@ export const getNormalizedRspackOptions = (
       }
       return {
         ...experiments,
-        lazyCompilation: optionalNestedConfig(
-          experiments.lazyCompilation,
-          (options) => (options === true ? {} : options),
-        ),
         incremental: optionalNestedConfig(experiments.incremental, (options) =>
           getNormalizedIncrementalOptions(options),
         ),
@@ -675,12 +671,6 @@ export type CacheNormalized =
     };
 
 export interface ExperimentsNormalized {
-  /**
-   * @deprecated This option is deprecated and will be removed in future versions.
-   *
-   * Please use the Configuration top-level `lazyCompilation` option instead.
-   */
-  lazyCompilation?: false | LazyCompilationOptions;
   asyncWebAssembly?: boolean;
   outputModule?: boolean;
   topLevelAwait?: boolean;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2753,12 +2753,6 @@ export type UseInputFileSystem = false | RegExp[];
  */
 export type Experiments = {
   /**
-   * Enable lazy compilation.
-   * @deprecated Please use the configuration top-level `lazyCompilation` option instead.
-   * @default false
-   */
-  lazyCompilation?: boolean | LazyCompilationOptions;
-  /**
    * Enable async WebAssembly.
    * Support the new WebAssembly according to the [updated specification](https://github.com/WebAssembly/esm-integration), it makes a WebAssembly module an async module.
    * @default false

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -46,7 +46,6 @@ module.exports = {
 			    inlineConst: true,
 			    inlineEnum: false,
 			    lazyBarrel: true,
-			    lazyCompilation: false,
 			    topLevelAwait: true,
 			    typeReexportsPresence: false,
 			    useInputFileSystem: false,


### PR DESCRIPTION
## Summary

The lazyCompilation had been stablized in https://github.com/web-infra-dev/rspack/pull/11337, so we can remove `experiments.lazyCompilation` in v2.0

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
