### PR TITLE
chore(ci): don't cancel diff CI task on main branch

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -26,8 +26,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'v1.x' }}
 
 permissions:
   # Allow commenting on issues for `reusable-build.yml`


### PR DESCRIPTION
## Summary
Fix lots of CI failure due to diff CI task canceling.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
