### PR TITLE
refactor: use readonly ref in runtime requirements in tree hook

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1309,11 +1309,12 @@ impl CompilationAdditionalTreeRuntimeRequirements
 impl CompilationRuntimeRequirementInTree for CompilationRuntimeRequirementInTreeTap {
   async fn run(
     &self,
-    compilation: &mut Compilation,
+    compilation: &Compilation,
     chunk_ukey: &ChunkUkey,
     all_runtime_requirements: &RuntimeGlobals,
     runtime_requirements: &RuntimeGlobals,
     runtime_requirements_mut: &mut RuntimeGlobals,
+    _runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
   ) -> rspack_error::Result<Option<()>> {
     let arg = JsRuntimeRequirementInTreeArg {
       chunk: ChunkWrapper::new(*chunk_ukey, compilation),

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -112,7 +112,7 @@ define_hook!(CompilationRuntimeRequirementInModule: SeriesBail(compilation: &Com
 define_hook!(CompilationAdditionalChunkRuntimeRequirements: Series(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, runtime_requirements: &mut RuntimeGlobals));
 define_hook!(CompilationRuntimeRequirementInChunk: SeriesBail(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals));
 define_hook!(CompilationAdditionalTreeRuntimeRequirements: Series(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, runtime_requirements: &mut RuntimeGlobals));
-define_hook!(CompilationRuntimeRequirementInTree: SeriesBail(compilation: &mut Compilation, chunk_ukey: &ChunkUkey, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals));
+define_hook!(CompilationRuntimeRequirementInTree: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals, runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>));
 define_hook!(CompilationOptimizeCodeGeneration: Series(compilation: &Compilation, build_module_graph_artifact: &mut BuildModuleGraphArtifact, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationAfterCodeGeneration: Series(compilation: &Compilation, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash),tracing=false);

--- a/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
+++ b/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
@@ -313,57 +313,63 @@ impl Compilation {
 
     let start = logger.time("runtime requirements.entries");
     for &entry_ukey in &entries {
+      let mut all_runtime_requirements = RuntimeGlobals::default();
+      let mut runtime_modules_to_add: Vec<(ChunkUkey, Box<dyn RuntimeModule>)> = Vec::new();
+
       let entry = self.chunk_by_ukey.expect_get(&entry_ukey);
-      let mut set = RuntimeGlobals::default();
       for chunk_ukey in entry
         .get_all_referenced_chunks(&self.chunk_group_by_ukey)
         .iter()
       {
         let runtime_requirements = ChunkGraph::get_chunk_runtime_requirements(self, chunk_ukey);
-        set.insert(*runtime_requirements);
+        all_runtime_requirements.insert(*runtime_requirements);
       }
 
       plugin_driver
         .compilation_hooks
         .additional_tree_runtime_requirements
-        .call(self, &entry_ukey, &mut set)
+        .call(self, &entry_ukey, &mut all_runtime_requirements)
         .await
         .map_err(|e| {
           e.wrap_err("caused by plugins in Compilation.hooks.additionalTreeRuntimeRequirements")
         })?;
 
-      self
-        .process_runtime_requirement_hook_mut(&mut set, {
-          let plugin_driver = plugin_driver.clone();
-          move |compilation,
-                all_runtime_requirements,
-                runtime_requirements,
-                runtime_requirements_mut| {
-            Box::pin({
-              let plugin_driver = plugin_driver.clone();
-              async move {
-                plugin_driver
-                  .compilation_hooks
-                  .runtime_requirement_in_tree
-                  .call(
-                    compilation,
-                    &entry_ukey,
-                    all_runtime_requirements,
-                    runtime_requirements,
-                    runtime_requirements_mut,
-                  )
-                  .await
-                  .map_err(|e| {
-                    e.wrap_err("caused by plugins in Compilation.hooks.runtimeRequirementInTree")
-                  })?;
-                Ok(())
-              }
-            })
+      // Inline process_runtime_requirement_hook logic for runtime_requirement_in_tree
+      {
+        let mut runtime_requirements_to_add = all_runtime_requirements;
+        let mut runtime_requirements_added;
+        loop {
+          runtime_requirements_added = runtime_requirements_to_add;
+          runtime_requirements_to_add = RuntimeGlobals::default();
+          plugin_driver
+            .compilation_hooks
+            .runtime_requirement_in_tree
+            .call(
+              self,
+              &entry_ukey,
+              &all_runtime_requirements,
+              &runtime_requirements_added,
+              &mut runtime_requirements_to_add,
+              &mut runtime_modules_to_add,
+            )
+            .await
+            .map_err(|e| {
+              e.wrap_err("caused by plugins in Compilation.hooks.runtimeRequirementInTree")
+            })?;
+          runtime_requirements_to_add = runtime_requirements_to_add
+            .difference(all_runtime_requirements.intersection(runtime_requirements_to_add));
+          if runtime_requirements_to_add.is_empty() {
+            break;
+          } else {
+            all_runtime_requirements.insert(runtime_requirements_to_add);
           }
-        })
-        .await?;
+        }
+      }
 
-      ChunkGraph::set_tree_runtime_requirements(self, entry_ukey, set);
+      ChunkGraph::set_tree_runtime_requirements(self, entry_ukey, all_runtime_requirements);
+      for (chunk_ukey, module) in runtime_modules_to_add {
+        self.add_runtime_module(&chunk_ukey, module)?;
+      }
     }
 
     // NOTE: webpack runs hooks.runtime_module in compilation.add_runtime_module

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -15,7 +15,8 @@ use rspack_core::{
   CompilationRuntimeRequirementInTree, CompilerCompilation, ConcatenatedModuleInfo,
   ConcatenationScope, DependencyType, ExternalModuleInfo, GetTargetResult, Logger, ModuleGraph,
   ModuleIdentifier, ModuleInfo, ModuleType, NormalModuleFactoryParser, ParserAndGenerator,
-  ParserOptions, Plugin, PrefetchExportsInfoMode, RuntimeGlobals, get_target, is_esm_dep_like,
+  ParserOptions, Plugin, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeModule, get_target,
+  is_esm_dep_like,
   rspack_sources::{ReplaceSource, Source},
 };
 use rspack_error::{Diagnostic, Result};
@@ -360,14 +361,15 @@ async fn additional_chunk_runtime_requirements(
 #[plugin_hook(CompilationRuntimeRequirementInTree for EsmLibraryPlugin)]
 async fn runtime_requirements_in_tree(
   &self,
-  compilation: &mut Compilation,
+  _compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   _runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   if runtime_requirements.contains(RuntimeGlobals::REQUIRE) {
-    compilation.add_runtime_module(chunk_ukey, Box::new(RegisterModuleRuntime::default()))?;
+    runtime_modules_to_add.push((*chunk_ukey, Box::new(RegisterModuleRuntime::default())));
   }
 
   Ok(None)

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -14,7 +14,7 @@ use rspack_core::{
   CompilationRuntimeRequirementInTree, CompilerCompilation, DependencyType, Filename,
   ManifestAssetType, Module, ModuleGraph, ModuleIdentifier, ModuleType, NormalModuleFactoryParser,
   ParserAndGenerator, ParserOptions, PathData, Plugin, RenderManifestEntry, RuntimeGlobals,
-  SourceType, get_undo_path,
+  RuntimeModule, SourceType, get_undo_path,
   rspack_sources::{
     BoxSource, CachedSource, ConcatSource, RawStringSource, SourceExt, SourceMap, SourceMapSource,
     WithoutOriginalOptions,
@@ -503,11 +503,12 @@ async fn compilation(
 #[plugin_hook(CompilationRuntimeRequirementInTree for PluginCssExtract)]
 async fn runtime_requirement_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   // different from webpack, Rspack can invoke this multiple times,
   // each time with current runtime_globals, and records every mutation
@@ -533,8 +534,8 @@ async fn runtime_requirement_in_tree(
     let filename = self.options.filename.clone();
     let chunk_filename = self.options.chunk_filename.clone();
 
-    compilation.add_runtime_module(
-      chunk_ukey,
+    runtime_modules_to_add.push((
+      *chunk_ukey,
       Box::new(GetChunkFilenameRuntimeModule::new(
         &compilation.runtime_template,
         "css",
@@ -562,10 +563,10 @@ async fn runtime_requirement_in_tree(
             })
         },
       )),
-    )?;
+    ));
 
-    compilation.add_runtime_module(
-      chunk_ukey,
+    runtime_modules_to_add.push((
+      *chunk_ukey,
       Box::new(CssLoadingRuntimeModule::new(
         &compilation.runtime_template,
         *chunk_ukey,
@@ -573,7 +574,7 @@ async fn runtime_requirement_in_tree(
         self.options.link_type.clone(),
         self.options.insert.clone(),
       )),
-    )?;
+    ));
   }
 
   Ok(None)

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_plugin.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use rspack_core::{
   ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationParams,
   CompilationRuntimeRequirementInTree, CompilerCompilation, DependencyId, ModuleIdentifier, Plugin,
-  RuntimeGlobals,
+  RuntimeGlobals, RuntimeModule,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -88,11 +88,12 @@ async fn additional_chunk_runtime_requirements_tree(
 #[plugin_hook(CompilationRuntimeRequirementInTree for EmbedFederationRuntimePlugin)]
 async fn runtime_requirement_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   _runtime_requirements: &RuntimeGlobals,
   _runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
 
@@ -118,13 +119,13 @@ async fn runtime_requirement_in_tree(
     };
 
     // Inject EmbedFederationRuntimeModule
-    compilation.add_runtime_module(
-      chunk_ukey,
+    runtime_modules_to_add.push((
+      *chunk_ukey,
       Box::new(EmbedFederationRuntimeModule::new(
         &compilation.runtime_template,
         emro,
       )),
-    )?;
+    ));
   }
 
   Ok(None)

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_plugin.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   ChunkUkey, Compilation, CompilationRuntimeRequirementInTree, Plugin, RuntimeGlobals,
-  RuntimeModuleExt,
+  RuntimeModule, RuntimeModuleExt,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -22,17 +22,18 @@ impl ShareRuntimePlugin {
 #[plugin_hook(CompilationRuntimeRequirementInTree for ShareRuntimePlugin)]
 async fn runtime_requirements_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   _runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   if runtime_requirements.contains(RuntimeGlobals::SHARE_SCOPE_MAP) {
-    compilation.add_runtime_module(
-      chunk_ukey,
+    runtime_modules_to_add.push((
+      *chunk_ukey,
       ShareRuntimeModule::new(&compilation.runtime_template, self.enhanced).boxed(),
-    )?;
+    ));
   }
   Ok(None)
 }

--- a/crates/rspack_plugin_runtime/src/bundler_info.rs
+++ b/crates/rspack_plugin_runtime/src/bundler_info.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   ChunkUkey, Compilation, CompilationAdditionalTreeRuntimeRequirements,
-  CompilationRuntimeRequirementInTree, Plugin, RuntimeGlobals,
+  CompilationRuntimeRequirementInTree, Plugin, RuntimeGlobals, RuntimeModule,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -59,31 +59,32 @@ async fn additional_tree_runtime_requirements(
 #[plugin_hook(CompilationRuntimeRequirementInTree for BundlerInfoPlugin)]
 async fn runtime_requirements_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   _runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   if runtime_requirements.contains(RuntimeGlobals::RSPACK_VERSION) {
-    compilation.add_runtime_module(
-      chunk_ukey,
+    runtime_modules_to_add.push((
+      *chunk_ukey,
       Box::new(RspackVersionRuntimeModule::new(
         &compilation.runtime_template,
         self.version.clone(),
       )),
-    )?;
+    ));
   }
 
   if runtime_requirements.contains(RuntimeGlobals::RSPACK_UNIQUE_ID) {
-    compilation.add_runtime_module(
-      chunk_ukey,
+    runtime_modules_to_add.push((
+      *chunk_ukey,
       Box::new(RspackUniqueIdRuntimeModule::new(
         &compilation.runtime_template,
         self.bundler_name.clone(),
         self.version.clone(),
       )),
-    )?;
+    ));
   }
   Ok(None)
 }

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   ChunkLoading, ChunkLoadingType, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationRuntimeRequirementInTree, Plugin,
-  RuntimeGlobals, RuntimeModuleExt,
+  RuntimeGlobals, RuntimeModule, RuntimeModuleExt,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -48,11 +48,12 @@ async fn additional_tree_runtime_requirements(
 #[plugin_hook(CompilationRuntimeRequirementInTree for CommonJsChunkLoadingPlugin)]
 async fn runtime_requirements_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   let chunk_loading_value = if self.async_chunk_loading {
     ChunkLoading::Enable(ChunkLoadingType::AsyncNode)
@@ -94,15 +95,15 @@ async fn runtime_requirements_in_tree(
     runtime_requirements_mut.insert(RuntimeGlobals::MODULE_FACTORIES_ADD_ONLY);
     runtime_requirements_mut.insert(RuntimeGlobals::HAS_OWN_PROPERTY);
     if self.async_chunk_loading {
-      compilation.add_runtime_module(
-        chunk_ukey,
+      runtime_modules_to_add.push((
+        *chunk_ukey,
         ReadFileChunkLoadingRuntimeModule::new(&compilation.runtime_template).boxed(),
-      )?;
+      ));
     } else {
-      compilation.add_runtime_module(
-        chunk_ukey,
+      runtime_modules_to_add.push((
+        *chunk_ukey,
         RequireChunkLoadingRuntimeModule::new(&compilation.runtime_template).boxed(),
-      )?;
+      ));
     }
   }
 

--- a/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   ChunkLoading, ChunkLoadingType, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationRuntimeRequirementInTree, Plugin,
-  RuntimeGlobals, RuntimeModuleExt,
+  RuntimeGlobals, RuntimeModule, RuntimeModuleExt,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -34,11 +34,12 @@ async fn additional_tree_runtime_requirements(
 #[plugin_hook(CompilationRuntimeRequirementInTree for ImportScriptsChunkLoadingPlugin)]
 async fn runtime_requirements_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   let chunk_loading_value = ChunkLoading::Enable(ChunkLoadingType::ImportScripts);
   let is_enabled_for_chunk = is_enabled_for_chunk(chunk_ukey, &chunk_loading_value, compilation);
@@ -77,14 +78,14 @@ async fn runtime_requirements_in_tree(
       if with_create_script_url {
         runtime_requirements_mut.insert(RuntimeGlobals::CREATE_SCRIPT_URL);
       }
-      compilation.add_runtime_module(
-        chunk_ukey,
+      runtime_modules_to_add.push((
+        *chunk_ukey,
         ImportScriptsChunkLoadingRuntimeModule::new(
           &compilation.runtime_template,
           with_create_script_url,
         )
         .boxed(),
-      )?;
+      ));
     }
   }
   Ok(None)

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -8,8 +8,9 @@ use rspack_collections::DatabaseItem;
 use rspack_core::{
   ChunkLoading, ChunkUkey, Compilation, CompilationId, CompilationParams,
   CompilationRuntimeRequirementInModule, CompilationRuntimeRequirementInTree, CompilerCompilation,
-  ModuleIdentifier, Plugin, PublicPath, RuntimeGlobals, RuntimeModuleExt, SourceType,
-  get_css_chunk_filename_template, get_js_chunk_filename_template, has_hash_placeholder,
+  ModuleIdentifier, Plugin, PublicPath, RuntimeGlobals, RuntimeModule, RuntimeModuleExt,
+  SourceType, get_css_chunk_filename_template, get_js_chunk_filename_template,
+  has_hash_placeholder,
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
@@ -235,11 +236,12 @@ async fn runtime_requirements_in_module(
 #[plugin_hook(CompilationRuntimeRequirementInTree for RuntimePlugin)]
 async fn runtime_requirements_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   if compilation.options.output.trusted_types.is_some() {
     if runtime_requirements.contains(RuntimeGlobals::LOAD_SCRIPT) {
@@ -313,10 +315,10 @@ async fn runtime_requirements_in_tree(
     if has_async_chunks {
       runtime_requirements_mut.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
     }
-    compilation.add_runtime_module(
-      chunk_ukey,
+    runtime_modules_to_add.push((
+      *chunk_ukey,
       EnsureChunkRuntimeModule::new(&compilation.runtime_template).boxed(),
-    )?;
+    ));
   }
 
   if runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_INCLUDE_ENTRIES) {
@@ -335,37 +337,37 @@ async fn runtime_requirements_in_tree(
   for runtime_requirement in runtime_requirements.iter() {
     match runtime_requirement {
       RuntimeGlobals::ASYNC_MODULE => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           AsyncRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::BASE_URI
         if is_enabled_for_chunk(chunk_ukey, &ChunkLoading::Disable, compilation) =>
       {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           BaseUriRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::PUBLIC_PATH => match &public_path {
         PublicPath::Filename(filename) => {
-          compilation.add_runtime_module(
-            chunk_ukey,
+          runtime_modules_to_add.push((
+            *chunk_ukey,
             PublicPathRuntimeModule::new(&compilation.runtime_template, Box::new(filename.clone()))
               .boxed(),
-          )?;
+          ));
         }
         PublicPath::Auto => {
-          compilation.add_runtime_module(
-            chunk_ukey,
+          runtime_modules_to_add.push((
+            *chunk_ukey,
             AutoPublicPathRuntimeModule::new(&compilation.runtime_template).boxed(),
-          )?;
+          ));
         }
       },
       RuntimeGlobals::GET_CHUNK_SCRIPT_FILENAME => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           GetChunkFilenameRuntimeModule::new(
             &compilation.runtime_template,
             "javascript",
@@ -387,11 +389,11 @@ async fn runtime_requirements_in_tree(
             },
           )
           .boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::GET_CHUNK_CSS_FILENAME => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           GetChunkFilenameRuntimeModule::new(
             &compilation.runtime_template,
             "css",
@@ -415,17 +417,17 @@ async fn runtime_requirements_in_tree(
             },
           )
           .boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::GET_CHUNK_UPDATE_SCRIPT_FILENAME => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           GetChunkUpdateFilenameRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::GET_UPDATE_MANIFEST_FILENAME => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           GetMainFilenameRuntimeModule::new(
             &compilation.runtime_template,
             "update manifest",
@@ -433,11 +435,11 @@ async fn runtime_requirements_in_tree(
             compilation.options.output.hot_update_main_filename.clone(),
           )
           .boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::LOAD_SCRIPT => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           LoadScriptRuntimeModule::new(
             &compilation.runtime_template,
             compilation.options.output.unique_name.clone(),
@@ -445,119 +447,119 @@ async fn runtime_requirements_in_tree(
             *chunk_ukey,
           )
           .boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::HAS_OWN_PROPERTY => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           HasOwnPropertyRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::GET_FULL_HASH => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           GetFullHashRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::GLOBAL => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           GlobalRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::CREATE_SCRIPT_URL => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           CreateScriptUrlRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::CREATE_SCRIPT => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           CreateScriptRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::ON_CHUNKS_LOADED => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           OnChunkLoadedRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::DEFINE_PROPERTY_GETTERS => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           DefinePropertyGettersRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::GET_TRUSTED_TYPES_POLICY => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           GetTrustedTypesPolicyRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           CreateFakeNamespaceObjectRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::MAKE_NAMESPACE_OBJECT => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           MakeNamespaceObjectRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::COMPAT_GET_DEFAULT_EXPORT => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           CompatGetDefaultExportRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::ESM_MODULE_DECORATOR => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           ESMModuleDecoratorRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::NODE_MODULE_DECORATOR => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           NodeModuleDecoratorRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::SYSTEM_CONTEXT if matches!(&library_type, Some(t) if t == "system") => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           SystemContextRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::SCRIPT_NONCE => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           NonceRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::RELATIVE_URL => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           RelativeUrlRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::CHUNK_NAME => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           ChunkNameRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::RUNTIME_ID => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           RuntimeIdRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::PREFETCH_CHUNK => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           ChunkPrefetchPreloadFunctionRuntimeModule::new(
             &compilation.runtime_template,
             "prefetch",
@@ -565,11 +567,11 @@ async fn runtime_requirements_in_tree(
             RuntimeGlobals::PREFETCH_CHUNK_HANDLERS,
           )
           .boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::PRELOAD_CHUNK => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           ChunkPrefetchPreloadFunctionRuntimeModule::new(
             &compilation.runtime_template,
             "preload",
@@ -577,36 +579,36 @@ async fn runtime_requirements_in_tree(
             RuntimeGlobals::PRELOAD_CHUNK_HANDLERS,
           )
           .boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::AMD_DEFINE => {
         if compilation.options.amd.is_some() {
-          compilation.add_runtime_module(
-            chunk_ukey,
+          runtime_modules_to_add.push((
+            *chunk_ukey,
             AmdDefineRuntimeModule::new(&compilation.runtime_template).boxed(),
-          )?;
+          ));
         }
       }
       RuntimeGlobals::AMD_OPTIONS => {
         if let Some(options) = &compilation.options.amd {
-          compilation.add_runtime_module(
-            chunk_ukey,
+          runtime_modules_to_add.push((
+            *chunk_ukey,
             AmdOptionsRuntimeModule::new(&compilation.runtime_template, options.clone()).boxed(),
-          )?;
+          ));
         }
       }
       RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           MakeDeferredNamespaceObjectRuntimeModule::new(&compilation.runtime_template, *chunk_ukey)
             .boxed(),
-        )?;
+        ));
       }
       RuntimeGlobals::TO_BINARY => {
-        compilation.add_runtime_module(
-          chunk_ukey,
+        runtime_modules_to_add.push((
+          *chunk_ukey,
           ToBinaryRuntimeModule::new(&compilation.runtime_template).boxed(),
-        )?;
+        ));
       }
       _ => {}
     }

--- a/crates/rspack_plugin_wasm/src/loading_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/loading_plugin.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   BoxPlugin, ChunkUkey, Compilation, CompilationRuntimeRequirementInTree, Plugin, PluginExt,
-  RuntimeGlobals, RuntimeModuleExt, WasmLoading, WasmLoadingType,
+  RuntimeGlobals, RuntimeModule, RuntimeModuleExt, WasmLoading, WasmLoadingType,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -22,19 +22,20 @@ pub struct FetchCompileAsyncWasmPlugin;
 #[plugin_hook(CompilationRuntimeRequirementInTree for FetchCompileAsyncWasmPlugin)]
 async fn fetch_compile_async_wasm_plugin_runtime_requirements_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   if !runtime_requirements.contains(RuntimeGlobals::INSTANTIATE_WASM) {
     return Ok(None);
   }
 
   runtime_requirements_mut.insert(RuntimeGlobals::PUBLIC_PATH);
-  compilation.add_runtime_module(
-    chunk_ukey,
+  runtime_modules_to_add.push((
+    *chunk_ukey,
     AsyncWasmLoadingRuntimeModule::new(
       &compilation.runtime_template,
       format!(
@@ -47,7 +48,7 @@ async fn fetch_compile_async_wasm_plugin_runtime_requirements_in_tree(
       *chunk_ukey,
     )
     .boxed(),
-  )?;
+  ));
 
   Ok(None)
 }
@@ -79,11 +80,12 @@ impl ReadFileCompileAsyncWasmPlugin {
 #[plugin_hook(CompilationRuntimeRequirementInTree for ReadFileCompileAsyncWasmPlugin)]
 async fn read_file_compile_async_wasm_plugin_runtime_requirements_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   _runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   if !runtime_requirements.contains(RuntimeGlobals::INSTANTIATE_WASM) {
     return Ok(None);
@@ -97,8 +99,8 @@ async fn read_file_compile_async_wasm_plugin_runtime_requirements_in_tree(
       .dynamic_import
       .unwrap_or_default();
 
-  compilation.add_runtime_module(
-    chunk_ukey,
+  runtime_modules_to_add.push((
+    *chunk_ukey,
     AsyncWasmLoadingRuntimeModule::new(
       &compilation.runtime_template,
       if import_enabled {
@@ -110,7 +112,7 @@ async fn read_file_compile_async_wasm_plugin_runtime_requirements_in_tree(
       *chunk_ukey,
     )
     .boxed(),
-  )?;
+  ));
 
   Ok(None)
 }
@@ -136,11 +138,12 @@ pub struct UniversalCompileAsyncWasmPlugin;
 #[plugin_hook(CompilationRuntimeRequirementInTree for UniversalCompileAsyncWasmPlugin)]
 async fn universal_compile_async_wasm_plugin_runtime_requirements_in_tree(
   &self,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _all_runtime_requirements: &RuntimeGlobals,
   runtime_requirements: &RuntimeGlobals,
   _runtime_requirements_mut: &mut RuntimeGlobals,
+  runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>,
 ) -> Result<Option<()>> {
   if !runtime_requirements.contains(RuntimeGlobals::INSTANTIATE_WASM) {
     return Ok(None);
@@ -193,8 +196,8 @@ var wasmUrl = $PATH;"#
 		}"#
     .to_string();
 
-  compilation.add_runtime_module(
-    chunk_ukey,
+  runtime_modules_to_add.push((
+    *chunk_ukey,
     AsyncWasmLoadingRuntimeModule::new_with_before_streaming(
       &compilation.runtime_template,
       generate_load_binary_code,
@@ -204,7 +207,7 @@ var wasmUrl = $PATH;"#
       *chunk_ukey,
     )
     .boxed(),
-  )?;
+  ));
 
   Ok(None)
 }


### PR DESCRIPTION
## Summary
Refactor `CompilationRuntimeRequirementInTreeHook` to use `&Compilation` other than `&mut Compilation`

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
