### PR TITLE
feat!: remove `experiments.typeReexportsPresence`

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2445,7 +2445,6 @@ export type Experiments = {
     buildHttp?: HttpUriOptions;
     useInputFileSystem?: UseInputFileSystem;
     nativeWatcher?: boolean;
-    typeReexportsPresence?: boolean;
     deferImport?: boolean;
 };
 
@@ -2511,8 +2510,6 @@ export interface ExperimentsNormalized {
     nativeWatcher?: boolean;
     // (undocumented)
     outputModule?: boolean;
-    // (undocumented)
-    typeReexportsPresence?: boolean;
     // (undocumented)
     useInputFileSystem?: false | RegExp[];
 }

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -243,9 +243,6 @@ const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
   // IGNORE(experiments.useInputFileSystem): Rspack specific configuration
   // Enable `useInputFileSystem` will introduce much more fs overheads,  So disable by default.
   D(experiments, 'useInputFileSystem', false);
-
-  // IGNORE(experiments.typeReexportsPresence): Rspack specific configuration for type reexports presence
-  D(experiments, 'typeReexportsPresence', false);
 };
 
 const applySnapshotDefaults = (

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -374,11 +374,6 @@ export const getNormalizedRspackOptions = (
     performance: config.performance,
     plugins: nestedArray(config.plugins, (p) => [...p]),
     experiments: nestedConfig(config.experiments, (experiments) => {
-      if (experiments.typeReexportsPresence) {
-        deprecate(
-          '`experiments.typeReexportsPresence` config is deprecated and will be removed in Rspack v2.0. typeReexportsPresence is already stable. Remove this option from your Rspack configuration.',
-        );
-      }
       return {
         ...experiments,
         incremental: optionalNestedConfig(experiments.incremental, (options) =>
@@ -653,7 +648,6 @@ export interface ExperimentsNormalized {
   futureDefaults?: boolean;
   buildHttp?: HttpUriPluginOptions;
   useInputFileSystem?: false | RegExp[];
-  typeReexportsPresence?: boolean;
   nativeWatcher?: boolean;
   deferImport?: boolean;
 }

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2801,12 +2801,6 @@ export type Experiments = {
    */
   nativeWatcher?: boolean;
   /**
-   * Enable type reexports presence feature
-   * @default false
-   * @deprecated This option is deprecated, it's already stable. Rspack will remove this option in future version
-   */
-  typeReexportsPresence?: boolean;
-  /**
    * Enable defer import feature
    * @default false
    */

--- a/tests/rspack-test/configCases/type-reexports-presence/no-tolerant/rspack.config.js
+++ b/tests/rspack-test/configCases/type-reexports-presence/no-tolerant/rspack.config.js
@@ -27,7 +27,4 @@ module.exports = /** @type {import("@rspack/core").Configuration} */ ({
 			}
 		]
 	},
-	experiments: {
-		typeReexportsPresence: true
-	}
 });

--- a/tests/rspack-test/configCases/type-reexports-presence/tolerant-no-check/rspack.config.js
+++ b/tests/rspack-test/configCases/type-reexports-presence/tolerant-no-check/rspack.config.js
@@ -28,7 +28,4 @@ module.exports = /** @type {import("@rspack/core").Configuration} */ ({
 			}
 		]
 	},
-	experiments: {
-		typeReexportsPresence: true
-	}
 });

--- a/tests/rspack-test/configCases/type-reexports-presence/tolerant/rspack.config.js
+++ b/tests/rspack-test/configCases/type-reexports-presence/tolerant/rspack.config.js
@@ -30,7 +30,4 @@ module.exports = /** @type {import("@rspack/core").Configuration} */ ({
 			}
 		]
 	},
-	experiments: {
-		typeReexportsPresence: true
-	}
 });

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -43,7 +43,6 @@ module.exports = {
 			      sideEffects: true,
 			      silent: true,
 			    },
-			    typeReexportsPresence: false,
 			    useInputFileSystem: false,
 			  },
 			  externals: undefined,

--- a/website/docs/en/config/deprecated-options.mdx
+++ b/website/docs/en/config/deprecated-options.mdx
@@ -43,18 +43,3 @@ An array to pass the loader package name and its options.
 :::warning
 This option has been deprecated. Use [rules[].use](/config/module-rules#rulesuse) instead.
 :::
-
-## experiments.typeReexportsPresence
-
-<ApiMeta deprecatedVersion="1.7.0" />
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Used to enable error tolerance for type re-exports.
-
-:::warning
-This configuration has been deprecated and is no longer required. Type re-exports presence checking is now controlled by [`module.parser.javascript.typeReexportsPresence`](/config/module#moduleparserjavascripttypereexportspresence) and [`builtin:swc-loader collectTypeScriptInfo.typeExports`](/guide/features/builtin-swc-loader#collecttypescriptinfotypeexports).
-
-Please refer to [type reexports presence example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/type-reexports-presence) for more details.
-:::

--- a/website/docs/zh/config/deprecated-options.mdx
+++ b/website/docs/zh/config/deprecated-options.mdx
@@ -43,18 +43,3 @@ export default {
 :::warning
 该选项已被废弃，请改用 [rules[].use](/config/module-rules#rulesuse)。
 :::
-
-## experiments.typeReexportsPresence
-
-<ApiMeta deprecatedVersion="1.7.0" />
-
-- **类型：** `boolean`
-- **默认值：** `false`
-
-用于启用类型重导出的错误容忍。
-
-:::warning
-此配置已被废弃，不再需要。类型重导出存在性检查现在由 [`module.parser.javascript.typeReexportsPresence`](/config/module#moduleparserjavascripttypereexportspresence) 和 [`builtin:swc-loader collectTypeScriptInfo.typeExports`](/guide/features/builtin-swc-loader#collecttypescriptinfotypeexports) 控制。
-
-详细示例可参考：[type reexports presence 示例](https://github.com/rstackjs/rstack-examples/tree/main/rspack/type-reexports-presence)
-:::


### PR DESCRIPTION
## Summary

The original [experiments.typeReexportsPresence](/config/deprecated-options#experimentstypereexportspresence) option is deprecated in v1.7, so we will remove it in v2.0. You can just use `parser.javascript.typeReexportsPresence` instead.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
