### PR TITLE
fix: allow to export the same name of same local, fix entry splitting algorithm

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -98,6 +98,12 @@ impl EsmLibraryPlugin {
     if ctx.exported_symbols.contains(&exported) {
       // the name is already exported and we know the exported_local is not the same
       if strict_exports {
+        if let Some(already_exported_names) = ctx.exports.get(&local)
+          && already_exported_names.contains(&exported)
+        {
+          return Some(exported);
+        }
+
         return None;
       }
 

--- a/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
+++ b/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
@@ -90,7 +90,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
   let mut chunk_map = chunk_map.into_iter().collect::<Vec<_>>();
   chunk_map.sort_by_key(|(chunks, _)| chunks.len());
 
-  for (chunks, modules) in chunk_map {
+  for (chunks, modules) in chunk_map.into_iter().rev() {
     if chunks.len() <= 1 {
       continue;
     }

--- a/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/__snapshots__/esm.snap.txt
@@ -1,0 +1,47 @@
+```mjs title=entry2.mjs
+import "./shared.mjs";
+
+// ./entry2.js
+
+
+const entry2 = "entry2"
+
+export { entry2 };
+
+```
+
+```mjs title=entry3.mjs
+import "./shared.mjs";
+
+// ./entry3.js
+
+
+const entry3 = "entry3"
+
+export { entry3 };
+
+```
+
+```mjs title=main.mjs
+
+// ./entry1.js
+
+
+
+it('should have all exports', async () => {
+  const {  entry3, entry2 } = await import(/*webpackIgnore: true*/'./main.mjs')
+
+  expect(entry2).toBe('entry2')
+  expect(entry3).toBe('entry3')
+})
+export { entry2 } from "./entry2.mjs";
+export { entry3 } from "./entry3.mjs";
+
+```
+
+```mjs title=shared.mjs
+// ./shared.js
+// side effects
+console.log.bind()
+
+```

--- a/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/entry1.js
+++ b/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/entry1.js
@@ -1,0 +1,9 @@
+export * from './entry2'
+export * from './entry3'
+
+it('should have all exports', async () => {
+  const {  entry3, entry2 } = await import(/*webpackIgnore: true*/'./main.mjs')
+
+  expect(entry2).toBe('entry2')
+  expect(entry3).toBe('entry3')
+})

--- a/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/entry2.js
+++ b/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/entry2.js
@@ -1,0 +1,3 @@
+import './shared'
+
+export const entry2 = "entry2"

--- a/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/entry3.js
+++ b/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/entry3.js
@@ -1,0 +1,3 @@
+import './shared'
+
+export const entry3 = "entry3"

--- a/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/rspack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  entry: {
+    main: './entry1.js',
+    entry2: './entry2.js',
+    entry3: './entry3.js',
+    shared: './shared.js'
+  },
+}

--- a/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/shared.js
+++ b/tests/rspack-test/esmOutputCases/basic/entry-depends-entry/shared.js
@@ -1,0 +1,2 @@
+// side effects
+console.log.bind()

--- a/tests/rspack-test/esmOutputCases/basic/single-entry-split/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/single-entry-split/__snapshots__/esm.snap.txt
@@ -1,10 +1,4 @@
 ```mjs title=bar.mjs
-
-export { v } from "./bar_js.mjs";
-
-```
-
-```mjs title=bar_js.mjs
 // ./bar.js
 const v = () => 42
 export { v };
@@ -12,13 +6,7 @@ export { v };
 ```
 
 ```mjs title=foo.mjs
-
-export { value } from "./foo_js.mjs";
-
-```
-
-```mjs title=foo_js.mjs
-import { v } from "./bar_js.mjs";
+import { v } from "./bar.mjs";
 
 // ./foo.js
 
@@ -30,7 +18,7 @@ export { value };
 ```
 
 ```mjs title=main.mjs
-import { value } from "./foo_js.mjs";
+import { value } from "./foo.mjs";
 
 // ./index.js
 


### PR DESCRIPTION


## Summary

fix bugs for EsmLibraryPlugin.

1. Entry depends entry, should firstly split the module whose belonging chunks is most, then others

2. Even if we export chunk with strict signature, we can export the same name if the local is already exported with the same name

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
