### PR TITLE
refactor: `SourceSizeCache` for module size cache

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2,15 +2,14 @@ use std::{
   borrow::Cow,
   collections::BTreeMap,
   fmt::Debug,
-  hash::{BuildHasherDefault, Hasher},
+  hash::Hasher,
   sync::{Arc, LazyLock},
 };
 
-use dashmap::DashMap;
 use indexmap::IndexMap;
 use rayon::prelude::*;
 use regex::Regex;
-use rspack_cacheable::{cacheable, cacheable_dyn, with::AsMap};
+use rspack_cacheable::{cacheable, cacheable_dyn, with::As};
 use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
@@ -24,7 +23,7 @@ use rspack_util::{
   SpanExt, ext::DynHash, fx_hash::FxIndexMap, itoa, json_stringify, json_stringify_str,
   source_map::SourceMapKind, swc::join_atom,
 };
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::{
   atoms::Atom,
   common::{FileName, Spanned, SyntaxContext},
@@ -54,8 +53,10 @@ use crate::{
   UsedName, UsedNameItem, escape_identifier, filter_runtime, find_target, get_runtime_key,
   impl_source_map_config, merge_runtime_condition, merge_runtime_condition_non_false,
   module_update_hash, property_access, property_name,
-  render_make_deferred_namespace_mode_from_exports_type, reserved_names::RESERVED_NAMES,
+  render_make_deferred_namespace_mode_from_exports_type,
+  reserved_names::RESERVED_NAMES,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
+  utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
@@ -609,8 +610,8 @@ pub struct ConcatenatedModule {
 
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  #[cacheable(with=AsMap)]
-  cached_source_sizes: DashMap<SourceType, f64, BuildHasherDefault<FxHasher>>,
+  #[cacheable(with=As<SourceSizeCacheSerde>)]
+  cached_source_sizes: SourceSizeCache,
   diagnostics: Vec<Diagnostic>,
   build_info: BuildInfo,
 }
@@ -635,7 +636,7 @@ impl ConcatenatedModule {
       runtime,
       dependencies: vec![],
       blocks: vec![],
-      cached_source_sizes: DashMap::default(),
+      cached_source_sizes: SourceSizeCache::default(),
       diagnostics: vec![],
       build_info: BuildInfo {
         cacheable: true,
@@ -845,12 +846,16 @@ impl Module for ConcatenatedModule {
   }
 
   fn size(&self, source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
-    if let Some(size_ref) = source_type.and_then(|st| self.cached_source_sizes.get(st)) {
-      *size_ref
-    } else {
+    if let Some(source_type) = source_type {
+      // Shared cache: builtin SourceType uses fixed atomic slots, Custom uses map fallback.
+      if let Some(size) = self.cached_source_sizes.get(source_type) {
+        return size;
+      }
+
       let size = self.modules.iter().fold(0.0, |acc, cur| acc + cur.size);
-      source_type.and_then(|st| self.cached_source_sizes.insert(*st, size));
-      size
+      self.cached_source_sizes.get_or_insert(source_type, size)
+    } else {
+      self.modules.iter().fold(0.0, |acc, cur| acc + cur.size)
     }
   }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -1,17 +1,16 @@
 use std::{
   borrow::Cow,
-  hash::{BuildHasherDefault, Hash},
+  hash::Hash,
   sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
   },
 };
 
-use dashmap::DashMap;
 use derive_more::Debug;
 use rspack_cacheable::{
   cacheable, cacheable_dyn,
-  with::{AsMap, AsOption, AsPreset},
+  with::{As, AsOption, AsPreset},
 };
 use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnosable, Diagnostic, Result, error};
@@ -27,7 +26,6 @@ use rspack_util::{
   ext::DynHash,
   source_map::{ModuleSourceMapConfig, SourceMapKind},
 };
-use rustc_hash::FxHasher;
 use serde_json::json;
 use tracing::{Instrument, info_span};
 
@@ -39,8 +37,10 @@ use crate::{
   ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
   ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult,
   ParserAndGenerator, ParserOptions, Resolve, RspackLoaderRunnerPlugin, RunnerContext,
-  RuntimeGlobals, RuntimeSpec, SourceType, contextify, diagnostics::ModuleBuildError, get_context,
-  module_update_hash,
+  RuntimeGlobals, RuntimeSpec, SourceType, contextify,
+  diagnostics::ModuleBuildError,
+  get_context, module_update_hash,
+  utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
 #[cacheable]
@@ -138,8 +138,8 @@ pub struct NormalModule {
 
   #[allow(unused)]
   debug_id: usize,
-  #[cacheable(with=AsMap)]
-  cached_source_sizes: DashMap<SourceType, f64, BuildHasherDefault<FxHasher>>,
+  #[cacheable(with=As<SourceSizeCacheSerde>)]
+  cached_source_sizes: SourceSizeCache,
   diagnostics: Vec<Diagnostic>,
 
   code_generation_dependencies: Option<Vec<BoxModuleDependency>>,
@@ -210,7 +210,7 @@ impl NormalModule {
       debug_id: DEBUG_ID.fetch_add(1, Ordering::Relaxed),
       extract_source_map,
 
-      cached_source_sizes: DashMap::default(),
+      cached_source_sizes: SourceSizeCache::default(),
       diagnostics: Default::default(),
       code_generation_dependencies: None,
       presentational_dependencies: None,
@@ -350,12 +350,16 @@ impl Module for NormalModule {
   }
 
   fn size(&self, source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
-    if let Some(size_ref) = source_type.and_then(|st| self.cached_source_sizes.get(st)) {
-      *size_ref
+    if let Some(source_type) = source_type {
+      // Fast-path: lock-free builtin slots / tiny fallback map for custom source types.
+      if let Some(size) = self.cached_source_sizes.get(source_type) {
+        return size;
+      }
+
+      let size = f64::max(1.0, self.parser_and_generator.size(self, Some(source_type)));
+      self.cached_source_sizes.get_or_insert(source_type, size)
     } else {
-      let size = f64::max(1.0, self.parser_and_generator.size(self, source_type));
-      source_type.and_then(|st| self.cached_source_sizes.insert(*st, size));
-      size
+      f64::max(1.0, self.parser_and_generator.size(self, source_type))
     }
   }
 

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -31,6 +31,7 @@ mod property_name;
 mod remove_bom;
 mod runtime;
 mod source;
+mod source_size_cache;
 pub mod task_loop;
 mod template;
 mod to_path;
@@ -56,6 +57,7 @@ pub use self::{
   remove_bom::*,
   runtime::*,
   source::*,
+  source_size_cache::*,
   template::*,
   to_path::to_path,
 };

--- a/crates/rspack_core/src/utils/source_size_cache.rs
+++ b/crates/rspack_core/src/utils/source_size_cache.rs
@@ -1,0 +1,130 @@
+use std::{
+  array,
+  sync::{
+    RwLock,
+    atomic::{AtomicU64, Ordering},
+  },
+};
+
+use rspack_cacheable::{
+  Result, cacheable,
+  with::{AsConverter, AsMap, AsPreset},
+};
+use rustc_hash::FxHashMap;
+use ustr::Ustr;
+
+use crate::SourceType;
+
+const SOURCE_SIZE_CACHE_SLOTS: usize = 13;
+const SOURCE_SIZE_UNSET: u64 = u64::MAX;
+
+#[derive(Debug)]
+pub struct SourceSizeCache {
+  // Fixed slots for builtin SourceType variants to avoid hashing/locking overhead.
+  builtins: [AtomicU64; SOURCE_SIZE_CACHE_SLOTS],
+  // Rare fallback for SourceType::Custom(...)
+  custom: RwLock<FxHashMap<Ustr, f64>>,
+}
+
+impl Default for SourceSizeCache {
+  fn default() -> Self {
+    Self {
+      builtins: array::from_fn(|_| AtomicU64::new(SOURCE_SIZE_UNSET)),
+      custom: RwLock::default(),
+    }
+  }
+}
+
+impl SourceSizeCache {
+  /// Maps builtin SourceType to a fixed slot. `Custom` is handled by the fallback map.
+  fn builtin_index(source_type: &SourceType) -> Option<usize> {
+    match source_type {
+      SourceType::JavaScript => Some(0),
+      SourceType::Css => Some(1),
+      SourceType::CssUrl => Some(2),
+      SourceType::Wasm => Some(3),
+      SourceType::Asset => Some(4),
+      SourceType::Expose => Some(5),
+      SourceType::Remote => Some(6),
+      SourceType::ShareInit => Some(7),
+      SourceType::ConsumeShared => Some(8),
+      SourceType::ShareContainerShared => Some(9),
+      SourceType::Unknown => Some(10),
+      SourceType::CssImport => Some(11),
+      SourceType::Runtime => Some(12),
+      SourceType::Custom(_) => None,
+    }
+  }
+
+  pub fn get(&self, source_type: &SourceType) -> Option<f64> {
+    if let Some(index) = Self::builtin_index(source_type) {
+      let bits = self.builtins[index].load(Ordering::Relaxed);
+      (bits != SOURCE_SIZE_UNSET).then_some(f64::from_bits(bits))
+    } else if let SourceType::Custom(custom) = source_type {
+      self
+        .custom
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(custom)
+        .copied()
+    } else {
+      None
+    }
+  }
+
+  pub fn get_or_insert(&self, source_type: &SourceType, size: f64) -> f64 {
+    if let Some(index) = Self::builtin_index(source_type) {
+      let bits = size.to_bits();
+      match self.builtins[index].compare_exchange(
+        SOURCE_SIZE_UNSET,
+        bits,
+        Ordering::Relaxed,
+        Ordering::Relaxed,
+      ) {
+        Ok(_) => size,
+        Err(existing) => f64::from_bits(existing),
+      }
+    } else if let SourceType::Custom(custom) = source_type {
+      let mut custom_sizes = self
+        .custom
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+      *custom_sizes.entry(*custom).or_insert(size)
+    } else {
+      size
+    }
+  }
+}
+
+#[cacheable(crate=rspack_cacheable)]
+pub struct SourceSizeCacheSerde {
+  builtins: [Option<f64>; SOURCE_SIZE_CACHE_SLOTS],
+  #[cacheable(with=AsMap<AsPreset>)]
+  custom: FxHashMap<Ustr, f64>,
+}
+
+impl AsConverter<SourceSizeCache> for SourceSizeCacheSerde {
+  fn serialize(data: &SourceSizeCache, _guard: &rspack_cacheable::ContextGuard) -> Result<Self> {
+    let builtins = array::from_fn(|index| {
+      let bits = data.builtins[index].load(Ordering::Relaxed);
+      (bits != SOURCE_SIZE_UNSET).then_some(f64::from_bits(bits))
+    });
+    let custom = data
+      .custom
+      .read()
+      .unwrap_or_else(|poisoned| poisoned.into_inner())
+      .clone();
+    Ok(Self { builtins, custom })
+  }
+
+  fn deserialize(self, _guard: &rspack_cacheable::ContextGuard) -> Result<SourceSizeCache> {
+    let builtins = array::from_fn(|index| match self.builtins[index] {
+      Some(size) => AtomicU64::new(size.to_bits()),
+      None => AtomicU64::new(SOURCE_SIZE_UNSET),
+    });
+    Ok(SourceSizeCache {
+      builtins,
+      custom: RwLock::new(self.custom),
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Implemented a targeted source-size cache optimization for `NormalModule` and `ConcatenatedModule`, replacing `DashMap<SourceType, f64>` with a specialized cache designed around `SourceType` shape and access patterns.

### New Cache Design

- **Builtin `SourceType` variants** are cached in fixed slots (`[AtomicU64; N]`) for lock-free reads/writes (CAS-based).
- **`SourceType::Custom(Ustr)`** is cached in a fallback map (`RwLock<FxHashMap<Ustr, f64>>`).
- This removes hash/shard overhead on the hot path while preserving support for dynamic custom source types.

### Cacheable Integration

- Replaced `#[cacheable(with=Skip)]` with a serializable bridge:
  - `#[cacheable(with=As<SourceSizeCacheSerde>)]`
- Added `SourceSizeCacheSerde` + `AsConverter` implementation to persist/restore cache state while keeping the runtime concurrency-optimized structure.

<img width="2386" height="1632" alt="image" src="https://github.com/user-attachments/assets/985973f7-92fd-42fd-b2a8-c3e649bfdcda" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
