### PR TITLE
refactor: Update process assets hook signature

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1523,7 +1523,11 @@ impl CompilationChunkAsset for CompilationChunkAssetTap {
 
 #[async_trait]
 impl CompilationProcessAssets for CompilationProcessAssetsTap {
-  async fn run(&self, compilation: &mut Compilation) -> rspack_error::Result<()> {
+  async fn run(
+    &self,
+    compilation: &Compilation,
+    _process_assets_mutations: &mut rspack_core::CompilationProcessAssetsMutations,
+  ) -> rspack_error::Result<()> {
     let compilation = JsCompilationWrapper::new(compilation);
     self.function.call_with_promise(compilation).await
   }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -128,7 +128,7 @@ define_hook!(CompilationContentHash: Series(compilation: &Compilation, chunk_uke
 define_hook!(CompilationDependentFullHash: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> bool);
 define_hook!(CompilationRenderManifest: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, manifest: &mut Vec<RenderManifestEntry>, diagnostics: &mut Vec<Diagnostic>),tracing=false);
 define_hook!(CompilationChunkAsset: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, filename: &str));
-define_hook!(CompilationProcessAssets: Series(compilation: &mut Compilation));
+define_hook!(CompilationProcessAssets: Series(compilation: &Compilation, process_assets_mutations: &mut CompilationProcessAssetsMutations));
 define_hook!(CompilationAfterProcessAssets: Series(compilation: &Compilation, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationAfterSeal: Series(compilation: &Compilation),tracing=true);
 
@@ -170,6 +170,84 @@ pub struct CompilationHooks {
   pub process_assets: CompilationProcessAssetsHook,
   pub after_process_assets: CompilationAfterProcessAssetsHook,
   pub after_seal: CompilationAfterSealHook,
+}
+
+pub struct CompilationProcessAssetsMutations {
+  compilation: *mut Compilation,
+}
+
+// SAFETY: Used only during `Compilation.hooks.processAssets` execution, where the underlying
+// `Compilation` lives for the whole hook call and access is coordinated by hook sequencing.
+unsafe impl Send for CompilationProcessAssetsMutations {}
+
+impl CompilationProcessAssetsMutations {
+  pub fn new(compilation: &mut Compilation) -> Self {
+    Self { compilation }
+  }
+
+  pub fn compilation_mut(&mut self) -> &mut Compilation {
+    // SAFETY: This wrapper is only created in `Compilation::process_assets` and
+    // used during `Compilation.hooks.processAssets` execution.
+    unsafe { &mut *self.compilation }
+  }
+
+  pub fn records_take(&mut self) -> Option<CompilationRecords> {
+    self.compilation_mut().records.take()
+  }
+
+  pub fn file_dependencies_mut(&mut self) -> &mut ArcPathIndexSet {
+    &mut self.compilation_mut().file_dependencies
+  }
+
+  pub fn context_dependencies_mut(&mut self) -> &mut ArcPathIndexSet {
+    &mut self.compilation_mut().context_dependencies
+  }
+
+  pub fn assets_mut(&mut self) -> &mut CompilationAssets {
+    self.compilation_mut().assets_mut()
+  }
+
+  pub fn chunk_by_ukey_mut(&mut self) -> &mut ChunkByUkey {
+    &mut self
+      .compilation_mut()
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+  }
+
+  pub fn push_diagnostic(&mut self, diagnostic: Diagnostic) {
+    self.compilation_mut().push_diagnostic(diagnostic);
+  }
+
+  pub fn extend_diagnostics(&mut self, diagnostics: impl IntoIterator<Item = Diagnostic>) {
+    self.compilation_mut().extend_diagnostics(diagnostics);
+  }
+
+  pub fn update_asset(
+    &mut self,
+    filename: &str,
+    updater: impl FnOnce(
+      BoxSource,
+      BindingCell<AssetInfo>,
+    ) -> Result<(BoxSource, BindingCell<AssetInfo>)>,
+  ) -> Result<()> {
+    self.compilation_mut().update_asset(filename, updater)
+  }
+
+  pub fn emit_asset(&mut self, filename: String, asset: CompilationAsset) {
+    self.compilation_mut().emit_asset(filename, asset);
+  }
+
+  pub fn delete_asset(&mut self, filename: &str) {
+    self.compilation_mut().delete_asset(filename);
+  }
+
+  pub fn rename_asset(&mut self, filename: &str, new_name: String) {
+    self.compilation_mut().rename_asset(filename, new_name);
+  }
+
+  pub fn par_rename_assets(&mut self, renames: Vec<(String, String)>) {
+    self.compilation_mut().par_rename_assets(renames);
+  }
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]

--- a/crates/rspack_core/src/compilation/process_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/process_assets/mod.rs
@@ -20,10 +20,11 @@ impl PassExt for ProcessAssetsPass {
 impl Compilation {
   #[instrument("Compilation:process_assets",target=TRACING_BENCH_TARGET, skip_all)]
   async fn process_assets(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
+    let mut process_assets_mutations = CompilationProcessAssetsMutations::new(self);
     plugin_driver
       .compilation_hooks
       .process_assets
-      .call(self)
+      .call(self, &mut process_assets_mutations)
       .await
       .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.processAssets"))
   }

--- a/crates/rspack_plugin_banner/src/lib.rs
+++ b/crates/rspack_plugin_banner/src/lib.rs
@@ -7,7 +7,8 @@ use cow_utils::CowUtils;
 use futures::future::BoxFuture;
 use regex::Regex;
 use rspack_core::{
-  Chunk, Compilation, CompilationProcessAssets, Filename, Logger, PathData, Plugin,
+  Chunk, Compilation, CompilationProcessAssets, CompilationProcessAssetsMutations, Filename,
+  Logger, PathData, Plugin,
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
   to_comment,
 };
@@ -125,7 +126,11 @@ impl BannerPlugin {
 }
 
 #[plugin_hook(CompilationProcessAssets for BannerPlugin, stage = self.config.stage.unwrap_or(Compilation::PROCESS_ASSETS_STAGE_ADDITIONS))]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   let logger = compilation.get_logger("rspack.BannerPlugin");
   let start = logger.time("add banner");
   let mut updates = vec![];
@@ -197,7 +202,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   }
 
   for (file, comment) in updates {
-    let _res = compilation.update_asset(file.as_str(), |old, info| {
+    let _res = process_assets_mutations.update_asset(file.as_str(), |old, info| {
       let new = self.update_source(comment, old, self.config.footer);
       Ok((new, info))
     });

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -14,7 +14,7 @@ use glob::{MatchOptions, Pattern as GlobPattern};
 use regex::Regex;
 use rspack_core::{
   AssetInfo, AssetInfoRelated, Compilation, CompilationAsset, CompilationLogger,
-  CompilationProcessAssets, Filename, Logger, PathData, Plugin,
+  CompilationProcessAssets, CompilationProcessAssetsMutations, Filename, Logger, PathData, Plugin,
   rspack_sources::{BoxSource, RawBufferSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Error, Result};
@@ -568,7 +568,11 @@ impl CopyRspackPlugin {
 }
 
 #[plugin_hook(CompilationProcessAssets for CopyRspackPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_ADDITIONAL)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   let logger = compilation.get_logger("rspack.CopyRspackPlugin");
   let start = logger.time("run pattern");
   let file_dependencies = DashSet::default();
@@ -603,13 +607,13 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   logger.time_end(start);
 
   let start = logger.time("emit assets");
-  compilation
-    .file_dependencies
+  process_assets_mutations
+    .file_dependencies_mut()
     .extend(file_dependencies.into_iter().map(Into::into));
-  compilation
-    .context_dependencies
+  process_assets_mutations
+    .context_dependencies_mut()
     .extend(context_dependencies.into_iter().map(Into::into));
-  compilation.extend_diagnostics(std::mem::take(
+  process_assets_mutations.extend_diagnostics(std::mem::take(
     diagnostics
       .lock()
       .expect("failed to obtain lock of `diagnostics`")
@@ -625,7 +629,10 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     let source_path = result.absolute_filename.clone();
     let dest_path = compilation.options.output.path.join(&result.filename);
 
-    if let Some(exist_asset) = compilation.assets_mut().get_mut(&result.filename) {
+    if let Some(exist_asset) = process_assets_mutations
+      .assets_mut()
+      .get_mut(&result.filename)
+    {
       if !result.force {
         return;
       }
@@ -646,7 +653,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         set_info(&mut asset_info, info);
       }
 
-      compilation.emit_asset(
+      process_assets_mutations.emit_asset(
         result.filename,
         CompilationAsset::new(Some(Arc::new(result.source)), asset_info),
       );

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -13,8 +13,8 @@ use rayon::prelude::*;
 use regex::Regex;
 use rspack_collections::DatabaseItem;
 use rspack_core::{
-  AssetInfo, Chunk, ChunkUkey, Compilation, CompilationAsset, CompilationProcessAssets, Filename,
-  Logger, ModuleIdentifier, PathData, Plugin,
+  AssetInfo, Chunk, ChunkUkey, Compilation, CompilationAsset, CompilationProcessAssets,
+  CompilationProcessAssetsMutations, Filename, Logger, ModuleIdentifier, PathData, Plugin,
   rspack_sources::{
     BoxSource, ConcatSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMap,
   },
@@ -760,7 +760,11 @@ impl SourceMapDevToolPlugin {
 }
 
 #[plugin_hook(CompilationProcessAssets for SourceMapDevToolPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_DEV_TOOLING)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   let logger = compilation.get_logger("rspack.SourceMapDevToolPlugin");
 
   // use to read
@@ -812,7 +816,10 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       asset: (source_filename, mut source_asset),
       source_map,
     } = mapped_asset;
-    if let Some(asset) = compilation.assets_mut().remove(source_filename.as_ref()) {
+    if let Some(asset) = process_assets_mutations
+      .assets_mut()
+      .remove(source_filename.as_ref())
+    {
       source_asset.info = asset.info;
       if let Some((ref source_map_filename, _)) = source_map {
         source_asset.info.related.source_map = Some(source_map_filename.clone());
@@ -820,14 +827,13 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     }
 
     let chunk_ukey = file_to_chunk_ukey.get(source_filename.as_ref());
-    compilation.emit_asset(source_filename.to_string(), source_asset);
+    process_assets_mutations.emit_asset(source_filename.to_string(), source_asset);
     if let Some((source_map_filename, source_map_asset)) = source_map {
-      compilation.emit_asset(source_map_filename.clone(), source_map_asset);
+      process_assets_mutations.emit_asset(source_map_filename.clone(), source_map_asset);
 
       let chunk = chunk_ukey.map(|ukey| {
-        compilation
-          .build_chunk_graph_artifact
-          .chunk_by_ukey
+        process_assets_mutations
+          .chunk_by_ukey_mut()
           .expect_get_mut(ukey)
       });
       if let Some(chunk) = chunk {

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -13,12 +13,12 @@ use rspack_core::{
   CompilationAdditionalTreeRuntimeRequirements, CompilationAfterCodeGeneration,
   CompilationConcatenationScope, CompilationFinishModules, CompilationOptimizeChunks,
   CompilationOptimizeDependencies, CompilationParams, CompilationProcessAssets,
-  CompilationRuntimeRequirementInTree, CompilerCompilation, ConcatenatedModuleInfo,
-  ConcatenationScope, DependencyType, ExportsInfoArtifact, ExternalModuleInfo, GetTargetResult,
-  Logger, ModuleFactoryCreateData, ModuleIdentifier, ModuleInfo, ModuleType,
-  NormalModuleFactoryAfterFactorize, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions,
-  Plugin, PrefetchExportsInfoMode, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
-  SideEffectsOptimizeArtifact, get_target, is_esm_dep_like,
+  CompilationProcessAssetsMutations, CompilationRuntimeRequirementInTree, CompilerCompilation,
+  ConcatenatedModuleInfo, ConcatenationScope, DependencyType, ExportsInfoArtifact,
+  ExternalModuleInfo, GetTargetResult, Logger, ModuleFactoryCreateData, ModuleIdentifier,
+  ModuleInfo, ModuleType, NormalModuleFactoryAfterFactorize, NormalModuleFactoryParser,
+  ParserAndGenerator, ParserOptions, Plugin, PrefetchExportsInfoMode, RuntimeCodeTemplate,
+  RuntimeGlobals, RuntimeModule, SideEffectsOptimizeArtifact, get_target, is_esm_dep_like,
   rspack_sources::{ReplaceSource, Source},
 };
 use rspack_error::{Diagnostic, Result};
@@ -378,7 +378,11 @@ static RSPACK_ESM_CHUNK_PLACEHOLDER_RE: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r##"__RSPACK_ESM_CHUNK_[^'"]+"##).expect("should have regex"));
 
 #[plugin_hook(CompilationProcessAssets for EsmLibraryPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_AFTER_OPTIMIZE_HASH)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   let mut replaced = vec![];
   let mut removed = vec![];
 
@@ -470,14 +474,14 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     }
   }
   for (replace_name, replace_source) in replaced {
-    compilation
+    process_assets_mutations
       .assets_mut()
       .get_mut(&replace_name)
       .expect("should have asset")
       .set_source(Some(Arc::new(replace_source)));
   }
   for remove_name in removed {
-    compilation.assets_mut().remove(&remove_name);
+    process_assets_mutations.assets_mut().remove(&remove_name);
   }
 
   Ok(())

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -7,10 +7,10 @@ use rspack_collections::{DatabaseItem, IdentifierSet, UkeyMap};
 use rspack_core::{
   AssetInfo, Chunk, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationAsset, CompilationParams,
-  CompilationProcessAssets, CompilationRecords, CompilerCompilation, DependencyType, LoaderContext,
-  ModuleId, ModuleIdentifier, ModuleType, NormalModuleFactoryParser, NormalModuleLoader,
-  ParserAndGenerator, ParserOptions, PathData, Plugin, RunnerContext, RuntimeGlobals,
-  RuntimeModule, RuntimeModuleExt, RuntimeSpec,
+  CompilationProcessAssets, CompilationProcessAssetsMutations, CompilationRecords,
+  CompilerCompilation, DependencyType, LoaderContext, ModuleId, ModuleIdentifier, ModuleType,
+  NormalModuleFactoryParser, NormalModuleLoader, ParserAndGenerator, ParserOptions, PathData,
+  Plugin, RunnerContext, RuntimeGlobals, RuntimeModule, RuntimeModuleExt, RuntimeSpec,
   chunk_graph_chunk::ChunkId,
   rspack_sources::{RawStringSource, SourceExt},
 };
@@ -55,7 +55,12 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilationProcessAssets for HotModuleReplacementPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_ADDITIONAL)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  _compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
+  let compilation = process_assets_mutations.compilation_mut();
   let Some(CompilationRecords {
     chunks: old_chunks,
     runtimes: all_old_runtime,

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -6,7 +6,10 @@ use std::{
 
 use atomic_refcell::AtomicRefCell;
 use cow_utils::CowUtils;
-use rspack_core::{Compilation, CompilationId, CompilationProcessAssets, Filename, Plugin};
+use rspack_core::{
+  Compilation, CompilationId, CompilationProcessAssets, CompilationProcessAssetsMutations,
+  Filename, Plugin,
+};
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 #[cfg(allocative)]
@@ -196,7 +199,12 @@ async fn generate_html(
 }
 
 #[plugin_hook(CompilationProcessAssets for HtmlRspackPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  _compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
+  let compilation = process_assets_mutations.compilation_mut();
   let config: &HtmlRspackPluginOptions = &self.config;
   let hooks = HtmlRspackPlugin::get_compilation_hooks(compilation.id());
 

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -13,7 +13,8 @@ use lightningcss::{
 use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
-  ChunkUkey, Compilation, CompilationChunkHash, CompilationProcessAssets, Plugin,
+  ChunkUkey, Compilation, CompilationChunkHash, CompilationProcessAssets,
+  CompilationProcessAssetsMutations, Plugin,
   diagnostics::MinifyError,
   rspack_sources::{
     MapOptions, ObjectPool, RawStringSource, SourceExt, SourceMap, SourceMapSource,
@@ -122,7 +123,11 @@ async fn chunk_hash(
 }
 
 #[plugin_hook(CompilationProcessAssets for LightningCssMinimizerRspackPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  _compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   let options = &self.options;
   let minimizer_options = &self.options.minimizer_options;
   let all_warnings: RwLock<Vec<Diagnostic>> = Default::default();
@@ -133,7 +138,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   };
 
   let tls: ThreadLocal<ObjectPool> = ThreadLocal::new();
-  compilation
+  process_assets_mutations
     .assets_mut()
     .par_iter_mut()
     .filter(|(filename, original)| {
@@ -283,7 +288,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       Ok(())
     }).map_err(MinifyError)?;
 
-  compilation.extend_diagnostics(all_warnings.into_inner().expect("should lock"));
+  process_assets_mutations.extend_diagnostics(all_warnings.into_inner().expect("should lock"));
 
   Ok(())
 }

--- a/crates/rspack_plugin_mf/src/manifest/mod.rs
+++ b/crates/rspack_plugin_mf/src/manifest/mod.rs
@@ -21,8 +21,8 @@ pub use options::{
   RemoteAliasTarget,
 };
 use rspack_core::{
-  Compilation, CompilationAsset, CompilationProcessAssets, ModuleIdentifier, ModuleType, Plugin,
-  PublicPath,
+  Compilation, CompilationAsset, CompilationProcessAssets, CompilationProcessAssetsMutations,
+  ModuleIdentifier, ModuleType, Plugin, PublicPath,
   rspack_sources::{RawStringSource, SourceExt},
 };
 use rspack_error::Result;
@@ -96,7 +96,11 @@ fn get_remote_entry_name(compilation: &Compilation, container_name: &str) -> Opt
   None
 }
 #[plugin_hook(CompilationProcessAssets for ModuleFederationManifestPlugin, stage = 0)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   // Prepare entrypoint names
   let entry_point_names: HashSet<String> = compilation
     .build_chunk_graph_artifact
@@ -624,7 +628,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   };
   // emit stats
   let stats_json = serde_json::to_string_pretty(&stats_root).expect("serialize stats");
-  compilation.emit_asset(
+  process_assets_mutations.emit_asset(
     self.options.stats_file_name.clone(),
     CompilationAsset::new(
       Some(RawStringSource::from(stats_json).boxed()),
@@ -673,7 +677,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       .collect(),
   };
   let manifest_json: String = serde_json::to_string_pretty(&manifest).expect("serialize manifest");
-  compilation.emit_asset(
+  process_assets_mutations.emit_asset(
     self.options.manifest_file_name.clone(),
     CompilationAsset::new(
       Some(RawStringSource::from(manifest_json).boxed()),

--- a/crates/rspack_plugin_mf/src/sharing/collect_shared_entry_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/collect_shared_entry_plugin.rs
@@ -5,8 +5,8 @@ use std::{
 
 use regex::Regex;
 use rspack_core::{
-  Compilation, CompilationAsset, CompilationProcessAssets, Context, DependenciesBlock, Module,
-  Plugin,
+  Compilation, CompilationAsset, CompilationProcessAssets, CompilationProcessAssetsMutations,
+  Context, DependenciesBlock, Module, Plugin,
   rspack_sources::{RawStringSource, SourceExt},
 };
 use rspack_error::Result;
@@ -97,7 +97,11 @@ impl CollectSharedEntryPlugin {
 }
 
 #[plugin_hook(CompilationProcessAssets for CollectSharedEntryPlugin)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   // Traverse ConsumeSharedModule in the graph and collect real resolved module paths from fallback
   let module_graph = compilation.get_module_graph();
   let mut ordered_requests: FxHashMap<String, Vec<[String; 2]>> = FxHashMap::default();
@@ -205,7 +209,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     .clone()
     .unwrap_or_else(|| DEFAULT_FILENAME.to_string());
 
-  compilation.emit_asset(
+  process_assets_mutations.emit_asset(
     filename,
     CompilationAsset::new(
       Some(RawStringSource::from(json).boxed()),

--- a/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
@@ -3,10 +3,10 @@ use std::sync::{Arc, RwLock};
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationDependencyReferencedExports,
-  CompilationOptimizeDependencies, CompilationProcessAssets, DependenciesBlock, Dependency,
-  DependencyId, DependencyType, ExportsInfoArtifact, ExtendedReferencedExport, Module, ModuleGraph,
-  ModuleIdentifier, Plugin, RuntimeGlobals, RuntimeModule, RuntimeModuleExt, RuntimeSpec,
-  SideEffectsOptimizeArtifact,
+  CompilationOptimizeDependencies, CompilationProcessAssets, CompilationProcessAssetsMutations,
+  DependenciesBlock, Dependency, DependencyId, DependencyType, ExportsInfoArtifact,
+  ExtendedReferencedExport, Module, ModuleGraph, ModuleIdentifier, Plugin, RuntimeGlobals,
+  RuntimeModule, RuntimeModuleExt, RuntimeSpec, SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
   rspack_sources::{RawStringSource, SourceExt, SourceValue},
 };
@@ -312,7 +312,11 @@ async fn optimize_dependencies(
 }
 
 #[plugin_hook(CompilationProcessAssets for SharedUsedExportsOptimizerPlugin, stage = 1)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   let file_names = vec![
     self.stats_file_name.clone(),
     self.manifest_file_name.clone(),
@@ -338,7 +342,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       let updated_content = serde_json::to_string_pretty(&stats_root)
         .map_err(|e| rspack_error::error!("Failed to serialize stats root: {}", e))?;
 
-      compilation.update_asset(file_name, |_, info| {
+      process_assets_mutations.update_asset(file_name, |_, info| {
         Ok((RawStringSource::from(updated_content).boxed(), info))
       })?;
     }

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -17,10 +17,10 @@ use rspack_core::{
   CompilationChunkIds, CompilationFinishModules, CompilationId, CompilationModuleIds,
   CompilationOptimizeChunkModules, CompilationOptimizeChunks, CompilationOptimizeCodeGeneration,
   CompilationOptimizeDependencies, CompilationOptimizeModules, CompilationOptimizeTree,
-  CompilationParams, CompilationProcessAssets, CompilationSeal, CompilationSucceedModule,
-  CompilerAfterEmit, CompilerClose, CompilerCompilation, CompilerEmit, CompilerFinishMake,
-  CompilerId, CompilerMake, CompilerThisCompilation, ExportsInfoArtifact, ModuleIdentifier,
-  ModuleIdsArtifact, Plugin, SideEffectsOptimizeArtifact,
+  CompilationParams, CompilationProcessAssets, CompilationProcessAssetsMutations, CompilationSeal,
+  CompilationSucceedModule, CompilerAfterEmit, CompilerClose, CompilerCompilation, CompilerEmit,
+  CompilerFinishMake, CompilerId, CompilerMake, CompilerThisCompilation, ExportsInfoArtifact,
+  ModuleIdentifier, ModuleIdsArtifact, Plugin, SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
 };
 use rspack_error::{Diagnostic, Result};
@@ -533,7 +533,11 @@ async fn optimize_code_generation(
 }
 
 #[plugin_hook(CompilationProcessAssets for ProgressPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_ADDITIONAL)]
-async fn process_assets(&self, _compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  _compilation: &Compilation,
+  _process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   self.sealing_hooks_report("process assets", 35).await
 }
 

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -13,7 +13,8 @@ use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
-  AssetInfo, BindingCell, Compilation, CompilationId, CompilationProcessAssets, Logger, Plugin,
+  AssetInfo, BindingCell, Compilation, CompilationId, CompilationProcessAssets,
+  CompilationProcessAssetsMutations, Logger, Plugin,
   rspack_sources::{BoxSource, RawStringSource, SourceExt, SourceValue},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
@@ -56,8 +57,12 @@ impl RealContentHashPlugin {
 }
 
 #[plugin_hook(CompilationProcessAssets for RealContentHashPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_OPTIMIZE_HASH)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
-  inner_impl(compilation).await
+async fn process_assets(
+  &self,
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
+  inner_impl(compilation, process_assets_mutations).await
 }
 
 impl Plugin for RealContentHashPlugin {
@@ -78,7 +83,10 @@ impl Plugin for RealContentHashPlugin {
   }
 }
 
-async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
+async fn inner_impl(
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   let logger = compilation.get_logger("rspack.RealContentHashPlugin");
   let start = logger.time("hash to asset names");
   let mut hash_to_asset_names: HashMap<&str, Vec<&str>> = HashMap::default();
@@ -262,7 +270,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   let start = logger.time("update assets");
   let mut asset_renames = Vec::with_capacity(updates.len());
   for (name, new_source, new_name) in updates {
-    compilation.update_asset(&name, |_, old_info| {
+    process_assets_mutations.update_asset(&name, |_, old_info| {
       let new_hashes: HashSet<_> = old_info
         .content_hash
         .iter()
@@ -284,7 +292,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
     }
   }
 
-  compilation.par_rename_assets(asset_renames);
+  process_assets_mutations.par_rename_assets(asset_renames);
 
   logger.time_end(start);
 

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -6,9 +6,10 @@ use futures::future::BoxFuture;
 use rspack_collections::{Identifiable, IdentifierMap};
 use rspack_core::{
   BoxDependency, ChunkUkey, Compilation, CompilationParams, CompilationProcessAssets,
-  CompilationRuntimeRequirementInTree, CompilerDone, CompilerFailed, CompilerFinishMake,
-  CompilerThisCompilation, Dependency, DependencyId, EntryDependency, EntryOptions, Logger, Plugin,
-  RuntimeGlobals, RuntimeModule, RuntimeSpec, get_entry_runtime,
+  CompilationProcessAssetsMutations, CompilationRuntimeRequirementInTree, CompilerDone,
+  CompilerFailed, CompilerFinishMake, CompilerThisCompilation, Dependency, DependencyId,
+  EntryDependency, EntryOptions, Logger, Plugin, RuntimeGlobals, RuntimeModule, RuntimeSpec,
+  get_entry_runtime,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -148,7 +149,11 @@ async fn runtime_requirements_in_tree(
 }
 
 #[plugin_hook(CompilationProcessAssets for RscServerPlugin)]
-async fn process_assets(&self, _compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  _compilation: &Compilation,
+  _process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   self.coordinator.idle().await?;
   Ok(())
 }

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -4,8 +4,9 @@ use std::{
 };
 
 use rspack_core::{
-  Compilation, CompilationParams, CompilationProcessAssets, CompilerCompilation, ModuleType,
-  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin,
+  Compilation, CompilationParams, CompilationProcessAssets, CompilationProcessAssetsMutations,
+  CompilerCompilation, ModuleType, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions,
+  Plugin,
   rspack_sources::{BoxSource, ReplaceSource, SourceExt},
 };
 use rspack_error::Result;
@@ -191,7 +192,11 @@ struct MockFlagPos {
 }
 
 #[plugin_hook(CompilationProcessAssets for RstestPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_ADDITIONAL)]
-async fn mock_hoist_process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn mock_hoist_process_assets(
+  &self,
+  compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   let mut files = Vec::with_capacity(compilation.build_chunk_graph_artifact.chunk_by_ukey.len());
 
   for chunk in compilation
@@ -210,7 +215,7 @@ async fn mock_hoist_process_assets(&self, compilation: &mut Compilation) -> Resu
   for file in files {
     let mut pos_map: std::collections::HashMap<String, MockFlagPos> =
       std::collections::HashMap::new();
-    let _res = compilation.update_asset(file.as_str(), |old, info| {
+    let _res = process_assets_mutations.update_asset(file.as_str(), |old, info| {
       // Only handles JavaScript.
       if info.javascript_module.is_none() {
         return Ok((old, info));

--- a/crates/rspack_plugin_sri/src/asset.rs
+++ b/crates/rspack_plugin_sri/src/asset.rs
@@ -3,7 +3,8 @@ use std::{cmp::Ordering, sync::Arc};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use rspack_core::{
   ChunkUkey, Compilation, CompilationAfterProcessAssets, CompilationAssets,
-  CompilationProcessAssets, CrossOriginLoading, ManifestAssetType,
+  CompilationProcessAssets, CompilationProcessAssetsMutations, CrossOriginLoading,
+  ManifestAssetType,
   chunk_graph_chunk::ChunkId,
   rspack_sources::{ReplaceSource, Source},
 };
@@ -269,7 +270,12 @@ async fn add_minssing_integrities(
 }
 
 #[plugin_hook(CompilationProcessAssets for SubresourceIntegrityPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE - 1)]
-pub async fn handle_assets(&self, compilation: &mut Compilation) -> Result<()> {
+pub async fn handle_assets(
+  &self,
+  _compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
+  let compilation = process_assets_mutations.compilation_mut();
   let integrities = process_chunks(&self.options.hash_func_names, compilation);
   let compilation_integrities =
     SubresourceIntegrityPlugin::get_compilation_integrities_mut(compilation.id());

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -11,7 +11,7 @@ use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
   AssetInfo, ChunkUkey, Compilation, CompilationAsset, CompilationParams, CompilationProcessAssets,
-  CompilerCompilation, Plugin,
+  CompilationProcessAssetsMutations, CompilerCompilation, Plugin,
   diagnostics::MinifyError,
   rspack_sources::{
     ConcatSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMapSource,
@@ -157,7 +157,11 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(CompilationProcessAssets for SwcJsMinimizerRspackPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE)]
-async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+async fn process_assets(
+  &self,
+  _compilation: &Compilation,
+  process_assets_mutations: &mut CompilationProcessAssetsMutations,
+) -> Result<()> {
   let options = &self.options;
   let minimizer_options = &self.options.minimizer_options;
 
@@ -175,7 +179,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let enter_span = tracing::Span::current();
 
   let tls: ThreadLocal<ObjectPool> = ThreadLocal::new();
-  compilation
+  process_assets_mutations
     .assets_mut()
     .par_iter_mut()
     .filter(|(filename, original)| {
@@ -396,7 +400,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 
       Ok(())
   })?;
-  compilation.extend_diagnostics(rx.into_iter().flatten().collect::<Vec<_>>());
+  process_assets_mutations.extend_diagnostics(rx.into_iter().flatten().collect::<Vec<_>>());
 
   // write all extracted comments to assets
   all_extracted_comments
@@ -405,7 +409,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     .clone()
     .into_iter()
     .for_each(|(_, comments)| {
-      compilation.emit_asset(
+      process_assets_mutations.emit_asset(
         comments.comments_file_name,
         CompilationAsset::new(
           Some(comments.source),


### PR DESCRIPTION
Summary
- adapt `CompilationProcessAssets` hook to accept an immutable `Compilation` plus a `CompilationProcessAssetsMutations` helper
- add the mutation wrapper with helper methods for asset, dependency, diagnostics, and chunk access
- update plugins and interceptor bindings to use the new API during process assets

Testing
- Not run (not requested)