### PR TITLE
fix: avoid import duplicate identifiers

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -407,34 +407,6 @@ impl EsmLibraryPlugin {
                 let target_info = concate_modules_map.get(&symbol_binding.module);
                 if matches!(target_info, Some(ModuleInfo::External(_))) {
                   chunk_link.imports.entry(symbol_binding.module).or_default();
-                } else if symbol_binding.ids.is_empty()
-                  && matches!(target_info, Some(ModuleInfo::Concatenated(_)))
-                {
-                  // For module-type externals stored as Concatenated, the raw_export_map
-                  // returns bare symbol names (e.g., "readFile") that aren't local variables.
-                  // When ids is empty, the symbol is directly referenced (not via property
-                  // access like ns.readFile), so we need to add an import from the external
-                  // source to make the binding available.
-                  //
-                  // Only do this for module-type externals. For other external types
-                  // (e.g., node-commonjs), the binding is already available from the
-                  // scope-hoisted code (e.g., `const X = require(...)`).
-                  let module_graph = compilation.get_module_graph();
-                  if let Some(ext) = module_graph
-                    .module_by_identifier(&symbol_binding.module)
-                    .and_then(|m| m.as_external_module())
-                    && ext.get_external_type().starts_with("module")
-                  {
-                    let request = ext.user_request().to_string();
-                    let import_spec = chunk_link
-                      .raw_import_stmts
-                      .entry((request, None))
-                      .or_default();
-                    import_spec
-                      .atoms
-                      .entry(symbol_binding.symbol.clone())
-                      .or_insert_with(|| symbol_binding.symbol.clone());
-                  }
                 }
               }
 


### PR DESCRIPTION
## Summary

There are some mistake in previous PR that will create duplicated unnesaray specifier

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
