### PR TITLE
refactor(core): lazily resolve dependency loc from range

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -91,7 +91,7 @@ impl Task<TaskContext> for FactorizeTask {
       Ok(result) => Some(result),
       Err(mut e) => {
         // Wrap source code if available
-        if let Some(s) = self.original_module_source {
+        if let Some(s) = self.original_module_source.as_ref() {
           let has_source_code = e.src.is_some();
           if !has_source_code {
             e.src = Some(s.source().into_string_lossy().into_owned());
@@ -103,7 +103,10 @@ impl Task<TaskContext> for FactorizeTask {
           return Err(e);
         }
         let mut diagnostic = Diagnostic::from(e);
-        diagnostic.loc = create_data.dependencies[0].loc();
+        diagnostic.loc = crate::get_dependency_location(
+          create_data.dependencies[0].as_ref(),
+          self.original_module_source.as_deref(),
+        );
         create_data.diagnostics.insert(0, diagnostic);
         None
       }

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -194,7 +194,7 @@ impl Compilation {
               .map(|diagnostics| {
                 diagnostics.into_iter().map(|mut diagnostic| {
                   diagnostic.module_identifier = Some(*module_identifier);
-                  diagnostic.loc = dependency.loc();
+                  diagnostic.loc = crate::get_dependency_location(dependency.as_ref(), None);
                   diagnostic
                 })
               })

--- a/crates/rspack_core/src/dependency/dependency_location.rs
+++ b/crates/rspack_core/src/dependency/dependency_location.rs
@@ -2,7 +2,10 @@ use std::fmt::{self, Debug};
 
 use rspack_cacheable::cacheable;
 use rspack_location::{DependencyLocation, RealDependencyLocation, SourcePosition};
+use rspack_sources::Source;
 use rspack_util::SpanExt;
+
+use super::Dependency;
 
 /// Represents a range in a dependency, typically used for tracking the span of code in a source file.
 /// It stores the start and end positions (as offsets) of the range, typically using base-0 indexing.
@@ -151,4 +154,18 @@ impl AsLoc for &str {
     let loc: &dyn SourceLocation = self;
     loc
   }
+}
+
+pub fn get_dependency_location(
+  dependency: &dyn Dependency,
+  source: Option<&dyn Source>,
+) -> Option<DependencyLocation> {
+  dependency.loc().or_else(|| {
+    dependency.range().and_then(|range| {
+      source.and_then(|source| {
+        let source = source.source().into_string_lossy();
+        range.to_loc(Some(source.as_ref()))
+      })
+    })
+  })
 }

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -1092,7 +1092,8 @@ impl Stats<'_> {
           } else {
             (None, None)
           };
-          let loc = dependency.loc().map(|l| l.to_string());
+          let loc =
+            crate::get_dependency_location(dependency.as_ref(), None).map(|l| l.to_string());
           let explanation = module_graph
             .get_dep_meta_if_existing(&connection.dependency_id)
             .and_then(|extra| extra.explanation);

--- a/crates/rspack_core/src/stats/utils.rs
+++ b/crates/rspack_core/src/stats/utils.rs
@@ -209,7 +209,7 @@ pub fn get_module_trace<'a>(
       .get_incoming_connections(&module_identifier)
       .filter_map(|c| {
         let dep = module_graph.dependency_by_id(&c.dependency_id);
-        let loc = dep.loc().map(|loc| loc.to_string())?;
+        let loc = crate::get_dependency_location(dep.as_ref(), None).map(|loc| loc.to_string())?;
         Some(StatsErrorModuleTraceDependency { loc })
       })
       .collect::<Vec<_>>();

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  FactorizeInfo, ModuleDependency, TemplateContext, TemplateReplaceSource,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, FactorizeInfo,
+  ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -13,7 +13,6 @@ pub struct CommonJsRequireDependency {
   optional: bool,
   range: DependencyRange,
   range_expr: Option<DependencyRange>,
-  loc: Option<DependencyLocation>,
   factorize_info: FactorizeInfo,
 }
 
@@ -23,16 +22,14 @@ impl CommonJsRequireDependency {
     range: DependencyRange,
     range_expr: Option<DependencyRange>,
     optional: bool,
-    source: Option<&str>,
+    _source: Option<&str>,
   ) -> Self {
-    let loc = range.to_loc(source);
     Self {
       id: DependencyId::new(),
       request,
       optional,
       range,
       range_expr,
-      loc,
       factorize_info: Default::default(),
     }
   }
@@ -42,10 +39,6 @@ impl CommonJsRequireDependency {
 impl Dependency for CommonJsRequireDependency {
   fn id(&self) -> &DependencyId {
     &self.id
-  }
-
-  fn loc(&self) -> Option<DependencyLocation> {
-    self.loc.clone()
   }
 
   fn category(&self) -> &DependencyCategory {


### PR DESCRIPTION
### Motivation

- Avoid eagerly computing `DependencyLocation` for every dependency to reduce unnecessary work during parsing/factorization. 
- Only compute `loc` when diagnostics or stats actually need it, enabling lazy, on-demand resolution from `range`+source. 
- Preserve existing explicit `loc` when present while falling back to a range->loc computation that can use the module source when available.

### Description

- Add helper `get_dependency_location(&dyn Dependency, Option<&dyn Source>)` in `crates/rspack_core/src/dependency/dependency_location.rs` that returns `dep.loc()` if present or lazily computes a `DependencyLocation` from `dep.range()` and an optional source. 
- Replace direct `dependency.loc()` usages in diagnostics/stats to use the lazy helper (`crates/rspack_core/src/compilation/finish_modules/mod.rs`, `crates/rspack_core/src/stats/mod.rs`, `crates/rspack_core/src/stats/utils.rs`). 
- Use the helper in the factorize error path and pass the issuer `original_module_source` when available so range->loc can be resolved with the proper source (`crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs`). 
- Remove the eagerly-stored `loc` field from `CommonJsRequireDependency` and stop computing `to_loc` in its constructor so it relies on `range` for lazy resolution (`crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs`).

### Testing

- Ran `cargo check -p rspack_core -p rspack_plugin_javascript`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c14534a148331862e93ba9b5930e7)