### PR TITLE
fix(template): add @rspack/dev-server to dev dependencies

### DIFF
--- a/packages/create-rspack/template-react-js/package.json
+++ b/packages/create-rspack/template-react-js/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "~1.2.0",
+    "@rspack/dev-server": "~1.2.1",
     "@rspack/plugin-react-refresh": "^1.6.0",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",

--- a/packages/create-rspack/template-react-ts/package.json
+++ b/packages/create-rspack/template-react-ts/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "~1.2.0",
+    "@rspack/dev-server": "~1.2.1",
     "@rspack/plugin-react-refresh": "^1.6.0",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",

--- a/packages/create-rspack/template-vanilla-js/package.json
+++ b/packages/create-rspack/template-vanilla-js/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "~1.2.0"
+    "@rspack/dev-server": "~1.2.1"
   }
 }

--- a/packages/create-rspack/template-vanilla-ts/package.json
+++ b/packages/create-rspack/template-vanilla-ts/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "~1.2.0",
+    "@rspack/dev-server": "~1.2.1",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/create-rspack/template-vue-js/package.json
+++ b/packages/create-rspack/template-vue-js/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "~1.2.0",
+    "@rspack/dev-server": "~1.2.1",
     "rspack-vue-loader": "^17.4.5"
   }
 }

--- a/packages/create-rspack/template-vue-ts/package.json
+++ b/packages/create-rspack/template-vue-ts/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "~1.2.0",
+    "@rspack/dev-server": "~1.2.1",
     "typescript": "^5.9.3",
     "rspack-vue-loader": "^17.4.5"
   }

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@rslib/core": "0.19.2",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "~1.2.0",
+    "@rspack/dev-server": "~1.2.1",
     "@rspack/test-tools": "workspace:*",
     "cac": "^6.7.14",
     "concat-stream": "^2.0.0",
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "@rspack/core": "^2.0.0-0",
-    "@rspack/dev-server": "~1.2.0"
+    "@rspack/dev-server": "~1.2.1"
   },
   "peerDependenciesMeta": {
     "@rspack/dev-server": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,8 +243,8 @@ importers:
         specifier: workspace:*
         version: link:../../rspack
       '@rspack/dev-server':
-        specifier: ~1.2.0
-        version: 1.2.0(@rspack/core@packages+rspack)(webpack@5.102.1)
+        specifier: ~1.2.1
+        version: 1.2.1(@rspack/core@packages+rspack)(webpack@5.102.1)
       '@rspack/plugin-react-refresh':
         specifier: ^1.6.0
         version: 1.6.0(react-refresh@0.18.0)
@@ -274,8 +274,8 @@ importers:
         specifier: workspace:*
         version: link:../../rspack
       '@rspack/dev-server':
-        specifier: ~1.2.0
-        version: 1.2.0(@rspack/core@packages+rspack)(webpack@5.102.1)
+        specifier: ~1.2.1
+        version: 1.2.1(@rspack/core@packages+rspack)(webpack@5.102.1)
       '@rspack/plugin-react-refresh':
         specifier: ^1.6.0
         version: 1.6.0(react-refresh@0.18.0)
@@ -301,8 +301,8 @@ importers:
         specifier: workspace:*
         version: link:../../rspack
       '@rspack/dev-server':
-        specifier: ~1.2.0
-        version: 1.2.0(@rspack/core@packages+rspack)(webpack@5.102.1)
+        specifier: ~1.2.1
+        version: 1.2.1(@rspack/core@packages+rspack)(webpack@5.102.1)
 
   packages/create-rspack/template-vanilla-ts:
     devDependencies:
@@ -313,8 +313,8 @@ importers:
         specifier: workspace:*
         version: link:../../rspack
       '@rspack/dev-server':
-        specifier: ~1.2.0
-        version: 1.2.0(@rspack/core@packages+rspack)(webpack@5.102.1)
+        specifier: ~1.2.1
+        version: 1.2.1(@rspack/core@packages+rspack)(webpack@5.102.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -332,8 +332,8 @@ importers:
         specifier: workspace:*
         version: link:../../rspack
       '@rspack/dev-server':
-        specifier: ~1.2.0
-        version: 1.2.0(@rspack/core@packages+rspack)(webpack@5.102.1)
+        specifier: ~1.2.1
+        version: 1.2.1(@rspack/core@packages+rspack)(webpack@5.102.1)
       rspack-vue-loader:
         specifier: ^17.4.5
         version: 17.4.5(vue@3.5.26(typescript@5.9.3))(webpack@5.102.1)
@@ -351,8 +351,8 @@ importers:
         specifier: workspace:*
         version: link:../../rspack
       '@rspack/dev-server':
-        specifier: ~1.2.0
-        version: 1.2.0(@rspack/core@packages+rspack)(webpack@5.102.1)
+        specifier: ~1.2.1
+        version: 1.2.1(@rspack/core@packages+rspack)(webpack@5.102.1)
       rspack-vue-loader:
         specifier: ^17.4.5
         version: 17.4.5(vue@3.5.26(typescript@5.9.3))(webpack@5.102.1)
@@ -470,8 +470,8 @@ importers:
         specifier: workspace:*
         version: link:../rspack
       '@rspack/dev-server':
-        specifier: ~1.2.0
-        version: 1.2.0(@rspack/core@packages+rspack)(webpack@5.102.1)
+        specifier: ~1.2.1
+        version: 1.2.1(@rspack/core@packages+rspack)(webpack@5.102.1)
       '@rspack/test-tools':
         specifier: workspace:*
         version: link:../rspack-test-tools
@@ -673,8 +673,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack
       '@rspack/dev-server':
-        specifier: ~1.2.0
-        version: 1.2.0(@rspack/core@packages+rspack)(webpack@5.102.1)
+        specifier: ~1.2.1
+        version: 1.2.1(@rspack/core@packages+rspack)(webpack@5.102.1)
       '@rspack/plugin-react-refresh':
         specifier: ^1.6.0
         version: 1.6.0(react-refresh@0.18.0)
@@ -3424,8 +3424,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/dev-server@1.2.0':
-    resolution: {integrity: sha512-lLgo2j/bLeey4NiHzaoy+1qiwz8S+9lQS4xUvjifY5lBk7IrQOAkaVcWGvj6fWB1+d5hloCr2W1gSz0oSgOczg==}
+  '@rspack/dev-server@1.2.1':
+    resolution: {integrity: sha512-e/ARvskYn2Qdd02qLvc0i6H9BnOmzP0xGHS2XCr7GZ3t2k5uC5ZlLkeN1iEebU0FkAW+6ot89NahFo3nupKuww==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@rspack/core': '*'
@@ -10894,7 +10894,7 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.18
 
-  '@rspack/dev-server@1.2.0(@rspack/core@packages+rspack)(webpack@5.102.1)':
+  '@rspack/dev-server@1.2.1(@rspack/core@packages+rspack)(webpack@5.102.1)':
     dependencies:
       '@rspack/core': link:packages/rspack
       '@types/bonjour': 3.5.13

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -14,7 +14,7 @@
     "core-js": "3.47.0",
     "@rspack/core": "workspace:*",
     "@rspack/browser": "workspace:*",
-    "@rspack/dev-server": "~1.2.0",
+    "@rspack/dev-server": "~1.2.1",
     "@rspack/plugin-react-refresh": "^1.6.0",
     "@module-federation/runtime-tools": "^0.22.0",
     "@swc/helpers": "0.5.18",


### PR DESCRIPTION
## Summary

- add @rspack/dev-server to dev dependencies of templates
- bump @rspack/dev-server to v1.2.1

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
