### PR TITLE
refactor: Improve codegen scope caching and async file reads

### DIFF
--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -134,21 +134,28 @@ pub(crate) async fn code_generation_modules(
   let mut jobs = Vec::new();
   for module in modules {
     let mut map: HashMap<RspackHashDigest, CodeGenerationJob> = HashMap::default();
+    let mut scope: Option<Option<ConcatenationScope>> = None;
     for runtime in chunk_graph.get_module_runtimes_iter(
       module,
       &compilation.build_chunk_graph_artifact.chunk_by_ukey,
     ) {
       let hash = ChunkGraph::get_module_hash(compilation, module, runtime)
         .expect("should have cgm.hash in code generation");
-      let scope = compilation
-        .plugin_driver
-        .compilation_hooks
-        .concatenation_scope
-        .call(compilation, module)
-        .await?;
       if let Some(job) = map.get_mut(hash) {
         job.runtimes.push(runtime.clone());
       } else {
+        let scope = if let Some(scope) = &scope {
+          scope.clone()
+        } else {
+          let new_scope = compilation
+            .plugin_driver
+            .compilation_hooks
+            .concatenation_scope
+            .call(compilation, module)
+            .await?;
+          scope = Some(new_scope.clone());
+          new_scope
+        };
         map.insert(
           hash.clone(),
           CodeGenerationJob {

--- a/crates/rspack_fs/src/native_fs.rs
+++ b/crates/rspack_fs/src/native_fs.rs
@@ -163,7 +163,7 @@ impl ReadableFileSystem for NativeFileSystem {
       return buffer.map_err(Error::from);
     }
 
-    fs::read(path).map_err(Error::from)
+    tokio::fs::read(path).await.to_fs_result()
   }
   #[instrument(skip(self), level = "debug")]
   fn read_sync(&self, path: &Utf8Path) -> Result<Vec<u8>> {

--- a/crates/rspack_plugin_schemes/src/file_uri.rs
+++ b/crates/rspack_plugin_schemes/src/file_uri.rs
@@ -8,7 +8,6 @@ use rspack_error::{Result, ToStringResultToRspackResultExt, error};
 use rspack_fs::ReadableFileSystem;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::AssertUtf8;
-use tokio::task::spawn_blocking;
 use url::Url;
 
 #[plugin]
@@ -53,13 +52,10 @@ async fn read_resource(
     && let Some(resource_path) = resource_data.path()
     && !resource_path.as_str().is_empty()
   {
-    let resource_path_owned = resource_path.to_owned();
-    let fs = fs.clone();
-    // use spawn_blocking to avoid block, see https://docs.rs/tokio/latest/src/tokio/fs/read.rs.html#48
-    let result = spawn_blocking(move || fs.read_sync(resource_path_owned.as_path()))
+    let result = fs
+      .read(resource_path)
       .await
-      .map_err(|e| error!("{e}, spawn task failed"))?;
-    let result = result.map_err(|e| error!("{e}, failed to read {resource_path}"))?;
+      .map_err(|e| error!("{e}, failed to read {resource_path}"))?;
     return Ok(Some(Content::from(result)));
   }
 

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-  collections::HashMap,
+  collections::{HashMap, HashSet},
   hash::Hash,
   path::Path,
   sync::{LazyLock, Mutex, mpsc},
@@ -162,8 +162,10 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let minimizer_options = &self.options.minimizer_options;
 
   let (tx, rx) = mpsc::channel::<Vec<Diagnostic>>();
-  // collect all extracted comments info
-  let all_extracted_comments = Mutex::new(HashMap::new());
+  let all_extracted_comments = options
+    .extract_comments
+    .as_ref()
+    .map(|_| Mutex::new(HashMap::new()));
   let extract_comments_condition = options
     .extract_comments
     .as_ref()
@@ -239,71 +241,35 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         });
 
         let javascript_compiler = JavaScriptCompiler::new();
-        let comments_op = |comments: &SingleThreadedComments| {
-          if let Some(ref extract_comments) = extract_comments_option {
-            let mut extracted_comments = vec![];
-            // add all matched comments to source
-
-            let (leading_trivial, trailing_trivial) = comments.borrow_all();
-
-            leading_trivial.iter().for_each(|(_, comments)| {
-              comments.iter().for_each(|c| {
-                if extract_comments.condition.is_match(&c.text) {
-                  let comment = match c.kind {
-                    CommentKind::Line => {
-                      format!("//{}", c.text)
-                    }
-                    CommentKind::Block => {
-                      format!("/*{}*/", c.text)
-                    }
-                  };
-                  if !extracted_comments.contains(&comment) {
-                    extracted_comments.push(comment);
-                  }
-                }
-              });
-            });
-            trailing_trivial.iter().for_each(|(_, comments)| {
-              comments.iter().for_each(|c| {
-                if extract_comments.condition.is_match(&c.text) {
-                  let comment = match c.kind {
-                    CommentKind::Line => {
-                      format!("//{}", c.text)
-                    }
-                    CommentKind::Block => {
-                      format!("/*{}*/", c.text)
-                    }
-                  };
-                  if !extracted_comments.contains(&comment) {
-                    extracted_comments.push(comment);
-                  }
-                }
-              });
-            });
-
-            // if not matched comments, we don't need to emit .License.txt file
-            if !extracted_comments.is_empty() {
-              extracted_comments.sort();
-              all_extracted_comments
-                .lock()
-                .expect("all_extract_comments lock failed")
-                .insert(
-                  filename.to_string(),
-                  ExtractedCommentsInfo {
-                    source: RawStringSource::from(extracted_comments.join("\n\n")).boxed(),
-                    comments_file_name: extract_comments.filename.clone(),
-                  },
-                );
-            }
-          }
+        let filename_string = filename.to_string();
+        let mut extracted_comments_info = None;
+        let (minify_result, banner) = if let Some(extract_comments_option) = extract_comments_option {
+          let minify_result = javascript_compiler.minify(
+            swc_core::common::FileName::Custom(filename_string.clone()),
+            input,
+            js_minify_options,
+            Some(|comments: &SingleThreadedComments| {
+              extracted_comments_info =
+                collect_extracted_comments_info(&extract_comments_option, comments);
+            }),
+          );
+          let banner = extracted_comments_info
+            .as_ref()
+            .and_then(|_| extract_comments_option.banner);
+          (minify_result, banner)
+        } else {
+          (
+            javascript_compiler.minify(
+              swc_core::common::FileName::Custom(filename_string.clone()),
+              input,
+              js_minify_options,
+              Option::<fn(&SingleThreadedComments)>::None,
+            ),
+            None,
+          )
         };
 
-        let mut output = match javascript_compiler.minify(
-          swc_core::common::FileName::Custom(filename.to_string()),
-          input,
-          js_minify_options,
-          Some(comments_op),
-        ) {
+        let mut output = match minify_result {
             Ok(r) => r,
             Err(e) => {
               let errors = e.into_inner().into_iter().map(|err| {
@@ -316,14 +282,14 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             },
         };
 
-        let banner = if all_extracted_comments
-          .lock()
-          .expect("all_extract_comments lock failed")
-          .contains_key(filename) {
-            extract_comments_option.and_then(|option| option.banner)
-          } else {
-            None
-          };
+        if let Some(extracted_comments_info) = extracted_comments_info {
+          all_extracted_comments
+            .as_ref()
+            .expect("must exist when extract comments enabled")
+            .lock()
+            .expect("all_extract_comments lock failed")
+            .insert(filename_string, extracted_comments_info);
+        }
 
         let source = match banner {
             Some(banner) => {
@@ -399,25 +365,76 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   compilation.extend_diagnostics(rx.into_iter().flatten().collect::<Vec<_>>());
 
   // write all extracted comments to assets
-  all_extracted_comments
-    .lock()
-    .expect("all_extracted_comments lock failed")
-    .clone()
-    .into_iter()
-    .for_each(|(_, comments)| {
-      compilation.emit_asset(
-        comments.comments_file_name,
-        CompilationAsset::new(
-          Some(comments.source),
-          AssetInfo {
-            minimized: Some(true),
-            ..Default::default()
-          },
-        ),
-      )
-    });
+  if let Some(all_extracted_comments) = all_extracted_comments {
+    all_extracted_comments
+      .lock()
+      .expect("all_extracted_comments lock failed")
+      .clone()
+      .into_iter()
+      .for_each(|(_, comments)| {
+        compilation.emit_asset(
+          comments.comments_file_name,
+          CompilationAsset::new(
+            Some(comments.source),
+            AssetInfo {
+              minimized: Some(true),
+              ..Default::default()
+            },
+          ),
+        )
+      });
+  }
 
   Ok(())
+}
+
+fn collect_extracted_comments_info(
+  extract_comments: &NormalizedExtractComments<'_>,
+  comments: &SingleThreadedComments,
+) -> Option<ExtractedCommentsInfo> {
+  let mut extracted_comments: HashSet<String> = HashSet::default();
+  let (leading_trivial, trailing_trivial) = comments.borrow_all();
+
+  leading_trivial.iter().for_each(|(_, comments)| {
+    comments.iter().for_each(|comment| {
+      if extract_comments.condition.is_match(&comment.text) {
+        extracted_comments.insert(match comment.kind {
+          CommentKind::Line => {
+            format!("//{}", comment.text)
+          }
+          CommentKind::Block => {
+            format!("/*{}*/", comment.text)
+          }
+        });
+      }
+    });
+  });
+  trailing_trivial.iter().for_each(|(_, comments)| {
+    comments.iter().for_each(|comment| {
+      if extract_comments.condition.is_match(&comment.text) {
+        extracted_comments.insert(match comment.kind {
+          CommentKind::Line => {
+            format!("//{}", comment.text)
+          }
+          CommentKind::Block => {
+            format!("/*{}*/", comment.text)
+          }
+        });
+      }
+    });
+  });
+
+  if extracted_comments.is_empty() {
+    return None;
+  }
+
+  let mut extracted_comments = extracted_comments.into_iter().collect::<Vec<_>>();
+  extracted_comments.sort();
+
+  Some(ExtractedCommentsInfo {
+    source: RawStringSource::from(extracted_comments.join("\n\n")).boxed(),
+    comments_file_name: extract_comments.filename.clone(),
+  })
 }
 
 pub fn match_object(obj: &PluginOptions, str: &str) -> bool {


### PR DESCRIPTION
## Summary
- cache the concatenation scope lookup per module when batching code generation jobs to avoid repeated hook calls
- switch native filesystem reading to `tokio::fs::read` and simplify file URI plugin to rely on the async API directly
- streamline the SWC comments extraction flow to avoid redundant locks and only allocate when needed

## Testing
- Not run (not requested)
