### PR TITLE
refactor: remove &mut Compilation in  CompilationAddEntry hook 

### DIFF
--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -87,7 +87,7 @@ use crate::{
   is_source_equal, to_identifier,
 };
 
-define_hook!(CompilationAddEntry: Series(compilation: &mut Compilation, entry_name: Option<&str>));
+define_hook!(CompilationAddEntry: Series(entry_name: Option<&str>, options: &mut EntryOptions));
 define_hook!(CompilationBuildModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule),tracing=false);
 define_hook!(CompilationRevokedModules: Series(compilation: &Compilation, revoked_modules: &IdentifierSet));
 define_hook!(CompilationStillValidModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule));
@@ -613,14 +613,16 @@ impl Compilation {
   pub async fn add_entry(&mut self, entry: BoxDependency, options: EntryOptions) -> Result<()> {
     let entry_id = *entry.id();
     let entry_name: Option<String> = options.name.clone();
+    let plugin_driver = self.plugin_driver.clone();
     self
       .build_module_graph_artifact
       .get_module_graph_mut()
       .add_dependency(entry);
-    if let Some(name) = &entry_name {
+    let entry_options = if let Some(name) = &entry_name {
       if let Some(data) = self.entries.get_mut(name) {
         data.dependencies.push(entry_id);
         data.options.merge(options)?;
+        &mut data.options
       } else {
         let data = EntryData {
           dependencies: vec![entry_id],
@@ -628,17 +630,21 @@ impl Compilation {
           options,
         };
         self.entries.insert(name.to_owned(), data);
+        &mut self
+          .entries
+          .get_mut(name)
+          .expect("entry should exist")
+          .options
       }
     } else {
       self.global_entry.dependencies.push(entry_id);
-    }
+      &mut self.global_entry.options
+    };
 
-    self
-      .plugin_driver
-      .clone()
+    plugin_driver
       .compilation_hooks
       .add_entry
-      .call(self, entry_name.as_deref())
+      .call(entry_name.as_deref(), entry_options)
       .await?;
 
     Ok(())

--- a/crates/rspack_plugin_runtime_chunk/src/lib.rs
+++ b/crates/rspack_plugin_runtime_chunk/src/lib.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use futures::future::BoxFuture;
-use rspack_core::{Compilation, CompilationAddEntry};
+use rspack_core::{CompilationAddEntry, EntryOptions};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 
@@ -44,11 +44,10 @@ pub type RuntimeChunkNameFn =
   Box<dyn for<'a> Fn(&'a str) -> BoxFuture<'a, Result<String>> + Sync + Send>;
 
 #[plugin_hook(CompilationAddEntry for RuntimeChunkPlugin)]
-async fn add_entry(&self, compilation: &mut Compilation, entry_name: Option<&str>) -> Result<()> {
+async fn add_entry(&self, entry_name: Option<&str>, options: &mut EntryOptions) -> Result<()> {
   if let Some(entry_name) = entry_name
-    && let Some(data) = compilation.entries.get_mut(entry_name)
-    && data.options.runtime.is_none()
-    && data.options.depend_on.is_none()
+    && options.runtime.is_none()
+    && options.depend_on.is_none()
   {
     let name = match &self.name {
       RuntimeChunkName::Single => "runtime".to_string(),
@@ -58,7 +57,7 @@ async fn add_entry(&self, compilation: &mut Compilation, entry_name: Option<&str
       RuntimeChunkName::String(name) => name.clone(),
       RuntimeChunkName::Fn(f) => f(entry_name).await?,
     };
-    data.options.runtime = Some(name.into());
+    options.runtime = Some(name.into());
   }
   Ok(())
 }


### PR DESCRIPTION
Summary
- update `CompilationAddEntry` hook to pass entry name and mutable options instead of the whole compilation
- adjust `Compilation::add_entry` so it provides a mutable reference to the relevant entry options and reuses the cloned plugin driver hook
- align `RuntimeChunkPlugin` to mutate the passed-in `EntryOptions` directly rather than fetching entry data

Testing
- Not run (not requested)