### PR TITLE
feat: keep unknown import.meta properties

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2388,7 +2388,7 @@ export interface RawJavascriptParserOptions {
   reexportExportsPresence?: string
   worker?: Array<string>
   overrideStrict?: string
-  importMeta?: boolean
+  importMeta?: string
   /**
    * This option is experimental in Rspack only and subject to change or be removed anytime.
    * @experimental

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -43,14 +43,15 @@ use rspack_core::{
   CssExportsConvention, CssGeneratorOptions, CssModuleGeneratorOptions, CssModuleParserOptions,
   CssParserImport, CssParserOptions, DynamicImportMode, EntryDescription, EntryOptions,
   EntryRuntime, Environment, Experiments, ExternalItem, ExternalType, Filename, GeneratorOptions,
-  GeneratorOptionsMap, JavascriptParserCommonjsExportsOption, JavascriptParserCommonjsOptions,
-  JavascriptParserOptions, JavascriptParserOrder, JavascriptParserUrl, JsonGeneratorOptions,
-  JsonParserOptions, LibraryName, LibraryNonUmdObject, LibraryOptions, LibraryType,
-  MangleExportsOption, Mode, ModuleNoParseRules, ModuleOptions, ModuleRule, ModuleRuleEffect,
-  ModuleType, NodeDirnameOption, NodeFilenameOption, NodeGlobalOption, NodeOption, Optimization,
-  OutputOptions, ParseOption, ParserOptions, ParserOptionsMap, PathInfo, PublicPath, Resolve,
-  RuleSetCondition, RuleSetLogicalConditions, SideEffectOption, StatsOptions, TrustedTypes,
-  UsedExportsOption, WasmLoading, WasmLoadingType, incremental::IncrementalOptions,
+  GeneratorOptionsMap, ImportMeta, JavascriptParserCommonjsExportsOption,
+  JavascriptParserCommonjsOptions, JavascriptParserOptions, JavascriptParserOrder,
+  JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions, LibraryName, LibraryNonUmdObject,
+  LibraryOptions, LibraryType, MangleExportsOption, Mode, ModuleNoParseRules, ModuleOptions,
+  ModuleRule, ModuleRuleEffect, ModuleType, NodeDirnameOption, NodeFilenameOption,
+  NodeGlobalOption, NodeOption, Optimization, OutputOptions, ParseOption, ParserOptions,
+  ParserOptionsMap, PathInfo, PublicPath, Resolve, RuleSetCondition, RuleSetLogicalConditions,
+  SideEffectOption, StatsOptions, TrustedTypes, UsedExportsOption, WasmLoading, WasmLoadingType,
+  incremental::IncrementalOptions,
 };
 use rspack_error::{Error, Result};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
@@ -1702,7 +1703,13 @@ impl ModuleOptionsBuilder {
           wrapped_context_critical: Some(false),
           wrapped_context_reg_exp: Some(RspackRegex::new(".*").expect("should initialize `Regex`")),
           worker: Some(vec!["...".to_string()]),
-          import_meta: Some(true),
+          import_meta: target_properties.module.map(|val| {
+            if val {
+              ImportMeta::PreserveUnknown
+            } else {
+              ImportMeta::Enabled
+            }
+          }),
           require_alias: Some(false),
           require_as_expression: Some(true),
           require_dynamic: Some(true),

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1654,7 +1654,7 @@ CompilerOptions {
                             ),
                             override_strict: None,
                             import_meta: Some(
-                                true,
+                                Auto,
                             ),
                             require_alias: Some(
                                 false,

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1654,7 +1654,7 @@ CompilerOptions {
                             ),
                             override_strict: None,
                             import_meta: Some(
-                                Auto,
+                                Enabled,
                             ),
                             require_alias: Some(
                                 false,

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -19,7 +19,7 @@ use rspack_core::{
   CssAutoGeneratorOptions, CssAutoParserOptions, CssGeneratorOptions, CssModuleGeneratorOptions,
   CssModuleParserOptions, CssParserImport, CssParserImportContext, CssParserOptions,
   DescriptionData, DynamicImportFetchPriority, DynamicImportMode, ExportPresenceMode, FuncUseCtx,
-  GeneratorOptions, GeneratorOptionsMap, JavascriptParserCommonjsExportsOption,
+  GeneratorOptions, GeneratorOptionsMap, ImportMeta, JavascriptParserCommonjsExportsOption,
   JavascriptParserCommonjsOptions, JavascriptParserOptions, JavascriptParserOrder,
   JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions, ModuleNoParseRule,
   ModuleNoParseRules, ModuleNoParseTestFn, ModuleOptions, ModuleRule, ModuleRuleEffect,
@@ -287,7 +287,7 @@ pub struct RawJavascriptParserOptions {
   pub reexport_exports_presence: Option<String>,
   pub worker: Option<Vec<String>>,
   pub override_strict: Option<String>,
-  pub import_meta: Option<bool>,
+  pub import_meta: Option<String>,
   /// This option is experimental in Rspack only and subject to change or be removed anytime.
   /// @experimental
   pub require_alias: Option<bool>,
@@ -365,7 +365,7 @@ impl From<RawJavascriptParserOptions> for JavascriptParserOptions {
       override_strict: value
         .override_strict
         .map(|e| OverrideStrict::from(e.as_str())),
-      import_meta: value.import_meta,
+      import_meta: value.import_meta.map(|e| ImportMeta::from(e.as_str())),
       require_alias: value.require_alias,
       require_as_expression: value.require_as_expression,
       require_dynamic: value.require_dynamic,

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -282,6 +282,24 @@ impl From<&str> for OverrideStrict {
 }
 
 #[cacheable]
+#[derive(Debug, Clone, Copy, MergeFrom)]
+pub enum ImportMeta {
+  PreserveUnknown,
+  Enabled,
+  Disabled,
+}
+
+impl From<&str> for ImportMeta {
+  fn from(value: &str) -> Self {
+    match value {
+      "preserve-unknown" => Self::PreserveUnknown,
+      "false" => Self::Disabled,
+      _ => Self::Enabled,
+    }
+  }
+}
+
+#[cacheable]
 #[derive(Debug, Clone, MergeFrom, Default)]
 pub struct JavascriptParserOptions {
   pub dynamic_import_mode: Option<DynamicImportMode>,
@@ -299,7 +317,7 @@ pub struct JavascriptParserOptions {
   pub type_reexports_presence: Option<TypeReexportPresenceMode>,
   pub worker: Option<Vec<String>>,
   pub override_strict: Option<OverrideStrict>,
-  pub import_meta: Option<bool>,
+  pub import_meta: Option<ImportMeta>,
   pub require_alias: Option<bool>,
   pub require_as_expression: Option<bool>,
   pub require_dynamic: Option<bool>,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use rspack_core::{ConstDependency, DependencyRange, property_access};
+use rspack_core::{ConstDependency, DependencyRange, ImportMeta, property_access};
 use rspack_error::{Error, Severity};
 use rspack_util::SpanExt;
 use swc_core::{
@@ -18,7 +18,7 @@ use crate::{
   },
 };
 
-pub struct ImportMetaPlugin;
+pub struct ImportMetaPlugin(pub(crate) ImportMeta);
 
 impl ImportMetaPlugin {
   fn import_meta_url(&self, parser: &JavascriptParser) -> String {
@@ -32,11 +32,15 @@ impl ImportMetaPlugin {
   }
 
   fn import_meta_unknown_property(&self, members: &Vec<String>) -> String {
-    format!(
-      r#"/* unsupported import.meta.{} */ undefined{}"#,
-      members.join("."),
-      property_access(members, 1)
-    )
+    if matches!(self.0, ImportMeta::PreserveUnknown) {
+      format!("import.meta{}", property_access(members, 0))
+    } else {
+      format!(
+        r#"/* unsupported import.meta.{} */ undefined{}"#,
+        members.join("."),
+        property_access(members, 1)
+      )
+    }
   }
 
   fn process_import_meta_resolve(
@@ -339,6 +343,9 @@ impl JavascriptParserPlugin for ImportMetaPlugin {
     match root_info {
       ExportedVariableInfo::Name(root) => {
         if root == expr_name::IMPORT_META {
+          if matches!(self.0, ImportMeta::PreserveUnknown) {
+            return Some(true);
+          }
           let members = parser
             .get_member_expression_info(ExprRef::Member(expr), AllowedMemberTypes::Expression)
             .and_then(|info| match info {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  CachedConstDependency, ConstDependency, NodeDirnameOption, NodeFilenameOption, NodeGlobalOption,
-  RuntimeGlobals, RuntimeRequirementsDependency, get_context, parse_resource,
+  CachedConstDependency, ConstDependency, ImportMeta, NodeDirnameOption, NodeFilenameOption,
+  NodeGlobalOption, RuntimeGlobals, RuntimeRequirementsDependency, get_context, parse_resource,
 };
 use rspack_error::{Diagnostic, cyan, yellow};
 use rspack_util::SpanExt;
@@ -589,7 +589,10 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
           return None;
         }
         // Skip if importMeta is disabled
-        if parser.javascript_options.import_meta == Some(false) {
+        if matches!(
+          parser.javascript_options.import_meta,
+          Some(ImportMeta::Disabled)
+        ) {
           return None;
         }
         // Skip if node: false or node.filename is disabled
@@ -625,7 +628,10 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
           return None;
         }
         // Skip if importMeta is disabled
-        if parser.javascript_options.import_meta == Some(false) {
+        if matches!(
+          parser.javascript_options.import_meta,
+          Some(ImportMeta::Disabled)
+        ) {
           return None;
         }
         // Skip if node: false or node.dirname is disabled
@@ -660,7 +666,10 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
     match for_name {
       expr_name::IMPORT_META_FILENAME => {
         // Skip processing if importMeta is disabled
-        if parser.javascript_options.import_meta == Some(false) {
+        if matches!(
+          parser.javascript_options.import_meta,
+          Some(ImportMeta::Disabled)
+        ) {
           return None;
         }
         // Skip processing if node: false or node.filename is disabled
@@ -681,7 +690,10 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
       }
       expr_name::IMPORT_META_DIRNAME => {
         // Skip processing if importMeta is disabled
-        if parser.javascript_options.import_meta == Some(false) {
+        if matches!(
+          parser.javascript_options.import_meta,
+          Some(ImportMeta::Disabled)
+        ) {
           return None;
         }
         // Skip processing if node: false or node.dirname is disabled
@@ -762,7 +774,10 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
         return None;
       }
       // Skip processing if importMeta is disabled
-      if parser.javascript_options.import_meta == Some(false) {
+      if matches!(
+        parser.javascript_options.import_meta,
+        Some(ImportMeta::Disabled)
+      ) {
         return None;
       }
       let property = if for_name == expr_name::IMPORT_META_FILENAME {
@@ -797,7 +812,10 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
     };
 
     // Skip processing if importMeta is disabled
-    if parser.javascript_options.import_meta == Some(false) {
+    if matches!(
+      parser.javascript_options.import_meta,
+      Some(ImportMeta::Disabled)
+    ) {
       return None;
     }
 
@@ -820,7 +838,10 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
     }
 
     // Skip processing if importMeta is disabled
-    if parser.javascript_options.import_meta == Some(false) {
+    if matches!(
+      parser.javascript_options.import_meta,
+      Some(ImportMeta::Disabled)
+    ) {
       return None;
     }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -22,7 +22,7 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
-  CompilerOptions, DependencyLocation, DependencyRange, FactoryMeta,
+  CompilerOptions, DependencyLocation, DependencyRange, FactoryMeta, ImportMeta,
   JavascriptParserCommonjsExportsOption, JavascriptParserOptions, ModuleIdentifier, ModuleLayer,
   ModuleType, ParseMeta, ResourceData, SideEffectsBailoutItemWithSpan,
 };
@@ -417,8 +417,12 @@ impl<'parser> JavascriptParser<'parser> {
       plugins.push(Box::new(
         parser_plugin::ImportMetaContextDependencyParserPlugin,
       ));
-      if let Some(true) = javascript_options.import_meta {
-        plugins.push(Box::new(parser_plugin::ImportMetaPlugin));
+      if matches!(javascript_options.import_meta, Some(ImportMeta::Enabled) | Some(ImportMeta::PreserveUnknown)) {
+        plugins.push(Box::new(parser_plugin::ImportMetaPlugin(
+          javascript_options
+            .import_meta
+            .expect("should have value"),
+        )));
       } else {
         plugins.push(Box::new(parser_plugin::ImportMetaDisabledPlugin));
       }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -417,11 +417,12 @@ impl<'parser> JavascriptParser<'parser> {
       plugins.push(Box::new(
         parser_plugin::ImportMetaContextDependencyParserPlugin,
       ));
-      if matches!(javascript_options.import_meta, Some(ImportMeta::Enabled) | Some(ImportMeta::PreserveUnknown)) {
+      if matches!(
+        javascript_options.import_meta,
+        Some(ImportMeta::Enabled | ImportMeta::PreserveUnknown)
+      ) {
         plugins.push(Box::new(parser_plugin::ImportMetaPlugin(
-          javascript_options
-            .import_meta
-            .expect("should have value"),
+          javascript_options.import_meta.expect("should have value"),
         )));
       } else {
         plugins.push(Box::new(parser_plugin::ImportMetaDisabledPlugin));

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -561,7 +561,10 @@ function getRawJavascriptParserOptions(
     dynamicImportPreload: parser.dynamicImportPreload?.toString(),
     dynamicImportPrefetch: parser.dynamicImportPrefetch?.toString(),
     dynamicImportFetchPriority: parser.dynamicImportFetchPriority,
-    importMeta: parser.importMeta,
+    importMeta:
+      typeof parser.importMeta === 'boolean'
+        ? String(parser.importMeta)
+        : parser.importMeta,
     url: parser.url?.toString(),
     exprContextCritical: parser.exprContextCritical,
     unknownContextCritical: parser.unknownContextCritical,

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -112,6 +112,7 @@ export const applyRspackOptionsDefaults = (
     mode: options.mode,
     uniqueName: options.output.uniqueName,
     deferImport: options.experiments.deferImport,
+    outputModule: options.output.module,
   });
 
   applyOutputDefaults(options, {
@@ -255,7 +256,13 @@ const applySnapshotDefaults = (
 
 const applyJavascriptParserOptionsDefaults = (
   parserOptions: JavascriptParserOptions,
-  { deferImport }: { deferImport?: boolean },
+  {
+    deferImport,
+    outputModule,
+  }: {
+    deferImport?: boolean;
+    outputModule: RspackOptionsNormalized['output']['module'];
+  },
 ) => {
   D(parserOptions, 'dynamicImportMode', 'lazy');
   D(parserOptions, 'dynamicImportPrefetch', false);
@@ -273,7 +280,7 @@ const applyJavascriptParserOptionsDefaults = (
   D(parserOptions, 'commonjs', true);
   D(parserOptions, 'importDynamic', true);
   D(parserOptions, 'worker', ['...']);
-  D(parserOptions, 'importMeta', true);
+  D(parserOptions, 'importMeta', outputModule ? 'preserve-unknown' : true);
   D(parserOptions, 'typeReexportsPresence', 'no-tolerant');
   D(parserOptions, 'jsx', false);
   D(parserOptions, 'deferImport', deferImport);
@@ -305,12 +312,14 @@ const applyModuleDefaults = (
     mode,
     uniqueName,
     deferImport,
+    outputModule,
   }: {
     asyncWebAssembly: boolean;
     targetProperties: false | TargetProperties;
     mode?: Mode;
     uniqueName?: string;
     deferImport?: boolean;
+    outputModule: RspackOptionsNormalized['output']['module'];
   },
 ) => {
   assertNotNill(module.parser);
@@ -328,6 +337,7 @@ const applyModuleDefaults = (
   assertNotNill(module.parser.javascript);
   applyJavascriptParserOptionsDefaults(module.parser.javascript, {
     deferImport,
+    outputModule,
   });
 
   F(module.parser, JSON_MODULE_TYPE, () => ({}));

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1113,10 +1113,10 @@ export type JavascriptParserOptions = {
   dynamicImportFetchPriority?: 'low' | 'high' | 'auto';
 
   /**
-   * Enable or disable evaluating import.meta.
-   * @default true
+   * Enable or disable evaluating import.meta. Set to 'preserve-unknown' to preserve unknown properties for runtime evaluation.
+   * @default 'preserve-unknown'
    */
-  importMeta?: boolean;
+  importMeta?: boolean | 'preserve-unknown';
 
   /**
    * Enable parsing of new URL() syntax.

--- a/tests/rspack-test/configCases/module/import-meta/index.js
+++ b/tests/rspack-test/configCases/module/import-meta/index.js
@@ -1,0 +1,41 @@
+if (!import.meta.UNKNOWN_PROPERTY) {
+  // runtime assignment
+  import.meta.UNKNOWN_PROPERTY = "HELLO";
+}
+
+const { pathToFileURL } = require("url");
+const url = pathToFileURL(
+  require("path").resolve("./configCases/module/import-meta/index.js")
+).toString();
+
+it("should keep import.meta.UNKNOWN_PROPERTY", () => {
+  try {
+    const UNKNOWN_PROPERTY = import.meta.UNKNOWN_PROPERTY;
+    expect(UNKNOWN_PROPERTY).toBe("HELLO");
+    expect(typeof import.meta.UNKNOWN_PROPERTY).toBe("string");
+
+    expect(typeof import.meta.webpack).toBe("number");
+
+    const { UNKNOWN_PROPERTY: UNKNOWN_PROPERTY_2, webpack: WEBPACK_PROPERTY_2 } = import.meta;
+    expect(UNKNOWN_PROPERTY_2).toBe("HELLO");
+    expect(typeof WEBPACK_PROPERTY_2).toBe("number");
+  } catch (_e) {
+    // ignore
+  }
+});
+
+it("should support destructuring assignment", async () => {
+  let version, url2, c, unknown;
+  ({ webpack: version } = { url: url2 } = { c } = { UNKNOWN_PROPERTY: unknown } = import.meta);
+  expect(version).toBeTypeOf("number");
+  expect(url2).toBe(url);
+  expect(c).toBe(undefined);
+  expect(unknown).toBe("HELLO");
+
+  let version2, url3, d, unknown2;
+  ({ webpack: version2 } = await ({ url: url3 } = ({ d } = { UNKNOWN_PROPERTY: unknown2 } = await import.meta)));
+  expect(version2).toBeTypeOf("number");
+  expect(url3).toBe(url);
+  expect(d).toBe(undefined);
+  expect(unknown2).toBe("HELLO");
+});

--- a/tests/rspack-test/configCases/module/import-meta/rspack.config.js
+++ b/tests/rspack-test/configCases/module/import-meta/rspack.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+  experiments: {
+    outputModule: true
+  },
+  output: {
+    module: true,
+    chunkFormat: "module"
+  }
+};

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -1215,9 +1215,18 @@ export default {
 
 <ApiMeta addedVersion="1.0.0-alpha.6" />
 
-<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+<PropertyType
+  type="boolean | 'preserve-unknown'"
+  defaultValueList={[{ defaultValue: 'true' }]}
+/>
 
 Enable or disable evaluating `import.meta`.
+
+When using [ESM output](/guide/features/esm), default value is set to `'preserve-unknown'`, otherwise `true`.
+
+- `"preserve-unknown"`: Unknown `import.meta` properties are determined at runtime instead of being statically analyzed at compile time.
+- `true`: All `import.meta` properties are statically analyzed at compile time.
+- `false`: All `import.meta` properties are determined at runtime
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -1224,9 +1224,9 @@ Enable or disable evaluating `import.meta`.
 
 When using [ESM output](/guide/features/esm), default value is set to `'preserve-unknown'`, otherwise `true`.
 
-- `"preserve-unknown"`: Unknown `import.meta` properties are determined at runtime instead of being statically analyzed at compile time.
-- `true`: All `import.meta` properties are statically analyzed at compile time.
-- `false`: All `import.meta` properties are determined at runtime
+- `"preserve-unknown"`: [Known `import.meta` properties](/api/runtime-api/module-variables#importmeta-esm) are statically analyzed at compile-time, other properties are preserved and evaluated at runtime.
+- `true`: All `import.meta` properties are statically analyzed at compile-time.
+- `false`: All `import.meta` properties are evaluated at runtime.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -1212,9 +1212,17 @@ export default {
 
 <ApiMeta addedVersion="1.0.0-alpha.6" />
 
-<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+<PropertyType
+  type="boolean | 'preserve-unknown'"
+  defaultValueList={[{ defaultValue: 'true' }]}
+/>
 
 是否要解析替换 `import.meta`。
+当输出是[ESM 格式产物](/zh/guide/features/esm)的时候，默认值为`'preserve-unknown'`，其他情况默认值为`true`。
+
+- `"preserve-unknown"`: 未知的 `import.meta` 字段会在运行时被计算，而不是编译期被替换。
+- `true`: 所有`import.meta`字段在编译期被替换。
+- `false`: 所有`import.meta`字段都不会被替换。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -1218,7 +1218,8 @@ export default {
 />
 
 是否要解析替换 `import.meta`。
-当输出是[ESM 格式产物](/zh/guide/features/esm)的时候，默认值为`'preserve-unknown'`，其他情况默认值为`true`。
+
+当输出为 [ESM 格式](/guide/features/esm) 时，默认值为 `'preserve-unknown'`，其他情况默认值为 `true`。
 
 - `"preserve-unknown"`: 未知的 `import.meta` 字段会在运行时被计算，而不是编译期被替换。
 - `true`: 所有`import.meta`字段在编译期被替换。

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -1219,11 +1219,11 @@ export default {
 
 是否要解析替换 `import.meta`。
 
-当输出为 [ESM 格式](/guide/features/esm) 时，默认值为 `'preserve-unknown'`，其他情况默认值为 `true`。
+当输出为[ESM 格式](/guide/features/esm)时，默认值为`'preserve-unknown'`，其他情况默认值为`true`。
 
-- `"preserve-unknown"`: 未知的 `import.meta` 字段会在运行时被计算，而不是编译期被替换。
+- `"preserve-unknown"`: [已知的`import.meta`字段](/api/runtime-api/module-variables#importmeta-esm)会在编译期被替换，其他字段会被保留并在运行时被计算。
 - `true`: 所有`import.meta`字段在编译期被替换。
-- `false`: 所有`import.meta`字段都不会被替换。
+- `false`: 所有`import.meta`字段都在运行时被计算。
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

Unknown import.meta properties are now determined at runtime instead of being statically analyzed at compile time.

## Related links

https://github.com/webpack/webpack/pull/20312

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
