### PR TITLE
refactor: reduce lock contention in swc js minimizer

### DIFF
--- a/crates/rspack_storage/src/fs/mod.rs
+++ b/crates/rspack_storage/src/fs/mod.rs
@@ -154,9 +154,6 @@ impl FileSystem for BridgeFileSystem {
   }
 
   async fn write_file(&self, path: &Utf8Path) -> FSResult<Writer> {
-    if self.exists(path).await? {
-      self.remove_file(path).await?;
-    }
     self
       .ensure_dir(path.parent().expect("should have parent"))
       .await?;


### PR DESCRIPTION
## Summary
- avoid allocating global extracted-comments map unless `extract_comments` is enabled
- avoid per-asset global mutex lookup for banner insertion
- use per-asset local flag (`Cell<bool>`) to decide whether banner is needed

## Why
Perf profiling on `/home/yj/github/build-tools-performance/cases/react-10k` showed lock contention in minimization path.

Before/after from perf (`cycles:uk`, `--no-children`):
- `std::sys::sync::mutex::futex::Mutex::lock_contended`: `0.85% -> 0.60%`
- `swc_ecma_minifier compress::pure visit_mut_expr`: `1.01% -> 0.65%`

Observed compile time in the same profiling scenario:
- `249 ms -> 229 ms` (single run)

## Validation
- `pnpm run build:binding:profiling`
- `perf record ... react-10k`
- `perf report --stdio --no-children -g none`
