### PR TITLE
perf: Add smallvec-backed member chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,6 +4588,7 @@ dependencies = [
  "rustc-hash",
  "serde_json",
  "slotmap",
+ "smallvec",
  "sugar_path",
  "swc_core",
  "swc_node_comments",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ sftrace-setup       = { version = "0.1.2", default-features = false }
 sha2                = { version = "0.10.9", default-features = false }
 signal-hook         = { version = "0.3.18", default-features = false, features = ["iterator"] }
 simd-json           = { version = "0.17.0", default-features = false }
+smallvec            = { version = "1.15.1", default-features = false }
 slotmap             = { version = "1.1.1", default-features = false }
 smol_str            = { version = "0.3.5", default-features = false }
 stacker             = { version = "0.1.23", default-features = false }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -35,6 +35,7 @@ rspack_regex = { workspace = true }
 rspack_util = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
+smallvec = { workspace = true }
 slotmap = { workspace = true }
 sugar_path = { workspace = true }
 swc_core = { workspace = true, features = [

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -23,8 +23,9 @@ use crate::{
   magic_comment::try_extract_magic_comment,
   utils::eval::{self, BasicEvaluatedExpression},
   visitors::{
-    JavascriptParser, TagInfoData, VariableDeclaration, VariableDeclarationKind, context_reg_exp,
-    create_context_dependency, create_traceable_error, expr_name, get_non_optional_part,
+    AtomMembers, JavascriptParser, TagInfoData, VariableDeclaration, VariableDeclarationKind,
+    context_reg_exp, create_context_dependency, create_traceable_error, expr_name,
+    get_non_optional_part,
   },
 };
 
@@ -53,9 +54,16 @@ impl RequireReferencesState {
   ) -> impl Iterator<Item = (RequireDependencyLocator, Vec<Vec<Atom>>)> + use<> {
     let inner = std::mem::take(&mut self.inner);
     inner.into_values().filter_map(|value| {
-      value
-        .dep_locator
-        .map(|dep_locator| (dep_locator, value.references))
+      value.dep_locator.map(|dep_locator| {
+        (
+          dep_locator,
+          value
+            .references
+            .into_iter()
+            .map(AtomMembers::into_vec)
+            .collect(),
+        )
+      })
     })
   }
 }
@@ -63,11 +71,11 @@ impl RequireReferencesState {
 #[derive(Debug, Default)]
 struct RequireReferences {
   dep_locator: Option<RequireDependencyLocator>,
-  references: Vec<Vec<Atom>>,
+  references: Vec<AtomMembers>,
 }
 
 impl RequireReferences {
-  pub fn add_reference(&mut self, reference: Vec<Atom>) {
+  pub fn add_reference(&mut self, reference: AtomMembers) {
     self.references.push(reference);
   }
 }
@@ -626,7 +634,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
       {
         let mut refs = Vec::new();
         keys.traverse_on_leaf(&mut |stack| {
-          refs.push(stack.iter().map(|p| p.id.clone()).collect());
+          refs.push(stack.iter().map(|p| p.id.clone()).collect::<AtomMembers>());
         });
         for ids in refs {
           parser
@@ -638,7 +646,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
         parser
           .common_js_require_references
           .get_require_mut_expect(&data.require_span)
-          .add_reference(vec![]);
+          .add_reference(AtomMembers::new());
       }
       return Some(true);
     }
@@ -670,7 +678,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     parser
       .common_js_require_references
       .get_require_mut_expect(&data.require_span)
-      .add_reference(ids.to_vec());
+      .add_reference(ids.iter().cloned().collect());
     Some(true)
   }
 
@@ -703,7 +711,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     parser
       .common_js_require_references
       .get_require_mut_expect(&data.require_span)
-      .add_reference(ids.to_vec());
+      .add_reference(ids.iter().cloned().collect());
     parser.walk_expr_or_spread(&expr.args);
     Some(true)
   }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -108,7 +108,7 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
       let mut dep = ESMExportImportedSpecifierDependency::new(
         settings.source,
         settings.source_order,
-        settings.ids,
+        settings.ids.into_vec(),
         Some(export_name.clone()),
         None,
         statement.span().into(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -14,9 +14,9 @@ use crate::{
   parser_plugin::inner_graph::state::InnerGraphUsageOperation,
   utils::object_properties::get_attributes,
   visitors::{
-    AllowedMemberTypes, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo, TagInfoData,
-    get_non_optional_member_chain_from_expr, get_non_optional_member_chain_from_member,
-    get_non_optional_part,
+    AllowedMemberTypes, AtomMembers, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo,
+    TagInfoData, get_non_optional_member_chain_from_expr,
+    get_non_optional_member_chain_from_member, get_non_optional_part,
   },
 };
 
@@ -28,7 +28,7 @@ pub const ESM_SPECIFIER_TAG: &str = "_identifier__esm_specifier_tag__";
 pub struct ESMSpecifierData {
   pub name: Atom,
   pub source: Atom,
-  pub ids: Vec<Atom>,
+  pub ids: AtomMembers,
   pub source_order: i32,
   pub phase: ImportPhase,
   pub attributes: Option<ImportAttributes>,
@@ -99,7 +99,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       Some(ESMSpecifierData {
         name: name.clone(),
         source: source.clone(),
-        ids: id.map(|id| vec![id.clone()]).unwrap_or_default(),
+        ids: id.into_iter().cloned().collect(),
         source_order: parser.last_esm_import_order,
         phase,
         attributes: statement.with.as_ref().map(|obj| get_attributes(obj)),
@@ -145,7 +145,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       parser.in_short_hand,
       !parser.is_asi_position(expr.span_lo()),
       expr.span.into(),
-      ids,
+      ids.into_vec(),
       parser.in_tagged_template_tag,
       direct_import,
       ExportPresenceMode::None,
@@ -211,7 +211,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       parser.in_short_hand,
       !parser.is_asi_position(ident.span_lo()),
       ident.span.into(),
-      settings.ids,
+      settings.ids.into_vec(),
       parser.in_tagged_template_tag,
       true,
       ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
@@ -271,7 +271,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       false,
       !parser.is_asi_position(call_expr.span_lo()),
       span.into(),
-      ids,
+      ids.into_vec(),
       true,
       direct_import,
       ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
@@ -339,7 +339,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       false,
       !parser.is_asi_position(member_expr.span_lo()),
       span.into(),
-      ids,
+      ids.into_vec(),
       false,
       false, // x.xx()
       ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -22,10 +22,10 @@ use crate::{
   magic_comment::try_extract_magic_comment,
   utils::object_properties::{get_attributes, get_value_by_obj_prop},
   visitors::{
-    AllowedMemberTypes, ContextModuleScanResult, ExportedVariableInfo, JavascriptParser,
-    MemberExpressionInfo, Statement, TagInfoData, TopLevelScope, VariableDeclaration,
-    VariableDeclarationKind, context_reg_exp, create_context_dependency, create_traceable_error,
-    get_non_optional_part, parse_order_string,
+    AllowedMemberTypes, AtomMembers, ContextModuleScanResult, ExportedVariableInfo,
+    JavascriptParser, MemberExpressionInfo, Statement, TagInfoData, TopLevelScope,
+    VariableDeclaration, VariableDeclarationKind, context_reg_exp, create_context_dependency,
+    create_traceable_error, get_non_optional_part, parse_order_string,
   },
 };
 
@@ -71,20 +71,29 @@ impl ImportsReferencesState {
     &mut self,
   ) -> impl Iterator<Item = (ImportDependencyLocator, Vec<Vec<Atom>>)> + use<> {
     let inner = std::mem::take(&mut self.inner);
-    inner
-      .into_values()
-      .filter_map(|value| value.dep_locator.map(|locator| (locator, value.references)))
+    inner.into_values().filter_map(|value| {
+      value.dep_locator.map(|locator| {
+        (
+          locator,
+          value
+            .references
+            .into_iter()
+            .map(AtomMembers::into_vec)
+            .collect(),
+        )
+      })
+    })
   }
 }
 
 #[derive(Debug, Default)]
 struct ImportReferences {
   dep_locator: Option<ImportDependencyLocator>,
-  references: Vec<Vec<Atom>>,
+  references: Vec<AtomMembers>,
 }
 
 impl ImportReferences {
-  pub fn add_reference(&mut self, reference: Vec<Atom>) {
+  pub fn add_reference(&mut self, reference: AtomMembers) {
     self.references.push(reference);
   }
 }
@@ -165,7 +174,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
     {
       let mut refs = Vec::new();
       keys.traverse_on_leaf(&mut |stack| {
-        refs.push(stack.iter().map(|p| p.id.clone()).collect());
+        refs.push(stack.iter().map(|p| p.id.clone()).collect::<AtomMembers>());
       });
       for ids in refs {
         parser
@@ -177,7 +186,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
       parser
         .dynamic_import_references
         .get_import_mut_expect(&data.import_span)
-        .add_reference(vec![]);
+        .add_reference(AtomMembers::new());
     }
     Some(true)
   }
@@ -202,7 +211,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
     parser
       .dynamic_import_references
       .get_import_mut_expect(&data.import_span)
-      .add_reference(ids.to_vec());
+      .add_reference(ids.iter().cloned().collect());
     Some(true)
   }
 
@@ -237,7 +246,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
     parser
       .dynamic_import_references
       .get_import_mut_expect(&data.import_span)
-      .add_reference(ids.to_vec());
+      .add_reference(ids.iter().cloned().collect());
     parser.walk_expr_or_spread(&expr.args);
     Some(true)
   }
@@ -597,7 +606,7 @@ fn walk_import_then_fulfilled_callback(
             .get_import_mut_expect(&import_call.span());
           let mut refs = Vec::new();
           keys.traverse_on_leaf(&mut |stack| {
-            refs.push(stack.iter().map(|p| p.id.clone()).collect());
+            refs.push(stack.iter().map(|p| p.id.clone()).collect::<AtomMembers>());
           });
           for ids in refs {
             import_references.add_reference(ids);

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
@@ -32,9 +32,9 @@ pub fn eval_member_expression<'a>(
         eval.set_identifier(
           info.name.into(),
           info.root_info,
-          Some(info.members),
-          Some(info.members_optionals),
-          Some(info.member_ranges),
+          Some(info.members.into_vec()),
+          Some(info.members_optionals.into_vec()),
+          Some(info.member_ranges.into_vec()),
         );
         Some(eval)
       })

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -15,9 +15,10 @@ use swc_core::common::{BytePos, Mark, comments::Comments};
 pub use self::{
   context_dependency_helper::{ContextModuleScanResult, create_context_dependency},
   parser::{
-    AllowedMemberTypes, CallExpressionInfo, CallHooksName, DestructuringAssignmentProperties,
-    DestructuringAssignmentProperty, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo,
-    RootName, ScopeTerminated, TagInfoData, TopLevelScope, ast::*, estree::*,
+    AllowedMemberTypes, AtomMembers, CallExpressionInfo, CallHooksName,
+    DestructuringAssignmentProperties, DestructuringAssignmentProperty, ExportedVariableInfo,
+    JavascriptParser, MemberExpressionInfo, MemberRanges, OptionalMembers, RootName,
+    ScopeTerminated, TagInfoData, TopLevelScope, ast::*, estree::*,
   },
   util::*,
 };

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -29,6 +29,7 @@ use rspack_core::{
 use rspack_error::{Diagnostic, Result};
 use rspack_util::{SpanExt, fx_hash::FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 use swc_core::{
   atoms::Atom,
   common::{BytePos, Mark, Span, Spanned, comments::Comments},
@@ -81,12 +82,17 @@ where
   }
 }
 
+// Most parsed member chains are one or two segments long, so keep them inline.
+pub type AtomMembers = SmallVec<[Atom; 2]>;
+pub type OptionalMembers = SmallVec<[bool; 2]>;
+pub type MemberRanges = SmallVec<[Span; 2]>;
+
 #[derive(Debug)]
 pub struct ExtractedMemberExpressionChainData<'ast> {
   pub object: ExprRef<'ast>,
-  pub members: Vec<Atom>,
-  pub members_optionals: Vec<bool>,
-  pub member_ranges: Vec<Span>,
+  pub members: AtomMembers,
+  pub members_optionals: OptionalMembers,
+  pub member_ranges: MemberRanges,
 }
 
 bitflags! {
@@ -107,19 +113,19 @@ pub enum MemberExpressionInfo<'ast> {
 pub struct CallExpressionInfo<'ast> {
   pub call: &'ast CallExpr,
   pub root_info: ExportedVariableInfo,
-  pub callee_members: Vec<Atom>,
-  pub members: Vec<Atom>,
-  pub members_optionals: Vec<bool>,
-  pub member_ranges: Vec<Span>,
+  pub callee_members: AtomMembers,
+  pub members: AtomMembers,
+  pub members_optionals: OptionalMembers,
+  pub member_ranges: MemberRanges,
 }
 
 #[derive(Debug)]
 pub struct ExpressionExpressionInfo {
   pub name: String,
   pub root_info: ExportedVariableInfo,
-  pub members: Vec<Atom>,
-  pub members_optionals: Vec<bool>,
-  pub member_ranges: Vec<Span>,
+  pub members: AtomMembers,
+  pub members_optionals: OptionalMembers,
+  pub member_ranges: MemberRanges,
 }
 
 #[derive(Debug, Clone)]
@@ -902,9 +908,9 @@ impl<'parser> JavascriptParser<'parser> {
   fn _get_member_expression_info<'ast>(
     &mut self,
     object: ExprRef<'ast>,
-    mut members: Vec<Atom>,
-    mut members_optionals: Vec<bool>,
-    mut member_ranges: Vec<Span>,
+    mut members: AtomMembers,
+    mut members_optionals: OptionalMembers,
+    mut member_ranges: MemberRanges,
     allowed_types: AllowedMemberTypes,
   ) -> Option<MemberExpressionInfo<'ast>> {
     match object {
@@ -918,7 +924,7 @@ impl<'parser> JavascriptParser<'parser> {
           let root_name = extracted.object.get_root_name()?;
           (root_name, extracted.members)
         } else {
-          (callee.get_root_name()?, vec![])
+          (callee.get_root_name()?, AtomMembers::new())
         };
         let NameInfo {
           info: root_info, ..
@@ -981,7 +987,13 @@ impl<'parser> JavascriptParser<'parser> {
       Expr::Member(_) | Expr::OptChain(_) => {
         self.get_member_expression_info(expr.into(), allowed_types)
       }
-      _ => self._get_member_expression_info(expr.into(), vec![], vec![], vec![], allowed_types),
+      _ => self._get_member_expression_info(
+        expr.into(),
+        AtomMembers::new(),
+        OptionalMembers::new(),
+        MemberRanges::new(),
+        allowed_types,
+      ),
     }
   }
 
@@ -1010,9 +1022,9 @@ impl<'parser> JavascriptParser<'parser> {
     expr: ExprRef<'ast>,
   ) -> ExtractedMemberExpressionChainData<'ast> {
     let mut object = expr;
-    let mut members = Vec::new();
-    let mut members_optionals = Vec::new();
-    let mut member_ranges = Vec::new();
+    let mut members = AtomMembers::new();
+    let mut members_optionals = OptionalMembers::new();
+    let mut member_ranges = MemberRanges::new();
     let mut in_optional_chain = self.member_expr_in_optional_chain;
     loop {
       match object {


### PR DESCRIPTION
## Summary
- introduce `AtomMembers`/`OptionalMembers`/`MemberRanges` wrappers backed by `SmallVec` to keep short member chains inline
- adapt dependency visitor exports and parser plugins to consume and emit `AtomMembers`, minimizing heap work while preserving API vectors only when needed
- add the `smallvec` dependency to the JS plugin crate and root workspace

## Testing
- Not run (not requested)