### PR TITLE
refactor: move exports info initialize to finish modules

### DIFF
--- a/crates/rspack_core/src/artifacts/exports_info_artifact.rs
+++ b/crates/rspack_core/src/artifacts/exports_info_artifact.rs
@@ -15,7 +15,7 @@ pub struct ExportsInfoArtifact {
 }
 
 impl ArtifactExt for ExportsInfoArtifact {
-  const PASS: IncrementalPasses = IncrementalPasses::BUILD_MODULE_GRAPH;
+  const PASS: IncrementalPasses = IncrementalPasses::FINISH_MODULES;
 
   fn recover(incremental: &Incremental, new: &mut Self, old: &mut Self) {
     if incremental.mutations_readable(Self::PASS) {
@@ -48,6 +48,10 @@ impl ExportsInfoArtifact {
       .module_exports_info
       .get(module_identifier)
       .unwrap_or_else(|| panic!("{} {:#?}", module_identifier, &self))
+  }
+
+  pub fn has_exports_info(&self, module_identifier: &ModuleIdentifier) -> bool {
+    self.module_exports_info.contains_key(module_identifier)
   }
 
   pub fn get_exports_info_data(&self, module_identifier: &ModuleIdentifier) -> &ExportsInfoData {

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -268,10 +268,11 @@ impl Cache for PersistentCache {
       match self.make_occasion.recovery().await {
         Ok(artifact) => {
           *compilation.build_module_graph_artifact = artifact;
+          // TODO: move to finish_modules recovery
           for (module, _) in compilation
             .build_module_graph_artifact
             .get_module_graph()
-            .modules()
+            .module_graph_modules()
           {
             compilation.exports_info_artifact.new_exports_info(*module);
           }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/mod.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashSet as HashSet;
 
 use self::{cutout::Cutout, repair::repair};
 use super::{BuildModuleGraphArtifact, BuildModuleGraphArtifactState};
-use crate::{Compilation, DependencyId, ExportsInfoArtifact};
+use crate::{Compilation, DependencyId};
 
 /// The param to update module graph
 #[derive(Debug, Clone)]
@@ -32,9 +32,8 @@ pub enum UpdateParam {
 pub async fn update_module_graph(
   compilation: &Compilation,
   mut artifact: BuildModuleGraphArtifact,
-  mut exports_info_artifact: ExportsInfoArtifact,
   params: Vec<UpdateParam>,
-) -> Result<(BuildModuleGraphArtifact, ExportsInfoArtifact)> {
+) -> Result<BuildModuleGraphArtifact> {
   artifact.state = BuildModuleGraphArtifactState::Initialized;
   let mut cutout = Cutout::default();
 
@@ -48,13 +47,7 @@ pub async fn update_module_graph(
     .call(compilation, &revoked_modules)
     .await?;
 
-  (artifact, exports_info_artifact) = repair(
-    compilation,
-    artifact,
-    exports_info_artifact,
-    build_dependencies,
-  )
-  .await?;
+  artifact = repair(compilation, artifact, build_dependencies).await?;
   cutout.fix_artifact(&mut artifact);
-  Ok((artifact, exports_info_artifact))
+  Ok(artifact)
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -93,10 +93,6 @@ impl Task<TaskContext> for AddTask {
 
     module_graph.add_module_graph_module(*self.module_graph_module);
 
-    context
-      .exports_info_artifact
-      .new_exports_info(module_identifier);
-
     set_resolved_module(
       module_graph,
       self.original_module_identifier,
@@ -105,6 +101,7 @@ impl Task<TaskContext> for AddTask {
     )?;
 
     tracing::trace!("Module added: {}", self.module.identifier());
+    println!("Module added: {}", self.module.identifier());
     context
       .artifact
       .affected_modules

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -7,8 +7,8 @@ use rustc_hash::FxHashMap as HashMap;
 use super::BuildModuleGraphArtifact;
 use crate::{
   Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory, ResolverFactory,
-  RuntimeTemplate, SharedPluginDriver, incremental::Incremental, module_graph::ModuleGraph,
+  DependencyTemplateType, DependencyType, ModuleFactory, ResolverFactory, RuntimeTemplate,
+  SharedPluginDriver, incremental::Incremental, module_graph::ModuleGraph,
 };
 
 #[derive(Debug)]
@@ -30,15 +30,10 @@ pub struct TaskContext {
   pub runtime_template: RuntimeTemplate,
 
   pub artifact: BuildModuleGraphArtifact,
-  pub exports_info_artifact: ExportsInfoArtifact,
 }
 
 impl TaskContext {
-  pub fn new(
-    compilation: &Compilation,
-    artifact: BuildModuleGraphArtifact,
-    exports_info_artifact: ExportsInfoArtifact,
-  ) -> Self {
+  pub fn new(compilation: &Compilation, artifact: BuildModuleGraphArtifact) -> Self {
     Self {
       compiler_id: compilation.compiler_id(),
       compilation_id: compilation.id(),
@@ -55,7 +50,6 @@ impl TaskContext {
       output_fs: compilation.output_filesystem.clone(),
       runtime_template: RuntimeTemplate::new(compilation.options.clone()),
       artifact,
-      exports_info_artifact,
     }
   }
 }
@@ -95,10 +89,6 @@ impl TaskContext {
       &mut *compilation.build_module_graph_artifact,
       &mut self.artifact,
     );
-    std::mem::swap(
-      &mut *compilation.exports_info_artifact,
-      &mut self.exports_info_artifact,
-    );
     compilation
   }
 
@@ -106,10 +96,6 @@ impl TaskContext {
     std::mem::swap(
       &mut *compilation.build_module_graph_artifact,
       &mut self.artifact,
-    );
-    std::mem::swap(
-      &mut *compilation.exports_info_artifact,
-      &mut self.exports_info_artifact,
     );
   }
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
@@ -11,16 +11,15 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use self::context::TaskContext;
 use super::BuildModuleGraphArtifact;
 use crate::{
-  BuildDependency, Compilation, ExportsInfoArtifact,
+  BuildDependency, Compilation,
   utils::task_loop::{Task, run_task_loop},
 };
 
 pub async fn repair(
   compilation: &Compilation,
   mut artifact: BuildModuleGraphArtifact,
-  exports_info_artifact: ExportsInfoArtifact,
   build_dependencies: HashSet<BuildDependency>,
-) -> Result<(BuildModuleGraphArtifact, ExportsInfoArtifact)> {
+) -> Result<BuildModuleGraphArtifact> {
   let module_graph = artifact.get_module_graph_mut();
   let mut grouped_deps = HashMap::default();
   for (dep_id, parent_module_identifier) in build_dependencies {
@@ -64,7 +63,7 @@ pub async fn repair(
     })
     .collect::<Vec<_>>();
 
-  let mut ctx = TaskContext::new(compilation, artifact, exports_info_artifact);
+  let mut ctx = TaskContext::new(compilation, artifact);
   run_task_loop(&mut ctx, init_tasks).await?;
-  Ok((ctx.artifact, ctx.exports_info_artifact))
+  Ok(ctx.artifact)
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/mod.rs
@@ -17,7 +17,7 @@ pub use self::{
   module_executor::{ExecuteModuleId, ExecutedRuntimeModule, ModuleExecutor},
 };
 pub use crate::{BuildModuleGraphArtifact, BuildModuleGraphArtifactState};
-use crate::{Compilation, ExportsInfoArtifact, logger::Logger};
+use crate::{Compilation, logger::Logger};
 
 pub async fn build_module_graph_pass(compilation: &mut Compilation) -> Result<()> {
   let logger = compilation.get_logger("rspack.Compiler");
@@ -38,11 +38,8 @@ impl Compilation {
     }
 
     let artifact = self.build_module_graph_artifact.steal();
-    let exports_info_artifact = self.exports_info_artifact.steal();
-    let (artifact, exports_info_artifact) =
-      build_module_graph(self, artifact, exports_info_artifact).await?;
+    let artifact = build_module_graph(self, artifact).await?;
     self.build_module_graph_artifact = artifact.into();
-    self.exports_info_artifact = exports_info_artifact.into();
 
     self.in_finish_make.store(true, Ordering::Release);
 
@@ -57,8 +54,7 @@ impl Compilation {
 pub async fn build_module_graph(
   compilation: &Compilation,
   mut artifact: BuildModuleGraphArtifact,
-  exports_info_artifact: ExportsInfoArtifact,
-) -> Result<(BuildModuleGraphArtifact, ExportsInfoArtifact)> {
+) -> Result<BuildModuleGraphArtifact> {
   let mut params = Vec::with_capacity(6);
 
   if !compilation.entries.is_empty() {
@@ -82,10 +78,8 @@ pub async fn build_module_graph(
     params.push(UpdateParam::RemovedFiles(compilation.removed_files.clone()));
   }
 
-  // reset temporary data
-  artifact.reset_temporary_data();
-  let artifacts = update_module_graph(compilation, artifact, exports_info_artifact, params).await?;
-  Ok(artifacts)
+  let artifact = update_module_graph(compilation, artifact, params).await?;
+  Ok(artifact)
 }
 
 /// Clean up module graph when finish make.
@@ -98,12 +92,10 @@ pub async fn build_module_graph(
 pub async fn finish_build_module_graph(
   compilation: &Compilation,
   artifact: BuildModuleGraphArtifact,
-  exports_info_artifact: ExportsInfoArtifact,
-) -> Result<(BuildModuleGraphArtifact, ExportsInfoArtifact)> {
+) -> Result<BuildModuleGraphArtifact> {
   update_module_graph(
     compilation,
     artifact,
-    exports_info_artifact,
     vec![UpdateParam::BuildEntryAndClean(
       compilation
         .entries

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/context.rs
@@ -1,7 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::{super::graph_updater::repair::context::TaskContext, module_tracker::ModuleTracker};
-use crate::{DependencyId, ModuleIdentifier};
+use crate::{DependencyId, ExportsInfoArtifact, ModuleIdentifier};
 
 /// The meta data for import_module.
 ///
@@ -18,6 +18,8 @@ pub struct ImportModuleMeta {
 pub struct ExecutorTaskContext {
   /// The make task context.
   pub origin_context: TaskContext,
+  /// Exports info artifact for module executor's isolated compilation environment.
+  pub exports_info_artifact: ExportsInfoArtifact,
   /// module tracker.
   pub tracker: ModuleTracker,
   /// entries.

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/entry.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/entry.rs
@@ -38,6 +38,7 @@ impl Task<ExecutorTaskContext> for EntryTask {
       origin_context,
       tracker,
       executed_entry_deps,
+      ..
     } = context;
 
     let mut res = vec![];

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
@@ -96,6 +96,7 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
 
     let ExecutorTaskContext {
       origin_context,
+      exports_info_artifact,
       entries,
       ..
     } = context;
@@ -217,10 +218,26 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
     }
 
     let mut compilation = origin_context.transform_to_temp_compilation();
+    std::mem::swap(
+      &mut *compilation.exports_info_artifact,
+      exports_info_artifact,
+    );
     let main_compilation_plugin_driver = compilation.plugin_driver.clone();
     compilation.plugin_driver = compilation.buildtime_plugin_driver.clone();
 
     tracing::debug!("modules: {:?}", &modules);
+
+    for module_identifier in modules.iter() {
+      if !compilation
+        .exports_info_artifact
+        .has_exports_info(module_identifier)
+      {
+        compilation
+          .exports_info_artifact
+          .new_exports_info(*module_identifier);
+      }
+    }
+    // dbg!(&modules, &compilation.exports_info_artifact);
 
     let mut chunk_graph = ChunkGraph::default();
 
@@ -414,6 +431,10 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
         }
       })
       .collect_vec();
+    std::mem::swap(
+      &mut *compilation.exports_info_artifact,
+      exports_info_artifact,
+    );
     origin_context.recovery_from_temp_compilation(compilation);
     result_sender
       .send(ExecuteResult {

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/mod.rs
@@ -79,11 +79,11 @@ impl ModuleExecutor {
     make_artifact.reset_temporary_data();
 
     // update the module affected by modified_files
-    (make_artifact, exports_info_artifact) =
-      update_module_graph(compilation, make_artifact, exports_info_artifact, params).await?;
+    make_artifact = update_module_graph(compilation, make_artifact, params).await?;
 
     let mut ctx = ExecutorTaskContext {
-      origin_context: TaskContext::new(compilation, make_artifact, exports_info_artifact),
+      origin_context: TaskContext::new(compilation, make_artifact),
+      exports_info_artifact,
       tracker: Default::default(),
       entries: std::mem::take(&mut self.entries),
       executed_entry_deps: Default::default(),
@@ -117,7 +117,7 @@ impl ModuleExecutor {
     };
     let mut make_artifact = ctx.origin_context.artifact;
     let mut entries = ctx.entries;
-    let mut exports_info_artifact = ctx.origin_context.exports_info_artifact;
+    let mut exports_info_artifact = ctx.exports_info_artifact;
 
     // clean removed entries
     let removed_module = compilation
@@ -128,10 +128,9 @@ impl ModuleExecutor {
     entries.retain(|k, v| {
       !removed_module.contains(&k.origin_module_identifier) || ctx.executed_entry_deps.contains(v)
     });
-    (make_artifact, exports_info_artifact) = update_module_graph(
+    make_artifact = update_module_graph(
       compilation,
       make_artifact,
-      exports_info_artifact,
       vec![UpdateParam::BuildEntryAndClean(
         entries.values().copied().collect(),
       )],

--- a/crates/rspack_core/src/compilation/build_module_graph/pass.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/pass.rs
@@ -42,6 +42,11 @@ impl PassExt for BuildModuleGraphPhasePass {
   ) -> Result<()> {
     let plugin_driver = compilation.plugin_driver.clone();
 
+    // reset temporary data
+    compilation
+      .build_module_graph_artifact
+      .reset_temporary_data();
+
     // Sub-phase: make hook
     make_hook_pass(compilation, plugin_driver.clone()).await?;
 

--- a/crates/rspack_core/src/compilation/finish_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_module_graph/mod.rs
@@ -24,11 +24,8 @@ impl Compilation {
     self.in_finish_make.store(false, Ordering::Release);
     // clean up the entry deps
     let make_artifact = self.build_module_graph_artifact.steal();
-    let exports_info_artifact = self.exports_info_artifact.steal();
-    let (make_artifact, exports_info_artifact) =
-      finish_build_module_graph(self, make_artifact, exports_info_artifact).await?;
+    let make_artifact = finish_build_module_graph(self, make_artifact).await?;
     self.build_module_graph_artifact = make_artifact.into();
-    self.exports_info_artifact = exports_info_artifact.into();
     // sync assets to module graph from module_executor
     if let Some(module_executor) = &mut self.module_executor {
       let mut module_executor = std::mem::take(module_executor);

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -26,7 +26,7 @@ impl PassExt for FinishModulesPhasePass {
     use crate::incremental::IncrementalPasses;
     if compilation
       .incremental
-      .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
+      .passes_enabled(IncrementalPasses::FINISH_MODULES)
     {
       compilation.exports_info_artifact.checkpoint();
     }
@@ -95,6 +95,8 @@ impl Compilation {
       tracing::debug!(target: incremental::TRACING_TARGET, passes = %IncrementalPasses::BUILD_MODULE_GRAPH, %mutations);
     }
 
+    self.ensure_exports_info_initialized(exports_info_artifact);
+
     // finish_modules means the module graph (modules, connections, dependencies) are
     // frozen and start to optimize (provided exports, infer async, etc.) based on the
     // module graph, so any kind of change that affect these should be done before the
@@ -120,6 +122,14 @@ impl Compilation {
     let diagnostics = build_module_graph_artifact.diagnostics();
     all_diagnostics.extend(diagnostics);
     Ok(all_diagnostics)
+  }
+
+  pub fn ensure_exports_info_initialized(&self, exports_info_artifact: &mut ExportsInfoArtifact) {
+    for module in self.build_module_graph_artifact.affected_modules.added() {
+      if !exports_info_artifact.has_exports_info(module) {
+        exports_info_artifact.new_exports_info(*module);
+      }
+    }
   }
 
   #[tracing::instrument("Compilation:collect_dependencies_diagnostics", skip_all)]

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -650,11 +650,9 @@ impl Compilation {
     }
 
     let make_artifact = self.build_module_graph_artifact.steal();
-    let exports_info_artifact = self.exports_info_artifact.steal();
-    let (make_artifact, exports_info_artifact) = update_module_graph(
+    let make_artifact = update_module_graph(
       self,
       make_artifact,
-      exports_info_artifact,
       vec![UpdateParam::BuildEntry(
         self
           .entries
@@ -667,6 +665,9 @@ impl Compilation {
     )
     .await?;
     self.build_module_graph_artifact = make_artifact.into();
+
+    let mut exports_info_artifact = self.exports_info_artifact.steal();
+    self.ensure_exports_info_initialized(&mut exports_info_artifact);
     self.exports_info_artifact = exports_info_artifact.into();
 
     Ok(())
@@ -704,11 +705,9 @@ impl Compilation {
     // Recheck entry and clean useless entry
     // This should before finish_modules hook is called, ensure providedExports effects on new added modules
     let make_artifact = self.build_module_graph_artifact.steal();
-    let exports_info_artifact = self.exports_info_artifact.steal();
-    let (make_artifact, exports_info_artifact) = update_module_graph(
+    let make_artifact = update_module_graph(
       self,
       make_artifact,
-      exports_info_artifact,
       vec![UpdateParam::BuildEntry(
         self
           .entries
@@ -721,6 +720,9 @@ impl Compilation {
     )
     .await?;
     self.build_module_graph_artifact = make_artifact.into();
+
+    let mut exports_info_artifact = self.exports_info_artifact.steal();
+    self.ensure_exports_info_initialized(&mut exports_info_artifact);
     self.exports_info_artifact = exports_info_artifact.into();
 
     Ok(())
@@ -1036,15 +1038,20 @@ impl Compilation {
     // https://github.com/webpack/webpack/blob/19ca74127f7668aaf60d59f4af8fcaee7924541a/lib/Compilation.js#L2462C21-L2462C25
     self.module_graph_cache_artifact.unfreeze();
 
-    let (artifact, updated_exports_info_artifact) = update_module_graph(
+    dbg!(&artifact.affected_modules, &exports_info_artifact);
+    let artifact = update_module_graph(
       self,
       artifact,
-      std::mem::take(exports_info_artifact),
       vec![UpdateParam::ForceBuildModules(module_identifiers.clone())],
     )
     .await?;
-    *exports_info_artifact = updated_exports_info_artifact;
     self.build_module_graph_artifact = artifact.into();
+
+    dbg!(
+      &self.build_module_graph_artifact.affected_modules,
+      &exports_info_artifact
+    );
+    self.ensure_exports_info_initialized(exports_info_artifact);
 
     let module_graph = self.get_module_graph();
     Ok(f(module_identifiers
@@ -1119,6 +1126,7 @@ impl Compilation {
       });
     entries.chain(async_entries)
   }
+
   pub fn add_runtime_module(
     &mut self,
     chunk_ukey: &ChunkUkey,


### PR DESCRIPTION
## Summary

**This PR is just for preserve the changes, for now I will move on and work on something else, may back to work on this again in future**

Current status: `pnpm test:base -t "compilation/rebuild-module"` is the blocker, need a new way to record correctly what module is added, and `new_exports_info()` for new added modules (`affected_modules.added()` is not work for `rebuildModule`)

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
