### PR TITLE
refactor: cache regex patterns for performance

### DIFF
--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -29,13 +29,18 @@ macro_rules! expect {
   };
 }
 
-use std::{borrow::Cow, future::ready, sync::Arc};
+use std::{
+  borrow::Cow,
+  future::ready,
+  sync::{Arc, LazyLock},
+};
 
 use builder_context::BuiltinPluginOptions;
 use derive_more::Debug;
 use devtool::DevtoolFlags;
 use externals::ExternalsPresets;
 use indexmap::IndexMap;
+use regex::Regex;
 use rspack_core::{
   AssetParserDataUrl, AssetParserDataUrlOptions, AssetParserOptions, BoxPlugin, ByDependency,
   CacheOptions, ChunkLoading, ChunkLoadingType, CleanOptions, Compiler, CompilerOptions,
@@ -2694,6 +2699,10 @@ impl OutputOptionsBuilder {
       }
     });
 
+    static CHUNK_FILENAME_BASENAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+      Regex::new(r"(^|\/)([^/]*(?:\?|$))").expect("should initialize chunk filename basename regex")
+    });
+
     let chunk_filename = f!(self.chunk_filename.take(), || {
       // Get template string from filename if it's not a function
       if let Some(template) = filename.template() {
@@ -2707,8 +2716,7 @@ impl OutputOptionsBuilder {
           filename.clone()
         } else {
           // Otherwise prefix "[id]." in front of the basename to make it changing
-          let new_template = regex::Regex::new(r"(^|\/)([^/]*(?:\?|$))")
-            .expect("should initialize `Regex`")
+          let new_template = CHUNK_FILENAME_BASENAME_RE
             .replace(template, "$1[id].$2")
             .into_owned();
           Filename::from(new_template)
@@ -2724,10 +2732,13 @@ impl OutputOptionsBuilder {
       CrossOriginLoading::Disable
     );
 
+    static JS_EXTENSION_IN_FILENAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+      Regex::new(r"\.[mc]?js(\?|$)").expect("should initialize js extension in filename regex")
+    });
+
     let css_filename = f!(self.css_filename.take(), || {
       if let Some(template) = filename.template() {
-        let new_template = regex::Regex::new(r"\.[mc]?js(\?|$)")
-          .expect("should initialize `Regex`")
+        let new_template = JS_EXTENSION_IN_FILENAME_RE
           .replace(template, ".css$1")
           .into_owned();
         Filename::from(new_template)
@@ -2738,8 +2749,7 @@ impl OutputOptionsBuilder {
 
     let css_chunk_filename = f!(self.css_chunk_filename.take(), || {
       if let Some(template) = chunk_filename.template() {
-        let new_template = regex::Regex::new(r"\.[mc]?js(\?|$)")
-          .expect("should initialize `Regex`")
+        let new_template = JS_EXTENSION_IN_FILENAME_RE
           .replace(template, ".css$1")
           .into_owned();
         Filename::from(new_template)
@@ -2761,6 +2771,11 @@ impl OutputOptionsBuilder {
     });
 
     // Generate unique name from library name or package.json
+    static LIBRARY_NAME_PLACEHOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
+      Regex::new(r"^\[(\\*[\w:]+\\*)\](\.)|(\.)\[(\\*[\w:]+\\*)\](\.|\z)|\[(\\*[\w:]+\\*)\]")
+        .expect("failed to create library name placeholder regex")
+    });
+
     let unique_name = f!(self.unique_name.take(), || {
       if let Some(library) = &self.library
         && let Some(name) = &library.name
@@ -2772,29 +2787,25 @@ impl OutputOptionsBuilder {
         };
 
         // Clean up library name using regex
-        let re = regex::Regex::new(
-          r"^\[(\\*[\w:]+\\*)\](\.)|(\.)\[(\\*[\w:]+\\*)\](\.|\z)|\[(\\*[\w:]+\\*)\]",
-        )
-        .expect("failed to create regex");
+        let cleaned_name =
+          LIBRARY_NAME_PLACEHOLDER_RE.replace_all(&library_name, |caps: &regex::Captures| {
+            let content = caps
+              .get(1)
+              .or_else(|| caps.get(4))
+              .or_else(|| caps.get(6))
+              .map_or("", |m| m.as_str());
 
-        let cleaned_name = re.replace_all(&library_name, |caps: &regex::Captures| {
-          let content = caps
-            .get(1)
-            .or_else(|| caps.get(4))
-            .or_else(|| caps.get(6))
-            .map_or("", |m| m.as_str());
-
-          if content.starts_with('\\') && content.ends_with('\\') {
-            format!(
-              "{}{}{}",
-              caps.get(3).map_or("", |_| "."),
-              format_args!("[{}]", &content[1..content.len() - 1]),
-              caps.get(2).map_or("", |_| ".")
-            )
-          } else {
-            String::new()
-          }
-        });
+            if content.starts_with('\\') && content.ends_with('\\') {
+              format!(
+                "{}{}{}",
+                caps.get(3).map_or("", |_| "."),
+                format_args!("[{}]", &content[1..content.len() - 1]),
+                caps.get(2).map_or("", |_| ".")
+              )
+            } else {
+              String::new()
+            }
+          });
 
         if !cleaned_name.is_empty() {
           return cleaned_name.into_owned();

--- a/crates/rspack/src/builder/target.rs
+++ b/crates/rspack/src/builder/target.rs
@@ -1,3 +1,6 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
 use rspack_browserslist::load_browserslist;
 use rspack_core::{CompilerPlatform, Context};
 
@@ -143,6 +146,25 @@ impl From<&TargetProperties> for CompilerPlatform {
   }
 }
 
+static NODE_TARGET_RE: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(r"^(async-)?node((\d+)(?:\.(\d+))?)?$").expect("should initialize `Regex`")
+});
+
+static BROWSERSLIST_TARGET_RE: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(r"^browserslist(?::(.+))?$").expect("should initialize `Regex`"));
+
+static ELECTRON_TARGET_RE: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(r"^electron((\d+)(?:\.(\d+))?)?-(main|preload|renderer)$")
+    .expect("should initialize `Regex`")
+});
+
+static NWJS_TARGET_RE: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(r"^(?:nwjs|node-webkit)((\d+)(?:\.(\d+))?)?$").expect("should initialize `Regex`")
+});
+
+static ES_TARGET_RE: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(r"^es(\d+)$").expect("should initialize `Regex`"));
+
 fn version_dependent(
   major: u32,
   minor: Option<u32>,
@@ -217,10 +239,7 @@ fn merge_target_properties(target_properties: &[TargetProperties]) -> TargetProp
 
 fn get_target_properties(target: &str, context: &Context) -> TargetProperties {
   // Parse target string
-  if let Some(captures) = regex::Regex::new(r"^(async-)?node((\d+)(?:\.(\d+))?)?$")
-    .expect("should initialize `Regex`")
-    .captures(target)
-  {
+  if let Some(captures) = NODE_TARGET_RE.captures(target) {
     let async_flag = captures.get(1).is_some();
     let major = captures.get(3).map(|m| {
       m.as_str()
@@ -269,10 +288,7 @@ fn get_target_properties(target: &str, context: &Context) -> TargetProperties {
     };
   }
 
-  if let Some(captures) = regex::Regex::new(r"^browserslist(?::(.+))?$")
-    .expect("should initialize `Regex`")
-    .captures(target)
-  {
+  if let Some(captures) = BROWSERSLIST_TARGET_RE.captures(target) {
     let rest = captures.get(1).map(|m| m.as_str());
 
     let browsers = load_browserslist(rest.map(|r| r.trim()), context).unwrap_or_default();
@@ -325,11 +341,7 @@ fn get_target_properties(target: &str, context: &Context) -> TargetProperties {
   }
 
   // Electron target
-  if let Some(captures) =
-    regex::Regex::new(r"^electron((\d+)(?:\.(\d+))?)?-(main|preload|renderer)$")
-      .expect("should initialize `Regex`")
-      .captures(target)
-  {
+  if let Some(captures) = ELECTRON_TARGET_RE.captures(target) {
     let major = captures.get(2).map(|m| {
       m.as_str()
         .parse::<u32>()
@@ -381,10 +393,7 @@ fn get_target_properties(target: &str, context: &Context) -> TargetProperties {
   }
 
   // NW.js target
-  if let Some(captures) = regex::Regex::new(r"^(?:nwjs|node-webkit)((\d+)(?:\.(\d+))?)?$")
-    .expect("should initialize `Regex`")
-    .captures(target)
-  {
+  if let Some(captures) = NWJS_TARGET_RE.captures(target) {
     let major = captures.get(2).map(|m| {
       m.as_str()
         .parse::<u32>()
@@ -428,10 +437,7 @@ fn get_target_properties(target: &str, context: &Context) -> TargetProperties {
   }
 
   // ES version target
-  if let Some(captures) = regex::Regex::new(r"^es(\d+)$")
-    .expect("should initialize `Regex`")
-    .captures(target)
-  {
+  if let Some(captures) = ES_TARGET_RE.captures(target) {
     let mut version = captures
       .get(1)
       .expect("should initialize `Regex`")

--- a/crates/rspack_browserslist/src/load_config.rs
+++ b/crates/rspack_browserslist/src/load_config.rs
@@ -1,4 +1,7 @@
+use std::sync::LazyLock;
+
 use browserslist::Opts;
+use regex::Regex;
 
 /// Configuration parsed from input string and context directory
 #[derive(Debug, Default)]
@@ -38,10 +41,12 @@ pub fn parse<'a>(input: Option<&str>, context: &'a str) -> BrowserslistHandlerCo
   // group 1: absolute path (optionally Windows drive letter)
   // group 2: optional env suffix after colon
   // same as JS: /^(?:((?:[A-Z]:)?[/\\].*?))?(?::(.+?))?$/i
-  let re = regex::Regex::new(r"^(?:((?:[A-Z]:)?[/\\].*?))?(?::(.+?))?$")
-    .expect("Should initialize browserlist regex");
+  static BROWSERSLIST_INPUT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:((?:[A-Z]:)?[/\\].*?))?(?::(.+?))?$")
+      .expect("Should initialize browserslist input regex")
+  });
 
-  if let Some(caps) = re.captures(input) {
+  if let Some(caps) = BROWSERSLIST_INPUT_RE.captures(input) {
     let config_path = caps.get(1).map(|m| m.as_str().to_string());
     let env = caps.get(2).map(|m| m.as_str().to_string());
 

--- a/crates/rspack_loader_swc/src/rsc_transforms/react_server_components.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/react_server_components.rs
@@ -23,6 +23,11 @@ use swc_core::{
 
 use super::{cjs_finder::contains_cjs, import_analyzer::ImportMap};
 
+static NODE_MODULES_PATH_REGEX: Lazy<Regex> = Lazy::new(|| {
+  #[allow(clippy::unwrap_used)]
+  Regex::new(r"node_modules[\\/]").unwrap()
+});
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum Config {
@@ -431,11 +436,7 @@ impl ReactServerComponentValidator {
   }
 
   fn is_from_node_modules(&self, filepath: &str) -> bool {
-    static RE: Lazy<Regex> = Lazy::new(|| {
-      #[allow(clippy::unwrap_used)]
-      Regex::new(r"node_modules[\\/]").unwrap()
-    });
-    RE.is_match(filepath)
+    NODE_MODULES_PATH_REGEX.is_match(filepath)
   }
 
   // Asserts the server lib apis

--- a/crates/rspack_plugin_esm_library/src/preserve_modules.rs
+++ b/crates/rspack_plugin_esm_library/src/preserve_modules.rs
@@ -8,6 +8,9 @@ use sugar_path::SugarPath;
 
 use crate::EsmLibraryPlugin;
 
+static EXTENSION_JS: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(r".+(\..+)$").expect("failed to compile EXTENSION_REGEXP"));
+
 pub fn entry_modules(compilation: &Compilation) -> FxHashMap<String, IdentifierSet> {
   let module_graph = compilation.get_module_graph();
   compilation
@@ -105,9 +108,6 @@ pub async fn preserve_modules(
         .unwrap_or(&compilation.options.output.filename)
         .template()
         .map_or(Cow::Borrowed(".js"), |tpl| {
-          static EXTENSION_JS: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r".+(\..+)$").expect("failed to compile EXTENSION_REGEXP"));
-
           if let Some(captures) = EXTENSION_JS.captures(tpl) {
             Cow::Owned(captures[1].to_string())
           } else {

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -38,6 +38,9 @@ use crate::{
 pub static PLUGIN_NAME: &str = "css-extract-rspack-plugin";
 
 pub static MODULE_TYPE_STR: LazyLock<Ustr> = LazyLock::new(|| Ustr::from("css/mini-extract"));
+
+static MEDIA_RE: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(r#";|\s*$"#).expect("should compile"));
 pub static MODULE_TYPE: LazyLock<ModuleType> =
   LazyLock::new(|| ModuleType::Custom(*MODULE_TYPE_STR));
 pub static SOURCE_TYPE: LazyLock<[SourceType; 1]> =
@@ -427,8 +430,6 @@ despite it was not able to fulfill desired ordering with these modules:
           external_source.add(header);
         }
         if let Some(media) = &module.media {
-          static MEDIA_RE: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r#";|\s*$"#).expect("should compile"));
           let new_content = MEDIA_RE.replace_all(content.as_ref(), media);
           external_source.add(RawStringSource::from(new_content.to_string() + "\n"));
         } else {

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -1,8 +1,9 @@
 use std::{
-  sync::Arc,
+  sync::{Arc, LazyLock},
   time::{Duration, Instant},
 };
 
+use regex::Regex;
 use rspack_core::{
   Compilation, CompilationParams, CompilationProcessAssets, CompilerCompilation, ModuleType,
   NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin,
@@ -13,6 +14,11 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   BoxJavascriptParserPlugin, parser_and_generator::JavaScriptParserAndGenerator,
 };
+
+static RSTEST_FLAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(r"\/\* RSTEST:(MOCK|UNMOCK|MOCKREQUIRE|HOISTED)_(.*?):(.*?) \*\/")
+    .expect("should initialize rstest flag regex")
+});
 
 use crate::{
   esm_import_dependency::{
@@ -204,9 +210,6 @@ async fn mock_hoist_process_assets(&self, compilation: &mut Compilation) -> Resu
     }
   }
 
-  let regex = regex::Regex::new(r"\/\* RSTEST:(MOCK|UNMOCK|MOCKREQUIRE|HOISTED)_(.*?):(.*?) \*\/")
-    .expect("should initialize `Regex`");
-
   for file in files {
     let mut pos_map: std::collections::HashMap<String, MockFlagPos> =
       std::collections::HashMap::new();
@@ -217,7 +220,7 @@ async fn mock_hoist_process_assets(&self, compilation: &mut Compilation) -> Resu
       }
 
       let content = old.source().into_string_lossy();
-      let captures: Vec<_> = regex.captures_iter(&content).collect();
+      let captures: Vec<_> = RSTEST_FLAG_RE.captures_iter(&content).collect();
 
       for c in captures {
         let [Some(full), Some(t), Some(request)] = [c.get(0), c.get(2), c.get(3)] else {

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -23,6 +23,9 @@ use rustc_hash::FxHashSet;
 use super::MaxSizeSetting;
 use crate::{SplitChunkSizes, SplitChunksPlugin};
 
+static MAX_SIZE_KEY_REGEX: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(r"^.*!|\?[^?!]*$").expect("should build regex"));
+
 #[derive(Debug)]
 struct GroupItem {
   module: ModuleIdentifier,
@@ -238,9 +241,7 @@ fn get_key(module: &dyn Module, delimiter: &str, compilation: &Compilation) -> S
       &name_for_condition,
     ))
   } else {
-    static RE: LazyLock<Regex> =
-      LazyLock::new(|| Regex::new(r"^.*!|\?[^?!]*$").expect("should build regex"));
-    RE.replace_all(&ident, "")
+    MAX_SIZE_KEY_REGEX.replace_all(&ident, "")
   };
 
   let full_key = format!(


### PR DESCRIPTION
## Summary
- Cache frequently used Rust regex patterns with module-level LazyLock/Regex to avoid repeated compilation on hot paths.
- Refactor builder targets, browserslist parsing, split chunks, extract CSS, rstest plugin and preserve_modules to use shared static regex instances.

## Test plan
- pnpm run build:cli:dev
- pnpm run test:base
- Verify no functional behavior changes in builder targets, filename templates, browserslist handling, splitChunks grouping, CSS extraction and rstest hoisting.