### PR TITLE
refactor!: remove default exports in hot modules

### DIFF
--- a/packages/rspack/hot/emitter.js
+++ b/packages/rspack/hot/emitter.js
@@ -20,6 +20,4 @@ EventEmitter.prototype.emit = function (eventName) {
 
 var emitter = new EventEmitter();
 
-// TODO: remove default export when rspack-dev-server refactored
-export default emitter;
 export { emitter };

--- a/packages/rspack/hot/log.js
+++ b/packages/rspack/hot/log.js
@@ -84,6 +84,4 @@ log.groupEnd = groupEnd;
 log.setLogLevel = setLogLevel;
 log.formatError = formatError;
 
-// TODO: remove default export when rspack-dev-server refactored
-export default log;
 export { log };


### PR DESCRIPTION
## Summary
- remove default export from `@rspack/core/hot/emitter.js`
- remove default export from `@rspack/core/hot/log.js`
- keep named exports only (`emitter` / `log`)

## Breaking Changes
- `@rspack/core/hot/emitter.js` no longer provides a default export. Use the named export `emitter`.
- `@rspack/core/hot/log.js` no longer provides a default export. Use the named export `log`.

### Migration

```js
// before
import emitter from '@rspack/core/hot/emitter.js';

// after
import { emitter } from '@rspack/core/hot/emitter.js';
```

```js
// before
import log from '@rspack/core/hot/log.js';

// after
import { log } from '@rspack/core/hot/log.js';
```

## Links
- Follow-up cleanup after rspack-dev-server upgrade in #13205.
