### PR TITLE
fix!: remove deprecated readResourceForScheme hook

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -5405,8 +5405,6 @@ interface NormalModuleCompilationHooks {
     loader: liteTapable.SyncHook<[LoaderContext, Module]>;
     // (undocumented)
     readResource: liteTapable.HookMap<liteTapable.AsyncSeriesBailHook<[LoaderContext], string | Buffer>>;
-    // (undocumented)
-    readResourceForScheme: any;
 }
 
 // @public (undocumented)

--- a/packages/rspack/src/NormalModule.ts
+++ b/packages/rspack/src/NormalModule.ts
@@ -1,4 +1,3 @@
-import util from 'node:util';
 import binding from '@rspack/binding';
 import * as liteTapable from '@rspack/lite-tapable';
 import type { Source } from 'webpack-sources';
@@ -40,63 +39,10 @@ Object.defineProperty(binding.NormalModule.prototype, 'emitFile', {
 
 export interface NormalModuleCompilationHooks {
   loader: liteTapable.SyncHook<[LoaderContext, Module]>;
-  readResourceForScheme: any;
   readResource: liteTapable.HookMap<
     liteTapable.AsyncSeriesBailHook<[LoaderContext], string | Buffer>
   >;
 }
-
-const createFakeHook = <T extends Record<string, any>>(
-  fakeHook: T,
-  message?: string,
-  code?: string,
-): FakeHook<T> => {
-  return Object.freeze(
-    Object.assign(
-      message && code
-        ? deprecateAllProperties(fakeHook, message, code)
-        : fakeHook,
-      { _fakeHook: true },
-    ),
-  );
-};
-type FakeHook<T> = {
-  _fakeHook: true;
-} & T;
-const deprecateAllProperties = <O extends object>(
-  obj: O,
-  message: string,
-  code: string,
-) => {
-  const newObj: any = {};
-  const descriptors = Object.getOwnPropertyDescriptors(obj);
-  for (const name of Object.keys(descriptors)) {
-    const descriptor = descriptors[name];
-    if (typeof descriptor.value === 'function') {
-      Object.defineProperty(newObj, name, {
-        ...descriptor,
-        value: util.deprecate(descriptor.value, message, code),
-      });
-    } else if (descriptor.get || descriptor.set) {
-      Object.defineProperty(newObj, name, {
-        ...descriptor,
-        get: descriptor.get && util.deprecate(descriptor.get, message, code),
-        set: descriptor.set && util.deprecate(descriptor.set, message, code),
-      });
-    } else {
-      let value = descriptor.value;
-      Object.defineProperty(newObj, name, {
-        configurable: descriptor.configurable,
-        enumerable: descriptor.enumerable,
-        get: util.deprecate(() => value, message, code),
-        set: descriptor.writable
-          ? util.deprecate((v: any) => (value = v), message, code)
-          : undefined,
-      });
-    }
-  }
-  return newObj;
-};
 
 Object.defineProperty(binding.NormalModule, 'getCompilationHooks', {
   enumerable: true,
@@ -114,26 +60,6 @@ Object.defineProperty(binding.NormalModule, 'getCompilationHooks', {
     if (hooks === undefined) {
       hooks = {
         loader: new liteTapable.SyncHook(['loaderContext', 'module']),
-        // TODO webpack 6 deprecate
-        readResourceForScheme: new liteTapable.HookMap((scheme) => {
-          const hook = hooks!.readResource.for(scheme);
-          return createFakeHook({
-            tap: (options: string, fn: any) =>
-              hook.tap(options, (loaderContext: LoaderContext) =>
-                fn(loaderContext.resource),
-              ),
-            tapAsync: (options: string, fn: any) =>
-              hook.tapAsync(
-                options,
-                (loaderContext: LoaderContext, callback: any) =>
-                  fn(loaderContext.resource, callback),
-              ),
-            tapPromise: (options: string, fn: any) =>
-              hook.tapPromise(options, (loaderContext: LoaderContext) =>
-                fn(loaderContext.resource),
-              ),
-          }) as any;
-        }),
         readResource: new liteTapable.HookMap(
           () => new liteTapable.AsyncSeriesBailHook(['loaderContext']),
         ),


### PR DESCRIPTION
## Summary

Remove the `NormalModule.getCompilationHooks(compilation).readResourceForScheme()` hook because it was never implemented in Rspack and has been deprecated in webpack (https://github.com/webpack/webpack/blob/124ba79918269ecc6018915655c993327947ff12/lib/NormalModule.js#L289-L290).

It appears that it is not used by any popular plugins: https://github.com/search?q=readResourceForScheme&type=code

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
