### PR TITLE
fix: correct watchpack require path

### DIFF
--- a/packages/rspack/src/node/NodeWatchFileSystem.ts
+++ b/packages/rspack/src/node/NodeWatchFileSystem.ts
@@ -71,7 +71,7 @@ export default class NodeWatchFileSystem implements WatchFileSystem {
     }
 
     const oldWatcher = this.watcher;
-    const Watchpack = require('watchpack');
+    const Watchpack = require('../compiled/watchpack/index.js');
     this.watcher = new Watchpack(options);
 
     if (callbackUndelayed) {


### PR DESCRIPTION
## Summary

Updated the import path for `watchpack` to use the compiled version from `../compiled/watchpack/index.js` instead of requiring it directly by package name.

<img width="1177" height="518" alt="Screenshot 2026-01-17 at 21 03 35" src="https://github.com/user-attachments/assets/7095a2a7-0bf1-42f5-b843-ffd56ad51279" />

## Related links

- https://github.com/web-infra-dev/rspack/pull/12733

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
