### PR TITLE
refactor: replace compiler.webpack references with rspack

### DIFF
--- a/packages/rspack-cli/tests/build/issue-6359/rspack.config.js
+++ b/packages/rspack-cli/tests/build/issue-6359/rspack.config.js
@@ -9,7 +9,7 @@ module.exports = /** @type {import('@rspack/cli').Configuration} */ {
   plugins: [
     {
       apply(compiler) {
-        new compiler.webpack.DefinePlugin({
+        new compiler.rspack.DefinePlugin({
           DEFINE_ME: JSON.stringify(
             `WEBPACK_SERVE=${process.env.WEBPACK_SERVE ?? '<EMPTY>'}`,
           ),

--- a/packages/rspack/src/container/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/container/ModuleFederationPlugin.ts
@@ -342,7 +342,7 @@ function getDefaultEntryRuntime(
     `const __module_federation_library_type__ = ${JSON.stringify(libraryType)}`,
     IS_BROWSER
       ? MF_RUNTIME_CODE
-      : compiler.webpack.Template.getFunctionContent(
+      : compiler.rspack.Template.getFunctionContent(
           require('./moduleFederationDefaultRuntime.js').default,
         ),
   ].join(';');

--- a/packages/rspack/src/sharing/CollectSharedEntryPlugin.ts
+++ b/packages/rspack/src/sharing/CollectSharedEntryPlugin.ts
@@ -59,7 +59,7 @@ export class CollectSharedEntryPlugin extends RspackBuiltinPlugin {
           {
             name: 'CollectSharedEntry',
             stage:
-              compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
+              compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
           },
           () => {
             compilation.getAssets().forEach((asset) => {

--- a/packages/rspack/src/sharing/IndependentSharedPlugin.ts
+++ b/packages/rspack/src/sharing/IndependentSharedPlugin.ts
@@ -97,7 +97,7 @@ class VirtualEntryPlugin {
         compilation.hooks.processAssets.tap(
           {
             name: 'RemoveVirtualEntryAsset',
-            stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
+            stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
           },
           () => {
             try {
@@ -248,7 +248,7 @@ export class IndependentSharedPlugin {
 
                 compilation.updateAsset(
                   filename,
-                  new compiler.webpack.sources.RawSource(
+                  new compiler.rspack.sources.RawSource(
                     JSON.stringify(statsContent),
                   ),
                 );

--- a/tests/rspack-test/compilerCases/assets.js
+++ b/tests/rspack-test/compilerCases/assets.js
@@ -186,7 +186,7 @@ module.exports = [{
 							{
 								name: "Plugin",
 								stage:
-									compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE - 1
+									compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE - 1
 							},
 							() => {
 								compilation.getAssets().forEach(a => {

--- a/tests/rspack-test/configCases/asset-modules/entry-with-runtimeChunk/rspack.config.js
+++ b/tests/rspack-test/configCases/asset-modules/entry-with-runtimeChunk/rspack.config.js
@@ -23,7 +23,7 @@ const common = {
 						{
 							name: "copy-webpack-plugin",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						() => {
 							const data = fs.readFileSync(

--- a/tests/rspack-test/configCases/asset/webpack-sources/rspack.config.js
+++ b/tests/rspack-test/configCases/asset/webpack-sources/rspack.config.js
@@ -20,12 +20,12 @@ module.exports = {
 					{
 						name: "PLUGIN",
 						stage:
-							compiler.webpack.Compilation
+							compiler.rspack.Compilation
 								.PROCESS_ASSETS_STAGE_OPTIMIZE_TRANSFER,
 						additionalAssets: true
 					},
 					assets => {
-						const { RawSource, SourceMapSource } = compiler.webpack.sources;
+						const { RawSource, SourceMapSource } = compiler.rspack.sources;
 
 						expect(assets["img.png"]).toBeInstanceOf(RawSource);
 						expect(assets["bundle0.js"]).toBeInstanceOf(SourceMapSource);

--- a/tests/rspack-test/configCases/chunk-loading/issue-4754/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-loading/issue-4754/rspack.config.js
@@ -12,7 +12,7 @@ module.exports = {
 				compiler.hooks.make.tap("make", compilation => {
 					const childEntry = path.resolve(__dirname, "./child-entry.js");
 					const childCompiler = compilation.createChildCompiler("name", {}, [
-						new compiler.webpack.EntryPlugin(compiler.context, childEntry)
+						new compiler.rspack.EntryPlugin(compiler.context, childEntry)
 					]);
 					childCompiler.compile(() => {});
 				});

--- a/tests/rspack-test/configCases/compilation/add-entry/rspack.config.js
+++ b/tests/rspack-test/configCases/compilation/add-entry/rspack.config.js
@@ -7,7 +7,7 @@ class Plugin {
 	 * @param {import("@rspack/core").Compiler} compiler
 	 */
 	apply(compiler) {
-		const { EntryPlugin } = compiler.webpack;
+		const { EntryPlugin } = compiler.rspack;
 
 		const fooDependency = EntryPlugin.createDependency(
 			path.resolve(__dirname, "foo.js")

--- a/tests/rspack-test/configCases/compilation/add-include/rspack.config.js
+++ b/tests/rspack-test/configCases/compilation/add-include/rspack.config.js
@@ -8,7 +8,7 @@ class Plugin {
 	 * @param {import("@rspack/core").Compiler} compiler
 	 */
 	apply(compiler) {
-		const { EntryPlugin, EntryDependency } = compiler.webpack;
+		const { EntryPlugin, EntryDependency } = compiler.rspack;
 
 		const modules = {};
 

--- a/tests/rspack-test/configCases/compilation/code-generation-results/rspack.config.js
+++ b/tests/rspack-test/configCases/compilation/code-generation-results/rspack.config.js
@@ -5,7 +5,7 @@ class Plugin {
      * @param {import("@rspack/core").Compiler} compiler
      */
     apply(compiler) {
-        const { Source } = compiler.webpack.sources;
+        const { Source } = compiler.rspack.sources;
 
         compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
             compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, () => {

--- a/tests/rspack-test/configCases/compilation/emit-asset/rspack.config.js
+++ b/tests/rspack-test/configCases/compilation/emit-asset/rspack.config.js
@@ -16,7 +16,7 @@ class Plugin {
 					stage: rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
 				},
 				() => {
-					compilation.emitAsset("/foo.txt", new compiler.webpack.sources.RawSource("foo"), {
+					compilation.emitAsset("/foo.txt", new compiler.rspack.sources.RawSource("foo"), {
 						bool: true,
 						number: 1,
 						string: "foo",

--- a/tests/rspack-test/configCases/compilation/modules/rspack.config.js
+++ b/tests/rspack-test/configCases/compilation/modules/rspack.config.js
@@ -7,7 +7,7 @@ class Plugin {
 	 * @param {import("@rspack/core").Compiler} compiler
 	 */
 	apply(compiler) {
-		const { AsyncDependenciesBlock } = compiler.webpack;
+		const { AsyncDependenciesBlock } = compiler.rspack;
 
 		compiler.hooks.make.tap(PLUGIN_NAME, compilation => {
 			compilation.hooks.processAssets.tap(

--- a/tests/rspack-test/configCases/context-module/module-instance/rspack.config.js
+++ b/tests/rspack-test/configCases/context-module/module-instance/rspack.config.js
@@ -3,7 +3,7 @@ class Plugin {
 	 * @param {import("@rspack/core").Compiler} compiler
 	 */
 	apply(compiler) {
-		const { ContextModule } = compiler.webpack;
+		const { ContextModule } = compiler.rspack;
 
 		compiler.hooks.afterEmit.tap("PLUGIN", compilation => {
 			const contextModule = Array.from(compilation.modules).find(

--- a/tests/rspack-test/configCases/css/no-extra-js-exports-output/rspack.config.js
+++ b/tests/rspack-test/configCases/css/no-extra-js-exports-output/rspack.config.js
@@ -57,7 +57,7 @@ const common = (i) => ({
 						{
 							name: "copy-webpack-plugin",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						() => {
 							const data = fs.readFileSync(

--- a/tests/rspack-test/configCases/css/runtime-data-webpack/rspack.config.js
+++ b/tests/rspack-test/configCases/css/runtime-data-webpack/rspack.config.js
@@ -21,7 +21,7 @@ module.exports = {
 						{
 							name: "Test",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE
 						},
 						assets => {
 							const name = "bundle0.css";
@@ -29,7 +29,7 @@ module.exports = {
 
 							compilation.updateAsset(
 								name,
-								new compiler.webpack.sources.RawSource(
+								new compiler.rspack.sources.RawSource(
 									`${code.replace(
 										"head{",
 										".class, head, body{"

--- a/tests/rspack-test/configCases/css/runtime-document-head-get-computed-style/rspack.config.js
+++ b/tests/rspack-test/configCases/css/runtime-document-head-get-computed-style/rspack.config.js
@@ -21,7 +21,7 @@ module.exports = {
 						{
 							name: "Test",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE
 						},
 						assets => {
 							const name = "bundle0.css";
@@ -29,7 +29,7 @@ module.exports = {
 
 							compilation.updateAsset(
 								name,
-								new compiler.webpack.sources.RawSource(
+								new compiler.rspack.sources.RawSource(
 									`${code}\n\n.after-head { color: red; }`
 								)
 							);

--- a/tests/rspack-test/configCases/entry/public-path/rspack.config.js
+++ b/tests/rspack-test/configCases/entry/public-path/rspack.config.js
@@ -33,7 +33,7 @@ module.exports = {
 	plugins: [
 		{
 			apply(compiler) {
-				const { EntryPlugin } = compiler.webpack;
+				const { EntryPlugin } = compiler.rspack;
 				for (const c of cases) {
 					new EntryPlugin(compiler.context, c.import, {
 						name: `bundle${bundleId++}`,

--- a/tests/rspack-test/configCases/externals/module-instance/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/module-instance/rspack.config.js
@@ -3,7 +3,7 @@ class Plugin {
 	 * @param {import("@rspack/core").Compiler} compiler
 	 */
 	apply(compiler) {
-		const { ExternalModule } = compiler.webpack;
+		const { ExternalModule } = compiler.rspack;
 
 		compiler.hooks.afterEmit.tap("AutoExternalPlugin", compilation => {
 			const externalModules = Array.from(compilation.modules).filter(

--- a/tests/rspack-test/configCases/hooks/asset-emitted-buffer/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/asset-emitted-buffer/rspack.config.js
@@ -5,7 +5,7 @@ class Plugin {
 		let hasEmittedAsset = false;
 		let contentLength = -1;
 		compiler.hooks.thisCompilation.tap(pluginName, compilation => {
-			const { RawSource } = compiler.webpack.sources;
+			const { RawSource } = compiler.rspack.sources;
 			compilation.hooks.processAssets.tap(pluginName, () => {
 				const buffer = Buffer.from("i am content of emit asset");
 				contentLength = buffer.length;

--- a/tests/rspack-test/configCases/hooks/create-module/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/create-module/rspack.config.js
@@ -7,7 +7,7 @@ module.exports = {
 					compiler.hooks.compilation.tap("mock-plugin", compilation => {
 						nmf.hooks.createModule.tap("mock-plugin", createData => {
 							if (createData.matchResource?.endsWith(".vanilla.css")) {
-								const { RawSource } = compiler.webpack.sources;
+								const { RawSource } = compiler.rspack.sources;
 								compilation.emitAsset(
 									"./createData.json",
 									new RawSource(JSON.stringify(createData, null, 2)),

--- a/tests/rspack-test/configCases/hooks/create-script/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/create-script/rspack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 	plugins: [
 		{
 			apply(compiler) {
-				const RuntimePlugin = compiler.webpack.RuntimePlugin;
+				const RuntimePlugin = compiler.rspack.RuntimePlugin;
 				compiler.hooks.compilation.tap("mock-plugin", compilation => {
 					const hooks = RuntimePlugin.getCompilationHooks(compilation);
 					hooks.createScript.tap("mock-plugin", (code, chunk) => {

--- a/tests/rspack-test/configCases/hooks/link-prefetch-preload/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/link-prefetch-preload/rspack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 	plugins: [
 		{
 			apply(compiler) {
-				const RuntimePlugin = compiler.webpack.RuntimePlugin;
+				const RuntimePlugin = compiler.rspack.RuntimePlugin;
 				compiler.hooks.compilation.tap("mock-plugin", compilation => {
 					const hooks = RuntimePlugin.getCompilationHooks(compilation);
 					hooks.linkPrefetch.tap("mock-plugin", (code, chunk) => {

--- a/tests/rspack-test/configCases/hooks/rspack-issue-4395/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/rspack-issue-4395/rspack.config.js
@@ -25,7 +25,7 @@ const config = {
 					compilation.hooks.processAssets.tap("mock-plugin", () => {
 						sub();
 						if (count === 0) {
-							const { RawSource } = compiler.webpack.sources;
+							const { RawSource } = compiler.rspack.sources;
 							compilation.emitAsset("./temp", new RawSource(""), {});
 						}
 					});

--- a/tests/rspack-test/configCases/hooks/runtime-requirement-in-tree/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/runtime-requirement-in-tree/rspack.config.js
@@ -16,7 +16,7 @@ class Plugin {
 
 			const once = new Set();
 			const customRuntimeGlobal = "__webpack_require__.custom";
-			const { RuntimeModule } = compiler.webpack;
+			const { RuntimeModule } = compiler.rspack;
 
 			class CustomRuntimeModule extends RuntimeModule {
 				constructor() {

--- a/tests/rspack-test/configCases/hooks/stage-compilation/plugin.js
+++ b/tests/rspack-test/configCases/hooks/stage-compilation/plugin.js
@@ -16,7 +16,7 @@ module.exports = class TestPlugin {
 					for (const file of Object.keys(assets)) {
 						compilation.updateAsset(file, old => {
 							const newContent = `${list.join("\n")}\n${old.source().toString()}`;
-							return new compiler.webpack.sources.RawSource(newContent);
+							return new compiler.rspack.sources.RawSource(newContent);
 						});
 					}
 				}

--- a/tests/rspack-test/configCases/hooks/stage-process-assets/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/stage-process-assets/rspack.config.js
@@ -20,7 +20,7 @@ module.exports = {
 				const {
 					sources: { ConcatSource, RawSource },
 					Compilation
-				} = compiler.webpack;
+				} = compiler.rspack;
 				compiler.hooks.compilation.tap("compilation", compilation => {
 					function addStage(stage) {
 						compilation.hooks.processAssets.tapPromise(

--- a/tests/rspack-test/configCases/hooks/update-asset-patch-asset-info/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/update-asset-patch-asset-info/rspack.config.js
@@ -9,14 +9,14 @@ module.exports = {
 				compilation.hooks.processAssets.tap(
 					{
 						name: "test",
-						stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+						stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
 					},
 					assets => {
 						Object.entries(assets).forEach(([filename, asset]) => {
 							const newContent = `// UPDATED\n${asset.source()}`;
 							compilation.updateAsset(
 								filename,
-								new compiler.webpack.sources.RawSource(newContent),
+								new compiler.rspack.sources.RawSource(newContent),
 								{ minimized: true }
 							);
 						});
@@ -26,7 +26,7 @@ module.exports = {
 					{
 						name: "test",
 						stage:
-							compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
+							compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
 					},
 					assets => {
 						compilation.getAssets().forEach(({ info }) => {

--- a/tests/rspack-test/configCases/hooks/update-asset-return-undefined/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/update-asset-return-undefined/rspack.config.js
@@ -9,14 +9,14 @@ module.exports = {
                 compilation.hooks.processAssets.tap(
                     {
                         name: "test",
-                        stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+                        stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
                     },
                     assets => {
                         Object.entries(assets).forEach(([filename, asset]) => {
                             const newContent = `// UPDATED\n${asset.source()}`;
                             compilation.updateAsset(
                                 filename,
-                                new compiler.webpack.sources.RawSource(newContent),
+                                new compiler.rspack.sources.RawSource(newContent),
                                 () => { }
                             );
                         });
@@ -26,7 +26,7 @@ module.exports = {
                     {
                         name: "test",
                         stage:
-                            compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
+                            compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
                     },
                     assets => {
                         compilation.getAssets().forEach(({ info }) => {

--- a/tests/rspack-test/configCases/hooks/update-asset/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/update-asset/rspack.config.js
@@ -9,14 +9,14 @@ module.exports = {
 				compilation.hooks.processAssets.tap(
 					{
 						name: "test",
-						stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+						stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
 					},
 					assets => {
 						Object.entries(assets).forEach(([filename, asset]) => {
 							const newContent = `// UPDATED\n${asset.source()}`;
 							compilation.updateAsset(
 								filename,
-								new compiler.webpack.sources.RawSource(newContent)
+								new compiler.rspack.sources.RawSource(newContent)
 							);
 						});
 					}
@@ -25,7 +25,7 @@ module.exports = {
 					{
 						name: "test",
 						stage:
-							compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
+							compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
 					},
 					assets => {
 						compilation.getAssets().forEach(({ info }) => {

--- a/tests/rspack-test/configCases/inline-const/basic/rspack.config.js
+++ b/tests/rspack-test/configCases/inline-const/basic/rspack.config.js
@@ -9,7 +9,7 @@ function config(index, { concatenateModules } = {}) {
 		},
 		plugins: [
 			function (compiler) {
-				new compiler.webpack.DefinePlugin({
+				new compiler.rspack.DefinePlugin({
 					CONCATENATED: JSON.stringify(concatenateModules)
 				}).apply(compiler);
 			}

--- a/tests/rspack-test/configCases/inline-enum/basic/rspack.config.js
+++ b/tests/rspack-test/configCases/inline-enum/basic/rspack.config.js
@@ -36,7 +36,7 @@ function config(index, { concatenateModules } = {}) {
 		},
 		plugins: [
 			function (compiler) {
-				new compiler.webpack.DefinePlugin({
+				new compiler.rspack.DefinePlugin({
 					CONCATENATED: JSON.stringify(concatenateModules)
 				}).apply(compiler);
 			}

--- a/tests/rspack-test/configCases/library/module-and-child-compilation/loader.js
+++ b/tests/rspack-test/configCases/library/module-and-child-compilation/loader.js
@@ -17,10 +17,10 @@ module.exports = async function loader() {
 		[]
 	);
 
-	const NodeTemplatePlugin = compiler.webpack.node.NodeTemplatePlugin;
+	const NodeTemplatePlugin = compiler.rspack.node.NodeTemplatePlugin;
 	new NodeTemplatePlugin().apply(childCompiler);
 
-	const NodeTargetPlugin = compiler.webpack.node.NodeTargetPlugin;
+	const NodeTargetPlugin = compiler.rspack.node.NodeTargetPlugin;
 	new NodeTargetPlugin().apply(childCompiler);
 
 	const {
@@ -28,7 +28,7 @@ module.exports = async function loader() {
 		library: {
 			EnableLibraryPlugin
 		}
-	} = compiler.webpack;
+	} = compiler.rspack;
 
 	new EnableLibraryPlugin('commonjs2').apply(childCompiler);
 
@@ -41,7 +41,7 @@ module.exports = async function loader() {
 		}
 	});
 
-	const LimitChunkCountPlugin = compiler.webpack.optimize.LimitChunkCountPlugin;
+	const LimitChunkCountPlugin = compiler.rspack.optimize.LimitChunkCountPlugin;
 
 	new LimitChunkCountPlugin({
 		maxChunks: 1

--- a/tests/rspack-test/configCases/module/change-parser-in-child-compiler/rspack.config.js
+++ b/tests/rspack-test/configCases/module/change-parser-in-child-compiler/rspack.config.js
@@ -12,8 +12,8 @@ module.exports = {
 						publicPath: ""
 					},
 					[
-						new compiler.webpack.library.EnableLibraryPlugin("commonjs"),
-						new compiler.webpack.EntryPlugin(
+						new compiler.rspack.library.EnableLibraryPlugin("commonjs"),
+						new compiler.rspack.EntryPlugin(
 							compilation.options.context,
 							"./child-entry.js",
 							{

--- a/tests/rspack-test/configCases/module/circular-externals/rspack.config.js
+++ b/tests/rspack-test/configCases/module/circular-externals/rspack.config.js
@@ -32,7 +32,7 @@ module.exports = {
 							{
 								name: "copy-external-files",
 								stage:
-									compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+									compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 							},
 							() => {
 								// Read the external module files
@@ -48,11 +48,11 @@ module.exports = {
 								// Emit them as assets
 								compilation.emitAsset(
 									"external-a.mjs",
-									new compiler.webpack.sources.RawSource(externalA)
+									new compiler.rspack.sources.RawSource(externalA)
 								);
 								compilation.emitAsset(
 									"external-b.mjs",
-									new compiler.webpack.sources.RawSource(externalB)
+									new compiler.rspack.sources.RawSource(externalB)
 								);
 							}
 						);

--- a/tests/rspack-test/configCases/module/non-webpack-require-warning/rspack.config.js
+++ b/tests/rspack-test/configCases/module/non-webpack-require-warning/rspack.config.js
@@ -17,7 +17,7 @@ module.exports = [
 							{
 								name: "copy-webpack-plugin",
 								stage:
-									compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+									compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 							},
 							() => {
 								compilation.emitAsset(

--- a/tests/rspack-test/configCases/module/non-webpack-require/rspack.config.js
+++ b/tests/rspack-test/configCases/module/non-webpack-require/rspack.config.js
@@ -24,7 +24,7 @@ module.exports = {
 						{
 							name: "copy-webpack-plugin",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						() => {
 							compilation.emitAsset(
@@ -39,7 +39,7 @@ module.exports = {
 						{
 							name: "copy-webpack-plugin",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						() => {
 							compilation.emitAsset(

--- a/tests/rspack-test/configCases/normal-module/module-instance/rspack.config.js
+++ b/tests/rspack-test/configCases/normal-module/module-instance/rspack.config.js
@@ -5,7 +5,7 @@ class Plugin {
 	 * @param {import("@rspack/core").Compiler} compiler
 	 */
 	apply(compiler) {
-		const { NormalModule } = compiler.webpack;
+		const { NormalModule } = compiler.rspack;
 
 		compiler.hooks.afterEmit.tap("AutoExternalPlugin", compilation => {
 			const normalModules = Array.from(compilation.modules).filter(

--- a/tests/rspack-test/configCases/output-module/non-webpack-require/rspack.config.js
+++ b/tests/rspack-test/configCases/output-module/non-webpack-require/rspack.config.js
@@ -22,7 +22,7 @@ module.exports = {
 						{
 							name: "copy-webpack-plugin",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						() => {
 							compilation.emitAsset(
@@ -37,7 +37,7 @@ module.exports = {
 						{
 							name: "copy-webpack-plugin",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						() => {
 							compilation.emitAsset(

--- a/tests/rspack-test/configCases/output-module/only-non-webpack-require/rspack.config.js
+++ b/tests/rspack-test/configCases/output-module/only-non-webpack-require/rspack.config.js
@@ -18,7 +18,7 @@ module.exports = {
 						{
 							name: "copy-webpack-plugin",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						() => {
 							compilation.emitAsset(

--- a/tests/rspack-test/configCases/parsing/dead-code-elimination/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/dead-code-elimination/rspack.config.js
@@ -30,7 +30,7 @@ module.exports = [
 							{
 								name: "copy-webpack-plugin",
 								stage:
-									compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+									compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 							},
 							() => {
 								const data = fs.readFileSync(

--- a/tests/rspack-test/configCases/plugins/chunk-modules/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/chunk-modules/rspack.config.js
@@ -41,7 +41,7 @@ module.exports = {
 					}
 					compilation.emitAsset(
 						"data.json",
-						new compiler.webpack.sources.RawSource(
+						new compiler.rspack.sources.RawSource(
 							JSON.stringify(chunkModules, null, 2)
 						)
 					);

--- a/tests/rspack-test/configCases/plugins/internal-processAssets-param-assets/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/internal-processAssets-param-assets/rspack.config.js
@@ -16,7 +16,7 @@ module.exports = {
 					compilation.hooks.processAssets.tapPromise(
 						{
 							name: "processAssets1",
-							stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE
+							stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE
 						},
 						async assets => {
 							const dup = "dup.txt";

--- a/tests/rspack-test/configCases/plugins/rspack-issue-4982/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/rspack-issue-4982/rspack.config.js
@@ -14,7 +14,7 @@ module.exports = {
 							filename: "child.js"
 						},
 						[
-							new compiler.webpack.EntryPlugin(
+							new compiler.rspack.EntryPlugin(
 								compiler.context,
 								path.resolve(__dirname, "./child.js"),
 								{ name: "child" }

--- a/tests/rspack-test/configCases/plugins/source-map-dev-tool-plugin-child-compiler/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/source-map-dev-tool-plugin-child-compiler/rspack.config.js
@@ -30,7 +30,7 @@ module.exports = {
 					CHILD_ID,
 					outputOptions
 				);
-				const SingleEntryPlugin = compiler.webpack.EntryPlugin;
+				const SingleEntryPlugin = compiler.rspack.EntryPlugin;
 				new SingleEntryPlugin(
 					compiler.context,
 					path.join(__dirname, CHILD_FILENAME),

--- a/tests/rspack-test/configCases/process-assets/additional-assets/rspack.config.js
+++ b/tests/rspack-test/configCases/process-assets/additional-assets/rspack.config.js
@@ -30,7 +30,7 @@ module.exports = {
 						() => {
 							compilation.emitAsset(
 								newName,
-								new compiler.webpack.sources.RawSource("text"),
+								new compiler.rspack.sources.RawSource("text"),
 								{
 									new: true
 								}
@@ -53,7 +53,7 @@ module.exports = {
 						() => {
 							compilation.emitAsset(
 								"file1.txt",
-								new compiler.webpack.sources.RawSource("text"),
+								new compiler.rspack.sources.RawSource("text"),
 								{
 									new: true
 								}

--- a/tests/rspack-test/configCases/source-map/auxiliary-files/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/auxiliary-files/rspack.config.js
@@ -4,7 +4,7 @@ module.exports = {
 	devtool: "source-map",
 	plugins: [
 		compiler => {
-			const { Compilation } = compiler.webpack;
+			const { Compilation } = compiler.rspack;
 			compiler.hooks.thisCompilation.tap("test case", compilation => {
 				compilation.hooks.processAssets.tap(
 					{

--- a/tests/rspack-test/configCases/source-map/custom-loader/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/custom-loader/rspack.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	devtool: false,
 	plugins: [
 		compiler => {
-			new compiler.webpack.SourceMapDevToolPlugin({}).apply(compiler);
+			new compiler.rspack.SourceMapDevToolPlugin({}).apply(compiler);
 		}
 	],
 	module: {

--- a/tests/rspack-test/configCases/web/prefetch-preload-module-only-js/rspack.config.js
+++ b/tests/rspack-test/configCases/web/prefetch-preload-module-only-js/rspack.config.js
@@ -28,7 +28,7 @@ module.exports = {
 						{
 							name: "Test",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE
 						},
 						assets => {
 							if (

--- a/tests/rspack-test/configCases/worker/ignore/rspack.config.js
+++ b/tests/rspack-test/configCases/worker/ignore/rspack.config.js
@@ -19,7 +19,7 @@ module.exports = {
 						{
 							name: "copy-webpack-plugin",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						() => {
 							const data = fs.readFileSync(
@@ -28,7 +28,7 @@ module.exports = {
 
 							compilation.emitAsset(
 								"worker.mjs",
-								new compiler.webpack.sources.RawSource(data)
+								new compiler.rspack.sources.RawSource(data)
 							);
 						}
 					);

--- a/tests/rspack-test/hookCases/compilation#processAssets/update-asset/test.js
+++ b/tests/rspack-test/hookCases/compilation#processAssets/update-asset/test.js
@@ -20,14 +20,14 @@ module.exports = {
 							{
 								name: "test",
 								stage:
-									compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+									compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
 							},
 							context.snapped(assets => {
 								Object.entries(assets).forEach(([filename, asset]) => {
 									const newContent = `// UPDATED\n${asset.source()}`;
 									compilation.updateAsset(
 										filename,
-										new compiler.webpack.sources.RawSource(newContent)
+										new compiler.rspack.sources.RawSource(newContent)
 									);
 								});
 							})
@@ -36,7 +36,7 @@ module.exports = {
 							{
 								name: "test",
 								stage:
-									compiler.webpack.Compilation
+									compiler.rspack.Compilation
 										.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
 							},
 							context.snapped(assets => {
@@ -50,7 +50,7 @@ module.exports = {
 							{
 								name: "test",
 								stage:
-									compiler.webpack.Compilation
+									compiler.rspack.Compilation
 										.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
 							},
 							assets => {

--- a/tests/rspack-test/hookCases/javascriptModulesPlugin#chunkHash/update-hash/test.js
+++ b/tests/rspack-test/hookCases/javascriptModulesPlugin#chunkHash/update-hash/test.js
@@ -9,7 +9,7 @@ module.exports = {
 				{
 					apply(compiler) {
 						compiler.hooks.compilation.tap("plugin", (compilation) => {
-							const hooks = compiler.webpack.javascript.JavascriptModulesPlugin.getCompilationHooks(compilation);
+							const hooks = compiler.rspack.javascript.JavascriptModulesPlugin.getCompilationHooks(compilation);
 							hooks.chunkHash.tap("plugin", context.snapped((chunk, hash) => {
 								updatedChunkHash = true;
 							}))

--- a/tests/rspack-test/statsAPICases/child-compiler.js
+++ b/tests/rspack-test/statsAPICases/child-compiler.js
@@ -13,7 +13,7 @@ class TestPlugin {
 						1,
 						compilation.outputOptions,
 						[
-							new compiler.webpack.EntryPlugin(
+							new compiler.rspack.EntryPlugin(
 								compiler.context,
 								"./fixtures/abc",
 								{ name: "TestChild" }

--- a/tests/rspack-test/statsOutputCases/minify-error/rspack.config.js
+++ b/tests/rspack-test/statsOutputCases/minify-error/rspack.config.js
@@ -8,13 +8,13 @@ module.exports = {
 	plugins: [
 		{
 			apply(compiler) {
-				const { ConcatSource, RawSource } = compiler.webpack.sources;
+				const { ConcatSource, RawSource } = compiler.rspack.sources;
 				compiler.hooks.compilation.tap("compilation", compilation => {
 					compilation.hooks.processAssets.tapPromise(
 						{
 							name: "Test",
 							stage:
-								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+								compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 						},
 						async assets => {
 							for (const [key, value] of Object.entries(assets)) {

--- a/tests/rspack-test/watchCases/add-include/reuse-deps-for-incremental-make/rspack.config.js
+++ b/tests/rspack-test/watchCases/add-include/reuse-deps-for-incremental-make/rspack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 	plugins: [
 		function (compiler) {
 			const PLUGIN_NAME = "TEST_PLUGIN";
-			const { EntryPlugin } = compiler.webpack;
+			const { EntryPlugin } = compiler.rspack;
 			compiler.hooks.finishMake.tapPromise(PLUGIN_NAME, compilation => {
 				return new Promise((resolve, reject) => {
 					const dependency = EntryPlugin.createDependency("./foo.js");


### PR DESCRIPTION
## Summary

Use `compiler.rspack` instead of `compiler.webpack` for consistency.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
