### PR TITLE
fix: handle `rs.requireActual` and `rs.importActual` in all contexts

### DIFF
--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -593,15 +593,7 @@ impl RstestParserPlugin {
         );
         Some(false)
       }
-      // rs.importActual
-      ("rs", "importActual") | ("rstest", "importActual") => {
-        self.process_import_actual(parser, call_expr)
-      }
-      // rs.requireActual
-      ("rs", "requireActual") | ("rstest", "requireActual") => {
-        self.process_require_actual(parser, call_expr);
-        Some(false)
-      }
+      // rs.importActual and rs.requireActual are handled by call_member_chain hook
       // rs.importMock
       ("rs", "importMock") | ("rstest", "importMock") => self.load_mock(parser, call_expr, true),
       // rs.requireMock
@@ -706,6 +698,30 @@ impl JavascriptParserPlugin for RstestParserPlugin {
       }
     }
 
+    None
+  }
+
+  fn call_member_chain(
+    &self,
+    parser: &mut JavascriptParser,
+    call_expr: &CallExpr,
+    for_name: &str,
+    members: &[Atom],
+    _members_optionals: &[bool],
+    _member_ranges: &[Span],
+  ) -> Option<bool> {
+    // Handle rs.requireActual and rs.importActual calls in any context
+    if (for_name == "rs" || for_name == "rstest") && members.len() == 1 {
+      match members[0].as_str() {
+        "requireActual" => {
+          return self.process_require_actual(parser, call_expr);
+        }
+        "importActual" => {
+          return self.process_import_actual(parser, call_expr);
+        }
+        _ => {}
+      }
+    }
     None
   }
 

--- a/tests/rspack-test/configCases/rstest/mock/importActual.js
+++ b/tests/rspack-test/configCases/rstest/mock/importActual.js
@@ -2,8 +2,11 @@ import { foo } from './src/barrel'
 
 rstest.mock('./src/foo')
 
+const getActual = () => rstest.importActual('./src/foo');
+
 it('importActual should works', async () => {
 	expect(foo).toBe('mocked_foo')
 	const originalFoo = await rstest.importActual('./src/foo')
 	expect(originalFoo.value).toBe('foo')
+	expect((await getActual()).value).toBe('foo')
 })

--- a/tests/rspack-test/configCases/rstest/mock/requireActual.js
+++ b/tests/rspack-test/configCases/rstest/mock/requireActual.js
@@ -2,8 +2,11 @@ const { foo } = require('./src/barrel');
 
 rs.mockRequire('./src/foo')
 
+const getActual = () => rs.requireActual('./src/foo');
+
 it('requireActual should works', async () => {
 	expect(foo).toBe('mocked_foo')
 	const originalFoo = rs.requireActual('./src/foo')
 	expect(originalFoo.value).toBe('foo')
+	expect(getActual().value).toBe('foo')
 })


### PR DESCRIPTION
## Summary

Previously, `rs.requireActual` and `rs.importActual` were only processed when used in direct variable declarations or expression statements. This caused issues when calling these methods inside arrow functions or other nested contexts.

Added `call_member_chain` hook to properly handle these methods in any context, and removed duplicate handling from `handle_rstest_method_call` to avoid double-processing.

```ts
const getActual = () => rs.requireActual('./src/foo');

it('requireActual should works', async () => {
	expect(getActual().value).toBe('foo')
})
```
<!-- Describe what this PR does and why. -->

## Related links

fix: https://github.com/web-infra-dev/rstest/issues/785
<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
