### PR TITLE
chore: remove `-production` bench cases

### DIFF
--- a/xtask/benchmark/benches/groups/bundle/util.rs
+++ b/xtask/benchmark/benches/groups/bundle/util.rs
@@ -90,18 +90,6 @@ pub fn derive_projects(
       {
         let builder = builder.clone();
         projects.push((
-          format!("{name}-production"),
-          Arc::new(move || {
-            let mut builder = builder();
-            builder.mode(Mode::Production);
-            builder
-          }),
-        ));
-      }
-
-      {
-        let builder = builder.clone();
-        projects.push((
           format!("{name}-production-sourcemap"),
           Arc::new(move || {
             let mut builder = builder();


### PR DESCRIPTION
## Summary

This pr remove the bench cases of "basic-react-production" and "threejs-production" to save ci times. Because they can be  observed in "xx-production-sourcemap"

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
