### PR TITLE
chore(test): unref makes the server garbage unstable

### DIFF
--- a/tests/rspack-test/configCases/asset-modules/http-redirect-security/server/index.js
+++ b/tests/rspack-test/configCases/asset-modules/http-redirect-security/server/index.js
@@ -57,7 +57,6 @@ function createServer() {
     res.writeHead(404);
     res.end("Not found");
   });
-  server.unref();
   return server;
 }
 

--- a/tests/rspack-test/configCases/asset-modules/http-url/server/index.js
+++ b/tests/rspack-test/configCases/asset-modules/http-url/server/index.js
@@ -37,7 +37,6 @@ function createServer() {
 		);
 		res.end(file);
 	});
-	server.unref();
 	return server;
 }
 


### PR DESCRIPTION
## Summary
Try fixing the flaky test  https://github.com/web-infra-dev/rspack/actions/runs/21599365976/job/62241272623#step:8:1265
Server is set up and shut down by compiler hooks, no need `unref` to introduce garbaging unstable.

```txt
Error 1: message =   × Error calling JavaScript HTTP client: Error: socket hang up
```



<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
