### PR TITLE
perf: Disable tracing features in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ textwrap            = { version = "0.16.1", default-features = false }
 thread_local        = { version = "1.1.9", default-features = false }
 tokio               = { version = "1.48.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 toml                = { version = "0.8.19", default-features = false, features = ["parse", "display"] }
-tracing             = { version = "0.1.44", default-features = false, features = ["max_level_trace", "release_max_level_trace"] }
+tracing             = { version = "0.1.44", default-features = false, features = ["max_level_trace", "release_max_level_off"] }
 tracing-subscriber  = { version = "0.3.22", default-features = false, features = ["fmt", "registry"] }
 trybuild            = { version = "1.0.116", default-features = false, features = ["diff"] }
 unicase             = { version = "2.8.1", default-features = false }

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -83,7 +83,6 @@ async function build() {
 			features.push("tracy-client");
 		}
 		if (values.profile === "release") {
-			features.push("info-level");
 			if (process.env.RUST_TARGET && !process.env.RUST_TARGET.includes("windows-msvc")) {
 				rustflags.push("-Cforce-unwind-tables=no");
 			}


### PR DESCRIPTION
Summary
- stop enabling tracing info-level and use `release_max_level_off` for `tracing` in Cargo.toml to ensure release builds omit tracing overhead
- avoid passing the `info-level` feature when building the node binding in release mode

Testing
- Not run (not requested)