### PR TITLE
feat: improve external module rendering

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -31,6 +31,7 @@ define_hook!(NormalModuleFactoryCreateModule: SeriesBail(data: &mut ModuleFactor
 define_hook!(NormalModuleFactoryModule: Series(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData, module: &mut BoxModule),tracing=false);
 define_hook!(NormalModuleFactoryParser: Series(module_type: &ModuleType, parser: &mut Box<dyn ParserAndGenerator>, parser_options: Option<&ParserOptions>),tracing=false);
 define_hook!(NormalModuleFactoryResolveLoader: SeriesBail(context: &Context, resolver: &Resolver, l: &ModuleRuleUseLoader) -> BoxLoader,tracing=false);
+define_hook!(NormalModuleFactoryAfterFactorize: Series(data: &mut ModuleFactoryCreateData, module: &mut BoxModule),tracing=false);
 
 pub enum NormalModuleFactoryResolveResult {
   Module(BoxModule),
@@ -53,6 +54,7 @@ pub struct NormalModuleFactoryHooks {
   /// So this hook is used to resolve inline loader (inline loader requests).
   // should move to ResolverFactory?
   pub resolve_loader: NormalModuleFactoryResolveLoaderHook,
+  pub after_factorize: NormalModuleFactoryAfterFactorizeHook,
 }
 
 #[derive(Debug)]
@@ -68,7 +70,16 @@ impl ModuleFactory for NormalModuleFactory {
     if let Some(before_resolve_data) = self.before_resolve(data).await? {
       return Ok(before_resolve_data);
     }
-    let factory_result = self.factorize(data).await?;
+    let mut factory_result = self.factorize(data).await?;
+
+    if let Some(module) = &mut factory_result.module {
+      self
+        .plugin_driver
+        .normal_module_factory_hooks
+        .after_factorize
+        .call(data, module)
+        .await?;
+    }
 
     Ok(factory_result)
   }

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -81,6 +81,27 @@ impl ConcatenationScope {
     raw_export_map.insert(export_name, symbol);
   }
 
+  pub fn register_namespace_import(
+    &mut self,
+    import_source: String,
+    attributes: Option<String>,
+    import_symbol: Atom,
+  ) -> &Atom {
+    let raw_import_map = self.current_module.import_map.get_or_insert_default();
+    let entry = raw_import_map
+      .entry((import_source, attributes))
+      .or_default();
+
+    if entry.namespace.is_none() {
+      entry.namespace = Some(import_symbol)
+    }
+
+    entry
+      .namespace
+      .as_ref()
+      .expect("should have namespace symbol")
+  }
+
   pub fn register_import(
     &mut self,
     import_source: String,
@@ -96,7 +117,7 @@ impl ConcatenationScope {
       return;
     };
 
-    entry.insert(import_symbol);
+    entry.specifiers.insert(import_symbol);
   }
 
   pub fn register_namespace_export(&mut self, symbol: &str) {

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case1.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case1.txt
@@ -1,16 +1,15 @@
+import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
 import * as __rspack_external_external2_alias_e5239a01 from "external2-alias";
 import { __webpack_require__ } from "./runtime~0.mjs";
-import "./906.mjs";
-
 __webpack_require__.add({
 42(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var external1__rspack_import_0 = __webpack_require__(825);
+/* import */ var external1__rspack_import_0 = __webpack_require__(322);
 
 /* reexport */ var __rspack_reexport = {};
 /* reexport */ for( const __rspack_import_key in external1__rspack_import_0) if(__rspack_import_key !== "default") __rspack_reexport[__rspack_import_key] =() => external1__rspack_import_0[__rspack_import_key]
 /* reexport */ __webpack_require__.d(__webpack_exports__, __rspack_reexport);
-/* import */ var external2__rspack_import_1 = __webpack_require__(908);
+/* import */ var external2__rspack_import_1 = __webpack_require__(101);
 
 /* reexport */ var __rspack_reexport = {};
 /* reexport */ for( const __rspack_import_key in external2__rspack_import_1) if(__rspack_import_key !== "default") __rspack_reexport[__rspack_import_key] =() => external2__rspack_import_1[__rspack_import_key]
@@ -20,7 +19,13 @@ __webpack_require__.r(__webpack_exports__);
 
 
 },
-908(module) {
+322(module) {
+
+module.exports = __rspack_external_external1_alias_bc4b12e4;
+
+
+},
+101(module) {
 
 module.exports = __rspack_external_external2_alias_e5239a01;
 

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case2.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case2.txt
@@ -1,14 +1,13 @@
-import { __webpack_require__ } from "./runtime~0.mjs";
-import "./906.mjs";
-
-const external_external1_alias_ = __webpack_require__("825");
-var a = external_external1_alias_.a;
-var b = external_external1_alias_.b;
+import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
 
 
 
 
 
 
-export { a, b, external_external1_alias_ as n1 };
+
+
+var a = __rspack_external_external1_alias_bc4b12e4.a;
+var b = __rspack_external_external1_alias_bc4b12e4.b;
+export { __rspack_external_external1_alias_bc4b12e4 as n1, a, b };
 export * from "external1-alias";

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case3.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case3.txt
@@ -1,4 +1,5 @@
-import "./906.mjs";
+import "external1-alias";
+
 
 
 const foo = 2

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case4.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case4.txt
@@ -1,4 +1,5 @@
-import "./906.mjs";
+import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
+
 
 
 

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case5.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case5.txt
@@ -1,10 +1,9 @@
-import { __webpack_require__ } from "./runtime~0.mjs";
-import "./906.mjs";
-
-const external_external1_alias_ = __webpack_require__("825");
+import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
 
 
-const bar = external_external1_alias_.foo + 1
+
+
+const bar = __rspack_external_external1_alias_bc4b12e4.foo + 1
 
 
 

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case6.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case6.txt
@@ -1,7 +1,6 @@
-import { __webpack_require__ } from "./runtime~0.mjs";
-import "./906.mjs";
+import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
 
-__webpack_require__("825");
+
 
 
 

--- a/tests/rspack-test/configCases/library/modern-module-named-import-externals/rspack.config.js
+++ b/tests/rspack-test/configCases/library/modern-module-named-import-externals/rspack.config.js
@@ -33,11 +33,12 @@ module.exports = {
 				compilation.hooks.processAssets.tap("testcase", assets => {
 					const source = assets["test.js"].source();
 					expect(source).toMatchInlineSnapshot(`
-						import * as __rspack_external_externals3 from "externals3";
 						import { HomeLayout as external_externals0_HomeLayout, a } from "externals0";
 						import { a as external_externals1_a } from "externals1";
 						import externals2 from "externals2";
+						import * as __rspack_external_externals3 from "externals3";
 						import "externals4";
+
 
 
 

--- a/tests/rspack-test/esmOutputCases/externals/aliased/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/aliased/__snapshots__/esm.snap.txt
@@ -2,6 +2,7 @@
 import { createRequire as __rspack_createRequire } from "node:module";
 const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
 import * as __rspack_external_path from "path";
+
 // external
 
 // ./index.js

--- a/tests/rspack-test/esmOutputCases/externals/externals-aliased/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/externals-aliased/__snapshots__/esm.snap.txt
@@ -1,12 +1,14 @@
 ```mjs title=main.mjs
 import { createRequire as __rspack_createRequire } from "node:module";
 const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
-// fs
+// fs?f23b
 
 // ./module.js
 
 
 console.log.bind(console)
+
+// fs?771d
 
 // ./index.js
 

--- a/tests/rspack-test/esmOutputCases/externals/multiple-externals/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/multiple-externals/__snapshots__/esm.snap.txt
@@ -1,0 +1,46 @@
+```mjs title=async_js.mjs
+import * as __rspack_external_fs from "fs";
+
+// fs?3cf4
+
+// ./async.js
+
+
+// access namespace
+console.log.bind(__rspack_external_fs)
+
+
+export { __rspack_external_fs };
+
+```
+
+```mjs title=main.mjs
+import fs, { readFile } from "fs";
+
+// fs?771d
+
+// fs?5ccf
+
+// ./other.js
+
+/* export default */ const other = (fs);
+
+
+// fs?22cf
+
+// ./other2.js
+
+
+// ./index.js
+
+
+
+
+it('should render external correctly', async () => {
+  const {ns} = await import("./async_js.mjs").then((mod) => ({ ns: mod.__rspack_external_fs }))
+
+  expect(fs).toBe(other).toBe(fs).toBe(ns.default)
+  expect(readFile).toBe(readFile).toBe(readFile).toBe(ns.readFile)
+})
+
+```

--- a/tests/rspack-test/esmOutputCases/externals/multiple-externals/async.js
+++ b/tests/rspack-test/esmOutputCases/externals/multiple-externals/async.js
@@ -1,0 +1,6 @@
+import * as ns from 'fs'
+
+// access namespace
+console.log.bind(ns)
+
+export {ns}

--- a/tests/rspack-test/esmOutputCases/externals/multiple-externals/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/multiple-externals/index.js
@@ -1,0 +1,10 @@
+import f1, { readFile } from 'fs'
+import f2, { readFile as readFile2 } from './other'
+import f3, { readFile3 } from './other2'
+
+it('should render external correctly', async () => {
+  const {ns} = await import('./async')
+
+  expect(f1).toBe(f2).toBe(f3).toBe(ns.default)
+  expect(readFile).toBe(readFile2).toBe(readFile3).toBe(ns.readFile)
+})

--- a/tests/rspack-test/esmOutputCases/externals/multiple-externals/other.js
+++ b/tests/rspack-test/esmOutputCases/externals/multiple-externals/other.js
@@ -1,0 +1,3 @@
+import f1, { readFile } from 'fs'
+export default f1
+export {readFile}

--- a/tests/rspack-test/esmOutputCases/externals/multiple-externals/other2.js
+++ b/tests/rspack-test/esmOutputCases/externals/multiple-externals/other2.js
@@ -1,0 +1,1 @@
+export { default as default, readFile as readFile3 } from 'fs'

--- a/tests/rspack-test/esmOutputCases/externals/multiple-externals/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/multiple-externals/rspack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  externals: {
+    "fs": "module-import fs",
+    "node:fs": "module-import fs",
+  }
+}

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-export-external/__snapshots__/esm.snap.txt
@@ -1,6 +1,7 @@
 ```mjs title=main.mjs
-import * as __rspack_external_fs from "fs";
 import { __webpack_require__ } from "./runtime.mjs";
+import * as __rspack_external_fs from "fs";
+
 // NAMESPACE OBJECT: ./externals.js
 var externals_namespaceObject = {};
 __webpack_require__.r(externals_namespaceObject);

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/esm.snap.txt
@@ -12,7 +12,7 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   lib: () => (lib)
 });
-/* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
+/* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs?f137");
 
 /* reexport */ var __rspack_reexport = {};
 /* reexport */ for( const __rspack_import_key in fs__rspack_import_0) if(["default","lib"].indexOf(__rspack_import_key) < 0) __rspack_reexport[__rspack_import_key] =() => fs__rspack_import_0[__rspack_import_key]
@@ -66,7 +66,7 @@ __webpack_require__.d(__webpack_exports__, {
   I: () => (lib_local),
   fs: () => (/* reexport module object */ fs__rspack_import_0)
 });
-/* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
+/* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs?c303");
 const lib3 = 42
 
 const lib_local = 24
@@ -76,7 +76,17 @@ const lib_local = 24
 
 
 },
-"fs"
+"fs?f137"
+/*!*********************!*\
+  !*** external "fs" ***!
+  \*********************/
+(module) {
+
+module.exports = __rspack_external_fs;
+
+
+},
+"fs?c303"
 /*!*********************!*\
   !*** external "fs" ***!
   \*********************/

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-3/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-3/__snapshots__/esm.snap.txt
@@ -1,9 +1,12 @@
 ```mjs title=main.mjs
 import * as __rspack_external_fs from "fs";
 import * as __rspack_external_path from "path";
-// fs
+
+// fs?f137
 
 // path
+
+// fs?c303
 
 // ./lib3.js
 const lib3_lib3 = 42

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-4/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-4/__snapshots__/esm.snap.txt
@@ -1,9 +1,12 @@
 ```mjs title=main.mjs
 import * as __rspack_external_fs from "fs";
 import * as __rspack_external_path from "path";
-// fs
+
+// fs?f137
 
 // path
+
+// fs?c303
 
 // ./lib3.js
 const lib3_lib3 = 42

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-4/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-4/rspack.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-
-}

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-wrapped/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-wrapped/__snapshots__/esm.snap.txt
@@ -1,6 +1,7 @@
 ```mjs title=main.mjs
 import * as __rspack_external_fs from "fs";
 import * as __rspack_external_path from "path";
+
 // fs
 
 // ./lib3.js

--- a/tests/rspack-test/esmOutputCases/re-exports/move-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/move-entry/__snapshots__/esm.snap.txt
@@ -1,5 +1,6 @@
 ```mjs title=lib.mjs
 import * as __rspack_external_fs from "fs";
+
 // fs
 
 // ./lib.js

--- a/tests/rspack-test/esmOutputCases/re-exports/re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/re-export-external/__snapshots__/esm.snap.txt
@@ -1,5 +1,6 @@
 ```mjs title=main.mjs
 import * as __rspack_external_fs from "fs";
+
 // fs
 
 // ./index.js

--- a/tests/rspack-test/esmOutputCases/re-exports/re-export-namespaced-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/re-export-namespaced-external/__snapshots__/esm.snap.txt
@@ -1,5 +1,6 @@
 ```mjs title=main.mjs
 import * as __rspack_external_fs from "fs";
+
 // fs
 
 // ./index.js


### PR DESCRIPTION
## Summary

External module can now be separate from each module. Before one external instance is shared by different modules.

Which means 2 modules can import different members of it, moduleA imports specifierA, and moduleB imports the namespace, if 2 modules are in different chunks, that will make the external module to be extracted in to a single chunk. And because of module B imports namespace, we have to make sure the external module export namespace, and it's hard to optimize it for moduleA.

In this PR, EsmLibraryPlugin will modify external module identifier, which makes each external imported by different modules can have different instances.

The benefit:

1. One module import namespace from external module won't break optimization for other named imports
2. External module no need to be in a single chunk


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
