### PR TITLE
feat: cjs require destructuring assignment tree shaking

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -2,8 +2,9 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsModuleDependency, ContextDependency, ContextOptions, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportsInfoArtifact, FactorizeInfo, ModuleGraph,
-  ModuleGraphCacheArtifact, ResourceIdentifier, TemplateContext, TemplateReplaceSource,
+  DependencyTemplateType, DependencyType, ExportsInfoArtifact, ExtendedReferencedExport,
+  FactorizeInfo, ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport, ResourceIdentifier,
+  RuntimeSpec, TemplateContext, TemplateReplaceSource, create_exports_object_referenced,
 };
 use rspack_error::Diagnostic;
 
@@ -80,6 +81,28 @@ impl Dependency for CommonJsRequireContextDependency {
       return Some(vec![critical.clone()]);
     }
     None
+  }
+
+  fn get_referenced_exports(
+    &self,
+    _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
+    _exports_info_artifact: &ExportsInfoArtifact,
+    _runtime: Option<&RuntimeSpec>,
+  ) -> Vec<ExtendedReferencedExport> {
+    if let Some(referenced_exports) = &self.options.referenced_exports {
+      return referenced_exports
+        .iter()
+        .map(|referenced_export| {
+          ExtendedReferencedExport::Export(ReferencedExport::new(
+            referenced_export.clone(),
+            false,
+            false,
+          ))
+        })
+        .collect();
+    }
+    create_exports_object_referenced()
   }
 
   fn loc(&self) -> Option<DependencyLocation> {

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -174,6 +174,7 @@ impl Module for LazyCompilationProxyModule {
       None,
       false,
       None,
+      None,
     );
     let mut dependencies = vec![];
     let mut blocks = vec![];

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -98,6 +98,7 @@ impl RstestParserPlugin {
             Some(call_expr.span.into()),
             parser.in_try,
             loc,
+            None,
           );
           parser.add_dependency(Box::new(dep));
 
@@ -508,6 +509,7 @@ impl RstestParserPlugin {
                   Some(call_expr.span.into()),
                   parser.in_try,
                   loc,
+                  None,
                 );
 
                 let callee_range = call_expr.callee.span().into();

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/require-destructuring-check-used/dir/a.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/require-destructuring-check-used/dir/a.js
@@ -1,0 +1,3 @@
+export const a = "a/a";
+export const b = "a/b";
+export const usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/require-destructuring-check-used/dir/b.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/require-destructuring-check-used/dir/b.js
@@ -1,0 +1,3 @@
+export const a = "b/a";
+export const b = "b/b";
+export const usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/require-destructuring-check-used/index.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/require-destructuring-check-used/index.js
@@ -1,0 +1,12 @@
+it("should static analyze require destructuring assignment", () => {
+	const { a, usedExports } = require("./module");
+	expect(a).toBe("a");
+	expect(usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should support require context destructuring assignment", () => {
+	const file = "a";
+	const { a, usedExports } = require(`./dir/${file}.js`);
+	expect(a).toBe("a/a");
+	expect(usedExports).toEqual(["a", "usedExports"]);
+});

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/require-destructuring-check-used/module.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/require-destructuring-check-used/module.js
@@ -1,0 +1,3 @@
+exports.a = "a";
+exports.b = "b";
+exports.usedExports = __webpack_exports_info__.usedExports;


### PR DESCRIPTION
## Summary

Support analyze `const { a } = require("./m")` for cjs tree shaking

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
