### PR TITLE
docs: add missing documentation for JavascriptParserOptions

### DIFF
--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1133,17 +1133,26 @@ export type JavascriptParserOptions = {
 
   /**
    * Control whether renaming of the CommonJS `require` function will be parsed and transformed.
-   * @default true
+   * @default false
    */
   requireAlias?: boolean;
 
-  // TODO: add docs
+  /**
+   * Control whether `require` used as an expression (e.g., `const req = require; req('./module')`) will be parsed.
+   * @default true
+   */
   requireAsExpression?: boolean;
 
-  // TODO: add docs
+  /**
+   * Control whether dynamic `require` calls (e.g., `require(variable)`) will be parsed.
+   * @default true
+   */
   requireDynamic?: boolean;
 
-  // TODO: add docs
+  /**
+   * Control whether `require.resolve()` calls will be parsed.
+   * @default true
+   */
   requireResolve?: boolean;
 
   /**
@@ -1152,7 +1161,10 @@ export type JavascriptParserOptions = {
    */
   commonjs?: JavascriptParserCommonjsOption;
 
-  // TODO: add docs
+  /**
+   * Control whether dynamic `import()` calls (e.g., `import(variable)`) will be parsed.
+   * @default true
+   */
   importDynamic?: boolean;
 
   /**
@@ -1166,7 +1178,11 @@ export type JavascriptParserOptions = {
   /** Whether to enable JSX parsing */
   jsx?: boolean;
 
-  /** Whether to enable defer import */
+  /**
+   * Whether to enable defer import.
+   * This option is controlled by `experiments.deferImport` and should not be set directly.
+   * @default false
+   */
   deferImport?: boolean;
 };
 

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -749,6 +749,106 @@ export default {
 };
 ```
 
+### module.parser.javascript.requireAlias
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'false' }]} />
+
+Control whether renaming of the CommonJS `require` function will be parsed and transformed.
+
+When set to `true`, Rspack will parse and transform cases where `require` is assigned to a variable or passed as a parameter (e.g., `const req = require; req('./module')`).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        requireAlias: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser.javascript.requireAsExpression
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+Control whether `require` used as an expression will be parsed.
+
+When set to `false`, Rspack will not parse `require` when it's used as an expression (e.g., `const req = require; req('./module')`). This can improve build performance if your code doesn't use this pattern.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        requireAsExpression: false,
+      },
+    },
+  },
+};
+```
+
+### module.parser.javascript.requireDynamic
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+Control whether dynamic `require` calls will be parsed.
+
+When set to `false`, Rspack will not parse dynamic `require` calls where the module path is not a static string (e.g., `require(variable)`). This can improve build performance if your code doesn't use dynamic requires.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        requireDynamic: false,
+      },
+    },
+  },
+};
+```
+
+### module.parser.javascript.requireResolve
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+Control whether `require.resolve()` calls will be parsed.
+
+When set to `false`, Rspack will not parse `require.resolve()` calls. This can improve build performance if your code doesn't use `require.resolve()`.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        requireResolve: false,
+      },
+    },
+  },
+};
+```
+
+### module.parser.javascript.importDynamic
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+Control whether dynamic `import()` calls will be parsed.
+
+When set to `false`, Rspack will not parse dynamic `import()` calls where the module path is not a static string (e.g., `import(variable)`). This can improve build performance if your code doesn't use dynamic imports.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        importDynamic: false,
+      },
+    },
+  },
+};
+```
+
 ### module.parser.javascript.jsx
 
 <ApiMeta stability={Stability.Experimental} addedVersion="1.5.7" />

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -749,6 +749,106 @@ export default {
 };
 ```
 
+### module.parser.javascript.requireAlias
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'false' }]} />
+
+控制是否解析和转换 CommonJS `require` 函数的重命名。
+
+当设置为 `true` 时，Rspack 会解析和转换将 `require` 赋值给变量或作为参数传递的情况（例如：`const req = require; req('./module')`）。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        requireAlias: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser.javascript.requireAsExpression
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+控制是否解析作为表达式使用的 `require`。
+
+当设置为 `false` 时，Rspack 不会解析作为表达式使用的 `require`（例如：`const req = require; req('./module')`）。如果代码中不使用这种模式，可以提高构建性能。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        requireAsExpression: false,
+      },
+    },
+  },
+};
+```
+
+### module.parser.javascript.requireDynamic
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+控制是否解析动态 `require` 调用。
+
+当设置为 `false` 时，Rspack 不会解析模块路径不是静态字符串的动态 `require` 调用（例如：`require(variable)`）。如果代码中不使用动态 require，可以提高构建性能。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        requireDynamic: false,
+      },
+    },
+  },
+};
+```
+
+### module.parser.javascript.requireResolve
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+控制是否解析 `require.resolve()` 调用。
+
+当设置为 `false` 时，Rspack 不会解析 `require.resolve()` 调用。如果代码中不使用 `require.resolve()`，可以提高构建性能。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        requireResolve: false,
+      },
+    },
+  },
+};
+```
+
+### module.parser.javascript.importDynamic
+
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+控制是否解析动态 `import()` 调用。
+
+当设置为 `false` 时，Rspack 不会解析模块路径不是静态字符串的动态 `import()` 调用（例如：`import(variable)`）。如果代码中不使用动态导入，可以提高构建性能。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        importDynamic: false,
+      },
+    },
+  },
+};
+```
+
 ### module.parser.javascript.jsx
 
 <ApiMeta stability={Stability.Experimental} addedVersion="1.5.7" />


### PR DESCRIPTION
## Summary

This PR adds missing documentation for several  properties that were previously marked with  comments. The following options now have complete documentation in both English and Chinese:

- `requireAlias` - Control whether renaming of the CommonJS `require` function will be parsed and transformed
- `requireAsExpression` - Control whether `require` used as an expression will be parsed
- `requireDynamic` - Control whether dynamic `require` calls will be parsed
- `requireResolve` - Control whether `require.resolve()` calls will be parsed
- `importDynamic` - Control whether dynamic `import()` calls will be parsed

Additionally, this PR:
- Updates JSDoc comments in the type definitions to accurately reflect default values
- Adds comprehensive documentation with examples for each option
- Ensures consistency between English and Chinese documentation

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).