### PR TITLE
fix(rstest): replace `mockRequire` to `rstest_mock_require`

### DIFF
--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -586,7 +586,14 @@ impl RstestParserPlugin {
       }
       // rs.mockRequire
       ("rs" | "rstest", "mockRequire") => {
-        self.process_mock(parser, call_expr, true, false, MockMethod::Mock, true);
+        self.process_mock(
+          parser,
+          call_expr,
+          true,
+          false,
+          MockMethod::MockRequire,
+          true,
+        );
         Some(false)
       }
       // rs.doMock

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -99,6 +99,8 @@ __webpack_require__.rstest_mock = (id, modFactory) => {
   }
 };
 
+__webpack_require__.rstest_mock_require = __webpack_require__.rstest_mock;
+
 __webpack_require__.rstest_do_mock = (id, modFactory) => {
   let requiredModule = undefined
   try {


### PR DESCRIPTION
## Summary

replace `mockRequire` to `rstest_mock_require`.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
