### PR TITLE
fix(mf): use dynamic exports type for MF modules

### DIFF
--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -6,9 +6,9 @@ use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   ChunkGraph, CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock,
-  Dependency, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleGraph, ModuleIdentifier,
-  ModuleType, RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config,
-  module_update_hash,
+  Dependency, DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleGraph,
+  ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -138,6 +138,15 @@ impl Module for RemoteModule {
 
   fn name_for_condition(&self) -> Option<Box<str>> {
     Some(self.request.as_str().into())
+  }
+
+  fn get_exports_type(
+    &self,
+    _module_graph: &ModuleGraph,
+    _module_graph_cache: &rspack_core::ModuleGraphCacheArtifact,
+    _strict: bool,
+  ) -> ExportsType {
+    ExportsType::Dynamic
   }
 
   async fn build(

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -6,7 +6,7 @@ use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo,
   BuildMeta, BuildResult, CodeGenerationResult, Compilation, ConcatenationScope, Context,
-  DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleGraph,
+  DependenciesBlock, DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleGraph,
   ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, impl_module_meta_info,
   impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
@@ -153,6 +153,15 @@ impl Module for ConsumeSharedModule {
 
   fn get_context(&self) -> Option<Box<Context>> {
     Some(Box::new(self.context.clone()))
+  }
+
+  fn get_exports_type(
+    &self,
+    _module_graph: &ModuleGraph,
+    _module_graph_cache: &rspack_core::ModuleGraphCacheArtifact,
+    _strict: bool,
+  ) -> ExportsType {
+    ExportsType::Dynamic
   }
 
   async fn build(

--- a/tests/e2e/cases/module-federation/async-startup-self-remote-runtimechunk-single/rspack.config.js
+++ b/tests/e2e/cases/module-federation/async-startup-self-remote-runtimechunk-single/rspack.config.js
@@ -13,14 +13,6 @@ module.exports = {
     filename: 'static/js/[name].js',
     chunkFilename: 'static/js/[name].js',
   },
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        type: 'javascript/auto',
-      },
-    ],
-  },
   optimization: {
     runtimeChunk: 'single',
     chunkIds: 'named',

--- a/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/index.js
+++ b/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/index.js
@@ -1,0 +1,10 @@
+it("should correctly handle default imports in .mjs files from shared modules", async () => {
+	await __webpack_init_sharing__("default");
+
+	const { testDefaultImport } = await import("./pure-esm-consumer.mjs");
+	const result = testDefaultImport();
+
+	expect(result.defaultType).toBe("function");
+	expect(result.defaultValue).toBe("shared default export");
+	expect(result.namedExportValue).toBe("shared named export");
+});

--- a/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/pure-esm-consumer.mjs
+++ b/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/pure-esm-consumer.mjs
@@ -1,0 +1,10 @@
+import something from "./shared-esm-pkg/index.js";
+import { namedExport } from "./shared-esm-pkg/index.js";
+
+export function testDefaultImport() {
+	return {
+		defaultType: typeof something,
+		defaultValue: typeof something === "function" ? something() : something,
+		namedExportValue: namedExport
+	};
+}

--- a/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/rspack.config.js
+++ b/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/rspack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const { rspack } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	plugins: [
+    new rspack.container.ModuleFederationPluginV1({
+      shared: ["./shared-esm-pkg/index.js"]
+    }),
+	]
+};

--- a/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/shared-esm-pkg/index.js
+++ b/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/shared-esm-pkg/index.js
@@ -1,0 +1,5 @@
+export default function sharedFunction() {
+	return "shared default export";
+}
+
+export const namedExport = "shared named export";

--- a/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/shared-esm-pkg/package.json
+++ b/tests/rspack-test/configCases/container-1-0/consume-module-mjs-default-export/shared-esm-pkg/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "shared-esm-pkg",
+	"version": "1.0.0",
+	"type": "module"
+}


### PR DESCRIPTION
## Summary

This implements `get_exports_type` for `RemoteModule` and `ConsumeSharedModule`. This fixes default imports when consuming shared modules in `.mjs` files and removes the need for `javascript/auto` workarounds.

## Related links

fix https://github.com/web-infra-dev/rspack/issues/8043

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
