### PR TITLE
feat!: do not expose EsmLibraryPlugin to user directly, use modern-module instead

### DIFF
--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -780,9 +780,6 @@ export type TTestConfig = {
     snapshotContent?(content: string): string;
     checkSteps?: boolean;
     ignoreNotFriendlyForIncrementalWarnings?: boolean;
-    esmLibPluginOptions?: {
-        preserveModules?: string;
-    };
     resourceLoader?: (url: string, element: HTMLScriptElement) => Buffer | null;
 };
 

--- a/packages/rspack-test-tools/src/case/esm-output.ts
+++ b/packages/rspack-test-tools/src/case/esm-output.ts
@@ -1,4 +1,4 @@
-import rspack, { type RspackOptions } from '@rspack/core';
+import type { RspackOptions } from '@rspack/core';
 import { BasicCaseCreator } from '../test/creator';
 import type { ITestContext, ITestEnv } from '../type';
 import {
@@ -35,30 +35,7 @@ const creator = new BasicCaseCreator({
           name,
           ['rspack.config.cjs', 'rspack.config.js', 'webpack.config.js'],
           defaultOptions,
-          (_index, context, options) => {
-            const testConfig = context.getTestConfig();
-            if (testConfig.esmLibPluginOptions) {
-              let target;
-
-              const otherPlugins =
-                options.plugins?.filter((plugin) => {
-                  const isTarget =
-                    plugin instanceof rspack.experiments.EsmLibraryPlugin;
-                  if (isTarget) {
-                    target = plugin;
-                  }
-                  return !isTarget;
-                }) ?? [];
-
-              options.plugins = [
-                ...otherPlugins,
-                new rspack.experiments.EsmLibraryPlugin({
-                  ...target!.options,
-                  ...testConfig.esmLibPluginOptions,
-                }),
-              ];
-            }
-          },
+          () => {},
         );
       },
       compiler: async (context: ITestContext) => {
@@ -113,6 +90,9 @@ const defaultOptions = (
     filename: '[name].mjs',
     pathinfo: true,
     module: true,
+    library: {
+      type: 'modern-module',
+    },
     bundlerInfo: {
       force: false,
     },
@@ -137,7 +117,6 @@ const defaultOptions = (
     fs: 'module-import fs',
     path: 'module-import path',
   },
-  plugins: [new rspack.experiments.EsmLibraryPlugin()],
   experiments: {
     outputModule: true,
   },

--- a/packages/rspack-test-tools/src/type.ts
+++ b/packages/rspack-test-tools/src/type.ts
@@ -182,10 +182,6 @@ export type TTestConfig = {
   checkSteps?: boolean;
   // Only valid for Watch tests
   ignoreNotFriendlyForIncrementalWarnings?: boolean;
-  // Only valid for ESM library tests
-  esmLibPluginOptions?: {
-    preserveModules?: string;
-  };
   resourceLoader?: (url: string, element: HTMLScriptElement) => Buffer | null;
 };
 

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2445,21 +2445,6 @@ interface Es6Config extends BaseModuleConfig {
 }
 
 // @public (undocumented)
-class EsmLibraryPlugin {
-    constructor(options?: {
-        preserveModules?: string;
-    });
-    // (undocumented)
-    apply(compiler: Compiler): void;
-    // (undocumented)
-    options?: {
-        preserveModules?: string;
-    };
-    // (undocumented)
-    static PLUGIN_NAME: string;
-}
-
-// @public (undocumented)
 interface EsParserConfig {
     allowReturnOutsideFunction?: boolean;
     allowSuperOutsideMethod?: boolean;
@@ -2569,8 +2554,6 @@ interface Experiments_2 {
     createNativePlugin: typeof createNativePlugin;
     // (undocumented)
     CssChunkingPlugin: typeof CssChunkingPlugin;
-    // (undocumented)
-    EsmLibraryPlugin: typeof EsmLibraryPlugin;
     // (undocumented)
     globalTrace: {
         register: (filter: string, layer: 'logger' | 'perfetto', output: string) => Promise<void>;
@@ -4432,7 +4415,7 @@ export type LibraryOptions = {
 };
 
 // @public
-export type LibraryType = LiteralUnion<'var' | 'module' | 'assign' | 'assign-properties' | 'this' | 'window' | 'self' | 'global' | 'commonjs' | 'commonjs2' | 'commonjs-module' | 'commonjs-static' | 'amd' | 'amd-require' | 'umd' | 'umd2' | 'jsonp' | 'system', string>;
+export type LibraryType = LiteralUnion<'var' | 'module' | 'modern-module' | 'assign' | 'assign-properties' | 'this' | 'window' | 'self' | 'global' | 'commonjs' | 'commonjs2' | 'commonjs-module' | 'commonjs-static' | 'amd' | 'amd-require' | 'umd' | 'umd2' | 'jsonp' | 'system', string>;
 
 // @public (undocumented)
 export type LightningcssFeatureOptions = {

--- a/packages/rspack/scripts/check-documentation-coverage.ts
+++ b/packages/rspack/scripts/check-documentation-coverage.ts
@@ -114,13 +114,19 @@ function checkPluginsDocumentationCoverage() {
     'RslibPlugin', // This plugin is not stable yet
   ];
 
+  const removedPlugins = [
+    'EsmLibraryPlugin', // This plugin has already been removed
+  ];
+
   const undocumentedPlugins = Array.from(implementedPlugins).filter(
     (plugin) =>
       !documentedPlugins.has(plugin) &&
       !excludedPlugins.includes(plugin as string),
   );
   const unimplementedPlugins = Array.from(documentedPlugins).filter(
-    (plugin) => !implementedPlugins.has(plugin),
+    (plugin) =>
+      !implementedPlugins.has(plugin) &&
+      !removedPlugins.includes(plugin as string),
   );
 
   if (undocumentedPlugins.length) {

--- a/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
@@ -75,7 +75,6 @@ function checkConfig(config: RspackOptionsNormalized): string | undefined {
   }
 
   if (config.output.chunkFormat !== false) {
-    console.log(config.output.chunkFormat);
     return 'You should disable default chunkFormat by `config.output.chunkFormat = false`';
   }
 }

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -110,6 +110,7 @@ export type LibraryExport = string | string[];
 export type LibraryType = LiteralUnion<
   | 'var'
   | 'module'
+  | 'modern-module'
   | 'assign'
   | 'assign-properties'
   | 'this'

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -133,7 +133,6 @@ export { LoaderTargetPlugin } from './lib/LoaderTargetPlugin';
 export type { OutputFileSystem, WatchFileSystem } from './util/fs';
 
 import {
-  EsmLibraryPlugin,
   FetchCompileAsyncWasmPlugin,
   lazyCompilationMiddleware,
   SubresourceIntegrityPlugin,
@@ -373,7 +372,6 @@ interface Experiments {
     cleanup: () => Promise<void>;
   };
   RemoveDuplicateModulesPlugin: typeof RemoveDuplicateModulesPlugin;
-  EsmLibraryPlugin: typeof EsmLibraryPlugin;
   RsdoctorPlugin: typeof RsdoctorPlugin;
   RstestPlugin: typeof RstestPlugin;
   RslibPlugin: typeof RslibPlugin;
@@ -409,7 +407,6 @@ export const experiments: Experiments = {
     },
   },
   RemoveDuplicateModulesPlugin,
-  EsmLibraryPlugin,
   /**
    * Note: This plugin is unstable yet
    *

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -295,7 +295,7 @@ export class RspackOptionsApply {
         }
       }
 
-      if (options.output.library?.preserveModules && modernModuleCount > 0) {
+      if (options.output.library?.preserveModules && modernModuleCount === 0) {
         throw new Error(
           'preserveModules only works for `modern-module` library type',
         );

--- a/tests/rspack-test/configCases/rslib/react-directives/rspack.config.js
+++ b/tests/rspack-test/configCases/rslib/react-directives/rspack.config.js
@@ -1,5 +1,5 @@
 const {
-	experiments: { RslibPlugin, EsmLibraryPlugin }
+	experiments: { RslibPlugin }
 } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
@@ -63,7 +63,7 @@ module.exports = [
 				type: "modern-module"
 			}
 		},
-		plugins: [new RslibPlugin(), new EsmLibraryPlugin()]
+		plugins: [new RslibPlugin()]
 	},
 	// Test entry
 	{

--- a/tests/rspack-test/esmOutputCases/invalid-config/chunk-loading/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/invalid-config/chunk-loading/rspack.config.js
@@ -1,9 +1,6 @@
 module.exports = {
 	output: {
 		chunkLoading: 'jsonp',
-		library: {
-			type: 'commonjs'
-		},
 	},
 	optimization: {
 		concatenateModules: true,

--- a/tests/rspack-test/esmOutputCases/preserve-modules/basic/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/basic/rspack.config.js
@@ -1,4 +1,11 @@
-/**@type {import('rspack').Configuration} */
+const path = require('path')
+/**@type {import('@rspack/core').Configuration} */
 module.exports = {
 	entry: './src/index.js',
+	output: {
+		library: {
+			type: "modern-module",
+			preserveModules: path.resolve(__dirname, 'src'),
+		}
+	}
 }

--- a/tests/rspack-test/esmOutputCases/preserve-modules/basic/test.config.js
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/basic/test.config.js
@@ -1,10 +1,5 @@
-const path = require('path')
-
 module.exports = {
 	findBundle() {
 		return ['index.mjs']
-	},
-	esmLibPluginOptions: {
-		preserveModules: path.resolve(__dirname, 'src'),
 	},
 }

--- a/tests/rspack-test/esmOutputCases/preserve-modules/conflict-symbol/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/conflict-symbol/rspack.config.js
@@ -1,4 +1,11 @@
+const path = require('path')
 /**@type {import('rspack').Configuration} */
 module.exports = {
 	entry: './src/index.js',
+	output: {
+		library: {
+			type: "modern-module",
+			preserveModules: path.resolve(__dirname, 'src'),
+		}
+	}
 }

--- a/tests/rspack-test/esmOutputCases/preserve-modules/conflict-symbol/test.config.js
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/conflict-symbol/test.config.js
@@ -1,10 +1,5 @@
-const path = require('path')
-
 module.exports = {
 	findBundle() {
 		return ['index.mjs']
-	},
-	esmLibPluginOptions: {
-		preserveModules: path.resolve(__dirname, 'src'),
 	},
 }

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1097,8 +1097,6 @@ export default {
 
 Output ES modules.
 
-However this feature is still experimental and not fully supported yet, so make sure to enable [`experiments.outputModule`](/config/experiments#experimentsoutputmodule) beforehand. In addition, you can track the development progress in [this thread](https://github.com/webpack/webpack/issues/2933#issuecomment-774253975).
-
 ##### type: 'modern-module'
 
 ```js title="rspack.config.mjs"
@@ -1116,7 +1114,7 @@ export default {
 };
 ```
 
-This configuration generates tree-shakable output for ES Modules.
+This configuration generates tree-shakable and code-splitting available output for ES Modules.
 
 However this feature is still experimental and not fully supported yet, so make sure to enable [`experiments.outputModule`](/config/experiments#experimentsoutputmodule) beforehand.
 

--- a/website/docs/en/guide/features/esm.mdx
+++ b/website/docs/en/guide/features/esm.mdx
@@ -91,7 +91,6 @@ Below are the main configuration options related to ESM and their descriptions, 
 3. [output.library.type](/config/output#outputlibrarytype): Set to `'modern-module'` for additional optimization of library ESM output format.
 4. [output.chunkLoading](/config/output#outputchunkloading): Set to `'import'` to use ESM `import` for loading chunks.
 5. [output.workerChunkLoading](/config/output#outputworkerchunkloading): Set to `'import'` to use ESM `import` for loading workers.
-6. [optimization.concatenateModules](/config/optimization#optimizationconcatenatemodules): modern-module depends on this option being enabled to ensure the output supports good tree-shaking and correct library exports.
-7. [optimization.avoidEntryIife](/config/optimization#optimizationavoidentryiife): In some cases, Rspack wraps ESM output in an IIFE, which breaks ESM's modular characteristics.
-8. [experiments.outputModule](/config/experiments#experimentsoutputmodule): Enable the experimental feature required for output.module.
-9. [HtmlWebpackPlugin.scriptLoading](/guide/tech/html#htmlwebpackplugin): Set to `'module'` to use ESM `<script type="module">` for loading `.mjs` modules.
+6. [optimization.avoidEntryIife](/config/optimization#optimizationavoidentryiife): In some cases, Rspack wraps ESM output in an IIFE, which breaks ESM's modular characteristics.
+7. [experiments.outputModule](/config/experiments#experimentsoutputmodule): Enable the experimental feature required for output.module.
+8. [HtmlWebpackPlugin.scriptLoading](/guide/tech/html#htmlwebpackplugin): Set to `'module'` to use ESM `<script type="module">` for loading `.mjs` modules.

--- a/website/docs/en/plugins/rspack/esm-library-plugin.mdx
+++ b/website/docs/en/plugins/rspack/esm-library-plugin.mdx
@@ -2,13 +2,15 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 
 # EsmLibraryPlugin
 
-<ApiMeta specific={['Rspack']} addedVersion="1.5.6" />
-
-Rspack provides experimental `EsmLibraryPlugin` plugin, provides statically analyzable, cleaner output for ESM library, and also supports code splitting.
+<ApiMeta specific={['Rspack']} addedVersion="1.5.6" removedVersion="2.0.0" />
 
 :::tip
+Since v2.0, this plugin has already bean the implementation for library with type ["modern-module"](/config/output#type-modern-module), you should use config instead of using plugin directly.
+
 🚧 This plugin is still work-in-progress, config may change at anytime.
 :::
+
+Rspack provides experimental `EsmLibraryPlugin` plugin, provides statically analyzable, cleaner output for ESM library, and also supports code splitting.
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1089,8 +1089,6 @@ export default {
 
 输出 ESM 模块。
 
-但这个特性仍然是实验性的，还没有完全支持，所以在使用之前确保启用了 [`experiments.outputModule`](/config/experiments#experimentsoutputmodule)。此外，你可以在这个 [issue](https://github.com/webpack/webpack/issues/2933#issuecomment-774253975) 中跟踪开发进度。
-
 ##### type: 'modern-module'
 
 ```js title="rspack.config.mjs"
@@ -1108,7 +1106,7 @@ export default {
 };
 ```
 
-这项配置将生成支持 tree-shaking 的 ES 模块输出。
+这项配置将生成支持 tree-shaking 和 code-splitting 的 ES 模块输出。
 
 但这个特性仍然是实验性的，还没有完全支持，所以在使用之前确保启用了 [`experiments.outputModule`](/config/experiments#experimentsoutputmodule)。
 

--- a/website/docs/zh/guide/features/esm.mdx
+++ b/website/docs/zh/guide/features/esm.mdx
@@ -91,7 +91,6 @@ export default {
 3. [output.library.type](/config/output#outputlibrarytype): 设置为 `'modern-module'`，表示对库的 ESM 产物格式进行额外的优化。
 4. [output.chunkLoading](/config/output#outputchunkloading): 设置为 `'import'`，表示使用 ESM 的 `import` 来加载 chunk。
 5. [output.workerChunkLoading](/config/output#outputworkerchunkloading): 设置为 `'import'`，表示使用 ESM 的 `import` 来加载 worker
-6. [optimization.concatenateModules](/config/optimization#optimizationconcatenatemodules): modern-module 依赖此选项的开启来保证输出的产物支持良好的 tree-shaking 和库的正确导出
-7. [optimization.avoidEntryIife](/config/optimization#optimizationavoidentryiife): 在某些情况下，Rspack 会将 ESM 产物的输出包裹在一个 IIFE 中，这会破坏 ESM 的模块化特性
-8. [experiments.outputModule](/config/experiments#experimentsoutputmodule): 开启 output.module 所需的前置实验特性
-9. [HtmlWebpackPlugin.scriptLoading](/guide/tech/html#htmlwebpackplugin): 设置为 `'module'`，表示使用 ESM 的 `<script type="module">` 来加载 `.mjs` 模块。
+6. [optimization.avoidEntryIife](/config/optimization#optimizationavoidentryiife): 在某些情况下，Rspack 会将 ESM 产物的输出包裹在一个 IIFE 中，这会破坏 ESM 的模块化特性
+7. [experiments.outputModule](/config/experiments#experimentsoutputmodule): 开启 output.module 所需的前置实验特性
+8. [HtmlWebpackPlugin.scriptLoading](/guide/tech/html#htmlwebpackplugin): 设置为 `'module'`，表示使用 ESM 的 `<script type="module">` 来加载 `.mjs` 模块。

--- a/website/docs/zh/plugins/rspack/esm-library-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/esm-library-plugin.mdx
@@ -2,13 +2,14 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 
 # EsmLibraryPlugin
 
-<ApiMeta specific={['Rspack']} addedVersion="1.5.6" />
-
-Rspack 提供实验性的 `EsmLibraryPlugin` 插件，用于生成静态可分析，支持 Code Splitting 并且更加美观干净的 ESM 库产物。
+<ApiMeta specific={['Rspack']} addedVersion="1.5.6" removedVersion="2.0.0" />
 
 :::tip
+该插件在 2.0 版本后已经是 ["modern-module"](/config/output#type-modern-module) 的底层实现，请使用配置开启。
 🚧 该插件仍在开发中，配置可能随时变动。
 :::
+
+Rspack 提供实验性的 `EsmLibraryPlugin` 插件，用于生成静态可分析，支持 Code Splitting 并且更加美观干净的 ESM 库产物。
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';


### PR DESCRIPTION
## Summary

Since v2.0, the EsmLibraryPlugin has already been used as the implementation of `modern-module`, we shouldn't expose this plugin directly to the user but use config instead

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
