### PR TITLE
fix: restore panic backtrace for macOS arm64 bindings

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -45,9 +45,9 @@ async function build() {
 		const features = [];
 		const envs = { ...process.env };
 		const use_build_std = values.profile === "release"
-				|| values.profile === "release-debug"
-				|| values.profile === "release-wasi"
-				|| values.profile === "profiling";
+			|| values.profile === "release-debug"
+			|| values.profile === "release-wasi"
+			|| values.profile === "profiling";
 
 		if (values.profile) {
 			args.push("--profile", values.profile);
@@ -87,6 +87,12 @@ async function build() {
 			if (process.env.RUST_TARGET && !process.env.RUST_TARGET.includes("windows-msvc")) {
 				rustflags.push("-Cforce-unwind-tables=no");
 			}
+		} else {
+			// enable unwind-table for backtrace for non-release profile
+			if (!process.env.RUST_TARGET || (process.env.RUST_TARGET && !process.env.RUST_TARGET.includes("windows-msvc"))) {
+				rustflags.push("-Cforce-unwind-tables=yes");
+			}
+
 		}
 		if (features.length) {
 			args.push(`--features ${features.join(",")}`);
@@ -142,9 +148,9 @@ async function build() {
 					renameSync("rspack.wasm32-wasi.wasm", "rspack.browser.wasm")
 				}
 
-				if(process.env.TRACY){
+				if (process.env.TRACY) {
 					// split debug symbols for tracy
-				  spawnSync('dsymutil', [
+					spawnSync('dsymutil', [
 						path.resolve(__dirname, "..", "rspack.darwin-arm64.node")
 					], {
 						stdio: "inherit",

--- a/crates/rspack_binding_api/src/panic.rs
+++ b/crates/rspack_binding_api/src/panic.rs
@@ -1,18 +1,25 @@
 pub fn install_panic_handler() {
-  std::panic::set_hook(Box::new(|panic| {
-    #[cfg(debug_assertions)]
-    {
-      use rspack_core::debug_info::DEBUG_INFO;
-      if let Ok(info) = DEBUG_INFO.lock() {
-        eprintln!("{info}");
-      }
-    }
+  static INSTALL_PANIC_HANDLER: std::sync::Once = std::sync::Once::new();
 
-    let backtrace = std::backtrace::Backtrace::force_capture();
-    eprintln!(
-      "Panic occurred at runtime. Please file an issue on GitHub with the panic info and backtrace below: https://github.com/web-infra-dev/rspack/issues"
-    );
-    eprintln!("panic: {panic}");
-    eprintln!("backtrace:\n{backtrace}");
-  }));
+  INSTALL_PANIC_HANDLER.call_once(|| {
+    let previous_hook = std::panic::take_hook();
+
+    std::panic::set_hook(Box::new(move |panic| {
+      #[cfg(debug_assertions)]
+      {
+        use rspack_core::debug_info::DEBUG_INFO;
+        if let Ok(info) = DEBUG_INFO.lock() {
+          eprintln!("{info}");
+        }
+      }
+
+      eprintln!(
+        "Panic occurred at runtime. Please file an issue on GitHub with the panic info and backtrace below: https://github.com/web-infra-dev/rspack/issues"
+      );
+
+      // Keep the original hook in the chain so the backtrace still points to the
+      // panic site instead of this custom hook frame.
+      previous_hook(panic);
+    }));
+  });
 }


### PR DESCRIPTION
## Summary
- keep the panic hook lightweight and idempotent in the binding API
- enable force-unwind-tables=yes for non-release macOS arm64 native binding builds
- restore the default Rust panic backtrace so it includes the missing Rust frames in Node bindings

## Verification
- cargo check -p rspack_binding_api --lib --message-format short
- pnpm --filter @rspack/binding run build:dev
- RUST_BACKTRACE=full node packages/rspack-cli/bin/rspack.js -c /Users/bytedance/github/rspack/examples/basic/rspack.config.mjs