### PR TITLE
perf: Replace ModuleGraphData dependencies with SlotMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,6 +3835,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "slotmap",
  "sugar_path",
  "swc_core",
  "swc_experimental_ecma_ast",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -59,6 +59,7 @@ rustc-hash                 = { workspace = true }
 scopeguard                 = { workspace = true }
 serde                      = { workspace = true }
 serde_json                 = { workspace = true }
+slotmap                    = { workspace = true }
 sugar_path                 = { workspace = true }
 swc_core                   = { workspace = true, features = ["__ecma", "__visit", "__utils", "__ecma_transforms", "ecma_ast", "ecma_parser", "ecma_codegen", "ecma_quote", "common_concurrent", "swc_ecma_ast", "ecma_transforms_react", "ecma_transforms_module", "swc_ecma_codegen", "swc_ecma_visit"] }
 tokio                      = { workspace = true, features = ["rt", "macros"] }

--- a/crates/rspack_core/src/cache/persistent/occasion/make/alternatives/dependency.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/alternatives/dependency.rs
@@ -12,6 +12,12 @@ pub struct TempDependency {
 }
 
 impl TempDependency {
+  pub fn new() -> Self {
+    Self {
+      id: DependencyId::new(),
+    }
+  }
+
   pub fn transform_from(dep: OwnedOrRef<BoxDependency>) -> OwnedOrRef<BoxDependency> {
     OwnedOrRef::Owned(Box::new(TempDependency {
       id: *dep.as_ref().id(),

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -114,7 +114,7 @@ impl Occasion for MakeOccasion {
     for (dep_id, dep) in mg.dependencies() {
       if let Some(info) = FactorizeInfo::get_from(dep) {
         if !info.is_success() {
-          make_failed_dependencies.insert(*dep_id);
+          make_failed_dependencies.insert(dep_id);
         }
         let resource = dep_id.into();
         file_dep.add_files(&resource, info.file_dependencies());

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -185,7 +185,7 @@ pub async fn recovery_module_graph(
   }
   let mut entry_dependencies: FxHashSet<DependencyId> = Default::default();
   for mid in entry_module {
-    let dep = TempDependency::default();
+    let dep = TempDependency::new();
     let connection = ModuleGraphConnection::new(*dep.id(), None, mid, false);
     entry_dependencies.insert(*dep.id());
     mg.add_dependency(Box::new(dep));

--- a/crates/rspack_core/src/dependency/dependency_id.rs
+++ b/crates/rspack_core/src/dependency/dependency_id.rs
@@ -1,38 +1,104 @@
 use rspack_cacheable::cacheable;
 use rspack_tasks::fetch_new_dependency_id;
-use serde::Serialize;
+use serde::{Serialize, Serializer};
+use slotmap::{Key, KeyData};
 
 #[cacheable(hashable)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
-pub struct DependencyId(u32);
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[repr(transparent)]
+pub struct DependencyId(u64);
 
 impl DependencyId {
   pub fn new() -> Self {
-    let id = fetch_new_dependency_id();
-    Self(id)
+    Self::from(fetch_new_dependency_id())
   }
 
   pub fn as_u32(&self) -> u32 {
+    self.0 as u32
+  }
+
+  pub fn as_ffi(&self) -> u64 {
     self.0
+  }
+
+  pub fn is_null(&self) -> bool {
+    <Self as Key>::is_null(self)
   }
 }
 
 impl Default for DependencyId {
   fn default() -> Self {
-    Self::new()
-  }
-}
-
-impl std::ops::Deref for DependencyId {
-  type Target = u32;
-
-  fn deref(&self) -> &Self::Target {
-    &self.0
+    <Self as Key>::null()
   }
 }
 
 impl From<u32> for DependencyId {
   fn from(id: u32) -> Self {
-    Self(id)
+    KeyData::from_ffi((1_u64 << 32) | u64::from(id)).into()
+  }
+}
+
+impl From<KeyData> for DependencyId {
+  fn from(value: KeyData) -> Self {
+    Self(value.as_ffi())
+  }
+}
+
+unsafe impl Key for DependencyId {
+  fn data(&self) -> KeyData {
+    KeyData::from_ffi(self.0)
+  }
+}
+
+impl std::fmt::Debug for DependencyId {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    self.data().fmt(f)
+  }
+}
+
+impl std::hash::Hash for DependencyId {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    state.write_u32(self.as_u32());
+  }
+}
+
+impl Serialize for DependencyId {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    serializer.serialize_u32(self.as_u32())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rspack_tasks::within_compiler_context_for_testing_sync;
+  use slotmap::SecondaryMap;
+
+  use super::DependencyId;
+
+  #[test]
+  fn default_dependency_id_is_null_key() {
+    assert!(DependencyId::default().is_null());
+  }
+
+  #[test]
+  fn generated_dependency_ids_work_with_secondary_map() {
+    within_compiler_context_for_testing_sync(|| {
+      let first = DependencyId::new();
+      let second = DependencyId::new();
+      let mut map = SecondaryMap::new();
+
+      assert_ne!(first, second);
+      assert!(!first.is_null());
+      assert!(!second.is_null());
+
+      map.insert(first, "first");
+      map.insert(second, "second");
+
+      assert_eq!(map.get(first), Some(&"first"));
+      assert_eq!(map.get(second), Some(&"second"));
+    });
   }
 }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -9,6 +9,7 @@ use rspack_collections::{IdentifierHasher, IdentifierMap};
 use rspack_error::Result;
 use rspack_hash::RspackHashDigest;
 use rustc_hash::{FxHashMap as HashMap, FxHasher};
+use slotmap::SecondaryMap;
 use swc_core::ecma::atoms::Atom;
 
 use crate::{
@@ -34,6 +35,49 @@ pub type BuildDependency = (
   DependencyId,
   Option<ModuleIdentifier>, /* parent module */
 );
+
+#[derive(Debug)]
+struct ModuleGraphDependencies {
+  inner: SecondaryMap<DependencyId, BoxDependency>,
+}
+
+impl Default for ModuleGraphDependencies {
+  fn default() -> Self {
+    Self {
+      inner: SecondaryMap::new(),
+    }
+  }
+}
+
+impl ModuleGraphDependencies {
+  fn get(&self, dependency_id: &DependencyId) -> Option<&BoxDependency> {
+    self.inner.get(*dependency_id)
+  }
+
+  fn get_mut(&mut self, dependency_id: &DependencyId) -> Option<&mut BoxDependency> {
+    self.inner.get_mut(*dependency_id)
+  }
+
+  fn insert(&mut self, dependency: BoxDependency) -> Option<BoxDependency> {
+    let dependency_id = *dependency.id();
+    assert!(
+      !dependency_id.is_null(),
+      "Dependency with null key cannot be inserted into ModuleGraph"
+    );
+    self.inner.insert(dependency_id, dependency)
+  }
+
+  fn remove(&mut self, dependency_id: &DependencyId) -> Option<BoxDependency> {
+    if dependency_id.is_null() {
+      return None;
+    }
+    self.inner.remove(*dependency_id)
+  }
+
+  fn iter(&self) -> impl Iterator<Item = (DependencyId, &BoxDependency)> {
+    self.inner.iter()
+  }
+}
 
 /// https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/ModuleGraph.js#L742-L748
 #[derive(Debug, Clone)]
@@ -111,8 +155,8 @@ pub(crate) struct ModuleGraphData {
   pub(crate) modules:
     rollback::RollbackMap<ModuleIdentifier, BoxModule, BuildHasherDefault<IdentifierHasher>>,
 
-  /// Dependencies indexed by `DependencyId`.
-  dependencies: HashMap<DependencyId, BoxDependency>,
+  /// Dependencies stored in a slotmap `SecondaryMap`, indexed by `DependencyId`.
+  dependencies: ModuleGraphDependencies,
   /// AsyncDependenciesBlocks indexed by `AsyncDependenciesBlockIdentifier`.
   blocks: AsyncDependenciesBlockIdentifierMap<Box<AsyncDependenciesBlock>>,
 
@@ -611,12 +655,12 @@ impl ModuleGraph {
     &self.inner.blocks
   }
 
-  pub fn dependencies(&self) -> impl Iterator<Item = (&DependencyId, &BoxDependency)> {
+  pub fn dependencies(&self) -> impl Iterator<Item = (DependencyId, &BoxDependency)> {
     self.inner.dependencies.iter()
   }
 
   pub fn add_dependency(&mut self, dependency: BoxDependency) {
-    self.inner.dependencies.insert(*dependency.id(), dependency);
+    self.inner.dependencies.insert(dependency);
   }
 
   /// Get a dependency by ID, panicking if not found.
@@ -1181,5 +1225,69 @@ impl ModuleGraph {
         .as_data_mut(exports_info_artifact)
         .set_used_name(used_name);
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rspack_tasks::within_compiler_context_for_testing_sync;
+
+  use super::ModuleGraphDependencies;
+  use crate::{BoxDependency, Context, EntryDependency};
+
+  fn entry_dependency(request: &str) -> BoxDependency {
+    Box::new(EntryDependency::new(
+      request.to_string(),
+      Context::from("/"),
+      None,
+      false,
+    ))
+  }
+
+  #[test]
+  fn dependency_store_keeps_lookup_consistent_after_removal() {
+    within_compiler_context_for_testing_sync(|| {
+      let mut dependencies = ModuleGraphDependencies::default();
+
+      let first = entry_dependency("./first");
+      let first_id = *first.id();
+      let second = entry_dependency("./second");
+      let second_id = *second.id();
+
+      dependencies.insert(first);
+      dependencies.insert(second);
+
+      assert_eq!(
+        dependencies.get(&first_id).map(|dep| dep.id()),
+        Some(&first_id)
+      );
+      assert_eq!(
+        dependencies.remove(&first_id).map(|dep| *dep.id()),
+        Some(first_id)
+      );
+      assert!(dependencies.get(&first_id).is_none());
+
+      let third = entry_dependency("./third");
+      let third_id = *third.id();
+      dependencies.insert(third);
+
+      assert_eq!(
+        dependencies.get(&second_id).map(|dep| dep.id()),
+        Some(&second_id)
+      );
+      assert_eq!(
+        dependencies.get(&third_id).map(|dep| dep.id()),
+        Some(&third_id)
+      );
+
+      let dependency_ids = dependencies
+        .iter()
+        .map(|(dependency_id, _)| dependency_id)
+        .collect::<Vec<_>>();
+
+      assert_eq!(dependency_ids.len(), 2);
+      assert!(dependency_ids.contains(&second_id));
+      assert!(dependency_ids.contains(&third_id));
+    });
   }
 }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -177,9 +177,9 @@ pub(crate) struct ModuleGraphData {
   ///     assert_eq!(parents_info.module, parent_module_id);
   ///   })
   /// ```
-  dependency_id_to_parents: HashMap<DependencyId, DependencyParents>,
+  dependency_id_to_parents: SecondaryMap<DependencyId, DependencyParents>,
   // TODO try move condition as connection field
-  connection_to_condition: HashMap<DependencyId, DependencyCondition>,
+  connection_to_condition: SecondaryMap<DependencyId, DependencyCondition>,
 
   /************************** Modified by Seal Phase **********************/
   /// ModuleGraphModule indexed by `ModuleIdentifier`.
@@ -350,8 +350,8 @@ impl ModuleGraph {
     }
     if force {
       self.inner.dependencies.remove(dep_id);
-      self.inner.dependency_id_to_parents.remove(dep_id);
-      self.inner.connection_to_condition.remove(dep_id);
+      self.inner.dependency_id_to_parents.remove(*dep_id);
+      self.inner.connection_to_condition.remove(*dep_id);
       if let Some(m_id) = original_module_identifier
         && let Some(module) = self.inner.modules.get_mut(&m_id)
       {
@@ -610,7 +610,7 @@ impl ModuleGraph {
     self
       .inner
       .dependency_id_to_parents
-      .get(dependency_id)
+      .get(*dependency_id)
       .map(|p| &p.module)
   }
 
@@ -621,7 +621,7 @@ impl ModuleGraph {
     self
       .inner
       .dependency_id_to_parents
-      .get(dependency_id)
+      .get(*dependency_id)
       .and_then(|p| p.block.as_ref())
   }
 
@@ -629,7 +629,7 @@ impl ModuleGraph {
     self
       .inner
       .dependency_id_to_parents
-      .get(dependency_id)
+      .get(*dependency_id)
       .map(|p| p.index_in_block)
   }
 
@@ -1068,7 +1068,7 @@ impl ModuleGraph {
     let condition = self
       .inner
       .connection_to_condition
-      .get(&connection.dependency_id)
+      .get(connection.dependency_id)
       .expect("should have condition");
     condition.get_connection_state(
       connection,
@@ -1091,7 +1091,7 @@ impl ModuleGraph {
     let condition = self
       .inner
       .connection_to_condition
-      .get(&connection.dependency_id)
+      .get(connection.dependency_id)
       .expect("should have condition");
     condition.is_connection_active(
       connection,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -58,7 +58,7 @@ impl ESMExportExpressionDependency {
     loc: Option<DependencyLocation>,
   ) -> Self {
     Self {
-      id: DependencyId::default(),
+      id: DependencyId::new(),
       range,
       range_stmt,
       declaration,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
@@ -27,7 +27,7 @@ impl ESMExportHeaderDependency {
       range,
       range_decl,
       loc,
-      id: DependencyId::default(),
+      id: DependencyId::new(),
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -19,7 +19,7 @@ impl IsIncludeDependency {
   pub fn new(range: DependencyRange, request: String) -> Self {
     Self {
       range,
-      id: DependencyId::default(),
+      id: DependencyId::new(),
       request,
       factorize_info: Default::default(),
     }

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -25,7 +25,7 @@ impl PureExpressionDependency {
     Self {
       range,
       used_by_exports: None,
-      id: DependencyId::default(),
+      id: DependencyId::new(),
       module_identifier,
     }
   }

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -419,7 +419,7 @@ async fn optimize_dependencies(
       .filter(|(_, dep)| dep.dependency_type() == &DependencyType::RstestMockModuleId)
       .filter_map(|(dep_id, _)| {
         module_graph
-          .module_identifier_by_dependency_id(dep_id)
+          .module_identifier_by_dependency_id(&dep_id)
           .copied()
       })
       .collect()

--- a/xtask/benchmark/benches/groups/module_graph_api.rs
+++ b/xtask/benchmark/benches/groups/module_graph_api.rs
@@ -79,7 +79,7 @@ pub fn module_graph_api_benchmark_inner(c: &mut Criterion) {
     let module_graph = compiler.compilation.get_module_graph();
     module_graph
       .dependencies()
-      .map(|(dependency_id, _)| *dependency_id)
+      .map(|(dependency_id, _)| dependency_id)
       .collect::<Vec<_>>()
   };
   let module_ids = {


### PR DESCRIPTION
Summary
- introduce a `ModuleGraphDependencies` wrapper backed by `slotmap` to replace the hash map in `ModuleGraphData`
- ensure dependencies stay in sync with their `DependencyId` slots, including insert/remove logic and iterator support
- add unit tests to cover lookup consistency after removals in the new dependency store

Testing
- Not run (not requested)