### PR TITLE
fix: revert verbatimModuleSyntax default value to false

### DIFF
--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -72,7 +72,7 @@ impl SwcLoader {
       transform.react.development =
         Some(Mode::is_development(&loader_context.context.options.mode));
       // Enable verbatimModuleSyntax by default for better TypeScript compatibility
-      transform.verbatim_module_syntax = Some(true).into();
+      transform.verbatim_module_syntax = Some(false).into();
 
       swc_options
         .config

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -71,7 +71,7 @@ impl SwcLoader {
       let mut transform = TransformConfig::default();
       transform.react.development =
         Some(Mode::is_development(&loader_context.context.options.mode));
-      // Enable verbatimModuleSyntax by default for better TypeScript compatibility
+      // Disable verbatimModuleSyntax by default; enabling it can improve TypeScript compatibility
       transform.verbatim_module_syntax = Some(false).into();
 
       swc_options


### PR DESCRIPTION
## Summary
setting verbatimModuleSyntax to true will cause huge performance regression caused by build unnecessary modules(which is removed by verbatimModuleSyntax) for some cases. so consider revert it back to false
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
