### PR TITLE
chore(test): show cli test stdout/err when child proceess killed

### DIFF
--- a/packages/rspack-cli/tests/build/basic/basic.test.ts
+++ b/packages/rspack-cli/tests/build/basic/basic.test.ts
@@ -3,13 +3,7 @@ import { readFile, run, runWatch } from '../../utils/test-utils';
 
 describe('build command', () => {
   it.concurrent('it should work ', async () => {
-    const { exitCode, stderr, stdout } = await run(
-      __dirname,
-      [],
-      {},
-      {},
-      false,
-    );
+    const { exitCode, stderr, stdout } = await run(__dirname, [], {}, {}, true);
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
     expect(stdout).toBeTruthy();
@@ -22,7 +16,7 @@ describe('build command', () => {
         ['--mode', 'development'],
         {},
         {},
-        false,
+        true,
       );
 
       expect(exitCode).toBe(0);
@@ -36,7 +30,7 @@ describe('build command', () => {
       ['--config', './entry.function.js'],
       {},
       {},
-      false,
+      true,
     );
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
@@ -50,7 +44,7 @@ describe('build command', () => {
         ['--config', './entry.env.js'],
         {},
         {},
-        false,
+        true,
       );
       expect(stdout).toContain('RSPACK_BUILD=true');
       expect(stdout).toContain('RSPACK_BUNDLE=true');
@@ -80,7 +74,7 @@ describe('build command', () => {
       ['--config', './entry.promise.js'],
       {},
       {},
-      false,
+      true,
     );
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
@@ -92,7 +86,7 @@ describe('build command', () => {
       ['--config', './entry.config.mjs'],
       {},
       {},
-      false,
+      true,
     );
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
@@ -111,7 +105,7 @@ describe('build command', () => {
       ],
       {},
       {},
-      false,
+      true,
     );
     const mainJs = await readFile(
       resolve(__dirname, 'dist/priority/main.js'),
@@ -133,7 +127,7 @@ describe('build command', () => {
         [command, 'dist/public', '--config', './entry.config.js'],
         {},
         {},
-        false,
+        true,
       );
       const mainJs = await readFile(
         resolve(__dirname, 'dist/public/main.js'),
@@ -162,7 +156,7 @@ describe('build command', () => {
         [command, option, '--config', './entry.config.js'],
         {},
         {},
-        false,
+        true,
       );
 
       const mainJs = await readFile(

--- a/packages/rspack-cli/tests/utils/test-utils.ts
+++ b/packages/rspack-cli/tests/utils/test-utils.ts
@@ -82,19 +82,23 @@ const createProcess = (cwd, args, options, env) => {
  * @param {string} cwd The path to folder that contains test
  * @param {Array<string>} args Array of arguments
  * @param {Object<string, any>} options Options for tests
+ * @param env
+ * @param diagnoseKilledProcess
  * @returns {Promise}
  */
 const run = async (
-  cwd,
+  cwd: string,
   args: string[] = [],
-  options = {},
-  env = {},
-  diagnoseKilledProcess = false,
-) => {
+  options: { [s: string]: any } = {},
+  env: { [s: string]: string } = {},
+  diagnoseKilledProcess: boolean = false,
+): Promise<any> => {
   const result = await createProcess(cwd, args, options, env);
 
   if (diagnoseKilledProcess && result.exitCode === undefined && result.signal) {
-    console.error('🔍 DIAGNOSIS: Process was killed by signal', args.join(' '));
+    console.error(
+      `🔍 DIAGNOSIS: Process(${args.join(' ')}) was killed by signal(${result.signal})`,
+    );
 
     if (result.stdout) {
       console.error('STDOUT:');


### PR DESCRIPTION
## Summary
For debugging why the rspack children process was killed during rspack-cli testing.

### background

When the `execa` children process is killed, the exitCode of the children process is [`undefined`](https://github.com/web-infra-dev/rspack/actions/runs/21556863904/job/62115370045?pr=12901#step:8:452).


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
