### PR TITLE
docs: fix typo in CSS docs

### DIFF
--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -66,7 +66,7 @@ When enabled, Rspack enables native CSS support and CSS-related parser and gener
 
 ### Migration
 
-To use CSS in Rspack 3.0, you need to manually add CSS rules to your configuration:
+To use CSS in Rspack 2.0, you need to manually add CSS rules to your configuration:
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

fix docs typo. 3.0 -> 2.0

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
