### PR TITLE
refactor: incremental.buildChunkGraph works only for skip building chunk graph

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -70,7 +70,11 @@ impl CodeSplittingCache {
     let module_graph = this_compilation.get_module_graph();
     let module_graph_cache = &this_compilation.module_graph_cache_artifact;
     let affected_modules = mutations.get_affected_modules_with_module_graph(module_graph);
-    let previous_modules_map = &self.code_splitter.block_modules_runtime_map;
+    let previous_modules_map = &this_compilation
+      .build_chunk_graph_artifact
+      .code_splitting_cache
+      .code_splitter
+      .block_modules_runtime_map;
 
     if previous_modules_map.is_empty() {
       logger.log("no cache detected, rebuilding chunk graph");
@@ -179,12 +183,13 @@ where
   let incremental_code_splitting = compilation
     .incremental
     .passes_enabled(IncrementalPasses::BUILD_CHUNK_GRAPH);
-  let no_change = compilation
-    .build_chunk_graph_artifact
-    .code_splitting_cache
-    .can_skip_rebuilding(compilation);
+  let no_change = incremental_code_splitting
+    && compilation
+      .build_chunk_graph_artifact
+      .code_splitting_cache
+      .can_skip_rebuilding(compilation);
 
-  if incremental_code_splitting || no_change {
+  if no_change {
     let cache = &mut compilation.build_chunk_graph_artifact.code_splitting_cache;
     rayon::scope(|s| {
       s.spawn(|_| compilation.chunk_by_ukey = cache.chunk_by_ukey.clone());

--- a/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
@@ -449,9 +449,12 @@ impl CodeSplitter {
 
   #[instrument(skip_all)]
   pub fn update_with_compilation(&mut self, compilation: &mut Compilation) -> Result<()> {
-    let enable_incremental = compilation
-      .incremental
-      .mutations_readable(IncrementalPasses::BUILD_CHUNK_GRAPH);
+    // TODO: heuristic incremental update is temporarily disabled
+    // Original code:
+    // let enable_incremental = compilation
+    //   .incremental
+    //   .mutations_readable(IncrementalPasses::BUILD_CHUNK_GRAPH);
+    let enable_incremental = false;
 
     // This optimization is from  https://github.com/webpack/webpack/pull/18090 by https://github.com/dmichon-msft
     // Thanks!

--- a/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
@@ -3,16 +3,19 @@
 
 use tracing::instrument;
 
-use crate::{Compilation, incremental::IncrementalPasses};
+use crate::Compilation;
 pub(crate) mod code_splitter;
 pub(crate) mod incremental;
 pub(crate) mod pass;
 
 #[instrument("Compilation:build_chunk_graph", skip_all)]
 pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<()> {
-  let enable_incremental = compilation
-    .incremental
-    .mutations_readable(IncrementalPasses::BUILD_CHUNK_GRAPH);
+  // TODO: heuristic incremental update is temporarily disabled
+  // Original code:
+  // let enable_incremental = compilation
+  //   .incremental
+  //   .mutations_readable(IncrementalPasses::BUILD_CHUNK_GRAPH);
+  let enable_incremental = false;
   let mut splitter = if enable_incremental {
     std::mem::take(
       &mut compilation

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -232,7 +232,7 @@ const applyIncrementalDefaults = (options: RspackOptionsNormalized) => {
     D(options.incremental, 'buildModuleGraph', true);
     D(options.incremental, 'finishModules', true);
     D(options.incremental, 'optimizeDependencies', true);
-    D(options.incremental, 'buildChunkGraph', false);
+    D(options.incremental, 'buildChunkGraph', true);
     D(options.incremental, 'moduleIds', true);
     D(options.incremental, 'chunkIds', true);
     D(options.incremental, 'modulesHashes', true);

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -446,7 +446,7 @@ const getNormalizedIncrementalOptions = (
       buildModuleGraph: true,
       finishModules: false,
       optimizeDependencies: false,
-      buildChunkGraph: false,
+      buildChunkGraph: true,
       moduleIds: false,
       chunkIds: false,
       modulesHashes: false,

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -39,7 +39,7 @@ module.exports = {
 			  externalsType: var,
 			  ignoreWarnings: undefined,
 			  incremental: Object {
-			    buildChunkGraph: false,
+			    buildChunkGraph: true,
 			    buildModuleGraph: true,
 			    chunkAsset: true,
 			    chunkIds: true,

--- a/tests/rspack-test/watchCases/build-chunk-graph/available-modules-change/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/available-modules-change/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/basic/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/basic/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/chunk-add-then-change-ava-module/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/chunk-add-then-change-ava-module/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/chunk-modify/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/chunk-modify/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/chunk-remove/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/chunk-remove/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/keep-order-index/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/keep-order-index/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/runtime-chunk-recover-error/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/runtime-chunk-recover-error/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/runtime-chunk/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/runtime-chunk/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/skip-building-chunk-graph-without-side-effects/rspack.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/skip-building-chunk-graph-without-side-effects/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 		innerGraph: true
 	},
 	incremental: {
-		buildChunkGraph: false
+		buildChunkGraph: true
 	},
 	module: {
 		rules: [

--- a/tests/rspack-test/watchCases/build-chunk-graph/skip-building-chunk-graph-without-side-effects/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/skip-building-chunk-graph-without-side-effects/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";

--- a/tests/rspack-test/watchCases/build-chunk-graph/skip-building-chunk-graph/rspack.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/skip-building-chunk-graph/rspack.config.js
@@ -5,9 +5,6 @@ module.exports = {
 		usedExports: false,
 		innerGraph: true
 	},
-	incremental: {
-		buildChunkGraph: false
-	},
 	module: {
 		rules: [
 			{

--- a/tests/rspack-test/watchCases/chunk-ids/update-module/test.filter.js
+++ b/tests/rspack-test/watchCases/chunk-ids/update-module/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";


### PR DESCRIPTION

## Summary

make `incremental.buildChunkGraph` works only for skip building chunk graph

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
