### PR TITLE
refactor: improve rspack_plugin_esm_library code style

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -280,6 +280,27 @@ pub struct ExternalModuleInfo {
   pub runtime_requirements: RuntimeGlobals,
 }
 
+impl ExternalModuleInfo {
+  pub fn new(index: usize, module: ModuleIdentifier) -> Self {
+    Self {
+      index,
+      module,
+      interop_namespace_object_used: false,
+      interop_namespace_object_name: None,
+      interop_namespace_object2_used: false,
+      interop_namespace_object2_name: None,
+      interop_default_access_used: false,
+      interop_default_access_name: None,
+      name: None,
+      deferred: false,
+      deferred_namespace_object_name: None,
+      deferred_namespace_object_used: false,
+      deferred_name: None,
+      runtime_requirements: RuntimeGlobals::default(),
+    }
+  }
+}
+
 #[derive(Debug, Clone)]
 struct ConcatenatedImport {
   connection: Arc<ModuleGraphConnection>,
@@ -1969,20 +1990,8 @@ impl ConcatenatedModule {
             }))
           }
           ConcatenationEntry::External(_) => ModuleInfo::External(ExternalModuleInfo {
-            index: i,
-            module: module_id,
-            interop_namespace_object_used: false,
-            interop_namespace_object_name: None,
-            interop_namespace_object2_used: false,
-            interop_namespace_object2_name: None,
-            interop_default_access_used: false,
-            interop_default_access_name: None,
-            name: None,
             deferred: mg.is_deferred(imported_by_defer_modules_artifact, &module_id),
-            deferred_namespace_object_name: None,
-            deferred_namespace_object_used: false,
-            deferred_name: None,
-            runtime_requirements: Default::default(),
+            ..ExternalModuleInfo::new(i, module_id)
           }),
         });
       let info = match concatenation_entry {
@@ -3085,7 +3094,7 @@ pub fn is_esm_dep_like(dep: &BoxDependency) -> bool {
   )
 }
 
-pub fn find_new_name(old_name: &str, used_names: &HashSet<Atom>, extra_info: &Vec<String>) -> Atom {
+pub fn find_new_name(old_name: &str, used_names: &HashSet<Atom>, extra_info: &[String]) -> Atom {
   let mut name = old_name.to_string();
 
   for info_part in extra_info {

--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -74,83 +74,64 @@ pub struct ExternalInterop {
   pub property_access: FxIndexMap<Atom, Atom>,
 }
 
+fn get_or_create_interop_name(
+  required_symbol: &mut Option<Atom>,
+  field: &mut Option<Atom>,
+  suffix: &str,
+  used_names: &mut FxHashSet<Atom>,
+) -> Atom {
+  if required_symbol.is_none() {
+    let new_name = find_new_name("", used_names, &[]);
+    used_names.insert(new_name.clone());
+    *required_symbol = Some(new_name);
+  }
+  if let Some(existing) = field {
+    return existing.clone();
+  }
+  let mut new_name = Atom::new(format!(
+    "{}{}",
+    required_symbol.as_ref().expect("already set"),
+    suffix
+  ));
+  if used_names.contains(&new_name) {
+    new_name = find_new_name(new_name.as_str(), used_names, &[]);
+  }
+  *field = Some(new_name.clone());
+  used_names.insert(new_name.clone());
+  new_name
+}
+
 impl ExternalInterop {
   pub fn namespace(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
-    if self.required_symbol.is_none() {
-      let new_name = find_new_name("", used_names, &vec![]);
-      used_names.insert(new_name.clone());
-      self.required_symbol = Some(new_name);
-    }
-
-    if let Some(namespace_object) = &self.namespace_object {
-      namespace_object.clone()
-    } else {
-      let mut new_name = Atom::new(format!(
-        "{}_namespace",
-        self.required_symbol.as_ref().expect("already set")
-      ));
-
-      if used_names.contains(&new_name) {
-        new_name = find_new_name(new_name.as_str(), used_names, &vec![]);
-      }
-      self.namespace_object = Some(new_name.clone());
-      used_names.insert(new_name.clone());
-      new_name
-    }
+    get_or_create_interop_name(
+      &mut self.required_symbol,
+      &mut self.namespace_object,
+      "_namespace",
+      used_names,
+    )
   }
 
   pub fn namespace2(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
-    if self.required_symbol.is_none() {
-      let new_name = find_new_name("", used_names, &vec![]);
-      used_names.insert(new_name.clone());
-      self.required_symbol = Some(new_name);
-    }
-
-    if let Some(namespace_object) = &self.namespace_object2 {
-      namespace_object.clone()
-    } else {
-      let mut new_name = Atom::new(format!(
-        "{}_namespace2",
-        self.required_symbol.as_ref().expect("already set")
-      ));
-
-      if used_names.contains(&new_name) {
-        new_name = find_new_name(new_name.as_str(), used_names, &vec![]);
-      }
-      self.namespace_object2 = Some(new_name.clone());
-      used_names.insert(new_name.clone());
-      new_name
-    }
+    get_or_create_interop_name(
+      &mut self.required_symbol,
+      &mut self.namespace_object2,
+      "_namespace2",
+      used_names,
+    )
   }
 
   pub fn default_access(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
-    if self.required_symbol.is_none() {
-      let new_name = find_new_name("", used_names, &vec![]);
-      used_names.insert(new_name.clone());
-      self.required_symbol = Some(new_name);
-    }
-
-    if let Some(default_access) = &self.default_access {
-      default_access.clone()
-    } else {
-      let mut new_name = Atom::new(format!(
-        "{}_default",
-        self.required_symbol.as_ref().expect("already set")
-      ));
-
-      if used_names.contains(&new_name) {
-        new_name = find_new_name(new_name.as_str(), used_names, &vec![]);
-      }
-
-      self.default_access = Some(new_name.clone());
-      used_names.insert(new_name.clone());
-      new_name
-    }
+    get_or_create_interop_name(
+      &mut self.required_symbol,
+      &mut self.default_access,
+      "_default",
+      used_names,
+    )
   }
 
   pub fn default_exported(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
     if self.required_symbol.is_none() {
-      let new_name = find_new_name("", used_names, &vec![]);
+      let new_name = find_new_name("", used_names, &[]);
       used_names.insert(new_name.clone());
       self.required_symbol = Some(new_name);
     }
@@ -160,7 +141,7 @@ impl ExternalInterop {
     }
 
     let default_access_symbol = self.default_access(used_names);
-    let default_exported_symbol = find_new_name(&default_access_symbol, used_names, &vec![]);
+    let default_exported_symbol = find_new_name(&default_access_symbol, used_names, &[]);
     used_names.insert(default_exported_symbol.clone());
     self.default_exported = Some(default_exported_symbol.clone());
     default_exported_symbol
@@ -168,7 +149,7 @@ impl ExternalInterop {
 
   pub fn property_access(&mut self, atom: &Atom, used_names: &mut FxHashSet<Atom>) -> Atom {
     self.property_access.get(atom).cloned().unwrap_or_else(|| {
-      let local_name = find_new_name(atom, used_names, &vec![]);
+      let local_name = find_new_name(atom, used_names, &[]);
       self.property_access.insert(atom.clone(), local_name);
       self
         .property_access

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -192,22 +192,7 @@ async fn finish_modules(
     } else {
       modules_map.insert(
         *module_identifier,
-        ModuleInfo::External(ExternalModuleInfo {
-          index: idx,
-          module: *module_identifier,
-          interop_namespace_object_used: false,
-          interop_namespace_object_name: None,
-          interop_namespace_object2_used: false,
-          interop_namespace_object2_name: None,
-          interop_default_access_used: false,
-          interop_default_access_name: None,
-          runtime_requirements: RuntimeGlobals::default(),
-          name: None,
-          deferred: false,
-          deferred_name: None,
-          deferred_namespace_object_name: None,
-          deferred_namespace_object_used: false,
-        }),
+        ModuleInfo::External(ExternalModuleInfo::new(idx, *module_identifier)),
       );
     }
   }
@@ -234,22 +219,10 @@ async fn finish_modules(
       if let Some(info) = modules_map.get_mut(dep_module)
         && let ModuleInfo::Concatenated(concate_info) = info
       {
-        *info = ModuleInfo::External(ExternalModuleInfo {
-          index: concate_info.index,
-          module: concate_info.module,
-          interop_namespace_object_used: false,
-          interop_namespace_object_name: None,
-          interop_namespace_object2_used: false,
-          interop_namespace_object2_name: None,
-          interop_default_access_used: false,
-          interop_default_access_name: None,
-          name: None,
-          runtime_requirements: RuntimeGlobals::default(),
-          deferred: false,
-          deferred_name: None,
-          deferred_namespace_object_name: None,
-          deferred_namespace_object_used: false,
-        });
+        *info = ModuleInfo::External(ExternalModuleInfo::new(
+          concate_info.index,
+          concate_info.module,
+        ));
         stack.push(*dep_module);
       }
     }
@@ -453,7 +426,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             .get(chunk_ukey)
             .expect("should have chunk for chunk ukey")
         }) else {
-          unreachable!("This should happen, please file an issue");
+          unreachable!("This should not happen, please file an issue");
         };
 
         let js_files = chunk

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{
+  borrow::Cow,
+  sync::{Arc, LazyLock},
+};
 
 use regex::Regex;
 use rspack_collections::{IdentifierIndexSet, UkeyIndexMap, UkeySet};
@@ -21,7 +24,6 @@ use rspack_util::{
   atom::Atom,
   fx_hash::{FxHashMap, FxIndexSet},
 };
-use swc_core::common::sync::Lazy;
 
 use crate::{
   chunk_link::{ChunkLinkContext, ReExportFrom, Ref},
@@ -39,8 +41,8 @@ fn get_chunk(compilation: &Compilation, chunk_ukey: ChunkUkey) -> &Chunk {
 
 use crate::{EsmLibraryPlugin, dependency::dyn_import::NAMESPACE_SYMBOL};
 
-static AUTO_PUBLIC_PATH_PLACEHOLDER_RE: Lazy<Regex> =
-  Lazy::new(|| Regex::new(AUTO_PUBLIC_PATH_PLACEHOLDER).expect("failed to create regex"));
+static AUTO_PUBLIC_PATH_PLACEHOLDER_RE: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(AUTO_PUBLIC_PATH_PLACEHOLDER).expect("failed to create regex"));
 
 impl EsmLibraryPlugin {
   pub(crate) fn get_runtime_chunk(chunk_ukey: ChunkUkey, compilation: &Compilation) -> ChunkUkey {


### PR DESCRIPTION
## Summary

- Fix incorrect error message (`"This should happen"` → `"This should not happen"`) in unreachable path
- Add `ExternalModuleInfo::new()` constructor to eliminate 3 duplicated struct initializations
- Migrate `swc_core::common::sync::Lazy` to `std::sync::LazyLock` for consistency
- Avoid cloning entire modules map in `analyze_module` by using `keys().copied().collect()` + `std::mem::take`
- Extract `get_or_create_interop_name` helper to deduplicate `namespace()`, `namespace2()`, `default_access()` in `ExternalInterop`
- Replace `unwrap()` with `expect()` and remove `#[allow(clippy::unwrap_used)]` in `preserve_modules`
- Change `find_new_name` param from `&Vec<String>` to `&[String]`, replace all `&vec![]` with `&[]`

All changes are refactoring-only with no behavioral change.