### PR TITLE
test: skip recover-from-error/delete-file in watchCases

### DIFF
--- a/tests/rspack-test/watchCases/recover-from-error/delete-file/test.filter.js
+++ b/tests/rspack-test/watchCases/recover-from-error/delete-file/test.filter.js
@@ -1,0 +1,2 @@
+module.exports = () =>
+  'TODO: The test is unstable and prone to timeouts on CI machines.';


### PR DESCRIPTION
## Summary

The recover-from-error/delete-file is unstable and prone to timeouts on CI machines.

<img width="2444" height="1276" alt="image" src="https://github.com/user-attachments/assets/950f023b-354a-40a5-b962-ded7ee7862bf" />


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
