### PR TITLE
refactor: use newtype for alias artifact

### DIFF
--- a/crates/rspack_core/src/artifacts/async_modules_artifact.rs
+++ b/crates/rspack_core/src/artifacts/async_modules_artifact.rs
@@ -1,0 +1,47 @@
+use std::ops::{Deref, DerefMut};
+
+use rspack_collections::IdentifierSet;
+
+#[derive(Debug, Default, Clone)]
+pub struct AsyncModulesArtifact(IdentifierSet);
+
+impl Deref for AsyncModulesArtifact {
+  type Target = IdentifierSet;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for AsyncModulesArtifact {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
+
+impl From<IdentifierSet> for AsyncModulesArtifact {
+  fn from(value: IdentifierSet) -> Self {
+    Self(value)
+  }
+}
+
+impl From<AsyncModulesArtifact> for IdentifierSet {
+  fn from(value: AsyncModulesArtifact) -> Self {
+    value.0
+  }
+}
+
+impl FromIterator<<IdentifierSet as IntoIterator>::Item> for AsyncModulesArtifact {
+  fn from_iter<T: IntoIterator<Item = <IdentifierSet as IntoIterator>::Item>>(iter: T) -> Self {
+    Self(IdentifierSet::from_iter(iter))
+  }
+}
+
+impl IntoIterator for AsyncModulesArtifact {
+  type Item = <IdentifierSet as IntoIterator>::Item;
+  type IntoIter = <IdentifierSet as IntoIterator>::IntoIter;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.0.into_iter()
+  }
+}

--- a/crates/rspack_core/src/artifacts/cgc_runtime_requirements_artifact.rs
+++ b/crates/rspack_core/src/artifacts/cgc_runtime_requirements_artifact.rs
@@ -1,0 +1,55 @@
+use std::ops::{Deref, DerefMut};
+
+use rspack_collections::UkeyMap;
+
+use crate::{ChunkUkey, RuntimeGlobals};
+
+#[derive(Debug, Default, Clone)]
+pub struct CgcRuntimeRequirementsArtifact(UkeyMap<ChunkUkey, RuntimeGlobals>);
+
+impl Deref for CgcRuntimeRequirementsArtifact {
+  type Target = UkeyMap<ChunkUkey, RuntimeGlobals>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for CgcRuntimeRequirementsArtifact {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
+
+impl From<UkeyMap<ChunkUkey, RuntimeGlobals>> for CgcRuntimeRequirementsArtifact {
+  fn from(value: UkeyMap<ChunkUkey, RuntimeGlobals>) -> Self {
+    Self(value)
+  }
+}
+
+impl From<CgcRuntimeRequirementsArtifact> for UkeyMap<ChunkUkey, RuntimeGlobals> {
+  fn from(value: CgcRuntimeRequirementsArtifact) -> Self {
+    value.0
+  }
+}
+
+impl FromIterator<<UkeyMap<ChunkUkey, RuntimeGlobals> as IntoIterator>::Item>
+  for CgcRuntimeRequirementsArtifact
+{
+  fn from_iter<
+    T: IntoIterator<Item = <UkeyMap<ChunkUkey, RuntimeGlobals> as IntoIterator>::Item>,
+  >(
+    iter: T,
+  ) -> Self {
+    Self(UkeyMap::from_iter(iter))
+  }
+}
+
+impl IntoIterator for CgcRuntimeRequirementsArtifact {
+  type Item = <UkeyMap<ChunkUkey, RuntimeGlobals> as IntoIterator>::Item;
+  type IntoIter = <UkeyMap<ChunkUkey, RuntimeGlobals> as IntoIterator>::IntoIter;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.0.into_iter()
+  }
+}

--- a/crates/rspack_core/src/artifacts/chunk_render_artifact.rs
+++ b/crates/rspack_core/src/artifacts/chunk_render_artifact.rs
@@ -1,0 +1,55 @@
+use std::ops::{Deref, DerefMut};
+
+use rspack_collections::UkeyMap;
+
+use crate::{ChunkRenderResult, ChunkUkey};
+
+#[derive(Debug, Default, Clone)]
+pub struct ChunkRenderArtifact(UkeyMap<ChunkUkey, ChunkRenderResult>);
+
+impl Deref for ChunkRenderArtifact {
+  type Target = UkeyMap<ChunkUkey, ChunkRenderResult>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for ChunkRenderArtifact {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
+
+impl From<UkeyMap<ChunkUkey, ChunkRenderResult>> for ChunkRenderArtifact {
+  fn from(value: UkeyMap<ChunkUkey, ChunkRenderResult>) -> Self {
+    Self(value)
+  }
+}
+
+impl From<ChunkRenderArtifact> for UkeyMap<ChunkUkey, ChunkRenderResult> {
+  fn from(value: ChunkRenderArtifact) -> Self {
+    value.0
+  }
+}
+
+impl FromIterator<<UkeyMap<ChunkUkey, ChunkRenderResult> as IntoIterator>::Item>
+  for ChunkRenderArtifact
+{
+  fn from_iter<
+    T: IntoIterator<Item = <UkeyMap<ChunkUkey, ChunkRenderResult> as IntoIterator>::Item>,
+  >(
+    iter: T,
+  ) -> Self {
+    Self(UkeyMap::from_iter(iter))
+  }
+}
+
+impl IntoIterator for ChunkRenderArtifact {
+  type Item = <UkeyMap<ChunkUkey, ChunkRenderResult> as IntoIterator>::Item;
+  type IntoIter = <UkeyMap<ChunkUkey, ChunkRenderResult> as IntoIterator>::IntoIter;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.0.into_iter()
+  }
+}

--- a/crates/rspack_core/src/artifacts/dependencies_diagnostics_artifact.rs
+++ b/crates/rspack_core/src/artifacts/dependencies_diagnostics_artifact.rs
@@ -1,0 +1,58 @@
+use std::ops::{Deref, DerefMut};
+
+use rspack_collections::IdentifierMap;
+use rspack_error::Diagnostic;
+
+#[derive(Debug, Default, Clone)]
+pub struct DependenciesDiagnosticsArtifact(IdentifierMap<Vec<Diagnostic>>);
+
+impl DependenciesDiagnosticsArtifact {
+  pub fn into_values(self) -> impl Iterator<Item = Vec<Diagnostic>> {
+    self.0.into_values()
+  }
+}
+
+impl Deref for DependenciesDiagnosticsArtifact {
+  type Target = IdentifierMap<Vec<Diagnostic>>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for DependenciesDiagnosticsArtifact {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
+
+impl From<IdentifierMap<Vec<Diagnostic>>> for DependenciesDiagnosticsArtifact {
+  fn from(value: IdentifierMap<Vec<Diagnostic>>) -> Self {
+    Self(value)
+  }
+}
+
+impl From<DependenciesDiagnosticsArtifact> for IdentifierMap<Vec<Diagnostic>> {
+  fn from(value: DependenciesDiagnosticsArtifact) -> Self {
+    value.0
+  }
+}
+
+impl FromIterator<<IdentifierMap<Vec<Diagnostic>> as IntoIterator>::Item>
+  for DependenciesDiagnosticsArtifact
+{
+  fn from_iter<T: IntoIterator<Item = <IdentifierMap<Vec<Diagnostic>> as IntoIterator>::Item>>(
+    iter: T,
+  ) -> Self {
+    Self(IdentifierMap::from_iter(iter))
+  }
+}
+
+impl IntoIterator for DependenciesDiagnosticsArtifact {
+  type Item = <IdentifierMap<Vec<Diagnostic>> as IntoIterator>::Item;
+  type IntoIter = <IdentifierMap<Vec<Diagnostic>> as IntoIterator>::IntoIter;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.0.into_iter()
+  }
+}

--- a/crates/rspack_core/src/artifacts/imported_by_defer_modules_artifact.rs
+++ b/crates/rspack_core/src/artifacts/imported_by_defer_modules_artifact.rs
@@ -1,0 +1,47 @@
+use std::ops::{Deref, DerefMut};
+
+use rspack_collections::IdentifierSet;
+
+#[derive(Debug, Default, Clone)]
+pub struct ImportedByDeferModulesArtifact(IdentifierSet);
+
+impl Deref for ImportedByDeferModulesArtifact {
+  type Target = IdentifierSet;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for ImportedByDeferModulesArtifact {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
+
+impl From<IdentifierSet> for ImportedByDeferModulesArtifact {
+  fn from(value: IdentifierSet) -> Self {
+    Self(value)
+  }
+}
+
+impl From<ImportedByDeferModulesArtifact> for IdentifierSet {
+  fn from(value: ImportedByDeferModulesArtifact) -> Self {
+    value.0
+  }
+}
+
+impl FromIterator<<IdentifierSet as IntoIterator>::Item> for ImportedByDeferModulesArtifact {
+  fn from_iter<T: IntoIterator<Item = <IdentifierSet as IntoIterator>::Item>>(iter: T) -> Self {
+    Self(IdentifierSet::from_iter(iter))
+  }
+}
+
+impl IntoIterator for ImportedByDeferModulesArtifact {
+  type Item = <IdentifierSet as IntoIterator>::Item;
+  type IntoIter = <IdentifierSet as IntoIterator>::IntoIter;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.0.into_iter()
+  }
+}

--- a/crates/rspack_core/src/artifacts/mod.rs
+++ b/crates/rspack_core/src/artifacts/mod.rs
@@ -1,31 +1,31 @@
-use rspack_collections::{IdentifierMap, IdentifierSet, UkeyMap};
-use rspack_error::Diagnostic;
-
-use crate::{ChunkRenderResult, ChunkUkey, ModuleId, RuntimeGlobals};
-
+mod async_modules_artifact;
+mod cgc_runtime_requirements_artifact;
 mod cgm_hash_artifact;
 mod cgm_runtime_requirement_artifact;
 mod chunk_hashes_artifact;
 mod chunk_ids_artifact;
+mod chunk_render_artifact;
 mod chunk_render_cache_artifact;
 mod code_generation_results;
+mod dependencies_diagnostics_artifact;
+mod imported_by_defer_modules_artifact;
 mod module_graph_cache_artifact;
+mod module_ids_artifact;
 mod module_static_cache_artifact;
 mod side_effects_do_optimize_artifact;
 
+pub use async_modules_artifact::AsyncModulesArtifact;
+pub use cgc_runtime_requirements_artifact::CgcRuntimeRequirementsArtifact;
 pub use cgm_hash_artifact::*;
 pub use cgm_runtime_requirement_artifact::*;
 pub use chunk_hashes_artifact::*;
 pub use chunk_ids_artifact::*;
+pub use chunk_render_artifact::ChunkRenderArtifact;
 pub use chunk_render_cache_artifact::ChunkRenderCacheArtifact;
 pub use code_generation_results::*;
+pub use dependencies_diagnostics_artifact::DependenciesDiagnosticsArtifact;
+pub use imported_by_defer_modules_artifact::ImportedByDeferModulesArtifact;
 pub use module_graph_cache_artifact::*;
+pub use module_ids_artifact::ModuleIdsArtifact;
 pub use module_static_cache_artifact::*;
 pub use side_effects_do_optimize_artifact::*;
-
-pub type AsyncModulesArtifact = IdentifierSet;
-pub type ImportedByDeferModulesArtifact = IdentifierSet;
-pub type DependenciesDiagnosticsArtifact = IdentifierMap<Vec<Diagnostic>>;
-pub type ModuleIdsArtifact = IdentifierMap<ModuleId>;
-pub type CgcRuntimeRequirementsArtifact = UkeyMap<ChunkUkey, RuntimeGlobals>;
-pub type ChunkRenderArtifact = UkeyMap<ChunkUkey, ChunkRenderResult>;

--- a/crates/rspack_core/src/artifacts/module_ids_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_ids_artifact.rs
@@ -1,0 +1,51 @@
+use std::ops::{Deref, DerefMut};
+
+use rspack_collections::IdentifierMap;
+
+use crate::ModuleId;
+
+#[derive(Debug, Default, Clone)]
+pub struct ModuleIdsArtifact(IdentifierMap<ModuleId>);
+
+impl Deref for ModuleIdsArtifact {
+  type Target = IdentifierMap<ModuleId>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for ModuleIdsArtifact {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
+
+impl From<IdentifierMap<ModuleId>> for ModuleIdsArtifact {
+  fn from(value: IdentifierMap<ModuleId>) -> Self {
+    Self(value)
+  }
+}
+
+impl From<ModuleIdsArtifact> for IdentifierMap<ModuleId> {
+  fn from(value: ModuleIdsArtifact) -> Self {
+    value.0
+  }
+}
+
+impl FromIterator<<IdentifierMap<ModuleId> as IntoIterator>::Item> for ModuleIdsArtifact {
+  fn from_iter<T: IntoIterator<Item = <IdentifierMap<ModuleId> as IntoIterator>::Item>>(
+    iter: T,
+  ) -> Self {
+    Self(IdentifierMap::from_iter(iter))
+  }
+}
+
+impl IntoIterator for ModuleIdsArtifact {
+  type Item = <IdentifierMap<ModuleId> as IntoIterator>::Item;
+  type IntoIter = <IdentifierMap<ModuleId> as IntoIterator>::IntoIter;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.0.into_iter()
+  }
+}

--- a/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
@@ -100,7 +100,7 @@ impl Compilation {
     })
     .await;
 
-    let mut chunk_render_results: UkeyMap<ChunkUkey, ChunkRenderResult> = Default::default();
+    let mut chunk_render_results = ChunkRenderArtifact::default();
     for result in results {
       let item = result.to_rspack_result()?;
       let (key, value) = item?;

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -161,7 +161,8 @@ impl Compilation {
           .collect::<Vec<_>>();
         (*module_identifier, diagnostics)
       })
-      .collect();
+      .collect::<rspack_collections::IdentifierMap<Vec<Diagnostic>>>()
+      .into();
     let all_modules_diagnostics = if has_mutations {
       dependencies_diagnostics_artifact.extend(dependencies_diagnostics);
       dependencies_diagnostics_artifact.clone()


### PR DESCRIPTION
## Summary
use newtype for artifact which is more extensible and we can add more meta info in artifact in the future
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
