### PR TITLE
perf: Parallelize create_module_assets processing

### DIFF
--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -21,36 +21,44 @@ impl PassExt for CreateModuleAssetsPass {
 impl Compilation {
   #[instrument("Compilation:create_module_assets",target=TRACING_BENCH_TARGET, skip_all)]
   async fn create_module_assets(&mut self, _plugin_driver: SharedPluginDriver) {
-    let mut chunk_asset_map = vec![];
-    let mut module_assets = vec![];
     let mg = self.get_module_graph();
-    for (identifier, module) in mg.modules() {
-      let assets = &module.build_info().assets;
-      if assets.is_empty() {
-        continue;
-      }
-
-      for (name, asset) in assets.as_ref() {
-        module_assets.push((name.clone(), asset.clone()));
-      }
-      // assets of executed modules are not in this compilation
-      if self
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .chunk_graph_module_by_module_identifier
-        .contains_key(identifier)
-      {
-        for chunk in self
-          .build_chunk_graph_artifact
-          .chunk_graph
-          .get_module_chunks(*identifier)
-          .iter()
-        {
-          for name in assets.keys() {
-            chunk_asset_map.push((*chunk, name.clone()))
-          }
+    let chunk_graph = &self.build_chunk_graph_artifact.chunk_graph;
+    let module_assets_and_chunk_asset_map = mg
+      .modules_par()
+      .filter_map(|(identifier, module)| {
+        let assets = module.build_info().assets.as_ref();
+        if assets.is_empty() {
+          return None;
         }
-      }
+
+        let module_assets = assets
+          .iter()
+          .map(|(name, asset)| (name.clone(), asset.clone()))
+          .collect::<Vec<_>>();
+
+        // assets of executed modules are not in this compilation
+        let chunk_asset_map = if chunk_graph
+          .chunk_graph_module_by_module_identifier
+          .contains_key(identifier)
+        {
+          chunk_graph
+            .get_module_chunks(*identifier)
+            .iter()
+            .flat_map(|chunk| assets.keys().map(move |name| (*chunk, name.clone())))
+            .collect::<Vec<_>>()
+        } else {
+          Vec::new()
+        };
+
+        Some((module_assets, chunk_asset_map))
+      })
+      .collect::<Vec<_>>();
+
+    let mut module_assets = Vec::new();
+    let mut chunk_asset_map = Vec::new();
+    for (assets, map) in module_assets_and_chunk_asset_map {
+      module_assets.extend(assets);
+      chunk_asset_map.extend(map);
     }
 
     for (name, asset) in module_assets {


### PR DESCRIPTION
Summary
- collect module assets and chunk mappings using parallel iteration over the module graph
- flatten the per-module results before emitting assets so chunk dependencies stay accurate

Testing
- Not run (not requested)