### PR TITLE
feat!: remove deprecated getHooks method from plugins

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3040,7 +3040,6 @@ export type HotUpdateMainFilename = FilenameTemplate;
 
 // @public (undocumented)
 export const HtmlRspackPlugin: typeof HtmlRspackPluginImpl & {
-    getHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
     getCompilationHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
     createHtmlTagObject: (tagName: string, attributes?: Record<string, string | boolean>, innerHTML?: string) => JsHtmlPluginTag;
     version: number;
@@ -6415,7 +6414,6 @@ type RewriteTo = (context: HistoryContext) => string;
 
 // @public (undocumented)
 const RsdoctorPlugin: typeof RsdoctorPluginImpl & {
-    getHooks: (compilation: Compilation) => RsdoctorPluginHooks;
     getCompilationHooks: (compilation: Compilation) => RsdoctorPluginHooks;
 };
 
@@ -7172,7 +7170,6 @@ enum RuntimeModuleStage {
 
 // @public (undocumented)
 export const RuntimePlugin: typeof RuntimePluginImpl & {
-    getHooks: (compilation: Compilation) => RuntimePluginHooks;
     getCompilationHooks: (compilation: Compilation) => RuntimePluginHooks;
 };
 

--- a/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RsdoctorPlugin.ts
@@ -107,16 +107,10 @@ const compilationHooksMap: WeakMap<Compilation, RsdoctorPluginHooks> =
   new WeakMap();
 
 const RsdoctorPlugin = RsdoctorPluginImpl as typeof RsdoctorPluginImpl & {
-  /**
-   * @deprecated Use `getCompilationHooks` instead.
-   */
-  getHooks: (compilation: Compilation) => RsdoctorPluginHooks;
   getCompilationHooks: (compilation: Compilation) => RsdoctorPluginHooks;
 };
 
-RsdoctorPlugin.getHooks = RsdoctorPlugin.getCompilationHooks = (
-  compilation: Compilation,
-) => {
+RsdoctorPlugin.getCompilationHooks = (compilation: Compilation) => {
   checkCompilation(compilation);
 
   let hooks = compilationHooksMap.get(compilation);

--- a/packages/rspack/src/builtin-plugin/RuntimePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RuntimePlugin.ts
@@ -20,19 +20,13 @@ export type RuntimePluginHooks = {
 };
 
 const RuntimePlugin = RuntimePluginImpl as typeof RuntimePluginImpl & {
-  /**
-   * @deprecated Use `getCompilationHooks` instead.
-   */
-  getHooks: (compilation: Compilation) => RuntimePluginHooks;
   getCompilationHooks: (compilation: Compilation) => RuntimePluginHooks;
 };
 
 const compilationHooksMap: WeakMap<Compilation, RuntimePluginHooks> =
   new WeakMap();
 
-RuntimePlugin.getHooks = RuntimePlugin.getCompilationHooks = (
-  compilation: Compilation,
-) => {
+RuntimePlugin.getCompilationHooks = (compilation: Compilation) => {
   checkCompilation(compilation);
 
   let hooks = compilationHooksMap.get(compilation);

--- a/packages/rspack/src/builtin-plugin/html-plugin/plugin.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/plugin.ts
@@ -243,10 +243,6 @@ function htmlTagObjectToString(tag: {
 }
 
 const HtmlRspackPlugin = HtmlRspackPluginImpl as typeof HtmlRspackPluginImpl & {
-  /**
-   * @deprecated Use `getCompilationHooks` instead.
-   */
-  getHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
   getCompilationHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
   createHtmlTagObject: (
     tagName: string,
@@ -287,8 +283,7 @@ HtmlRspackPlugin.createHtmlTagObject = (
   };
 };
 
-HtmlRspackPlugin.getHooks = HtmlRspackPlugin.getCompilationHooks =
-  getPluginHooks;
+HtmlRspackPlugin.getCompilationHooks = getPluginHooks;
 HtmlRspackPlugin.version = 5;
 
 export { HtmlRspackPlugin };


### PR DESCRIPTION
## Summary

This PR removes the deprecated `getHooks` method from `HtmlRspackPlugin`, `RsdoctorPlugin`, and `RuntimePlugin`. These plugins now only expose `getCompilationHooks` method, which is the recommended way to access compilation hooks. This change simplifies the API and removes deprecated functionality that was marked for removal.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).