### PR TITLE
feat!: remove `experiments.layers`

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2440,7 +2440,6 @@ export type Experiments = {
     asyncWebAssembly?: boolean;
     outputModule?: boolean;
     css?: boolean;
-    layers?: boolean;
     incremental?: IncrementalPresets | Incremental;
     futureDefaults?: boolean;
     buildHttp?: HttpUriOptions;
@@ -2515,8 +2514,6 @@ export interface ExperimentsNormalized {
     inlineConst?: boolean;
     // @deprecated (undocumented)
     inlineEnum?: boolean;
-    // @deprecated (undocumented)
-    layers?: boolean;
     // @deprecated (undocumented)
     lazyBarrel?: boolean;
     // (undocumented)

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -374,11 +374,6 @@ export const getNormalizedRspackOptions = (
     performance: config.performance,
     plugins: nestedArray(config.plugins, (p) => [...p]),
     experiments: nestedConfig(config.experiments, (experiments) => {
-      if (experiments.layers) {
-        deprecate(
-          '`experiments.layers` config is deprecated and will be removed in Rspack v2.0. Feature layers will always be enabled. Remove this option from your Rspack configuration.',
-        );
-      }
       if (experiments.lazyBarrel) {
         deprecate(
           '`experiments.lazyBarrel` config is deprecated and will be removed in Rspack v2.0. Lazy barrel is already stable and enabled by default. Remove this option from your Rspack configuration.',
@@ -669,10 +664,6 @@ export interface ExperimentsNormalized {
   asyncWebAssembly?: boolean;
   outputModule?: boolean;
   css?: boolean;
-  /**
-   * @deprecated This option is deprecated, layers is enabled since v1.6.0
-   */
-  layers?: boolean;
   incremental?: false | Incremental;
   futureDefaults?: boolean;
   buildHttp?: HttpUriPluginOptions;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2777,12 +2777,6 @@ export type Experiments = {
    */
   css?: boolean;
   /**
-   * Enable module layers feature.
-   * @deprecated This option is deprecated, layers is enabled since v1.6.0
-   * @default false
-   */
-  layers?: boolean;
-  /**
    * Enable incremental builds.
    */
   incremental?: IncrementalPresets | Incremental;

--- a/tests/rspack-test/configCases/layer/define-multiple-entries/rspack.config.js
+++ b/tests/rspack-test/configCases/layer/define-multiple-entries/rspack.config.js
@@ -10,9 +10,6 @@ module.exports = {
 		paid: { dependOn: "common", import: "./paid.js", layer: "paid" },
 		free: { dependOn: "common", import: "./free.js", layer: "free" }
 	},
-	experiments: {
-		layers: true
-	},
 	optimization: {
 		splitChunks: {
 			cacheGroups: {

--- a/tests/rspack-test/configCases/layer/define-single-entry/rspack.config.js
+++ b/tests/rspack-test/configCases/layer/define-single-entry/rspack.config.js
@@ -8,9 +8,6 @@ module.exports = {
 		paid: { import: "./main.js", layer: "paid" },
 		free: { import: "./main.js", layer: "free" }
 	},
-	experiments: {
-		layers: true
-	},
 	optimization: {
 		splitChunks: {
 			cacheGroups: {

--- a/tests/rspack-test/configCases/source-map/resource-path/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/resource-path/rspack.config.js
@@ -4,9 +4,6 @@ module.exports = {
 		__dirname: false,
 		__filename: false
 	},
-	experiments: {
-		layers: true
-	},
 	devtool: "source-map",
 	entry: {
 		main: {

--- a/website/docs/en/config/deprecated-options.mdx
+++ b/website/docs/en/config/deprecated-options.mdx
@@ -35,31 +35,6 @@ This configuration has been deprecated. Use top-level [`collectTypeScriptInfo`](
 
 :::
 
-## experiments.layers
-
-<ApiMeta deprecatedVersion="1.6.0" />
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-Controls whether to enable the layer feature. Layers add an identifier prefix to all modules in a subgraph starting from a module in the module graph, to distinguish them from modules in different layers. For example:
-
-The `layer` of the `index.js` module is `null` by default, and its `identifier` is `./index.js`. If we set `layer = 'client'` for it, its `identifier` becomes `(client)/./index.js`. At this point, the `index.js` modules in these two different layers are treated as distinct modules, because their unique `identifier`s differ. The final output includes the artifacts of both modules.
-
-By default, a module's layer is `null`, and it inherits its parent module's layer. You can add a layer to an entry module using `entryOptions.layer`, and add a layer to matched modules using [`module.rule[].layer`](/config/module-rules#ruleslayer). Additionally, you can match based on the parent module's layer using [`module.rule[].issuerLayer`](/config/module-rules#rulesissuerlayer).
-
-```js title="rspack.config.mjs"
-export default {
-  experiments: {
-    layers: true,
-  },
-};
-```
-
-:::warning
-This option is deprecated. Layers are now always enabled. Remove this option from your Rspack configuration.
-:::
-
 ## experiments.parallelCodeSplitting
 
 <ApiMeta deprecatedVersion="1.6.2" />

--- a/website/docs/en/config/entry.mdx
+++ b/website/docs/en/config/entry.mdx
@@ -226,10 +226,6 @@ Specifies the layer in which modules of this entrypoint are placed. Make the cor
 
 For more information about layers, see the [Layer guide](/guide/features/layer).
 
-:::warning
-For version before v1.6.0, this configuration will only take effect when [experiments.layers](/config/deprecated-options#experimentslayers) is `true`.
-:::
-
 ```js title="rspack.config.mjs"
 export default {
   entry: {

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -248,10 +248,6 @@ Matches all modules that match this resource, and will match against layer of th
 
 For more information about layers, see the [Layer guide](/guide/features/layer).
 
-:::warning
-For version before v1.6.0, this configuration will only work if [experiments.layers = true](/config/deprecated-options#experimentslayers).
-:::
-
 A basic example:
 
 ```js title="rspack.config.mjs"
@@ -642,10 +638,6 @@ The meanings of all `type` options are as follows:
 Used to mark the layer of the matching module. A group of modules could be united in one layer which could then be used in split chunks, stats or [entry options](/config/entry#entrydescriptionlayer).
 
 For more information about layers, see the [Layer guide](/guide/features/layer).
-
-:::warning
-For version before v1.6.0, this configuration will only work if [experiments.layers = true](/config/deprecated-options#experimentslayers).
-:::
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/deprecated-options.mdx
+++ b/website/docs/zh/config/deprecated-options.mdx
@@ -35,31 +35,6 @@ import { ApiMeta } from '../../../components/ApiMeta';
 
 :::
 
-## experiments.layers
-
-<ApiMeta deprecatedVersion="1.6.0" />
-
-- **类型：** `boolean`
-- **默认值：** `true`
-
-控制是否启用 layer 功能，layer 可以为模块图中以一个模块作为起点的子图中的所有模块添加标识符前缀，用来与其他不同 layer 的模块进行区分，比如：
-
-`index.js` 模块的 layer 为默认的 `null`，其 `identifier` 为 `./index.js`，我们为其添加 `layer = 'client'`，其 `identifier` 会变成 `(client)/./index.js`，这时这两个不同 layer 的 `index.js` 会被区分为不同的模块，因为其唯一标识 `identifier` 不一样，最终产物中也会存在这两个模块的产物。
-
-模块默认的 layer 为 `null`，模块默认会继承其父模块的 layer，你可以通过 `entryOptions.layer` 为一个入口模块添加 layer，也可以通过 [`module.rule[].layer`](/config/module-rules#ruleslayer) 为匹配到的模块添加 layer，同时可以通过 [`module.rule[].issuerLayer`](/config/module-rules#rulesissuerlayer) 根据父模块的 layer 进行匹配。
-
-```js title="rspack.config.mjs"
-export default {
-  experiments: {
-    layers: true,
-  },
-};
-```
-
-:::warning
-该配置项已经废弃，layers 特性已始终开启，请从 Rspack 配置项中移除此配置。
-:::
-
 ## experiments.parallelCodeSplitting
 
 <ApiMeta deprecatedVersion="1.6.2" />

--- a/website/docs/zh/config/entry.mdx
+++ b/website/docs/zh/config/entry.mdx
@@ -226,10 +226,6 @@ export default {
 
 更多关于 layer 的信息，请参考 [Layer 指南](/guide/features/layer)。
 
-:::warning
-对于 v1.6.0 之前的版本，只有在 [experiments.layers = true](/config/experiments#experimentslayers) 时该配置才会生效。
-:::
-
 ```js title="rspack.config.mjs"
 export default {
   entry: {

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -248,10 +248,6 @@ export default {
 
 更多关于 layer 的信息，请参考 [Layer 指南](/guide/features/layer)。
 
-:::warning
-对于 v1.6.0 之前的版本，只有在 [experiments.layers = true](/config/experiments#experimentslayers) 时该配置才会生效。
-:::
-
 一个基础示例：
 
 ```js title="rspack.config.mjs"
@@ -641,10 +637,6 @@ export default {
 用于标识匹配的模块的 layer。可以将一组模块聚合到一个 layer 中，该 layer 随后可以在 split chunks, stats 或 [entry options](/config/entry#entrydescriptionlayer) 中使用。
 
 更多关于 layer 的信息，请参考 [Layer 指南](/guide/features/layer)。
-
-:::warning
-对于 v1.6.0 之前的版本，只有在 [experiments.layers = true](/config/experiments#experimentslayers) 时该配置才会生效。
-:::
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

Layer is a feature for organizing modules into different layers, which can be useful in advanced scenarios such as React Server Components. By assigning different layers to modules, you can gain finer control over their build behavior, for example:

- Compiling modules in different layers for different target environments
- Outputting them to separate build directories

Starting from Rspack 1.6, the layer feature has become stable enough that the experimental flag [experiments.layers](/config/experiments#experimentslayers) has been deprecated. You can now use the layer feature directly without the experimental flag.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
