### PR TITLE
refactor(side-effects): batch optimize dependency updates

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -6,9 +6,8 @@ use rspack_core::{
   BoxModule, Compilation, CompilationOptimizeDependencies, ConnectionState, DependencyExtraMeta,
   DependencyId, ExportsInfoArtifact, FactoryMeta, GetTargetResult, Logger, ModuleFactoryCreateData,
   ModuleGraph, ModuleGraphConnection, ModuleIdentifier, NormalModuleCreateData,
-  NormalModuleFactoryModule, Plugin, PrefetchExportsInfoMode, RayonConsumer,
-  ResolvedExportInfoTarget, SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget,
-  SideEffectsOptimizeArtifact,
+  NormalModuleFactoryModule, Plugin, PrefetchExportsInfoMode, ResolvedExportInfoTarget,
+  SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget, SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
   can_move_target, get_target,
   incremental::{self, IncrementalPasses, Mutation},
@@ -246,7 +245,7 @@ async fn optimize_dependencies(
   logger.time_end(inner_start);
 
   let inner_start = logger.time("find optimizable connections");
-  modules
+  let optimized_connections: Vec<_> = modules
     .par_iter()
     .filter(|module| side_effects_state_map[module] == ConnectionState::Active(false))
     .flat_map(|module| {
@@ -265,13 +264,14 @@ async fn optimize_dependencies(
         ),
       )
     })
-    .consume(|(dep_id, can_optimize)| {
-      if let Some(do_optimize) = can_optimize {
-        side_effects_optimize_artifact.insert(dep_id, do_optimize);
-      } else {
-        side_effects_optimize_artifact.remove(&dep_id);
-      }
-    });
+    .collect();
+  for (dep_id, can_optimize) in optimized_connections {
+    if let Some(do_optimize) = can_optimize {
+      side_effects_optimize_artifact.insert(dep_id, do_optimize);
+    } else {
+      side_effects_optimize_artifact.remove(&dep_id);
+    }
+  }
   logger.time_end(inner_start);
 
   let mut do_optimizes = side_effects_optimize_artifact.clone();


### PR DESCRIPTION
## Summary

- replace `RayonConsumer::consume` in `SideEffectsFlagPlugin::optimize_dependencies` with parallel `collect` plus sequential apply
- remove per-item channel sends from the side-effects optimization hot loop
- local `cases/all` baseline was `2.01 real` / `1.84 s`; kept-commit runs were `1.97`, `2.05`, `2.02` real, with the best reported compile time at `1.81 s`
- the top `std::sync::mpmc::...::start_send` hotspot dropped out of the top perf report; `Stealer::steal` moved from `3.79%` to `3.48%`

## Perf excerpt

```text
before (baseline)
  3.79%  <crossbeam_deque::deque::Stealer<rayon_core::job::JobRef>>::steal
  1.02%  <rspack_core::module_graph::rollback::overlay_map::OverlayMap<..., ModuleGraphConnection>>::get
  0.81%  <rspack_core::exports::exports_info_getter::ExportsInfoGetter>::prefetch
  0.57%  <std::sync::mpmc::list::Channel<(DependencyId, Option<SideEffectsDoOptimize>)>>::start_send
  0.39%  <rspack_core::artifacts::module_graph_cache_artifact::get_exports_type::GetExportsTypeCache>::get

after (kept change)
  3.48%  <crossbeam_deque::deque::Stealer<rayon_core::job::JobRef>>::steal
  0.92%  <rspack_core::module_graph::rollback::overlay_map::OverlayMap<..., ModuleGraphConnection>>::get
  0.91%  <rspack_core::exports::exports_info_getter::ExportsInfoGetter>::prefetch
  dropped from top report: <std::sync::mpmc::list::Channel<(DependencyId, Option<SideEffectsDoOptimize>)>>::start_send
  0.37%  <rspack_core::artifacts::module_graph_cache_artifact::get_exports_type::GetExportsTypeCache>::get
```

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
