### PR TITLE
refactor: Add iterators to module graph helpers to avoid cloning

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -225,12 +225,12 @@ where
   let compilation = task(compilation).await?;
   let mg = compilation.get_module_graph();
   let mut map = IdentifierMap::default();
-  for (mid, mgm) in mg.module_graph_modules() {
+  for (mid, mgm) in mg.module_graph_modules_iter() {
     let (Some(pre), Some(post)) = (mgm.pre_order_index, mgm.post_order_index) else {
       continue;
     };
 
-    map.insert(mid, (pre, post));
+    map.insert(*mid, (pre, post));
   }
   compilation.build_chunk_graph_artifact.module_idx = map;
   Ok(())

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -82,15 +82,15 @@ impl MakeOccasion {
     let mut context_dep = FileCounter::default();
     let mut missing_dep = FileCounter::default();
     let mut build_dep = FileCounter::default();
-    for (mid, module) in mg.modules() {
+    for (mid, module) in mg.modules_iter() {
       let build_info = module.build_info();
-      let resource_id = ResourceId::from(mid);
+      let resource_id = ResourceId::from(*mid);
       file_dep.add_files(&resource_id, &build_info.file_dependencies);
       context_dep.add_files(&resource_id, &build_info.context_dependencies);
       missing_dep.add_files(&resource_id, &build_info.missing_dependencies);
       build_dep.add_files(&resource_id, &build_info.build_dependencies);
       if !module.diagnostics().is_empty() {
-        make_failed_module.insert(mid);
+        make_failed_module.insert(*mid);
       }
     }
 

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -181,7 +181,7 @@ pub async fn recovery_module_graph(
 
   // recovery entry
   let mut entry_module: Vec<ModuleIdentifier> = vec![];
-  for (_, mgm) in mg.module_graph_modules() {
+  for (_, mgm) in mg.module_graph_modules_iter() {
     if mgm.issuer().identifier().is_none() {
       entry_module.push(mgm.module_identifier);
     };
@@ -195,6 +195,6 @@ pub async fn recovery_module_graph(
     mg.cache_recovery_connection(connection);
   }
 
-  tracing::debug!("recovery {} module", mg.modules().len());
+  tracing::debug!("recovery {} module", mg.modules_len());
   Ok((mg, module_to_lazy_make, entry_dependencies))
 }

--- a/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
@@ -504,7 +504,7 @@ impl CodeSplitter {
     // Thanks!
     let module_graph = compilation.get_module_graph();
     let ordinal_by_module = &mut self.ordinal_by_module;
-    for m in module_graph.modules().keys() {
+    for m in module_graph.modules_keys() {
       if !ordinal_by_module.contains_key(m) {
         ordinal_by_module.insert(*m, ordinal_by_module.len() as u64 + 1);
       }
@@ -550,8 +550,7 @@ impl CodeSplitter {
       (
         compilation
           .get_module_graph()
-          .modules()
-          .keys()
+          .modules_keys()
           .copied()
           .collect(),
         Default::default(),

--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -55,15 +55,14 @@ async fn code_generation_pass_impl(compilation: &mut Compilation) -> Result<()> 
     logger.log(format!(
       "{} modules are affected, {} in total",
       modules.len(),
-      compilation.get_module_graph().modules().len()
+      compilation.get_module_graph().modules_len()
     ));
     modules
   } else {
     *compilation.code_generation_results = Default::default();
     compilation
       .get_module_graph()
-      .modules()
-      .keys()
+      .modules_keys()
       .copied()
       .collect()
   };

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -24,7 +24,7 @@ impl Compilation {
     let mut chunk_asset_map = vec![];
     let mut module_assets = vec![];
     let mg = self.get_module_graph();
-    for (identifier, module) in mg.modules() {
+    for (identifier, module) in mg.modules_iter() {
       let assets = &module.build_info().assets;
       if assets.is_empty() {
         continue;
@@ -38,12 +38,12 @@ impl Compilation {
         .build_chunk_graph_artifact
         .chunk_graph
         .chunk_graph_module_by_module_identifier
-        .contains_key(&identifier)
+        .contains_key(identifier)
       {
         for chunk in self
           .build_chunk_graph_artifact
           .chunk_graph
-          .get_module_chunks(identifier)
+          .get_module_chunks(*identifier)
           .iter()
         {
           for name in assets.keys() {

--- a/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
@@ -49,7 +49,7 @@ async fn create_module_hashes_pass_impl(compilation: &mut Compilation) -> Result
 
     // check if module runtime changes
     let mg = compilation.get_module_graph();
-    for mi in mg.modules().keys() {
+    for mi in mg.modules_keys() {
       let module_runtimes = compilation
         .build_chunk_graph_artifact
         .chunk_graph
@@ -105,15 +105,14 @@ async fn create_module_hashes_pass_impl(compilation: &mut Compilation) -> Result
     logger.log(format!(
       "{} modules are affected, {} in total",
       modules.len(),
-      mg.modules().len()
+      mg.modules_len()
     ));
 
     modules
   } else {
     compilation
       .get_module_graph()
-      .modules()
-      .keys()
+      .modules_keys()
       .copied()
       .collect()
   };

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -151,18 +151,14 @@ impl Compilation {
           logger.log(format!(
             "{} modules are affected, {} in total",
             modules.len(),
-            build_module_graph_artifact
-              .get_module_graph()
-              .modules()
-              .len()
+            build_module_graph_artifact.get_module_graph().modules_len()
           ));
           (modules, true)
         } else {
           (
             build_module_graph_artifact
               .get_module_graph()
-              .modules()
-              .keys()
+              .modules_keys()
               .copied()
               .collect(),
             true,
@@ -172,8 +168,7 @@ impl Compilation {
         (
           build_module_graph_artifact
             .get_module_graph()
-            .modules()
-            .keys()
+            .modules_keys()
             .copied()
             .collect(),
           false,

--- a/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
+++ b/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
@@ -53,7 +53,7 @@ async fn runtime_requirements_pass_impl(compilation: &mut Compilation) -> Result
     logger.log(format!(
       "{} modules are affected, {} in total",
       modules.len(),
-      compilation.get_module_graph().modules().len()
+      compilation.get_module_graph().modules_len()
     ));
     modules
   } else {
@@ -61,8 +61,7 @@ async fn runtime_requirements_pass_impl(compilation: &mut Compilation) -> Result
       CgmRuntimeRequirementsArtifact::default().into();
     compilation
       .get_module_graph()
-      .modules()
-      .keys()
+      .modules_keys()
       .copied()
       .collect()
   };

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -131,16 +131,43 @@ impl ModuleGraph {
 }
 
 impl ModuleGraph {
+  #[inline]
+  pub fn modules_len(&self) -> usize {
+    self.inner.modules.len()
+  }
+
+  #[inline]
+  pub fn modules_iter(&self) -> impl Iterator<Item = (&ModuleIdentifier, &BoxModule)> {
+    self.inner.modules.iter()
+  }
+
+  #[inline]
+  pub fn modules_par_iter(
+    &self,
+  ) -> impl rayon::prelude::ParallelIterator<Item = (&ModuleIdentifier, &BoxModule)> {
+    self.inner.modules.par_iter()
+  }
+
+  #[inline]
+  pub fn modules_keys(&self) -> impl Iterator<Item = &ModuleIdentifier> {
+    self.inner.modules.iter().map(|(k, _)| k)
+  }
+
+  #[inline]
+  pub fn module_graph_modules_iter(
+    &self,
+  ) -> impl Iterator<Item = (&ModuleIdentifier, &ModuleGraphModule)> {
+    self.inner.module_graph_modules.iter()
+  }
+
   /// Return an unordered iterator of modules
   pub fn modules(&self) -> IdentifierMap<&BoxModule> {
-    self.inner.modules.iter().map(|(k, v)| (*k, v)).collect()
+    self.modules_iter().map(|(k, v)| (*k, v)).collect()
   }
 
   pub fn module_graph_modules(&self) -> IdentifierMap<&ModuleGraphModule> {
     self
-      .inner
-      .module_graph_modules
-      .iter()
+      .module_graph_modules_iter()
       .map(|(k, v)| (*k, v))
       .collect()
   }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -216,11 +216,11 @@ async fn finish_modules(
     logger.log(format!(
       "{} modules are affected, {} in total",
       modules.len(),
-      module_graph.modules().len()
+      module_graph.modules_len()
     ));
     modules
   } else {
-    module_graph.modules().keys().copied().collect()
+    module_graph.modules_keys().copied().collect()
   };
   let module_graph_cache = compilation.module_graph_cache_artifact.clone();
 

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -60,7 +60,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     let mut module_graph = self.build_module_graph_artifact.get_module_graph_mut();
     self.exports_info_artifact.reset_all_exports_info_used();
 
-    for mgm in module_graph.module_graph_modules().values() {
+    for (_, mgm) in module_graph.module_graph_modules_iter() {
       self.exports_info_module_map.insert(
         self
           .exports_info_artifact

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -38,15 +38,14 @@ async fn finish_modules(
   }
 
   let module_graph = compilation.get_module_graph();
-  let modules = module_graph.modules();
   let mut sync_modules = IdentifierLinkedSet::default();
   let mut async_modules = IdentifierLinkedSet::default();
-  for (module_identifier, module) in modules {
+  for (module_identifier, module) in module_graph.modules_iter() {
     let build_meta = module.build_meta();
     if build_meta.has_top_level_await {
-      async_modules.insert(module_identifier);
+      async_modules.insert(*module_identifier);
     } else {
-      sync_modules.insert(module_identifier);
+      sync_modules.insert(*module_identifier);
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
@@ -114,12 +114,11 @@ async fn optimize_dependencies(
   }
 
   let mg = build_module_graph_artifact.get_module_graph_mut();
-  let modules = mg.modules();
 
   let mut visited: FxHashSet<ExportsInfo> = FxHashSet::default();
 
-  let mut q = modules
-    .keys()
+  let mut q = mg
+    .modules_keys()
     .map(|mid| exports_info_artifact.get_exports_info(mid))
     .collect_vec();
 

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -77,12 +77,11 @@ async fn optimize_code_generation(
   }
 
   let mg = build_module_graph_artifact.get_module_graph_mut();
-  let modules = mg.modules();
 
   let mut exports_info_cache = FxHashMap::default();
 
-  let mut q = modules
-    .iter()
+  let mut q = mg
+    .modules_iter()
     .map(|(mid, module)| {
       let is_namespace = matches!(
         module.build_meta().exports_type,
@@ -182,9 +181,9 @@ async fn optimize_code_generation(
     }
   }
 
-  let mut queue = modules
-    .into_keys()
-    .map(|mid| exports_info_artifact.get_exports_info(&mid))
+  let mut queue = mg
+    .modules_keys()
+    .map(|mid| exports_info_artifact.get_exports_info(mid))
     .collect_vec();
 
   while !queue.is_empty() {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -870,9 +870,8 @@ impl ModuleConcatenationPlugin {
 
     // filter modules that can be root
     let modules: Vec<_> = module_graph
-      .module_graph_modules()
-      .keys()
-      .copied()
+      .module_graph_modules_iter()
+      .map(|(k, _)| *k)
       .collect();
     let res: Vec<_> = modules
       .into_par_iter()

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -163,10 +163,8 @@ async fn optimize_dependencies(
 
   let module_graph = build_module_graph_artifact.get_module_graph();
 
-  let all_modules = module_graph.modules();
-
-  let side_effects_state_map: IdentifierMap<ConnectionState> = all_modules
-    .par_iter()
+  let side_effects_state_map: IdentifierMap<ConnectionState> = module_graph
+    .modules_par_iter()
     .map(|(module_identifier, module)| {
       (
         *module_identifier,
@@ -238,12 +236,12 @@ async fn optimize_dependencies(
     logger.log(format!(
       "{} modules are affected, {} in total",
       modules.len(),
-      all_modules.len()
+      module_graph.modules_len()
     ));
 
     modules
   } else {
-    all_modules.keys().copied().collect()
+    module_graph.modules_keys().copied().collect()
   };
   logger.time_end(inner_start);
 


### PR DESCRIPTION
Summary
- expose iterator helpers and size accessors on `ModuleGraph`/`RollbackMap` to avoid rebuilding whole maps
- update numerous call sites to use the new iterator/length APIs to reduce cloning and make iteration more direct
- tighten module identifier usage while walking module graph caches and plugins

Testing
- Not run (not requested)