### PR TITLE
perf: Enable more Clippy performance checks and reduce redundant clones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -508,6 +508,9 @@ verbose_file_reads              = "warn"
 #mem_forget                      = "warn"
 
 # performance
+iter_filter_is_ok       = "warn"
+iter_filter_is_some     = "warn"
+iter_with_drain         = "warn"
 redundant_clone         = "warn"
 regex_creation_in_loops = "warn"
 

--- a/crates/rspack_binding_api/src/compilation/diagnostics.rs
+++ b/crates/rspack_binding_api/src/compilation/diagnostics.rs
@@ -183,7 +183,7 @@ impl Diagnostics {
       i += 1;
     }
 
-    for diagnostic in to_insert.drain(..) {
+    for diagnostic in to_insert {
       new_diagnostics.push(diagnostic);
     }
 

--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -244,16 +244,16 @@ impl ArtifactExt for BuildChunkGraphArtifact {
   fn recover(_incremental: &crate::incremental::Incremental, new: &mut Self, old: &mut Self) {
     new.code_splitter = mem::take(&mut old.code_splitter);
     rayon::scope(|s| {
-      s.spawn(|_| new.chunk_by_ukey = old.chunk_by_ukey.clone());
-      s.spawn(|_| new.chunk_graph = old.chunk_graph.clone());
-      s.spawn(|_| new.chunk_group_by_ukey = old.chunk_group_by_ukey.clone());
+      s.spawn(|_| new.chunk_by_ukey.clone_from(&old.chunk_by_ukey));
+      s.spawn(|_| new.chunk_graph.clone_from(&old.chunk_graph));
+      s.spawn(|_| new.chunk_group_by_ukey.clone_from(&old.chunk_group_by_ukey));
 
-      s.spawn(|_| new.async_entrypoints = old.async_entrypoints.clone());
-      s.spawn(|_| new.named_chunk_groups = old.named_chunk_groups.clone());
-      s.spawn(|_| new.named_chunks = old.named_chunks.clone());
+      s.spawn(|_| new.async_entrypoints.clone_from(&old.async_entrypoints));
+      s.spawn(|_| new.named_chunk_groups.clone_from(&old.named_chunk_groups));
+      s.spawn(|_| new.named_chunks.clone_from(&old.named_chunks));
       s.spawn(|_| {
-        new.entrypoints = old.entrypoints.clone();
-        new.module_idx = old.module_idx.clone();
+        new.entrypoints.clone_from(&old.entrypoints);
+        new.module_idx.clone_from(&old.module_idx);
       });
     });
   }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -1160,6 +1160,6 @@ impl ChunkGraph {
 
         None
       })
-      .unwrap_or(module.source_types(module_graph).iter().copied().collect())
+      .unwrap_or_else(|| module.source_types(module_graph).iter().copied().collect())
   }
 }

--- a/crates/rspack_core/src/compilation/assign_runtime_ids/mod.rs
+++ b/crates/rspack_core/src/compilation/assign_runtime_ids/mod.rs
@@ -27,7 +27,7 @@ impl PassExt for AssignRuntimeIdsPass {
           Some(EntryRuntime::String(s)) => Some(s.to_owned()),
           _ => None,
         })
-        .or(entrypoint.name().map(|n| n.to_string()));
+        .or_else(|| entrypoint.name().map(|n| n.to_string()));
       if let (Some(runtime), Some(chunk)) = (
         runtime,
         chunk_by_ukey.get(&entrypoint.get_runtime_chunk(chunk_group_by_ukey)),

--- a/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
@@ -460,7 +460,7 @@ impl CodeSplitter {
 
     let cgi = self.chunk_group_infos.expect_get_mut(&cgi_ukey);
     let group_ukey = cgi.chunk_group;
-    cgi.skipped_items = cache_result.skipped_modules.clone();
+    cgi.skipped_items.clone_from(&cache_result.skipped_modules);
 
     let chunk_graph = &mut compilation.build_chunk_graph_artifact.chunk_graph;
     for module in &cache_result.modules {
@@ -475,8 +475,12 @@ impl CodeSplitter {
       .build_chunk_graph_artifact
       .chunk_group_by_ukey
       .expect_get_mut(&group_ukey);
-    group.module_pre_order_indices = cache_result.pre_order_indices.clone();
-    group.module_post_order_indices = cache_result.post_order_indices.clone();
+    group
+      .module_pre_order_indices
+      .clone_from(&cache_result.pre_order_indices);
+    group
+      .module_post_order_indices
+      .clone_from(&cache_result.post_order_indices);
 
     for block in &cache_result.outgoings {
       self.make_chunk_group(

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
@@ -132,13 +132,11 @@ impl Cutout {
       }
     }
     // add entry dependencies
-    for dep in next_entry_dependencies
-      .difference(&entry_dependencies)
-      .copied()
-      .collect::<Vec<_>>()
-    {
-      build_deps.insert((dep, None));
-      entry_dependencies.insert(dep);
+    for dep in next_entry_dependencies.iter() {
+      if !entry_dependencies.contains(dep) {
+        build_deps.insert((*dep, None));
+        entry_dependencies.insert(*dep);
+      }
     }
     artifact.entry_dependencies = entry_dependencies;
 

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -182,7 +182,7 @@ impl Task<TaskContext> for BuildResultTask {
 
     {
       let mgm = module_graph.module_graph_module_by_identifier_mut(&module.identifier());
-      mgm.all_dependencies = all_dependencies.clone();
+      mgm.all_dependencies.clone_from(&all_dependencies);
     }
 
     let module_identifier = module.identifier();

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/lazy.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/lazy.rs
@@ -28,13 +28,10 @@ impl Task<TaskContext> for ProcessUnlazyDependenciesTask {
       .module_to_lazy_make
       .get_lazy_dependencies(&original_module_identifier)
       .expect("only module has lazy dependencies should run into ProcessUnlazyDependenciesTask");
-    let requested_deps: Vec<DependencyId> = lazy_dependencies
-      .requested_lazy_dependencies(&forwarded_ids)
-      .into_iter()
-      .collect();
 
     let module_graph = &mut context.artifact.module_graph;
-    let dependencies_to_process: Vec<DependencyId> = requested_deps
+    let dependencies_to_process: Vec<DependencyId> = lazy_dependencies
+      .requested_lazy_dependencies(&forwarded_ids)
       .into_iter()
       .filter(|dep| {
         let dep = module_graph.dependency_by_id_mut(dep);

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/entry.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/entry.rs
@@ -46,7 +46,7 @@ impl Task<ExecutorTaskContext> for EntryTask {
         // not exist, generate a new dependency
         let dep = Box::new(LoaderImportDependency::new(
           meta.request.clone(),
-          origin_module_context.unwrap_or(Context::from("")),
+          origin_module_context.unwrap_or_else(|| Context::from("")),
         ));
         let dep_id = *dep.id();
 

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -199,7 +199,8 @@ impl Compilation {
         .map(|runtime_chunk| (runtime_chunk, (Vec::new(), 0)))
         .collect();
     let mut remaining: u32 = 0;
-    for runtime_chunk_ukey in runtime_chunks_map.keys().copied().collect::<Vec<_>>() {
+    let runtime_chunk_keys: Vec<_> = runtime_chunks_map.keys().copied().collect();
+    for runtime_chunk_ukey in runtime_chunk_keys {
       let runtime_chunk = self
         .build_chunk_graph_artifact
         .chunk_by_ukey
@@ -302,7 +303,7 @@ impl Compilation {
         .map(|chunk| {
           chunk
             .name()
-            .or(chunk.id().map(|id| id.as_str()))
+            .or_else(|| chunk.id().map(|id| id.as_str()))
             .unwrap_or("no id chunk")
         })
         .join(", ");

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -1404,7 +1404,9 @@ impl AssetInfo {
     // "another" first fields
     self.minimized = another.minimized;
 
-    self.source_filename = another.source_filename.or(self.source_filename.take());
+    self.source_filename = another
+      .source_filename
+      .or_else(|| self.source_filename.take());
     self.version = another.version;
     self.related.merge_another(another.related);
 
@@ -1416,7 +1418,9 @@ impl AssetInfo {
     // self.module_hash.extend(another.module_hash.iter().cloned());
 
     // old first fields or truthy first fields
-    self.javascript_module = another.javascript_module.or(self.javascript_module.take());
+    self.javascript_module = another
+      .javascript_module
+      .or_else(|| self.javascript_module.take());
     self.immutable = another.immutable.or(self.immutable);
     self.development = another.development.or(self.development);
     self.hot_module_replacement = another

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -160,7 +160,7 @@ impl Compiler {
     let module_executor = ModuleExecutor::default();
 
     let id = CompilerId::new();
-    let compiler_context = compiler_context.unwrap_or(Arc::new(CompilerContext::new()));
+    let compiler_context = compiler_context.unwrap_or_else(|| Arc::new(CompilerContext::new()));
     Self {
       id,
       compiler_path,

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1367,7 +1367,7 @@ impl Module for ConcatenatedModule {
     let mut exports_final_names: Vec<(String, String)> = vec![];
 
     for (_, export_info) in exports_info.exports() {
-      let name = export_info.name().cloned().unwrap_or("".into());
+      let name = export_info.name().cloned().unwrap_or_else(|| "".into());
       if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
         continue;
       }
@@ -1559,7 +1559,7 @@ impl Module for ConcatenatedModule {
               &compilation.exports_info_artifact,
               &compilation.module_static_cache,
               module_info_id,
-              vec![export_info.name().cloned().unwrap_or("".into())],
+              vec![export_info.name().cloned().unwrap_or_else(|| "".into())],
               &module_to_info_map,
               runtime,
               false,
@@ -1711,7 +1711,7 @@ impl Module for ConcatenatedModule {
           runtime_template
             .runtime_requirements_mut()
             .insert(info.runtime_requirements);
-          name = info.namespace_object_name.clone();
+          name.clone_from(&info.namespace_object_name);
         }
         ModuleInfo::External(info) => {
           // Deferred modules namespace objects is hoisted up at above loop
@@ -1742,7 +1742,7 @@ impl Module for ConcatenatedModule {
               .expect("should json stringify module id")
             )));
 
-            name = info.name.clone();
+            name.clone_from(&info.name);
           }
           // If a module is deferred in other places, but used as non-deferred here,
           // the module itself will be emitted as mod_deferred (in the case "external"),

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hash, sync::Arc};
+use std::{borrow::Cow, fmt::Write, hash::Hash, sync::Arc};
 
 use cow_utils::CowUtils;
 use derive_more::Debug;
@@ -1309,13 +1309,13 @@ fn create_identifier(options: &ContextModuleOptions, resource: Option<&str>) -> 
     }
     id += "|groupOptions: {";
     if let Some(o) = group.prefetch_order {
-      id.push_str(&format!("prefetchOrder: {o},"));
+      write!(id, "prefetchOrder: {o},").expect("infallible write to String");
     }
     if let Some(o) = group.preload_order {
-      id.push_str(&format!("preloadOrder: {o},"));
+      write!(id, "preloadOrder: {o},").expect("infallible write to String");
     }
     if let Some(o) = group.fetch_priority {
-      id.push_str(&format!("fetchPriority: {o},"));
+      write!(id, "fetchPriority: {o},").expect("infallible write to String");
     }
     id += "}";
   }

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -300,7 +300,9 @@ impl ContextModuleFactory {
       Ok(ResolveResult::Resource(resource)) => {
         let mut dependency_options = dependency.options().clone();
         dependency_options.recursive = before_resolve_data.recursive;
-        dependency_options.reg_exp = before_resolve_data.reg_exp.clone();
+        dependency_options
+          .reg_exp
+          .clone_from(&before_resolve_data.reg_exp);
 
         let options = ContextModuleOptions {
           addon: loader_request.clone(),
@@ -319,7 +321,9 @@ impl ContextModuleFactory {
         // should create an empty context module when ignored
         let mut dependency_options = dependency.options().clone();
         dependency_options.recursive = before_resolve_data.recursive;
-        dependency_options.reg_exp = before_resolve_data.reg_exp.clone();
+        dependency_options
+          .reg_exp
+          .clone_from(&before_resolve_data.reg_exp);
 
         let options = ContextModuleOptions {
           addon: loader_request.clone(),
@@ -383,10 +387,12 @@ impl ContextModuleFactory {
         let parsed_resource = parse_resource(after_resolve_data.resource.as_str());
         if let Some(parsed_resource) = parsed_resource {
           if let Some(query) = &parsed_resource.query {
-            context_module_options.resource_query = query.clone();
+            context_module_options.resource_query.clone_from(query);
           }
           if let Some(fragment) = &parsed_resource.fragment {
-            context_module_options.resource_fragment = fragment.clone();
+            context_module_options
+              .resource_fragment
+              .clone_from(fragment);
           }
         }
 

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -292,7 +292,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     for (_, export_info) in self.get_exports_in_exports_info(exports_info) {
       match export_info.provided() {
         Some(ExportProvided::Provided | ExportProvided::Unknown) | None => {
-          ret.push(export_info.name().cloned().unwrap_or("".into()));
+          ret.push(export_info.name().cloned().unwrap_or_else(|| "".into()));
         }
         _ => {}
       }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -478,7 +478,7 @@ impl Module for NormalModule {
         GeneratorOptions::AssetResource(g) => g.binary,
         _ => None,
       })
-      .unwrap_or(self.module_type.is_binary());
+      .unwrap_or_else(|| self.module_type.is_binary());
 
     let content = if is_binary {
       Content::Buffer(loader_result.content.into_bytes())

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -1,5 +1,5 @@
 use std::{
-  fmt::Debug,
+  fmt::{Debug, Write},
   sync::{Arc, LazyLock, Mutex},
 };
 
@@ -1287,11 +1287,13 @@ impl ModuleCodeTemplate {
             )
           );
         }
-        appending.push_str(&format!(
+        write!(
+          appending,
           ".then({}.bind({}, {module_id_expr}, {mode}))",
           self.render_runtime_globals(&RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT),
           self.render_runtime_globals(&RuntimeGlobals::REQUIRE)
-        ));
+        )
+        .expect("infallible write to String");
       } else if let Some(header) = header {
         let rendered_async_deps_fn =
           self.render_runtime_globals(&RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT);

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -1268,7 +1268,9 @@ impl Stats<'_> {
     if stats.built || stats.code_generated || options.cached_modules {
       stats.identifier = Some(module.identifier);
       stats.name = Some(module.name.clone().into());
-      stats.name_for_condition = module.name_for_condition.clone();
+      stats
+        .name_for_condition
+        .clone_from(&module.name_for_condition);
       stats.cacheable = Some(module.cacheable);
       stats.optional = Some(false);
       stats.orphan = Some(true);

--- a/crates/rspack_core/src/utils/file_counter/mod.rs
+++ b/crates/rspack_core/src/utils/file_counter/mod.rs
@@ -119,30 +119,30 @@ mod test {
 
     counter.add_files(&resource_1, &file_list_all);
     counter.add_files(&resource_2, &file_list_a);
-    assert_eq!(counter.files().collect::<Vec<_>>().len(), 2);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 2);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.files().count(), 2);
+    assert_eq!(counter.added_files().count(), 2);
+    assert_eq!(counter.removed_files().count(), 0);
 
     // test repeated additions
     counter.add_files(&resource_1, &file_list_all);
-    assert_eq!(counter.files().collect::<Vec<_>>().len(), 2);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 2);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.files().count(), 2);
+    assert_eq!(counter.added_files().count(), 2);
+    assert_eq!(counter.removed_files().count(), 0);
 
     counter.remove_files(&resource_1, &file_list_a);
-    assert_eq!(counter.files().collect::<Vec<_>>().len(), 2);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 2);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.files().count(), 2);
+    assert_eq!(counter.added_files().count(), 2);
+    assert_eq!(counter.removed_files().count(), 0);
 
     counter.remove_files(&resource_1, &file_list_b);
-    assert_eq!(counter.files().collect::<Vec<_>>().len(), 1);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 1);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.files().count(), 1);
+    assert_eq!(counter.added_files().count(), 1);
+    assert_eq!(counter.removed_files().count(), 0);
 
     counter.remove_files(&resource_2, &file_list_a);
-    assert_eq!(counter.files().collect::<Vec<_>>().len(), 0);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.files().count(), 0);
+    assert_eq!(counter.added_files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 0);
   }
 
   #[test]
@@ -172,35 +172,35 @@ mod test {
     let resource_2 = ResourceId::Module("B".into());
 
     counter.add_files(&resource_1, &file_list_a);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 1);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.added_files().count(), 1);
+    assert_eq!(counter.removed_files().count(), 0);
 
     counter.reset_incremental_info();
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.added_files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 0);
 
     counter.remove_files(&resource_1, &file_list_a);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 1);
+    assert_eq!(counter.added_files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 1);
 
     counter.add_files(&resource_1, &file_list_a);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.added_files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 0);
 
     counter.reset_incremental_info();
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.added_files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 0);
 
     counter.add_files(&resource_2, &file_list_a);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.added_files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 0);
 
     counter.remove_files(&resource_1, &file_list_a);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 0);
+    assert_eq!(counter.added_files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 0);
 
     counter.remove_files(&resource_2, &file_list_a);
-    assert_eq!(counter.added_files().collect::<Vec<_>>().len(), 0);
-    assert_eq!(counter.removed_files().collect::<Vec<_>>().len(), 1);
+    assert_eq!(counter.added_files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 1);
   }
 }

--- a/crates/rspack_fs/src/native_fs.rs
+++ b/crates/rspack_fs/src/native_fs.rs
@@ -240,7 +240,7 @@ impl ReadableFileSystem for NativeFileSystem {
             for path in zip.dirs.iter().chain(zip.files.keys()) {
               let pathbuf = PathBuf::from(path);
               if let Some(file_name) = pathbuf.file_name() {
-                let parent_path = pathbuf.parent().unwrap_or(Path::new("."));
+                let parent_path = pathbuf.parent().unwrap_or_else(|| Path::new("."));
                 if Path::new(&info.zip_path) == parent_path {
                   res.push(file_name.to_string_lossy().to_string());
                 }

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -61,9 +61,10 @@ impl JavaScriptCompiler {
     P: Pass + 'a,
     S: Into<String>,
   {
-    let fm = self
-      .cm
-      .new_source_file(filename.unwrap_or(Arc::new(FileName::Anon)), source.into());
+    let fm = self.cm.new_source_file(
+      filename.unwrap_or_else(|| Arc::new(FileName::Anon)),
+      source.into(),
+    );
     let javascript_transformer =
       JavaScriptTransformer::new(self.cm.clone(), fm, comments, self, options)?;
 

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -92,7 +92,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
       hash_to_asset_names
         .entry(hash)
         .and_modify(|names| names.push(name))
-        .or_insert(vec![name]);
+        .or_insert_with(|| vec![name]);
     }
   }
   logger.time_end(start);

--- a/crates/rspack_storage/src/pack/strategy/split/write_scope.rs
+++ b/crates/rspack_storage/src/pack/strategy/split/write_scope.rs
@@ -259,7 +259,7 @@ impl ScopeWriteStrategy for SplitPackStrategy {
       .collect::<HashMap<_, _>>();
 
     for (meta, (hash, pack)) in new_pack_metas.into_iter().zip(write_results.into_iter()) {
-      meta.hash = hash.clone();
+      meta.hash.clone_from(&hash);
       meta.size = pack.size();
       wrote_files.insert(pack.path.clone());
       wrote_packs.insert(hash, pack);

--- a/crates/rspack_tracing/src/perfetto.rs
+++ b/crates/rspack_tracing/src/perfetto.rs
@@ -77,7 +77,7 @@ impl Tracer for PerfettoTracer {
         let (javascript_scoped_descriptor, parent_uuid) = create_scope_sliced_packet(
           event
             .process_name
-            .unwrap_or(JAVASCRIPT_ANALYSIS_TRACK.to_string()),
+            .unwrap_or_else(|| JAVASCRIPT_ANALYSIS_TRACK.to_string()),
         );
         let mut packet = idl::TracePacket::default();
         // specify the track name for track event using track_descriptor

--- a/crates/rspack_tracing_perfetto/src/lib.rs
+++ b/crates/rspack_tracing_perfetto/src/lib.rs
@@ -211,8 +211,9 @@ where
     };
 
     attrs.record(&mut visitor);
-    let (custom_scope_packet, process_uuid) =
-      create_scope_sliced_packet(user_process_name.unwrap_or(DEFAULT_PROCESS_NAME.to_string()));
+    let (custom_scope_packet, process_uuid) = create_scope_sliced_packet(
+      user_process_name.unwrap_or_else(|| DEFAULT_PROCESS_NAME.to_string()),
+    );
 
     // resolve the optional track descriptor for this span (either inherited from parent or user set, or None)
     let span_track_descriptor = user_track_name
@@ -313,8 +314,9 @@ where
         })
       })
       .flatten();
-    let (custom_scope_packet, process_uuid) =
-      create_scope_sliced_packet(user_process_name.unwrap_or(DEFAULT_PROCESS_NAME.to_string()));
+    let (custom_scope_packet, process_uuid) = create_scope_sliced_packet(
+      user_process_name.unwrap_or_else(|| DEFAULT_PROCESS_NAME.to_string()),
+    );
     let event_track_descriptor = user_track_name
       .map(|name| {
         create_track_descriptor(

--- a/crates/rspack_watcher/src/scanner.rs
+++ b/crates/rspack_watcher/src/scanner.rs
@@ -105,7 +105,7 @@ fn scan_path_changed(
 fn check_path_metadata(filepath: &ArcPath, start_time: &SystemTime) -> bool {
   if let Ok(m_time) = filepath
     .metadata()
-    .and_then(|metadata| metadata.modified().or(metadata.created()))
+    .and_then(|metadata| metadata.modified().or_else(|_| metadata.created()))
   {
     *start_time < m_time
   } else {

--- a/crates/swc_plugin_import/src/lib.rs
+++ b/crates/swc_plugin_import/src/lib.rs
@@ -284,10 +284,7 @@ impl ImportPlugin<'_> {
       Ok(Some(format!(
         "{}/{}/{}",
         &config.library_name,
-        config
-          .library_directory
-          .as_ref()
-          .unwrap_or(&"lib".to_string()),
+        config.library_directory.as_deref().unwrap_or("lib"),
         transformed_name
       )))
     };

--- a/crates/swc_plugin_import/src/template.rs
+++ b/crates/swc_plugin_import/src/template.rs
@@ -60,7 +60,7 @@ impl<'a> Template<'a> {
       }
 
       let tag_start = start + 2;
-      let end = find_subsequence(s, tag_start, "}}").ok_or(TemplateError::UnclosedTag {
+      let end = find_subsequence(s, tag_start, "}}").ok_or_else(|| TemplateError::UnclosedTag {
         value: input.to_string(),
       })?;
 


### PR DESCRIPTION
Summary
- enabled the `iter_filter_is_ok`, `iter_filter_is_some`, and `iter_with_drain` clippy performance lints in `Cargo.toml`
- replaced `.clone()` with `clone_from`, `unwrap_or_else`, `or_else`, etc., across numerous crates to satisfy the new lint expectations and avoid unnecessary allocations
- simplified iteration logic (e.g., module dependencies, diagnostics, counters) to remove redundant collections and iterations

Testing
- Not run (not requested)