### PR TITLE
refactor(core): reduce exports info overhead

### DIFF
--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, collections::hash_map::Entry, sync::Arc};
 
 use either::Either;
 use itertools::Itertools;
@@ -32,6 +32,11 @@ pub struct PrefetchedExportsInfoWrapper<'a> {
    */
   exports: Arc<UkeyMap<ExportsInfo, &'a ExportsInfoData>>,
   /**
+   * Cached data for the current entry to avoid repeated UkeyMap lookups
+   * on the hottest access path.
+   */
+  current: &'a ExportsInfoData,
+  /**
    * The entry of the current exports info
    */
   entry: ExportsInfo,
@@ -48,6 +53,11 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   pub fn redirect(&self, entry: ExportsInfo, nested: bool) -> Self {
     Self {
       exports: self.exports.clone(),
+      current: self
+        .exports
+        .get(&entry)
+        .copied()
+        .expect("should have nested exports info"),
       entry,
       mode: if nested {
         match self.mode {
@@ -66,10 +76,19 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
    * Get the data of the current exports info
    */
   pub fn data(&self) -> &ExportsInfoData {
-    self
-      .exports
-      .get(&self.entry)
-      .expect("should have nested exports info")
+    self.current
+  }
+
+  #[inline]
+  fn data_for(&self, exports_info: &ExportsInfo) -> &ExportsInfoData {
+    if *exports_info == self.entry {
+      self.current
+    } else {
+      self
+        .exports
+        .get(exports_info)
+        .expect("should have nested exports info")
+    }
   }
 
   pub fn meta(&self) -> (ExportsInfo, Vec<ExportsInfo>) {
@@ -89,30 +108,34 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   fn get_other_in_exports_info(&self, exports_info: &ExportsInfo) -> &ExportInfoData {
-    let data = self
-      .exports
-      .get(exports_info)
-      .expect("should have nested exports info");
-    data.other_exports_info()
+    self.data_for(exports_info).other_exports_info()
   }
 
   fn get_side_effects_in_exports_info(&self, exports_info: &ExportsInfo) -> &ExportInfoData {
-    let data = self
-      .exports
-      .get(exports_info)
-      .expect("should have nested exports info");
-    data.side_effects_only_info()
+    self.data_for(exports_info).side_effects_only_info()
   }
 
   fn get_exports_in_exports_info(
     &self,
     exports_info: &ExportsInfo,
   ) -> impl Iterator<Item = (&Atom, &ExportInfoData)> {
-    let data = self
-      .exports
-      .get(exports_info)
-      .expect("should have nested exports info");
-    data.exports().iter()
+    self.data_for(exports_info).exports().iter()
+  }
+
+  #[inline]
+  fn get_named_export_in_data<'b>(
+    data: &'b ExportsInfoData,
+    name: &Atom,
+  ) -> Option<&'b ExportInfoData> {
+    data.exports().get(name)
+  }
+
+  #[inline]
+  fn get_read_only_export_info_in_data<'b>(
+    data: &'b ExportsInfoData,
+    name: &Atom,
+  ) -> &'b ExportInfoData {
+    Self::get_named_export_in_data(data, name).unwrap_or_else(|| data.other_exports_info())
   }
 
   fn get_named_export_in_exports_info(
@@ -120,11 +143,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     exports_info: &ExportsInfo,
     name: &Atom,
   ) -> Option<&ExportInfoData> {
-    let data = self
-      .exports
-      .get(exports_info)
-      .expect("should have nested exports info");
-    data.exports().get(name)
+    Self::get_named_export_in_data(self.data_for(exports_info), name)
   }
 
   pub fn get_read_only_export_info(&self, name: &Atom) -> &ExportInfoData {
@@ -136,57 +155,48 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     exports_info: &ExportsInfo,
     name: &Atom,
   ) -> &ExportInfoData {
-    if let Some(export_info) = self.get_named_export_in_exports_info(exports_info, name) {
-      return export_info;
-    }
-    self.get_other_in_exports_info(exports_info)
+    Self::get_read_only_export_info_in_data(self.data_for(exports_info), name)
   }
 
   pub fn get_read_only_export_info_recursive(&self, names: &[Atom]) -> Option<&ExportInfoData> {
-    let (exports_info, name) = self.get_read_only_export_info_recursive_impl(names)?;
-    let data = self
-      .exports
-      .get(&exports_info)
-      .expect("should have nested exports info");
-    data.exports().get(&name)
-  }
-
-  fn get_read_only_export_info_recursive_impl(
-    &self,
-    names: &[Atom],
-  ) -> Option<(ExportsInfo, Atom)> {
     if names.is_empty() {
       return None;
     }
-    let export_info = self.get_read_only_export_info(&names[0]);
-    if names.len() == 1 {
-      return Some((self.entry, names[0].clone()));
-    }
 
-    export_info.exports_info().and_then(move |exports_info| {
-      let redirect = self.redirect(exports_info, true);
-      redirect.get_read_only_export_info_recursive_impl(&names[1..])
-    })
-  }
+    let mut current_data = self.current;
 
-  pub fn get_nested_exports_info(&self, name: Option<&[Atom]>) -> Option<&ExportsInfoData> {
-    let exports_info = self.get_nested_exports_info_impl(name)?;
-    self.exports.get(&exports_info).copied()
-  }
+    for (idx, name) in names.iter().enumerate() {
+      let export_info = Self::get_read_only_export_info_in_data(current_data, name);
+      if idx + 1 == names.len() {
+        return Self::get_named_export_in_data(current_data, name);
+      }
 
-  fn get_nested_exports_info_impl(&self, name: Option<&[Atom]>) -> Option<ExportsInfo> {
-    if let Some(name) = name
-      && !name.is_empty()
-    {
-      let info = self.get_read_only_export_info(&name[0]);
-      if let Some(exports_info) = &info.exports_info() {
-        let redirect = self.redirect(*exports_info, true);
-        return redirect.get_nested_exports_info_impl(Some(&name[1..]));
+      if let Some(next_exports_info) = export_info.exports_info() {
+        current_data = self.data_for(&next_exports_info);
       } else {
         return None;
       }
     }
-    Some(self.entry)
+
+    None
+  }
+
+  pub fn get_nested_exports_info(&self, name: Option<&[Atom]>) -> Option<&ExportsInfoData> {
+    let Some(names) = name else {
+      return Some(self.current);
+    };
+    if names.is_empty() {
+      return Some(self.current);
+    }
+
+    let mut current_data = self.current;
+    for name in names {
+      let export_info = Self::get_read_only_export_info_in_data(current_data, name);
+      let next_exports_info = export_info.exports_info()?;
+      current_data = self.data_for(&next_exports_info);
+    }
+
+    Some(current_data)
   }
 
   pub fn get_relevant_exports(&self, runtime: Option<&RuntimeSpec>) -> Vec<&ExportInfoData> {
@@ -198,10 +208,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     exports_info: &ExportsInfo,
     runtime: Option<&RuntimeSpec>,
   ) -> Vec<&ExportInfoData> {
-    let data = self
-      .exports
-      .get(exports_info)
-      .expect("should have nested exports info");
+    let data = self.data_for(exports_info);
     let mut list = Vec::with_capacity(data.exports().len() + 1);
     for export_info in data.exports().values() {
       let used = export_info.get_used(runtime);
@@ -379,45 +386,44 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 
   pub fn is_export_provided(&self, names: &[Atom]) -> Option<ExportProvided> {
-    let name = names.first()?;
-    let info_data = self.get_read_only_export_info(name);
-    if let Some(nested_exports_info) = &info_data.exports_info()
-      && names.len() > 1
-    {
-      let redirected = self.redirect(*nested_exports_info, true);
-      return redirected.is_export_provided(&names[1..]);
-    }
-    let provided = info_data.provided()?;
+    names.first()?;
 
-    match provided {
-      ExportProvided::Provided => {
-        if names.len() == 1 {
-          Some(ExportProvided::Provided)
-        } else {
-          None
-        }
+    let mut current_data = self.current;
+
+    for (idx, name) in names.iter().enumerate() {
+      let info_data = Self::get_read_only_export_info_in_data(current_data, name);
+      if idx + 1 == names.len() {
+        return info_data.provided();
       }
-      _ => Some(provided),
+
+      let Some(nested_exports_info) = info_data.exports_info() else {
+        return match info_data.provided()? {
+          ExportProvided::Provided => None,
+          provided => Some(provided),
+        };
+      };
+      current_data = self.data_for(&nested_exports_info);
     }
+
+    None
   }
 
   pub fn get_used(&self, names: &[Atom], runtime: Option<&RuntimeSpec>) -> UsageState {
-    if names.len() == 1 {
-      let value = &names[0];
-      let info = self.get_read_only_export_info(value);
-      let used = info.get_used(runtime);
-      return used;
-    }
     if names.is_empty() {
       return self.other_exports_info().get_used(runtime);
     }
-    let info_data = self.get_read_only_export_info(&names[0]);
-    if let Some(exports_info) = &info_data.exports_info()
-      && names.len() > 1
-    {
-      let redirected = self.redirect(*exports_info, true);
-      return redirected.get_used(&names[1..], runtime);
+
+    let mut current_data = self.current;
+    let mut info_data = Self::get_read_only_export_info_in_data(current_data, &names[0]);
+
+    for name in names.iter().skip(1) {
+      let Some(exports_info) = info_data.exports_info() else {
+        return info_data.get_used(runtime);
+      };
+      current_data = self.data_for(&exports_info);
+      info_data = Self::get_read_only_export_info_in_data(current_data, name);
     }
+
     info_data.get_used(runtime)
   }
 
@@ -479,13 +485,14 @@ impl ExportsInfoGetter {
       res: &mut UkeyMap<ExportsInfo, &'a ExportsInfoData>,
       mode: PrefetchExportsInfoMode<'a>,
     ) {
-      if res.contains_key(id) {
-        return;
-      }
-
-      let exports_info = id.as_data(exports_info_artifact);
-      res.insert(*id, exports_info);
-
+      let exports_info = match res.entry(*id) {
+        Entry::Occupied(_) => return,
+        Entry::Vacant(entry) => {
+          let exports_info = id.as_data(exports_info_artifact);
+          entry.insert(exports_info);
+          exports_info
+        }
+      };
       match mode {
         PrefetchExportsInfoMode::Default => {}
         PrefetchExportsInfoMode::Nested(names) => {
@@ -562,8 +569,13 @@ impl ExportsInfoGetter {
     };
     let mut res = UkeyMap::with_capacity_and_hasher(initial_capacity, Default::default());
     prefetch_exports(id, exports_info_artifact, &mut res, mode.clone());
+    let current = res
+      .get(id)
+      .copied()
+      .expect("should have entry exports info");
     PrefetchedExportsInfoWrapper {
       exports: Arc::new(res),
+      current,
       entry: *id,
       mode,
     }
@@ -627,33 +639,35 @@ impl ExportsInfoGetter {
           }
           return Some(UsedName::Normal(vec![]));
         }
-        let export_info = info.get_read_only_export_info(&names[0]);
-        let first = export_info.get_used_name(Some(&names[0]), runtime)?;
-        let mut arr = match first {
+        let mut current_data = info.current;
+        let mut export_info =
+          PrefetchedExportsInfoWrapper::get_read_only_export_info_in_data(current_data, &names[0]);
+        let mut arr = match export_info.get_used_name(Some(&names[0]), runtime)? {
           UsedNameItem::Str(first) => UsedName::Normal(vec![first]),
           UsedNameItem::Inlined(inlined) => UsedName::Inlined(InlinedUsedName::new(inlined)),
         };
-        if names.len() == 1 {
-          return Some(arr);
-        }
-        if let Some(exports_info) = &export_info.exports_info()
-          && export_info.get_used(runtime) == UsageState::OnlyPropertiesUsed
-        {
-          let nested_exports_info: PrefetchedExportsInfoWrapper<'_> =
-            info.redirect(*exports_info, true);
-          let nested = Self::get_used_name(
-            GetUsedNameParam::WithNames(&nested_exports_info),
-            runtime,
-            &names[1..],
-          )?;
-          let nested = match nested {
-            UsedName::Inlined(_) => return Some(nested),
-            UsedName::Normal(names) => names,
+
+        for (index, name) in names.iter().enumerate().skip(1) {
+          let Some(exports_info) = export_info.exports_info() else {
+            arr.append(names[index..].iter().cloned());
+            return Some(arr);
           };
-          arr.append(nested);
-          return Some(arr);
+          if export_info.get_used(runtime) != UsageState::OnlyPropertiesUsed {
+            arr.append(names[index..].iter().cloned());
+            return Some(arr);
+          }
+
+          current_data = info.data_for(&exports_info);
+          export_info =
+            PrefetchedExportsInfoWrapper::get_read_only_export_info_in_data(current_data, name);
+          match export_info.get_used_name(Some(name), runtime)? {
+            UsedNameItem::Str(next) => arr.append(std::iter::once(next)),
+            UsedNameItem::Inlined(inlined) => {
+              return Some(UsedName::Inlined(InlinedUsedName::new(inlined)));
+            }
+          }
         }
-        arr.append(names.iter().skip(1).cloned());
+
         Some(arr)
       }
     }
@@ -668,9 +682,14 @@ impl ExportsInfoGetter {
       .into_iter()
       .map(|e| (e, exports_info_artifact.get_exports_info_by_id(&e)))
       .collect::<UkeyMap<_, _>>();
+    let current = exports
+      .get(&entry)
+      .copied()
+      .expect("should have entry exports info");
 
     PrefetchedExportsInfoWrapper {
       exports: Arc::new(exports),
+      current,
       entry,
       mode: PrefetchExportsInfoMode::Full,
     }

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -6,9 +6,8 @@ use rspack_core::{
   BoxModule, Compilation, CompilationOptimizeDependencies, ConnectionState, DependencyExtraMeta,
   DependencyId, ExportsInfoArtifact, FactoryMeta, GetTargetResult, Logger, ModuleFactoryCreateData,
   ModuleGraph, ModuleGraphConnection, ModuleIdentifier, NormalModuleCreateData,
-  NormalModuleFactoryModule, Plugin, PrefetchExportsInfoMode, RayonConsumer,
-  ResolvedExportInfoTarget, SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget,
-  SideEffectsOptimizeArtifact,
+  NormalModuleFactoryModule, Plugin, PrefetchExportsInfoMode, ResolvedExportInfoTarget,
+  SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget, SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
   can_move_target, get_target,
   incremental::{self, IncrementalPasses, Mutation},
@@ -246,14 +245,10 @@ async fn optimize_dependencies(
   logger.time_end(inner_start);
 
   let inner_start = logger.time("find optimizable connections");
-  modules
+  let optimizable_connections: Vec<_> = modules
     .par_iter()
     .filter(|module| side_effects_state_map[module] == ConnectionState::Active(false))
-    .flat_map(|module| {
-      module_graph
-        .get_incoming_connections(module)
-        .collect::<Vec<_>>()
-    })
+    .flat_map_iter(|module| module_graph.get_incoming_connections(module))
     .map(|connection| {
       (
         connection.dependency_id,
@@ -265,13 +260,14 @@ async fn optimize_dependencies(
         ),
       )
     })
-    .consume(|(dep_id, can_optimize)| {
-      if let Some(do_optimize) = can_optimize {
-        side_effects_optimize_artifact.insert(dep_id, do_optimize);
-      } else {
-        side_effects_optimize_artifact.remove(&dep_id);
-      }
-    });
+    .collect();
+  for (dep_id, can_optimize) in optimizable_connections {
+    if let Some(do_optimize) = can_optimize {
+      side_effects_optimize_artifact.insert(dep_id, do_optimize);
+    } else {
+      side_effects_optimize_artifact.remove(&dep_id);
+    }
+  }
   logger.time_end(inner_start);
 
   let mut do_optimizes = side_effects_optimize_artifact.clone();


### PR DESCRIPTION
## Summary
- reduce exports info wrapper and prefetch lookup churn
- keep lowering hashing and allocation overhead in module graph hot paths for `cases/all`

## Validation
- cargo check -p rspack_core
- cargo test -p rspack_core exports_info --lib
- pnpm run build:binding:profiling
- local `cases/all` runs improved from about `1.62 s` to about `1.54-1.55 s`
