### PR TITLE
docs: update bundlerInfo version and formatting

### DIFF
--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -46,11 +46,11 @@ export default {
 };
 ```
 
-### output.bundlerInfo
+## output.bundlerInfo
 
 <ApiMeta addedVersion="2.0.0" />
 
-> In versions 1.x, you can use `experiments.rspackFuture.bundlerInfo` instead.
+> In versions 1.x, use `experiments.rspackFuture.bundlerInfo` instead.
 
 - **Type**:
 

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -46,9 +46,9 @@ export default {
 };
 ```
 
-### output.bundlerInfo
+## output.bundlerInfo
 
-<ApiMeta addedVersion="1.0.0" />
+<ApiMeta addedVersion="2.0.0" />
 
 > 在 1.x 版本中，你可以使用 `experiments.rspackFuture.bundlerInfo`。
 


### PR DESCRIPTION
## Summary

- Changed the heading for `output.bundlerInfo` from a level 3 (`###`) to a level 2 (`##`) 
- Updated the `addedVersion` in the `<ApiMeta>` tag from `1.0.0` to `2.0.0`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
