### PR TITLE
chore(ci): remove setting mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       test: true
       bench: true
       prefer_docker: false
+      test-runner: '"ubuntu-22.04"'
 
   test-windows:
     name: Test Windows

--- a/.github/workflows/reusable-build-bench.yml
+++ b/.github/workflows/reusable-build-bench.yml
@@ -76,27 +76,6 @@ jobs:
       - name: Build JS
         run: pnpm run build:js
 
-      - name: Replace Ubuntu APT sources
-        if: startsWith(runner.name, 'rspack-ubuntu')
-        run: |
-          CODENAME=$(lsb_release -cs)
-          echo "Detected Ubuntu codename: $CODENAME"
-
-          # Backup and clean PPA sources
-          sudo mkdir -p /etc/apt/sources.list.d.bak
-          sudo mv /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d.bak/ 2>/dev/null || true
-
-          # Replace main sources
-          sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak
-          sudo tee /etc/apt/sources.list > /dev/null <<EOF
-          deb https://mirrors.volces.com/ubuntu $CODENAME main restricted universe multiverse
-          deb https://mirrors.volces.com/ubuntu $CODENAME-updates main restricted universe multiverse
-          deb https://mirrors.volces.com/ubuntu $CODENAME-security main restricted universe multiverse
-          deb https://mirrors.volces.com/ubuntu $CODENAME-backports main restricted universe multiverse
-          EOF
-
-          sudo apt update
-
       - name: Run benchmark
         uses: ./.github/actions/codspeed
         timeout-minutes: 30


### PR DESCRIPTION
## Summary

1. Remove APT config. The runner's new image already configures the mirror
2. Use GitHub runner to run CI test, which is more stable.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
