### PR TITLE
perf: remove unused env call

### DIFF
--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -5,7 +5,7 @@
  * Author Donny/강동윤
  * Copyright (c)
  */
-use std::{env, fs::File, path::PathBuf, sync::Arc};
+use std::{fs::File, path::PathBuf, sync::Arc};
 
 use anyhow::{Context, bail};
 use base64::prelude::*;
@@ -199,7 +199,7 @@ impl<'a> JavaScriptTransformer<'a> {
       error = true;
     }
 
-    let mut res = program_result.map_err(|e| {
+    let res = program_result.map_err(|e| {
       e.into_diagnostic(handler).emit();
       anyhow::Error::msg("Syntax Error")
     });
@@ -207,11 +207,6 @@ impl<'a> JavaScriptTransformer<'a> {
     if error {
       return Err(anyhow::anyhow!("Syntax Error"));
     }
-
-    if env::var("SWC_DEBUG").unwrap_or_default() == "1" {
-      res = res.with_context(|| format!("Parser config: {syntax:?}"));
-    }
-
     res
   }
 


### PR DESCRIPTION
## Summary
SWC_DEBUG seems never used and it cause thousands of env::var cal for large projects l which is unnecessary
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
