### PR TITLE
docs: update webpack migration guide for Rspack 2.0

### DIFF
--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -13,31 +13,31 @@ For projects not using webpack 5, there are other migration guides that can be r
 
 ## Installing Rspack
 
-In your project directory, install Rspack as a `devDependencies`:
+Install Rspack in your project directory:
 
-<PackageManagerTabs command="add @rspack/core @rspack/cli -D" />
+<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server -D" />
+
+Both `@rspack/cli` and `@rspack/dev-server` are optional dependencies:
+
+- If you are not using `webpack-cli`, no need to install `@rspack/cli`.
+- If you are not using `webpack-dev-server`, no need to install `@rspack/dev-server`.
 
 Now you can remove the webpack-related dependencies from your project:
 
 <PackageManagerTabs command="remove webpack webpack-cli webpack-dev-server" />
 
-:::tip
-In some cases, you will still need to keep `webpack` as a dev dependency, such as when using [vue-loader](https://github.com/vuejs/vue-loader) (you can use [rspack-vue-loader](https://github.com/rstackjs/rspack-vue-loader) instead).
-
-This is because these packages directly `import` subpaths of webpack and couple with webpack. If you encounter this issue, you can provide feedback to the maintainers of these plugins, asking them if they can make `webpack` an optional dependency.
-:::
-
 ## Updating package.json
 
-Update your build scripts to use Rspack instead of webpack:
+Update your build scripts to use Rspack instead of webpack, see [CLI](/api/cli) for more details.
 
 ```diff title="package.json"
 {
   "scripts": {
--   "serve": "webpack serve",
+-   "dev": "webpack serve",
 -   "build": "webpack build",
-+   "serve": "rspack serve",
++   "dev": "rspack dev",
 +   "build": "rspack build",
++   "preview": "rspack preview",
   }
 }
 ```
@@ -51,15 +51,7 @@ Rspack commands can specify the configuration file with `-c` or `--config`, simi
 However, unlike webpack, if a configuration file is not explicitly specified, Rspack defaults to using `rspack.config.js`.
 :::
 
-Rspack is actively working on implementing webpack's upcoming features, so some configuration defaults differ from webpack 5, as shown below:
-
-| Configuration     | webpack Default | Rspack Default |
-| ----------------- | --------------- | -------------- |
-| node.global       | true            | 'warn'         |
-| node.\_\_filename | 'mock'          | 'warn-mock'    |
-| node.\_\_dirname  | 'mock'          | 'warn-mock'    |
-
-You can refer to [Configure Rspack](/config/index) to see the configurations supported by Rspack.
+Rspack supports most webpack configuration options. See [Configure Rspack](/config/index) for the complete list of supported options.
 
 ## Webpack built-in plugins
 
@@ -67,22 +59,22 @@ Rspack has implemented most of webpack's built-in plugins, with the same names a
 
 For example, replacing the [DefinePlugin](/plugins/webpack/define-plugin):
 
-```diff title="rspack.config.js"
-- const webpack = require('webpack');
-+ const { rspack } = require('@rspack/core');
+```js title="rspack.config.js"
+const webpack = require('webpack'); // [!code --]
+const { rspack } = require('@rspack/core'); // [!code ++]
 
 module.exports = {
   //...
   plugins: [
--   new webpack.DefinePlugin({
-+   new rspack.DefinePlugin({
+    new webpack.DefinePlugin({ // [!code --]
+    new rspack.DefinePlugin({ // [!code ++]
       // ...
     }),
   ],
 }
 ```
 
-See [Webpack-aligned built-in plugins](/plugins/webpack/index) for more information about supported webpack plugins in Rspack.
+See [Built-in plugins](/plugins/webpack/index) for more information about supported webpack plugins in Rspack.
 
 ## Community plugins
 
@@ -90,25 +82,25 @@ Rspack supports most of the webpack community plugins and also offers alternativ
 
 Check [Plugin compat](/guide/compatibility/plugin) for more information on Rspack's compatibility with popular webpack community plugins.
 
-### `copy-webpack-plugin`
+### copy-webpack-plugin
 
 Use [rspack.CopyRspackPlugin](/plugins/rspack/copy-rspack-plugin) instead of [copy-webpack-plugin](https://github.com/webpack/copy-webpack-plugin):
 
-```diff title="rspack.config.js"
-- const CopyWebpackPlugin = require('copy-webpack-plugin');
-+ const { rspack } = require('@rspack/core');
+```js title="rspack.config.js"
+const CopyWebpackPlugin = require('copy-webpack-plugin'); // [!code --]
+const { rspack } = require('@rspack/core'); // [!code ++]
 
 module.exports = {
   plugins: [
--   new CopyWebpackPlugin({
-+   new rspack.CopyRspackPlugin({
+    new CopyWebpackPlugin({ // [!code --]
+    new rspack.CopyRspackPlugin({ // [!code ++]
       // ...
     }),
   ]
 }
 ```
 
-### `mini-css-extract-plugin`
+### mini-css-extract-plugin
 
 Use [rspack.CssExtractRspackPlugin](/plugins/rspack/css-extract-rspack-plugin) instead of [mini-css-extract-plugin](https://github.com/webpack/mini-css-extract-plugin):
 
@@ -132,136 +124,149 @@ module.exports = {
 +         rspack.CssExtractRspackPlugin.loader,
           "css-loader"
         ],
-+       type: 'javascript/auto'
       }
     ]
   }
 }
 ```
 
-### `tsconfig-paths-webpack-plugin`
+### tsconfig-paths-webpack-plugin
 
-Use [resolve.tsConfig](/config/resolve#resolvetsconfig) instead of [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin):
+Use [resolve.tsConfig](/config/resolve#resolvetsconfig) option instead of [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin):
 
-```diff title="rspack.config.js"
-- const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+```js title="rspack.config.js"
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin'); // [!code --]
 
 module.exports = {
   resolve: {
--   plugins: [new TsconfigPathsPlugin({})]
-+   tsConfig: {}
-  }
-}
+    plugins: [new TsconfigPathsPlugin({})], // [!code --]
+    tsConfig: {}, // [!code ++]
+  },
+};
 ```
 
-### `fork-ts-checker-webpack-plugin`
+### fork-ts-checker-webpack-plugin
 
 Use [ts-checker-rspack-plugin](https://github.com/rstackjs/ts-checker-rspack-plugin) instead of [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin):
 
-```diff title="rspack.config.js"
-- const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-+ const { TsCheckerRspackPlugin } = require('ts-checker-rspack-plugin');
+```js title="rspack.config.js"
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin'); // [!code --]
+const { TsCheckerRspackPlugin } = require('ts-checker-rspack-plugin'); // [!code ++]
 
 module.exports = {
   plugins: [
--   new ForkTsCheckerWebpackPlugin()
-+   new TsCheckerRspackPlugin()
-  ]
-}
+    new ForkTsCheckerWebpackPlugin(), // [!code --]
+    new TsCheckerRspackPlugin(), // [!code ++]
+  ],
+};
 ```
 
 ## Loaders
 
-Rspack's loader runner is fully compatible with webpack's loader functionality, supporting the vast majority of webpack loaders.
-You can use your existing loaders without any changes. However, to achieve the best performance, consider migrating the following loaders:
+Rspack is compatible with most webpack loaders, so existing loaders can typically be reused without changes.
 
-### [babel-loader](https://github.com/babel/babel-loader) / [swc-loader](https://swc.rs/docs/usage/swc-loader) → builtin:swc-loader
+For optimal performance and consistency, we recommend the following migrations where applicable:
 
-Using `builtin:swc-loader` offers better performance compared to the `babel-loader` and the external `swc-loader`, as it avoids frequent communication between JavaScript and Rust.
+### babel-loader
+
+Migrate [babel-loader](https://github.com/babel/babel-loader) to [builtin:swc-loader](/guide/features/builtin-swc-loader) to use Rspack's built-in SWC transform for better performance.
 
 If you need custom transformation logic using Babel plugins, you can retain `babel-loader`, but it is recommended to limit its use to fewer files to prevent significant performance degradation.
 
+- Replace [@babel/preset-typescript](http://npmjs.com/package/@babel/preset-typescript) with SWC's `syntax: 'typescript'` option:
+
 ```diff title="rspack.config.js"
 module.exports = {
-   module: {
-     rules: [
--      {
--        test: /\.tsx?$/i,
--        use: [
--          {
--            loader: 'babel-loader',
--            options: {
--              presets: ['@babel/preset-typescript'],
--            },
--          },
--        ],
--        test: /\.jsx?$/i,
--        use: [
--          {
--            loader: 'babel-loader',
--            options: {
--              presets: ['@babel/preset-react'],
--            },
--          },
--        ],
--      },
-+      {
+  module: {
+    rules: [
+      {
+-        test: /\.(j|t)sx?$/,
 +        test: /\.(j|t)s$/,
-+        exclude: [/[\\/]node_modules[\\/]/],
-+        loader: 'builtin:swc-loader',
-+        options: {
-+          jsc: {
-+            parser: {
-+              syntax: 'typescript',
-+            },
-+            externalHelpers: true,
-+            transform: {
-+              react: {
-+                runtime: 'automatic',
-+                development: !prod,
-+                refresh: !prod,
+        exclude: [/[\\/]node_modules[\\/]/],
+        use: [
+          {
+-            loader: 'babel-loader',
++            loader: 'builtin:swc-loader',
+            options: {
+-              presets: ['@babel/preset-typescript'],
++              jsc: {
++                parser: {
++                  syntax: 'typescript',
++                },
 +              },
-+            },
-+          },
-+          env: {
-+            targets: 'Chrome >= 48',
-+          },
-+        },
-+      },
-+      {
-+        test: /\.(j|t)sx$/,
-+        loader: 'builtin:swc-loader',
-+        exclude: [/[\\/]node_modules[\\/]/],
-+        options: {
-+          jsc: {
-+            parser: {
-+              syntax: 'typescript',
-+              tsx: true,
-+            },
-+            transform: {
-+              react: {
-+                runtime: 'automatic',
-+                development: !prod,
-+                refresh: !prod,
-+              },
-+            },
-+            externalHelpers: true,
-+          },
-+          env: {
-+            targets: 'Chrome >= 48', // browser compatibility
-+          },
-+        },
-+      },
-     ],
-   },
- };
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
 ```
 
-### [file-loader](https://github.com/webpack-contrib/raw-loader) / [url-loader](https://github.com/webpack-contrib/url-loader) / [raw-loader](https://github.com/webpack-contrib/raw-loader) → [Asset Modules](/guide/features/asset-module)
+- Replace [@babel/preset-react](http://npmjs.com/package/@babel/preset-react) with SWC's `jsc.transform.react` option:
 
-Rspack implements webpack 5's [Asset Modules](https://webpack.js.org/guides/asset-modules), using asset modules to replace `file-loader`, `url-loader`, and `raw-loader` for better performance.
+```diff title="rspack.config.js"
++const isDev = process.env.NODE_ENV === 'development';
 
-#### file-loader → asset/resource
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(j|t)sx?$/,
+        exclude: [/[\\/]node_modules[\\/]/],
+        use: [
+          {
+-            loader: 'babel-loader',
++            loader: 'builtin:swc-loader',
+            options: {
+-              presets: ['@babel/preset-typescript', '@babel/preset-react'],
++              jsc: {
++                parser: {
++                  syntax: 'typescript',
++                  tsx: true,
++                },
++                transform: {
++                  react: {
++                    runtime: 'automatic',
++                    development: isDev,
++                    refresh: isDev,
++                  },
++                },
++              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+### swc-loader
+
+When migrating external [swc-loader](https://swc.rs/docs/usage/swc-loader) to [builtin:swc-loader](/guide/features/builtin-swc-loader), only the loader name changes to `builtin:swc-loader`; all the options remain exactly the same as your original `swc-loader` config.
+
+```js title="rspack.config.js"
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(j|t)sx?$/,
+        use: [
+          {
+            loader: 'swc-loader', // [!code --]
+            loader: 'builtin:swc-loader', // [!code ++]
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+### file-loader
+
+Migrate [file-loader](https://github.com/webpack-contrib/file-loader) to [Asset Modules](/guide/features/asset-module) with `asset/resource`.
 
 ```diff title="rspack.config.js"
  module.exports = {
@@ -280,7 +285,9 @@ Rspack implements webpack 5's [Asset Modules](https://webpack.js.org/guides/asse
  };
 ```
 
-#### url-loader → asset/inline
+### url-loader
+
+Migrate [url-loader](https://github.com/webpack-contrib/url-loader) to [Asset Modules](/guide/features/asset-module) with `asset/inline`.
 
 ```diff title="rspack.config.js"
  module.exports = {
@@ -299,7 +306,9 @@ Rspack implements webpack 5's [Asset Modules](https://webpack.js.org/guides/asse
  };
 ```
 
-#### raw-loader → asset/source
+### raw-loader
+
+Migrate [raw-loader](https://github.com/webpack-contrib/raw-loader) to [Asset Modules](/guide/features/asset-module) with `asset/source`.
 
 ```diff title="rspack.config.js"
  module.exports = {

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -12,31 +12,31 @@ Rspack 的配置是基于 webpack 的设计实现的，以此你能够非常轻�
 
 ## 安装 Rspack
 
-在你的项目目录下，安装 Rspack 为开发依赖：
+在你的项目目录下安装 Rspack：
 
-<PackageManagerTabs command="add @rspack/core @rspack/cli -D" />
+<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server -D" />
+
+其中 `@rspack/cli` 和 `@rspack/dev-server` 为可选依赖：
+
+- 未使用 `webpack-cli` 时，不需要安装 `@rspack/cli`
+- 未使用 `webpack-dev-server` 时，不需要安装 `@rspack/dev-server`
 
 现在你可以移除项目中 webpack 相关的依赖了：
 
 <PackageManagerTabs command="remove webpack webpack-cli webpack-dev-server" />
 
-:::tip
-在个别情况下，你仍然需要保留 `webpack` 作为开发依赖，例如使用 [vue-loader](https://github.com/vuejs/vue-loader) 时 (你可以使用 [rspack-vue-loader](https://github.com/rstackjs/rspack-vue-loader) 替代)。
-
-这是因为这些库直接 `import` 了 webpack 的子路径，与 webpack 产生了耦合。如果你遇到了这种情况，可以向这些插件的维护者反馈，询问他们能否将 `webpack` 作为可选依赖。
-:::
-
 ## 修改 package.json
 
-更新构建脚本以使用 Rspack 代替 webpack：
+更新构建脚本以使用 Rspack 代替 webpack，查看 [CLI](/api/cli) 了解更多。
 
 ```diff title="package.json"
 {
   "scripts": {
--   "serve": "webpack serve",
+-   "dev": "webpack serve",
 -   "build": "webpack build",
-+   "serve": "rspack serve",
++   "dev": "rspack dev",
 +   "build": "rspack build",
++   "preview": "rspack preview",
   }
 }
 ```
@@ -49,15 +49,7 @@ Rspack 的配置是基于 webpack 的设计实现的，以此你能够非常轻�
 Rspack 命令与 webpack 命令相同，均可通过 `-c` 或 `--config` 指定配置文件。但与 webpack 不同的是，如果你未显式指定配置文件，Rspack 默认使用 `rspack.config.js`。
 :::
 
-Rspack 正在积极推动 webpack 的下一个版本的功能，因此在部分配置项上与 webpack 5 的默认值不同，如下：
-
-| 配置              | webpack 默认值 | Rspack 默认值 |
-| ----------------- | -------------- | ------------- |
-| node.global       | true           | 'warn'        |
-| node.\_\_filename | 'mock'         | 'warn-mock'   |
-| node.\_\_dirname  | 'mock'         | 'warn-mock'   |
-
-查阅[配置 Rspack](/config/index) 来了解 Rspack 支持的所有配置。
+Rspack 兼容 webpack 的绝大部分配置项，查阅 [配置 Rspack](/config/index) 来了解 Rspack 支持的所有配置。
 
 ## webpack 内置插件
 
@@ -65,22 +57,22 @@ Rspack 实现了大部分 webpack 内置插件，其命名和参数配置与 web
 
 例如替换 [DefinePlugin](/plugins/webpack/define-plugin)：
 
-```diff title="rspack.config.js"
-- const webpack = require('webpack');
-+ const { rspack } = require('@rspack/core');
+```js title="rspack.config.js"
+const webpack = require('webpack'); // [!code --]
+const { rspack } = require('@rspack/core'); // [!code ++]
 
 module.exports = {
   //...
   plugins: [
--   new webpack.DefinePlugin({
-+   new rspack.DefinePlugin({
+    new webpack.DefinePlugin({ // [!code --]
+    new rspack.DefinePlugin({ // [!code ++]
       // ...
     }),
   ],
 }
 ```
 
-查看[同步自 webpack 的内置插件](/plugins/webpack/index)以了解 Rspack 对 webpack 所有内置插件的支持情况。
+查看 [内置插件](/plugins/webpack/index) 以了解 Rspack 对 webpack 所有内置插件的支持情况。
 
 ## 社区插件
 
@@ -88,25 +80,25 @@ Rspack 支持大部分 webpack 社区插件，并为暂不支持的插件提供�
 
 查看 [Plugin 兼容](/guide/compatibility/plugin) 以了解 Rspack 对 webpack 常见社区插件的兼容情况。
 
-### `copy-webpack-plugin`
+### copy-webpack-plugin
 
 使用 [rspack.CopyRspackPlugin](/plugins/rspack/copy-rspack-plugin) 代替 [copy-webpack-plugin](https://github.com/webpack/copy-webpack-plugin)：
 
-```diff title="rspack.config.js"
-- const CopyWebpackPlugin = require('copy-webpack-plugin');
-+ const { rspack } = require('@rspack/core');
+```js title="rspack.config.js"
+const CopyWebpackPlugin = require('copy-webpack-plugin'); // [!code --]
+const { rspack } = require('@rspack/core'); // [!code ++]
 
 module.exports = {
   plugins: [
--   new CopyWebpackPlugin({
-+   new rspack.CopyRspackPlugin({
+    new CopyWebpackPlugin({ // [!code --]
+    new rspack.CopyRspackPlugin({ // [!code ++]
       // ...
     }),
   ]
 }
 ```
 
-### `mini-css-extract-plugin`
+### mini-css-extract-plugin
 
 使用 [rspack.CssExtractRspackPlugin](/plugins/rspack/css-extract-rspack-plugin) 代替 [mini-css-extract-plugin](https://github.com/webpack/mini-css-extract-plugin)：
 
@@ -130,135 +122,149 @@ module.exports = {
 +         rspack.CssExtractRspackPlugin.loader,
           "css-loader"
         ],
-+       type: 'javascript/auto'
       }
     ]
   }
 }
 ```
 
-### `tsconfig-paths-webpack-plugin`
+### tsconfig-paths-webpack-plugin
 
-使用 [resolve.tsConfig](/config/resolve#resolvetsconfig) 代替 [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)：
+使用 [resolve.tsConfig](/config/resolve#resolvetsconfig) 选项代替 [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)：
 
-```diff title="rspack.config.js"
-- const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+```js title="rspack.config.js"
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin'); // [!code --]
 
 module.exports = {
   resolve: {
--   plugins: [new TsconfigPathsPlugin({})]
-+   tsConfig: {}
-  }
-}
+    plugins: [new TsconfigPathsPlugin({})], // [!code --]
+    tsConfig: {}, // [!code ++]
+  },
+};
 ```
 
-### `fork-ts-checker-webpack-plugin`
+### fork-ts-checker-webpack-plugin
 
 使用 [ts-checker-rspack-plugin](https://github.com/rstackjs/ts-checker-rspack-plugin) 代替 [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin)：
 
-```diff title="rspack.config.js"
-- const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-+ const { TsCheckerRspackPlugin } = require('ts-checker-rspack-plugin');
+```js title="rspack.config.js"
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin'); // [!code --]
+const { TsCheckerRspackPlugin } = require('ts-checker-rspack-plugin'); // [!code ++]
 
 module.exports = {
   plugins: [
--   new ForkTsCheckerWebpackPlugin()
-+   new TsCheckerRspackPlugin()
-  ]
-}
+    new ForkTsCheckerWebpackPlugin(), // [!code --]
+    new TsCheckerRspackPlugin(), // [!code ++]
+  ],
+};
 ```
 
-## Loader
+## Loaders
 
-Rspack 已实现了与 webpack 功能完全对齐的 loader 执行器，支持绝大多数 webpack loader，因此你可以直接使用现有的 loader 而无需修改。不过，为了获得最佳性能，我们仍建议进行以下迁移：
+Rspack 与绝大多数 webpack loader 保持兼容，因此通常可以直接复用现有的 loader 生态，无需额外改造。
 
-### [babel-loader](https://github.com/babel/babel-loader) / [swc-loader](https://swc.rs/docs/usage/swc-loader) → builtin:swc-loader
+不过，为了获得更优的构建性能与更稳定的行为，我们仍然建议按照下面的方式进行适当迁移：
 
-通过 `builtin:swc-loader` 使用 Rspack 内置的 `swc-loader`，相比于 `babel-loader` 和外置的 `swc-loader`，它不需要在 JavaScript 和 Rust 之间进行频繁的通信，从而具有最佳的性能。
+### babel-loader
+
+将 [babel-loader](https://github.com/babel/babel-loader) 迁移为 [builtin:swc-loader](/guide/features/builtin-swc-loader)，以使用 Rspack 内置的 SWC 转换能力并获得更高性能。
 
 如果你需要通过 babel 插件进行自定义转换逻辑，可以保留 `babel-loader`，但不建议对大量文件使用 `babel-loader`，因为这会导致显著的性能下降。
 
+- 将 [@babel/preset-typescript](http://npmjs.com/package/@babel/preset-typescript) 替换为 SWC 的 `syntax: 'typescript'` 选项：
+
 ```diff title="rspack.config.js"
 module.exports = {
-   module: {
-     rules: [
--      {
--        test: /\.tsx?$/i,
--        use: [
--          {
--            loader: 'babel-loader',
--            options: {
--              presets: ['@babel/preset-typescript'],
--            },
--          },
--        ],
--        test: /\.jsx?$/i,
--        use: [
--          {
--            loader: 'babel-loader',
--            options: {
--              presets: ['@babel/preset-react'],
--            },
--          },
--        ],
--      },
-+      {
+  module: {
+    rules: [
+      {
+-        test: /\.(j|t)sx?$/,
 +        test: /\.(j|t)s$/,
-+        exclude: [/[\\/]node_modules[\\/]/],
-+        loader: 'builtin:swc-loader',
-+        options: {
-+          jsc: {
-+            parser: {
-+              syntax: 'typescript',
-+            },
-+            externalHelpers: true,
-+            transform: {
-+              react: {
-+                runtime: 'automatic',
-+                development: !prod,
-+                refresh: !prod,
+        exclude: [/[\\/]node_modules[\\/]/],
+        use: [
+          {
+-            loader: 'babel-loader',
++            loader: 'builtin:swc-loader',
+            options: {
+-              presets: ['@babel/preset-typescript'],
++              jsc: {
++                parser: {
++                  syntax: 'typescript',
++                },
 +              },
-+            },
-+          },
-+          env: {
-+            targets: 'Chrome >= 48',
-+          },
-+        },
-+      },
-+      {
-+        test: /\.(j|t)sx$/,
-+        loader: 'builtin:swc-loader',
-+        exclude: [/[\\/]node_modules[\\/]/],
-+        options: {
-+          jsc: {
-+            parser: {
-+              syntax: 'typescript',
-+              tsx: true,
-+            },
-+            transform: {
-+              react: {
-+                runtime: 'automatic',
-+                development: !prod,
-+                refresh: !prod,
-+              },
-+            },
-+            externalHelpers: true,
-+          },
-+          env: {
-+            targets: 'Chrome >= 48', // browser compatibility
-+          },
-+        },
-+      },
-     ],
-   },
- };
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
 ```
 
-### [file-loader](https://github.com/webpack-contrib/raw-loader) / [url-loader](https://github.com/webpack-contrib/url-loader) / [raw-loader](https://github.com/webpack-contrib/raw-loader) → [资源模块](/guide/features/asset-module)
+- 将 [@babel/preset-react](http://npmjs.com/package/@babel/preset-react) 替换为 SWC 的 `jsc.transform.react` 选项：
 
-Rspack 实现了 webpack 5 的[资源模块](https://webpack.js.org/guides/asset-modules)，使用资源模块来代替 `file-loader`、`url-loader` 和 `raw-loader` 以达到最佳的性能。
+```diff title="rspack.config.js"
++const isDev = process.env.NODE_ENV === 'development';
 
-#### file-loader → asset/resource
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(j|t)sx?$/,
+        exclude: [/[\\/]node_modules[\\/]/],
+        use: [
+          {
+-            loader: 'babel-loader',
++            loader: 'builtin:swc-loader',
+            options: {
+-              presets: ['@babel/preset-typescript', '@babel/preset-react'],
++              jsc: {
++                parser: {
++                  syntax: 'typescript',
++                  tsx: true,
++                },
++                transform: {
++                  react: {
++                    runtime: 'automatic',
++                    development: isDev,
++                    refresh: isDev,
++                  },
++                },
++              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+### swc-loader
+
+将外置 [swc-loader](https://swc.rs/docs/usage/swc-loader) 迁移为 [builtin:swc-loader](/guide/features/builtin-swc-loader) 时，除了 loader 名称改为 `builtin:swc-loader` 外，其余选项与原 `swc-loader` 完全一致。
+
+```js title="rspack.config.js"
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(j|t)sx?$/,
+        use: [
+          {
+            loader: 'swc-loader', // [!code --]
+            loader: 'builtin:swc-loader', // [!code ++]
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+### file-loader
+
+将 [file-loader](https://github.com/webpack-contrib/file-loader) 迁移为 [资源模块](/guide/features/asset-module) 的 `asset/resource` 类型。
 
 ```diff title="rspack.config.js"
  module.exports = {
@@ -277,7 +283,9 @@ Rspack 实现了 webpack 5 的[资源模块](https://webpack.js.org/guides/asset
  };
 ```
 
-#### url-loader → asset/inline
+### url-loader
+
+将 [url-loader](https://github.com/webpack-contrib/url-loader) 迁移为 [资源模块](/guide/features/asset-module) 的 `asset/inline` 类型。
 
 ```diff title="rspack.config.js"
  module.exports = {
@@ -296,7 +304,9 @@ Rspack 实现了 webpack 5 的[资源模块](https://webpack.js.org/guides/asset
  };
 ```
 
-#### raw-loader → asset/source
+### raw-loader
+
+将 [raw-loader](https://github.com/webpack-contrib/raw-loader) 迁移为 [资源模块](/guide/features/asset-module) 的 `asset/source` 类型。
 
 ```diff title="rspack.config.js"
  module.exports = {


### PR DESCRIPTION
## Summary

- clarify optional dependencies for `@rspack/cli` and `@rspack/dev-server`
- update build script commands and add preview command
- simplify configuration defaults section
- improve plugin migration examples with code annotations
- reorganize loader migration sections with clearer instructions
- add specific migration steps for babel-loader and swc-loader

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
