### PR TITLE
docs: remove deprecated parallelCodeSplitting

### DIFF
--- a/website/docs/en/config/deprecated-options.mdx
+++ b/website/docs/en/config/deprecated-options.mdx
@@ -6,36 +6,6 @@ This page lists configuration options that have been deprecated in Rspack.
 
 These options are kept for backward compatibility only and should not be used in new projects.
 
-## experiments.parallelCodeSplitting
-
-<ApiMeta deprecatedVersion="1.6.2" />
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Enabling this configuration will activate a new multi-threaded code splitting algorithm. If your project includes many dynamic imports and doesn't have cyclic chunks, this can greatly reduce the time spent on the code splitting process.
-
-```js title="rspack.config.mjs"
-export default {
-  experiments: {
-    parallelCodeSplitting: true,
-  },
-  optimization: {
-    removeAvailableModules: true,
-  },
-};
-```
-
-:::warning
-This option is deprecated, it has a huge performance regression in some edge cases where the chunk graph has lots of cycles. We'll improve the performance of build_chunk_graph in the future instead.
-:::
-
-:::warning
-When `parallelCodeSplitting` is enabled, ensure that 'optimization.removeAvailableModules' is also enabled (this has been enabled by default since version 1.3.0).
-
-This maintains consistency with the previous code splitting algorithm, which enforced `removeAvailableModules` internally and ignored the `optimization.removeAvailableModules` configuration.
-:::
-
 ## rules[].loaders
 
 An array to pass the loader package name and its options.

--- a/website/docs/zh/config/deprecated-options.mdx
+++ b/website/docs/zh/config/deprecated-options.mdx
@@ -6,36 +6,6 @@ import { ApiMeta } from '../../../components/ApiMeta';
 
 这些选项仅为向后兼容而保留，不应在新项目中使用。
 
-## experiments.parallelCodeSplitting
-
-<ApiMeta deprecatedVersion="1.6.2" />
-
-- **类型：** `boolean`
-- **默认值：** `false`
-
-开启后会启用新的多线程 code splitting 算法，如果你的项目中包含较多的动态引用，并且不包含循环 chunk，开启后可以显著降低 code splitting 阶段耗时。
-
-```js title="rspack.config.mjs"
-export default {
-  experiments: {
-    parallelCodeSplitting: true,
-  },
-  optimization: {
-    removeAvailableModules: true,
-  },
-};
-```
-
-:::warning
-该选项已被废弃，在某些包含大量循环 chunk 的边缘情况下会出现严重的性能问题，我们会在未来改进 build_chunk_graph 的性能来替代该选项。
-:::
-
-:::warning
-当启用 `parallelCodeSplitting` 时，请确保 `optimization.removeAvailableModules` 也被启用（从 1.3.0 版本起，这已默认启用）。
-
-这保持了与旧版本的 code splitting 算法的一致性，旧版算法在内部强制开启 `removeAvailableModules`，并且不受到 `optimization.removeAvailableModules` 控制。
-:::
-
 ## rules[].loaders
 
 用于传递 Loader 包名与其选项的数组。


### PR DESCRIPTION
## Summary

This PR removes documentation for the deprecated `experiments.parallelCodeSplitting` option.

Additionally, the documentation for `experiments.parallelCodeSplitting` has been removed from both English and Chinese documentation files, as this option was deprecated in version 1.6.2.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).