### PR TITLE
refactor: Improve module graph iteration performance

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
@@ -24,9 +24,8 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
 
   let all_modules = compilation
     .get_module_graph()
-    .modules()
-    .keys()
-    .copied()
+    .modules_iter()
+    .map(|(mi, _)| *mi)
     .collect::<Vec<_>>();
 
   splitter.prepare(&all_modules, compilation)?;

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
@@ -50,12 +50,10 @@ impl Cutout {
           clean_entry_dependencies = true;
         }
         UpdateParam::CheckNeedBuild => {
-          force_build_modules.extend(module_graph.modules().values().filter_map(|module| {
-            if module.need_build(&compilation.value_cache_versions) {
-              Some(module.identifier())
-            } else {
-              None
-            }
+          force_build_modules.extend(module_graph.modules_iter().filter_map(|(_, module)| {
+            module
+              .need_build(&compilation.value_cache_versions)
+              .then_some(module.identifier())
           }));
         }
         UpdateParam::ModifiedFiles(files) | UpdateParam::RemovedFiles(files) => {

--- a/crates/rspack_core/src/compilation/module_ids/mod.rs
+++ b/crates/rspack_core/src/compilation/module_ids/mod.rs
@@ -15,8 +15,8 @@ fn get_modules_needing_ids(
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
   compilation
     .get_module_graph()
-    .modules()
-    .values()
+    .modules_iter()
+    .map(|(_, m)| m)
     .filter(|m| {
       m.need_id()
         && ChunkGraph::get_module_id(module_ids_artifact, m.identifier()).is_none()


### PR DESCRIPTION
- Summary
  - swap existing `.modules()` and `.modules().values()` iterations for the faster `modules_iter`/`dependencies_iter` helpers and batch-update mutations directly via mutable references
  - streamline affected-module calculations by deduplicating incoming dependencies and using precomputed AffectType state for each referencing module
  - tighten async module traversal by collecting unique ESM targets before recursing
- Testing
  - Not run (not requested)