### PR TITLE
feat!: remove `experiments.lazyBarrel`

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2133,7 +2133,6 @@ export interface RawExperiments {
 incremental?: false | { [key: string]: boolean }
 useInputFileSystem?: false | Array<RegExp>
 css?: boolean
-lazyBarrel: boolean
 deferImport: boolean
 }
 

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -3734,7 +3734,6 @@ impl ExperimentsBuilder {
     Ok(Experiments {
       incremental,
       css: d!(self.css, false),
-      lazy_barrel: true,
       defer_import: false,
     })
   }

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1515,7 +1515,6 @@ CompilerOptions {
             ),
         },
         css: false,
-        lazy_barrel: true,
         defer_import: false,
     },
     node: Some(

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
@@ -15,7 +15,6 @@ pub struct RawExperiments {
   #[napi(ts_type = "false | Array<RegExp>")]
   pub use_input_file_system: Option<WithFalse<Vec<RspackRegex>>>,
   pub css: Option<bool>,
-  pub lazy_barrel: bool,
   pub defer_import: bool,
 }
 
@@ -30,7 +29,6 @@ impl From<RawExperiments> for Experiments {
         None => IncrementalOptions::empty_passes(),
       },
       css: value.css.unwrap_or(false),
-      lazy_barrel: value.lazy_barrel,
       defer_import: value.defer_import,
     }
   }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -44,11 +44,7 @@ impl Task<TaskContext> for AddTask {
       return Ok(vec![]);
     }
 
-    let forwarded_ids = if context.compiler_options.experiments.lazy_barrel {
-      ForwardedIdSet::from_dependencies(&self.dependencies)
-    } else {
-      ForwardedIdSet::All
-    };
+    let forwarded_ids = ForwardedIdSet::from_dependencies(&self.dependencies);
 
     // reuse module if module is already added by other dependency
     if module_graph
@@ -62,36 +58,34 @@ impl Task<TaskContext> for AddTask {
         module_identifier,
       )?;
 
-      if context.compiler_options.experiments.lazy_barrel {
-        if self.from_unlazy {
-          context
-            .artifact
-            .affected_modules
-            .mark_as_add(&module_identifier);
-        }
+      if self.from_unlazy {
+        context
+          .artifact
+          .affected_modules
+          .mark_as_add(&module_identifier);
+      }
 
-        if module_graph
-          .module_by_identifier(&module_identifier)
-          .is_some()
+      if module_graph
+        .module_by_identifier(&module_identifier)
+        .is_some()
+      {
+        if context
+          .artifact
+          .module_to_lazy_make
+          .has_lazy_dependencies(&module_identifier)
+          && !forwarded_ids.is_empty()
         {
-          if context
-            .artifact
-            .module_to_lazy_make
-            .has_lazy_dependencies(&module_identifier)
-            && !forwarded_ids.is_empty()
-          {
-            return Ok(vec![Box::new(ProcessUnlazyDependenciesTask {
-              forwarded_ids,
-              original_module_identifier: module_identifier,
-            })]);
-          }
-        } else {
-          let pending_forwarded_ids = context
-            .artifact
-            .module_to_lazy_make
-            .pending_forwarded_ids(module_identifier);
-          pending_forwarded_ids.append(forwarded_ids);
+          return Ok(vec![Box::new(ProcessUnlazyDependenciesTask {
+            forwarded_ids,
+            original_module_identifier: module_identifier,
+          })]);
         }
+      } else {
+        let pending_forwarded_ids = context
+          .artifact
+          .module_to_lazy_make
+          .pending_forwarded_ids(module_identifier);
+        pending_forwarded_ids.append(forwarded_ids);
       }
 
       return Ok(vec![]);

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -150,9 +150,7 @@ impl Task<TaskContext> for BuildResultTask {
      -> Vec<Box<AsyncDependenciesBlock>> {
       for (index_in_block, dependency) in dependencies.into_iter().enumerate() {
         let dependency_id = *dependency.id();
-        if context.compiler_options.experiments.lazy_barrel
-          && let Some(until) = dependency.lazy()
-        {
+        if let Some(until) = dependency.lazy() {
           lazy_dependencies.insert(&dependency, until);
         }
         if current_block.is_none() {

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -7,6 +7,5 @@ use crate::incremental::IncrementalOptions;
 pub struct Experiments {
   pub incremental: IncrementalOptions,
   pub css: bool,
-  pub lazy_barrel: bool,
   pub defer_import: bool,
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -58,11 +58,10 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
       Some(parser.source_rope().clone()),
       statement.is_star_export(),
     );
-    if parser.compiler_options.experiments.lazy_barrel
-      && parser
-        .factory_meta
-        .and_then(|meta| meta.side_effect_free)
-        .unwrap_or_default()
+    if parser
+      .factory_meta
+      .and_then(|meta| meta.side_effect_free)
+      .unwrap_or_default()
     {
       side_effect_dep.set_lazy();
     }
@@ -114,11 +113,10 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
         settings.attributes,
         Some(parser.source_rope().clone()),
       );
-      if parser.compiler_options.experiments.lazy_barrel
-        && parser
-          .factory_meta
-          .and_then(|meta| meta.side_effect_free)
-          .unwrap_or_default()
+      if parser
+        .factory_meta
+        .and_then(|meta| meta.side_effect_free)
+        .unwrap_or_default()
       {
         dep.set_lazy();
       }
@@ -205,11 +203,10 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
     if !is_asi_safe {
       parser.set_asi_position(statement.span_hi());
     }
-    if parser.compiler_options.experiments.lazy_barrel
-      && parser
-        .factory_meta
-        .and_then(|meta| meta.side_effect_free)
-        .unwrap_or_default()
+    if parser
+      .factory_meta
+      .and_then(|meta| meta.side_effect_free)
+      .unwrap_or_default()
     {
       dep.set_lazy();
     }

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2448,7 +2448,6 @@ export type Experiments = {
     inlineConst?: boolean;
     inlineEnum?: boolean;
     typeReexportsPresence?: boolean;
-    lazyBarrel?: boolean;
     deferImport?: boolean;
 };
 
@@ -2514,8 +2513,6 @@ export interface ExperimentsNormalized {
     inlineConst?: boolean;
     // @deprecated (undocumented)
     inlineEnum?: boolean;
-    // @deprecated (undocumented)
-    lazyBarrel?: boolean;
     // (undocumented)
     nativeWatcher?: boolean;
     // (undocumented)

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -254,9 +254,6 @@ const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
 
   // IGNORE(experiments.typeReexportsPresence): Rspack specific configuration for type reexports presence
   D(experiments, 'typeReexportsPresence', false);
-
-  // IGNORE(experiments.lazyBarrel): Rspack specific configuration for lazy make side effects free barrel file
-  D(experiments, 'lazyBarrel', true);
 };
 
 const applySnapshotDefaults = (

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -374,11 +374,6 @@ export const getNormalizedRspackOptions = (
     performance: config.performance,
     plugins: nestedArray(config.plugins, (p) => [...p]),
     experiments: nestedConfig(config.experiments, (experiments) => {
-      if (experiments.lazyBarrel) {
-        deprecate(
-          '`experiments.lazyBarrel` config is deprecated and will be removed in Rspack v2.0. Lazy barrel is already stable and enabled by default. Remove this option from your Rspack configuration.',
-        );
-      }
       if (experiments.inlineConst) {
         deprecate(
           '`experiments.inlineConst` config is deprecated and will be removed in Rspack v2.0. Inline Const is already stable and enabled by default. Remove this option from your Rspack configuration.',
@@ -677,10 +672,6 @@ export interface ExperimentsNormalized {
    */
   inlineEnum?: boolean;
   typeReexportsPresence?: boolean;
-  /**
-   * @deprecated This option is deprecated, it's already stable and enabled by default, Rspack will remove this option in future version
-   */
-  lazyBarrel?: boolean;
   nativeWatcher?: boolean;
   deferImport?: boolean;
 }

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2819,12 +2819,6 @@ export type Experiments = {
    */
   typeReexportsPresence?: boolean;
   /**
-   * Enable lazy make side effects free barrel file
-   * @default false
-   * @deprecated This option is deprecated, it's already stable and enabled by default, Rspack will remove this option in future version
-   */
-  lazyBarrel?: boolean;
-  /**
    * Enable defer import feature
    * @default false
    */

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -45,7 +45,6 @@ module.exports = {
 			    },
 			    inlineConst: true,
 			    inlineEnum: false,
-			    lazyBarrel: true,
 			    typeReexportsPresence: false,
 			    useInputFileSystem: false,
 			  },

--- a/tests/rspack-test/watchCases/compilation/unlazy-dependencies/rspack.config.js
+++ b/tests/rspack-test/watchCases/compilation/unlazy-dependencies/rspack.config.js
@@ -1,6 +1,5 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	experiments: {
-		lazyBarrel: true
 	}
 };

--- a/website/docs/en/config/deprecated-options.mdx
+++ b/website/docs/en/config/deprecated-options.mdx
@@ -101,25 +101,6 @@ This configuration has been deprecated and is no longer required. Inline enum op
 Please refer to [inline enum example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/inline-enum) for more details.
 :::
 
-## experiments.lazyBarrel
-
-<ApiMeta deprecatedVersion="1.7.0" />
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-Used to enable lazy barrel optimization for skipping the building of unused re-export modules in side-effect-free barrel files.
-
-:::warning
-This configuration has been deprecated and will be removed in Rspack v2.0. Lazy barrel optimization is already stable and enabled by default. Remove this option from your Rspack configuration.
-:::
-
-:::tip
-Lazy barrel is now a stable feature that is always enabled. It helps optimize build performance by skipping the building of unused re-export modules in side-effect-free barrel files.
-
-For more details, see the [Lazy barrel guide](/guide/optimization/lazy-barrel).
-:::
-
 ## experiments.typeReexportsPresence
 
 <ApiMeta deprecatedVersion="1.7.0" />

--- a/website/docs/en/guide/optimization/lazy-barrel.mdx
+++ b/website/docs/en/guide/optimization/lazy-barrel.mdx
@@ -171,24 +171,6 @@ Rspack can analyze whether a module has side effects (this capability is already
 
 During the make phase, dependencies must be built before their side effects can be analyzed. Lazy barrel is specifically designed to avoid building those dependencies. Therefore, it relies on explicit markers like `"sideEffects": false` in `package.json` or `rules[].sideEffects`, which don't require dependency checking since they declare the entire package or matched modules as side-effect-free.
 
-## Configuration
-
-Lazy barrel is enabled by default since Rspack 1.6.0. No configuration is needed.
-
-If you're using an older version and have `experiments.lazyBarrel` in your configuration, you can safely remove it:
-
-```diff title="rspack.config.mjs"
-export default {
--  experiments: {
--    lazyBarrel: true,
--  },
-};
-```
-
-:::warning Deprecated configuration
-The `experiments.lazyBarrel` configuration option has been deprecated and will be removed in Rspack v2.0.
-:::
-
 ## Further reading
 
 - [RFC: Lazy make for reexports in side effects free barrel file](https://github.com/web-infra-dev/rspack/discussions/11273)

--- a/website/docs/zh/config/deprecated-options.mdx
+++ b/website/docs/zh/config/deprecated-options.mdx
@@ -101,25 +101,6 @@ export default {
 详细示例可参考：[inline enum 示例](https://github.com/rstackjs/rstack-examples/tree/main/rspack/inline-enum)
 :::
 
-## experiments.lazyBarrel
-
-<ApiMeta deprecatedVersion="1.7.0" />
-
-- **类型：** `boolean`
-- **默认值：** `true`
-
-用于启用 barrel 文件的惰性编译优化，跳过无副作用的重导出模块中未使用的模块的构建。
-
-:::warning
-此配置已被废弃，将在 Rspack v2.0 中移除。Lazy barrel 优化已经稳定并默认启用。请从 Rspack 配置中移除此选项。
-:::
-
-:::tip
-Lazy barrel 现在是一个稳定功能，始终处于启用状态。它通过跳过无副作用 barrel 文件中未使用的重导出模块的构建来优化构建性能。
-
-更多详情，请参阅 [Lazy barrel 指南](/guide/optimization/lazy-barrel)。
-:::
-
 ## experiments.typeReexportsPresence
 
 <ApiMeta deprecatedVersion="1.7.0" />

--- a/website/docs/zh/guide/optimization/lazy-barrel.mdx
+++ b/website/docs/zh/guide/optimization/lazy-barrel.mdx
@@ -202,24 +202,6 @@ Rspack 可以分析模块是否有副作用（这个能力已经被 [`optimizati
 
 在 make 阶段，必须先构建依赖才能分析它们的副作用。Lazy barrel 专门设计用于避免构建这些依赖。因此，它依赖于显式标记，如 `package.json` 中的 `"sideEffects": false` 或 `rules[].sideEffects`，这些标记不需要依赖检查，因为它们声明整个包或匹配的模块都是无副作用的。
 
-## 配置
-
-Lazy barrel 自 Rspack 1.6.0 起默认启用。无需配置。
-
-如果你使用的是旧版本且配置中有 `experiments.lazyBarrel`，可以安全地移除它：
-
-```diff title="rspack.config.mjs"
-export default {
--  experiments: {
--    lazyBarrel: true,
--  },
-};
-```
-
-:::warning 废弃的配置
-`experiments.lazyBarrel` 配置选项已被废弃，将在 Rspack v2.0 中移除。参见[废弃选项](/config/deprecated-options#experimentslazybarrel)。
-:::
-
 ## 延伸阅读
 
 - [RFC: Lazy make for reexports in side effects free barrel file](https://github.com/web-infra-dev/rspack/discussions/11273)


### PR DESCRIPTION
## Summary

`experiments.lazyBarrel` has been deprecated and will be removed in Rspack v2.0. Lazy barrel optimization is already stable and enabled by default. Remove this option from your Rspack configuration.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
