### PR TITLE
fix: enable panic backtrace for release-debug

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -71,7 +71,7 @@ async function build() {
 			rustflags.push("-Zfmt-debug=none");
 		}
 		args.push("--no-dts-cache");
-		if (!values.profile || values.profile === "dev") {
+		if (!values.profile || values.profile === "dev" || values.profile === "release-debug") {
 			features.push("color-backtrace");
 		}
 		if (process.env.SFTRACE) {


### PR DESCRIPTION
## Summary
* before
<img width="2078" height="644" alt="image" src="https://github.com/user-attachments/assets/433aa1b4-f84b-4f63-8296-dbb93f7736b0" />

* after
<img width="1916" height="608" alt="image" src="https://github.com/user-attachments/assets/a0a2ea21-8812-4598-91e2-1a30b78c9831" />

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
