### PR TITLE
perf: Optimize build module dependency handling

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -1,6 +1,7 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use rspack_fs::ReadableFileSystem;
+use rustc_hash::FxHashSet;
 
 use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
@@ -9,9 +10,7 @@ use crate::{
   AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CompilationId,
   CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate, ResolverFactory,
   SharedPluginDriver,
-  compilation::build_module_graph::{
-    ForwardedIdSet, HasLazyDependencies, LazyDependencies, LazyUntil,
-  },
+  compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
   utils::{
     ResourceId,
     task_loop::{Task, TaskResult, TaskType},
@@ -141,11 +140,8 @@ impl Task<TaskContext> for BuildResultTask {
 
     let module_graph = &mut context.artifact.module_graph;
     let mut lazy_dependencies = LazyDependencies::default();
-    let root_dependencies_len = build_result.dependencies.len();
-    let root_blocks_len = build_result.blocks.len();
-    let mut queue = VecDeque::with_capacity(root_blocks_len);
-    let mut all_dependencies = Vec::with_capacity(root_dependencies_len);
-    let mut eager_dependencies = Vec::with_capacity(root_dependencies_len);
+    let mut queue = VecDeque::new();
+    let mut all_dependencies = vec![];
     let mut handle_block = |dependencies: Vec<BoxDependency>,
                             blocks: Vec<Box<AsyncDependenciesBlock>>,
                             current_block: Option<Box<AsyncDependenciesBlock>>|
@@ -153,13 +149,7 @@ impl Task<TaskContext> for BuildResultTask {
       for (index_in_block, dependency) in dependencies.into_iter().enumerate() {
         let dependency_id = *dependency.id();
         if let Some(until) = dependency.lazy() {
-          let should_process_now = matches!(&until, LazyUntil::Local(_));
           lazy_dependencies.insert(&dependency, until);
-          if should_process_now {
-            eager_dependencies.push(dependency_id);
-          }
-        } else {
-          eager_dependencies.push(dependency_id);
         }
         if current_block.is_none() {
           module.add_dependency_id(dependency_id);
@@ -192,16 +182,21 @@ impl Task<TaskContext> for BuildResultTask {
 
     {
       let mgm = module_graph.module_graph_module_by_identifier_mut(&module.identifier());
-      mgm.all_dependencies = all_dependencies;
+      mgm.all_dependencies.clone_from(&all_dependencies);
     }
 
     let module_identifier = module.identifier();
 
     module_graph.add_module(module);
 
-    let mut tasks: Vec<Box<dyn Task<TaskContext>>> = Vec::with_capacity(2);
+    let mut tasks: Vec<Box<dyn Task<TaskContext>>> = vec![];
 
     let dependencies_to_process = if !lazy_dependencies.is_empty() {
+      let lazy_dependency_ids = lazy_dependencies
+        .all_lazy_dependencies()
+        .collect::<FxHashSet<_>>();
+      all_dependencies.retain(|dep| !lazy_dependency_ids.contains(dep));
+
       if let Some(HasLazyDependencies::Pending(pending_forwarded_ids)) = context
         .artifact
         .module_to_lazy_make
@@ -218,13 +213,13 @@ impl Task<TaskContext> for BuildResultTask {
         tasks.push(Box::new(task));
       }
 
-      eager_dependencies
+      all_dependencies
     } else {
       context
         .artifact
         .module_to_lazy_make
         .update_module_lazy_dependencies(module_identifier, None);
-      eager_dependencies
+      all_dependencies
     };
 
     tasks.push(Box::new(ProcessDependenciesTask {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -9,7 +9,9 @@ use crate::{
   AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CompilationId,
   CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate, ResolverFactory,
   SharedPluginDriver,
-  compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
+  compilation::build_module_graph::{
+    ForwardedIdSet, HasLazyDependencies, LazyDependencies, LazyUntil,
+  },
   utils::{
     ResourceId,
     task_loop::{Task, TaskResult, TaskType},
@@ -151,7 +153,11 @@ impl Task<TaskContext> for BuildResultTask {
       for (index_in_block, dependency) in dependencies.into_iter().enumerate() {
         let dependency_id = *dependency.id();
         if let Some(until) = dependency.lazy() {
+          let should_process_now = matches!(&until, LazyUntil::Local(_));
           lazy_dependencies.insert(&dependency, until);
+          if should_process_now {
+            eager_dependencies.push(dependency_id);
+          }
         } else {
           eager_dependencies.push(dependency_id);
         }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -1,7 +1,6 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use rspack_fs::ReadableFileSystem;
-use rustc_hash::FxHashSet;
 
 use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
@@ -10,7 +9,9 @@ use crate::{
   AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CompilationId,
   CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate, ResolverFactory,
   SharedPluginDriver,
-  compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
+  compilation::build_module_graph::{
+    ForwardedIdSet, HasLazyDependencies, LazyDependencies, LazyUntil,
+  },
   utils::{
     ResourceId,
     task_loop::{Task, TaskResult, TaskType},
@@ -140,8 +141,11 @@ impl Task<TaskContext> for BuildResultTask {
 
     let module_graph = &mut context.artifact.module_graph;
     let mut lazy_dependencies = LazyDependencies::default();
-    let mut queue = VecDeque::new();
-    let mut all_dependencies = vec![];
+    let root_dependencies_len = build_result.dependencies.len();
+    let root_blocks_len = build_result.blocks.len();
+    let mut queue = VecDeque::with_capacity(root_blocks_len);
+    let mut all_dependencies = Vec::with_capacity(root_dependencies_len);
+    let mut eager_dependencies = Vec::with_capacity(root_dependencies_len);
     let mut handle_block = |dependencies: Vec<BoxDependency>,
                             blocks: Vec<Box<AsyncDependenciesBlock>>,
                             current_block: Option<Box<AsyncDependenciesBlock>>|
@@ -149,7 +153,13 @@ impl Task<TaskContext> for BuildResultTask {
       for (index_in_block, dependency) in dependencies.into_iter().enumerate() {
         let dependency_id = *dependency.id();
         if let Some(until) = dependency.lazy() {
+          let should_process_now = matches!(&until, LazyUntil::Local(_));
           lazy_dependencies.insert(&dependency, until);
+          if should_process_now {
+            eager_dependencies.push(dependency_id);
+          }
+        } else {
+          eager_dependencies.push(dependency_id);
         }
         if current_block.is_none() {
           module.add_dependency_id(dependency_id);
@@ -182,21 +192,16 @@ impl Task<TaskContext> for BuildResultTask {
 
     {
       let mgm = module_graph.module_graph_module_by_identifier_mut(&module.identifier());
-      mgm.all_dependencies.clone_from(&all_dependencies);
+      mgm.all_dependencies = all_dependencies;
     }
 
     let module_identifier = module.identifier();
 
     module_graph.add_module(module);
 
-    let mut tasks: Vec<Box<dyn Task<TaskContext>>> = vec![];
+    let mut tasks: Vec<Box<dyn Task<TaskContext>>> = Vec::with_capacity(2);
 
     let dependencies_to_process = if !lazy_dependencies.is_empty() {
-      let lazy_dependency_ids = lazy_dependencies
-        .all_lazy_dependencies()
-        .collect::<FxHashSet<_>>();
-      all_dependencies.retain(|dep| !lazy_dependency_ids.contains(dep));
-
       if let Some(HasLazyDependencies::Pending(pending_forwarded_ids)) = context
         .artifact
         .module_to_lazy_make
@@ -213,13 +218,13 @@ impl Task<TaskContext> for BuildResultTask {
         tasks.push(Box::new(task));
       }
 
-      all_dependencies
+      eager_dependencies
     } else {
       context
         .artifact
         .module_to_lazy_make
         .update_module_lazy_dependencies(module_identifier, None);
-      all_dependencies
+      eager_dependencies
     };
 
     tasks.push(Box::new(ProcessDependenciesTask {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -1,7 +1,6 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use rspack_fs::ReadableFileSystem;
-use rustc_hash::FxHashSet;
 
 use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
@@ -140,8 +139,11 @@ impl Task<TaskContext> for BuildResultTask {
 
     let module_graph = &mut context.artifact.module_graph;
     let mut lazy_dependencies = LazyDependencies::default();
-    let mut queue = VecDeque::new();
-    let mut all_dependencies = vec![];
+    let root_dependencies_len = build_result.dependencies.len();
+    let root_blocks_len = build_result.blocks.len();
+    let mut queue = VecDeque::with_capacity(root_blocks_len);
+    let mut all_dependencies = Vec::with_capacity(root_dependencies_len);
+    let mut eager_dependencies = Vec::with_capacity(root_dependencies_len);
     let mut handle_block = |dependencies: Vec<BoxDependency>,
                             blocks: Vec<Box<AsyncDependenciesBlock>>,
                             current_block: Option<Box<AsyncDependenciesBlock>>|
@@ -150,6 +152,8 @@ impl Task<TaskContext> for BuildResultTask {
         let dependency_id = *dependency.id();
         if let Some(until) = dependency.lazy() {
           lazy_dependencies.insert(&dependency, until);
+        } else {
+          eager_dependencies.push(dependency_id);
         }
         if current_block.is_none() {
           module.add_dependency_id(dependency_id);
@@ -182,21 +186,16 @@ impl Task<TaskContext> for BuildResultTask {
 
     {
       let mgm = module_graph.module_graph_module_by_identifier_mut(&module.identifier());
-      mgm.all_dependencies.clone_from(&all_dependencies);
+      mgm.all_dependencies = all_dependencies;
     }
 
     let module_identifier = module.identifier();
 
     module_graph.add_module(module);
 
-    let mut tasks: Vec<Box<dyn Task<TaskContext>>> = vec![];
+    let mut tasks: Vec<Box<dyn Task<TaskContext>>> = Vec::with_capacity(2);
 
     let dependencies_to_process = if !lazy_dependencies.is_empty() {
-      let lazy_dependency_ids = lazy_dependencies
-        .all_lazy_dependencies()
-        .collect::<FxHashSet<_>>();
-      all_dependencies.retain(|dep| !lazy_dependency_ids.contains(dep));
-
       if let Some(HasLazyDependencies::Pending(pending_forwarded_ids)) = context
         .artifact
         .module_to_lazy_make
@@ -213,13 +212,13 @@ impl Task<TaskContext> for BuildResultTask {
         tasks.push(Box::new(task));
       }
 
-      all_dependencies
+      eager_dependencies
     } else {
       context
         .artifact
         .module_to_lazy_make
         .update_module_lazy_dependencies(module_identifier, None);
-      all_dependencies
+      eager_dependencies
     };
 
     tasks.push(Box::new(ProcessDependenciesTask {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -5,9 +5,9 @@ use rspack_sources::BoxSource;
 
 use super::{TaskContext, add::AddTask};
 use crate::{
-  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, FactorizeInfo, ModuleFactory,
-  ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer, Resolve,
-  ResolverFactory,
+  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, DependencyId, FactorizeInfo,
+  ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer,
+  Resolve, ResolverFactory,
   module_graph::ModuleGraphModule,
   utils::{
     ResourceId,
@@ -20,6 +20,7 @@ pub struct FactorizeTask {
   pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
   pub module_factory: Arc<dyn ModuleFactory>,
+  pub dependencies_marked: bool,
   pub original_module_identifier: Option<ModuleIdentifier>,
   pub original_module_source: Option<Arc<BoxSource>>,
   pub original_module_context: Option<Box<Context>>,
@@ -123,6 +124,12 @@ impl Task<TaskContext> for FactorizeTask {
     Ok(vec![Box::new(FactorizeResultTask {
       original_module_identifier: self.original_module_identifier,
       factory_result,
+      dependencies_marked: self.dependencies_marked,
+      pre_marked_dependencies: create_data
+        .dependencies
+        .iter()
+        .map(|dep| *dep.id())
+        .collect(),
       dependencies: create_data.dependencies,
       factorize_info,
       from_unlazy: self.from_unlazy,
@@ -136,6 +143,8 @@ pub struct FactorizeResultTask {
   pub original_module_identifier: Option<ModuleIdentifier>,
   /// Result will be available if [crate::ModuleFactory::create] returns `Ok`.
   pub factory_result: Option<ModuleFactoryResult>,
+  pub dependencies_marked: bool,
+  pub pre_marked_dependencies: Vec<DependencyId>,
   pub dependencies: Vec<BoxDependency>,
   pub factorize_info: FactorizeInfo,
   pub from_unlazy: bool,
@@ -150,6 +159,8 @@ impl Task<TaskContext> for FactorizeResultTask {
     let FactorizeResultTask {
       original_module_identifier,
       factory_result,
+      dependencies_marked,
+      pre_marked_dependencies,
       mut dependencies,
       mut factorize_info,
       from_unlazy,
@@ -173,10 +184,9 @@ impl Task<TaskContext> for FactorizeResultTask {
       .add_files(&resource_id, factorize_info.missing_dependencies());
 
     for dep in &mut dependencies {
-      // Some dependencies do not come from the process_dependencies task,
-      // so add all dependencies here.
-      artifact.affected_dependencies.mark_as_add(dep.id());
-
+      if !dependencies_marked || !pre_marked_dependencies.contains(dep.id()) {
+        artifact.affected_dependencies.mark_as_add(dep.id());
+      }
       let dep_factorize_info = if let Some(d) = dep.as_context_dependency_mut() {
         d.factorize_info_mut()
       } else if let Some(d) = dep.as_module_dependency_mut() {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -20,8 +20,9 @@ pub struct FactorizeTask {
   pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
   pub module_factory: Arc<dyn ModuleFactory>,
+  pub dependencies_marked: bool,
   pub original_module_identifier: Option<ModuleIdentifier>,
-  pub original_module_source: Option<BoxSource>,
+  pub original_module_source: Option<Arc<BoxSource>>,
   pub original_module_context: Option<Box<Context>>,
   pub issuer: Option<Box<str>>,
   pub issuer_layer: Option<ModuleLayer>,
@@ -91,7 +92,7 @@ impl Task<TaskContext> for FactorizeTask {
       Ok(result) => Some(result),
       Err(mut e) => {
         // Wrap source code if available
-        if let Some(s) = self.original_module_source {
+        if let Some(s) = self.original_module_source.as_ref() {
           let has_source_code = e.src.is_some();
           if !has_source_code {
             e.src = Some(s.source().into_string_lossy().into_owned());
@@ -123,6 +124,7 @@ impl Task<TaskContext> for FactorizeTask {
     Ok(vec![Box::new(FactorizeResultTask {
       original_module_identifier: self.original_module_identifier,
       factory_result,
+      dependencies_marked: self.dependencies_marked,
       dependencies: create_data.dependencies,
       factorize_info,
       from_unlazy: self.from_unlazy,
@@ -136,6 +138,7 @@ pub struct FactorizeResultTask {
   pub original_module_identifier: Option<ModuleIdentifier>,
   /// Result will be available if [crate::ModuleFactory::create] returns `Ok`.
   pub factory_result: Option<ModuleFactoryResult>,
+  pub dependencies_marked: bool,
   pub dependencies: Vec<BoxDependency>,
   pub factorize_info: FactorizeInfo,
   pub from_unlazy: bool,
@@ -150,6 +153,7 @@ impl Task<TaskContext> for FactorizeResultTask {
     let FactorizeResultTask {
       original_module_identifier,
       factory_result,
+      dependencies_marked,
       mut dependencies,
       mut factorize_info,
       from_unlazy,
@@ -173,10 +177,9 @@ impl Task<TaskContext> for FactorizeResultTask {
       .add_files(&resource_id, factorize_info.missing_dependencies());
 
     for dep in &mut dependencies {
-      // Some dependencies do not come from the process_dependencies task,
-      // so add all dependencies here.
-      artifact.affected_dependencies.mark_as_add(dep.id());
-
+      if !dependencies_marked {
+        artifact.affected_dependencies.mark_as_add(dep.id());
+      }
       let dep_factorize_info = if let Some(d) = dep.as_context_dependency_mut() {
         d.factorize_info_mut()
       } else if let Some(d) = dep.as_module_dependency_mut() {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -5,9 +5,9 @@ use rspack_sources::BoxSource;
 
 use super::{TaskContext, add::AddTask};
 use crate::{
-  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, DependencyId, FactorizeInfo,
-  ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer,
-  Resolve, ResolverFactory,
+  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, FactorizeInfo, ModuleFactory,
+  ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer, Resolve,
+  ResolverFactory,
   module_graph::ModuleGraphModule,
   utils::{
     ResourceId,
@@ -20,7 +20,6 @@ pub struct FactorizeTask {
   pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
   pub module_factory: Arc<dyn ModuleFactory>,
-  pub dependencies_marked: bool,
   pub original_module_identifier: Option<ModuleIdentifier>,
   pub original_module_source: Option<Arc<BoxSource>>,
   pub original_module_context: Option<Box<Context>>,
@@ -124,12 +123,6 @@ impl Task<TaskContext> for FactorizeTask {
     Ok(vec![Box::new(FactorizeResultTask {
       original_module_identifier: self.original_module_identifier,
       factory_result,
-      dependencies_marked: self.dependencies_marked,
-      pre_marked_dependencies: create_data
-        .dependencies
-        .iter()
-        .map(|dep| *dep.id())
-        .collect(),
       dependencies: create_data.dependencies,
       factorize_info,
       from_unlazy: self.from_unlazy,
@@ -143,8 +136,6 @@ pub struct FactorizeResultTask {
   pub original_module_identifier: Option<ModuleIdentifier>,
   /// Result will be available if [crate::ModuleFactory::create] returns `Ok`.
   pub factory_result: Option<ModuleFactoryResult>,
-  pub dependencies_marked: bool,
-  pub pre_marked_dependencies: Vec<DependencyId>,
   pub dependencies: Vec<BoxDependency>,
   pub factorize_info: FactorizeInfo,
   pub from_unlazy: bool,
@@ -159,8 +150,6 @@ impl Task<TaskContext> for FactorizeResultTask {
     let FactorizeResultTask {
       original_module_identifier,
       factory_result,
-      dependencies_marked,
-      pre_marked_dependencies,
       mut dependencies,
       mut factorize_info,
       from_unlazy,
@@ -184,9 +173,10 @@ impl Task<TaskContext> for FactorizeResultTask {
       .add_files(&resource_id, factorize_info.missing_dependencies());
 
     for dep in &mut dependencies {
-      if !dependencies_marked || !pre_marked_dependencies.contains(dep.id()) {
-        artifact.affected_dependencies.mark_as_add(dep.id());
-      }
+      // Some dependencies do not come from the process_dependencies task,
+      // so add all dependencies here.
+      artifact.affected_dependencies.mark_as_add(dep.id());
+
       let dep_factorize_info = if let Some(d) = dep.as_context_dependency_mut() {
         d.factorize_info_mut()
       } else if let Some(d) = dep.as_module_dependency_mut() {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -5,9 +5,9 @@ use rspack_sources::BoxSource;
 
 use super::{TaskContext, add::AddTask};
 use crate::{
-  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, FactorizeInfo, ModuleFactory,
-  ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer, Resolve,
-  ResolverFactory,
+  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, DependencyId, FactorizeInfo,
+  ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer,
+  Resolve, ResolverFactory,
   module_graph::ModuleGraphModule,
   utils::{
     ResourceId,
@@ -125,6 +125,11 @@ impl Task<TaskContext> for FactorizeTask {
       original_module_identifier: self.original_module_identifier,
       factory_result,
       dependencies_marked: self.dependencies_marked,
+      pre_marked_dependencies: create_data
+        .dependencies
+        .iter()
+        .map(|dep| *dep.id())
+        .collect(),
       dependencies: create_data.dependencies,
       factorize_info,
       from_unlazy: self.from_unlazy,
@@ -139,6 +144,7 @@ pub struct FactorizeResultTask {
   /// Result will be available if [crate::ModuleFactory::create] returns `Ok`.
   pub factory_result: Option<ModuleFactoryResult>,
   pub dependencies_marked: bool,
+  pub pre_marked_dependencies: Vec<DependencyId>,
   pub dependencies: Vec<BoxDependency>,
   pub factorize_info: FactorizeInfo,
   pub from_unlazy: bool,
@@ -154,6 +160,7 @@ impl Task<TaskContext> for FactorizeResultTask {
       original_module_identifier,
       factory_result,
       dependencies_marked,
+      pre_marked_dependencies,
       mut dependencies,
       mut factorize_info,
       from_unlazy,
@@ -177,7 +184,7 @@ impl Task<TaskContext> for FactorizeResultTask {
       .add_files(&resource_id, factorize_info.missing_dependencies());
 
     for dep in &mut dependencies {
-      if !dependencies_marked {
+      if !dependencies_marked || !pre_marked_dependencies.contains(dep.id()) {
         artifact.affected_dependencies.mark_as_add(dep.id());
       }
       let dep_factorize_info = if let Some(d) = dep.as_context_dependency_mut() {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
@@ -22,6 +22,7 @@ pub async fn repair(
   build_dependencies: HashSet<BuildDependency>,
 ) -> Result<(BuildModuleGraphArtifact, ExportsInfoArtifact)> {
   let module_graph = artifact.get_module_graph_mut();
+  let build_dependencies_len = build_dependencies.len();
   let mut grouped_deps = HashMap::default();
   for (dep_id, parent_module_identifier) in build_dependencies {
     grouped_deps
@@ -29,40 +30,41 @@ pub async fn repair(
       .or_insert(vec![])
       .push(dep_id);
   }
-  let init_tasks = grouped_deps
-    .into_iter()
-    .flat_map(|(parent_module_identifier, dependencies)| {
-      if let Some(original_module_identifier) = parent_module_identifier {
-        return vec![Box::new(process_dependencies::ProcessDependenciesTask {
-          original_module_identifier,
-          dependencies,
-          from_unlazy: false,
-        }) as Box<dyn Task<TaskContext>>];
-      }
-      // entry dependencies
-      dependencies
-        .into_iter()
-        .map(|dep_id| {
-          let dependency = module_graph.dependency_by_id(&dep_id);
-          Box::new(factorize::FactorizeTask {
-            compiler_id: compilation.compiler_id(),
-            compilation_id: compilation.id(),
-            module_factory: compilation.get_dependency_factory(dependency),
-            original_module_identifier: None,
-            original_module_source: None,
-            issuer: None,
-            issuer_layer: None,
-            original_module_context: None,
-            dependencies: vec![dependency.clone()],
-            resolve_options: None,
-            options: compilation.options.clone(),
-            resolver_factory: compilation.resolver_factory.clone(),
-            from_unlazy: false,
-          }) as Box<dyn Task<TaskContext>>
-        })
-        .collect::<Vec<_>>()
-    })
-    .collect::<Vec<_>>();
+  let compiler_id = compilation.compiler_id();
+  let compilation_id = compilation.id();
+  let options = compilation.options.clone();
+  let resolver_factory = compilation.resolver_factory.clone();
+  let mut init_tasks: Vec<Box<dyn Task<TaskContext>>> = Vec::with_capacity(build_dependencies_len);
+  for (parent_module_identifier, dependencies) in grouped_deps {
+    if let Some(original_module_identifier) = parent_module_identifier {
+      init_tasks.push(Box::new(process_dependencies::ProcessDependenciesTask {
+        original_module_identifier,
+        dependencies,
+        from_unlazy: false,
+      }));
+      continue;
+    }
+
+    for dep_id in dependencies {
+      let dependency = module_graph.dependency_by_id(&dep_id);
+      init_tasks.push(Box::new(factorize::FactorizeTask {
+        compiler_id,
+        compilation_id,
+        module_factory: compilation.get_dependency_factory(dependency),
+        dependencies_marked: false,
+        original_module_identifier: None,
+        original_module_source: None,
+        issuer: None,
+        issuer_layer: None,
+        original_module_context: None,
+        dependencies: vec![dependency.clone()],
+        resolve_options: None,
+        options: options.clone(),
+        resolver_factory: resolver_factory.clone(),
+        from_unlazy: false,
+      }));
+    }
+  }
 
   let mut ctx = TaskContext::new(compilation, artifact, exports_info_artifact);
   run_task_loop(&mut ctx, init_tasks).await?;

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
@@ -22,7 +22,6 @@ pub async fn repair(
   build_dependencies: HashSet<BuildDependency>,
 ) -> Result<(BuildModuleGraphArtifact, ExportsInfoArtifact)> {
   let module_graph = artifact.get_module_graph_mut();
-  let build_dependencies_len = build_dependencies.len();
   let mut grouped_deps = HashMap::default();
   for (dep_id, parent_module_identifier) in build_dependencies {
     grouped_deps
@@ -30,41 +29,40 @@ pub async fn repair(
       .or_insert(vec![])
       .push(dep_id);
   }
-  let compiler_id = compilation.compiler_id();
-  let compilation_id = compilation.id();
-  let options = compilation.options.clone();
-  let resolver_factory = compilation.resolver_factory.clone();
-  let mut init_tasks: Vec<Box<dyn Task<TaskContext>>> = Vec::with_capacity(build_dependencies_len);
-  for (parent_module_identifier, dependencies) in grouped_deps {
-    if let Some(original_module_identifier) = parent_module_identifier {
-      init_tasks.push(Box::new(process_dependencies::ProcessDependenciesTask {
-        original_module_identifier,
-        dependencies,
-        from_unlazy: false,
-      }));
-      continue;
-    }
-
-    for dep_id in dependencies {
-      let dependency = module_graph.dependency_by_id(&dep_id);
-      init_tasks.push(Box::new(factorize::FactorizeTask {
-        compiler_id,
-        compilation_id,
-        module_factory: compilation.get_dependency_factory(dependency),
-        dependencies_marked: false,
-        original_module_identifier: None,
-        original_module_source: None,
-        issuer: None,
-        issuer_layer: None,
-        original_module_context: None,
-        dependencies: vec![dependency.clone()],
-        resolve_options: None,
-        options: options.clone(),
-        resolver_factory: resolver_factory.clone(),
-        from_unlazy: false,
-      }));
-    }
-  }
+  let init_tasks = grouped_deps
+    .into_iter()
+    .flat_map(|(parent_module_identifier, dependencies)| {
+      if let Some(original_module_identifier) = parent_module_identifier {
+        return vec![Box::new(process_dependencies::ProcessDependenciesTask {
+          original_module_identifier,
+          dependencies,
+          from_unlazy: false,
+        }) as Box<dyn Task<TaskContext>>];
+      }
+      // entry dependencies
+      dependencies
+        .into_iter()
+        .map(|dep_id| {
+          let dependency = module_graph.dependency_by_id(&dep_id);
+          Box::new(factorize::FactorizeTask {
+            compiler_id: compilation.compiler_id(),
+            compilation_id: compilation.id(),
+            module_factory: compilation.get_dependency_factory(dependency),
+            original_module_identifier: None,
+            original_module_source: None,
+            issuer: None,
+            issuer_layer: None,
+            original_module_context: None,
+            dependencies: vec![dependency.clone()],
+            resolve_options: None,
+            options: compilation.options.clone(),
+            resolver_factory: compilation.resolver_factory.clone(),
+            from_unlazy: false,
+          }) as Box<dyn Task<TaskContext>>
+        })
+        .collect::<Vec<_>>()
+    })
+    .collect::<Vec<_>>();
 
   let mut ctx = TaskContext::new(compilation, artifact, exports_info_artifact);
   run_task_loop(&mut ctx, init_tasks).await?;

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use rustc_hash::FxHashMap as HashMap;
 
@@ -73,13 +73,19 @@ impl Task<TaskContext> for ProcessDependenciesTask {
     let module = module_graph
       .module_by_identifier(&original_module_identifier)
       .expect("Module expected");
+    let original_module_source = module
+      .as_normal_module()
+      .and_then(|m| m.source().cloned())
+      .map(Arc::new);
+    let original_module_context = module.get_context();
+    let issuer = module
+      .as_normal_module()
+      .and_then(|module| module.name_for_condition());
+    let issuer_layer = module.get_layer().cloned();
+    let resolve_options = module.get_resolve_options();
 
-    let mut res: Vec<Box<dyn Task<TaskContext>>> = vec![];
+    let mut res: Vec<Box<dyn Task<TaskContext>>> = Vec::with_capacity(sorted_dependencies.len());
     for dependencies in sorted_dependencies.into_values() {
-      let original_module_source = module_graph
-        .module_by_identifier(&original_module_identifier)
-        .and_then(|m| m.as_normal_module())
-        .and_then(|m| m.source().cloned());
       let dependency = &dependencies[0];
       let dependency_type = dependency.dependency_type();
       // TODO move module_factory calculate to dependency factories
@@ -98,15 +104,14 @@ impl Task<TaskContext> for ProcessDependenciesTask {
         compiler_id: context.compiler_id,
         compilation_id: context.compilation_id,
         module_factory,
+        dependencies_marked: true,
         original_module_identifier: Some(module.identifier()),
-        original_module_context: module.get_context(),
-        original_module_source,
-        issuer: module
-          .as_normal_module()
-          .and_then(|module| module.name_for_condition()),
-        issuer_layer: module.get_layer().cloned(),
+        original_module_context: original_module_context.clone(),
+        original_module_source: original_module_source.clone(),
+        issuer: issuer.clone(),
+        issuer_layer: issuer_layer.clone(),
         dependencies,
-        resolve_options: module.get_resolve_options(),
+        resolve_options: resolve_options.clone(),
         options: context.compiler_options.clone(),
         resolver_factory: context.resolver_factory.clone(),
         from_unlazy,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
@@ -77,7 +77,14 @@ impl Task<TaskContext> for ProcessDependenciesTask {
       .as_normal_module()
       .and_then(|m| m.source().cloned())
       .map(Arc::new);
-    let mut res: Vec<Box<dyn Task<TaskContext>>> = vec![];
+    let original_module_context = module.get_context();
+    let issuer = module
+      .as_normal_module()
+      .and_then(|module| module.name_for_condition());
+    let issuer_layer = module.get_layer().cloned();
+    let resolve_options = module.get_resolve_options();
+
+    let mut res: Vec<Box<dyn Task<TaskContext>>> = Vec::with_capacity(sorted_dependencies.len());
     for dependencies in sorted_dependencies.into_values() {
       let dependency = &dependencies[0];
       let dependency_type = dependency.dependency_type();
@@ -97,15 +104,14 @@ impl Task<TaskContext> for ProcessDependenciesTask {
         compiler_id: context.compiler_id,
         compilation_id: context.compilation_id,
         module_factory,
+        dependencies_marked: true,
         original_module_identifier: Some(module.identifier()),
-        original_module_context: module.get_context(),
+        original_module_context: original_module_context.clone(),
         original_module_source: original_module_source.clone(),
-        issuer: module
-          .as_normal_module()
-          .and_then(|module| module.name_for_condition()),
-        issuer_layer: module.get_layer().cloned(),
+        issuer: issuer.clone(),
+        issuer_layer: issuer_layer.clone(),
         dependencies,
-        resolve_options: module.get_resolve_options(),
+        resolve_options: resolve_options.clone(),
         options: context.compiler_options.clone(),
         resolver_factory: context.resolver_factory.clone(),
         from_unlazy,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
@@ -77,14 +77,7 @@ impl Task<TaskContext> for ProcessDependenciesTask {
       .as_normal_module()
       .and_then(|m| m.source().cloned())
       .map(Arc::new);
-    let original_module_context = module.get_context();
-    let issuer = module
-      .as_normal_module()
-      .and_then(|module| module.name_for_condition());
-    let issuer_layer = module.get_layer().cloned();
-    let resolve_options = module.get_resolve_options();
-
-    let mut res: Vec<Box<dyn Task<TaskContext>>> = Vec::with_capacity(sorted_dependencies.len());
+    let mut res: Vec<Box<dyn Task<TaskContext>>> = vec![];
     for dependencies in sorted_dependencies.into_values() {
       let dependency = &dependencies[0];
       let dependency_type = dependency.dependency_type();
@@ -104,14 +97,15 @@ impl Task<TaskContext> for ProcessDependenciesTask {
         compiler_id: context.compiler_id,
         compilation_id: context.compilation_id,
         module_factory,
-        dependencies_marked: true,
         original_module_identifier: Some(module.identifier()),
-        original_module_context: original_module_context.clone(),
+        original_module_context: module.get_context(),
         original_module_source: original_module_source.clone(),
-        issuer: issuer.clone(),
-        issuer_layer: issuer_layer.clone(),
+        issuer: module
+          .as_normal_module()
+          .and_then(|module| module.name_for_condition()),
+        issuer_layer: module.get_layer().cloned(),
         dependencies,
-        resolve_options: resolve_options.clone(),
+        resolve_options: module.get_resolve_options(),
         options: context.compiler_options.clone(),
         resolver_factory: context.resolver_factory.clone(),
         from_unlazy,

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/entry.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/entry.rs
@@ -66,7 +66,6 @@ impl Task<ExecutorTaskContext> for EntryTask {
               )
             })
             .clone(),
-          dependencies_marked: false,
           original_module_identifier: None,
           original_module_source: None,
           issuer: None,

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/entry.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/entry.rs
@@ -66,6 +66,7 @@ impl Task<ExecutorTaskContext> for EntryTask {
               )
             })
             .clone(),
+          dependencies_marked: false,
           original_module_identifier: None,
           original_module_source: None,
           issuer: None,


### PR DESCRIPTION
Summary
- pre‑allocate queues/dependency vectors in repair build for better reuse and cache behavior
- mark existing dependencies before running ProcessDependenciesTask so FactorizeTask doesn’t duplicate work
- streamline initialization of repair tasks with shared compiler/context state

Testing
- Not run (not requested)