### PR TITLE
fix(core): type issues when skipLibCheck is disabled

### DIFF
--- a/packages/rspack/module.d.ts
+++ b/packages/rspack/module.d.ts
@@ -176,7 +176,10 @@ declare namespace Rspack {
     id: ModuleId;
     loaded: boolean;
     parents: NodeJS.Module['id'][] | null | undefined;
-    children: NodeJS.Module['id'][];
+    // Keep `any[]` for compatibility:
+    // - Rspack runtime uses module ids
+    // - `@types/node` defines `children` as `Module[]`.
+    children: any[];
     hot?: Hot;
   }
 
@@ -210,7 +213,6 @@ declare namespace Rspack {
   interface Process {
     env: {
       [key: string]: any;
-      NODE_ENV: 'development' | 'production' | (string & {});
     };
   }
 }

--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -197,8 +197,7 @@ export default defineConfig({
         build: true,
         alias: {
           // alias to pre-bundled types as they are public API
-          '@rspack/lite-tapable':
-            './compiled/@rspack/lite-tapable/dist/index.d.ts',
+          '@rspack/lite-tapable': './compiled/@rspack/lite-tapable/dist',
         },
       },
       redirect: {


### PR DESCRIPTION
## Summary

Fix all type issues when skipLibCheck is disabled.

- Conflicts with `@types/node`:

<img width="1136" height="576" alt="Screenshot 2026-02-26 at 19 03 03" src="https://github.com/user-attachments/assets/1241c8c5-cb39-4fcd-a05c-b434f91fbf73" />

- Correct `@rspack/lite-tapable` import path:

<img width="1118" height="349" alt="Screenshot 2026-02-26 at 18 49 49" src="https://github.com/user-attachments/assets/c5506677-dd4a-48d4-9270-767460da7e45" />


## Related links

- https://github.com/web-infra-dev/rspack/pull/10382
- https://github.com/web-infra-dev/rspack/pull/13048

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
