### PR TITLE
refactor: Move ModuleExecutor state into BuildModuleGraphArtifact

### DIFF
--- a/crates/rspack_binding_api/src/compilation/mod.rs
+++ b/crates/rspack_binding_api/src/compilation/mod.rs
@@ -678,8 +678,7 @@ impl JsCompilation {
       callback,
       within_compiler_context(compiler_context, async {
         let module_executor = compilation
-          .module_executor
-          .as_ref()
+          .module_executor()
           .expect("should have module executor");
         let res = module_executor
           .import_module(

--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
   ArtifactExt, BuildDependency, DependencyId, FactorizeInfo, ModuleGraph, ModuleIdentifier,
-  compilation::build_module_graph::ModuleToLazyMake,
+  compilation::build_module_graph::{ModuleExecutor, ModuleToLazyMake},
   incremental::IncrementalPasses,
   incremental_info::IncrementalInfo,
   utils::{FileCounter, ResourceId},
@@ -27,6 +27,9 @@ pub enum BuildModuleGraphArtifactState {
 /// Make Artifact, including all side effects of the make stage.
 #[derive(Debug)]
 pub struct BuildModuleGraphArtifact {
+  // module executor runtime state
+  pub module_executor: Option<Box<ModuleExecutor>>,
+
   // temporary data, used by subsequent steps of BuildModuleGraph, should be reset when rebuild.
   /// BuildModuleGraph stage affected modules.
   ///
@@ -72,6 +75,7 @@ impl BuildModuleGraphArtifact {
   #[allow(clippy::new_without_default)]
   pub fn new() -> Self {
     Self {
+      module_executor: Default::default(),
       affected_modules: Default::default(),
       affected_dependencies: Default::default(),
       issuer_update_modules: Default::default(),

--- a/crates/rspack_core/src/cache/disable.rs
+++ b/crates/rspack_core/src/cache/disable.rs
@@ -10,6 +10,8 @@ pub struct DisableCache;
 #[async_trait::async_trait]
 impl Cache for DisableCache {
   async fn before_build_module_graph(&mut self, compilation: &mut Compilation) {
+    let module_executor = compilation.take_module_executor();
     *compilation.build_module_graph_artifact = BuildModuleGraphArtifact::new();
+    compilation.set_module_executor(module_executor);
   }
 }

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -267,7 +267,9 @@ impl Cache for PersistentCache {
     {
       match self.make_occasion.recovery().await {
         Ok(artifact) => {
+          let module_executor = compilation.take_module_executor();
           *compilation.build_module_graph_artifact = artifact;
+          compilation.set_module_executor(module_executor);
           for (module, _) in compilation
             .build_module_graph_artifact
             .get_module_graph()

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -32,6 +32,7 @@ impl MakeOccasion {
     let BuildModuleGraphArtifact {
       // write all of field here to avoid forget to update occasion when add new fields
       // for module graph
+      module_executor: _,
       module_graph,
       module_to_lazy_make,
       affected_modules,
@@ -111,6 +112,7 @@ impl MakeOccasion {
     Ok(BuildModuleGraphArtifact {
       // write all of field here to avoid forget to update occasion when add new fields
       // temporary data set to default
+      module_executor: Default::default(),
       affected_modules: Default::default(),
       affected_dependencies: Default::default(),
       issuer_update_modules: Default::default(),

--- a/crates/rspack_core/src/compilation/build_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/mod.rs
@@ -30,18 +30,19 @@ pub async fn build_module_graph_pass(compilation: &mut Compilation) -> Result<()
 #[instrument("Compilation:build_module_graph",target=TRACING_BENCH_TARGET, skip_all)]
 pub async fn do_build_module_graph(compilation: &mut Compilation) -> Result<()> {
   // run module_executor
-  if let Some(module_executor) = &mut compilation.module_executor {
-    let mut module_executor = std::mem::take(module_executor);
+  if let Some(mut module_executor) = compilation.take_module_executor() {
     module_executor
       .before_build_module_graph(compilation)
       .await?;
-    compilation.module_executor = Some(module_executor);
+    compilation.set_module_executor(Some(module_executor));
   }
 
-  let artifact = compilation.build_module_graph_artifact.steal();
+  let mut artifact = compilation.build_module_graph_artifact.steal();
+  compilation.set_module_executor(artifact.module_executor.take());
   let exports_info_artifact = compilation.exports_info_artifact.steal();
-  let (artifact, exports_info_artifact) =
+  let (mut artifact, exports_info_artifact) =
     build_module_graph(compilation, artifact, exports_info_artifact).await?;
+  artifact.module_executor = compilation.take_module_executor();
   compilation.build_module_graph_artifact = artifact.into();
   compilation.exports_info_artifact = exports_info_artifact.into();
 

--- a/crates/rspack_core/src/compilation/finish_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_module_graph/mod.rs
@@ -22,19 +22,20 @@ pub async fn finish_module_graph_pass(compilation: &mut Compilation) -> Result<(
 pub async fn finish_build_module_graph_pass(compilation: &mut Compilation) -> Result<()> {
   compilation.in_finish_make.store(false, Ordering::Release);
   // clean up the entry deps
-  let make_artifact = compilation.build_module_graph_artifact.steal();
+  let mut make_artifact = compilation.build_module_graph_artifact.steal();
+  compilation.set_module_executor(make_artifact.module_executor.take());
   let exports_info_artifact = compilation.exports_info_artifact.steal();
-  let (make_artifact, exports_info_artifact) =
+  let (mut make_artifact, exports_info_artifact) =
     finish_build_module_graph(compilation, make_artifact, exports_info_artifact).await?;
+  make_artifact.module_executor = compilation.take_module_executor();
   compilation.build_module_graph_artifact = make_artifact.into();
   compilation.exports_info_artifact = exports_info_artifact.into();
   // sync assets to module graph from module_executor
-  if let Some(module_executor) = &mut compilation.module_executor {
-    let mut module_executor = std::mem::take(module_executor);
+  if let Some(mut module_executor) = compilation.take_module_executor() {
     module_executor
       .after_build_module_graph(compilation)
       .await?;
-    compilation.module_executor = Some(module_executor);
+    compilation.set_module_executor(Some(module_executor));
   }
   // make finished, make artifact should be readonly thereafter.
   Ok(())

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -278,8 +278,8 @@ pub struct Compilation {
 
   import_var_map: IdentifierDashMap<RuntimeKeyMap<ImportVarMap>>,
 
-  // TODO move to MakeArtifact
-  pub module_executor: Option<ModuleExecutor>,
+  // Hold module executor while build_module_graph_artifact is stolen in make stage.
+  active_module_executor: Option<Box<ModuleExecutor>>,
   in_finish_make: AtomicBool,
 
   pub modified_files: ArcPathSet,
@@ -406,10 +406,13 @@ impl Compilation {
 
       import_var_map: IdentifierDashMap::default(),
 
-      module_executor,
+      active_module_executor: Default::default(),
       in_finish_make: AtomicBool::new(false),
 
-      build_module_graph_artifact: StealCell::new(BuildModuleGraphArtifact::new()),
+      build_module_graph_artifact: StealCell::new(BuildModuleGraphArtifact {
+        module_executor: module_executor.map(Box::new),
+        ..BuildModuleGraphArtifact::new()
+      }),
       modified_files,
       removed_files,
       input_filesystem,
@@ -427,6 +430,30 @@ impl Compilation {
 
   pub fn compiler_id(&self) -> CompilerId {
     self.compiler_id
+  }
+
+  pub fn module_executor(&self) -> Option<&ModuleExecutor> {
+    if let Some(artifact) = self.build_module_graph_artifact.try_read() {
+      artifact.module_executor.as_deref()
+    } else {
+      self.active_module_executor.as_deref()
+    }
+  }
+
+  pub fn take_module_executor(&mut self) -> Option<Box<ModuleExecutor>> {
+    if let Some(artifact) = self.build_module_graph_artifact.try_write() {
+      artifact.module_executor.take()
+    } else {
+      self.active_module_executor.take()
+    }
+  }
+
+  pub fn set_module_executor(&mut self, module_executor: Option<Box<ModuleExecutor>>) {
+    if let Some(artifact) = self.build_module_graph_artifact.try_write() {
+      artifact.module_executor = module_executor;
+    } else {
+      self.active_module_executor = module_executor;
+    }
   }
 
   pub fn get_module_graph(&self) -> &ModuleGraph {

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -8,11 +8,9 @@ use rspack_tasks::within_compiler_context;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-  ChunkGraph, ChunkKind, Compilation, Compiler, RuntimeSpec,
-  chunk_graph_chunk::ChunkId,
-  chunk_graph_module::ModuleId,
-  compilation::build_module_graph::ModuleExecutor,
-  incremental::{Incremental, IncrementalPasses},
+  ChunkGraph, ChunkKind, Compilation, Compiler, RuntimeSpec, chunk_graph_chunk::ChunkId,
+  chunk_graph_module::ModuleId, compilation::build_module_graph::ModuleExecutor,
+  incremental::Incremental,
 };
 
 impl Compiler {
@@ -91,14 +89,6 @@ impl Compiler {
         self.compiler_context.clone(),
       );
       next_compilation.hot_index = self.compilation.hot_index + 1;
-
-      if next_compilation
-        .incremental
-        .mutations_readable(IncrementalPasses::BUILD_MODULE_GRAPH)
-      {
-        // reuse module executor
-        next_compilation.module_executor = std::mem::take(&mut self.compilation.module_executor);
-      }
 
       // Store old compilation in cache for artifact recovery during run_passes
       // The cache hooks will recover artifacts based on their associated incremental passes

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -107,7 +107,7 @@ impl<'compilation> StatsContext<'compilation> {
   }
 
   fn module_executor(&self) -> Option<&'compilation ModuleExecutor> {
-    self.0.module_executor.as_ref()
+    self.0.module_executor()
   }
 }
 


### PR DESCRIPTION
Summary
- store the `ModuleExecutor` inside `BuildModuleGraphArtifact` and add helpers on `Compilation` for safely swapping it while the artifact is stolen
- keep cache hooks and make/finish passes in sync by preserving the executor across artifact recovery and build stages
- update JS bindings to read the executor through the new accessors so it remains available during async module imports

Testing
- Not run (not requested)