### PR TITLE
fix(config): case-sensitive extension matching in default module rules

### DIFF
--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -117,9 +117,7 @@ pub enum Algo {
 impl Algo {
   pub(crate) fn new(expr: &str, flags: &str) -> Result<Algo, Error> {
     let ignore_case = flags.contains('i') || flags.contains('g') || flags.contains('y');
-    if let Some(algo) = Self::try_compile_to_end_with_fast_path(expr)
-      && !ignore_case
-    {
+    if !ignore_case && let Some(algo) = Self::try_compile_to_end_with_fast_path(expr) {
       Ok(algo)
     } else {
       match HashRegressRegex::new(expr, flags) {

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -417,7 +417,7 @@ const applyModuleDefaults = (
         type: 'javascript/auto',
       },
       {
-        test: /\.json$/i,
+        test: /\.json$/,
         type: 'json',
       },
       {
@@ -425,22 +425,22 @@ const applyModuleDefaults = (
         type: 'json',
       },
       {
-        test: /\.mjs$/i,
+        test: /\.mjs$/,
         ...esm,
       },
       {
-        test: /\.js$/i,
+        test: /\.js$/,
         descriptionData: {
           type: 'module',
         },
         ...esm,
       },
       {
-        test: /\.cjs$/i,
+        test: /\.cjs$/,
         ...commonjs,
       },
       {
-        test: /\.js$/i,
+        test: /\.js$/,
         descriptionData: {
           type: 'commonjs',
         },
@@ -469,7 +469,7 @@ const applyModuleDefaults = (
         ],
       };
       rules.push({
-        test: /\.wasm$/i,
+        test: /\.wasm$/,
         ...wasm,
       });
       rules.push({


### PR DESCRIPTION
## Summary

- Use case-sensitive extension matching in default module rules (remove `i` flag from regex for `.json`, `.mjs`, `.js`, `.cjs`, `.wasm`) for consistency with case-sensitive file systems.
- Reorder condition in rspack_regex algo (`!ignore_case` before `try_compile_to_end_with_fast_path`) for clarity.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default module rule `test` regexes to stop matching uppercase extensions, which may affect projects relying on `.JSON`/`.JS`-style filenames. Also tweaks regex fast-path selection logic in `rspack_regex`, though behavior should remain the same for case-insensitive flags.
> 
> **Overview**
> **Default module rule extension matching is now case-sensitive.** The built-in `module.defaultRules` no longer uses `/.../i` for `.json`, `.mjs`, `.js`, `.cjs`, and `.wasm`, so only lowercase extensions match by default.
> 
> Separately, `rspack_regex` refactors `Algo::new` to check `!ignore_case` before attempting the `EndWith` fast path, improving clarity without intended behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2995fd9981a3c439f1081a4b5ca0958d4fcab9fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->