### PR TITLE
perf: Disable incremental tracking when build module graph incremental is off

### DIFF
--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -95,6 +95,16 @@ impl BuildModuleGraphArtifact {
     &mut self.module_graph
   }
 
+  pub fn disable_incremental_tracking(&mut self) {
+    self.affected_modules.disable();
+    self.affected_dependencies.disable();
+    self.issuer_update_modules.clear();
+    self.file_dependencies.disable_incremental_info();
+    self.context_dependencies.disable_incremental_info();
+    self.missing_dependencies.disable_incremental_info();
+    self.build_dependencies.disable_incremental_info();
+  }
+
   /// revoke a module and return multiple parent ModuleIdentifier and DependencyId pair that can generate it.
   ///
   /// This function will update index on MakeArtifact.

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -26,7 +26,10 @@ use self::{
   storage::{Storage, StorageOptions, create_storage},
 };
 use super::Cache;
-use crate::{BuildModuleGraphArtifactState, Compilation, CompilerOptions, Logger};
+use crate::{
+  BuildModuleGraphArtifactState, Compilation, CompilerOptions, Logger,
+  incremental::IncrementalPasses,
+};
 
 #[cacheable]
 #[derive(Debug, Clone, Hash)]
@@ -161,6 +164,13 @@ impl Cache for PersistentCache {
     // rebuild will pass modified_files and removed_files from js side,
     // so only calculate them when build.
     if self.valid && !compilation.is_rebuild {
+      if !compilation
+        .incremental
+        .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
+      {
+        return false;
+      }
+
       let mut is_hot_start = false;
       let mut modified_paths = ArcPathSet::default();
       let mut removed_paths = ArcPathSet::default();
@@ -208,45 +218,58 @@ impl Cache for PersistentCache {
       // save meta
       self.meta_occasion.save();
 
-      // save snapshot
-      // TODO add a all_dependencies to collect dependencies
-      let (_, file_added, file_updated, file_removed) = compilation.file_dependencies();
-      let (_, context_added, context_updated, context_removed) = compilation.context_dependencies();
-      let (_, missing_added, missing_updated, missing_removed) = compilation.missing_dependencies();
-      let (_, build_added, build_updated, _) = compilation.build_dependencies();
-      self
-        .snapshot
-        .remove(SnapshotScope::FILE, file_removed.cloned());
-      self
-        .snapshot
-        .remove(SnapshotScope::CONTEXT, context_removed.cloned());
-      self
-        .snapshot
-        .remove(SnapshotScope::MISSING, missing_removed.cloned());
-      self
-        .snapshot
-        .add(SnapshotScope::FILE, file_added.chain(file_updated).cloned())
-        .await;
-      self
-        .snapshot
-        .add(
-          SnapshotScope::CONTEXT,
-          context_added.chain(context_updated).cloned(),
-        )
-        .await;
-      self
-        .snapshot
-        .add(
-          SnapshotScope::MISSING,
-          missing_added.chain(missing_updated).cloned(),
-        )
-        .await;
-      self.warnings.extend(
+      let build_module_graph_incremental_enabled = compilation
+        .incremental
+        .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH);
+
+      if build_module_graph_incremental_enabled {
+        // save snapshot
+        // TODO add a all_dependencies to collect dependencies
+        let (_, file_added, file_updated, file_removed) = compilation.file_dependencies();
+        let (_, context_added, context_updated, context_removed) =
+          compilation.context_dependencies();
+        let (_, missing_added, missing_updated, missing_removed) =
+          compilation.missing_dependencies();
+        let (_, build_added, build_updated, _) = compilation.build_dependencies();
         self
-          .build_deps
-          .add(build_added.chain(build_updated).cloned())
-          .await,
-      );
+          .snapshot
+          .remove(SnapshotScope::FILE, file_removed.cloned());
+        self
+          .snapshot
+          .remove(SnapshotScope::CONTEXT, context_removed.cloned());
+        self
+          .snapshot
+          .remove(SnapshotScope::MISSING, missing_removed.cloned());
+        self
+          .snapshot
+          .add(SnapshotScope::FILE, file_added.chain(file_updated).cloned())
+          .await;
+        self
+          .snapshot
+          .add(
+            SnapshotScope::CONTEXT,
+            context_added.chain(context_updated).cloned(),
+          )
+          .await;
+        self
+          .snapshot
+          .add(
+            SnapshotScope::MISSING,
+            missing_added.chain(missing_updated).cloned(),
+          )
+          .await;
+        self.warnings.extend(
+          self
+            .build_deps
+            .add(build_added.chain(build_updated).cloned())
+            .await,
+        );
+      } else {
+        let (build_all, _, _, _) = compilation.build_dependencies();
+        self
+          .warnings
+          .extend(self.build_deps.add(build_all.cloned()).await);
+      }
 
       self.save().await;
     }
@@ -258,6 +281,13 @@ impl Cache for PersistentCache {
   }
 
   async fn before_build_module_graph(&mut self, compilation: &mut Compilation) {
+    if !compilation
+      .incremental
+      .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
+    {
+      return;
+    }
+
     // TODO When does not need to pass variables through make_artifact.state, use compilation.is_rebuild to check
     if self.valid
       && matches!(
@@ -282,7 +312,11 @@ impl Cache for PersistentCache {
   }
 
   async fn after_build_module_graph(&self, compilation: &Compilation) {
-    if !self.readonly {
+    if !self.readonly
+      && compilation
+        .incremental
+        .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
+    {
       self
         .make_occasion
         .save(&compilation.build_module_graph_artifact);

--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -92,6 +92,19 @@ impl Snapshot {
       .await;
   }
 
+  #[tracing::instrument("Cache::Snapshot::replace", skip_all)]
+  pub async fn replace(
+    &self,
+    scope: SnapshotScope,
+    paths: impl Iterator<Item = ArcPath>,
+  ) -> Result<()> {
+    for (key, _) in self.storage.load(scope.name()).await? {
+      self.storage.remove(scope.name(), &key);
+    }
+    self.add(scope, paths).await;
+    Ok(())
+  }
+
   pub fn remove(&self, scope: SnapshotScope, paths: impl Iterator<Item = ArcPath>) {
     for item in paths {
       self

--- a/crates/rspack_core/src/compilation/build_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/mod.rs
@@ -16,8 +16,10 @@ pub use self::{
   },
   module_executor::{ExecuteModuleId, ExecutedRuntimeModule, ModuleExecutor},
 };
+use crate::{
+  BoxDependency, Compilation, ExportsInfoArtifact, incremental::IncrementalPasses, logger::Logger,
+};
 pub use crate::{BuildModuleGraphArtifact, BuildModuleGraphArtifactState};
-use crate::{Compilation, ExportsInfoArtifact, logger::Logger};
 
 pub async fn build_module_graph_pass(compilation: &mut Compilation) -> Result<()> {
   let logger = compilation.get_logger("rspack.Compiler");
@@ -57,8 +59,34 @@ pub async fn do_build_module_graph(compilation: &mut Compilation) -> Result<()> 
 pub async fn build_module_graph(
   compilation: &Compilation,
   mut artifact: BuildModuleGraphArtifact,
-  exports_info_artifact: ExportsInfoArtifact,
+  mut exports_info_artifact: ExportsInfoArtifact,
 ) -> Result<(BuildModuleGraphArtifact, ExportsInfoArtifact)> {
+  if !compilation.incremental.enabled() {
+    artifact.disable_incremental_tracking();
+  }
+
+  if !compilation
+    .incremental
+    .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
+  {
+    let entry_dependencies: Vec<BoxDependency> = compilation
+      .entries
+      .values()
+      .flat_map(|item| item.all_dependencies())
+      .chain(compilation.global_entry.all_dependencies())
+      .map(|dep_id| artifact.get_module_graph().dependency_by_id(dep_id).clone())
+      .collect();
+
+    artifact = BuildModuleGraphArtifact::new();
+    if !compilation.incremental.enabled() {
+      artifact.disable_incremental_tracking();
+    }
+    for dep in entry_dependencies {
+      artifact.get_module_graph_mut().add_dependency(dep);
+    }
+    exports_info_artifact = ExportsInfoArtifact::default();
+  }
+
   let mut params = Vec::with_capacity(6);
 
   if !compilation.entries.is_empty() {

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/mod.rs
@@ -29,7 +29,8 @@ use super::{
 };
 use crate::{
   Compilation, CompilationAsset, Context, DependencyId, ExportsInfoArtifact, PublicPath, StealCell,
-  build_module_graph::module_executor::execute::ExecuteResult, task_loop::run_task_loop,
+  build_module_graph::module_executor::execute::ExecuteResult, incremental::IncrementalPasses,
+  task_loop::run_task_loop,
 };
 
 #[derive(Debug)]
@@ -66,6 +67,23 @@ impl ModuleExecutor {
   pub async fn before_build_module_graph(&mut self, compilation: &Compilation) -> Result<()> {
     let mut make_artifact = self.make_artifact.steal();
     let mut exports_info_artifact = self.exports_info_artifact.steal();
+
+    if !compilation.incremental.enabled() {
+      make_artifact.disable_incremental_tracking();
+    }
+
+    if !compilation
+      .incremental
+      .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
+    {
+      make_artifact = BuildModuleGraphArtifact::new();
+      if !compilation.incremental.enabled() {
+        make_artifact.disable_incremental_tracking();
+      }
+      exports_info_artifact = ExportsInfoArtifact::default();
+      self.entries.clear();
+    }
+
     let mut params = Vec::with_capacity(5);
     params.push(UpdateParam::CheckNeedBuild);
     if !compilation.modified_files.is_empty() {

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -37,6 +37,7 @@ use std::{
 };
 
 use dashmap::DashSet;
+use either::Either;
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -464,19 +465,43 @@ impl Compilation {
       .file_dependencies
       .files()
       .chain(&self.file_dependencies);
-    let added_files = self
-      .build_module_graph_artifact
-      .file_dependencies
-      .added_files()
-      .chain(&self.file_dependencies);
-    let updated_files = self
-      .build_module_graph_artifact
-      .file_dependencies
-      .updated_files();
-    let removed_files = self
-      .build_module_graph_artifact
-      .file_dependencies
-      .removed_files();
+    let added_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .file_dependencies
+          .added_files()
+          .chain(&self.file_dependencies),
+      )
+    } else {
+      Either::Right(
+        self
+          .build_module_graph_artifact
+          .file_dependencies
+          .files()
+          .chain(&self.file_dependencies),
+      )
+    };
+    let updated_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .file_dependencies
+          .updated_files(),
+      )
+    } else {
+      Either::Right(std::iter::empty())
+    };
+    let removed_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .file_dependencies
+          .removed_files(),
+      )
+    } else {
+      Either::Right(std::iter::empty())
+    };
     (all_files, added_files, updated_files, removed_files)
   }
 
@@ -493,19 +518,43 @@ impl Compilation {
       .context_dependencies
       .files()
       .chain(&self.context_dependencies);
-    let added_files = self
-      .build_module_graph_artifact
-      .context_dependencies
-      .added_files()
-      .chain(&self.file_dependencies);
-    let updated_files = self
-      .build_module_graph_artifact
-      .context_dependencies
-      .updated_files();
-    let removed_files = self
-      .build_module_graph_artifact
-      .context_dependencies
-      .removed_files();
+    let added_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .context_dependencies
+          .added_files()
+          .chain(&self.file_dependencies),
+      )
+    } else {
+      Either::Right(
+        self
+          .build_module_graph_artifact
+          .context_dependencies
+          .files()
+          .chain(&self.context_dependencies),
+      )
+    };
+    let updated_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .context_dependencies
+          .updated_files(),
+      )
+    } else {
+      Either::Right(std::iter::empty())
+    };
+    let removed_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .context_dependencies
+          .removed_files(),
+      )
+    } else {
+      Either::Right(std::iter::empty())
+    };
     (all_files, added_files, updated_files, removed_files)
   }
 
@@ -522,19 +571,43 @@ impl Compilation {
       .missing_dependencies
       .files()
       .chain(&self.missing_dependencies);
-    let added_files = self
-      .build_module_graph_artifact
-      .missing_dependencies
-      .added_files()
-      .chain(&self.file_dependencies);
-    let updated_files = self
-      .build_module_graph_artifact
-      .missing_dependencies
-      .updated_files();
-    let removed_files = self
-      .build_module_graph_artifact
-      .missing_dependencies
-      .removed_files();
+    let added_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .missing_dependencies
+          .added_files()
+          .chain(&self.file_dependencies),
+      )
+    } else {
+      Either::Right(
+        self
+          .build_module_graph_artifact
+          .missing_dependencies
+          .files()
+          .chain(&self.missing_dependencies),
+      )
+    };
+    let updated_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .missing_dependencies
+          .updated_files(),
+      )
+    } else {
+      Either::Right(std::iter::empty())
+    };
+    let removed_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .missing_dependencies
+          .removed_files(),
+      )
+    } else {
+      Either::Right(std::iter::empty())
+    };
     (all_files, added_files, updated_files, removed_files)
   }
 
@@ -551,19 +624,43 @@ impl Compilation {
       .build_dependencies
       .files()
       .chain(&self.build_dependencies);
-    let added_files = self
-      .build_module_graph_artifact
-      .build_dependencies
-      .added_files()
-      .chain(&self.file_dependencies);
-    let updated_files = self
-      .build_module_graph_artifact
-      .build_dependencies
-      .updated_files();
-    let removed_files = self
-      .build_module_graph_artifact
-      .build_dependencies
-      .removed_files();
+    let added_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .build_dependencies
+          .added_files()
+          .chain(&self.file_dependencies),
+      )
+    } else {
+      Either::Right(
+        self
+          .build_module_graph_artifact
+          .build_dependencies
+          .files()
+          .chain(&self.build_dependencies),
+      )
+    };
+    let updated_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .build_dependencies
+          .updated_files(),
+      )
+    } else {
+      Either::Right(std::iter::empty())
+    };
+    let removed_files = if self.incremental.enabled() {
+      Either::Left(
+        self
+          .build_module_graph_artifact
+          .build_dependencies
+          .removed_files(),
+      )
+    } else {
+      Either::Right(std::iter::empty())
+    };
     (all_files, added_files, updated_files, removed_files)
   }
 

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -46,6 +46,10 @@ impl<'compilation> StatsContext<'compilation> {
     Self(compilation)
   }
 
+  fn incremental_enabled(&self) -> bool {
+    self.0.incremental.enabled()
+  }
+
   fn options(&self) -> &'compilation CompilerOptions {
     self.0.options.as_ref()
   }
@@ -1143,7 +1147,9 @@ impl Stats<'_> {
       .module_graph_module_by_identifier(&identifier)
       .unwrap_or_else(|| panic!("Could not find ModuleGraphModule by identifier: {identifier:?}"));
 
-    let built = if executed {
+    let built = if !self.context.incremental_enabled() {
+      module.as_concatenated_module().is_none()
+    } else if executed {
       self.module_executor_is_module_built(&identifier)
     } else {
       build_module_graph_artifact

--- a/crates/rspack_core/src/utils/file_counter/mod.rs
+++ b/crates/rspack_core/src/utils/file_counter/mod.rs
@@ -71,6 +71,10 @@ impl FileCounter {
     self.incremental_info.reset();
   }
 
+  pub fn disable_incremental_info(&mut self) {
+    self.incremental_info.disable();
+  }
+
   /// Added files compared to the `files()` when call reset_incremental_info
   pub fn added_files(&self) -> impl Iterator<Item = &ArcPath> {
     self.incremental_info.added().iter()

--- a/crates/rspack_core/src/utils/incremental_info.rs
+++ b/crates/rspack_core/src/utils/incremental_info.rs
@@ -9,6 +9,7 @@ use rustc_hash::FxBuildHasher;
 ///
 /// The `added`, `updated`, `removed` are disjoint.
 pub struct IncrementalInfo<T, S = FxBuildHasher> {
+  enabled: bool,
   /// The added data but never removed.
   added: HashSet<T, S>,
   /// The added data that has been removed.
@@ -36,6 +37,7 @@ where
 {
   fn default() -> Self {
     Self {
+      enabled: true,
       added: HashSet::default(),
       updated: HashSet::default(),
       removed: HashSet::default(),
@@ -50,6 +52,9 @@ where
 {
   /// Mark a data as added.
   pub fn mark_as_add(&mut self, data: &T) {
+    if !self.enabled {
+      return;
+    }
     if self.removed.remove(data) {
       self.updated.insert(data.clone());
       return;
@@ -62,6 +67,9 @@ where
 
   /// Mark a data as removed.
   pub fn mark_as_remove(&mut self, data: &T) {
+    if !self.enabled {
+      return;
+    }
     if self.added.remove(data) {
       return;
     }
@@ -74,6 +82,11 @@ where
     self.added = HashSet::default();
     self.updated = HashSet::default();
     self.removed = HashSet::default();
+  }
+
+  pub fn disable(&mut self) {
+    self.enabled = false;
+    self.reset();
   }
 
   /// Get added data.

--- a/packages/rspack/src/Watching.ts
+++ b/packages/rspack/src/Watching.ts
@@ -36,6 +36,9 @@ export class Watching {
   #closed: boolean;
   #collectedChangedFiles?: Set<string>;
   #collectedRemovedFiles?: Set<string>;
+  #lastFileDependencies?: Set<string>;
+  #lastContextDependencies?: Set<string>;
+  #lastMissingDependencies?: Set<string>;
   suspended: boolean;
 
   constructor(
@@ -326,6 +329,38 @@ export class Watching {
     });
   }
 
+  #diffDependencies(
+    current: Set<string>,
+    previous?: Set<string>,
+  ): {
+    added: Set<string>;
+    removed: Set<string>;
+  } {
+    if (!previous) {
+      return {
+        added: new Set(current),
+        removed: new Set(),
+      };
+    }
+
+    const added = new Set<string>();
+    const removed = new Set<string>();
+
+    for (const item of current) {
+      if (!previous.has(item)) {
+        added.add(item);
+      }
+    }
+
+    for (const item of previous) {
+      if (!current.has(item)) {
+        removed.add(item);
+      }
+    }
+
+    return { added, removed };
+  }
+
   /**
    * The reason why this is _done instead of #done, is that in Webpack,
    * it will rewrite this function to another function
@@ -381,18 +416,14 @@ export class Watching {
 
       process.nextTick(() => {
         if (!this.#closed) {
+          const incrementalEnabled =
+            this.compiler.options.incremental !== false;
           const fileDependencies = new Set([
             ...compilation.fileDependencies,
           ]) as unknown as Iterable<string> & {
             added?: Iterable<string>;
             removed?: Iterable<string>;
           };
-          fileDependencies.added = new Set(
-            compilation.__internal__addedFileDependencies,
-          );
-          fileDependencies.removed = new Set(
-            compilation.__internal__removedFileDependencies,
-          );
 
           const contextDependencies = new Set([
             ...compilation.contextDependencies,
@@ -400,12 +431,6 @@ export class Watching {
             added?: Iterable<string>;
             removed?: Iterable<string>;
           };
-          contextDependencies.added = new Set(
-            compilation.__internal__addedContextDependencies,
-          );
-          contextDependencies.removed = new Set(
-            compilation.__internal__removedContextDependencies,
-          );
 
           const missingDependencies = new Set([
             ...compilation.missingDependencies,
@@ -413,12 +438,58 @@ export class Watching {
             added?: Iterable<string>;
             removed?: Iterable<string>;
           };
-          missingDependencies.added = new Set(
-            compilation.__internal__addedMissingDependencies,
-          );
-          missingDependencies.removed = new Set(
-            compilation.__internal__removedMissingDependencies,
-          );
+
+          if (incrementalEnabled) {
+            fileDependencies.added = new Set(
+              compilation.__internal__addedFileDependencies,
+            );
+            fileDependencies.removed = new Set(
+              compilation.__internal__removedFileDependencies,
+            );
+            contextDependencies.added = new Set(
+              compilation.__internal__addedContextDependencies,
+            );
+            contextDependencies.removed = new Set(
+              compilation.__internal__removedContextDependencies,
+            );
+            missingDependencies.added = new Set(
+              compilation.__internal__addedMissingDependencies,
+            );
+            missingDependencies.removed = new Set(
+              compilation.__internal__removedMissingDependencies,
+            );
+          } else {
+            const fileDiff = this.#diffDependencies(
+              fileDependencies as Set<string>,
+              this.#lastFileDependencies,
+            );
+            fileDependencies.added = fileDiff.added;
+            fileDependencies.removed = fileDiff.removed;
+
+            const contextDiff = this.#diffDependencies(
+              contextDependencies as Set<string>,
+              this.#lastContextDependencies,
+            );
+            contextDependencies.added = contextDiff.added;
+            contextDependencies.removed = contextDiff.removed;
+
+            const missingDiff = this.#diffDependencies(
+              missingDependencies as Set<string>,
+              this.#lastMissingDependencies,
+            );
+            missingDependencies.added = missingDiff.added;
+            missingDependencies.removed = missingDiff.removed;
+
+            this.#lastFileDependencies = new Set(
+              fileDependencies as Set<string>,
+            );
+            this.#lastContextDependencies = new Set(
+              contextDependencies as Set<string>,
+            );
+            this.#lastMissingDependencies = new Set(
+              missingDependencies as Set<string>,
+            );
+          }
 
           this.watch(
             fileDependencies,

--- a/tests/rspack-test/cacheCases/common/update-file-incremental-disabled/file.js
+++ b/tests/rspack-test/cacheCases/common/update-file-incremental-disabled/file.js
@@ -1,0 +1,9 @@
+export default 1;
+---
+export default 2;
+---
+export default 2;
+---
+<force_write>export default 2;
+---
+export default 3;

--- a/tests/rspack-test/cacheCases/common/update-file-incremental-disabled/index.js
+++ b/tests/rspack-test/cacheCases/common/update-file-incremental-disabled/index.js
@@ -1,0 +1,23 @@
+import value from "./file";
+
+it("should rebuild on every start when incremental build module graph is disabled", async () => {
+	if (COMPILER_INDEX == 0) {
+		expect(value).toBe(1);
+		await NEXT_HMR();
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 2) {
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 3) {
+		expect(value).toBe(3);
+	}
+});
+
+module.hot.accept("./file");

--- a/tests/rspack-test/cacheCases/common/update-file-incremental-disabled/loader.js
+++ b/tests/rspack-test/cacheCases/common/update-file-incremental-disabled/loader.js
@@ -1,0 +1,5 @@
+module.exports = function (content) {
+	const options = this.getOptions();
+	options.files.push(this.resourcePath);
+	return content;
+};

--- a/tests/rspack-test/cacheCases/common/update-file-incremental-disabled/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/update-file-incremental-disabled/rspack.config.js
@@ -1,0 +1,32 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	incremental: false,
+	module: {
+		rules: [
+			{
+				test: /file\.js$/,
+				loader: "./loader.js",
+				options: {
+					files: []
+				}
+			}
+		]
+	},
+	cache: {
+		type: "persistent"
+	},
+	plugins: [
+		{
+			updateIndex: 0,
+			apply(compiler) {
+				compiler.hooks.done.tap("Test", () => {
+					const options = compiler.options.module.rules[0].options;
+					expect(options.files.length).toBe(1);
+					options.files = [];
+					this.updateIndex++;
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
Summary
- stop persisting and tracking module graph caches when the incremental build module graph pass is disabled
- reset file/context/missing dependency bookkeeping and file counter state in disabled incremental scenarios (including watching changes)
- add regression coverage for incremental-disabled caching in cacheCases/common

Testing
- Not run (not requested)