### PR TITLE
chore: use httpClient to mock test server

### DIFF
--- a/tests/rspack-test/configCases/asset-modules/http-redirect-security/rspack.config.js
+++ b/tests/rspack-test/configCases/asset-modules/http-redirect-security/rspack.config.js
@@ -1,6 +1,77 @@
-const ServerPlugin = require("./server");
+const httpClient = async (url) => {
+  const parsedUrl = new URL(url);
+  const pathname = parsedUrl.pathname;
 
-const serverPlugin = new ServerPlugin(9991);
+  if (pathname === "/redirect-to-disallowed") {
+    return {
+      status: 302,
+      headers: { "location": "https://evil.com/malicious.js" },
+      body: Buffer.from("")
+    };
+  }
+
+  if (pathname === "/redirect-to-non-http") {
+    return {
+      status: 302,
+      headers: { "location": "ftp://example.com/file.js" },
+      body: Buffer.from("")
+    };
+  }
+
+  if (pathname === "/redirect-chain") {
+    return {
+      status: 302,
+      headers: { "location": "http://localhost:9991/redirect-chain-1" },
+      body: Buffer.from("")
+    };
+  }
+
+  if (pathname === "/redirect-chain-1") {
+    return {
+      status: 302,
+      headers: { "location": "http://localhost:9991/redirect-chain-2" },
+      body: Buffer.from("")
+    };
+  }
+
+  if (pathname === "/redirect-chain-2") {
+    return {
+      status: 302,
+      headers: { "location": "http://localhost:9991/redirect-chain-3" },
+      body: Buffer.from("")
+    };
+  }
+
+  if (pathname === "/redirect-chain-3") {
+    return {
+      status: 302,
+      headers: { "location": "http://localhost:9991/redirect-chain-4" },
+      body: Buffer.from("")
+    };
+  }
+
+  if (pathname === "/redirect-chain-4") {
+    return {
+      status: 302,
+      headers: { "location": "http://localhost:9991/redirect-chain-5" },
+      body: Buffer.from("")
+    };
+  }
+
+  if (pathname === "/redirect-chain-5") {
+    return {
+      status: 302,
+      headers: { "location": "http://localhost:9991/redirect-chain-6" },
+      body: Buffer.from("")
+    };
+  }
+
+  return {
+    status: 404,
+    headers: { "content-type": "text/plain" },
+    body: Buffer.from("Not found")
+  };
+};
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -9,15 +80,13 @@ module.exports = {
   optimization: {
     moduleIds: 'named'
   },
-  plugins: [
-    serverPlugin,
-  ],
   experiments: {
     buildHttp: {
       frozen: false,
       allowedUris: [
         "http://localhost:9991/"
       ],
+      httpClient
     }
   }
 };


### PR DESCRIPTION
Due to globalAgent, which enables keep-alive in Node.js, in some edge cases, it results in the client using a closed socket, which has been closed in server side.

Use a stable mock httpClient in testing to avoid this problem.  