### PR TITLE
chore: use new rule to generate crate version

### DIFF
--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -99,7 +99,10 @@ export async function version_handler(version, options) {
     } else {
       nextVersion = semver.inc(lastVersion, version);
     }
-    // Rust crate version is major version of `@rspack/core` - 1
+    // Rust crate version mapping:
+    //   - crate major is always 0
+    //   - crate minor encodes the npm major and minor as (npm_major - 1) * 100 + npm_minor
+    //   - remaining npm components are placed into the crate patch segment
     const [nextMajor, nextMinor, ...remain] = nextVersion.split('.');
     const nextCrateVersion = `0.${(Number(nextMajor) - 1) * 100 + Number(nextMinor)}.${remain.join('.')}`;
     await $`${path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../x')} crate-version custom ${nextCrateVersion}`;


### PR DESCRIPTION
## Summary

Update the rule for generating Rust crate version from `@rspack/core` (npm) version during release.

## Previous behavior

Crate version was `(major - 1).minor.patch`, e.g. `@rspack/core` `2.5.3` → crate `1.5.3`.

## New behavior

Crate version is now `0.X.patch` where `X = (major - 1) * 100 + minor`, e.g.:

- `@rspack/core` `2.0.0` → crate `0.100.0`
- `@rspack/core` `2.5.3` → crate `0.105.3`
- `@rspack/core` `3.1.0` → crate `0.201.0`

This keeps the crate in a `0.x.y` form (common for pre-1.0 Rust crates) while encoding both major and minor from the JS version, avoiding collision when many minor versions exist per major.