### PR TITLE
fix: fix panic caused by missing lazy dependency

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/lazy.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/lazy.rs
@@ -2,6 +2,7 @@ use super::{TaskContext, process_dependencies::ProcessDependenciesTask};
 use crate::{
   DependencyId, ModuleIdentifier,
   compilation::build_module_graph::ForwardedIdSet,
+  internal::try_dependency_by_id_mut,
   task_loop::{Task, TaskResult, TaskType},
 };
 
@@ -37,7 +38,10 @@ impl Task<TaskContext> for ProcessUnlazyDependenciesTask {
     let dependencies_to_process: Vec<DependencyId> = requested_deps
       .into_iter()
       .filter(|dep| {
-        let dep = module_graph.dependency_by_id_mut(dep);
+        //@FIXME: It seems a bug that dependency is not found here, needs to find out the reason
+        let Some(dep) = try_dependency_by_id_mut(module_graph, dep) else {
+          return false;
+        };
         dep.unset_lazy()
       })
       .collect();

--- a/crates/rspack_core/src/module_graph/internal.rs
+++ b/crates/rspack_core/src/module_graph/internal.rs
@@ -33,6 +33,13 @@ pub fn try_dependency_by_id<'a>(
 ) -> Option<&'a BoxDependency> {
   module_graph.inner.dependencies.get(dependency_id)
 }
+#[inline]
+pub fn try_dependency_by_id_mut<'a>(
+  module_graph: &'a mut ModuleGraph,
+  dependency_id: &DependencyId,
+) -> Option<&'a mut BoxDependency> {
+  module_graph.inner.dependencies.get_mut(dependency_id)
+}
 
 /// Try to get a mutable module graph module by identifier, returning None if not found.
 ///


### PR DESCRIPTION
## Summary
revert this change https://github.com/web-infra-dev/rspack/pull/12569/changes#diff-8543abddbc5dd4ac766da9c7bddf6cd7abc79c702ad8999576cf11e7d663341cL40
but we still needs to figure out why lazy dependency is missing here
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
