### PR TITLE
fix(mf): async startup e2e test

### DIFF
--- a/tests/e2e/cases/module-federation/async-startup-self-remote-runtimechunk-single/rspack.config.js
+++ b/tests/e2e/cases/module-federation/async-startup-self-remote-runtimechunk-single/rspack.config.js
@@ -13,6 +13,14 @@ module.exports = {
     filename: 'static/js/[name].js',
     chunkFilename: 'static/js/[name].js',
   },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        type: 'javascript/auto',
+      },
+    ],
+  },
   optimization: {
     runtimeChunk: 'single',
     chunkIds: 'named',


### PR DESCRIPTION
## Summary

Workaround for async startup e2e test, need to find a better solution for mf use with `type: "module"`

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
