### PR TITLE
fix(collections): use FxHasher for Ukey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,6 +3844,7 @@ dependencies = [
  "rayon",
  "rspack-allocative",
  "rspack_cacheable",
+ "rustc-hash",
  "serde",
  "ustr-fxhash",
 ]

--- a/crates/rspack_collections/Cargo.toml
+++ b/crates/rspack_collections/Cargo.toml
@@ -15,6 +15,7 @@ hashlink         = { workspace = true }
 indexmap         = { workspace = true }
 rayon            = { workspace = true }
 rspack_cacheable = { workspace = true }
+rustc-hash       = { workspace = true }
 serde            = { workspace = true, features = ["derive"] }
 ustr             = { workspace = true, features = ["serde"] }
 

--- a/crates/rspack_collections/src/ukey.rs
+++ b/crates/rspack_collections/src/ukey.rs
@@ -7,6 +7,7 @@ use std::{
 use dashmap::{DashMap, DashSet};
 use indexmap::{IndexMap, IndexSet};
 use rayon::prelude::*;
+use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
 
 #[macro_export]
@@ -60,22 +61,7 @@ impl From<Ukey> for u32 {
   }
 }
 
-#[derive(Copy, Clone, Debug, Default)]
-pub struct UkeyHasher(u32);
-
-impl std::hash::Hasher for UkeyHasher {
-  fn write(&mut self, _bytes: &[u8]) {
-    unimplemented!("UkeyHasher should only used for UKey")
-  }
-
-  fn write_u32(&mut self, i: u32) {
-    self.0 = i;
-  }
-
-  fn finish(&self) -> u64 {
-    self.0 as u64
-  }
-}
+pub type UkeyHasher = FxHasher;
 
 pub trait DatabaseItem
 where


### PR DESCRIPTION
## Summary

- switch `Ukey` collections and `Database` to use `FxHasher` via `BuildHasherDefault`
- add `rustc-hash` to `rspack_collections`
- validation: `cargo test -p rspack_collections`, `cargo fmt --all --check`

## Related links

- N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).