### PR TITLE
chore(ci): add timeout for benchmark action

### DIFF
--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -111,6 +111,7 @@ jobs:
         run: pnpm run build:js
 
       - name: Run rspack-ecosystem-benchmark
+        timeout-minutes: 40
         id: run-benchmark
         run: |
           RSPACK_DIR=$(pwd)


### PR DESCRIPTION
## Summary
GitHub Action's default timeout is 360 minutes, which is too long when something goes wrong.
Adjust to 40 minutes.


<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
