### PR TITLE
feat!: remove deprecated cssHeadDataCompression option

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -5536,7 +5536,6 @@ export type Output = {
     chunkFilename?: ChunkFilename;
     crossOriginLoading?: CrossOriginLoading;
     cssFilename?: CssFilename;
-    cssHeadDataCompression?: boolean;
     cssChunkFilename?: CssChunkFilename;
     hotUpdateMainFilename?: HotUpdateMainFilename;
     hotUpdateChunkFilename?: HotUpdateChunkFilename;

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -12,7 +12,6 @@ import path from 'node:path';
 import type { HttpUriPluginOptions } from '../builtin-plugin';
 import type { Compilation } from '../Compilation';
 import type WebpackError from '../lib/WebpackError';
-import { deprecate } from '../util';
 import type {
   Amd,
   AssetModuleFilename,
@@ -150,12 +149,6 @@ export const getNormalizedRspackOptions = (
             )(config.entry)
           : getNormalizedEntryStatic(config.entry),
     output: nestedConfig(config.output, (output) => {
-      if ('cssHeadDataCompression' in output) {
-        deprecate(
-          'cssHeadDataCompression is not used now, see https://github.com/web-infra-dev/rspack/pull/8534, this option could be removed in the future',
-        );
-      }
-
       const { library } = output;
       const libraryAsName = library;
       const libraryBase =

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -484,15 +484,6 @@ export type Output = {
   /** This option determines the name of CSS output files on disk. */
   cssFilename?: CssFilename;
 
-  /**
-   * @deprecated this config is unused, and will be removed in the future.
-   * Rspack adds some metadata in CSS to parse CSS modules, and this configuration determines whether to compress these metadata.
-   *
-   * The value is `true` in production mode.
-   * The value is `false` in development mode.
-   * */
-  cssHeadDataCompression?: boolean;
-
   /** This option determines the name of non-initial CSS output files on disk. */
   cssChunkFilename?: CssChunkFilename;
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1895,36 +1895,3 @@ Please use [`output.library.type`](#outputlibrarytype) instead as we might drop 
 :::warning
 Prefer to use [`output.library.umdNamedDefine`](#outputlibraryumdnameddefine) instead.
 :::
-
-## output.cssHeadDataCompression
-
-<ApiMeta addedVersion={'1.0.0'} />
-
-- **Type:** `boolean`
-- **Default:** `false` for development mode, `true` for production mode
-
-Rspack adds some metadata in CSS to parse CSS modules, and this configuration determines whether to compress these metadata.
-
-For example
-
-```css
-.local-a {
-  color: blue;
-}
-
-head {
-  --webpack-main: a: local-a/&\.\/ src\/index\.module\.css;
-}
-```
-
-After compress 👇
-
-```css
-.local-a {
-  color: blue;
-}
-
-head {
-  --webpack-main: &\.\/ srcăindexāmoduleācss;
-}
-```

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1887,36 +1887,3 @@ export default {
 :::warning
 最好使用 [`output.library.umdNamedDefine`](#outputlibraryumdnameddefine)。
 :::
-
-## output.cssHeadDataCompression
-
-<ApiMeta addedVersion={'1.0.0'} />
-
-- **类型：** `boolean`
-- **默认值：** 在 development 模式下为 `false`，在 production 模式下为 `true`
-
-Rspack 会在 CSS 中添加一些元信息，用以解析 CSS modules，此配置决定是否压缩元信息。
-
-例如 👇
-
-```css
-.local-a {
-  color: blue;
-}
-
-head {
-  --webpack-main: a: local-a/&\.\/ src\/index\.module\.css;
-}
-```
-
-压缩后
-
-```css
-.local-a {
-  color: blue;
-}
-
-head {
-  --webpack-main: &\.\/ srcăindexāmoduleācss;
-}
-```


### PR DESCRIPTION
## Summary

This PR removes the deprecated `cssHeadDataCompression` configuration option from Rspack. This option was marked as deprecated and unused (see https://github.com/web-infra-dev/rspack/pull/8534), and has now been completely removed from the codebase.

The removal includes:
- Type definition in `config/types.ts`
- Deprecation warning logic in `config/normalization.ts`
- API documentation in `core.api.md`
- Documentation sections in both English and Chinese config guides

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).