### PR TITLE
feat!: remove deprecated draft option from LightningCSS minimizer

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2409,7 +2409,6 @@ export interface RawLightningCssMinimizerOptions {
   targets?: Array<string>
   include?: number
   exclude?: number
-  draft?: RawDraft
   drafts?: RawDraft
   nonStandard?: RawNonStandard
   pseudoClasses?: RawLightningCssPseudoClasses

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_lightning_css_minimizer.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_lightning_css_minimizer.rs
@@ -27,8 +27,6 @@ pub struct RawLightningCssMinimizerOptions {
   pub targets: Option<Vec<String>>,
   pub include: Option<u32>,
   pub exclude: Option<u32>,
-  // TODO: deprecate `draft` in favor of `drafts`
-  pub draft: Option<RawDraft>,
   pub drafts: Option<RawDraft>,
   pub non_standard: Option<RawNonStandard>,
   pub pseudo_classes: Option<RawLightningCssPseudoClasses>,
@@ -93,14 +91,9 @@ impl TryFrom<RawLightningCssMinimizerRspackPluginOptions> for PluginOptions {
           .flatten(),
         include: value.minimizer_options.include,
         exclude: value.minimizer_options.exclude,
-        // We should use `drafts` if it is present, otherwise use `draft`
-        draft: value
-          .minimizer_options
-          .drafts
-          .or(value.minimizer_options.draft)
-          .map(|d| Draft {
-            custom_media: d.custom_media,
-          }),
+        drafts: value.minimizer_options.drafts.map(|d| Draft {
+          custom_media: d.custom_media,
+        }),
         non_standard: value.minimizer_options.non_standard.map(|n| NonStandard {
           deep_selector_combinator: n.deep_selector_combinator,
         }),

--- a/crates/rspack_loader_lightningcss/src/config.rs
+++ b/crates/rspack_loader_lightningcss/src/config.rs
@@ -41,7 +41,7 @@ pub struct Config {
   pub targets: Option<Browsers>,
   pub include: Option<u32>,
   pub exclude: Option<u32>,
-  pub draft: Option<Draft>,
+  pub drafts: Option<Draft>,
   pub non_standard: Option<NonStandard>,
   pub pseudo_classes: Option<PseudoClasses>,
   pub unused_symbols: Option<Vec<String>>,
@@ -55,8 +55,6 @@ pub struct RawConfig {
   pub targets: Option<Vec<String>>,
   pub include: Option<u32>,
   pub exclude: Option<u32>,
-  // TODO: deprecate `draft` in favor of `drafts`
-  pub draft: Option<Draft>,
   pub drafts: Option<Draft>,
   pub non_standard: Option<NonStandard>,
   pub pseudo_classes: Option<PseudoClasses>,
@@ -77,8 +75,7 @@ impl TryFrom<RawConfig> for Config {
         .flatten(),
       include: value.include,
       exclude: value.exclude,
-      // We should use `drafts` if it is present, otherwise use `draft`
-      draft: value.drafts.or(value.draft),
+      drafts: value.drafts,
       non_standard: value.non_standard,
       pseudo_classes: value.pseudo_classes,
       unused_symbols: value.unused_symbols,

--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -72,7 +72,7 @@ impl LightningCssLoader {
     let mut parser_flags = ParserFlags::empty();
     parser_flags.set(
       ParserFlags::CUSTOM_MEDIA,
-      matches!(&self.config.draft, Some(draft) if draft.custom_media),
+      matches!(&self.config.drafts, Some(drafts) if drafts.custom_media),
     );
     parser_flags.set(
       ParserFlags::DEEP_SELECTOR_COMBINATOR,

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -63,7 +63,7 @@ pub struct MinimizerOptions {
   pub targets: Option<Browsers>,
   pub include: Option<u32>,
   pub exclude: Option<u32>,
-  pub draft: Option<Draft>,
+  pub drafts: Option<Draft>,
   pub non_standard: Option<NonStandard>,
   pub pseudo_classes: Option<PseudoClasses>,
   pub unused_symbols: Vec<String>,
@@ -74,7 +74,7 @@ impl Hash for MinimizerOptions {
     self.error_recovery.hash(state);
     self.include.hash(state);
     self.exclude.hash(state);
-    self.draft.hash(state);
+    self.drafts.hash(state);
     self.non_standard.hash(state);
     self.unused_symbols.hash(state);
     if let Some(pseudo_classes) = &self.pseudo_classes {
@@ -162,7 +162,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         let mut parser_flags = ParserFlags::empty();
         parser_flags.set(
           ParserFlags::CUSTOM_MEDIA,
-          matches!(&minimizer_options.draft, Some(draft) if draft.custom_media),
+          matches!(&minimizer_options.drafts, Some(drafts) if drafts.custom_media),
         );
         parser_flags.set(
           ParserFlags::DEEP_SELECTOR_COMBINATOR,

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4340,7 +4340,6 @@ export type LightningcssLoaderOptions = {
     targets?: Targets | string[] | string;
     include?: LightningcssFeatureOptions;
     exclude?: LightningcssFeatureOptions;
-    draft?: Drafts;
     drafts?: Drafts;
     nonStandard?: NonStandard;
     pseudoClasses?: PseudoClasses;
@@ -4369,7 +4368,6 @@ export type LightningCssMinimizerRspackPluginOptions = {
         targets?: string[] | string;
         include?: LightningcssFeatureOptions;
         exclude?: LightningcssFeatureOptions;
-        draft?: Drafts;
         drafts?: Drafts;
         nonStandard?: NonStandard;
         pseudoClasses?: PseudoClasses;

--- a/packages/rspack/src/builtin-loader/lightningcss/index.ts
+++ b/packages/rspack/src/builtin-loader/lightningcss/index.ts
@@ -205,11 +205,6 @@ export type LoaderOptions = {
   targets?: Targets | string[] | string;
   include?: FeatureOptions;
   exclude?: FeatureOptions;
-  /**
-   * @deprecated Use `drafts` instead.
-   * This will be removed in the next major version.
-   */
-  draft?: Drafts;
   drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;

--- a/packages/rspack/src/builtin-plugin/LightningCssMinimizerRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/LightningCssMinimizerRspackPlugin.ts
@@ -23,11 +23,6 @@ export type LightningCssMinimizerRspackPluginOptions = {
     targets?: string[] | string;
     include?: FeatureOptions;
     exclude?: FeatureOptions;
-    /**
-     * @deprecated Use `drafts` instead.
-     * This will be removed in the next major version.
-     */
-    draft?: Drafts;
     drafts?: Drafts;
     nonStandard?: NonStandard;
     pseudoClasses?: PseudoClasses;
@@ -40,7 +35,7 @@ export const LightningCssMinimizerRspackPlugin = create(
   (
     options?: LightningCssMinimizerRspackPluginOptions,
   ): RawLightningCssMinimizerRspackPluginOptions => {
-    const { include, exclude, draft, nonStandard, pseudoClasses, drafts } =
+    const { include, exclude, nonStandard, pseudoClasses, drafts } =
       options?.minimizerOptions ?? {};
     const targets = options?.minimizerOptions?.targets ?? 'fully supports es6'; // last not support es module chrome version
     return {
@@ -54,7 +49,6 @@ export const LightningCssMinimizerRspackPlugin = create(
         include: include ? toFeatures(include) : undefined,
         exclude: exclude ? toFeatures(exclude) : undefined,
         targets: typeof targets === 'string' ? [targets] : targets,
-        draft: draft ? { customMedia: draft.customMedia ?? false } : undefined,
         drafts: drafts
           ? { customMedia: drafts.customMedia ?? false }
           : undefined,

--- a/tests/rspack-test/diagnosticsCases/config/builtin-lightningcss-loader/rspack.config.js
+++ b/tests/rspack-test/diagnosticsCases/config/builtin-lightningcss-loader/rspack.config.js
@@ -18,7 +18,7 @@ module.exports = {
 						options: {
 							unusedSymbols: ["unused"],
 							targets: "> 0.2%",
-							draft: "xx"
+							drafts: "xx"
 						}
 					}
 				],

--- a/tests/rspack-test/diagnosticsCases/config/builtin-lightningcss-loader/stats.err
+++ b/tests/rspack-test/diagnosticsCases/config/builtin-lightningcss-loader/stats.err
@@ -1,10 +1,10 @@
 ERROR in ./index.js 1:1-21
   × Could not parse builtin:lightningcss-loader options
-   ╭─[8:14]
+   ╭─[8:15]
  6 │     "> 0.2%"
  7 │   ],
- 8 │   "draft": "xx"
-   ·               ▲
-   ·               ╰── invalid type: string "xx", expected struct Draft at line 8 column 15
+ 8 │   "drafts": "xx"
+   ·                ▲
+   ·                ╰── invalid type: string "xx", expected struct Draft at line 8 column 16
  9 │ }
    ╰────

--- a/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
@@ -102,11 +102,6 @@ type LightningcssLoaderOptions = {
   targets?: string[] | string;
   include?: LightningcssFeatureOptions;
   exclude?: LightningcssFeatureOptions;
-  /**
-   * @deprecated Use `drafts` instead.
-   * This will be removed in the next major version.
-   */
-  draft?: Drafts;
   drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;

--- a/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
@@ -90,11 +90,6 @@ type LightningCssMinimizerOptions = {
   targets?: string[] | string;
   include?: LightningcssFeatureOptions;
   exclude?: LightningcssFeatureOptions;
-  /**
-   * @deprecated Use `drafts` instead.
-   * This will be removed in the next major version.
-   */
-  draft?: Drafts;
   drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;

--- a/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
@@ -102,11 +102,6 @@ type LightningcssLoaderOptions = {
   targets?: string[] | string;
   include?: LightningcssFeatureOptions;
   exclude?: LightningcssFeatureOptions;
-  /**
-   * @deprecated Use `drafts` instead.
-   * This will be removed in the next major version.
-   */
-  draft?: Drafts;
   drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;

--- a/website/docs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
@@ -90,11 +90,6 @@ type LightningCssMinimizerOptions = {
   targets?: string[] | string;
   include?: LightningcssFeatureOptions;
   exclude?: LightningcssFeatureOptions;
-  /**
-   * @deprecated Use `drafts` instead.
-   * This will be removed in the next major version.
-   */
-  draft?: Drafts;
   drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;


### PR DESCRIPTION
## Summary

This PR removes the deprecated `draft` option from the LightningCSS minimizer plugin. The option was previously marked as deprecated in favor of `drafts`, and this change completes the deprecation cycle by removing the old option entirely. Users should now use the `drafts` option instead.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).