### PR TITLE
fix(mf): filter runtime plugin invocation for used exports

### DIFF
--- a/packages/rspack/src/container/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/container/ModuleFederationPlugin.ts
@@ -349,7 +349,9 @@ function getDefaultEntryRuntime(
     );
     const paramsCode =
       pluginParams === undefined ? 'undefined' : JSON.stringify(pluginParams);
-    runtimePluginVars.push(`${runtimePluginVar}(${paramsCode})`);
+    runtimePluginVars.push(
+      `{ plugin: ${runtimePluginVar}, params: ${paramsCode} }`,
+    );
   }
 
   const content = [
@@ -359,7 +361,7 @@ function getDefaultEntryRuntime(
     ...runtimePluginImports,
     `const __module_federation_runtime_plugins__ = [${runtimePluginVars.join(
       ', ',
-    )}]`,
+    )}].filter(({ plugin }) => plugin).map(({ plugin, params }) => plugin(params))`,
     `const __module_federation_remote_infos__ = ${JSON.stringify(remoteInfos)}`,
     `const __module_federation_container_name__ = ${JSON.stringify(
       options.name ?? compiler.options.output.uniqueName,

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-params/index.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-params/index.js
@@ -3,9 +3,9 @@ it("should inject runtime plugin with params", async () => {
 		expect(App()).toBe("App rendered with [This is react 0.2.1]");
 		const runtimePlugin = __webpack_require__.federation.initOptions.plugins[0];
 		expect(runtimePlugin.getParams()).toMatchObject({
-			  'custom-params': {
-						msg: 'custom-params',
-					}
+			'custom-params': {
+				msg: 'custom-params',
+			}
 		});
 	});
 });

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-params/rspack.config.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-params/rspack.config.js
@@ -2,16 +2,12 @@ const { ModuleFederationPlugin } = require("@rspack/core").container;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  output: {
-    filename: "[name].js",
-    uniqueName: "runtime-plugin-with-params"
-  },
   plugins: [
     new ModuleFederationPlugin({
       name: "container-runtime-plugin-with-params",
       filename: "container.js",
       library: { type: "commonjs-module" },
-				shared: {
+      shared: {
 				react: {
 					version: false,
 					requiredVersion: false,

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/bootstrap.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/bootstrap.js
@@ -1,0 +1,26 @@
+import { Worker } from "worker_threads";
+import React from "react";
+
+const msg = 'Hello, Rspack!';
+
+const worker = new Worker(new URL('./worker.js', import.meta.url), {
+	name: 'the-worker',
+});
+
+export function getWorkerMessage() {
+	return new Promise((resolve, reject) => {
+		worker.on('message', (data) => {
+			resolve(data);
+		});
+
+		worker.on('error', (data) => {
+			reject(data);
+		});
+
+		worker.postMessage(msg);
+	});
+}
+
+export function getMessage() {
+	return `App rendered with [${React()}]`;
+}

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/index.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/index.js
@@ -1,0 +1,10 @@
+it("should generate correct worker runtime code with tree shaking and MF runtime plugin", async () => {
+	const { getMessage, getWorkerMessage } = await import('./bootstrap.js');
+	expect(getMessage()).toBe('App rendered with [This is react 0.2.1]');
+
+	const plugins = __webpack_require__.federation.initOptions.plugins;
+	expect(plugins.length).toBeGreaterThan(0);
+	expect(plugins.some(p => p.name === 'my-runtime-plugin')).toBe(true);
+
+	expect(await getWorkerMessage()).toBe('Echo: Hello, Rspack!');
+});

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/node_modules/react.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/node_modules/react.js
@@ -1,0 +1,2 @@
+let version = "0.1.2";
+export default () => `This is react ${version}`;

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/rspack.config.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/rspack.config.js
@@ -1,0 +1,29 @@
+const path = require("path");
+const { ModuleFederationPlugin } = require("@rspack/core").container;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		providedExports: true,
+		usedExports: true,
+	},
+	plugins: [
+		new ModuleFederationPlugin({
+			name: "runtime-plugin-with-used-exports",
+			filename: "container.js",
+			library: { type: "commonjs-module" },
+			shared: {
+				react: {
+					version: false,
+					requiredVersion: false,
+					singleton: true,
+					strictVersion: false,
+					version: "0.1.2"
+				}
+			},
+			runtimePlugins: [
+				path.resolve(__dirname, "runtime-plugin.js")
+			]
+		})
+	]
+};

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/runtime-plugin.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/runtime-plugin.js
@@ -1,0 +1,15 @@
+module.exports = function MyRuntimePlugin() {
+	return {
+		name: 'my-runtime-plugin',
+		resolveShare: function(args) {
+			const { shareScopeMap, scope, pkgName, version, GlobalFederation } = args;
+			args.resolver = function () {
+				shareScopeMap[scope][pkgName][version] = {
+					lib: ()=>()=> 'This is react 0.2.1'
+				};
+				return shareScopeMap[scope][pkgName][version];
+			};
+			return args;
+		}
+	};
+}

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/worker.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/worker.js
@@ -1,0 +1,5 @@
+import { parentPort } from "worker_threads";
+
+parentPort.on("message", (data) => {
+	parentPort.postMessage(`Echo: ${data}`);
+});


### PR DESCRIPTION
## Summary

When usedExports optimization is enabled, runtime plugin imports may be tree-shaken to undefined. This change add a filter for plugins invocation to avoid calling undefined as a function

fix https://github.com/web-infra-dev/rspack/issues/12605
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
