### PR TITLE
feat!: make @rspack/dev-server an optional peer dependency

### DIFF
--- a/packages/rspack-cli/README.md
+++ b/packages/rspack-cli/README.md
@@ -6,6 +6,26 @@
 
 Command-line interface for rspack.
 
+## Installation
+
+```bash
+pnpm add -D @rspack/cli
+# or
+npm install -D @rspack/cli
+```
+
+## Required dependencies
+
+The `rspack dev` and `rspack preview` commands require `@rspack/dev-server` to be installed as a peer dependency:
+
+```bash
+pnpm add -D @rspack/dev-server
+# or
+npm install -D @rspack/dev-server
+```
+
+If you try to use these commands without installing `@rspack/dev-server`, you will see a helpful error message with installation instructions.
+
 ## Wasm test
 
 See [@rspack/test-tools](../rspack-test-tools) for details.

--- a/packages/rspack-cli/README.md
+++ b/packages/rspack-cli/README.md
@@ -12,6 +12,8 @@ Command-line interface for rspack.
 pnpm add -D @rspack/cli
 # or
 npm install -D @rspack/cli
+# or
+yarn add -D @rspack/cli
 ```
 
 ## Required dependencies
@@ -22,6 +24,8 @@ The `rspack dev` and `rspack preview` commands require `@rspack/dev-server` to b
 pnpm add -D @rspack/dev-server
 # or
 npm install -D @rspack/dev-server
+# or
+yarn add -D @rspack/dev-server
 ```
 
 If you try to use these commands without installing `@rspack/dev-server`, you will see a helpful error message with installation instructions.

--- a/packages/rspack-cli/README.md
+++ b/packages/rspack-cli/README.md
@@ -18,7 +18,7 @@ yarn add -D @rspack/cli
 
 ## Required dependencies
 
-The `rspack dev` and `rspack preview` commands require `@rspack/dev-server` to be installed as a peer dependency:
+The `rspack dev` and `rspack preview` commands require [@rspack/dev-server](https://www.npmjs.com/package/@rspack/dev-server) to be installed as a peer dependency:
 
 ```bash
 pnpm add -D @rspack/dev-server

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -33,12 +33,12 @@
   },
   "dependencies": {
     "@discoveryjs/json-ext": "^0.5.7",
-    "@rspack/dev-server": "~1.1.5",
     "exit-hook": "^4.0.0"
   },
   "devDependencies": {
     "@rslib/core": "0.19.1",
     "@rspack/core": "workspace:*",
+    "@rspack/dev-server": "~1.1.5",
     "@rspack/test-tools": "workspace:*",
     "cac": "^6.7.14",
     "concat-stream": "^2.0.0",
@@ -50,7 +50,13 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@rspack/core": "^1.0.0-alpha || ^1.x"
+    "@rspack/core": "^1.0.0-alpha || ^1.x",
+    "@rspack/dev-server": "~1.1.5"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/dev-server": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -4,6 +4,7 @@ import type {
   MultiCompiler,
   MultiRspackOptions,
 } from '@rspack/core';
+import { rspack } from '@rspack/core';
 // @ts-ignore
 import type { RspackDevServer as RspackDevServerType } from '@rspack/dev-server';
 import type { RspackCLI } from '../cli';
@@ -69,15 +70,15 @@ export class ServeCommand implements RspackCommand {
         ) {
           logger.error(
             'The "@rspack/dev-server" package is required to use the serve command.\n' +
-            'Please install it by running:\n' +
-            '  pnpm add -D @rspack/dev-server\n' +
-            '  or\n' +
-            '  npm install -D @rspack/dev-server',
+              'Please install it by running:\n' +
+              '  pnpm add -D @rspack/dev-server\n' +
+              '  or\n' +
+              '  npm install -D @rspack/dev-server',
           );
         } else {
           logger.error(
             'Failed to load "@rspack/dev-server":\n' +
-            ((error as Error)?.message || String(error)),
+              ((error as Error)?.message || String(error)),
           );
         }
         process.exit(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,9 +438,6 @@ importers:
       '@discoveryjs/json-ext':
         specifier: ^0.5.7
         version: 0.5.7
-      '@rspack/dev-server':
-        specifier: ~1.1.5
-        version: 1.1.5(@rspack/core@packages+rspack)(@types/express@4.17.23)(webpack@5.102.1)
       exit-hook:
         specifier: ^4.0.0
         version: 4.0.0
@@ -451,6 +448,9 @@ importers:
       '@rspack/core':
         specifier: workspace:*
         version: link:../rspack
+      '@rspack/dev-server':
+        specifier: ~1.1.5
+        version: 1.1.5(@rspack/core@packages+rspack)(@types/express@4.17.23)(webpack@5.102.1)
       '@rspack/test-tools':
         specifier: workspace:*
         version: link:../rspack-test-tools

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -120,7 +120,7 @@ Options:
 `rspack preview` is used to preview the production build output locally, note that you need to build the output first by running the `rspack build` command.
 
 :::info Required dependency
-The `rspack preview` command requires `@rspack/dev-server` to be installed. If you haven't installed it yet, run:
+The `rspack preview` command requires [@rspack/dev-server](https://www.npmjs.com/package/@rspack/dev-server) to be installed. If you haven't installed it yet, run:
 
 <PackageManagerTabs command="add @rspack/dev-server -D" />
 

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -73,6 +73,16 @@ Options:
 
 `rspack dev` is used to run Rspack dev server, which will start a local dev server that will listen for file changes and automatically refresh the browser.
 
+:::info Required dependency
+The `rspack dev` command requires `@rspack/dev-server` to be installed. If you haven't installed it yet, run:
+
+```bash
+pnpm add -D @rspack/dev-server
+# or
+npm install -D @rspack/dev-server
+```
+:::
+
 ```bash
 npx rspack dev
 ```
@@ -110,6 +120,16 @@ Options:
 ## rspack preview
 
 `rspack preview` is used to preview the production build output locally, note that you need to build the output first by running the `rspack build` command.
+
+:::info Required dependency
+The `rspack preview` command requires `@rspack/dev-server` to be installed. If you haven't installed it yet, run:
+
+```bash
+pnpm add -D @rspack/dev-server
+# or
+npm install -D @rspack/dev-server
+```
+:::
 
 ```bash
 npx rspack preview

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -1,3 +1,5 @@
+import { PackageManagerTabs } from '@theme';
+
 # Command line interface
 
 [@rspack/cli](https://npmjs.com/package/@rspack/cli) is the command line tool for Rspack, providing a variety of commands to make working with Rspack easier.
@@ -76,12 +78,7 @@ Options:
 :::info Required dependency
 The `rspack dev` command requires `@rspack/dev-server` to be installed. If you haven't installed it yet, run:
 
-```bash
-pnpm add -D @rspack/dev-server
-# or
-npm install -D @rspack/dev-server
-```
-
+<PackageManagerTabs command="add @rspack/dev-server -D" />
 :::
 
 ```bash
@@ -125,11 +122,7 @@ Options:
 :::info Required dependency
 The `rspack preview` command requires `@rspack/dev-server` to be installed. If you haven't installed it yet, run:
 
-```bash
-pnpm add -D @rspack/dev-server
-# or
-npm install -D @rspack/dev-server
-```
+<PackageManagerTabs command="add @rspack/dev-server -D" />
 
 :::
 

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -81,6 +81,7 @@ pnpm add -D @rspack/dev-server
 # or
 npm install -D @rspack/dev-server
 ```
+
 :::
 
 ```bash
@@ -129,6 +130,7 @@ pnpm add -D @rspack/dev-server
 # or
 npm install -D @rspack/dev-server
 ```
+
 :::
 
 ```bash

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -76,7 +76,7 @@ Options:
 `rspack dev` is used to run Rspack dev server, which will start a local dev server that will listen for file changes and automatically refresh the browser.
 
 :::info Required dependency
-The `rspack dev` command requires `@rspack/dev-server` to be installed. If you haven't installed it yet, run:
+The `rspack dev` command requires [@rspack/dev-server](https://www.npmjs.com/package/@rspack/dev-server) to be installed. If you haven't installed it yet, run:
 
 <PackageManagerTabs command="add @rspack/dev-server -D" />
 :::

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -76,7 +76,7 @@ Options:
 `rspack dev` 用于运行 Rspack 开发服务器，将会在本地启动一个开发服务器，监听文件变化并自动刷新浏览器。
 
 :::info 必需依赖
-`rspack dev` 命令需要安装 `@rspack/dev-server`。如果尚未安装，请运行：
+`rspack dev` 命令需要安装 [@rspack/dev-server](https://www.npmjs.com/package/@rspack/dev-server)。如果尚未安装，请运行：
 
 <PackageManagerTabs command="add @rspack/dev-server -D" />
 

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -81,6 +81,7 @@ pnpm add -D @rspack/dev-server
 # 或
 npm install -D @rspack/dev-server
 ```
+
 :::
 
 ```bash
@@ -129,6 +130,7 @@ pnpm add -D @rspack/dev-server
 # 或
 npm install -D @rspack/dev-server
 ```
+
 :::
 
 ```bash

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -121,7 +121,7 @@ Options:
 `rspack preview` 用于在本地预览生产模式构建的产物, 注意你需要提前执行 `rspack build` 命令构建出产物。
 
 :::info 必需依赖
-`rspack preview` 命令需要安装 `@rspack/dev-server`。如果尚未安装，请运行：
+`rspack preview` 命令需要安装 [@rspack/dev-server](https://www.npmjs.com/package/@rspack/dev-server)。如果尚未安装，请运行：
 
 <PackageManagerTabs command="add @rspack/dev-server -D" />
 

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -1,3 +1,5 @@
+import { PackageManagerTabs } from '@theme';
+
 # 命令行工具
 
 [@rspack/cli](https://npmjs.com/package/@rspack/cli) 是 Rspack 的命令行工具，它提供了多种命令来简化 Rspack 的使用。
@@ -76,11 +78,7 @@ Options:
 :::info 必需依赖
 `rspack dev` 命令需要安装 `@rspack/dev-server`。如果尚未安装，请运行：
 
-```bash
-pnpm add -D @rspack/dev-server
-# 或
-npm install -D @rspack/dev-server
-```
+<PackageManagerTabs command="add @rspack/dev-server -D" />
 
 :::
 
@@ -125,11 +123,7 @@ Options:
 :::info 必需依赖
 `rspack preview` 命令需要安装 `@rspack/dev-server`。如果尚未安装，请运行：
 
-```bash
-pnpm add -D @rspack/dev-server
-# 或
-npm install -D @rspack/dev-server
-```
+<PackageManagerTabs command="add @rspack/dev-server -D" />
 
 :::
 

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -73,6 +73,16 @@ Options:
 
 `rspack dev` 用于运行 Rspack 开发服务器，将会在本地启动一个开发服务器，监听文件变化并自动刷新浏览器。
 
+:::info 必需依赖
+`rspack dev` 命令需要安装 `@rspack/dev-server`。如果尚未安装，请运行：
+
+```bash
+pnpm add -D @rspack/dev-server
+# 或
+npm install -D @rspack/dev-server
+```
+:::
+
 ```bash
 npx rspack dev
 ```
@@ -110,6 +120,16 @@ Options:
 ## rspack preview
 
 `rspack preview` 用于在本地预览生产模式构建的产物, 注意你需要提前执行 `rspack build` 命令构建出产物。
+
+:::info 必需依赖
+`rspack preview` 命令需要安装 `@rspack/dev-server`。如果尚未安装，请运行：
+
+```bash
+pnpm add -D @rspack/dev-server
+# 或
+npm install -D @rspack/dev-server
+```
+:::
 
 ```bash
 npx rspack preview


### PR DESCRIPTION
## Summary

This PR makes `@rspack/dev-server` an optional peer dependency of `@rspack/cli` instead of a direct dependency. This change allows users to choose whether to install the dev-server package, reducing the bundle size for users who only need the build functionality.

The main changes include:
- Moving `@rspack/dev-server` from `dependencies` to `peerDependencies` (marked as optional)
- Adding `@rspack/dev-server` to `devDependencies` to ensure tests can run properly
- Adding error handling in `serve` and `preview` commands to provide helpful error messages when dev-server is not installed
- Updating documentation (README and website docs) to inform users about the required dependency

This change improves the modularity of the Rspack CLI and allows users to have more control over their dependencies.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).