### PR TITLE
fix: huge file dependencies cause range error

### DIFF
--- a/packages/rspack/src/util/MergeCaller.ts
+++ b/packages/rspack/src/util/MergeCaller.ts
@@ -22,6 +22,9 @@ export default class MergeCaller<D> {
     if (this.callArgs.length === 0) {
       queueMicrotask(this.finalCall);
     }
-    this.callArgs.push(...data);
+    // Avoid push(...data) which can exceed max call stack when data is huge
+    for (let i = 0; i < data.length; i++) {
+      this.callArgs.push(data[i]);
+    }
   }
 }

--- a/tests/rspack-test/configCases/dependencies/file-dependencies-huge/index.js
+++ b/tests/rspack-test/configCases/dependencies/file-dependencies-huge/index.js
@@ -1,0 +1,1 @@
+it("should not throw when adding many file dependencies in done hook", () => {});

--- a/tests/rspack-test/configCases/dependencies/file-dependencies-huge/rspack.config.js
+++ b/tests/rspack-test/configCases/dependencies/file-dependencies-huge/rspack.config.js
@@ -1,0 +1,20 @@
+const path = require("path");
+
+// Number large enough to exceed engine's max arguments (e.g. ~65536) when
+// spread in push(...data), which would cause "Maximum call stack size exceeded".
+const HUGE_DEPS_COUNT = 100_000;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	plugins: [
+		compiler => {
+			compiler.hooks.done.tap("HugeFileDepsPlugin", ({ compilation }) => {
+				const largeDeps = Array.from(
+					{ length: HUGE_DEPS_COUNT },
+					(_, i) => path.resolve(__dirname, `fake-dep-${i}.js`)
+				);
+				compilation.fileDependencies.addAll(largeDeps);
+			});
+		}
+	]
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Fixes a RangeError triggered when adding a very large number of file dependencies (e.g. via `compilation.fileDependencies.addAll`) by changing the batching utility used for dependency collection, and adds a regression config-case.

```
RangeError: Maximum call stack size exceeded
  at MergeCaller.push
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
