### PR TITLE
docs: add Rspack 2.x docs links to v1 website

### DIFF
--- a/website/docs/en/_nav.json
+++ b/website/docs/en/_nav.json
@@ -71,7 +71,11 @@
         "link": "https://github.com/web-infra-dev/rspack/releases"
       },
       {
-        "text": "Rspack 0.x Doc",
+        "text": "Rspack 2.x Docs",
+        "link": "http://v2.rspack.rs/"
+      },
+      {
+        "text": "Rspack 0.x Docs",
         "link": "http://v0.rspack.rs/"
       }
     ]

--- a/website/docs/zh/_nav.json
+++ b/website/docs/zh/_nav.json
@@ -71,6 +71,10 @@
         "link": "https://github.com/web-infra-dev/rspack/releases"
       },
       {
+        "text": "Rspack 2.x 文档",
+        "link": "http://v2.rspack.rs/zh/"
+      },
+      {
         "text": "Rspack 0.x 文档",
         "link": "http://v0.rspack.rs/zh/"
       }


### PR DESCRIPTION
## Summary

Updates the navigation menus to add links for the new Rspack 2.x documentation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
