### PR TITLE
docs(config): clarify output.uniqueName default value and usage

### DIFF
--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1777,13 +1777,21 @@ export default {
 ## output.uniqueName
 
 - **Type:** `string`
-- **Default:** It defaults to [`output.library`](#outputlibrary) name or the package name from `package.json` in the context, if both aren't found, it is set to an `''`.
+- **Default:** Derived in the following priority order:
+  1. The `name` of [`output.library`](#outputlibrary)
+  2. The `name` field in `package.json` under the `context` directory
+  3. `''` (empty string)
 
-A unique name of the Rspack build to avoid multiple Rspack runtimes to conflict when using globals.
+This option is used to identify a unique name for the current build. It mainly helps prevent runtime code conflicts when multiple Rspack applications run in the same global environment.
 
-`output.uniqueName` will be used to generate unique globals for:
+`output.uniqueName` affects the default values of the following options:
 
-- [`output.chunkLoadingGlobal`](#outputchunkloadingglobal)
+- [output.chunkLoadingGlobal](#outputchunkloadingglobal)
+- [output.hotUpdateGlobal](#outputhotupdateglobal)
+- [output.devtoolNamespace](#outputdevtoolnamespace)
+- [output.trustedTypes.policyName](#outputtrustedtypes)
+
+To override the default value:
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1769,13 +1769,21 @@ export default {
 ## output.uniqueName
 
 - **类型：** `string`
-- **默认值：** 默认使用 [`output.library`](/config/output#outputlibrary) 名称或者上下文中的 package.json 的 包名称（package name）， 如果两者都不存在，值为 `''`。
+- **默认值：** 按以下优先级依次推导：
+  1. [`output.library`](#outputlibrary) 的 `name`
+  2. `context` 目录下 `package.json` 的 `name`
+  3. `''`（空字符串）
 
-此选项决定了在全局环境下为防止多个 Rspack 运行时 冲突所使用的唯一名称。
+该选项用于标识当前构建的唯一名称，主要用于避免多个 Rspack 应用在同一全局环境中运行时，其运行时代码发生冲突。
 
-`output.uniqueName` 将用于生成唯一全局变量:
+`output.uniqueName` 会影响以下配置项的默认值：
 
-- [`output.chunkLoadingGlobal`](/config/output#outputchunkloadingglobal)
+- [output.chunkLoadingGlobal](#outputchunkloadingglobal)
+- [output.hotUpdateGlobal](#outputhotupdateglobal)
+- [output.devtoolNamespace](#outputdevtoolnamespace)
+- [output.trustedTypes.policyName](#outputtrustedtypes)
+
+你也可以覆盖默认值：
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

Updates the documentation for the `output.uniqueName` option, clarify the priority order for how the default value is determined, expand the explanation of its purpose, and list additional options affected by this value.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
