### PR TITLE
refactor: Refactor optimize chunks to use immutable compilation

### DIFF
--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -108,7 +108,7 @@ define_hook!(CompilationOptimizeDependencies: SeriesBail(compilation: &Compilati
  diagnostics: &mut Vec<Diagnostic>) -> bool);
 define_hook!(CompilationOptimizeModules: SeriesBail(compilation: &Compilation, diagnostics: &mut Vec<Diagnostic>) -> bool);
 define_hook!(CompilationAfterOptimizeModules: Series(compilation: &Compilation));
-define_hook!(CompilationOptimizeChunks: SeriesBail(compilation: &mut Compilation) -> bool);
+define_hook!(CompilationOptimizeChunks: SeriesBail(compilation: &Compilation, build_chunk_graph_artifact: &mut BuildChunkGraphArtifact, diagnostics: &mut Vec<Diagnostic>) -> bool);
 define_hook!(CompilationOptimizeTree: Series(compilation: &Compilation));
 define_hook!(CompilationOptimizeChunkModules: SeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationBeforeModuleIds: Series(compilation: &Compilation, modules: &IdentifierSet, module_ids: &mut ModuleIdsArtifact));

--- a/crates/rspack_core/src/compilation/optimize_chunks/mod.rs
+++ b/crates/rspack_core/src/compilation/optimize_chunks/mod.rs
@@ -12,17 +12,26 @@ impl PassExt for OptimizeChunksPass {
   }
 
   async fn run_pass(&self, compilation: &mut Compilation) -> Result<()> {
+    let mut diagnostics = vec![];
+    let mut build_chunk_graph_artifact =
+      std::mem::take(&mut compilation.build_chunk_graph_artifact);
     while matches!(
       compilation
         .plugin_driver
         .clone()
         .compilation_hooks
         .optimize_chunks
-        .call(compilation)
+        .call(
+          compilation,
+          &mut build_chunk_graph_artifact,
+          &mut diagnostics,
+        )
         .await
         .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.optimizeChunks"))?,
       Some(true)
     ) {}
+    compilation.build_chunk_graph_artifact = build_chunk_graph_artifact;
+    compilation.extend_diagnostics(diagnostics);
 
     Ok(())
   }

--- a/crates/rspack_plugin_css_chunking/src/lib.rs
+++ b/crates/rspack_plugin_css_chunking/src/lib.rs
@@ -8,10 +8,10 @@ use rspack_collections::{
   UkeySet,
 };
 use rspack_core::{
-  ChunkUkey, Compilation, CompilationOptimizeChunks, CompilationParams, CompilerCompilation,
-  Logger, Module, ModuleIdentifier, Plugin, SourceType,
+  BuildChunkGraphArtifact, ChunkUkey, Compilation, CompilationOptimizeChunks, CompilationParams,
+  CompilerCompilation, Logger, Module, ModuleIdentifier, Plugin, SourceType,
 };
-use rspack_error::Result;
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_css::CssPlugin;
 use rspack_regex::RspackRegex;
@@ -73,7 +73,12 @@ struct ChunkState {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for CssChunkingPlugin, stage = 5)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
   let strict = self.strict;
 
   if self.once.load(Ordering::Relaxed) {
@@ -89,8 +94,8 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     Default::default();
 
   // Collect all css modules in chunks and the execpted order of them
-  let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
-  let chunks = &compilation.build_chunk_graph_artifact.chunk_by_ukey;
+  let chunk_graph = &build_chunk_graph_artifact.chunk_graph;
+  let chunks = &build_chunk_graph_artifact.chunk_by_ukey;
   let module_graph = compilation.get_module_graph();
 
   for (chunk_ukey, chunk) in chunks.iter() {
@@ -117,8 +122,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     if modules.is_empty() {
       continue;
     }
-    let chunk = compilation
-      .build_chunk_graph_artifact
+    let chunk = build_chunk_graph_artifact
       .chunk_by_ukey
       .expect_get(chunk_ukey);
     let (ordered_modules, _) = CssPlugin::get_modules_in_order(chunk, modules, compilation);
@@ -375,17 +379,15 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
         break;
       }
     }
-    let new_chunk_ukey =
-      Compilation::add_chunk(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
+    let new_chunk_ukey = Compilation::add_chunk(&mut build_chunk_graph_artifact.chunk_by_ukey);
     #[allow(clippy::unwrap_used)]
-    let new_chunk = compilation
-      .build_chunk_graph_artifact
+    let new_chunk = build_chunk_graph_artifact
       .chunk_by_ukey
       .get_mut(&new_chunk_ukey)
       .unwrap();
     new_chunk.prevent_integration();
     new_chunk.add_id_name_hints("css".to_string());
-    let chunk_graph = &mut compilation.build_chunk_graph_artifact.chunk_graph;
+    let chunk_graph = &mut build_chunk_graph_artifact.chunk_graph;
     for module_identifier in &new_chunk_modules {
       remaining_modules.shift_remove(module_identifier);
       chunk_graph.connect_chunk_and_module(new_chunk_ukey, *module_identifier);
@@ -395,7 +397,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
   logger.time_end(start);
 
   let start = logger.time("apply split chunks");
-  let chunk_graph = &mut compilation.build_chunk_graph_artifact.chunk_graph;
+  let chunk_graph = &mut build_chunk_graph_artifact.chunk_graph;
   for chunk_state in chunk_states.values() {
     let mut chunks: UkeySet<ChunkUkey> = UkeySet::default();
     for module_identifier in &chunk_state.modules {
@@ -405,12 +407,12 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
           continue;
         }
         chunks.insert(*new_chunk_ukey);
-        let chunk_by_ukey = &mut compilation.build_chunk_graph_artifact.chunk_by_ukey;
+        let chunk_by_ukey = &mut build_chunk_graph_artifact.chunk_by_ukey;
         let [chunk, new_chunk] = chunk_by_ukey.get_many_mut([&chunk_state.chunk, new_chunk_ukey]);
         #[allow(clippy::unwrap_used)]
         chunk.unwrap().split(
           new_chunk.unwrap(),
-          &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+          &mut build_chunk_graph_artifact.chunk_group_by_ukey,
         );
       }
     }

--- a/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
+++ b/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
@@ -1,5 +1,7 @@
-use rspack_core::{Compilation, CompilationOptimizeChunks, Logger, Plugin};
-use rspack_error::Result;
+use rspack_core::{
+  BuildChunkGraphArtifact, Compilation, CompilationOptimizeChunks, Logger, Plugin,
+};
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use tracing::info;
@@ -9,11 +11,15 @@ use tracing::info;
 pub struct EnsureChunkConditionsPlugin;
 
 #[plugin_hook(CompilationOptimizeChunks for EnsureChunkConditionsPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_BASIC)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
   let logger = compilation.get_logger(self.name());
   let start = logger.time("ensure chunk conditions");
-  compilation
-    .build_chunk_graph_artifact
+  build_chunk_graph_artifact
     .chunk_graph
     .generate_dot(compilation, "before-ensure-chunk-conditions")
     .await;
@@ -22,8 +28,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     .get_module_graph()
     .modules()
     .for_each(|(module_id, module)| {
-      let source_chunks = compilation
-        .build_chunk_graph_artifact
+      let source_chunks = build_chunk_graph_artifact
         .chunk_graph
         .get_module_chunks(module.identifier())
         .iter()
@@ -53,11 +58,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     let mut target_chunks = HashSet::default();
     for chunk_key in chunk_keys {
       adjust_chunk_size += 1;
-      if let Some(chunk) = compilation
-        .build_chunk_graph_artifact
-        .chunk_by_ukey
-        .get(chunk_key)
-      {
+      if let Some(chunk) = build_chunk_graph_artifact.chunk_by_ukey.get(chunk_key) {
         let mut chunk_group_keys = chunk.groups().iter().collect::<Vec<_>>();
         visited_chunk_group_keys.clear();
         'out: while let Some(chunk_group_key) = chunk_group_keys.pop() {
@@ -65,8 +66,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
             continue;
           }
           visited_chunk_group_keys.insert(chunk_group_key);
-          if let Some(chunk_group) = compilation
-            .build_chunk_graph_artifact
+          if let Some(chunk_group) = build_chunk_graph_artifact
             .chunk_group_by_ukey
             .get(chunk_group_key)
           {
@@ -105,7 +105,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     adjust_chunk_in_chunk_group_size = adjust_chunk_in_chunk_group_size,
 
   );
-  let mut chunk_graph = std::mem::take(&mut compilation.build_chunk_graph_artifact.chunk_graph);
+  let mut chunk_graph = std::mem::take(&mut build_chunk_graph_artifact.chunk_graph);
   for (module_id, chunks) in source_module_chunks {
     for chunk in chunks {
       chunk_graph.disconnect_chunk_and_module(&chunk, module_id);
@@ -117,7 +117,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
       chunk_graph.connect_chunk_and_module(chunk, module_id);
     }
   }
-  compilation.build_chunk_graph_artifact.chunk_graph = chunk_graph;
+  build_chunk_graph_artifact.chunk_graph = chunk_graph;
 
   logger.time_end(start);
 

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -1,6 +1,8 @@
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, UkeyDashSet, UkeyMap, UkeySet};
-use rspack_core::{ChunkGroupUkey, ChunkUkey, Compilation, incremental::Mutation};
+use rspack_core::{
+  BuildChunkGraphArtifact, ChunkGroupUkey, ChunkUkey, Compilation, incremental::Mutation,
+};
 
 /// Ensure that all entry chunks only export the exports used by other chunks,
 /// this requires no other chunks depend on the entry chunk to get exports
@@ -9,14 +11,16 @@ use rspack_core::{ChunkGroupUkey, ChunkUkey, Compilation, incremental::Mutation}
 /// entry chunk: a, b
 /// async chunk: c
 /// c depends on a, so entry chunk needs to re-export symbols from a
-pub(crate) fn ensure_entry_exports(compilation: &mut Compilation) {
+pub(crate) fn ensure_entry_exports(
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+) {
   let module_graph = compilation.get_module_graph();
   let mut entrypoint_chunks = UkeyMap::<ChunkUkey, ChunkGroupUkey>::default();
   let mut entry_module_belongs: IdentifierMap<UkeySet<ChunkUkey>> = IdentifierMap::default();
 
-  for entrypoint_ukey in compilation.entrypoints().values() {
-    let entrypoint = compilation
-      .build_chunk_graph_artifact
+  for entrypoint_ukey in build_chunk_graph_artifact.entrypoints.values() {
+    let entrypoint = build_chunk_graph_artifact
       .chunk_group_by_ukey
       .expect_get(entrypoint_ukey);
     let entrypoint_chunk = entrypoint.get_entrypoint_chunk();
@@ -24,8 +28,7 @@ pub(crate) fn ensure_entry_exports(compilation: &mut Compilation) {
     // we should use get_chunk_modules instead of entrydata.modules
     // because entry modules may be moved to another chunk
     // we only care if the real entry chunk is a dependency of other chunks
-    let entry_modules = compilation
-      .build_chunk_graph_artifact
+    let entry_modules = build_chunk_graph_artifact
       .chunk_graph
       .get_chunk_modules_identifier(&entrypoint_chunk);
 
@@ -41,15 +44,13 @@ pub(crate) fn ensure_entry_exports(compilation: &mut Compilation) {
 
   let dirty_chunks = UkeyDashSet::default();
 
-  compilation
-    .build_chunk_graph_artifact
+  build_chunk_graph_artifact
     .chunk_by_ukey
     .iter()
     .par_bridge()
     .filter(|(ukey, _)| !entrypoint_chunks.contains_key(ukey))
     .for_each(|(ukey, _)| {
-      let modules = compilation
-        .build_chunk_graph_artifact
+      let modules = build_chunk_graph_artifact
         .chunk_graph
         .get_chunk_modules_identifier(ukey);
 
@@ -78,66 +79,56 @@ pub(crate) fn ensure_entry_exports(compilation: &mut Compilation) {
   // And we should split a runtime chunk as well, to make sure the new chunk depends on runtime
   // will not cause circular dependency
   for entry_chunk_ukey in dirty_chunks {
-    let entry_modules = compilation
-      .build_chunk_graph_artifact
+    let entry_modules = build_chunk_graph_artifact
       .chunk_graph
       .get_chunk_modules_identifier(&entry_chunk_ukey)
       .iter()
       .copied()
       .collect::<Vec<_>>();
 
-    let new_chunk_ukey =
-      Compilation::add_chunk(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
+    let new_chunk_ukey = Compilation::add_chunk(&mut build_chunk_graph_artifact.chunk_by_ukey);
     if let Some(mut mutation) = compilation.incremental.mutations_write() {
       mutation.add(Mutation::ChunkAdd {
         chunk: new_chunk_ukey,
       });
     }
-    compilation
-      .build_chunk_graph_artifact
+    build_chunk_graph_artifact
       .chunk_graph
       .add_chunk(new_chunk_ukey);
 
     // move entrypoint runtime as well
     let entrypoint_ukey = entrypoint_chunks[&entry_chunk_ukey];
-    let entrypoint = compilation
-      .build_chunk_graph_artifact
+    let entrypoint = build_chunk_graph_artifact
       .chunk_group_by_ukey
       .expect_get(&entrypoint_ukey);
-    if entrypoint.get_runtime_chunk(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
+    if entrypoint.get_runtime_chunk(&build_chunk_graph_artifact.chunk_group_by_ukey)
       == entry_chunk_ukey
     {
-      let entrypoint = compilation
-        .build_chunk_graph_artifact
+      let entrypoint = build_chunk_graph_artifact
         .chunk_group_by_ukey
         .expect_get_mut(&entrypoint_ukey);
       entrypoint.set_runtime_chunk(new_chunk_ukey);
     }
 
     for m in entry_modules {
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_graph
         .disconnect_chunk_and_entry_module(&entry_chunk_ukey, m);
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_graph
         .disconnect_chunk_and_module(&entry_chunk_ukey, m);
 
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_graph
         .connect_chunk_and_module(new_chunk_ukey, m);
 
       let entrypoint = entrypoint_chunks[&entry_chunk_ukey];
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_graph
         .connect_chunk_and_entry_module(new_chunk_ukey, m, entrypoint);
     }
 
-    let [Some(entry_chunk), Some(new_chunk)] = compilation
-      .build_chunk_graph_artifact
+    let [Some(entry_chunk), Some(new_chunk)] = build_chunk_graph_artifact
       .chunk_by_ukey
       .get_many_mut([&entry_chunk_ukey, &new_chunk_ukey])
     else {
@@ -146,7 +137,7 @@ pub(crate) fn ensure_entry_exports(compilation: &mut Compilation) {
 
     entry_chunk.split(
       new_chunk,
-      &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+      &mut build_chunk_graph_artifact.chunk_group_by_ukey,
     );
   }
 }

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -8,8 +8,8 @@ use atomic_refcell::AtomicRefCell;
 use regex::Regex;
 use rspack_collections::{Identifiable, Identifier, IdentifierIndexMap, IdentifierSet, UkeyMap};
 use rspack_core::{
-  ApplyContext, AssetInfo, AsyncModulesArtifact, BoxModule, BuildModuleGraphArtifact, ChunkUkey,
-  Compilation, CompilationAdditionalChunkRuntimeRequirements,
+  ApplyContext, AssetInfo, AsyncModulesArtifact, BoxModule, BuildChunkGraphArtifact,
+  BuildModuleGraphArtifact, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationAdditionalTreeRuntimeRequirements, CompilationAfterCodeGeneration,
   CompilationConcatenationScope, CompilationFinishModules, CompilationOptimizeChunks,
   CompilationOptimizeDependencies, CompilationParams, CompilationProcessAssets,
@@ -484,15 +484,25 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for EsmLibraryPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
   // check if we have to generate proxy chunks
   if let Some(preserve_modules_root) = &self.preserve_modules {
-    let errors = preserve_modules(preserve_modules_root, compilation).await;
+    let errors = preserve_modules(
+      preserve_modules_root,
+      compilation,
+      build_chunk_graph_artifact,
+    )
+    .await;
     if !errors.is_empty() {
-      compilation.extend_diagnostics(errors);
+      diagnostics.extend(errors);
     }
   } else {
-    ensure_entry_exports(compilation);
+    ensure_entry_exports(compilation, build_chunk_graph_artifact);
   }
 
   Ok(None)

--- a/crates/rspack_plugin_esm_library/src/preserve_modules.rs
+++ b/crates/rspack_plugin_esm_library/src/preserve_modules.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, path::Path, sync::LazyLock};
 
 use regex::Regex;
 use rspack_collections::{IdentifierMap, IdentifierSet};
-use rspack_core::Compilation;
+use rspack_core::{BuildChunkGraphArtifact, Compilation};
 use rspack_util::fx_hash::{FxHashMap, FxHashSet};
 use sugar_path::SugarPath;
 
@@ -49,7 +49,8 @@ pub fn entry_name_for_module(
 
 pub async fn preserve_modules(
   root: &Path,
-  compilation: &mut Compilation,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
 ) -> Vec<rspack_error::Diagnostic> {
   let mut errors = vec![];
   let modules = compilation
@@ -62,8 +63,7 @@ pub async fn preserve_modules(
   let entry_name_for_module = entry_name_for_module(&entry_modules);
 
   for module_id in modules {
-    if compilation
-      .build_chunk_graph_artifact
+    if build_chunk_graph_artifact
       .chunk_graph
       .get_module_chunks(module_id)
       .is_empty()
@@ -90,8 +90,7 @@ pub async fn preserve_modules(
       continue;
     };
     let chunk = EsmLibraryPlugin::get_module_chunk(module_id, compilation);
-    let old_chunk = compilation
-      .build_chunk_graph_artifact
+    let old_chunk = build_chunk_graph_artifact
       .chunk_by_ukey
       .expect_get_mut(&chunk);
 
@@ -126,8 +125,7 @@ pub async fn preserve_modules(
         file_path.to_string_lossy().to_string().into()
       };
 
-      if compilation
-        .build_chunk_graph_artifact
+      if build_chunk_graph_artifact
         .chunk_graph
         .get_chunk_modules_identifier(&chunk)
         .len()
@@ -138,14 +136,11 @@ pub async fn preserve_modules(
         continue;
       }
 
-      let new_chunk_ukey =
-        Compilation::add_chunk(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
-      compilation
-        .build_chunk_graph_artifact
+      let new_chunk_ukey = Compilation::add_chunk(&mut build_chunk_graph_artifact.chunk_by_ukey);
+      build_chunk_graph_artifact
         .chunk_graph
         .add_chunk(new_chunk_ukey);
-      let [Some(new_chunk), Some(old_chunk)] = compilation
-        .build_chunk_graph_artifact
+      let [Some(new_chunk), Some(old_chunk)] = build_chunk_graph_artifact
         .chunk_by_ukey
         .get_many_mut([&new_chunk_ukey, &chunk])
       else {
@@ -155,16 +150,14 @@ pub async fn preserve_modules(
       new_chunk.set_filename_template(Some(new_filename));
       old_chunk.split(
         new_chunk,
-        &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+        &mut build_chunk_graph_artifact.chunk_group_by_ukey,
       );
       // disconnect module from other chunks
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_graph
         .disconnect_chunk_and_module(&chunk, module_id);
 
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_graph
         .connect_chunk_and_module(new_chunk_ukey, module_id);
 
@@ -184,22 +177,26 @@ pub async fn preserve_modules(
           );
         }
 
-        compilation
-          .build_chunk_graph_artifact
+        build_chunk_graph_artifact
           .chunk_graph
           .disconnect_chunk_and_entry_module(&chunk, module_id);
 
-        let entrypoint = compilation.entrypoint_by_name_mut(
-          entry_names
-            .iter()
-            .next()
-            .expect("entry_names should not be empty"),
-        );
+        let entrypoint_ukey = *build_chunk_graph_artifact
+          .entrypoints
+          .get(
+            entry_names
+              .iter()
+              .next()
+              .expect("entry_names should not be empty"),
+          )
+          .expect("entrypoint not found");
+        let entrypoint = build_chunk_graph_artifact
+          .chunk_group_by_ukey
+          .expect_get_mut(&entrypoint_ukey);
         let ukey = entrypoint.ukey;
         entrypoint.set_entrypoint_chunk(new_chunk_ukey);
 
-        compilation
-          .build_chunk_graph_artifact
+        build_chunk_graph_artifact
           .chunk_graph
           .connect_chunk_and_entry_module(new_chunk_ukey, module_id, ukey);
       }

--- a/crates/rspack_plugin_limit_chunk_count/src/lib.rs
+++ b/crates/rspack_plugin_limit_chunk_count/src/lib.rs
@@ -5,10 +5,10 @@ use std::collections::HashSet;
 use chunk_combination::{ChunkCombination, ChunkCombinationBucket, ChunkCombinationUkey};
 use rspack_collections::{UkeyMap, UkeySet};
 use rspack_core::{
-  ChunkSizeOptions, ChunkUkey, Compilation, CompilationOptimizeChunks, Plugin,
-  compare_chunks_with_graph, incremental::Mutation,
+  BuildChunkGraphArtifact, ChunkSizeOptions, ChunkUkey, Compilation, CompilationOptimizeChunks,
+  Plugin, compare_chunks_with_graph, incremental::Mutation,
 };
-use rspack_error::Result;
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 
 fn add_to_set_map(
@@ -55,14 +55,18 @@ impl LimitChunkCountPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for LimitChunkCountPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
   let max_chunks = self.options.max_chunks;
   if max_chunks < 1 {
     return Ok(None);
   }
 
-  let mut chunks_ukeys = compilation
-    .build_chunk_graph_artifact
+  let mut chunks_ukeys = build_chunk_graph_artifact
     .chunk_by_ukey
     .keys()
     .copied()
@@ -71,17 +75,13 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     return Ok(None);
   }
 
-  let chunk_by_ukey = &compilation.build_chunk_graph_artifact.chunk_by_ukey.clone();
-  let chunk_group_by_ukey = &compilation
-    .build_chunk_graph_artifact
-    .chunk_group_by_ukey
-    .clone();
-  let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph.clone();
-  let mut new_chunk_by_ukey =
-    std::mem::take(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
+  let chunk_by_ukey = &build_chunk_graph_artifact.chunk_by_ukey.clone();
+  let chunk_group_by_ukey = &build_chunk_graph_artifact.chunk_group_by_ukey.clone();
+  let chunk_graph = &build_chunk_graph_artifact.chunk_graph.clone();
+  let mut new_chunk_by_ukey = std::mem::take(&mut build_chunk_graph_artifact.chunk_by_ukey);
   let mut new_chunk_group_by_ukey =
-    std::mem::take(&mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey);
-  let mut new_chunk_graph = std::mem::take(&mut compilation.build_chunk_graph_artifact.chunk_graph);
+    std::mem::take(&mut build_chunk_graph_artifact.chunk_group_by_ukey);
+  let mut new_chunk_graph = std::mem::take(&mut build_chunk_graph_artifact.chunk_graph);
 
   //    let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph.clone();
   let module_graph = compilation.get_module_graph();
@@ -300,9 +300,9 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     }
   }
 
-  compilation.build_chunk_graph_artifact.chunk_by_ukey = new_chunk_by_ukey;
-  compilation.build_chunk_graph_artifact.chunk_group_by_ukey = new_chunk_group_by_ukey;
-  compilation.build_chunk_graph_artifact.chunk_graph = new_chunk_graph;
+  build_chunk_graph_artifact.chunk_by_ukey = new_chunk_by_ukey;
+  build_chunk_graph_artifact.chunk_group_by_ukey = new_chunk_group_by_ukey;
+  build_chunk_graph_artifact.chunk_graph = new_chunk_graph;
 
   if let Some(mut mutations) = compilation.incremental.mutations_write() {
     // ChunkRemove mutations must be added last because a chunk can be removed after another chunk

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -1,10 +1,10 @@
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rspack_collections::UkeySet;
 use rspack_core::{
-  ChunkUkey, Compilation, CompilationOptimizeChunks, ExportsInfoData, Plugin, RuntimeSpec,
-  incremental::Mutation, is_runtime_equal,
+  BuildChunkGraphArtifact, ChunkUkey, Compilation, CompilationOptimizeChunks, ExportsInfoData,
+  Plugin, RuntimeSpec, incremental::Mutation, is_runtime_equal,
 };
-use rspack_error::Result;
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashSet as HashSet;
 
@@ -13,27 +13,29 @@ use rustc_hash::FxHashSet as HashSet;
 pub struct MergeDuplicateChunksPlugin;
 
 #[plugin_hook(CompilationOptimizeChunks for MergeDuplicateChunksPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_BASIC)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
   let mut not_duplicates = HashSet::default();
 
-  let mut chunk_ukeys = compilation
-    .build_chunk_graph_artifact
+  let mut chunk_ukeys = build_chunk_graph_artifact
     .chunk_by_ukey
     .keys()
     .copied()
     .collect::<Vec<_>>();
 
   chunk_ukeys.sort_by_key(|ukey| {
-    compilation
-      .build_chunk_graph_artifact
+    build_chunk_graph_artifact
       .chunk_by_ukey
       .expect_get(ukey)
       .name()
   });
 
   for chunk_ukey in chunk_ukeys {
-    if !compilation
-      .build_chunk_graph_artifact
+    if !build_chunk_graph_artifact
       .chunk_by_ukey
       .contains(&chunk_ukey)
     {
@@ -41,15 +43,13 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
       continue;
     }
     let mut possible_duplicates: Option<UkeySet<ChunkUkey>> = None;
-    for module in compilation
-      .build_chunk_graph_artifact
+    for module in build_chunk_graph_artifact
       .chunk_graph
       .get_chunk_modules_identifier(&chunk_ukey)
     {
       if let Some(ref mut possible_duplicates) = possible_duplicates {
         possible_duplicates.retain(|dup| {
-          compilation
-            .build_chunk_graph_artifact
+          build_chunk_graph_artifact
             .chunk_graph
             .is_module_in_chunk(module, *dup)
         });
@@ -57,18 +57,15 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
           break;
         }
       } else {
-        for dup in compilation
-          .build_chunk_graph_artifact
+        for dup in build_chunk_graph_artifact
           .chunk_graph
           .get_module_chunks(*module)
         {
           if *dup != chunk_ukey
-            && compilation
-              .build_chunk_graph_artifact
+            && build_chunk_graph_artifact
               .chunk_graph
               .get_number_of_chunk_modules(&chunk_ukey)
-              == compilation
-                .build_chunk_graph_artifact
+              == build_chunk_graph_artifact
                 .chunk_graph
                 .get_number_of_chunk_modules(dup)
             && !not_duplicates.contains(dup)
@@ -86,29 +83,25 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
       && !possible_duplicates.is_empty()
     {
       'outer: for other_chunk_ukey in possible_duplicates {
-        let chunk = compilation
-          .build_chunk_graph_artifact
+        let chunk = build_chunk_graph_artifact
           .chunk_by_ukey
           .expect_get(&chunk_ukey);
-        let other_chunk = compilation
-          .build_chunk_graph_artifact
+        let other_chunk = build_chunk_graph_artifact
           .chunk_by_ukey
           .expect_get(&other_chunk_ukey);
-        if other_chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
-          != chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
+        if other_chunk.has_runtime(&build_chunk_graph_artifact.chunk_group_by_ukey)
+          != chunk.has_runtime(&build_chunk_graph_artifact.chunk_group_by_ukey)
         {
           continue;
         }
-        if compilation
-          .build_chunk_graph_artifact
+        if build_chunk_graph_artifact
           .chunk_graph
           .get_number_of_entry_modules(&chunk_ukey)
           > 0
         {
           continue;
         }
-        if compilation
-          .build_chunk_graph_artifact
+        if build_chunk_graph_artifact
           .chunk_graph
           .get_number_of_entry_modules(&other_chunk_ukey)
           > 0
@@ -116,8 +109,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
           continue;
         }
         if !is_runtime_equal(chunk.runtime(), other_chunk.runtime()) {
-          let is_all_equal = compilation
-            .build_chunk_graph_artifact
+          let is_all_equal = build_chunk_graph_artifact
             .chunk_graph
             .get_chunk_modules_identifier(&chunk_ukey)
             .into_par_iter()
@@ -134,22 +126,19 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
             continue 'outer;
           }
         }
-        if compilation
-          .build_chunk_graph_artifact
+        if build_chunk_graph_artifact
           .chunk_graph
           .can_chunks_be_integrated(
             &chunk_ukey,
             &other_chunk_ukey,
-            &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-            &compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+            &build_chunk_graph_artifact.chunk_by_ukey,
+            &build_chunk_graph_artifact.chunk_group_by_ukey,
           )
         {
-          let mut chunk_graph =
-            std::mem::take(&mut compilation.build_chunk_graph_artifact.chunk_graph);
-          let mut chunk_by_ukey =
-            std::mem::take(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
+          let mut chunk_graph = std::mem::take(&mut build_chunk_graph_artifact.chunk_graph);
+          let mut chunk_by_ukey = std::mem::take(&mut build_chunk_graph_artifact.chunk_by_ukey);
           let mut chunk_group_by_ukey =
-            std::mem::take(&mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey);
+            std::mem::take(&mut build_chunk_graph_artifact.chunk_group_by_ukey);
           chunk_graph.integrate_chunks(
             &chunk_ukey,
             &other_chunk_ukey,
@@ -165,9 +154,9 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
               chunk: other_chunk_ukey,
             });
           }
-          compilation.build_chunk_graph_artifact.chunk_graph = chunk_graph;
-          compilation.build_chunk_graph_artifact.chunk_by_ukey = chunk_by_ukey;
-          compilation.build_chunk_graph_artifact.chunk_group_by_ukey = chunk_group_by_ukey;
+          build_chunk_graph_artifact.chunk_graph = chunk_graph;
+          build_chunk_graph_artifact.chunk_by_ukey = chunk_by_ukey;
+          build_chunk_graph_artifact.chunk_group_by_ukey = chunk_group_by_ukey;
         }
       }
     }

--- a/crates/rspack_plugin_mf/src/container/hoist_container_references_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/hoist_container_references_plugin.rs
@@ -19,10 +19,10 @@ use std::{
 
 use async_trait::async_trait;
 use rspack_core::{
-  Compilation, CompilationOptimizeChunks, CompilerCompilation, Dependency, DependencyId,
-  ModuleIdentifier, Plugin, incremental::Mutation,
+  BuildChunkGraphArtifact, Compilation, CompilationOptimizeChunks, CompilerCompilation, Dependency,
+  DependencyId, ModuleIdentifier, Plugin, incremental::Mutation,
 };
-use rspack_error::Result;
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -136,7 +136,12 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilationOptimizeChunks for HoistContainerReferencesPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED + 1)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
   // Helper: recursively collect all referenced modules
   fn get_all_referenced_modules(
     compilation: &Compilation,
@@ -193,11 +198,19 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     .collect::<FxHashSet<_>>();
 
   // Hoist referenced modules to their runtime chunk
-  let runtime_chunk_by_runtime = compilation
-    .get_chunk_graph_entries()
+  let runtime_chunk_by_runtime = build_chunk_graph_artifact
+    .entrypoints
+    .values()
+    .copied()
+    .chain(build_chunk_graph_artifact.async_entrypoints.iter().copied())
+    .map(|entrypoint_ukey| {
+      let entrypoint = build_chunk_graph_artifact
+        .chunk_group_by_ukey
+        .expect_get(&entrypoint_ukey);
+      entrypoint.get_runtime_chunk(&build_chunk_graph_artifact.chunk_group_by_ukey)
+    })
     .filter_map(|runtime_chunk| {
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_by_ukey
         .get(&runtime_chunk)
         .map(|chunk| (chunk.runtime().clone(), runtime_chunk))
@@ -205,24 +218,18 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     .flat_map(|(runtime, runtime_chunk)| runtime.into_iter().map(move |r| (r, runtime_chunk)))
     .collect::<FxHashMap<_, _>>();
   for module in &all_modules_to_hoist {
-    let runtime_chunks = compilation
-      .build_chunk_graph_artifact
+    let runtime_chunks = build_chunk_graph_artifact
       .chunk_graph
-      .get_module_runtimes_iter(
-        *module,
-        &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-      )
+      .get_module_runtimes_iter(*module, &build_chunk_graph_artifact.chunk_by_ukey)
       .flat_map(|runtime| runtime.iter())
       .filter_map(|runtime| runtime_chunk_by_runtime.get(runtime).copied())
       .collect::<Vec<_>>();
     for runtime_chunk in runtime_chunks {
-      if !compilation
-        .build_chunk_graph_artifact
+      if !build_chunk_graph_artifact
         .chunk_graph
         .is_module_in_chunk(module, runtime_chunk)
       {
-        compilation
-          .build_chunk_graph_artifact
+        build_chunk_graph_artifact
           .chunk_graph
           .connect_chunk_and_module(runtime_chunk, *module);
       }
@@ -235,8 +242,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     .copied()
     .collect::<FxHashSet<_>>();
   for module in all_modules_to_hoist {
-    let non_runtime_chunks = compilation
-      .build_chunk_graph_artifact
+    let non_runtime_chunks = build_chunk_graph_artifact
       .chunk_graph
       .get_module_chunks(module)
       .iter()
@@ -244,44 +250,29 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
       .copied()
       .collect::<Vec<_>>();
     for chunk in non_runtime_chunks {
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_graph
         .disconnect_chunk_and_module(&chunk, module);
 
-      if compilation
-        .build_chunk_graph_artifact
+      if build_chunk_graph_artifact
         .chunk_graph
         .get_number_of_chunk_modules(&chunk)
         == 0
-        && compilation
-          .build_chunk_graph_artifact
+        && build_chunk_graph_artifact
           .chunk_graph
           .get_number_of_entry_modules(&chunk)
           == 0
-        && let Some(mut removed_chunk) = compilation
-          .build_chunk_graph_artifact
-          .chunk_by_ukey
-          .remove(&chunk)
+        && let Some(mut removed_chunk) = build_chunk_graph_artifact.chunk_by_ukey.remove(&chunk)
       {
-        compilation
-          .build_chunk_graph_artifact
-          .chunk_graph
-          .disconnect_chunk(
-            &mut removed_chunk,
-            &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
-          );
-        compilation
-          .build_chunk_graph_artifact
-          .chunk_graph
-          .remove_chunk(&chunk);
+        build_chunk_graph_artifact.chunk_graph.disconnect_chunk(
+          &mut removed_chunk,
+          &mut build_chunk_graph_artifact.chunk_group_by_ukey,
+        );
+        build_chunk_graph_artifact.chunk_graph.remove_chunk(&chunk);
 
         // Remove from named chunks if it has a name
         if let Some(name) = removed_chunk.name() {
-          compilation
-            .build_chunk_graph_artifact
-            .named_chunks
-            .remove(name);
+          build_chunk_graph_artifact.named_chunks.remove(name);
         }
         // Record mutation
         if let Some(mut mutations) = compilation.incremental.mutations_write() {

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -12,15 +12,15 @@ use futures::future::BoxFuture;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rspack_collections::IdentifierMap;
 use rspack_core::{
-  AsyncModulesArtifact, BoxModule, ChunkByUkey, ChunkNamedIdArtifact, Compilation,
-  CompilationAfterOptimizeModules, CompilationAfterProcessAssets, CompilationBuildModule,
-  CompilationChunkIds, CompilationFinishModules, CompilationId, CompilationModuleIds,
-  CompilationOptimizeChunkModules, CompilationOptimizeChunks, CompilationOptimizeCodeGeneration,
-  CompilationOptimizeDependencies, CompilationOptimizeModules, CompilationOptimizeTree,
-  CompilationParams, CompilationProcessAssets, CompilationSeal, CompilationSucceedModule,
-  CompilerAfterEmit, CompilerClose, CompilerCompilation, CompilerEmit, CompilerFinishMake,
-  CompilerId, CompilerMake, CompilerThisCompilation, ExportsInfoArtifact, ModuleIdentifier,
-  ModuleIdsArtifact, Plugin, SideEffectsOptimizeArtifact,
+  AsyncModulesArtifact, BoxModule, BuildChunkGraphArtifact, ChunkByUkey, ChunkNamedIdArtifact,
+  Compilation, CompilationAfterOptimizeModules, CompilationAfterProcessAssets,
+  CompilationBuildModule, CompilationChunkIds, CompilationFinishModules, CompilationId,
+  CompilationModuleIds, CompilationOptimizeChunkModules, CompilationOptimizeChunks,
+  CompilationOptimizeCodeGeneration, CompilationOptimizeDependencies, CompilationOptimizeModules,
+  CompilationOptimizeTree, CompilationParams, CompilationProcessAssets, CompilationSeal,
+  CompilationSucceedModule, CompilerAfterEmit, CompilerClose, CompilerCompilation, CompilerEmit,
+  CompilerFinishMake, CompilerId, CompilerMake, CompilerThisCompilation, ExportsInfoArtifact,
+  ModuleIdentifier, ModuleIdsArtifact, Plugin, SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
 };
 use rspack_error::{Diagnostic, Result};
@@ -482,7 +482,12 @@ async fn after_optimize_modules(&self, _compilation: &Compilation) -> Result<()>
 }
 
 #[plugin_hook(CompilationOptimizeChunks for ProgressPlugin)]
-async fn optimize_chunks(&self, _compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(
+  &self,
+  _compilation: &Compilation,
+  _build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
   self.sealing_hooks_report("optimize chunks", 9).await?;
   Ok(None)
 }

--- a/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
+++ b/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
@@ -4,10 +4,10 @@ use dashmap::DashMap;
 use rayon::prelude::*;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  ChunkUkey, Compilation, CompilationOptimizeChunks, ModuleIdentifier, Plugin,
-  incremental::Mutation,
+  BuildChunkGraphArtifact, ChunkUkey, Compilation, CompilationOptimizeChunks, ModuleIdentifier,
+  Plugin, incremental::Mutation,
 };
-use rspack_error::Result;
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 
 #[derive(Debug)]
@@ -23,13 +23,12 @@ impl std::default::Default for RemoveDuplicateModulesPlugin {
 }
 
 fn find_reusable_chunk(
-  compilation: &Compilation,
+  build_chunk_graph_artifact: &BuildChunkGraphArtifact,
   chunks: &[ChunkUkey],
   modules: &[ModuleIdentifier],
 ) -> Option<ChunkUkey> {
   let filter = |chunk: &&ChunkUkey| {
-    let chunk_modules = compilation
-      .build_chunk_graph_artifact
+    let chunk_modules = build_chunk_graph_artifact
       .chunk_graph
       .get_chunk_modules_identifier(chunk);
     modules.len() == chunk_modules.len()
@@ -44,9 +43,14 @@ fn find_reusable_chunk(
 }
 
 #[plugin_hook(CompilationOptimizeChunks for RemoveDuplicateModulesPlugin)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
   let module_graph = compilation.get_module_graph();
-  let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+  let chunk_graph = &build_chunk_graph_artifact.chunk_graph;
 
   let chunk_map: DashMap<Vec<ChunkUkey>, Vec<ModuleIdentifier>> = DashMap::default();
 
@@ -93,31 +97,29 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     }
 
     // split chunks from original chunks and create new chunk
-    let new_chunk_ukey = if let Some(chunk) = find_reusable_chunk(compilation, &chunks, &modules) {
-      // we can use this chunk directly
-      // all modules are into existing chunk, the chunkMap needs update
+    let new_chunk_ukey =
+      if let Some(chunk) = find_reusable_chunk(build_chunk_graph_artifact, &chunks, &modules) {
+        // we can use this chunk directly
+        // all modules are into existing chunk, the chunkMap needs update
 
-      chunk
-    } else {
-      let new_chunk_ukey =
-        Compilation::add_chunk(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
-      if let Some(mut mutations) = compilation.incremental.mutations_write() {
-        mutations.add(Mutation::ChunkAdd {
-          chunk: new_chunk_ukey,
-        });
+        chunk
+      } else {
+        let new_chunk_ukey = Compilation::add_chunk(&mut build_chunk_graph_artifact.chunk_by_ukey);
+        if let Some(mut mutations) = compilation.incremental.mutations_write() {
+          mutations.add(Mutation::ChunkAdd {
+            chunk: new_chunk_ukey,
+          });
+        };
+        let new_chunk = build_chunk_graph_artifact
+          .chunk_by_ukey
+          .expect_get_mut(&new_chunk_ukey);
+        *new_chunk.chunk_reason_mut() = Some("modules are shared across multiple chunks".into());
+        build_chunk_graph_artifact
+          .chunk_graph
+          .add_chunk(new_chunk_ukey);
+
+        new_chunk_ukey
       };
-      let new_chunk = compilation
-        .build_chunk_graph_artifact
-        .chunk_by_ukey
-        .expect_get_mut(&new_chunk_ukey);
-      *new_chunk.chunk_reason_mut() = Some("modules are shared across multiple chunks".into());
-      compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .add_chunk(new_chunk_ukey);
-
-      new_chunk_ukey
-    };
 
     let mut entry_modules = IdentifierSet::default();
 
@@ -126,22 +128,20 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
         continue;
       }
 
-      let [Some(new_chunk), Some(origin)] = compilation
-        .build_chunk_graph_artifact
+      let [Some(new_chunk), Some(origin)] = build_chunk_graph_artifact
         .chunk_by_ukey
         .get_many_mut([&new_chunk_ukey, chunk_ukey])
       else {
         panic!("should have both chunks")
       };
       entry_modules.extend(
-        compilation
-          .build_chunk_graph_artifact
+        build_chunk_graph_artifact
           .chunk_graph
           .get_chunk_entry_modules(chunk_ukey),
       );
       origin.split(
         new_chunk,
-        &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+        &mut build_chunk_graph_artifact.chunk_group_by_ukey,
       );
       if let Some(mut mutations) = compilation.incremental.mutations_write() {
         mutations.add(Mutation::ChunkSplit {
@@ -157,39 +157,33 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
         if chunk_ukey == &new_chunk_ukey {
           continue;
         }
-        compilation
-          .build_chunk_graph_artifact
+        build_chunk_graph_artifact
           .chunk_graph
           .disconnect_chunk_and_module(chunk_ukey, m);
 
         if is_entry {
-          compilation
-            .build_chunk_graph_artifact
+          build_chunk_graph_artifact
             .chunk_graph
             .disconnect_chunk_and_entry_module(chunk_ukey, m);
         }
       }
 
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_graph
         .connect_chunk_and_module(new_chunk_ukey, m);
 
       if is_entry {
-        let chunk = compilation
-          .build_chunk_graph_artifact
+        let chunk = build_chunk_graph_artifact
           .chunk_by_ukey
           .expect_get(&new_chunk_ukey);
         for group in chunk.groups().iter().filter(|group| {
-          let group = compilation
-            .build_chunk_graph_artifact
+          let group = build_chunk_graph_artifact
             .chunk_group_by_ukey
             .expect_get(group);
 
           group.is_initial() && group.kind.is_entrypoint()
         }) {
-          compilation
-            .build_chunk_graph_artifact
+          build_chunk_graph_artifact
             .chunk_graph
             .connect_chunk_and_entry_module(new_chunk_ukey, m, *group);
         }

--- a/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
+++ b/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
@@ -1,8 +1,11 @@
 // Port of https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/optimize/RemoveEmptyChunksPlugin.js
 
 use rspack_collections::DatabaseItem;
-use rspack_core::{Compilation, CompilationOptimizeChunks, Logger, Plugin, incremental::Mutation};
-use rspack_error::Result;
+use rspack_core::{
+  BuildChunkGraphArtifact, Compilation, CompilationOptimizeChunks, Logger, Plugin,
+  incremental::Mutation,
+};
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 
 #[plugin]
@@ -10,32 +13,31 @@ use rspack_hook::{plugin, plugin_hook};
 pub struct RemoveEmptyChunksPlugin;
 
 impl RemoveEmptyChunksPlugin {
-  fn remove_empty_chunks(&self, compilation: &mut Compilation) {
+  fn remove_empty_chunks(
+    &self,
+    compilation: &Compilation,
+    build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  ) {
     let logger = compilation.get_logger(self.name());
     let start = logger.time("remove empty chunks");
 
-    let chunk_graph = &mut compilation.build_chunk_graph_artifact.chunk_graph;
-    let empty_chunks = compilation
-      .build_chunk_graph_artifact
+    let chunk_graph = &mut build_chunk_graph_artifact.chunk_graph;
+    let empty_chunks = build_chunk_graph_artifact
       .chunk_by_ukey
       .values()
       .filter(|chunk| {
         chunk_graph.get_number_of_chunk_modules(&chunk.ukey()) == 0
-          && !chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
+          && !chunk.has_runtime(&build_chunk_graph_artifact.chunk_group_by_ukey)
           && chunk_graph.get_number_of_entry_modules(&chunk.ukey()) == 0
       })
       .map(|chunk| chunk.ukey())
       .collect::<Vec<_>>();
 
     for chunk_ukey in empty_chunks.iter() {
-      if let Some(mut chunk) = compilation
-        .build_chunk_graph_artifact
-        .chunk_by_ukey
-        .remove(chunk_ukey)
-      {
+      if let Some(mut chunk) = build_chunk_graph_artifact.chunk_by_ukey.remove(chunk_ukey) {
         chunk_graph.disconnect_chunk(
           &mut chunk,
-          &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+          &mut build_chunk_graph_artifact.chunk_group_by_ukey,
         );
         if let Some(mut mutations) = compilation.incremental.mutations_write() {
           mutations.add(Mutation::ChunkRemove { chunk: *chunk_ukey });
@@ -48,8 +50,13 @@ impl RemoveEmptyChunksPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for RemoveEmptyChunksPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
-  self.remove_empty_chunks(compilation);
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
+  self.remove_empty_chunks(compilation, build_chunk_graph_artifact);
   Ok(None)
 }
 

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -7,9 +7,10 @@ use atomic_refcell::AtomicRefCell;
 use futures::future::BoxFuture;
 use rspack_collections::{Identifier, IdentifierMap};
 use rspack_core::{
-  ChunkGroupUkey, Compilation, CompilationAfterCodeGeneration, CompilationAfterProcessAssets,
-  CompilationId, CompilationModuleIds, CompilationOptimizeChunkModules, CompilationOptimizeChunks,
-  CompilationParams, CompilerCompilation, ModuleIdsArtifact, Plugin,
+  BuildChunkGraphArtifact, ChunkGroupUkey, Compilation, CompilationAfterCodeGeneration,
+  CompilationAfterProcessAssets, CompilationId, CompilationModuleIds,
+  CompilationOptimizeChunkModules, CompilationOptimizeChunks, CompilationParams,
+  CompilerCompilation, ModuleIdsArtifact, Plugin,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
@@ -198,16 +199,21 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilationOptimizeChunks for RsdoctorPlugin, stage = 9999)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
   if !self.has_chunk_graph_feature(RsdoctorPluginChunkGraphFeature::ChunkGraph) {
     return Ok(None);
   }
 
   let hooks = RsdoctorPlugin::get_compilation_hooks(compilation.id());
 
-  let chunk_by_ukey = &compilation.build_chunk_graph_artifact.chunk_by_ukey;
-  let chunk_group_by_ukey = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
-  let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+  let chunk_by_ukey = &build_chunk_graph_artifact.chunk_by_ukey;
+  let chunk_group_by_ukey = &build_chunk_graph_artifact.chunk_group_by_ukey;
+  let chunk_graph = &build_chunk_graph_artifact.chunk_graph;
   let chunks = chunk_by_ukey.iter().collect::<HashMap<_, _>>();
 
   let mut rsd_chunks = HashMap::default();
@@ -228,7 +234,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
 
   // 3. collect entrypoints
   rsd_entrypoints.extend(collect_entrypoints(
-    &compilation.build_chunk_graph_artifact.entrypoints,
+    &build_chunk_graph_artifact.entrypoints,
     &rsd_chunks,
     chunk_group_by_ukey,
   ));

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -1,6 +1,8 @@
 use rayon::prelude::*;
 use rspack_collections::{DatabaseItem, IdentifierMap, UkeySet};
-use rspack_core::{Chunk, ChunkUkey, Compilation, ModuleIdentifier, incremental::Mutation};
+use rspack_core::{
+  BuildChunkGraphArtifact, Chunk, ChunkUkey, Compilation, ModuleIdentifier, incremental::Mutation,
+};
 
 use crate::{SplitChunksPlugin, common::ModuleChunks, module_group::ModuleGroup};
 
@@ -24,9 +26,9 @@ fn put_split_chunk_reason(
 impl SplitChunksPlugin {
   pub(crate) fn get_module_chunks(
     all_modules: &[ModuleIdentifier],
-    compilation: &Compilation,
+    build_chunk_graph_artifact: &BuildChunkGraphArtifact,
   ) -> ModuleChunks {
-    let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+    let chunk_graph = &build_chunk_graph_artifact.chunk_graph;
     all_modules
       .par_iter()
       .map(|module| (*module, chunk_graph.get_module_chunks(*module).clone()))
@@ -39,17 +41,14 @@ impl SplitChunksPlugin {
   /// for the current `ModuleGroup`.
   pub(crate) fn find_the_best_reusable_chunk(
     &self,
-    compilation: &mut Compilation,
+    _compilation: &Compilation,
+    build_chunk_graph_artifact: &BuildChunkGraphArtifact,
     module_group: &mut ModuleGroup,
   ) -> Option<ChunkUkey> {
     let candidates = module_group.chunks.iter().filter_map(|chunk| {
-      let chunk = compilation
-        .build_chunk_graph_artifact
-        .chunk_by_ukey
-        .expect_get(chunk);
+      let chunk = build_chunk_graph_artifact.chunk_by_ukey.expect_get(chunk);
 
-      if compilation
-        .build_chunk_graph_artifact
+      if build_chunk_graph_artifact
         .chunk_graph
         .get_number_of_chunk_modules(&chunk.ukey())
         != module_group.modules.len()
@@ -59,8 +58,7 @@ impl SplitChunksPlugin {
       }
 
       if module_group.chunks.len() > 1
-        && compilation
-          .build_chunk_graph_artifact
+        && build_chunk_graph_artifact
           .chunk_graph
           .get_number_of_entry_modules(&chunk.ukey())
           > 0
@@ -77,8 +75,7 @@ impl SplitChunksPlugin {
       }
 
       let is_all_module_in_chunk = module_group.modules.iter().all(|each_module| {
-        compilation
-          .build_chunk_graph_artifact
+        build_chunk_graph_artifact
           .chunk_graph
           .is_module_in_chunk(each_module, chunk.ukey())
       });
@@ -116,32 +113,28 @@ impl SplitChunksPlugin {
 
   pub(crate) fn get_corresponding_chunk(
     &self,
-    compilation: &mut Compilation,
+    compilation: &Compilation,
+    build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
     module_group: &mut ModuleGroup,
     is_reuse_existing_chunk: &mut bool,
     is_reuse_existing_chunk_with_all_modules: &mut bool,
   ) -> ChunkUkey {
     if let Some(chunk_name) = &module_group.chunk_name {
-      if let Some(chunk) = compilation
-        .build_chunk_graph_artifact
-        .named_chunks
-        .get(chunk_name)
-      {
+      if let Some(chunk) = build_chunk_graph_artifact.named_chunks.get(chunk_name) {
         *is_reuse_existing_chunk = true;
         *chunk
       } else {
         let (new_chunk_ukey, created) = Compilation::add_named_chunk(
           chunk_name.clone(),
-          &mut compilation.build_chunk_graph_artifact.chunk_by_ukey,
-          &mut compilation.build_chunk_graph_artifact.named_chunks,
+          &mut build_chunk_graph_artifact.chunk_by_ukey,
+          &mut build_chunk_graph_artifact.named_chunks,
         );
         if created && let Some(mut mutations) = compilation.incremental.mutations_write() {
           mutations.add(Mutation::ChunkAdd {
             chunk: new_chunk_ukey,
           });
         }
-        let new_chunk = compilation
-          .build_chunk_graph_artifact
+        let new_chunk = build_chunk_graph_artifact
           .chunk_by_ukey
           .expect_get_mut(&new_chunk_ukey);
 
@@ -150,28 +143,26 @@ impl SplitChunksPlugin {
           *is_reuse_existing_chunk_with_all_modules,
         );
 
-        compilation
-          .build_chunk_graph_artifact
+        build_chunk_graph_artifact
           .chunk_graph
           .add_chunk(new_chunk.ukey());
         new_chunk.ukey()
       }
     } else if module_group.cache_group_reuse_existing_chunk
-      && let Some(reusable_chunk) = self.find_the_best_reusable_chunk(compilation, module_group)
+      && let Some(reusable_chunk) =
+        self.find_the_best_reusable_chunk(compilation, build_chunk_graph_artifact, module_group)
     {
       *is_reuse_existing_chunk = true;
       *is_reuse_existing_chunk_with_all_modules = true;
       reusable_chunk
     } else {
-      let new_chunk_ukey =
-        Compilation::add_chunk(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
+      let new_chunk_ukey = Compilation::add_chunk(&mut build_chunk_graph_artifact.chunk_by_ukey);
       if let Some(mut mutations) = compilation.incremental.mutations_write() {
         mutations.add(Mutation::ChunkAdd {
           chunk: new_chunk_ukey,
         });
       }
-      let new_chunk = compilation
-        .build_chunk_graph_artifact
+      let new_chunk = build_chunk_graph_artifact
         .chunk_by_ukey
         .expect_get_mut(&new_chunk_ukey);
 
@@ -180,8 +171,7 @@ impl SplitChunksPlugin {
         *is_reuse_existing_chunk_with_all_modules,
       );
 
-      compilation
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_graph
         .add_chunk(new_chunk.ukey());
       new_chunk.ukey()
@@ -195,7 +185,8 @@ impl SplitChunksPlugin {
     item: &ModuleGroup,
     new_chunk: ChunkUkey,
     original_chunks: &UkeySet<ChunkUkey>,
-    compilation: &mut Compilation,
+    compilation: &Compilation,
+    build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
   ) {
     let modules = item
       .modules
@@ -215,13 +206,11 @@ impl SplitChunksPlugin {
 
     let chunks = original_chunks.iter().copied().collect::<Vec<_>>();
 
-    compilation
-      .build_chunk_graph_artifact
+    build_chunk_graph_artifact
       .chunk_graph
       .disconnect_chunks_and_modules(&chunks, &modules);
 
-    compilation
-      .build_chunk_graph_artifact
+    build_chunk_graph_artifact
       .chunk_graph
       .connect_chunk_and_modules(new_chunk, &modules);
   }
@@ -236,13 +225,13 @@ impl SplitChunksPlugin {
     _item: &ModuleGroup,
     original_chunks: &UkeySet<ChunkUkey>,
     new_chunk: ChunkUkey,
-    compilation: &mut Compilation,
+    compilation: &Compilation,
+    build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
   ) {
     let new_chunk_ukey = new_chunk;
     for original_chunk_ukey in original_chunks {
       debug_assert!(&new_chunk_ukey != original_chunk_ukey);
-      let [Some(new_chunk), Some(original_chunk)] = compilation
-        .build_chunk_graph_artifact
+      let [Some(new_chunk), Some(original_chunk)] = build_chunk_graph_artifact
         .chunk_by_ukey
         .get_many_mut([&new_chunk_ukey, original_chunk_ukey])
       else {
@@ -250,7 +239,7 @@ impl SplitChunksPlugin {
       };
       original_chunk.split(
         new_chunk,
-        &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+        &mut build_chunk_graph_artifact.chunk_group_by_ukey,
       );
       if let Some(mut mutations) = compilation.incremental.mutations_write() {
         mutations.add(Mutation::ChunkSplit {

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_request.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_request.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use rspack_collections::{DatabaseItem, UkeySet};
-use rspack_core::{ChunkUkey, Compilation};
+use rspack_core::{BuildChunkGraphArtifact, ChunkUkey, Compilation};
 
 use crate::{CacheGroup, SplitChunksPlugin};
 
@@ -11,12 +11,13 @@ impl SplitChunksPlugin {
   // #[tracing::instrument(skip_all)]
   pub(crate) fn ensure_max_request_fit(
     &self,
-    compilation: &Compilation,
+    _compilation: &Compilation,
+    build_chunk_graph_artifact: &BuildChunkGraphArtifact,
     cache_group: &CacheGroup,
     used_chunks: &mut Cow<UkeySet<ChunkUkey>>,
   ) {
-    let chunk_db = &compilation.build_chunk_graph_artifact.chunk_by_ukey;
-    let chunk_group_db = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
+    let chunk_db = &build_chunk_graph_artifact.chunk_by_ukey;
+    let chunk_group_db = &build_chunk_graph_artifact.chunk_group_by_ukey;
     let invalided_chunks = used_chunks
       .iter()
       .map(|c| chunk_db.expect_get(c))

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -12,8 +12,8 @@ use std::{borrow::Cow, hash::Hash, sync::LazyLock};
 use regex::Regex;
 use rspack_collections::{DatabaseItem, UkeyMap};
 use rspack_core::{
-  ChunkUkey, Compilation, CompilerOptions, DEFAULT_DELIMITER, Module, ModuleIdentifier, SourceType,
-  incremental::Mutation,
+  BuildChunkGraphArtifact, ChunkUkey, Compilation, CompilerOptions, DEFAULT_DELIMITER, Module,
+  ModuleIdentifier, SourceType, incremental::Mutation,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -255,6 +255,7 @@ fn get_key(module: &dyn Module, delimiter: &str, compilation: &Compilation) -> S
 
 fn deterministic_grouping_for_modules(
   compilation: &Compilation,
+  build_chunk_graph_artifact: &BuildChunkGraphArtifact,
   chunk: &ChunkUkey,
   allow_max_size: &SplitChunkSizes,
   min_size: &SplitChunkSizes,
@@ -263,8 +264,7 @@ fn deterministic_grouping_for_modules(
   let mut results: Vec<Group> = Default::default();
   let module_graph = compilation.get_module_graph();
 
-  let items = compilation
-    .build_chunk_graph_artifact
+  let items = build_chunk_graph_artifact
     .chunk_graph
     .get_chunk_modules(chunk, module_graph);
 
@@ -474,22 +474,22 @@ impl SplitChunksPlugin {
   // #[tracing::instrument(skip_all)]
   pub(super) async fn ensure_max_size_fit(
     &self,
-    compilation: &mut Compilation,
+    compilation: &Compilation,
+    build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
     max_size_setting_map: &UkeyMap<ChunkUkey, MaxSizeSetting>,
   ) -> Result<()> {
     let fallback_cache_group = &self.fallback_cache_group;
-    let chunk_group_db = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
-    let compilation_ref = &*compilation;
+    let chunk_group_db = &build_chunk_graph_artifact.chunk_group_by_ukey;
+    let compilation_ref = compilation;
 
     let chunks_with_size_info_results = rspack_futures::scope::<_, Result<_>>(|token| {
-      compilation_ref
-        .build_chunk_graph_artifact
+      build_chunk_graph_artifact
         .chunk_by_ukey
         .values()
         .for_each(|chunk| {
         let s = unsafe {
           token.used((
-            &*compilation,
+            compilation,
             chunk,
             fallback_cache_group,
             chunk_group_db,
@@ -600,6 +600,7 @@ impl SplitChunksPlugin {
         } = &info;
         let results = deterministic_grouping_for_modules(
           compilation_ref,
+          build_chunk_graph_artifact,
           chunk,
           allow_max_size,
           min_size,
@@ -630,8 +631,7 @@ impl SplitChunksPlugin {
         } else {
           index.to_string()
         };
-        let chunk = compilation
-          .build_chunk_graph_artifact
+        let chunk = build_chunk_graph_artifact
           .chunk_by_ukey
           .expect_get_mut(&info.chunk);
         let delimiter = max_size_setting_map
@@ -654,8 +654,8 @@ impl SplitChunksPlugin {
           let new_chunk_ukey = if let Some(name) = name {
             let (new_chunk_ukey, created) = Compilation::add_named_chunk(
               name,
-              &mut compilation.build_chunk_graph_artifact.chunk_by_ukey,
-              &mut compilation.build_chunk_graph_artifact.named_chunks,
+              &mut build_chunk_graph_artifact.chunk_by_ukey,
+              &mut build_chunk_graph_artifact.named_chunks,
             );
             if created && let Some(mut mutations) = compilation.incremental.mutations_write() {
               mutations.add(Mutation::ChunkAdd {
@@ -665,7 +665,7 @@ impl SplitChunksPlugin {
             new_chunk_ukey
           } else {
             let new_chunk_ukey =
-              Compilation::add_chunk(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
+              Compilation::add_chunk(&mut build_chunk_graph_artifact.chunk_by_ukey);
             if let Some(mut mutations) = compilation.incremental.mutations_write() {
               mutations.add(Mutation::ChunkAdd {
                 chunk: new_chunk_ukey,
@@ -674,8 +674,7 @@ impl SplitChunksPlugin {
             new_chunk_ukey
           };
 
-          let [Some(new_part), Some(chunk)] = compilation
-            .build_chunk_graph_artifact
+          let [Some(new_part), Some(chunk)] = build_chunk_graph_artifact
             .chunk_by_ukey
             .get_many_mut([&new_chunk_ukey, &old_chunk])
           else {
@@ -684,7 +683,7 @@ impl SplitChunksPlugin {
           let new_part_ukey = new_part.ukey();
           chunk.split(
             new_part,
-            &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+            &mut build_chunk_graph_artifact.chunk_group_by_ukey,
           );
           *new_part.chunk_reason_mut() = chunk.chunk_reason().map(ToString::to_string);
           if chunk.filename_template().is_some() {
@@ -698,8 +697,7 @@ impl SplitChunksPlugin {
           }
 
           group.nodes.iter().for_each(|module| {
-            compilation
-              .build_chunk_graph_artifact
+            build_chunk_graph_artifact
               .chunk_graph
               .add_chunk(new_part_ukey);
 
@@ -712,13 +710,11 @@ impl SplitChunksPlugin {
             }
 
             // Add module to new chunk
-            compilation
-              .build_chunk_graph_artifact
+            build_chunk_graph_artifact
               .chunk_graph
               .connect_chunk_and_module(new_part_ukey, module.module);
             // Remove module from used chunks
-            compilation
-              .build_chunk_graph_artifact
+            build_chunk_graph_artifact
               .chunk_graph
               .disconnect_chunk_and_module(&old_chunk, module.module)
           })

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -8,8 +8,10 @@ use std::{borrow::Cow, cmp::Ordering, fmt::Debug};
 
 use itertools::Itertools;
 use rspack_collections::{DatabaseItem, IdentifierMap, UkeyMap, UkeySet};
-use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};
-use rspack_error::Result;
+use rspack_core::{
+  BuildChunkGraphArtifact, ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin,
+};
+use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::{fx_hash::FxIndexMap, tracing_preset::TRACING_BENCH_TARGET};
 use tracing::instrument;
@@ -46,7 +48,11 @@ impl SplitChunksPlugin {
     )
   }
   #[instrument(name = "Compilation:SplitChunks",target=TRACING_BENCH_TARGET, skip_all)]
-  async fn inner_impl(&self, compilation: &mut Compilation) -> Result<()> {
+  async fn inner_impl(
+    &self,
+    compilation: &Compilation,
+    build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  ) -> Result<()> {
     let logger = compilation.get_logger(self.name());
     let start = logger.time("prepare module data");
 
@@ -59,12 +65,11 @@ impl SplitChunksPlugin {
     all_modules.sort_unstable();
 
     let module_sizes = Self::get_module_sizes(&all_modules, compilation);
-    let module_chunks = Self::get_module_chunks(&all_modules, compilation);
+    let module_chunks = Self::get_module_chunks(&all_modules, build_chunk_graph_artifact);
     logger.time_end(start);
 
     let chunk_index_map: UkeyMap<ChunkUkey, u64> = {
-      let mut ordered_chunks = compilation
-        .build_chunk_graph_artifact
+      let mut ordered_chunks = build_chunk_graph_artifact
         .chunk_by_ukey
         .values()
         .collect::<Vec<_>>();
@@ -75,8 +80,7 @@ impl SplitChunksPlugin {
           .groups()
           .iter()
           .map(|group| {
-            compilation
-              .build_chunk_graph_artifact
+            build_chunk_graph_artifact
               .chunk_group_by_ukey
               .expect_get(group)
           })
@@ -138,7 +142,7 @@ impl SplitChunksPlugin {
       combinator.prepare_group_by_used_exports(
         &all_modules,
         &compilation.exports_info_artifact,
-        &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+        &build_chunk_graph_artifact.chunk_by_ukey,
         &module_chunks,
         &chunk_index_map,
       );
@@ -179,13 +183,13 @@ impl SplitChunksPlugin {
         let mut is_reuse_existing_chunk_with_all_modules = false;
         let new_chunk = self.get_corresponding_chunk(
           compilation,
+          build_chunk_graph_artifact,
           &mut module_group,
           &mut is_reuse_existing_chunk,
           &mut is_reuse_existing_chunk_with_all_modules,
         );
 
-        let new_chunk_mut = compilation
-          .build_chunk_graph_artifact
+        let new_chunk_mut = build_chunk_graph_artifact
           .chunk_by_ukey
           .expect_get_mut(&new_chunk);
         tracing::trace!(
@@ -214,7 +218,12 @@ impl SplitChunksPlugin {
 
         let mut used_chunks = Cow::Borrowed(&module_group.chunks);
 
-        self.ensure_max_request_fit(compilation, cache_group, &mut used_chunks);
+        self.ensure_max_request_fit(
+          compilation,
+          build_chunk_graph_artifact,
+          cache_group,
+          &mut used_chunks,
+        );
 
         if used_chunks.len() != module_group.chunks.len() {
           // There are some chunks removed by `ensure_max_request_fit`
@@ -252,15 +261,23 @@ impl SplitChunksPlugin {
           new_chunk,
           &used_chunks,
           compilation,
+          build_chunk_graph_artifact,
         );
 
-        self.split_from_original_chunks(&module_group, &used_chunks, new_chunk, compilation);
+        self.split_from_original_chunks(
+          &module_group,
+          &used_chunks,
+          new_chunk,
+          compilation,
+          build_chunk_graph_artifact,
+        );
 
         self.remove_all_modules_from_other_module_groups(
           &module_group,
           &mut module_group_map,
           &used_chunks,
           compilation,
+          build_chunk_graph_artifact,
           &module_sizes,
         );
 
@@ -278,7 +295,11 @@ impl SplitChunksPlugin {
 
     let start = logger.time("ensure max size fit");
     self
-      .ensure_max_size_fit(compilation, &max_size_setting_map)
+      .ensure_max_size_fit(
+        compilation,
+        build_chunk_graph_artifact,
+        &max_size_setting_map,
+      )
       .await?;
     logger.time_end(start);
 
@@ -295,10 +316,16 @@ impl Debug for SplitChunksPlugin {
 }
 
 #[plugin_hook(CompilationOptimizeChunks for SplitChunksPlugin, stage = Compilation::OPTIMIZE_CHUNKS_STAGE_ADVANCED)]
-async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
-  self.inner_impl(compilation).await?;
-  compilation
-    .build_chunk_graph_artifact
+async fn optimize_chunks(
+  &self,
+  compilation: &Compilation,
+  build_chunk_graph_artifact: &mut BuildChunkGraphArtifact,
+  _diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<bool>> {
+  self
+    .inner_impl(compilation, build_chunk_graph_artifact)
+    .await?;
+  build_chunk_graph_artifact
     .chunk_graph
     .generate_dot(compilation, "after-split-chunks")
     .await;

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -8,8 +8,8 @@ use futures::future::join_all;
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, UkeyIndexMap, UkeyMap, UkeySet};
 use rspack_core::{
-  ChunkByUkey, ChunkUkey, Compilation, ExportsInfoArtifact, Module, ModuleIdentifier,
-  PrefetchExportsInfoMode, RuntimeKeyMap, UsageKey, get_runtime_key,
+  BuildChunkGraphArtifact, ChunkByUkey, ChunkUkey, Compilation, ExportsInfoArtifact, Module,
+  ModuleIdentifier, PrefetchExportsInfoMode, RuntimeKeyMap, UsageKey, get_runtime_key,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_util::tracing_preset::TRACING_BENCH_TARGET;
@@ -463,7 +463,8 @@ impl SplitChunksPlugin {
     current_module_group: &ModuleGroup,
     module_group_map: &mut ModuleGroupMap,
     used_chunks: &UkeySet<ChunkUkey>,
-    compilation: &Compilation,
+    _compilation: &Compilation,
+    build_chunk_graph_artifact: &BuildChunkGraphArtifact,
     module_sizes: &ModuleSizes,
   ) {
     // remove all modules from other entries and update size
@@ -504,7 +505,7 @@ impl SplitChunksPlugin {
 
         // Since there are modules removed, make sure the rest of chunks are all used.
         other_module_group.chunks.retain(|c| {
-          compilation.build_chunk_graph_artifact.chunk_graph
+          build_chunk_graph_artifact.chunk_graph
             .is_any_module_in_chunk(other_module_group.modules.iter(), *c)
         });
 


### PR DESCRIPTION
## Summary
- have `CompilationOptimizeChunks` work with `&Compilation` and accept the datasets it needs rather than mutating the compilation
- update all affected plugins and optimize-chunk helpers to match the new signature and pass the required arguments across
## Testing
- Not run (not requested)