### PR TITLE
feat(resolve): add "rspack" as default condition name

### DIFF
--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1285,7 +1285,7 @@ fn get_resolve_defaults(
   target_properties: &TargetProperties,
   css: bool,
 ) -> Resolve {
-  let mut conditions = vec!["webpack".to_string()];
+  let mut conditions = vec!["rspack".to_string(), "webpack".to_string()];
 
   // Add mode condition
   conditions.push(match mode {
@@ -1385,7 +1385,7 @@ fn get_resolve_defaults(
 
   // Add CSS dependencies if enabled
   if css {
-    let mut style_conditions = vec!["webpack".to_string()];
+    let mut style_conditions = vec!["rspack".to_string(), "webpack".to_string()];
     style_conditions.push(match mode {
       Mode::Development => "development".to_string(),
       _ => "production".to_string(),

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -164,6 +164,7 @@ CompilerOptions {
         ),
         condition_names: Some(
             [
+                "rspack",
                 "webpack",
                 "production",
                 "browser",

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -1138,7 +1138,7 @@ const getResolveDefaults = ({
   mode?: Mode;
   css: boolean;
 }) => {
-  const conditions = ['webpack'];
+  const conditions = ['rspack', 'webpack'];
 
   conditions.push(mode === 'development' ? 'development' : 'production');
 
@@ -1209,7 +1209,7 @@ const getResolveDefaults = ({
 
   if (css) {
     const styleConditions = [];
-
+    styleConditions.push('rspack');
     styleConditions.push('webpack');
     styleConditions.push(mode === 'development' ? 'development' : 'production');
     styleConditions.push('style');

--- a/tests/rspack-test/normalCases/resolve/condition-names/index.js
+++ b/tests/rspack-test/normalCases/resolve/condition-names/index.js
@@ -1,0 +1,10 @@
+import a from 'a';
+import b from 'b';
+
+it('should use rspack as condition names', async () => {
+  expect(a).toBe('a');
+})
+
+it('should fallback to webpack as condition names', async () => {
+  expect(b).toBe('b');
+})

--- a/tests/rspack-test/normalCases/resolve/condition-names/node_modules/a/a.js
+++ b/tests/rspack-test/normalCases/resolve/condition-names/node_modules/a/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/tests/rspack-test/normalCases/resolve/condition-names/node_modules/a/b.js
+++ b/tests/rspack-test/normalCases/resolve/condition-names/node_modules/a/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/tests/rspack-test/normalCases/resolve/condition-names/node_modules/a/package.json
+++ b/tests/rspack-test/normalCases/resolve/condition-names/node_modules/a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "a",
+  "type": "module",
+  "exports": {
+    ".": {
+      "rspack": "./a.js",
+      "webpack": "./b.js"
+    }
+  }
+}

--- a/tests/rspack-test/normalCases/resolve/condition-names/node_modules/b/b.js
+++ b/tests/rspack-test/normalCases/resolve/condition-names/node_modules/b/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/tests/rspack-test/normalCases/resolve/condition-names/node_modules/b/package.json
+++ b/tests/rspack-test/normalCases/resolve/condition-names/node_modules/b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "b",
+  "type": "module",
+  "exports": {
+    ".": {
+      "webpack": "./b.js"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add "rspack" to the default condition names in resolve configuration, placing it before "webpack". This allows library authors to provide rspack-specific exports in their package.json while maintaining backward compatibility with webpack.

When a library defines both `rspack` and `webpack` conditions in exports, rspack will now prefer the rspack-specific entry, enabling optimizations or rspack-specific implementations.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).