### PR TITLE
chore(ci): allow `check-codspeed` to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,17 +169,19 @@ jobs:
     steps:
       - name: Log
         run: echo ${{ join(needs.*.result, ',') }}
+      # PR checks: size-limit must succeed; check-codspeed may succeed or fail.
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name == 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success' }}
-        run: echo "Tess Failed" && exit 1
+          && !contains(fromJSON('["success,success,success,success,success,success,success,success","failure,success,success,success,success,success,success,success"]'), join(needs.*.result, ',')) }}
+        run: echo "Test Failed" && exit 1
 
+      # Non-PR checks: size-limit is skipped; check-codspeed may succeed or fail.
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name != 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,skipped,success' }}
-        run: echo "Tess Failed" && exit 1
+          && !contains(fromJSON('["success,success,success,success,success,success,skipped,success","failure,success,success,success,success,success,skipped,success"]'), join(needs.*.result, ',')) }}
+        run: echo "Test Failed" && exit 1
 
       - name: No check to Run test
         run: echo "Success"


### PR DESCRIPTION
## Summary

`check-codspeed` has been intermittently failing due to CI machine instability rather than real performance regressions.

To avoid blocking PRs with non-deterministic failures, this job is now marked as allowed to fail.

https://github.com/web-infra-dev/rspack/actions/runs/21932425194?pr=13025

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
