### PR TITLE
fix: generating correct types for `@rspack/lite-tapable`

### DIFF
--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -197,7 +197,8 @@ export default defineConfig({
         build: true,
         alias: {
           // alias to pre-bundled types as they are public API
-          '@rspack/lite-tapable': './compiled/@rspack/lite-tapable/dist/index',
+          '@rspack/lite-tapable':
+            './compiled/@rspack/lite-tapable/dist/index.d.ts',
         },
       },
       redirect: {


### PR DESCRIPTION
## Summary

Generating `.d.ts` instead of `.d` in output.

```diff
- import * as liteTapable from '../compiled/@rspack/lite-tapable/dist/index.d';
+ import * as liteTapable from '../compiled/@rspack/lite-tapable/dist/index.d.ts';
```

## Related links

Fix the build error in https://github.com/rstackjs/rsbuild-plugin-tailwindcss/pull/71.

Also see https://github.com/web-infra-dev/rspack/pull/13031.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
