### PR TITLE
docs: fix html-rspack-plugin hook types of beforeEmit and afterEmit

### DIFF
--- a/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
@@ -802,7 +802,7 @@ export default {
 
 This hook will be called before generating the HTML asset file, and it is the final chance to modify the HTML content.
 
-- **Type**: `SyncHook<[BeforeEmitData]>`
+- **Type**: `AsyncSeriesWaterfallHook<[BeforeEmitData]>`
 - **Parameters**:
   ```ts
   type BeforeEmitData = {
@@ -847,7 +847,7 @@ export default {
 
 This hook will be called after generating the HTML asset file and is only used for notification.
 
-- **Type**: `SyncHook<[AfterEmitData]>`
+- **Type**: `AsyncSeriesWaterfallHook<[AfterEmitData]>`
 - **Parameters**:
   ```ts
   type AfterEmitData = {

--- a/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
@@ -792,7 +792,7 @@ export default {
 
 在生成 HTML 产物前调用，修改 HTML 产物内容的最终机会。
 
-- **类型：** `SyncHook<[BeforeEmitData]>`
+- **类型：** `AsyncSeriesWaterfallHook<[BeforeEmitData]>`
 - **参数：**
   ```ts
   type BeforeEmitData = {
@@ -836,7 +836,7 @@ export default {
 
 在生成 HTML 产物后调用，仅用于事件通知。
 
-- **类型：** `SyncHook<[AfterEmitData]>`
+- **类型：** `AsyncSeriesWaterfallHook<[AfterEmitData]>`
 - **参数：**
   ```ts
   type AfterEmitData = {


### PR DESCRIPTION
- Change beforeEmit hook type from SyncHook to AsyncSeriesWaterfallHook
- Change afterEmit hook type from SyncHook to AsyncSeriesWaterfallHook

## Summary
<!-- Describe what this PR does and why. -->
Fix type in document


## Related links
<!-- Related issues or discussions. -->
https://github.com/web-infra-dev/rspack/blob/21e4aa12eeb02f7f2237530abb7d9e03b6f651bd/packages/rspack/src/builtin-plugin/html-plugin/hooks.ts#L35C1-L40C5


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
