### PR TITLE
fix(esm-library): fix dynamic import of same-chunk concatenated modules and external name deconfliction

### DIFF
--- a/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
+++ b/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
@@ -4,7 +4,7 @@ use atomic_refcell::AtomicRefCell;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
   Dependency, DependencyId, DependencyTemplate, ExportsType, FakeNamespaceObjectMode, ModuleGraph,
-  RuntimeGlobals, TemplateContext, get_exports_type,
+  ModuleReferenceOptions, RuntimeGlobals, TemplateContext, get_exports_type,
 };
 use rspack_plugin_javascript::dependency::ImportDependency;
 use rspack_plugin_rslib::dyn_import_external::render_dyn_import_external_module;
@@ -221,7 +221,31 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
       return;
     }
 
-    // Check if the module needs namespace remapping (exports were renamed or namespace access)
+    if already_in_chunk {
+      // Same chunk + scope hoisted: the module's variables are already in scope.
+      // Use a namespace module reference so the link phase resolves it to the
+      // module's namespace object (e.g., `Promise.resolve(dynamic_namespaceObject)`).
+      let ns_ref = concatenation_scope.create_module_reference(
+        &ref_module.identifier(),
+        &ModuleReferenceOptions {
+          ids: vec![],
+          call: false,
+          direct_import: true,
+          deferred_import: false,
+          asi_safe: Some(true),
+          ..Default::default()
+        },
+      );
+      source.replace(
+        import_dep.range.start,
+        import_dep.range.end,
+        &format!("Promise.resolve({ns_ref})"),
+        None,
+      );
+      return;
+    }
+
+    // Cross-chunk: check if the module needs namespace remapping (exports were renamed or namespace access)
     let ns_name = {
       let ns_map = self.dyn_import_ns_map.borrow();
       ns_map.get(&ref_module.identifier()).cloned()

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -748,6 +748,24 @@ var {} = {{}};
       }
     }
 
+    // Build a targeted set for external module name deconfliction:
+    // Start from chunk_link.used_names (cross-chunk accumulated names) and add
+    // import binding names from raw_import_stmts. We do NOT use all_used_names here
+    // because it contains binding_to_ref keys (e.g., `cjs`, `foo`) that will be
+    // replaced during rendering and should not block external module names.
+    let mut external_used_names = chunk_link.used_names.clone();
+    for import_spec in chunk_link.raw_import_stmts.values() {
+      if let Some(ns) = &import_spec.ns_import {
+        external_used_names.insert(ns.clone());
+      }
+      for atom in import_spec.atoms.values() {
+        external_used_names.insert(atom.clone());
+      }
+      if let Some(default_import) = &import_spec.default_import {
+        external_used_names.insert(default_import.clone());
+      }
+    }
+
     for external_module in chunk_link.decl_modules.iter() {
       let ModuleInfo::External(info) = &mut concate_modules_map[external_module] else {
         unreachable!("should be un-scope-hoisted module");
@@ -761,11 +779,13 @@ var {} = {{}};
           context,
         );
 
-        info.name = Some(find_new_name(
+        let name = find_new_name(
           "",
-          &chunk_link.used_names,
+          &external_used_names,
           &escaped_identifiers[&readable_identifier],
-        ));
+        );
+        external_used_names.insert(name.clone());
+        info.name = Some(name);
       }
     }
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
@@ -7,12 +7,83 @@ export default dynamic;
 ```
 
 ```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+// NAMESPACE OBJECT: ./dynamic.js?1
+var dynamic1_namespaceObject = {};
+__webpack_require__.r(dynamic1_namespaceObject);
+__webpack_require__.d(dynamic1_namespaceObject, { 
+  "default": () => (dynamic1) });
+
+
+// ./dynamic.js?1
+/* export default */ const dynamic1 = (42);
+
 // ./index.js
+
+
 it('should support dynamic import', async () => {
 	const value = await import("./dynamic.mjs")
+	const value2 = await Promise.resolve(dynamic1_namespaceObject)
+
 	expect(value.default).toBe(42)
+	expect(dynamic1).toBe(42)
+	expect(value2.default).toBe(42)
 })
 
 
+```
+
+```mjs title=runtime.mjs
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, definition) => {
+	for(var key in definition) {
+        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+        }
+    }
+};
+})();
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+})();
+
+export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/basic/index.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/basic/index.js
@@ -1,5 +1,10 @@
+import defaultValue from "./dynamic?1";
+
 it('should support dynamic import', async () => {
 	const value = await import('./dynamic')
-	expect(value.default).toBe(42)
-})
+	const value2 = await import('./dynamic?1')
 
+	expect(value.default).toBe(42)
+	expect(defaultValue).toBe(42)
+	expect(value2.default).toBe(42)
+})


### PR DESCRIPTION
## Summary

- Fix dynamic import returning undefined for modules already concatenated in the same chunk by using namespace module references via ConcatenationScope
- Fix SyntaxError from duplicate identifier declarations by deconflicting external module names against import binding names
- Update dynamic-import/basic test case to cover static + dynamic import of the same module

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
