### PR TITLE
fix(esm-lib-plugin): support inline export for dyn import

### DIFF
--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -750,21 +750,19 @@ var {} = {{}};
         && let Some((in_same_chunk, binding_ref)) = chunk_link.dyn_refs.get(atom.as_str())
       {
         let final_name = match binding_ref {
-          Ref::Symbol(symbol_ref) => Cow::Owned(symbol_ref.render()),
+          Ref::Symbol(symbol_ref) => Cow::Owned(if *in_same_chunk {
+            symbol_ref.render()
+          } else {
+            format!("{NAMESPACE_SYMBOL}.{}", symbol_ref.render())
+          }),
           Ref::Inline(inline) => Cow::Borrowed(inline),
-        };
-
-        let final_name = if *in_same_chunk {
-          final_name.into_owned()
-        } else {
-          format!("{NAMESPACE_SYMBOL}.{final_name}")
         };
 
         for ref_atom in refs {
           let name = if ref_atom.shorthand {
             Cow::Owned(format!("{}: {}", &ref_atom.id.sym, final_name.as_str()))
           } else {
-            Cow::Borrowed(&final_name)
+            final_name.clone()
           };
           source.replace(
             ref_atom.id.span.real_lo(),

--- a/tests/rspack-test/esmOutputCases/dynamic-import/inline/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/inline/__snapshots__/esm.snap.txt
@@ -1,0 +1,15 @@
+```mjs title=foo_js.mjs
+// ./foo.js
+
+
+```
+
+```mjs title=main.mjs
+// ./index.js
+it('should have correct inline export', async () => {
+  const { value } = await import("./foo_js.mjs").then((mod) => ({ value: (/* inlined export .value */42) }))
+  expect(value).toBe(42)
+})
+
+
+```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/inline/foo.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/inline/foo.js
@@ -1,0 +1,1 @@
+export {value} from './lib'

--- a/tests/rspack-test/esmOutputCases/dynamic-import/inline/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/inline/index.js
@@ -1,0 +1,4 @@
+it('should have correct inline export', async () => {
+  const { value } = await import('./foo')
+  expect(value).toBe(42)
+})

--- a/tests/rspack-test/esmOutputCases/dynamic-import/inline/lib.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/inline/lib.js
@@ -1,0 +1,1 @@
+export const value = 42


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

fix syntax error when using inline export for dynamic import

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
