### PR TITLE
fix: __webpack_chunk_load__ api compile wrong

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -165,7 +165,7 @@ impl JavascriptParserPlugin for APIPlugin {
         Some(true)
       }
       API_CHUNK_LOAD => {
-        parser.add_presentational_dependency(Box::new(RuntimeRequirementsDependency::call(
+        parser.add_presentational_dependency(Box::new(RuntimeRequirementsDependency::new(
           ident.span.into(),
           RuntimeGlobals::ENSURE_CHUNK,
         )));

--- a/tests/rspack-test/configCases/chunk-loading/chunk-load-api/index.js
+++ b/tests/rspack-test/configCases/chunk-loading/chunk-load-api/index.js
@@ -1,0 +1,4 @@
+it("should have __webpack_chunk_load__ API available", () => {
+    expect(__webpack_chunk_load__).toBeDefined();
+    expect(typeof __webpack_chunk_load__).toBe("function");
+});


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR fixes a bug in the compilation of the `__webpack_chunk_load__` API. The API was incorrectly being rendered as a function call (`__webpack_chunk_load__()`) instead of as a function reference (`__webpack_chunk_load__`), which prevented it from being used correctly in user code.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
