### PR TITLE
perf(binding): reduce module graph connection traversal overhead

### DIFF
--- a/crates/rspack_binding_api/src/module_graph.rs
+++ b/crates/rspack_binding_api/src/module_graph.rs
@@ -163,11 +163,16 @@ impl JsModuleGraph {
   ) -> napi::Result<Array<'a>> {
     let (compilation, module_graph) = self.as_ref()?;
     let vec = &mut self.connection_vec_buffer;
-    for connection in module_graph.get_outgoing_connections(&module.identifier) {
-      vec.push(ModuleGraphConnectionWrapper::new(
-        connection.dependency_id,
-        compilation,
-      ));
+    if let Some(module_graph_module) =
+      module_graph.module_graph_module_by_identifier(&module.identifier)
+    {
+      vec.reserve(module_graph_module.outgoing_connections().len());
+      for dependency_id in module_graph_module.outgoing_connections() {
+        vec.push(ModuleGraphConnectionWrapper::new(
+          *dependency_id,
+          compilation,
+        ));
+      }
     }
     let mut arr = env.create_array(vec.len() as u32)?;
     for (i, v) in vec.drain(..).enumerate() {
@@ -213,11 +218,16 @@ impl JsModuleGraph {
     let (compilation, module_graph) = self.as_ref()?;
 
     let vec = &mut self.connection_vec_buffer;
-    for connection in module_graph.get_incoming_connections(&module.identifier) {
-      vec.push(ModuleGraphConnectionWrapper::new(
-        connection.dependency_id,
-        compilation,
-      ));
+    if let Some(module_graph_module) =
+      module_graph.module_graph_module_by_identifier(&module.identifier)
+    {
+      vec.reserve(module_graph_module.incoming_connections().len());
+      for dependency_id in module_graph_module.incoming_connections() {
+        vec.push(ModuleGraphConnectionWrapper::new(
+          *dependency_id,
+          compilation,
+        ));
+      }
     }
     let mut arr = env.create_array(vec.len() as u32)?;
     for (i, v) in vec.drain(..).enumerate() {


### PR DESCRIPTION
## Summary
- update `JsModuleGraph.get_outgoing_connections` and `get_incoming_connections` to iterate dependency ids directly from `ModuleGraphModule` edge sets instead of materializing iterators that repeatedly probe `connection_by_dependency_id`
- keep the existing reusable `connection_vec_buffer` path so N-API array construction still avoids per-call Vec reallocations while cutting extra hash lookups and transient work
- target a memory-allocation/perf hotspot from the ScriptedAlchemy perf-opportunities notes for module graph traversal APIs

## Performance Verification
- build: `pnpm run build:binding:dev`
- benchmark script: Node benchmark over `tests/bench/fixtures/ts-react`, 30,000 rounds of:
  - `moduleGraph.getOutgoingConnections(module)`
  - `moduleGraph.getOutgoingConnectionsInOrder(module)`
  - `moduleGraph.getIncomingConnections(module)`
- baseline (before): `2647.09 ms`
- optimized (after): `2412.70 ms`
- improvement: **8.85% faster**