### PR TITLE
refactor: move mg save before finish_modules pass

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -143,7 +143,7 @@ pub async fn recovery_module_graph(
     })
     .with_max_len(1)
     .consume(|node| {
-      let mut mgm = node.mgm.into_owned();
+      let mgm: ModuleGraphModule = node.mgm.into_owned();
       let module = node.module.into_owned();
       for (index_in_block, (dep, parent_block)) in node.dependencies.into_iter().enumerate() {
         let dep = dep.into_owned();
@@ -170,10 +170,6 @@ pub async fn recovery_module_graph(
         module_to_lazy_make
           .update_module_lazy_dependencies(module.identifier(), Some(lazy_info.into_owned()));
       }
-      // recovery exports/export info
-      let exports_info = ExportsInfoData::default();
-      mgm.exports = exports_info.id();
-      mg.set_exports_info(exports_info.id(), exports_info);
 
       mg.add_module_graph_module(mgm);
       mg.add_module(module);

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, hash::Hash, sync::atomic::Ordering::Relaxed};
+use std::{collections::BTreeMap, hash::Hash, sync::atomic::Ordering::Relaxed, u32};
 
 use rspack_cacheable::cacheable;
 use rspack_collections::{Ukey, impl_item_ukey};
@@ -19,7 +19,9 @@ impl ExportsInfo {
   pub fn new() -> Self {
     Self(NEXT_EXPORTS_INFO_UKEY.fetch_add(1, Relaxed).into())
   }
-
+  pub fn uninit() -> Self {
+    Self(Ukey::new(u32::MAX))
+  }
   pub fn as_data<'a>(&self, mg: &'a ModuleGraph) -> &'a ExportsInfoData {
     mg.get_exports_info_by_id(self)
   }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -96,7 +96,7 @@ pub(crate) struct ModuleGraphData {
   connections: rollback::OverlayMap<DependencyId, ModuleGraphConnection>,
   // ExportsInfoData indexed by ExportsInfo id
   // modified here https://github.com/web-infra-dev/rspack/blob/9ae2f0f3be22370197cd9ed3308982f84f2bb738/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs#L332
-  exports_info_map: rollback::OverlayMap<ExportsInfo, ExportsInfoData>,
+  pub exports_info_map: HashMap<ExportsInfo, ExportsInfoData>,
 
   /***************** only Modified during Seal Phase ********************/
   // setting here https://github.com/web-infra-dev/rspack/blob/9ae2f0f3be22370197cd9ed3308982f84f2bb738/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs#L318
@@ -107,8 +107,7 @@ impl ModuleGraphData {
     self.modules.checkpoint();
     self.module_graph_modules.checkpoint();
     self.connections.checkpoint();
-
-    self.exports_info_map.checkpoint();
+    dbg!(&self.exports_info_map);
 
     // exports_info_map and dep_meta_map are not used for build_module_graph
   }
@@ -117,7 +116,7 @@ impl ModuleGraphData {
     self.modules.reset();
     self.module_graph_modules.reset();
     self.connections.reset();
-    self.exports_info_map.reset();
+    self.exports_info_map.clear();
     // reset data to save memory
     self.dep_meta_map.clear();
   }
@@ -125,7 +124,7 @@ impl ModuleGraphData {
 
 #[derive(Debug, Default)]
 pub struct ModuleGraph {
-  pub(super) inner: ModuleGraphData,
+  pub inner: ModuleGraphData,
 }
 impl ModuleGraph {
   // checkpoint

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -178,27 +178,13 @@ async fn finish_modules(
   compilation: &mut Compilation,
   _async_modules_artifact: &mut AsyncModulesArtifact,
 ) -> Result<()> {
-  let modules: IdentifierSet = if let Some(mutations) = compilation
-    .incremental
-    .mutations_read(IncrementalPasses::FINISH_MODULES)
-  {
-    let modules = mutations.get_affected_modules_with_module_graph(compilation.get_module_graph());
-    tracing::debug!(target: incremental::TRACING_TARGET, passes = %IncrementalPasses::FINISH_MODULES, %mutations, ?modules);
-    let logger = compilation.get_logger("rspack.incremental.finishModules");
-    logger.log(format!(
-      "{} modules are affected, {} in total",
-      modules.len(),
-      compilation.get_module_graph().modules().len()
-    ));
-    modules
-  } else {
+  let modules: IdentifierSet =
     compilation
       .get_module_graph()
       .modules()
       .keys()
       .copied()
-      .collect()
-  };
+      .collect();
   let module_graph_cache = compilation.module_graph_cache_artifact.clone();
 
   let module_graph = compilation

--- a/examples/basic/rspack.config.mjs
+++ b/examples/basic/rspack.config.mjs
@@ -9,4 +9,7 @@ export default defineConfig({
   output: {
     path: path.resolve(import.meta.dirname, 'dist'),
   },
+  cache: {
+    type: 'persistent',
+  },
 });

--- a/examples/basic/src/answer.js
+++ b/examples/basic/src/answer.js
@@ -1,0 +1,2 @@
+export const a = 1;
+export const b = 2;

--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -1,1 +1,2 @@
-import './lib.js';
+import { b as value } from './lib.js';
+console.log('The answer is:', value);

--- a/examples/basic/src/lib.js
+++ b/examples/basic/src/lib.js
@@ -1,1 +1,2 @@
 console.log('Debugging Rspack');
+export * from './answer.js';


### PR DESCRIPTION
## Summary
this is blocked until exports_info is moved out of module graph
currently build_module_graph and finish_modules overlap which is confusing and error prone
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
