### PR TITLE
feat: add Node.js version check during initialization

### DIFF
--- a/packages/rspack/src/checkNodeVersion.ts
+++ b/packages/rspack/src/checkNodeVersion.ts
@@ -1,0 +1,21 @@
+function checkNodeVersion() {
+  const { node, bun, deno } = process.versions;
+  // Skip non-Node runtimes
+  if (!node || bun || deno) return;
+
+  const [majorStr, minorStr] = node.split('.');
+  const major = parseInt(majorStr, 10);
+  const minor = parseInt(minorStr || '0', 10);
+  const supported =
+    (major === 20 && minor >= 19) ||
+    (major === 22 && minor >= 12) ||
+    major > 22;
+
+  if (!supported) {
+    console.error(
+      `Unsupported Node.js version "${node}". Rspack requires Node.js 20.19+ or 22.12+. Please upgrade your Node.js version.\n`,
+    );
+  }
+}
+
+checkNodeVersion();

--- a/packages/rspack/src/index.ts
+++ b/packages/rspack/src/index.ts
@@ -1,3 +1,4 @@
+import './checkNodeVersion';
 import * as rspackExports from './exports';
 import { rspack as rspackFn } from './rspack';
 


### PR DESCRIPTION
## Summary

Add runtime version validation to ensure compatibility with supported Node.js versions (20.19+ or 22.12+). This helps users identify unsupported environments early.

### Before

<img width="994" height="420" alt="Screenshot 2026-03-09 at 16 26 27" src="https://github.com/user-attachments/assets/9ecd08b1-40d8-4c2a-96d3-f89028758539" />


### After

<img width="1105" height="484" alt="Screenshot 2026-03-09 at 16 29 44" src="https://github.com/user-attachments/assets/62938d5b-c0d4-4445-8edf-7a90a1147a3c" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
