### PR TITLE
docs(config): add examples module rules

### DIFF
--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -461,9 +461,46 @@ export default {
 
 `rules[].loader` is a shortcut to `rules[].use: [ { loader } ]`. See [rules[].use](/config/module-rules#rulesuse) for details.
 
+For example, use the built-in swc-loader to compile TypeScript files:
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'builtin:swc-loader',
+      },
+    ],
+  },
+};
+```
+
 ## rules[].options
 
 `rules[].options` is a shortcut to `rules[].use: [ { options } ]`. See [rules[].use](/config/module-rules#rulesuse) for details.
+
+For example, pass options to the swc-loader:
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'builtin:swc-loader',
+        options: {
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+```
 
 ## rules[].parser
 

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -461,9 +461,46 @@ export default {
 
 `rules[].loader` 是 `rules[].use: [ { loader } ]` 的简略写法。 详情见 [rules[].use](/config/module-rules#rulesuse).
 
+例如，使用 `builtin:swc-loader` 来编译 TypeScript 文件：
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'builtin:swc-loader',
+      },
+    ],
+  },
+};
+```
+
 ## rules[].options
 
 `rules[].options` 是 `rules[].use: [ { options } ]` 的简略写法。 详情见 [rules[].use](/config/module-rules#rulesuse).
+
+例如，向 `builtin:swc-loader` 传递选项：
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'builtin:swc-loader',
+        options: {
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+```
 
 ## rules[].parser
 


### PR DESCRIPTION
## Summary

Adds practical usage examples to documentation for configuring module rules in Rspack.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
