### PR TITLE
feat!: remove `rspack.experiments.lazyCompilationMiddleware`

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2466,8 +2466,6 @@ interface Experiments_2 {
         register: (filter: string, layer: 'logger' | 'perfetto', output: string) => Promise<void>;
         cleanup: () => Promise<void>;
     };
-    // @deprecated (undocumented)
-    lazyCompilationMiddleware: typeof lazyCompilationMiddleware;
     // (undocumented)
     RemoveDuplicateModulesPlugin: typeof RemoveDuplicateModulesPlugin;
     // (undocumented)

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -381,10 +381,6 @@ interface Experiments {
   RsdoctorPlugin: typeof RsdoctorPlugin;
   RstestPlugin: typeof RstestPlugin;
   RslibPlugin: typeof RslibPlugin;
-  /**
-   * @deprecated Use `rspack.lazyCompilationMiddleware` instead
-   */
-  lazyCompilationMiddleware: typeof lazyCompilationMiddleware;
   swc: {
     transform: typeof transform;
     minify: typeof minify;
@@ -436,7 +432,6 @@ export const experiments: Experiments = {
    * @internal
    */
   RslibPlugin,
-  lazyCompilationMiddleware,
   swc: {
     minify,
     transform,

--- a/website/docs/en/guide/features/lazy-compilation.mdx
+++ b/website/docs/en/guide/features/lazy-compilation.mdx
@@ -120,10 +120,6 @@ server.start();
 
 - `compiler`: The current [Compiler](/api/javascript-api/compiler) instance, use `lazyCompilation` config from it.
 
-:::tip
-Prior to Rspack 1.7, this middleware was only available via `rspack.experiments.lazyCompilationMiddleware`.
-:::
-
 ## Customizing lazy compilation endpoint
 
 By default, the lazy compilation middleware uses the `/lazy-compilation-using-` prefix for handling requests. If you need to customize this prefix, you can use the `prefix` option:

--- a/website/docs/zh/guide/features/lazy-compilation.mdx
+++ b/website/docs/zh/guide/features/lazy-compilation.mdx
@@ -122,10 +122,6 @@ server.start();
 
 - `compiler`: 当前的 [Compiler](/api/javascript-api/compiler)，使用该 Compiler 对应的 `lazyCompilation` 配置。
 
-:::tip
-在 Rspack 1.7 版本之前，该中间件需要通过 `rspack.experiments.lazyCompilationMiddleware` 来获取。
-:::
-
 ## 自定义懒编译端点
 
 默认情况下，懒编译中间件使用 `/lazy-compilation-using-` 前缀来处理请求。如果你需要自定义这个前缀，可以使用 `prefix` 选项：


### PR DESCRIPTION
## Summary

The `lazyCompilationMiddleware` had been stablized. So we can remove `rspack.experiments.lazyCompilationMiddleware` and just use `rspack.lazyCompilationMiddleware` instead

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
