### PR TITLE
Update toolchain and remove nightly-only flags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 # workaround for getting workspace root dir, reference: https://github.com/rust-lang/cargo/issues/3946
 [env]
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
+RUSTC_BOOTSTRAP = "1"
 
 [alias]
 lint = "clippy --workspace --all-targets -- --deny warnings"
@@ -32,8 +33,7 @@ rustflags = [
   # "-Wclippy::same_name_method",
 
   "-Aclippy::default_constructed_unit_structs",
-  "-Zshare-generics=y", # make the current crate share its generic instantiations
-  "-Zthreads=8", # parallel frontend https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
+  # Removed nightly-only `-Z*` flags to support stable toolchain.
   "-Csymbol-mangling-version=v0", # symbol mangling v0 https://doc.rust-lang.org/stable/rustc/symbol-mangling/v0.html
 ]
 

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -23,37 +23,6 @@ jobs:
     name: Run Rust Tests
     uses: ./.github/workflows/reusable-rust-test.yml
 
-  rust_test_miri:
-    name: Rust test miri
-    # TODO: enable it after self hosted runners are ready
-    # if: needs.rust_changes.outputs.changed == 'true' && github.ref_name == 'main' && github.repository_owner == 'web-infra-dev'
-    if: false
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
-        with:
-          save-if: ${{ github.ref_name == 'main' }}
-          key: check
-
-      - name: Run Cargo codegen
-        run: cargo codegen
-
-      # Compile test without debug info for reducing the CI cache size
-      - name: Change profile.test
-        shell: bash
-        run: |
-          echo '[profile.test]' >> Cargo.toml
-          echo 'debug = false' >> Cargo.toml
-
-      - name: Run test
-        env:
-          MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-disable-isolation
-        # reason for excluding https://github.com/napi-rs/napi-rs/issues/2200
-        run: cargo miri test --workspace --exclude rspack_node -- --nocapture
-
   test_required_check:
     # this job will be used for GitHub actions to determine required job success or not;
     # When code changed, it will check if any of the test jobs failed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ quote               = { version = "1.0.44", default-features = false }
 rayon               = { version = "1.11.0", default-features = false }
 regex               = { version = "1.12.3", default-features = false }
 regex-syntax        = { version = "0.8.9", default-features = false, features = ["std"] }
-regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
+regress             = { version = "0.10.5", default-features = false }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "0.6.6", default-features = false }
 rspack_sources      = { version = "=0.4.17", default-features = false }
 rustc-hash          = { version = "2.1.1", default-features = false }

--- a/crates/rspack_cacheable_test/tests/macro/cacheable_dyn.rs
+++ b/crates/rspack_cacheable_test/tests/macro/cacheable_dyn.rs
@@ -49,6 +49,7 @@ fn test_cacheable_dyn_macro() {
 
   #[cacheable]
   struct Data {
+    #[cacheable(with=::rspack_cacheable::with::AsCacheable)]
     animal: Box<dyn Animal>,
   }
 
@@ -128,6 +129,7 @@ fn test_cacheable_dyn_macro_with_generics() {
 
   #[cacheable]
   struct Data {
+    #[cacheable(with=::rspack_cacheable::with::AsCacheable)]
     animal_1: Box<dyn Animal<&'static str>>,
     animal_2: Box<dyn Animal<String>>,
   }

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
@@ -240,6 +240,7 @@ fn test_manual_cacheable_dyn_macro() {
 
   #[cacheable]
   struct Data {
+    #[cacheable(with=::rspack_cacheable::with::AsCacheable)]
     animal: Box<dyn Animal>,
   }
 

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
@@ -236,6 +236,7 @@ fn test_manual_cacheable_dyn_macro_with_generics() {
 
   #[cacheable]
   struct Data {
+    #[cacheable(with=::rspack_cacheable::with::AsCacheable)]
     animal_1: Box<dyn Animal<&'static str>>,
     animal_2: Box<dyn Animal<String>>,
   }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -75,6 +75,7 @@ pub struct RootModuleContext {
   pub name_for_condition: Option<Box<str>>,
   pub lib_indent: Option<String>,
   pub resolve_options: Option<Arc<Resolve>>,
+  #[cacheable(with=::rspack_cacheable::with::AsCacheable)]
   pub code_generation_dependencies: Option<Vec<BoxModuleDependency>>,
   pub presentational_dependencies: Option<Vec<BoxDependencyTemplate>>,
   pub context: Option<Context>,

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -65,7 +65,7 @@ pub struct AsyncDependenciesBlock {
   // Vec<Box<T: Sized>> makes sense if T is a large type (see #3530, 1st comment).
   // #3530: https://github.com/rust-lang/rust-clippy/issues/3530
   #[allow(clippy::vec_box)]
-  #[cacheable(omit_bounds)]
+  #[cacheable(with=::rspack_cacheable::with::AsCacheable, omit_bounds)]
   blocks: Vec<Box<AsyncDependenciesBlock>>,
   block_ids: Vec<AsyncDependenciesBlockIdentifier>,
   dependency_ids: Vec<DependencyId>,

--- a/crates/rspack_core/src/module_graph/rollback/overlay_map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/overlay_map.rs
@@ -136,11 +136,13 @@ where
   {
     if self.overlay.is_some() {
       self.materialize_overlay_value(key);
-      let overlay = self.overlay.as_mut().expect("overlay checked above");
-      match overlay.get_mut(key) {
-        Some(OverlayValue::Value(value)) => Some(value),
-        _ => None,
+      if let Some(overlay) = self.overlay.as_mut() {
+        return match overlay.get_mut(key) {
+          Some(OverlayValue::Value(value)) => Some(value),
+          _ => None,
+        };
       }
+      None
     } else {
       self.base.get_mut(key)
     }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -19,7 +19,7 @@ num-bigint = { workspace = true }
 once_cell = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
-regress = { workspace = true, features = ["pattern"] }
+regress = { workspace = true }
 rspack_cacheable = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_core = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/initialize_evaluating.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/initialize_evaluating.rs
@@ -197,7 +197,15 @@ impl JavascriptParserPlugin for InitializeEvaluating {
       } else if arg.is_regexp() {
         let raw = arg.regexp();
         let regex = eval_regexp_to_regexp(&raw.0, &raw.1);
-        param.string().split(&regex).map(|s| s.to_owned()).collect()
+        let input = param.string();
+        let mut result = Vec::new();
+        let mut last = 0;
+        for matched in regex.find_iter(input) {
+          result.push(input[last..matched.start()].to_owned());
+          last = matched.end();
+        }
+        result.push(input[last..].to_owned());
+        result
       } else {
         return None;
       };

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -18,7 +18,7 @@ dashmap          = { workspace = true }
 indexmap         = { workspace = true }
 itoa             = { workspace = true }
 memchr           = { workspace = true }
-regex            = { workspace = true, features = ["pattern"] }
+regex            = { workspace = true }
 rspack_cacheable = { workspace = true }
 rspack_paths     = { workspace = true }
 rustc-hash       = { workspace = true }

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -129,7 +129,9 @@ pub fn insert_zero_width_space_for_fragment(s: &str) -> Cow<'_, str> {
 fn split_keep<'a>(r: &Regex, text: &'a str) -> Vec<&'a str> {
   let mut result = Vec::new();
   let mut last = 0;
-  for (index, matched) in text.match_indices(r) {
+  for matched in r.find_iter(text) {
+    let index = matched.start();
+    let matched = matched.as_str();
     if last != index {
       result.push(&text[last..index]);
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "default"
 components = ["rust-src"]
-# Use nightly for better access to the latest Rust features.
-channel = "nightly-2025-11-13"
+# Use stable for maximum compatibility.
+channel = "stable"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "default"
 components = ["rust-src"]
-# Use stable for maximum compatibility.
-channel = "stable"
+# Pin to a fixed stable version for reproducibility.
+channel = "1.93.0"


### PR DESCRIPTION
Summary
- switch the workspace to the stable Rust toolchain and drop nightly-only compiler flags
- remove regress pattern feature usages and adjust cacheable annotations to keep dyn traits serializable
- tweak regex splitting helpers to handle matches without regex engine `.split`

Testing
- Not run (not requested)