### PR TITLE
fix: when there are 2+ dep targets in the same chunk, create facade chunks for all of them

### DIFF
--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/__snapshots__/esm.snap.txt
@@ -1,0 +1,43 @@
+```mjs title=0.mjs
+
+export { value } from "./ab-chunk.mjs";
+
+```
+
+```mjs title=1.mjs
+
+export { value_0 as value } from "./ab-chunk.mjs";
+
+```
+
+```mjs title=ab-chunk.mjs
+// ./a.js
+const value = 1
+
+// ./b.js
+const b_value = 2
+
+export { b_value as value_0, value };
+
+```
+
+```mjs title=main.mjs
+import { value, value_0 as b_value } from "./ab-chunk.mjs";
+
+// ./index.js
+
+
+
+it('should handle conflicting exports from multi-module chunk', async () => {
+	expect(value).toBe(1)
+	expect(b_value).toBe(2)
+
+	const modA = await import("./0.mjs")
+	const modB = await import("./1.mjs")
+
+	expect(modA.value).toBe(1)
+	expect(modB.value).toBe(2)
+})
+
+
+```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/a.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/a.js
@@ -1,0 +1,1 @@
+export const value = 1

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/b.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/b.js
@@ -1,0 +1,1 @@
+export const value = 2

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/index.js
@@ -1,0 +1,13 @@
+import { value as aValue } from './a'
+import { value as bValue } from './b'
+
+it('should handle conflicting exports from multi-module chunk', async () => {
+	expect(aValue).toBe(1)
+	expect(bValue).toBe(2)
+
+	const modA = await import('./a')
+	const modB = await import('./b')
+
+	expect(modA.value).toBe(1)
+	expect(modB.value).toBe(2)
+})

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/rspack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				ab: {
+					test: /[ab]\.js$/,
+					name: "ab-chunk",
+					chunks: "all",
+				}
+			}
+		}
+	}
+}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/__snapshots__/esm.snap.txt
@@ -1,0 +1,29 @@
+```mjs title=main.mjs
+// ./index.js
+it('should dynamically import module with default interop from external', async () => {
+	const mod = await import("./wrapper_js.mjs")
+	expect(mod.default).toBeDefined()
+	expect(mod.readFile).toBeDefined()
+	expect(mod.ns).toBeDefined()
+})
+
+
+```
+
+```mjs title=wrapper_js.mjs
+import * as __rspack_external_fs from "fs";
+
+// fs
+
+// ./wrapper.js
+
+
+;
+
+
+var default_0 = __rspack_external_fs["default"];
+var readFile = __rspack_external_fs.readFile;
+export { __rspack_external_fs as ns, readFile };
+export default default_0;
+
+```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/index.js
@@ -1,0 +1,6 @@
+it('should dynamically import module with default interop from external', async () => {
+	const mod = await import('./wrapper')
+	expect(mod.default).toBeDefined()
+	expect(mod.readFile).toBeDefined()
+	expect(mod.ns).toBeDefined()
+})

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	externals: {
+		'fs': 'module fs'
+	}
+}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/wrapper.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/wrapper.js
@@ -1,0 +1,4 @@
+export { default } from 'fs'
+export { readFile } from 'fs'
+import * as ns from 'fs'
+export { ns }

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/__snapshots__/esm.snap.txt
@@ -1,0 +1,24 @@
+```mjs title=main.mjs
+// ./index.js
+it('should dynamically import module with mixed external re-exports and local exports', async () => {
+	const mod = await import("./wrapper_js.mjs")
+	expect(mod.readFile).toBeDefined()
+	expect(mod.localValue).toBe(42)
+	expect(mod.localFn()).toBe('hello')
+})
+
+
+```
+
+```mjs title=wrapper_js.mjs
+// fs
+
+// ./wrapper.js
+
+const localValue = 42
+const localFn = () => 'hello'
+
+export { localFn, localValue };
+export { readFile } from "fs";
+
+```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/index.js
@@ -1,0 +1,6 @@
+it('should dynamically import module with mixed external re-exports and local exports', async () => {
+	const mod = await import('./wrapper')
+	expect(mod.readFile).toBeDefined()
+	expect(mod.localValue).toBe(42)
+	expect(mod.localFn()).toBe('hello')
+})

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	externals: {
+		'fs': 'module fs'
+	}
+}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/wrapper.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/wrapper.js
@@ -1,0 +1,3 @@
+export { readFile } from 'fs'
+export const localValue = 42
+export const localFn = () => 'hello'

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/__snapshots__/esm.snap.txt
@@ -1,0 +1,55 @@
+```mjs title=1.mjs
+
+var a_value = (/* inlined export .value */42);
+export { a_value as value };
+export { readFile } from "./ab-chunk.mjs";
+
+```
+
+```mjs title=2.mjs
+
+export { helper, join } from "./ab-chunk.mjs";
+
+```
+
+```mjs title=ab-chunk.mjs
+// fs
+
+// ./a.js
+
+
+
+// ./shared.js
+const value = 42
+const helper = () => 1
+
+// path
+
+// ./b.js
+
+
+
+export { helper };
+export { readFile } from "fs";
+export { join } from "path";
+
+```
+
+```mjs title=main.mjs
+// ./index.js
+
+
+it('should dynamically import modules from multi-module chunk with mixed re-exports', async () => {
+	expect((/* inlined export .value */42)).toBe(42)
+
+	const modA = await import("./1.mjs")
+	expect(modA.value).toBe(42)
+	expect(modA.readFile).toBeDefined()
+
+	const modB = await import("./2.mjs")
+	expect(modB.helper()).toBe(1)
+	expect(modB.join).toBeDefined()
+})
+
+
+```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/a.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/a.js
@@ -1,0 +1,2 @@
+export { value } from './shared'
+export { readFile } from 'fs'

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/b.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/b.js
@@ -1,0 +1,2 @@
+export { helper } from './shared'
+export { join } from 'path'

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/index.js
@@ -1,0 +1,13 @@
+import { value } from './shared'
+
+it('should dynamically import modules from multi-module chunk with mixed re-exports', async () => {
+	expect(value).toBe(42)
+
+	const modA = await import('./a')
+	expect(modA.value).toBe(42)
+	expect(modA.readFile).toBeDefined()
+
+	const modB = await import('./b')
+	expect(modB.helper()).toBe(1)
+	expect(modB.join).toBeDefined()
+})

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/rspack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+	externals: {
+		'fs': 'module fs',
+		'path': 'module path'
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				ab: {
+					test: /[ab]\.js$/,
+					name: "ab-chunk",
+					chunks: "all",
+				}
+			}
+		}
+	}
+}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/shared.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-re-export/shared.js
@@ -1,0 +1,2 @@
+export const value = 42
+export const helper = () => 1

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/__snapshots__/esm.snap.txt
@@ -1,0 +1,34 @@
+```mjs title=main.mjs
+// ./index.js
+
+
+it('should dynamically import module that re-exports from cross-chunk module', async () => {
+	expect((/* inlined export .value */42)).toBe(42)
+
+	const mod = await import("./wrapper_js.mjs")
+	expect(mod.value).toBe(42)
+	expect(mod.helper()).toBe(1)
+})
+
+
+```
+
+```mjs title=shared-chunk.mjs
+// ./shared.js
+const value = 42
+const helper = () => 1
+
+export { helper };
+
+```
+
+```mjs title=wrapper_js.mjs
+
+// ./wrapper.js
+
+
+var wrapper_value = (/* inlined export .value */42);
+export { wrapper_value as value };
+export { helper } from "./shared-chunk.mjs";
+
+```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/index.js
@@ -1,0 +1,9 @@
+import { value } from './shared'
+
+it('should dynamically import module that re-exports from cross-chunk module', async () => {
+	expect(value).toBe(42)
+
+	const mod = await import('./wrapper')
+	expect(mod.value).toBe(42)
+	expect(mod.helper()).toBe(1)
+})

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/rspack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				shared: {
+					test: /shared\.js$/,
+					name: "shared-chunk",
+				}
+			}
+		}
+	}
+}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/shared.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/shared.js
@@ -1,0 +1,2 @@
+export const value = 42
+export const helper = () => 1

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/wrapper.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/wrapper.js
@@ -1,0 +1,1 @@
+export { value, helper } from './shared'

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/__snapshots__/esm.snap.txt
@@ -1,0 +1,21 @@
+```mjs title=main.mjs
+// ./index.js
+it('should dynamically import module that re-exports from external', async () => {
+	const mod = await import("./wrapper_js.mjs")
+	expect(mod.readFile).toBeDefined()
+	expect(mod.fsDefault).toBeDefined()
+})
+
+
+```
+
+```mjs title=wrapper_js.mjs
+// fs
+
+// ./wrapper.js
+
+
+
+export { default as fsDefault, readFile } from "fs";
+
+```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/index.js
@@ -1,0 +1,5 @@
+it('should dynamically import module that re-exports from external', async () => {
+	const mod = await import('./wrapper')
+	expect(mod.readFile).toBeDefined()
+	expect(mod.fsDefault).toBeDefined()
+})

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	externals: {
+		'fs': 'module fs'
+	}
+}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/wrapper.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/wrapper.js
@@ -1,0 +1,2 @@
+export { readFile } from 'fs'
+export { default as fsDefault } from 'fs'

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/__snapshots__/esm.snap.txt
@@ -1,0 +1,19 @@
+```mjs title=main.mjs
+// ./index.js
+it('should dynamically import module with star re-export from external', async () => {
+	const mod = await import("./wrapper_js.mjs")
+	expect(mod.readFile).toBeDefined()
+})
+
+
+```
+
+```mjs title=wrapper_js.mjs
+// fs
+
+// ./wrapper.js
+
+
+export { readFile } from "fs";
+
+```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/index.js
@@ -1,0 +1,4 @@
+it('should dynamically import module with star re-export from external', async () => {
+	const mod = await import('./wrapper')
+	expect(mod.readFile).toBeDefined()
+})

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	externals: {
+		'fs': 'module fs'
+	}
+}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/wrapper.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/wrapper.js
@@ -1,0 +1,1 @@
+export * from 'fs'

--- a/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/__snapshots__/esm.snap.txt
@@ -1,0 +1,33 @@
+```mjs title=async_js.mjs
+// fs?3cf4
+
+// ./async.js
+
+const asyncValue = 'async'
+
+var async_asyncValue = /* unused export */ undefined;
+export { async_asyncValue as asyncValue };
+export { readFile } from "fs";
+
+```
+
+```mjs title=main.mjs
+import { readFile } from "fs";
+
+// fs?771d
+
+// ./index.js
+
+
+
+
+it('should handle external used in both entry and dynamic import', async () => {
+	const mod = await import("./async_js.mjs")
+	expect(mod.readFile).toBeDefined()
+	expect(readFile).toBeDefined()
+	expect(mod.readFile).toBe(readFile)
+})
+
+export { readFile };
+
+```

--- a/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/async.js
+++ b/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/async.js
@@ -1,0 +1,2 @@
+export { readFile } from 'fs'
+export const asyncValue = 'async'

--- a/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/index.js
@@ -1,0 +1,10 @@
+import { readFile } from 'fs'
+
+export { readFile }
+
+it('should handle external used in both entry and dynamic import', async () => {
+	const mod = await import('./async')
+	expect(mod.readFile).toBeDefined()
+	expect(readFile).toBeDefined()
+	expect(mod.readFile).toBe(readFile)
+})

--- a/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	externals: {
+		'fs': 'module fs'
+	}
+}

--- a/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/__snapshots__/esm.snap.txt
@@ -1,0 +1,27 @@
+```mjs title=leaf-chunk.mjs
+// ./leaf.js
+const value = 42
+const helper = () => 1
+
+export { helper };
+
+```
+
+```mjs title=main.mjs
+
+// ./index.js
+
+
+
+
+it('should have correct exports through cross-chunk re-export chain', async () => {
+	const mod = await import(/*webpackIgnore: true*/ './main.mjs')
+	expect(mod.value).toBe(42)
+	expect(mod.helper()).toBe(1)
+})
+
+var index_value = (/* inlined export .value */42);
+export { index_value as value };
+export { helper } from "./leaf-chunk.mjs";
+
+```

--- a/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/index.js
+++ b/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/index.js
@@ -1,0 +1,9 @@
+import { value, helper } from './middle'
+
+export { value, helper }
+
+it('should have correct exports through cross-chunk re-export chain', async () => {
+	const mod = await import(/*webpackIgnore: true*/ './main.mjs')
+	expect(mod.value).toBe(42)
+	expect(mod.helper()).toBe(1)
+})

--- a/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/leaf.js
+++ b/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/leaf.js
@@ -1,0 +1,2 @@
+export const value = 42
+export const helper = () => 1

--- a/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/middle.js
+++ b/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/middle.js
@@ -1,0 +1,1 @@
+export { value, helper } from './leaf'

--- a/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/split-chunks/cross-chunk-re-export-chain/rspack.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				middle: {
+					test: /middle\.js$/,
+					name: "middle-chunk",
+				},
+				leaf: {
+					test: /leaf\.js$/,
+					name: "leaf-chunk",
+				}
+			}
+		}
+	}
+}

--- a/tests/rspack-test/esmOutputCases/split-chunks/re-export-external-cross-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/split-chunks/re-export-external-cross-chunk/__snapshots__/esm.snap.txt
@@ -1,0 +1,30 @@
+```mjs title=main.mjs
+
+// ./index.js
+
+
+
+
+it('should have correct exports from cross-chunk external re-exports', async () => {
+	const mod = await import(/*webpackIgnore: true*/ './main.mjs')
+	expect(mod.readFile).toBeDefined()
+	expect(mod.join).toBeDefined()
+})
+
+export { join, readFile } from "./wrapper-chunk.mjs";
+
+```
+
+```mjs title=wrapper-chunk.mjs
+// fs
+
+// path
+
+// ./wrapper.js
+
+
+
+export { readFile } from "fs";
+export { join } from "path";
+
+```

--- a/tests/rspack-test/esmOutputCases/split-chunks/re-export-external-cross-chunk/index.js
+++ b/tests/rspack-test/esmOutputCases/split-chunks/re-export-external-cross-chunk/index.js
@@ -1,0 +1,9 @@
+import { readFile, join } from './wrapper'
+
+export { readFile, join }
+
+it('should have correct exports from cross-chunk external re-exports', async () => {
+	const mod = await import(/*webpackIgnore: true*/ './main.mjs')
+	expect(mod.readFile).toBeDefined()
+	expect(mod.join).toBeDefined()
+})

--- a/tests/rspack-test/esmOutputCases/split-chunks/re-export-external-cross-chunk/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/split-chunks/re-export-external-cross-chunk/rspack.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+	externals: {
+		'fs': 'module fs',
+		'path': 'module path'
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				wrapper: {
+					test: /wrapper\.js$/,
+					name: "wrapper-chunk",
+				}
+			}
+		}
+	}
+}

--- a/tests/rspack-test/esmOutputCases/split-chunks/re-export-external-cross-chunk/wrapper.js
+++ b/tests/rspack-test/esmOutputCases/split-chunks/re-export-external-cross-chunk/wrapper.js
@@ -1,0 +1,2 @@
+export { readFile } from 'fs'
+export { join } from 'path'


### PR DESCRIPTION
## Summary

When multiple dynamic import targets share the same multi-module chunk, their exports would be merged into one chunk namespace. If they had overlapping export names (e.g., both export value), this caused a build error ("conflict exports").

Fix: Track how many dynamic import targets exist per multi-module chunk. When there are 2+ targets in the same chunk, create facade chunks for all of them so each import() gets the correct module's namespace with properly deconflicted export names.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
