### PR TITLE
fix: revert lastCompilation check for stats

### DIFF
--- a/packages/rspack/src/Stats.ts
+++ b/packages/rspack/src/Stats.ts
@@ -100,6 +100,21 @@ export class Stats {
         if (statsCompilationMap.has(compilation)) {
           return statsCompilationMap.get(compilation)!;
         }
+        // return empty stats for stale compilation
+        // TODO: Find a better way to handle accessing stats from stale compilations
+        if (this.compilation !== this.compilation.compiler._lastCompilation) {
+          return {
+            assets: [],
+            assetsByChunkName: [],
+            chunks: [],
+            entrypoints: [],
+            errors: [],
+            hash: 'XXXX',
+            modules: [],
+            namedChunkGroups: [],
+            warnings: [],
+          };
+        }
         const innerStats = this.#getInnerByCompilation(compilation);
         options.warnings = false;
         const innerStatsCompilation = innerStats.toJson(options);
@@ -131,6 +146,21 @@ export class Stats {
       ): binding.JsStatsCompilation => {
         if (statsCompilationMap.has(compilation)) {
           return statsCompilationMap.get(compilation)!;
+        }
+        // return empty stats for stale compilation
+        // TODO: Find a better way to handle accessing stats from stale compilations
+        if (this.compilation !== this.compilation.compiler._lastCompilation) {
+          return {
+            assets: [],
+            assetsByChunkName: [],
+            chunks: [],
+            entrypoints: [],
+            errors: [],
+            hash: 'XXXX',
+            modules: [],
+            namedChunkGroups: [],
+            warnings: [],
+          };
         }
         const innerStats = this.#getInnerByCompilation(compilation);
         const innerStatsCompilation = innerStats.toJson(options);


### PR DESCRIPTION
## Summary
we still need lastCompilation check since it's still possible `stats(lastCompilation).toJson()` and mutate artifact happens together 
fix failing ci in https://github.com/web-infra-dev/rspack/actions/runs/22706032717/job/65834607525#step:10:338
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
