### PR TITLE
refactor: use runtime template for context module codegen

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -587,6 +587,7 @@ impl ContextModule {
         (user_request, value)
       })
       .collect::<HashMap<_, _>>();
+
     let chunks_position = if has_fake_map { 2 } else { 1 };
     let async_deps_position = chunks_position + 1;
     let request_prefix = if has_no_chunk {
@@ -616,48 +617,57 @@ impl ContextModule {
       if short_mode { "invalid" } else { "ids[1]" },
       runtime_template,
     );
+
+    let has_own_property =
+      runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY);
     let async_context = if has_no_chunk {
+      let then_function = runtime_template.basic_function(
+        "",
+        &formatdoc! {
+          r#"if(!{has_own_property}(map, req)) {{
+            var e = new Error("Cannot find module '" + req + "'");
+            e.code = 'MODULE_NOT_FOUND';
+            throw e;
+          }}
+
+          {}
+          return {return_module_object};"#,
+          if short_mode {
+            "var id = map[req];"
+          } else {
+            "var ids = map[req], id = ids[0];"
+          }
+        },
+      );
       formatdoc! {r#"
         function __rspack_async_context(req) {{
-          return Promise.resolve().then(function() {{
-            if(!{}(map, req)) {{
-              var e = new Error("Cannot find module '" + req + "'");
-              e.code = 'MODULE_NOT_FOUND';
-              throw e;
-            }}
-
-            {}
-            return {return_module_object};
-          }});
+          return Promise.resolve().then({then_function});
         }}
-        "#,
-        runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY),
-        if short_mode {
-          "var id = map[req];"
-        } else {
-          "var ids = map[req], id = ids[0];"
-        }
-      }
+      "#}
     } else {
+      let then_function = runtime_template.returning_function(&return_module_object, "");
+      let module_not_found = runtime_template.basic_function(
+        "",
+        &formatdoc! {
+          r#"var e = new Error("Cannot find module '" + req + "'");
+            e.code = 'MODULE_NOT_FOUND';
+            throw e;"#
+        },
+      );
       formatdoc! {r#"
         function __rspack_async_context(req) {{
           if(!{}(map, req)) {{
-            return Promise.resolve().then(function() {{
-              var e = new Error("Cannot find module '" + req + "'");
-              e.code = 'MODULE_NOT_FOUND';
-              throw e;
-            }});
+            return Promise.resolve().then({module_not_found});
           }}
 
           var ids = map[req], id = ids[0];
-          return {request_prefix}.then(function() {{
-            return {return_module_object};
-          }});
+          return {request_prefix}.then({then_function});
         }}
         "#,
         runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY),
       }
     };
+
     formatdoc! {r#"
       var map = {map};
       {async_context}
@@ -692,13 +702,30 @@ impl ContextModule {
       .is_defer()
       .then(|| self.get_module_deferred_async_deps_map(dependencies, compilation));
 
-    let then_function = formatdoc! {r#"
-      function(id) {{
-        return {};
-      }}
-      "#,
-      self.get_return_module_object_source(&fake_map, true, async_deps_map.is_some().then(|| "asyncDepsMap[id]".to_string()), "fakeMap[id]", runtime_template),
-    };
+    let return_module_object_source = self.get_return_module_object_source(
+      &fake_map,
+      true,
+      async_deps_map
+        .is_some()
+        .then(|| "asyncDepsMap[id]".to_string()),
+      "fakeMap[id]",
+      runtime_template,
+    );
+    let then_function = runtime_template.returning_function(&return_module_object_source, "id");
+
+    let has_own_property =
+      runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY);
+    let module_not_found = runtime_template.basic_function(
+      "",
+      &formatdoc! {
+        r#"if(!{has_own_property}(map, req)) {{
+          var e = new Error("Cannot find module '" + req + "'");
+          e.code = 'MODULE_NOT_FOUND';
+          throw e;
+        }}
+        return map[req];"#
+      },
+    );
 
     formatdoc! {r#"
       var map = {map};
@@ -709,14 +736,7 @@ impl ContextModule {
         return __rspack_async_context_resolve(req).then({then_function});
       }}
       function __rspack_async_context_resolve(req) {{
-        return {promise}.then(function() {{
-          if(!{has_own_property}(map, req)) {{
-            var e = new Error("Cannot find module '" + req + "'");
-            e.code = 'MODULE_NOT_FOUND';
-            throw e;
-          }}
-          return map[req];
-        }})
+        return {promise}.then({module_not_found});
       }}
       __rspack_async_context.keys = {keys};
       __rspack_async_context.resolve = __rspack_async_context_resolve;
@@ -727,7 +747,6 @@ impl ContextModule {
       map = json_stringify(&map),
       fake_map_init_statement = self.get_fake_map_init_statement(&fake_map),
       async_deps_map_init_statement = self.get_module_deferred_async_deps_map_init_statement(async_deps_map.as_ref()),
-      has_own_property = runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY),
       keys = runtime_template.returning_function("Object.keys(map)", ""),
       id = json_stringify(self.get_module_id(&compilation.module_ids_artifact))
     }
@@ -748,6 +767,7 @@ impl ContextModule {
       .unwrap_or_default()
       .is_defer()
       .then(|| self.get_module_deferred_async_deps_map(dependencies, compilation));
+
     let return_module_object = self.get_return_module_object_source(
       &fake_map,
       true,
@@ -757,32 +777,45 @@ impl ContextModule {
       "fakeMap[id]",
       runtime_template,
     );
+    let module_factories =
+      runtime_template.render_runtime_globals(&RuntimeGlobals::MODULE_FACTORIES);
+    let then_function = runtime_template.basic_function(
+      "id",
+      &formatdoc! {
+        r#"if(!{module_factories}[id]) {{
+          var e = new Error("Module '" + req + "' ('" + id + "') is not available (weak dependency)");
+          e.code = 'MODULE_NOT_FOUND';
+          throw e;
+        }}
+        return {return_module_object};"#
+      },
+    );
+    let has_own_property =
+      runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY);
+    let module_not_found = runtime_template.basic_function(
+      "",
+      &formatdoc! {
+        r#"if(!{has_own_property}(map, req)) {{
+          var e = new Error("Cannot find module '" + req + "'");
+          e.code = 'MODULE_NOT_FOUND';
+          throw e;
+        }}
+        return map[req];"#
+      },
+    );
+
     formatdoc! {r#"
       var map = {map};
       {fake_map_init_statement}
       {async_deps_map_init_statement}
 
       function __rspack_async_context(req) {{
-        return __rspack_async_context_resolve(req).then(function(id) {{
-          if(!{module_factories}[id]) {{
-            var e = new Error("Module '" + req + "' ('" + id + "') is not available (weak dependency)");
-            e.code = 'MODULE_NOT_FOUND';
-            throw e;
-          }}
-          return {return_module_object};
-        }});
+        return __rspack_async_context_resolve(req).then({then_function});
       }}
       function __rspack_async_context_resolve(req) {{
         // Here Promise.resolve().then() is used instead of new Promise() to prevent
         // uncaught exception popping up in devtools
-        return Promise.resolve().then(function() {{
-          if(!{has_own_property}(map, req)) {{
-            var e = new Error("Cannot find module '" + req + "'");
-            e.code = 'MODULE_NOT_FOUND';
-            throw e;
-          }}
-          return map[req];
-        }})
+        return Promise.resolve().then({module_not_found});
       }}
       __rspack_async_context.keys = {keys};
       __rspack_async_context.resolve = __rspack_async_context_resolve;
@@ -793,8 +826,6 @@ impl ContextModule {
       map = json_stringify(&map),
       fake_map_init_statement = self.get_fake_map_init_statement(&fake_map),
       async_deps_map_init_statement = self.get_module_deferred_async_deps_map_init_statement(async_deps_map.as_ref()),
-      module_factories = runtime_template.render_runtime_globals(&RuntimeGlobals::MODULE_FACTORIES),
-      has_own_property = runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY),
       keys = runtime_template.returning_function("Object.keys(map)", ""),
       id = json_stringify(self.get_module_id(&compilation.module_ids_artifact))
     }
@@ -861,13 +892,30 @@ impl ContextModule {
       .unwrap_or_default()
       .is_defer()
       .then(|| self.get_module_deferred_async_deps_map(dependencies, compilation));
-    let then_function = formatdoc! {r#"
-      function(id) {{
-        return {};
-      }}
-      "#,
-      self.get_return_module_object_source(&fake_map, true, async_deps_map.is_some().then(|| "asyncDepsMap[id]".to_string()), "fakeMap[id]", runtime_template),
-    };
+    let return_module_object_source = self.get_return_module_object_source(
+      &fake_map,
+      true,
+      async_deps_map
+        .is_some()
+        .then(|| "asyncDepsMap[id]".to_string()),
+      "fakeMap[id]",
+      runtime_template,
+    );
+    let then_function = runtime_template.returning_function(&return_module_object_source, "id");
+    let has_own_property =
+      runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY);
+    let module_not_found = runtime_template.basic_function(
+      "",
+      &formatdoc! {
+        r#"if(!{has_own_property}(map, req)) {{
+          var e = new Error("Cannot find module '" + req + "'");
+          e.code = 'MODULE_NOT_FOUND';
+          throw e;
+        }}
+        return map[req];"#
+      },
+    );
+
     formatdoc! {r#"
       var map = {map};
       {fake_map_init_statement}
@@ -879,14 +927,7 @@ impl ContextModule {
       function __rspack_async_context_resolve(req) {{
         // Here Promise.resolve().then() is used instead of new Promise() to prevent
         // uncaught exception popping up in devtools
-        return Promise.resolve().then(function() {{
-          if(!{has_own_property}(map, req)) {{
-            var e = new Error("Cannot find module '" + req + "'");
-            e.code = 'MODULE_NOT_FOUND';
-            throw e;
-          }}
-          return map[req];
-        }})
+        return Promise.resolve().then({module_not_found});
       }}
       __rspack_async_context.keys = {keys};
       __rspack_async_context.resolve = __rspack_async_context_resolve;
@@ -897,7 +938,6 @@ impl ContextModule {
       map = json_stringify(&map),
       fake_map_init_statement = self.get_fake_map_init_statement(&fake_map),
       async_deps_map_init_statement = self.get_module_deferred_async_deps_map_init_statement(async_deps_map.as_ref()),
-      has_own_property = runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY),
       keys = runtime_template.returning_function("Object.keys(map)", ""),
       id = json_stringify(self.get_module_id(&compilation.module_ids_artifact))
     }
@@ -929,9 +969,7 @@ impl ContextModule {
         }}
         return map[req];
       }}
-      __rspack_context.keys = function webpackContextKeys() {{
-        return Object.keys(map);
-      }};
+      __rspack_context.keys = {keys};
       __rspack_context.resolve = __rspack_context_resolve;
       {module}.exports = __rspack_context;
       __rspack_context.id = {id};
@@ -940,6 +978,7 @@ impl ContextModule {
       map = json_stringify(&map),
       fake_map_init_statement = self.get_fake_map_init_statement(&fake_map),
       has_own_property = runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY),
+      keys = runtime_template.returning_function("Object.keys(map)", ""),
       id = json_stringify(self.get_module_id(&compilation.module_ids_artifact))
     }
   }

--- a/tests/rspack-test/builtinCases/plugin-javascript/issuse_2960/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-javascript/issuse_2960/__snapshots__/output.snap.txt
@@ -40,9 +40,7 @@ function __rspack_context_resolve(req) {
   }
   return map[req];
 }
-__rspack_context.keys = function webpackContextKeys() {
-  return Object.keys(map);
-};
+__rspack_context.keys = () => (Object.keys(map));
 __rspack_context.resolve = __rspack_context_resolve;
 module.exports = __rspack_context;
 __rspack_context.id = "./resources sync recursive ^\\.\\/pre_.*\\.js$";

--- a/tests/rspack-test/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
@@ -49,17 +49,15 @@ var map = {
 };
 function __rspack_async_context(req) {
   if(!__webpack_require__.o(map, req)) {
-    return Promise.resolve().then(function() {
-      var e = new Error("Cannot find module '" + req + "'");
-      e.code = 'MODULE_NOT_FOUND';
-      throw e;
-    });
+    return Promise.resolve().then(() => {
+var e = new Error("Cannot find module '" + req + "'");
+e.code = 'MODULE_NOT_FOUND';
+throw e;
+});
   }
 
   var ids = map[req], id = ids[0];
-  return __webpack_require__.e(ids[1][0]).then(function() {
-    return __webpack_require__(id);
-  });
+  return __webpack_require__.e(ids[1][0]).then(() => (__webpack_require__(id)));
 }
 
 __rspack_async_context.keys = () => (Object.keys(map));

--- a/tests/rspack-test/treeShakingCases/context-module/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/context-module/__snapshots__/treeshaking.snap.txt
@@ -39,9 +39,7 @@ function __rspack_context_resolve(req) {
   }
   return map[req];
 }
-__rspack_context.keys = function webpackContextKeys() {
-  return Object.keys(map);
-};
+__rspack_context.keys = () => (Object.keys(map));
 __rspack_context.resolve = __rspack_context_resolve;
 module.exports = __rspack_context;
 __rspack_context.id = "./child sync recursive ^\\.\\/.*\\.js$";


### PR DESCRIPTION
## Summary

use runtime template for context module codegen

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
