### PR TITLE
fix: build_chunk_graph recover logic

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -247,8 +247,7 @@ pub struct BuildChunkGraphArtifact {
 
 impl ArtifactExt for BuildChunkGraphArtifact {
   const PASS: IncrementalPasses = IncrementalPasses::BUILD_CHUNK_GRAPH;
-  // FIXME: BuildChunkGraphArtifact is controlled by BUILD_MODULE_GRAPH PASS currently because it enables no_change optimization when BUILD_MODULE_GRAPH is enabled.
   fn should_recover(incremental: &crate::incremental::Incremental) -> bool {
-    incremental.passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
+    incremental.passes_enabled(IncrementalPasses::BUILD_CHUNK_GRAPH)
   }
 }


### PR DESCRIPTION
## Summary
since https://github.com/web-infra-dev/rspack/pull/12845 make incremental bulid_chunk_graph  follows  BUILD_CHUNK_GRAPH, so we should align artifact recover logic with it
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
