### PR TITLE
docs: update webpack migration guide for minimizers

### DIFF
--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -165,15 +165,16 @@ module.exports = {
 
 For projects that use [terser-webpack-plugin](https://github.com/webpack/terser-webpack-plugin) to minify JavaScript, we recommend switching to [rspack.SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin) for better build performance:
 
-```diff title="rspack.config.js"
-- const TerserPlugin = require('terser-webpack-plugin');
-+ const { rspack } = require('@rspack/core');
+```js title="rspack.config.js"
+const TerserPlugin = require('terser-webpack-plugin'); // [!code --]
+const { rspack } = require('@rspack/core'); // [!code ++]
 
 module.exports = {
   optimization: {
     minimizer: [
--     new TerserPlugin(),
-+     new rspack.SwcJsMinimizerRspackPlugin(),
+      new TerserPlugin(), // [!code --]
+      new rspack.SwcJsMinimizerRspackPlugin(), // [!code ++]
+      new rspack.LightningCssMinimizerRspackPlugin(),
     ],
   },
 };
@@ -187,15 +188,16 @@ When you explicitly configure [optimization.minimizer](/config/optimization#opti
 
 For projects that use [css-minimizer-webpack-plugin](https://github.com/webpack/css-minimizer-webpack-plugin) to minify CSS, we recommend switching to [rspack.LightningCssMinimizerRspackPlugin](/plugins/rspack/lightning-css-minimizer-rspack-plugin) for better build performance:
 
-```diff title="rspack.config.js"
-- const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-+ const { rspack } = require('@rspack/core');
+```js title="rspack.config.js"
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin'); // [!code --]
+const { rspack } = require('@rspack/core'); // [!code ++]
 
 module.exports = {
   optimization: {
     minimizer: [
--     new CssMinimizerPlugin(),
-+     new rspack.LightningCssMinimizerRspackPlugin(),
+      new rspack.SwcJsMinimizerRspackPlugin(),
+      new CssMinimizerPlugin(), // [!code --]
+      new rspack.LightningCssMinimizerRspackPlugin(), // [!code ++]
     ],
   },
 };

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -163,15 +163,16 @@ module.exports = {
 
 对于使用 [terser-webpack-plugin](https://github.com/webpack/terser-webpack-plugin) 压缩 JavaScript 的项目，建议改用 [rspack.SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin) 以获得更好的构建性能：
 
-```diff title="rspack.config.js"
-- const TerserPlugin = require('terser-webpack-plugin');
-+ const { rspack } = require('@rspack/core');
+```js title="rspack.config.js"
+const TerserPlugin = require('terser-webpack-plugin'); // [!code --]
+const { rspack } = require('@rspack/core'); // [!code ++]
 
 module.exports = {
   optimization: {
     minimizer: [
--     new TerserPlugin(),
-+     new rspack.SwcJsMinimizerRspackPlugin(),
+      new TerserPlugin(), // [!code --]
+      new rspack.SwcJsMinimizerRspackPlugin(), // [!code ++]
+      new rspack.LightningCssMinimizerRspackPlugin(),
     ],
   },
 };
@@ -185,15 +186,16 @@ module.exports = {
 
 对于使用 [css-minimizer-webpack-plugin](https://github.com/webpack/css-minimizer-webpack-plugin) 压缩 CSS 的项目，建议改用 [rspack.LightningCssMinimizerRspackPlugin](/plugins/rspack/lightning-css-minimizer-rspack-plugin) 以获得更好的构建性能：
 
-```diff title="rspack.config.js"
-- const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-+ const { rspack } = require('@rspack/core');
+```js title="rspack.config.js"
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin'); // [!code --]
+const { rspack } = require('@rspack/core'); // [!code ++]
 
 module.exports = {
   optimization: {
     minimizer: [
--     new CssMinimizerPlugin(),
-+     new rspack.LightningCssMinimizerRspackPlugin(),
+      new rspack.SwcJsMinimizerRspackPlugin(),
+      new CssMinimizerPlugin(), // [!code --]
+      new rspack.LightningCssMinimizerRspackPlugin(), // [!code ++]
     ],
   },
 };


### PR DESCRIPTION
## Summary

Add recommendations to replace `terser-webpack-plugin` and `css-minimizer-webpack-plugin` with Rspack's built-in minifier plugins for better performance.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
