### PR TITLE
docs: correct plugin hook in SRI plugin

### DIFF
--- a/website/docs/en/plugins/rspack/subresource-integrity-plugin.mdx
+++ b/website/docs/en/plugins/rspack/subresource-integrity-plugin.mdx
@@ -135,7 +135,7 @@ With [`html-webpack-plugin`](https://github.com/jantimon/html-webpack-plugin), y
 The `integrity` can also be obtained from `stats.assets`. For example:
 
 ```js
-compiler.plugin('done', (stats) => {
+compiler.hooks.done.tap('MyPlugin', (stats) => {
   const integrityValues = stats
     .toJson()
     .assets.map((asset) => [asset.name, asset.integrity]);

--- a/website/docs/zh/plugins/rspack/subresource-integrity-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/subresource-integrity-plugin.mdx
@@ -135,7 +135,7 @@ export default {
 若不使用 HTML 插件，也可以从 `stats.assets` 中获取 `integrity` 属性，如：
 
 ```js
-compiler.plugin('done', (stats) => {
+compiler.hooks.done.tap('MyPlugin', (stats) => {
   const integrityValues = stats
     .toJson()
     .assets.map((asset) => [asset.name, asset.integrity]);


### PR DESCRIPTION
## Summary

Updated the example to use `compiler.hooks.done.tap` instead of the `compiler.plugin('done', ...)`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
