### PR TITLE
refactor: remove misleadning naming and adjust cache call place

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/mod.rs
@@ -32,7 +32,7 @@ impl Compilation {
     // run module_executor
     if let Some(module_executor) = &mut self.module_executor {
       let mut module_executor = std::mem::take(module_executor);
-      module_executor.hook_before_make(self).await?;
+      module_executor.before_build_module_graph(self).await?;
       self.module_executor = Some(module_executor);
     }
 

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/mod.rs
@@ -46,7 +46,7 @@ pub struct ModuleExecutor {
 }
 
 impl ModuleExecutor {
-  pub async fn hook_before_make(&mut self, compilation: &Compilation) -> Result<()> {
+  pub async fn before_build_module_graph(&mut self, compilation: &Compilation) -> Result<()> {
     let mut make_artifact = std::mem::take(&mut self.make_artifact);
     let mut params = Vec::with_capacity(5);
     params.push(UpdateParam::CheckNeedBuild);
@@ -85,7 +85,7 @@ impl ModuleExecutor {
     Ok(())
   }
 
-  pub async fn hook_after_finish_modules(&mut self, compilation: &mut Compilation) -> Result<()> {
+  pub async fn after_build_module_graph(&mut self, compilation: &mut Compilation) -> Result<()> {
     let sender = std::mem::take(&mut self.event_sender);
     sender
       .expect("should have sender")

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -7,7 +7,7 @@ pub async fn finish_modules_pass(compilation: &mut Compilation) -> Result<()> {
   let dependencies_diagnostics_artifact = compilation.dependencies_diagnostics_artifact.clone();
   let async_modules_artifact = compilation.async_modules_artifact.clone();
   let diagnostics = compilation
-    .collect_build_module_graph_effects(
+    .finish_modules_inner(
       &mut dependencies_diagnostics_artifact.borrow_mut(),
       &mut async_modules_artifact.borrow_mut(),
     )
@@ -18,8 +18,8 @@ pub async fn finish_modules_pass(compilation: &mut Compilation) -> Result<()> {
 }
 
 impl Compilation {
-  #[tracing::instrument("Compilation:collect_build_module_graph_effects", skip_all)]
-  pub async fn collect_build_module_graph_effects(
+  #[tracing::instrument("Compilation:finish_modules_inner", skip_all)]
+  pub async fn finish_modules_inner(
     &mut self,
     dependencies_diagnostics_artifact: &mut DependenciesDiagnosticsArtifact,
     async_modules_artifact: &mut AsyncModulesArtifact,

--- a/crates/rspack_core/src/compilation/make/mod.rs
+++ b/crates/rspack_core/src/compilation/make/mod.rs
@@ -1,17 +1,12 @@
 use rspack_error::Result;
 
-use crate::{Compilation, SharedPluginDriver, cache::Cache, logger::Logger};
+use crate::{Compilation, SharedPluginDriver, logger::Logger};
 
 pub async fn make_hook_pass(
   compilation: &mut Compilation,
   plugin_driver: SharedPluginDriver,
-  cache: &mut dyn Cache,
 ) -> Result<()> {
   let logger = compilation.get_logger("rspack.Compiler");
-
-  cache
-    .before_build_module_graph(&mut compilation.build_module_graph_artifact)
-    .await;
 
   let start = logger.time("make hook");
   plugin_driver.compiler_hooks.make.call(compilation).await?;


### PR DESCRIPTION
## Summary
the origin `hook_after_finish_modules` is misleading since it's actually called before `finish_modules` hook. 
align the naming with https://github.com/web-infra-dev/rspack/blob/9c6024dc7af732d0e4ebe0d6fcec70bcd552d58b/crates/rspack_core/src/cache/persistent/mod.rs#L251
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
