### PR TITLE
feat: optimize star exports from externals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4874,6 +4874,7 @@ version = "0.100.0-beta.3"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
+ "rspack_collections",
  "rspack_core",
  "rspack_error",
  "rspack_fs",
@@ -4881,6 +4882,7 @@ dependencies = [
  "rspack_hook",
  "rspack_plugin_asset",
  "rspack_plugin_javascript",
+ "rustc-hash",
  "serde_json",
  "swc_core",
  "tracing",

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1061,6 +1061,19 @@ var {} = {{}};
     };
 
     for dep in module.get_dependencies() {
+      let Some(conn) = module_graph.connection_by_dependency_id(dep) else {
+        continue;
+      };
+
+      if !conn.is_active(
+        module_graph,
+        None,
+        module_graph_cache,
+        exports_info_artifact,
+      ) {
+        continue;
+      }
+
       let dep = module_graph.dependency_by_id(dep);
       if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>()
         && dep.name.is_none()
@@ -1072,9 +1085,8 @@ var {} = {{}};
           exports_info_artifact,
         );
 
-        if matches!(mode, ExportMode::DynamicReexport(_))
-          && let Some(ref_module) = module_graph.module_identifier_by_dependency_id(&dep.id)
-        {
+        if matches!(mode, ExportMode::DynamicReexport(_)) {
+          let ref_module = conn.module_identifier();
           // collect all exports from ref module
           exports.extend(Self::resolve_re_export_star_from_unknown(
             *ref_module,

--- a/crates/rspack_plugin_rslib/Cargo.toml
+++ b/crates/rspack_plugin_rslib/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 rspack_cacheable         = { workspace = true }
+rspack_collections       = { workspace = true }
 rspack_core              = { workspace = true }
 rspack_error             = { workspace = true }
 rspack_fs                = { workspace = true }
@@ -18,6 +19,7 @@ rspack_plugin_asset      = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
 
 async-trait = { workspace = true }
+rustc-hash  = { workspace = true }
 serde_json  = { workspace = true }
 swc_core    = { workspace = true }
 tracing     = { workspace = true }

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -1,11 +1,158 @@
 use std::sync::Arc;
 
+use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  BuildModuleGraphArtifact, DependenciesBlock, Dependency, DependencyTemplate, ExternalModule,
+  BuildModuleGraphArtifact, Compilation, DependenciesBlock, Dependency, DependencyId,
+  DependencyTemplate, ExportsInfoArtifact, ExternalModule, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, NormalInitFragment,
 };
-use rspack_plugin_javascript::dependency::ImportDependency;
+use rspack_plugin_javascript::dependency::{
+  ESMExportImportedSpecifierDependency, ESMImportSideEffectDependency, ImportDependency,
+};
+use rustc_hash::FxHashSet;
 
-pub fn cutout_dyn_import_external(build_module_graph_artifact: &mut BuildModuleGraphArtifact) {
+fn has_unknown(exports: &rspack_core::ExportNameOrSpec) -> bool {
+  match exports {
+    rspack_core::ExportNameOrSpec::String(_) => false,
+    rspack_core::ExportNameOrSpec::ExportSpec(export_spec) => {
+      if let Some(exports) = &export_spec.exports {
+        if exports.unknown_provided {
+          return true;
+        }
+
+        exports.exports.iter().any(has_unknown)
+      } else {
+        false
+      }
+    }
+  }
+}
+
+pub fn cutout_star_re_export_externals(
+  compilation: &Compilation,
+  build_module_graph_artifact: &mut BuildModuleGraphArtifact,
+  exports_info_artifact: &mut ExportsInfoArtifact,
+) {
+  let mg = build_module_graph_artifact.get_module_graph();
+  let mut connections_to_disable = FxHashSet::default();
+
+  let entry_modules = build_module_graph_artifact
+    .entry_dependencies
+    .iter()
+    .filter_map(|dep_id| mg.module_identifier_by_dependency_id(dep_id))
+    .copied()
+    .collect::<IdentifierSet>();
+
+  for module_id in &entry_modules {
+    let module = mg
+      .module_by_identifier(module_id)
+      .expect("should have entry module");
+    let mut side_effects_deps_by_module = IdentifierMap::<Vec<DependencyId>>::default();
+    let mut star_export_deps_by_module = IdentifierMap::default();
+
+    for dep_id in module.get_dependencies() {
+      let dep = mg.dependency_by_id(dep_id);
+      let Some(module) = mg
+        .module_identifier_by_dependency_id(dep_id)
+        .and_then(|module_id| mg.module_by_identifier(module_id))
+      else {
+        continue;
+      };
+
+      let Some(external_module) = module.as_external_module() else {
+        continue;
+      };
+      let external_type = external_module.get_external_type().as_str();
+      if external_type != "module" && external_type != "module-import" {
+        continue;
+      }
+
+      if dep.as_any().is::<ESMImportSideEffectDependency>() {
+        side_effects_deps_by_module
+          .entry(external_module.id)
+          .or_default()
+          .push(*dep_id);
+      } else if let Some(esm_export_dep) = dep
+        .as_any()
+        .downcast_ref::<ESMExportImportedSpecifierDependency>()
+        && esm_export_dep.name.is_none()
+        && esm_export_dep.other_star_exports.is_some()
+      {
+        *star_export_deps_by_module
+          .entry(external_module.id)
+          .or_insert(0) += 1;
+
+        connections_to_disable.insert(*dep_id);
+      }
+    }
+
+    for (module_id, side_effect_deps) in side_effects_deps_by_module {
+      let star_count = star_export_deps_by_module.get(&module_id).unwrap_or(&0);
+      if side_effect_deps.len() == *star_count {
+        connections_to_disable.extend(side_effect_deps);
+      }
+    }
+  }
+
+  let mg = build_module_graph_artifact.get_module_graph_mut();
+  for dep_id in &connections_to_disable {
+    let conn = mg
+      .connection_by_dependency_id_mut(dep_id)
+      .expect("definitely has connection");
+    conn.force_inactive();
+  }
+
+  // correct exports info
+  for module_id in entry_modules {
+    let module = mg
+      .module_by_identifier(&module_id)
+      .expect("should have entry module");
+
+    if !module.build_meta().esm {
+      continue;
+    }
+
+    let exports_info = exports_info_artifact.get_exports_info_data(&module_id);
+
+    // re check
+    if matches!(
+      exports_info.other_exports_info().provided(),
+      Some(rspack_core::ExportProvided::Unknown)
+    ) {
+      let has_unknown_exports = module.get_dependencies().iter().any(|dep_id| {
+        if connections_to_disable.contains(dep_id) {
+          return false;
+        }
+
+        let dep = mg.dependency_by_id(dep_id);
+        let Some(exports) = dep.get_exports(
+          mg,
+          &compilation.module_graph_cache_artifact,
+          exports_info_artifact,
+        ) else {
+          return false;
+        };
+
+        match &exports.exports {
+          rspack_core::ExportsOfExportsSpec::UnknownExports => true,
+          rspack_core::ExportsOfExportsSpec::NoExports => false,
+          rspack_core::ExportsOfExportsSpec::Names(export_name_or_specs) => {
+            export_name_or_specs.iter().any(has_unknown)
+          }
+        }
+      });
+
+      if !has_unknown_exports {
+        let exports_info = exports_info_artifact.get_exports_info_data_mut(&module_id);
+        exports_info
+          .other_exports_info_mut()
+          .set_provided(Some(rspack_core::ExportProvided::NotProvided));
+      }
+    }
+  }
+}
+
+pub fn cutout_dyn_import_externals(build_module_graph_artifact: &mut BuildModuleGraphArtifact) {
   let mg = build_module_graph_artifact.get_module_graph();
   let mut connections_to_disable = Vec::new();
   for (_, module) in mg.modules() {
@@ -107,6 +254,62 @@ impl DependencyTemplate for ImportDependencyTemplate {
       .and_then(|module_id| mg.module_by_identifier(module_id));
     if let Some(external) = ref_module.and_then(|m| m.as_external_module()) {
       render_dyn_import_external_module(dep, external, source);
+      return;
+    }
+
+    if let Some(template) = &self.template {
+      template.render(dep, source, code_generatable_context);
+    }
+  }
+}
+
+#[derive(Debug)]
+pub(crate) struct ExportImportedDependencyTemplate {
+  pub(crate) template: Option<Arc<dyn DependencyTemplate>>,
+}
+
+impl DependencyTemplate for ExportImportedDependencyTemplate {
+  fn render(
+    &self,
+    dep: &dyn rspack_core::DependencyCodeGeneration,
+    source: &mut rspack_core::rspack_sources::ReplaceSource,
+    code_generatable_context: &mut rspack_core::TemplateContext,
+  ) {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<ESMExportImportedSpecifierDependency>()
+      .expect("should be export imported dependency");
+    let mg = code_generatable_context.compilation.get_module_graph();
+    let module = mg.module_identifier_by_dependency_id(&dep.id);
+
+    if dep.name.is_none()
+      && dep.other_star_exports.is_some()
+      && let Some(module) = module
+        .and_then(|mid| mg.module_by_identifier(mid))
+        .and_then(|m| {
+          m.as_external_module().filter(|&m| m.get_external_type() == "module" || m.get_external_type() == "module-import")
+        })
+      // TODO: should cache calculate results for this
+      && code_generatable_context
+        .compilation
+        .entry_modules()
+        .contains(&code_generatable_context.module.identifier())
+    {
+      let request = module.get_request();
+      let chunk_init_fragments = code_generatable_context.chunk_init_fragments();
+      chunk_init_fragments.push(
+        NormalInitFragment::new(
+          format!(
+            "export * from {};\n",
+            serde_json::to_string(request.primary()).expect("invalid json to_string")
+          ),
+          InitFragmentStage::StageESMImports,
+          0,
+          InitFragmentKey::Const(format!("esm_module_reexport_star_{}", dep.request)),
+          None,
+        )
+        .boxed(),
+      );
       return;
     }
 

--- a/crates/rspack_plugin_rslib/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rslib/src/parser_plugin.rs
@@ -3,7 +3,7 @@ use swc_core::ecma::ast::MemberExpr;
 
 #[derive(PartialEq, Debug, Default)]
 pub struct RslibParserPlugin {
-  pub intercept_api_plugin: bool,
+  intercept_api_plugin: bool,
 }
 
 impl RslibParserPlugin {

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -21,7 +21,10 @@ use rspack_plugin_javascript::{
 
 use crate::{
   asset::RslibAssetParserAndGenerator,
-  dyn_import_external::{ImportDependencyTemplate, cutout_dyn_import_external},
+  dyn_import_external::{
+    ExportImportedDependencyTemplate, ImportDependencyTemplate, cutout_dyn_import_externals,
+    cutout_star_re_export_externals,
+  },
   hashbang_parser_plugin::HashbangParserPlugin,
   parser_plugin::RslibParserPlugin,
   react_directives_parser_plugin::ReactDirectivesParserPlugin,
@@ -95,13 +98,26 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  let template = compilation.get_dependency_template(
+  let import_template = compilation.get_dependency_template(
     rspack_core::DependencyTemplateType::Dependency(DependencyType::DynamicImport),
   );
   compilation.set_dependency_template(
     rspack_core::DependencyTemplateType::Dependency(DependencyType::DynamicImport),
-    Arc::new(ImportDependencyTemplate { template }),
+    Arc::new(ImportDependencyTemplate {
+      template: import_template,
+    }),
   );
+
+  let export_template = compilation.get_dependency_template(
+    rspack_core::DependencyTemplateType::Dependency(DependencyType::EsmExportImportedSpecifier),
+  );
+  compilation.set_dependency_template(
+    rspack_core::DependencyTemplateType::Dependency(DependencyType::EsmExportImportedSpecifier),
+    Arc::new(ExportImportedDependencyTemplate {
+      template: export_template,
+    }),
+  );
+
   // Register render hook for hashbang and directives handling during chunk generation
   let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   let mut hooks = hooks.write().await;
@@ -176,13 +192,19 @@ async fn render(
 #[plugin_hook(CompilationOptimizeDependencies for RslibPlugin)]
 async fn optimize_dependencies(
   &self,
-  _compilation: &Compilation,
+  compilation: &Compilation,
   _side_effects_optimize_artifact: &mut SideEffectsOptimizeArtifact,
   build_module_graph_artifact: &mut BuildModuleGraphArtifact,
-  _exports_info_artifact: &mut ExportsInfoArtifact,
+  exports_info_artifact: &mut ExportsInfoArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
-  cutout_dyn_import_external(build_module_graph_artifact);
+  cutout_dyn_import_externals(build_module_graph_artifact);
+  cutout_star_re_export_externals(
+    compilation,
+    build_module_graph_artifact,
+    exports_info_artifact,
+  );
+
   Ok(None)
 }
 

--- a/tests/rspack-test/esmOutputCases/basic/hidden-folder/.hidden/index.js
+++ b/tests/rspack-test/esmOutputCases/basic/hidden-folder/.hidden/index.js
@@ -1,0 +1,1 @@
+export const value = () => 42

--- a/tests/rspack-test/esmOutputCases/basic/hidden-folder/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/hidden-folder/__snapshots__/esm.snap.txt
@@ -1,0 +1,16 @@
+```mjs title=_hidden_index_js.mjs
+// ./.hidden/index.js
+const value = () => 42
+export { value };
+
+```
+
+```mjs title=main.mjs
+// ./index.js
+it("should render hidden folder", async () => {
+  const {value} = await import("./_hidden_index_js.mjs").then((mod) => ({ value: mod.value }))
+
+  expect(value()).toBe(42)
+})
+
+```

--- a/tests/rspack-test/esmOutputCases/basic/hidden-folder/index.js
+++ b/tests/rspack-test/esmOutputCases/basic/hidden-folder/index.js
@@ -1,0 +1,5 @@
+it("should render hidden folder", async () => {
+  const {value} = await import('./.hidden/index')
+
+  expect(value()).toBe(42)
+})

--- a/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/esm.snap.txt
@@ -1,0 +1,125 @@
+```mjs title=main.mjs
+import * as __rspack_external_fs from "fs";
+export * from "fs";
+export * from "path";
+import { __webpack_require__ } from "./runtime.mjs";
+__webpack_require__.add({
+"./dynamic-exports.js"
+/*!****************************!*\
+  !*** ./dynamic-exports.js ***!
+  \****************************/
+(__unused_rspack_module, exports) {
+const def = (o) => {
+  o.readFile = () => 42
+}
+
+def(exports)
+
+
+},
+"./runtime-decide.js"
+/*!***************************!*\
+  !*** ./runtime-decide.js ***!
+  \***************************/
+(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+/* import */ var _dynamic_exports__rspack_import_0 = __webpack_require__(/*! ./dynamic-exports */ "./dynamic-exports.js");
+/* import */ var _dynamic_exports__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(_dynamic_exports__rspack_import_0);
+if(__webpack_require__.o(_dynamic_exports__rspack_import_0, "readFile")) __webpack_require__.d(__webpack_exports__, { readFile: function() { return _dynamic_exports__rspack_import_0.readFile; } });
+/* import */ var fs__rspack_import_1 = __webpack_require__(/*! fs */ "fs");
+if(__webpack_require__.o(fs__rspack_import_1, "readFile")) __webpack_require__.d(__webpack_exports__, { readFile: function() { return fs__rspack_import_1.readFile; } });
+
+
+// side effects
+console.log.bind()
+
+
+},
+"fs"
+/*!*********************!*\
+  !*** external "fs" ***!
+  \*********************/
+(module) {
+
+module.exports = __rspack_external_fs;
+
+
+},
+});
+// ./index.js
+const runtime_decide = __webpack_require__("./runtime-decide.js");
+
+
+
+;
+
+it('should have correct exports as its exports is decided at runtime', async () => {
+  const { resolve } = await import(/* webpackIgnore: true */ './main.mjs');
+  const { resolve: nodeResolve } = await import(/* webpackIgnore: true */ 'path');
+
+  expect(resolve).toBe(nodeResolve)
+  expect(runtime_decide.readFile()).toBe(42)
+})
+
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-ESM modules
+__webpack_require__.n = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, definition) => {
+	for(var key in definition) {
+        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+        }
+    }
+};
+})();
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/externals/runtime-decide/dynamic-exports.js
+++ b/tests/rspack-test/esmOutputCases/externals/runtime-decide/dynamic-exports.js
@@ -1,0 +1,5 @@
+const def = (o) => {
+  o.readFile = () => 42
+}
+
+def(exports)

--- a/tests/rspack-test/esmOutputCases/externals/runtime-decide/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/runtime-decide/index.js
@@ -1,0 +1,12 @@
+export * from 'fs'
+export * from 'path'
+
+import * as runtime from './runtime-decide'
+
+it('should have correct exports as its exports is decided at runtime', async () => {
+  const { resolve } = await import(/* webpackIgnore: true */ './main.mjs');
+  const { resolve: nodeResolve } = await import(/* webpackIgnore: true */ 'path');
+
+  expect(resolve).toBe(nodeResolve)
+  expect(runtime.readFile()).toBe(42)
+})

--- a/tests/rspack-test/esmOutputCases/externals/runtime-decide/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/runtime-decide/rspack.config.js
@@ -1,0 +1,11 @@
+const { experiments: { RslibPlugin } } = require('@rspack/core')
+
+module.exports = {
+  externals: {
+    fs: 'module fs',
+    path: 'module path',
+  },
+  plugins: [
+    new RslibPlugin()
+  ]
+}

--- a/tests/rspack-test/esmOutputCases/externals/runtime-decide/runtime-decide.js
+++ b/tests/rspack-test/esmOutputCases/externals/runtime-decide/runtime-decide.js
@@ -1,0 +1,4 @@
+export * from './dynamic-exports'
+export * from 'fs'
+// side effects
+console.log.bind()

--- a/tests/rspack-test/esmOutputCases/externals/star-re-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/star-re-export/__snapshots__/esm.snap.txt
@@ -1,0 +1,10 @@
+```mjs title=main.mjs
+export * from "fs";
+export * from "path";
+// ./index.js
+
+
+const value = 42
+export { value };
+
+```

--- a/tests/rspack-test/esmOutputCases/externals/star-re-export/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/star-re-export/index.js
@@ -1,0 +1,3 @@
+export * from 'fs'
+export * from 'path'
+export const value = 42

--- a/tests/rspack-test/esmOutputCases/externals/star-re-export/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/star-re-export/rspack.config.js
@@ -1,0 +1,11 @@
+const { experiments: { RslibPlugin } } = require('@rspack/core')
+
+module.exports = {
+  externals: {
+    fs: 'module fs',
+    path: 'module path',
+  },
+  plugins: [
+    new RslibPlugin()
+  ]
+}


### PR DESCRIPTION
## Summary

Optimize star reexports from external module, make module with unknown reexports have static exports info

Fix path rendering bug, file with dot prefix should render as './' + file

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
