### PR TITLE
chore: enable backtrace for release-debug

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -45,7 +45,6 @@ async function build() {
 		const features = [];
 		const envs = { ...process.env };
 		const use_build_std = values.profile === "release"
-				|| values.profile === "release-debug"
 				|| values.profile === "release-wasi"
 				|| values.profile === "profiling";
 


### PR DESCRIPTION
## Summary
#12854 support backtrace but  backtrace is empty becase build_std remove unwind-table info

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
