### PR TITLE
test: use tapAsyc api to wait server to close

### DIFF
--- a/tests/rspack-test/configCases/asset-modules/http-redirect-security/server/index.js
+++ b/tests/rspack-test/configCases/asset-modules/http-redirect-security/server/index.js
@@ -94,7 +94,7 @@ class ServerPlugin {
       }
     );
 
-    compiler.hooks.done.tap("ServerPlugin", (stats, callback) => {
+    compiler.hooks.done.tapAsync("ServerPlugin", (stats, callback) => {
       const s = this.server;
       if (s && --this.refs === 0) {
         this.server = undefined;


### PR DESCRIPTION
## Summary
try to fix the socket hang-up error, e.g.
<img width="2318" height="402" alt="image" src="https://github.com/user-attachments/assets/6bfd4afe-310c-470f-83ad-f6b1367f3a04" />


`tap` API doesn't have a callback parameter.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
