### PR TITLE
test: update imports to use rspack instead of webpack

### DIFF
--- a/tests/rspack-test/configCases/asset-modules/entry-with-runtimeChunk/rspack.config.js
+++ b/tests/rspack-test/configCases/asset-modules/entry-with-runtimeChunk/rspack.config.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const fs = require("fs");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 const common = {
 	module: {
@@ -32,7 +32,7 @@ const common = {
 
 							compilation.emitAsset(
 								"test.js",
-								new webpack.sources.RawSource(data)
+								new rspack.sources.RawSource(data)
 							);
 						}
 					);

--- a/tests/rspack-test/configCases/asset-modules/only-entry/rspack.config.js
+++ b/tests/rspack-test/configCases/asset-modules/only-entry/rspack.config.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const fs = require("fs");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {(number, any) => import("@rspack/core").Configuration} */
 const common = (i, options) => ({
@@ -30,9 +30,9 @@ const common = (i, options) => ({
 				compiler.hooks.compilation.tap("Test", compilation => {
 					compilation.hooks.processAssets.tap(
 						{
-							name: "copy-webpack-plugin",
+							name: "copy-rspack-plugin",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						() => {
 							const data = fs.readFileSync(
@@ -41,7 +41,7 @@ const common = (i, options) => ({
 
 							compilation.emitAsset(
 								"test.js",
-								new webpack.sources.RawSource(data)
+								new rspack.sources.RawSource(data)
 							);
 						}
 					);

--- a/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/rspack.config.js
@@ -1,5 +1,5 @@
-const webpack = require("@rspack/core");
-const { ModuleFederationPluginV1: ModuleFederationPlugin } = webpack.container;
+const { rspack } = require("@rspack/core");
+const { ModuleFederationPluginV1: ModuleFederationPlugin } = rspack.container;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {

--- a/tests/rspack-test/configCases/clean/ignore-hook/rspack.config.js
+++ b/tests/rspack-test/configCases/clean/ignore-hook/rspack.config.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const webpack = require("@rspack/core");
-const { RawSource } = require("webpack-sources");
+const { rspack } = require("@rspack/core");
 const readDir = require("../enabled/readdir");
 
 /** @type {import("@rspack/core").Configuration} */
@@ -42,7 +41,7 @@ module.exports = {
 						fs.writeFileSync(path.join(ignoredTooDir, "file.ext"), "");
 						once = false;
 					}
-					assets["this/dir/should/not/be/removed/file.ext"] = new RawSource("");
+					assets["this/dir/should/not/be/removed/file.ext"] = new rspack.sources.RawSource("");
 				});
 			});
 			compiler.hooks.afterEmit.tap("Test", compilation => {

--- a/tests/rspack-test/configCases/clean/lib-manifest-plugin/rspack.config.js
+++ b/tests/rspack-test/configCases/clean/lib-manifest-plugin/rspack.config.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const readDir = require("./readdir");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = (_, { testPath }) => {
@@ -9,7 +9,7 @@ module.exports = (_, { testPath }) => {
 			clean: true
 		},
 		plugins: [
-			new webpack.DllPlugin({
+			new rspack.DllPlugin({
 				name: "[name]_dll",
 				path: path.resolve(testPath, "manifest.json")
 			}),

--- a/tests/rspack-test/configCases/context-modules/multiple-alias-2/rspack.config.js
+++ b/tests/rspack-test/configCases/context-modules/multiple-alias-2/rspack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -10,5 +10,5 @@ module.exports = {
 			app: [path.join(__dirname, "src/main"), path.join(__dirname, "src/foo")]
 		}
 	},
-	plugins: [new webpack.ContextReplacementPlugin(/main/, "../override")]
+	plugins: [new rspack.ContextReplacementPlugin(/main/, "../override")]
 };

--- a/tests/rspack-test/configCases/context-modules/multiple-alias/rspack.config.js
+++ b/tests/rspack-test/configCases/context-modules/multiple-alias/rspack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -11,7 +11,7 @@ module.exports = {
 		}
 	},
 	plugins: [
-		new webpack.ContextReplacementPlugin(/main/, (context) => {
+		new rspack.ContextReplacementPlugin(/main/, (context) => {
 			Object.assign(context, {
 				resource: ["../override"] // resolved relatively
 			});

--- a/tests/rspack-test/configCases/context-modules/replacement-a/rspack.config.js
+++ b/tests/rspack-test/configCases/context-modules/replacement-a/rspack.config.js
@@ -1,11 +1,11 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	plugins: [
-		new webpack.ContextReplacementPlugin(
+		new rspack.ContextReplacementPlugin(
 			/replacement.a$/,
 			"new-context",
 			true,

--- a/tests/rspack-test/configCases/context-modules/replacement-b/rspack.config.js
+++ b/tests/rspack-test/configCases/context-modules/replacement-b/rspack.config.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	plugins: [new webpack.ContextReplacementPlugin(/replacement.b$/, /^\.\/only/)]
+	plugins: [new rspack.ContextReplacementPlugin(/replacement.b$/, /^\.\/only/)]
 };

--- a/tests/rspack-test/configCases/context-modules/replacement-c/rspack.config.js
+++ b/tests/rspack-test/configCases/context-modules/replacement-c/rspack.config.js
@@ -1,12 +1,12 @@
 "use strict";
 
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	plugins: [
-		new webpack.ContextReplacementPlugin(
+		new rspack.ContextReplacementPlugin(
 			/replacement.c$/,
 			path.resolve(__dirname, "modules"),
 			{

--- a/tests/rspack-test/configCases/context-modules/replacement-d/rspack.config.js
+++ b/tests/rspack-test/configCases/context-modules/replacement-d/rspack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -14,7 +14,7 @@ module.exports = {
 		]
 	},
 	plugins: [
-		new webpack.ContextReplacementPlugin(
+		new rspack.ContextReplacementPlugin(
 			/replacement.d$/,
 			path.resolve(__dirname, "modules?cats=meow"),
 			{

--- a/tests/rspack-test/configCases/context-modules/replacement-e/rspack.config.js
+++ b/tests/rspack-test/configCases/context-modules/replacement-e/rspack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -9,7 +9,7 @@ module.exports = {
 		modules: ["...", path.resolve(__dirname, "new-context/modules")]
 	},
 	plugins: [
-		new webpack.ContextReplacementPlugin(
+		new rspack.ContextReplacementPlugin(
 			/replacement.e$/,
 			"new-context",
 			true,

--- a/tests/rspack-test/configCases/context-modules/replacement-f/rspack.config.js
+++ b/tests/rspack-test/configCases/context-modules/replacement-f/rspack.config.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	plugins: [new webpack.ContextReplacementPlugin(/folder$/, false, /(a|b)/)]
+	plugins: [new rspack.ContextReplacementPlugin(/folder$/, false, /(a|b)/)]
 };

--- a/tests/rspack-test/configCases/context-replacement/e/rspack.config.js
+++ b/tests/rspack-test/configCases/context-replacement/e/rspack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -7,7 +7,7 @@ module.exports = {
 		modules: ["...", path.resolve(__dirname, "new-context/modules")]
 	},
 	plugins: [
-		new webpack.ContextReplacementPlugin(
+		new rspack.ContextReplacementPlugin(
 			/context-replacement.e$/,
 			"new-context",
 			true,

--- a/tests/rspack-test/configCases/css/css-modules/rspack.config.js
+++ b/tests/rspack-test/configCases/css/css-modules/rspack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {(env: Env, options: TestOptions) => import("@rspack/core").Configuration[]} */
 module.exports = (env, { testPath }) => [
@@ -50,13 +50,13 @@ module.exports = (env, { testPath }) => [
 			__filename: false
 		},
 		plugins: [
-			new webpack.ids.DeterministicModuleIdsPlugin({
+			new rspack.ids.DeterministicModuleIdsPlugin({
 				maxLength: 3,
 				failOnConflict: true,
 				fixedLength: true,
 				test: (m) => m.type.startsWith("css")
 			}),
-			new webpack.experiments.ids.SyncModuleIdsPlugin({
+			new rspack.experiments.ids.SyncModuleIdsPlugin({
 				test: (m) => m.type.startsWith("css"),
 				path: path.resolve(testPath, "module-ids.json"),
 				mode: "create"

--- a/tests/rspack-test/configCases/css/exports-convention/rspack.config.js
+++ b/tests/rspack-test/configCases/css/exports-convention/rspack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @typedef {import("@rspack/core").GeneratorOptionsByModuleTypeKnown} GeneratorOptionsByModuleTypeKnown */
 
@@ -66,7 +66,7 @@ module.exports = [
 		mode: "development",
 		target: "web",
 		plugins: [
-			new webpack.DefinePlugin({
+			new rspack.DefinePlugin({
 				"process.env.TARGET": JSON.stringify("web")
 			})
 		]
@@ -76,7 +76,7 @@ module.exports = [
 		mode: "production",
 		target: "web",
 		plugins: [
-			new webpack.DefinePlugin({
+			new rspack.DefinePlugin({
 				"process.env.TARGET": JSON.stringify("web")
 			})
 		]
@@ -86,7 +86,7 @@ module.exports = [
 		mode: "development",
 		target: "node",
 		plugins: [
-			new webpack.DefinePlugin({
+			new rspack.DefinePlugin({
 				"process.env.TARGET": JSON.stringify("node")
 			})
 		]
@@ -96,7 +96,7 @@ module.exports = [
 		mode: "production",
 		target: "node",
 		plugins: [
-			new webpack.DefinePlugin({
+			new rspack.DefinePlugin({
 				"process.env.TARGET": JSON.stringify("node")
 			})
 		]

--- a/tests/rspack-test/configCases/css/import-module/rspack.config.js
+++ b/tests/rspack-test/configCases/css/import-module/rspack.config.js
@@ -1,7 +1,7 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	plugins: [new webpack.HotModuleReplacementPlugin()],
+	plugins: [new rspack.HotModuleReplacementPlugin()],
 	target: "web",
 	mode: "development",
 	module: {

--- a/tests/rspack-test/configCases/css/import/rspack.config.js
+++ b/tests/rspack-test/configCases/css/import/rspack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = [
@@ -53,7 +53,7 @@ module.exports = [
 			"external-13.css": "css-import external-13.css",
 			"external-14.css": "css-import external-14.css"
 		},
-		plugins: [new webpack.IgnorePlugin({ resourceRegExp: /ignore\.css/ })]
+		plugins: [new rspack.IgnorePlugin({ resourceRegExp: /ignore\.css/ })]
 	},
 	{
 		target: "web",

--- a/tests/rspack-test/configCases/css/no-extra-js-exports-output/rspack.config.js
+++ b/tests/rspack-test/configCases/css/no-extra-js-exports-output/rspack.config.js
@@ -2,7 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /**
  * @param {0 | 1 | 2} i index
@@ -66,7 +66,7 @@ const common = (i) => ({
 
 							compilation.emitAsset(
 								"test.js",
-								new webpack.sources.RawSource(data)
+								new rspack.sources.RawSource(data)
 							);
 						}
 					);

--- a/tests/rspack-test/configCases/css/url/rspack.config.js
+++ b/tests/rspack-test/configCases/css/url/rspack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = [
@@ -32,7 +32,7 @@ module.exports = [
 			"external-url-2.png": "test",
 			"schema:test": "asset 'img.png'"
 		},
-		plugins: [new webpack.IgnorePlugin({ resourceRegExp: /ignore\.png/ })]
+		plugins: [new rspack.IgnorePlugin({ resourceRegExp: /ignore\.png/ })]
 	},
 	{
 		target: "web",

--- a/tests/rspack-test/configCases/externals/externals-array/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/externals-array/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration[]} */
 module.exports = [
 	{
@@ -9,8 +9,8 @@ module.exports = [
 			external: ["@rspack/core", "version"]
 		},
 		plugins: [
-			new webpack.DefinePlugin({
-				EXPECTED: JSON.stringify(webpack.version)
+			new rspack.DefinePlugin({
+				EXPECTED: JSON.stringify(rspack.version)
 			})
 		]
 	},
@@ -19,7 +19,7 @@ module.exports = [
 			external: ["Array", "isArray"]
 		},
 		plugins: [
-			new webpack.DefinePlugin({
+			new rspack.DefinePlugin({
 				EXPECTED: "Array.isArray"
 			})
 		]

--- a/tests/rspack-test/configCases/externals/node-require/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/node-require/rspack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -11,9 +11,9 @@ module.exports = {
 		external: ["webpack", "version"]
 	},
 	plugins: [
-		new webpack.DefinePlugin({
+		new rspack.DefinePlugin({
 			NODE_VERSION: JSON.stringify(process.version),
-			EXPECTED: JSON.stringify(webpack.version)
+			EXPECTED: JSON.stringify(rspack.version)
 		})
 	]
 };

--- a/tests/rspack-test/configCases/externals/non-amd-externals-amd/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/non-amd-externals-amd/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	output: {
@@ -17,7 +17,7 @@ module.exports = {
 		node: true
 	},
 	plugins: [
-		new webpack.BannerPlugin({
+		new rspack.BannerPlugin({
 			raw: true,
 			banner:
 				"function define(deps, fn) { fn(...deps.map(dep => require(dep))); }\n"

--- a/tests/rspack-test/configCases/hooks/modify-extract-css-loading-runtime/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/modify-extract-css-loading-runtime/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 class Plugin {
 	apply(compiler) {
@@ -25,10 +25,10 @@ module.exports = {
 		rules: [
 			{
 				test: /\.css$/,
-				use: [webpack.CssExtractRspackPlugin.loader, "css-loader"],
+				use: [rspack.CssExtractRspackPlugin.loader, "css-loader"],
 				type: "javascript/auto"
 			}
 		]
 	},
-	plugins: [new webpack.CssExtractRspackPlugin(), new Plugin()]
+	plugins: [new rspack.CssExtractRspackPlugin(), new Plugin()]
 };

--- a/tests/rspack-test/configCases/ignore/side-effects/rspack.config.js
+++ b/tests/rspack-test/configCases/ignore/side-effects/rspack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -11,7 +11,7 @@ module.exports = {
 			"./ignored-module": false
 		}
 	},
-	plugins: [new webpack.IgnorePlugin({ resourceRegExp: /(b\.js|b)$/ })],
+	plugins: [new rspack.IgnorePlugin({ resourceRegExp: /(b\.js|b)$/ })],
 	optimization: {
 		sideEffects: true
 	}

--- a/tests/rspack-test/configCases/loaders/hot-in-context/rspack.config.js
+++ b/tests/rspack-test/configCases/loaders/hot-in-context/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration[]} */
 module.exports = [
 	{
@@ -6,6 +6,6 @@ module.exports = [
 	},
 	{
 		// with hmr
-		plugins: [new webpack.HotModuleReplacementPlugin()]
+		plugins: [new rspack.HotModuleReplacementPlugin()]
 	}
 ];

--- a/tests/rspack-test/configCases/module/issue-19799/rspack.config.js
+++ b/tests/rspack-test/configCases/module/issue-19799/rspack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {(env: Env, options: TestOptions) => import("@rspack/core").Configuration[]} */
 module.exports = (env, { testPath }) => [
@@ -18,7 +18,7 @@ module.exports = (env, { testPath }) => [
 				apply(compiler) {
 					compiler.hooks.compilation.tap("MyPlugin", (compilation) => {
 						const hooks =
-							webpack.javascript.JavascriptModulesPlugin.getCompilationHooks(
+							rspack.javascript.JavascriptModulesPlugin.getCompilationHooks(
 								compilation
 							);
 						hooks.inlineInRuntimeBailout.tap("test", () => "test bailout");

--- a/tests/rspack-test/configCases/module/non-webpack-require-warning/rspack.config.js
+++ b/tests/rspack-test/configCases/module/non-webpack-require-warning/rspack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration[]} */
 module.exports = [
@@ -22,7 +22,7 @@ module.exports = [
 							() => {
 								compilation.emitAsset(
 									"bar.js",
-									new webpack.sources.RawSource("module.exports = 1;")
+									new rspack.sources.RawSource("module.exports = 1;")
 								);
 							}
 						);
@@ -37,7 +37,7 @@ module.exports = [
 		},
 		target: "web",
 		plugins: [
-			new webpack.BannerPlugin({
+			new rspack.BannerPlugin({
 				raw: true,
 				banner:
 					'import { createRequire } from "module"; const require = createRequire(import.meta.url)'

--- a/tests/rspack-test/configCases/module/non-webpack-require/rspack.config.js
+++ b/tests/rspack-test/configCases/module/non-webpack-require/rspack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -29,7 +29,7 @@ module.exports = {
 						() => {
 							compilation.emitAsset(
 								"mod.js",
-								new webpack.sources.RawSource(
+								new rspack.sources.RawSource(
 									"module.exports = 'module text';\n"
 								)
 							);
@@ -44,7 +44,7 @@ module.exports = {
 						() => {
 							compilation.emitAsset(
 								"node_modules/external-module/index.js",
-								new webpack.sources.RawSource(
+								new rspack.sources.RawSource(
 									"module.exports = 'external module text';\n"
 								)
 							);

--- a/tests/rspack-test/configCases/optimization/chunk/rspack.config.js
+++ b/tests/rspack-test/configCases/optimization/chunk/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	optimization: {

--- a/tests/rspack-test/configCases/output-module/only-non-webpack-require/rspack.config.js
+++ b/tests/rspack-test/configCases/output-module/only-non-webpack-require/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -23,7 +23,7 @@ module.exports = {
 						() => {
 							compilation.emitAsset(
 								"mod.js",
-								new webpack.sources.RawSource(
+								new rspack.sources.RawSource(
 									"module.exports = 'module text';\n"
 								)
 							);

--- a/tests/rspack-test/configCases/parsing/dead-code-elimination/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/dead-code-elimination/rspack.config.js
@@ -2,7 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration[]} */
 module.exports = [
@@ -39,7 +39,7 @@ module.exports = [
 
 								compilation.emitAsset(
 									"test.js",
-									new webpack.sources.RawSource(data)
+									new rspack.sources.RawSource(data)
 								);
 							}
 						);

--- a/tests/rspack-test/configCases/parsing/destructuring-computed-property/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/destructuring-computed-property/rspack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -8,7 +8,7 @@ module.exports = {
 		concatenateModules: true
 	},
 	plugins: [
-		new webpack.DefinePlugin({
+		new rspack.DefinePlugin({
 			PROPERTY: JSON.stringify("foo")
 		})
 	]

--- a/tests/rspack-test/configCases/parsing/issue-8293/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/issue-8293/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -20,7 +20,7 @@ module.exports = {
 		__dirname: false
 	},
 	plugins: [
-		new webpack.DefinePlugin({
+		new rspack.DefinePlugin({
 			CONST_PREFIX0: JSON.stringify("prefix0"),
 			CONST_SUFFIX0: JSON.stringify("suffix0"),
 			CONST_PREFIX1: JSON.stringify("prefix1"),

--- a/tests/rspack-test/configCases/plugins/banner-plugin-hashing/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/banner-plugin-hashing/rspack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -16,7 +16,7 @@ module.exports = {
 		filename: "[name].js?value",
 	},
 	plugins: [
-		new webpack.BannerPlugin({
+		new rspack.BannerPlugin({
 			banner:
 				"fullhash:[fullhash], chunkhash:[chunkhash], name:[name], base:[base], query:[query], file:[file], path:[path], ext:[ext]",
 		}),

--- a/tests/rspack-test/configCases/plugins/manifest-plugin/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/manifest-plugin/rspack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { RawSource } = require("webpack-sources");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @typedef {import("../../../../lib/Compiler")} Compiler */
 
@@ -14,7 +14,7 @@ class CopyPlugin {
 	apply(compiler) {
 		const hookOptions = {
 			name: "MockCopyPlugin",
-			stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+			stage: rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
 		};
 
 		compiler.hooks.thisCompilation.tap(hookOptions, (compilation) => {
@@ -40,7 +40,7 @@ module.exports = [
 		},
 		plugins: [
 			new CopyPlugin(),
-			new webpack.ManifestPlugin({
+			new rspack.ManifestPlugin({
 				filename: "foo.json"
 			})
 		],
@@ -73,7 +73,7 @@ module.exports = [
 		},
 		plugins: [
 			new CopyPlugin(),
-			new webpack.ManifestPlugin({
+			new rspack.ManifestPlugin({
 				filename: "bar.json"
 			})
 		],

--- a/tests/rspack-test/configCases/plugins/progress-plugin/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/progress-plugin/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {{ value: number, msg: string, info: { builtModules: number, moduleIdentifier?: string } }[]} */
 const progressItems = [];
@@ -6,7 +6,7 @@ const progressItems = [];
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	plugins: [
-		new webpack.ProgressPlugin((value, msg, info) => {
+		new rspack.ProgressPlugin((value, msg, info) => {
 			progressItems.push({ value, msg, info });
 		}),
 		{

--- a/tests/rspack-test/configCases/plugins/source-map-dev-tool-plugin-append-function/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/source-map-dev-tool-plugin-append-function/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 const TerserPlugin = require("terser-webpack-plugin");
 
 /** @type {import("@rspack/core").Configuration} */
@@ -18,7 +18,7 @@ module.exports = {
 		minimizer: [new TerserPlugin()]
 	},
 	plugins: [
-		new webpack.SourceMapDevToolPlugin({
+		new rspack.SourceMapDevToolPlugin({
 			filename: "sourcemaps/[file].map",
 			append: data => `\n//# sourceMappingURL=http://localhost:50505/[file].map`
 		})

--- a/tests/rspack-test/configCases/plugins/virtual-url-plugin/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/virtual-url-plugin/rspack.config.js
@@ -2,9 +2,9 @@
 
 const fs = require("fs");
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
-const { VirtualUrlPlugin } = webpack.experiments.schemes;
+const { VirtualUrlPlugin } = rspack.experiments.schemes;
 
 const watchDir = path.join(__dirname, "./routes");
 

--- a/tests/rspack-test/configCases/source-map/eval-source-map-ignore-list/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/eval-source-map-ignore-list/rspack.config.js
@@ -1,12 +1,12 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	devtool: false,
 	plugins: [
-		new webpack.EvalSourceMapDevToolPlugin({
+		new rspack.EvalSourceMapDevToolPlugin({
 			ignoreList: [/ignored\.js/]
 		})
 	],

--- a/tests/rspack-test/configCases/source-map/source-map-ignore-list/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/source-map-ignore-list/rspack.config.js
@@ -1,13 +1,13 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	mode: "development",
 	devtool: false,
 	plugins: [
-		new webpack.SourceMapDevToolPlugin({
+		new rspack.SourceMapDevToolPlugin({
 			filename: "[file].map",
 			ignoreList: [/ignored\.js/]
 		})

--- a/tests/rspack-test/configCases/source-map/test-fn-modules-source-map/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/test-fn-modules-source-map/rspack.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -16,7 +16,7 @@ module.exports = {
 		filename: "[name].js"
 	},
 	plugins: [
-		new webpack.EvalSourceMapDevToolPlugin({
+		new rspack.EvalSourceMapDevToolPlugin({
 			test: (str) => {
 				if (str.endsWith(".js")) return true;
 				return false;

--- a/tests/rspack-test/configCases/target/amd-container-named/rspack.config.js
+++ b/tests/rspack-test/configCases/target/amd-container-named/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	output: {
@@ -13,7 +13,7 @@ module.exports = {
 		__filename: false
 	},
 	plugins: [
-		new webpack.BannerPlugin({
+		new rspack.BannerPlugin({
 			raw: true,
 			banner:
 				"function define(name, deps, fn) { fn(); }\nconst window = {};\nwindow['clientContainer'] = { define };\n"

--- a/tests/rspack-test/configCases/target/amd-container-require/rspack.config.js
+++ b/tests/rspack-test/configCases/target/amd-container-require/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	output: {
@@ -12,7 +12,7 @@ module.exports = {
 		__filename: false
 	},
 	plugins: [
-		new webpack.BannerPlugin({
+		new rspack.BannerPlugin({
 			raw: true,
 			banner:
 				"var nodeRequire = require;\nvar require = function(deps, fn) { fn(); }\nconst window = {};\nwindow['clientContainer'] = { require };\n"

--- a/tests/rspack-test/configCases/target/amd-container-unnamed/rspack.config.js
+++ b/tests/rspack-test/configCases/target/amd-container-unnamed/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	output: {
@@ -12,7 +12,7 @@ module.exports = {
 		__filename: false
 	},
 	plugins: [
-		new webpack.BannerPlugin({
+		new rspack.BannerPlugin({
 			raw: true,
 			banner:
 				"function define(fn) { fn(); }\nconst window = {};\nwindow['clientContainer'] = { define };\n"

--- a/tests/rspack-test/configCases/target/amd-named/rspack.config.js
+++ b/tests/rspack-test/configCases/target/amd-named/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	output: {
@@ -9,7 +9,7 @@ module.exports = {
 		__filename: false
 	},
 	plugins: [
-		new webpack.BannerPlugin({
+		new rspack.BannerPlugin({
 			raw: true,
 			banner: "function define(name, deps, fn) { fn(); }\n"
 		})

--- a/tests/rspack-test/configCases/target/amd-require/rspack.config.js
+++ b/tests/rspack-test/configCases/target/amd-require/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	output: {
@@ -9,7 +9,7 @@ module.exports = {
 		__filename: false
 	},
 	plugins: [
-		new webpack.BannerPlugin({
+		new rspack.BannerPlugin({
 			raw: true,
 			banner:
 				"var nodeRequire = require;\nvar require = function(deps, fn) { fn(); }\n"

--- a/tests/rspack-test/configCases/target/amd-unnamed/rspack.config.js
+++ b/tests/rspack-test/configCases/target/amd-unnamed/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	output: {
@@ -9,7 +9,7 @@ module.exports = {
 		__filename: false
 	},
 	plugins: [
-		new webpack.BannerPlugin({
+		new rspack.BannerPlugin({
 			raw: true,
 			banner: "function define(fn) { fn(); }\n"
 		})

--- a/tests/rspack-test/configCases/web/nonce copy/rspack.config.js
+++ b/tests/rspack-test/configCases/web/nonce copy/rspack.config.js
@@ -1,7 +1,7 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	target: "web",
 	// plugin that intercepts __webpack_require__
-	plugins: [new webpack.HotModuleReplacementPlugin()]
+	plugins: [new rspack.HotModuleReplacementPlugin()]
 };

--- a/tests/rspack-test/configCases/worker/node-worker-hmr/rspack.config.js
+++ b/tests/rspack-test/configCases/worker/node-worker-hmr/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -11,5 +11,5 @@ module.exports = {
 	output: {
 		filename: "[name].[contenthash].js"
 	},
-	plugins: [new webpack.HotModuleReplacementPlugin()]
+	plugins: [new rspack.HotModuleReplacementPlugin()]
 };

--- a/tests/rspack-test/hotCases/define/issue-6962/rspack.config.js
+++ b/tests/rspack-test/hotCases/define/issue-6962/rspack.config.js
@@ -1,11 +1,11 @@
 "use strict";
 
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	plugins: [
-		new webpack.DefinePlugin({
+		new rspack.DefinePlugin({
 			DEFINE_PATH: JSON.stringify("./a")
 		})
 	]

--- a/tests/rspack-test/serialCases/css/css-modules-broken-keyframes/rspack.config.js
+++ b/tests/rspack-test/serialCases/css/css-modules-broken-keyframes/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 const path = require("path");
 
 /** @type {function(any, any): import("@rspack/core").Configuration} */
@@ -18,13 +18,13 @@ module.exports = (env, { testPath }) => ({
 	},
 ,
 	plugins: [
-		new webpack.ids.DeterministicModuleIdsPlugin({
+		new rspack.ids.DeterministicModuleIdsPlugin({
 			maxLength: 3,
 			failOnConflict: true,
 			fixedLength: true,
 			test: m => m.type.startsWith("css")
 		}),
-		new webpack.experiments.ids.SyncModuleIdsPlugin({
+		new rspack.experiments.ids.SyncModuleIdsPlugin({
 			test: m => m.type.startsWith("css"),
 			path: path.resolve(testPath, "module-ids.json"),
 			mode: "create"

--- a/tests/rspack-test/serialCases/css/css-modules/rspack.config.js
+++ b/tests/rspack-test/serialCases/css/css-modules/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 const path = require("path");
 
 /** @type {function(any, any): import("@rspack/core").Configuration[]} */
@@ -32,13 +32,13 @@ module.exports = (env, { testPath }) => [
 		},
 
 		plugins: [
-			new webpack.ids.DeterministicModuleIdsPlugin({
+			new rspack.ids.DeterministicModuleIdsPlugin({
 				maxLength: 3,
 				failOnConflict: true,
 				fixedLength: true,
 				test: m => m.type.startsWith("css")
 			}),
-			new webpack.experiments.ids.SyncModuleIdsPlugin({
+			new rspack.experiments.ids.SyncModuleIdsPlugin({
 				test: m => m.type.startsWith("css"),
 				path: path.resolve(testPath, "module-ids.json"),
 				mode: "create"

--- a/tests/rspack-test/serialCases/css/exports-convention/rspack.config.js
+++ b/tests/rspack-test/serialCases/css/exports-convention/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 const common = {
 	optimization: {
@@ -64,7 +64,7 @@ module.exports = [
 		mode: "development",
 		target: "web",
 		plugins: [
-			new webpack.DefinePlugin({
+			new rspack.DefinePlugin({
 				"process.env.TARGET": JSON.stringify("web")
 			})
 		]
@@ -74,7 +74,7 @@ module.exports = [
 		mode: "production",
 		target: "web",
 		plugins: [
-			new webpack.DefinePlugin({
+			new rspack.DefinePlugin({
 				"process.env.TARGET": JSON.stringify("web")
 			})
 		]
@@ -84,7 +84,7 @@ module.exports = [
 		mode: "development",
 		target: "node",
 		plugins: [
-			new webpack.DefinePlugin({
+			new rspack.DefinePlugin({
 				"process.env.TARGET": JSON.stringify("node")
 			})
 		]
@@ -94,7 +94,7 @@ module.exports = [
 		mode: "production",
 		target: "node",
 		plugins: [
-			new webpack.DefinePlugin({
+			new rspack.DefinePlugin({
 				"process.env.TARGET": JSON.stringify("node")
 			})
 		]

--- a/tests/rspack-test/serialCases/library/0-create-library/rspack.config.js
+++ b/tests/rspack-test/serialCases/library/0-create-library/rspack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {function(any, any): import("@rspack/core").Configuration[]} */
 module.exports = (env, { testPath }) => [
 	{
@@ -265,7 +265,7 @@ module.exports = (env, { testPath }) => [
 			}
 		},
 		plugins: [
-			new webpack.BannerPlugin({
+			new rspack.BannerPlugin({
 				raw: true,
 				banner: "module.exports = () => globalName;\n"
 			})
@@ -285,7 +285,7 @@ module.exports = (env, { testPath }) => [
 			}
 		},
 		plugins: [
-			new webpack.BannerPlugin({
+			new rspack.BannerPlugin({
 				raw: true,
 				banner: "module.exports = () => globalName;\n"
 			})

--- a/tests/rspack-test/watchCases/cache/loader-import-module-progress/rspack.config.js
+++ b/tests/rspack-test/watchCases/cache/loader-import-module-progress/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -15,7 +15,7 @@ module.exports = {
 		]
 	},
 	plugins: [
-		new webpack.ProgressPlugin(),
+		new rspack.ProgressPlugin(),
 		{
 			apply(compiler) {
 				compiler.hooks.done.tapPromise("CacheTest", async () => {

--- a/tests/rspack-test/watchCases/cache/loader-load-module-progress/rspack.config.js
+++ b/tests/rspack-test/watchCases/cache/loader-load-module-progress/rspack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -14,7 +14,7 @@ module.exports = {
 		]
 	},
 	plugins: [
-		new webpack.ProgressPlugin(),
+		new rspack.ProgressPlugin(),
 		{
 			apply(compiler) {
 				compiler.hooks.done.tapPromise("CacheTest", async () => {

--- a/tests/rspack-test/watchCases/plugins/define-plugin/rspack.config.js
+++ b/tests/rspack-test/watchCases/plugins/define-plugin/rspack.config.js
@@ -1,22 +1,22 @@
 const path = require("path");
 const fs = require("fs");
-const webpack = require("@rspack/core");
+const { rspack } = require("@rspack/core");
 /** @type {function(any, any): import("@rspack/core").Configuration} */
 module.exports = (env, { srcPath }) => {
 	const valueFile = path.resolve(srcPath, "value.txt");
 	return {
 		plugins: [
-			new webpack.DefinePlugin({
-				TEST_VALUE: webpack.DefinePlugin.runtimeValue(() => {
+			new rspack.DefinePlugin({
+				TEST_VALUE: rspack.DefinePlugin.runtimeValue(() => {
 					return JSON.stringify(fs.readFileSync(valueFile, "utf-8").trim());
 				}, [valueFile]),
-				TEST_VALUE2: webpack.DefinePlugin.runtimeValue(() => {
+				TEST_VALUE2: rspack.DefinePlugin.runtimeValue(() => {
 					return JSON.stringify(fs.readFileSync(valueFile, "utf-8").trim());
 				}, []),
-				TEST_VALUE3: webpack.DefinePlugin.runtimeValue(() => {
+				TEST_VALUE3: rspack.DefinePlugin.runtimeValue(() => {
 					return JSON.stringify(fs.readFileSync(valueFile, "utf-8").trim());
 				}, true),
-				TEST_VALUE4: webpack.DefinePlugin.runtimeValue(
+				TEST_VALUE4: rspack.DefinePlugin.runtimeValue(
 					() => {
 						return JSON.stringify(fs.readFileSync(valueFile, "utf-8").trim());
 					},
@@ -24,7 +24,7 @@ module.exports = (env, { srcPath }) => {
 						fileDependencies: [valueFile]
 					}
 				),
-				TEST_VALUE5: webpack.DefinePlugin.runtimeValue(
+				TEST_VALUE5: rspack.DefinePlugin.runtimeValue(
 					({ version, key }) => {
 						return JSON.stringify({ version, key });
 					},


### PR DESCRIPTION
## Summary

Update all test config files to import from `@rspack/core` using the `rspack` namespace instead of the `webpack`. This aligns with the package's naming conventions and improves consistency across the codebase.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
