### PR TITLE
feat(esm-library): auto-name unnamed dynamic import chunks with deterministic module name

### DIFF
--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -1,11 +1,11 @@
-use std::sync::Arc;
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use atomic_refcell::AtomicRefCell;
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet, UkeyDashSet, UkeyMap, UkeySet};
 use rspack_core::{
-  ChunkGroupUkey, ChunkUkey, Compilation, DependenciesBlock, DependencyType, find_new_name,
-  get_cached_readable_identifier, incremental::Mutation, split_readable_identifier,
+  ChunkGroupUkey, ChunkUkey, Compilation, DependenciesBlock, DependencyType, ModuleIdentifier,
+  find_new_name, get_cached_readable_identifier, incremental::Mutation, split_readable_identifier,
 };
 use rspack_util::{atom::Atom, fx_hash::FxHashSet};
 
@@ -405,4 +405,140 @@ pub(crate) fn analyze_dyn_import_targets(
   }
 
   (strict_chunks, all_dyn_targets, namespace_targets)
+}
+
+/// Compute a short name from a module identifier.
+///
+/// Rules:
+/// - If the filename stem is "index", use the parent directory name
+/// - Otherwise, use the filename stem (without extension)
+///
+/// Examples:
+/// - `node_modules/lib/index.js` → `lib`
+/// - `/path/to/src/index.js` → `src`
+/// - `/path/to/src/app.js` → `app`
+fn short_name_from_identifier(identifier: &str) -> Option<String> {
+  let path = Path::new(identifier);
+  let stem = path.file_stem()?.to_str()?;
+  if stem == "index" {
+    let parent = path.parent()?;
+    let dir_name = parent.file_name()?.to_str()?;
+    Some(dir_name.to_string())
+  } else {
+    Some(stem.to_string())
+  }
+}
+
+/// For unnamed dynamic-import chunks with exactly one root module,
+/// assign a short name derived from the root module's identifier.
+///
+/// Names are deduplicated: if a name conflicts with any existing named chunk
+/// or another computed name, a `~N` suffix is appended (deterministic index).
+pub(crate) fn assign_dyn_import_chunk_short_names(compilation: &mut Compilation) {
+  let module_graph = compilation.get_module_graph();
+
+  // Collect all existing named chunks
+  let mut used_names: HashMap<String, usize> = HashMap::default();
+  for name in compilation.build_chunk_graph_artifact.named_chunks.keys() {
+    used_names.insert(name.clone(), 1);
+  }
+
+  // Collect candidates: (chunk_ukey, root_module_identifier) for unnamed non-initial chunks
+  // with exactly one root module
+  let mut candidates: Vec<(ChunkUkey, ModuleIdentifier)> = Vec::new();
+
+  for (chunk_ukey, chunk) in compilation.build_chunk_graph_artifact.chunk_by_ukey.iter() {
+    // Skip chunks that already have a name
+    if chunk.name().is_some() {
+      continue;
+    }
+    // Only target non-initial chunks (dynamic import chunks)
+    if chunk.can_be_initial(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey) {
+      continue;
+    }
+    let root_modules = compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_chunk_root_modules(
+        chunk_ukey,
+        module_graph,
+        &compilation.module_graph_cache_artifact,
+        &compilation.exports_info_artifact,
+      );
+    if root_modules.len() == 1 {
+      candidates.push((*chunk_ukey, root_modules[0]));
+    }
+  }
+
+  // Sort by module identifier for deterministic ordering
+  candidates.sort_by(|a, b| a.1.cmp(&b.1));
+
+  // Compute short names and track duplicates
+  // name_to_chunks: maps base_name → list of (chunk_ukey, module_identifier) in sorted order
+  let mut name_to_chunks: Vec<(String, Vec<(ChunkUkey, ModuleIdentifier)>)> = Vec::new();
+  let mut name_index_map: HashMap<String, usize> = HashMap::default();
+
+  for (chunk_ukey, module_id) in &candidates {
+    let Some(module_path) = module_graph
+      .module_by_identifier(module_id)
+      .expect("should have module")
+      .name_for_condition()
+    else {
+      continue;
+    };
+    let Some(base_name) = short_name_from_identifier(module_path.as_ref()) else {
+      continue;
+    };
+    if let Some(&idx) = name_index_map.get(&base_name) {
+      name_to_chunks[idx].1.push((*chunk_ukey, *module_id));
+    } else {
+      let idx = name_to_chunks.len();
+      name_index_map.insert(base_name.clone(), idx);
+      name_to_chunks.push((base_name, vec![(*chunk_ukey, *module_id)]));
+    }
+  }
+
+  // Assign names, handling deduplication
+  let mut assignments: Vec<(ChunkUkey, String)> = Vec::new();
+
+  for (base_name, chunks) in &name_to_chunks {
+    if chunks.len() == 1 && !used_names.contains_key(base_name) {
+      // Unique name, no conflict
+      assignments.push((chunks[0].0, base_name.clone()));
+      used_names.insert(base_name.clone(), 1);
+    } else {
+      // Need dedup suffixes: chunks are already sorted by module identifier
+      for (chunk_ukey, _module_id) in chunks {
+        let mut index = used_names.get(base_name).copied().unwrap_or(0);
+        let name = loop {
+          let candidate = if index == 0 {
+            base_name.clone()
+          } else {
+            format!("{base_name}~{index}")
+          };
+          if !used_names.contains_key(&candidate) {
+            break candidate;
+          }
+          index += 1;
+        };
+        // Record the next index to try for this base_name
+        used_names.insert(base_name.clone(), index + 1);
+        used_names.insert(name.clone(), 1);
+        assignments.push((*chunk_ukey, name));
+      }
+    }
+  }
+
+  // Apply assignments
+  for (chunk_ukey, name) in assignments {
+    let chunk = compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .expect_get_mut(&chunk_ukey);
+    chunk.set_name(Some(name.clone()));
+    compilation
+      .build_chunk_graph_artifact
+      .named_chunks
+      .insert(name, chunk_ukey);
+  }
 }

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -38,7 +38,10 @@ use crate::{
   chunk_link::ChunkLinkContext,
   dependency::dyn_import::DynamicImportDependencyTemplate,
   esm_lib_parser_plugin::EsmLibParserPlugin,
-  optimize_chunks::{analyze_dyn_import_targets, ensure_entry_exports, optimize_runtime_chunks},
+  optimize_chunks::{
+    analyze_dyn_import_targets, assign_dyn_import_chunk_short_names, ensure_entry_exports,
+    optimize_runtime_chunks,
+  },
   preserve_modules::preserve_modules,
   runtime::EsmRegisterModuleRuntimeModule,
 };
@@ -692,6 +695,8 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
   *self.strict_export_chunks.borrow_mut() = strict_chunks;
   *self.all_dyn_targets.borrow_mut() = all_dyn_targets;
   *self.namespace_targets.borrow_mut() = namespace_targets;
+
+  assign_dyn_import_chunk_short_names(compilation);
 
   Ok(None)
 }

--- a/tests/rspack-test/esmOutputCases/basic/hidden-folder/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/hidden-folder/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=_hidden_index_js.mjs
+```mjs title=.hidden.mjs
 // ./.hidden/index.js
 const value = () => 42
 export { value };
@@ -8,7 +8,7 @@ export { value };
 ```mjs title=main.mjs
 // ./index.js
 it("should render hidden folder", async () => {
-  const {value} = await import("./_hidden_index_js.mjs")
+  const {value} = await import("./.hidden.mjs")
 
   expect(value()).toBe(42)
 })

--- a/tests/rspack-test/esmOutputCases/deconflict/other-chunk-local/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/other-chunk-local/__snapshots__/esm.snap.txt
@@ -9,14 +9,14 @@ it('should have deconflicted symbol', async () => {
 	expect((/* inlined export .value */42)).toBe(42)
 	expect(local).toBe('index')
 	expect(index_local).toBe('')
-	const {value: v} = await import("./other_js.mjs")
+	const {value: v} = await import("./other.mjs")
 	expect(v).toBe((/* inlined export .value */42))
 })
 
 
 ```
 
-```mjs title=other_js.mjs
+```mjs title=other.mjs
 // ./other.js
 
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=dynamic_js.mjs
+```mjs title=dynamic.mjs
 // ./dynamic.js
 /* export default */ const dynamic = (42);
 
@@ -9,7 +9,7 @@ export default dynamic;
 ```mjs title=main.mjs
 // ./index.js
 it('should support dynamic import', async () => {
-	const value = await import("./dynamic_js.mjs")
+	const value = await import("./dynamic.mjs")
 	expect(value.default).toBe(42)
 })
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-default-interop-external/__snapshots__/esm.snap.txt
@@ -1,7 +1,7 @@
 ```mjs title=main.mjs
 // ./index.js
 it('should dynamically import module with default interop from external', async () => {
-	const mod = await import("./wrapper_js.mjs")
+	const mod = await import("./wrapper.mjs")
 	expect(mod.default).toBeDefined()
 	expect(mod.readFile).toBeDefined()
 	expect(mod.ns).toBeDefined()
@@ -10,7 +10,7 @@ it('should dynamically import module with default interop from external', async 
 
 ```
 
-```mjs title=wrapper_js.mjs
+```mjs title=wrapper.mjs
 import * as __rspack_external_fs from "fs";
 
 // fs

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-chunks/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-chunks/__snapshots__/esm.snap.txt
@@ -2,7 +2,7 @@
 // ./index.js
 it('should handle mixed: single-module chunk + multi-module chunk', async () => {
 	// solo is alone in its chunk - direct import works
-	const solo = await import("./solo_js.mjs")
+	const solo = await import("./solo.mjs")
 	expect(solo).toHaveProperty('default', 'solo')
 	expect(solo).toHaveProperty('value', 100)
 
@@ -105,7 +105,7 @@ export default m1;
 
 ```
 
-```mjs title=solo_js.mjs
+```mjs title=solo.mjs
 // ./solo.js
 /* export default */ const solo = ('solo');
 const value = 100;

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-external-local/__snapshots__/esm.snap.txt
@@ -1,7 +1,7 @@
 ```mjs title=main.mjs
 // ./index.js
 it('should dynamically import module with mixed external re-exports and local exports', async () => {
-	const mod = await import("./wrapper_js.mjs")
+	const mod = await import("./wrapper.mjs")
 	expect(mod.readFile).toBeDefined()
 	expect(mod.localValue).toBe(42)
 	expect(mod.localFn()).toBe('hello')
@@ -10,7 +10,7 @@ it('should dynamically import module with mixed external re-exports and local ex
 
 ```
 
-```mjs title=wrapper_js.mjs
+```mjs title=wrapper.mjs
 // fs
 
 // ./wrapper.js

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-cross-chunk/__snapshots__/esm.snap.txt
@@ -5,7 +5,7 @@
 it('should dynamically import module that re-exports from cross-chunk module', async () => {
 	expect((/* inlined export .value */42)).toBe(42)
 
-	const mod = await import("./wrapper_js.mjs")
+	const mod = await import("./wrapper.mjs")
 	expect(mod.value).toBe(42)
 	expect(mod.helper()).toBe(1)
 })
@@ -22,7 +22,7 @@ export { helper };
 
 ```
 
-```mjs title=wrapper_js.mjs
+```mjs title=wrapper.mjs
 
 // ./wrapper.js
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-re-export-external/__snapshots__/esm.snap.txt
@@ -1,7 +1,7 @@
 ```mjs title=main.mjs
 // ./index.js
 it('should dynamically import module that re-exports from external', async () => {
-	const mod = await import("./wrapper_js.mjs")
+	const mod = await import("./wrapper.mjs")
 	expect(mod.readFile).toBeDefined()
 	expect(mod.fsDefault).toBeDefined()
 })
@@ -9,7 +9,7 @@ it('should dynamically import module that re-exports from external', async () =>
 
 ```
 
-```mjs title=wrapper_js.mjs
+```mjs title=wrapper.mjs
 // fs
 
 // ./wrapper.js

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-short-name/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-short-name/__snapshots__/esm.snap.txt
@@ -1,0 +1,27 @@
+```mjs title=app.mjs
+// ./src/app.js
+const value = 1
+
+export { value };
+
+```
+
+```mjs title=lib.mjs
+// ./lib/index.js
+const value = 2
+
+export { value };
+
+```
+
+```mjs title=main.mjs
+// ./index.js
+it('should assign short names to dynamic import chunks', async () => {
+	const app = await import("./app.mjs")
+	const lib = await import("./lib.mjs")
+	expect(app.value).toBe(1)
+	expect(lib.value).toBe(2)
+})
+
+
+```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-short-name/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-short-name/index.js
@@ -1,0 +1,6 @@
+it('should assign short names to dynamic import chunks', async () => {
+	const app = await import('./src/app')
+	const lib = await import('./lib/index.js')
+	expect(app.value).toBe(1)
+	expect(lib.value).toBe(2)
+})

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-short-name/lib/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-short-name/lib/index.js
@@ -1,0 +1,1 @@
+export const value = 2

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-short-name/src/app.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-short-name/src/app.js
@@ -1,0 +1,1 @@
+export const value = 1

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-star-re-export-external/__snapshots__/esm.snap.txt
@@ -1,14 +1,14 @@
 ```mjs title=main.mjs
 // ./index.js
 it('should dynamically import module with star re-export from external', async () => {
-	const mod = await import("./wrapper_js.mjs")
+	const mod = await import("./wrapper.mjs")
 	expect(mod.readFile).toBeDefined()
 })
 
 
 ```
 
-```mjs title=wrapper_js.mjs
+```mjs title=wrapper.mjs
 // fs
 
 // ./wrapper.js

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=dynamic_js.mjs
+```mjs title=dynamic.mjs
 import { __webpack_require__ } from "./runtime.mjs";
 __webpack_require__.add({
 "./dynamic.js"
@@ -21,9 +21,9 @@ export default dynamic_default_0;
 
 ```
 
-```mjs title=esm_js.mjs
+```mjs title=esm.mjs
 import { __webpack_require__ } from "./runtime.mjs";
-import "./dynamic_js.mjs";
+import "./dynamic.mjs";
 
 // ./esm.js
 
@@ -38,8 +38,8 @@ export { value };
 import { __webpack_require__ } from "./runtime.mjs";
 // ./index.js
 it('should support dynamic import', async () => {
-	const mod = await import("./dynamic_js.mjs").then(__webpack_require__.t.bind(__webpack_require__, /*! ./dynamic */ "./dynamic.js", 19))
-	const mod2 = await import("./esm_js.mjs")
+	const mod = await import("./dynamic.mjs").then(__webpack_require__.t.bind(__webpack_require__, /*! ./dynamic */ "./dynamic.js", 19))
+	const mod2 = await import("./esm.mjs")
 	expect(mod.value).toBe(42)
 	expect(mod2.value).toBe(42)
 })

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-self/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-self/__snapshots__/esm.snap.txt
@@ -5,7 +5,7 @@
 const conflict = 42;
 
 it('should have access to the value from the same file', async () => {
-	const { conflict: c } = await import("./value_js.mjs")
+	const { conflict: c } = await import("./value.mjs")
 
 	expect(conflict).toBe(42)
 	expect(c).toBe(24)
@@ -14,7 +14,7 @@ it('should have access to the value from the same file', async () => {
 
 ```
 
-```mjs title=value_js.mjs
+```mjs title=value.mjs
 // ./value.js
 const conflict = 24
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/inline/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/inline/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=foo_js.mjs
+```mjs title=foo.mjs
 // ./foo.js
 
 var foo_value = (/* inlined export .value */42);
@@ -9,7 +9,7 @@ export { foo_value as value };
 ```mjs title=main.mjs
 // ./index.js
 it('should have correct inline export', async () => {
-  const { value } = await import("./foo_js.mjs")
+  const { value } = await import("./foo.mjs")
   expect(value).toBe(42)
 })
 

--- a/tests/rspack-test/esmOutputCases/externals/multiple-externals/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/multiple-externals/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=async_js.mjs
+```mjs title=async.mjs
 import * as __rspack_external_fs from "fs";
 
 // fs?3cf4
@@ -37,7 +37,7 @@ import fs, { readFile } from "fs";
 
 
 it('should render external correctly', async () => {
-  const {ns} = await import("./async_js.mjs")
+  const {ns} = await import("./async.mjs")
 
   expect(fs).toBe(other).toBe(fs).toBe(ns.default)
   expect(readFile).toBe(readFile).toBe(readFile).toBe(ns.readFile)

--- a/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/shared-external-entry-and-dyn/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=async_js.mjs
+```mjs title=async.mjs
 // fs?3cf4
 
 // ./async.js
@@ -22,7 +22,7 @@ import { readFile } from "fs";
 
 
 it('should handle external used in both entry and dynamic import', async () => {
-	const mod = await import("./async_js.mjs")
+	const mod = await import("./async.mjs")
 	expect(mod.readFile).toBeDefined()
 	expect(readFile).toBeDefined()
 	expect(mod.readFile).toBe(readFile)

--- a/tests/rspack-test/esmOutputCases/invalid-config/chunk-loading/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/invalid-config/chunk-loading/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=foo_js.mjs
+```mjs title=foo.mjs
 // ./foo.js
 console.log.bind('foo')
 
@@ -8,7 +8,7 @@ console.log.bind('foo')
 ```mjs title=main.mjs
 // ./index.js
 it('should import chunk', async () => {
-	await import("./foo_js.mjs")
+	await import("./foo.mjs")
 })
 
 

--- a/tests/rspack-test/esmOutputCases/re-exports/strict-exports/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/strict-exports/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=chunk_js.mjs
+```mjs title=chunk.mjs
 import { __webpack_require__ } from "./runtime.mjs";
 import "./index_js.mjs";
 
@@ -30,7 +30,7 @@ const cjs = __webpack_require__("./cjs.js");
 
 
 it('should only contains needed exports', async () => {
-	await import("./chunk_js.mjs")
+	await import("./chunk.mjs")
 	expect((0,cjs.foo)()).toBe(42)
 
 	const exports = await import(/*webpackIgnore: true*/'./main.mjs')

--- a/tests/rspack-test/esmOutputCases/top-level-await/detect-tla/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/top-level-await/detect-tla/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=async_js.mjs
+```mjs title=async.mjs
 // ./async.js
 const value = () => 42
 export { value };
@@ -11,7 +11,7 @@ function cb(v) {
   return v
 }
 
-const mod = await import("./async_js.mjs")
+const mod = await import("./async.mjs")
 const {value: value} = cb(mod);
 
 it('should have correct value', () => {


### PR DESCRIPTION
## Summary

- Assign short names to unnamed dynamic-import chunks in ESM library output based on their root module identifier

- When a chunk has no name and exactly one root module, derive a name from the module path: use the filename stem (e.g., app.js → app), or the parent directory name if the file is index (e.g., lib/index.js → lib)

- Deduplicate names with ~N suffixes using deterministic ordering by module identifier


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
