### PR TITLE
docs(ecosystem): add Meteor to ecosystem page

### DIFF
--- a/website/docs/en/guide/start/ecosystem.mdx
+++ b/website/docs/en/guide/start/ecosystem.mdx
@@ -74,7 +74,7 @@ Docusaurus supports Rspack as the bundler since v3.6, see [Docusaurus Faster](ht
 
 [Meteor](https://www.meteor.com/) is a full-stack JavaScript platform for developing modern web and mobile applications.
 
-Meteor 3.4 provides an Rspack integration with faster builds and smaller bundles.
+[Meteor 3.4](https://blog.meteor.com/meteor-3-4-is-out-rspack-integration-4x-faster-builds-8x-smaller-bundles-and-extended-bundler-36600fb45976) provides an Rspack integration with faster builds and smaller bundles.
 
 ### Next.js
 

--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -70,7 +70,7 @@ Docusaurus 从 v3.6 开始支持使用 Rspack 作为打包工具，详见 [Docus
 
 [Meteor](https://www.meteor.com/) 是一个全栈 JavaScript 平台，用于开发现代 Web 和移动应用。
 
-Meteor 3.4 提供了基于 Rspack 的集成，带来更快的构建速度和更小的打包体积。
+[Meteor 3.4](https://blog.meteor.com/meteor-3-4-is-out-rspack-integration-4x-faster-builds-8x-smaller-bundles-and-extended-bundler-36600fb45976) 提供了基于 Rspack 的集成，带来更快的构建速度和更小的打包体积。
 
 ### Next.js
 


### PR DESCRIPTION
## Summary

Adds information about Meteor's Rspack integration, highlights Meteor 3.4's support for faster builds and smaller bundles using Rspack.

## Related links

- https://blog.meteor.com/meteor-3-4-is-out-rspack-integration-4x-faster-builds-8x-smaller-bundles-and-extended-bundler-36600fb45976

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
