### PR TITLE
fix: fix used exports for global entry that inject to async entrypoints

### DIFF
--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -533,6 +533,10 @@ impl ModuleGraph {
       .expect("should insert block before get it")
   }
 
+  pub fn blocks(&self) -> &HashMap<AsyncDependenciesBlockIdentifier, Box<AsyncDependenciesBlock>> {
+    &self.inner.blocks
+  }
+
   pub fn dependencies(&self) -> HashMap<DependencyId, &BoxDependency> {
     self
       .inner
@@ -550,7 +554,7 @@ impl ModuleGraph {
   ///
   /// **PREFERRED METHOD**: Use this for ALL internal Rust code including:
   /// - Core compilation logic
-  /// - All plugins (`rspack_plugin_*`)  
+  /// - All plugins (`rspack_plugin_*`)
   /// - Stats generation, code generation, runtime templates
   /// - Chunk graph building, export analysis
   /// - Module graph building operations

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/index.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/index.js
@@ -3,8 +3,8 @@ it("should generate correct worker runtime code with tree shaking and MF runtime
 	expect(getMessage()).toBe('App rendered with [This is react 0.2.1]');
 
 	const plugins = __webpack_require__.federation.initOptions.plugins;
-	expect(plugins.length).toBeGreaterThan(0);
-	expect(plugins.some(p => p.name === 'my-runtime-plugin')).toBe(true);
+	expect(plugins.length).toBe(2);
+	expect(plugins.map(p => p.name)).toEqual(['my-runtime-plugin', 'my-runtime-plugin-esm']);
 
 	expect(await getWorkerMessage()).toBe('Echo: Hello, Rspack!');
 });

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/rspack.config.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/rspack.config.js
@@ -22,7 +22,8 @@ module.exports = {
 				}
 			},
 			runtimePlugins: [
-				path.resolve(__dirname, "runtime-plugin.js")
+  			path.resolve(__dirname, "runtime-plugin.js"),
+				path.resolve(__dirname, "runtime-plugin-esm.js")
 			]
 		})
 	]

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/runtime-plugin-esm.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/runtime-plugin-esm.js
@@ -1,0 +1,15 @@
+export default function MyRuntimePlugin() {
+	return {
+		name: 'my-runtime-plugin-esm',
+		resolveShare: function(args) {
+			const { shareScopeMap, scope, pkgName, version, GlobalFederation } = args;
+			args.resolver = function () {
+				shareScopeMap[scope][pkgName][version] = {
+					lib: ()=>()=> 'This is react 0.2.1'
+				};
+				return shareScopeMap[scope][pkgName][version];
+			};
+			return args;
+		}
+	};
+}


### PR DESCRIPTION
## Summary

Collect runtimes from async entrypoints in `FlagDependencyUsagePlugin`. This ensures correct tree shaking for Module Federation injected runtime (which will also injected to async entrypoints now if worker exists) by properly tracking usage in associated async entrypoint.

<!-- Describe what this PR does and why. -->

## Related links

A more correct fix for https://github.com/web-infra-dev/rspack/issues/12605 (than https://github.com/web-infra-dev/rspack/pull/12807)

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
