### PR TITLE
chore(test): remove rust flaky test 

### DIFF
--- a/crates/rspack_core/src/utils/iterator_consumer/future.rs
+++ b/crates/rspack_core/src/utils/iterator_consumer/future.rs
@@ -45,11 +45,6 @@ where
 
 #[cfg(test)]
 mod test {
-  use std::time::SystemTime;
-
-  use futures::future::join_all;
-  use tokio::time::{Duration, sleep};
-
   use super::FutureConsumer;
 
   #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/rspack_core/src/utils/iterator_consumer/rayon.rs
+++ b/crates/rspack_core/src/utils/iterator_consumer/rayon.rs
@@ -43,8 +43,6 @@ where
 
 #[cfg(test)]
 mod test {
-  use std::time::{Duration, SystemTime};
-
   use rayon::prelude::*;
 
   use super::RayonConsumer;

--- a/crates/rspack_core/src/utils/iterator_consumer/rayon_fut.rs
+++ b/crates/rspack_core/src/utils/iterator_consumer/rayon_fut.rs
@@ -47,11 +47,7 @@ where
 
 #[cfg(test)]
 mod test {
-  use std::time::SystemTime;
-
-  use futures::future::join_all;
   use rayon::prelude::*;
-  use tokio::time::{Duration, sleep};
 
   use super::RayonFutureConsumer;
 


### PR DESCRIPTION
## Summary
Wall-clock time is not a reliable signal for asserting parallelism benefits, as OS thread scheduling can cause [flaky results](https://github.com/web-infra-dev/rspack/actions/runs/21599365862/job/62240779321?pr=12913#step:7:438).

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
