### PR TITLE
fix(mf): respect request changes in shared plugins

### DIFF
--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -408,7 +408,7 @@ async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<B
   ) {
     return Ok(None);
   }
-  let request = dep.request();
+  let request = &data.request;
   let consumes = self.get_matched_consumes();
   if let Some(matched) = consumes.unresolved.get(request) {
     let module = self

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_plugin.rs
@@ -242,7 +242,7 @@ async fn normal_module_factory_module(
   {
     return Ok(());
   }
-  let request = &create_data.raw_request;
+  let request = &data.request;
   {
     let match_provides = self.match_provides.read().await;
     if let Some(config) = match_provides.get(request) {

--- a/tests/rspack-test/configCases/container-1-0/change-data-request/bootstrap.js
+++ b/tests/rspack-test/configCases/container-1-0/change-data-request/bootstrap.js
@@ -1,7 +1,11 @@
 import a from "myA";
+import x from "myX";
 
 export function test(it) {
 	it("should have correct value for remote module", () => {
 		expect(a).toBe("a");
-	});
+  });
+	it("should have correct value for shared module", () => {
+    expect(x).toBe("x");
+  });
 }

--- a/tests/rspack-test/configCases/container-1-0/change-data-request/rspack.config.js
+++ b/tests/rspack-test/configCases/container-1-0/change-data-request/rspack.config.js
@@ -17,7 +17,8 @@ module.exports = {
 			remoteType: "commonjs-module",
 			remotes: {
 				A: "./container-a.js"
-			}
+      },
+      shared: ["myX"],
 		}),
 		function (compiler) {
 			compiler.hooks.thisCompilation.tap(
@@ -28,6 +29,9 @@ module.exports = {
 						data => {
 							if (data.request === "myA") {
 								data.request = "A";
+              }
+              if (data.request === "myX") {
+                data.request = "./x";
 							}
 						}
 					);

--- a/tests/rspack-test/configCases/container-1-0/change-data-request/x.js
+++ b/tests/rspack-test/configCases/container-1-0/change-data-request/x.js
@@ -1,0 +1,1 @@
+export default 'x'


### PR DESCRIPTION
## Summary

Update ConsumeSharedPlugin and ProvideSharedPlugin to use `data.request` instead of the original dependency request. This ensures that modifications made to the request in hooks like beforeResolve are correctly handled.


<!-- Describe what this PR does and why. -->

## Related links

fix https://github.com/web-infra-dev/rspack/issues/11437

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
