### PR TITLE
docs: update externals function callback about `boolean` type

### DIFF
--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -149,7 +149,9 @@ Here're arguments the function can receive:
 The callback function takes three arguments:
 
 - `err` (`Error`): Used to indicate if there has been an error while externalizing the import. If there is an error, this should be the only parameter used.
-- `result` (`string | string[] | object`): Describes the external module with the other external formats ([`string`](#string), [`string[]`](#string-array), or [`object`](#object))
+- `result` (`string | string[] | object | boolean`): Describes the external module.
+  - `string | string[] | object`: Describes the external module with the other external formats ([`string`](#string), [`string[]`](#string-array), or [`object`](#object)).
+  - `boolean`: Passing `true` externalizes the dependency using the original request path as the external module name. Passing `false` tells Rspack to skip the remaining external configuration and bundle the dependency instead.
 - `type` (`string`): Optional parameter that indicates the module [external type](#externalstype) (if it has not already been indicated in the `result` parameter).
 
 As an example, to externalize all imports where the import path matches a regular expression you could do the following:

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -149,7 +149,9 @@ export default {
 回调函数接收三个参数：
 
 - `err` (`Error`): 用于标识外部化导入时是否出现错误。如果有错误，这应该是唯一使用的参数。
-- `result` (`string | string[] | object`): 使用其他外部格式描述外部模块（[字符串](#字符串)，[字符串数组](#字符串数组)或[对象](#对象) ）。
+- `result` (`string | string[] | object | boolean`): 描述外部模块。
+  - `string | string[] | object`: 使用其他外部格式描述外部模块（[字符串](#字符串)，[字符串数组](#字符串数组)或[对象](#对象)）。
+  - `boolean`: 传递 `true` 会将依赖外部化，使用原始的请求路径作为外部模块名称。传递 `false` 会告诉 Rspack 跳过剩余的 external 配置并打包该依赖。
 - `type` (`string`): 指示 [externalsType](#externalstype) 的可选参数（如果还没有在 `result` 参数中指出的话）。
 
 例如，要外部化所有导入路径与正则表达式匹配的导入，可以这样做：


### PR DESCRIPTION
## Summary

Update externals function callback documentation about `boolean` type.

### Changes

- Added documentation for `true`: Externalizes the dependency using the original request path as the external module name
- Added documentation for `false`: Tells Rspack to skip the remaining external configuration and bundle the dependency instead
- Restructured the `result` parameter documentation with nested bullet points for better readability
