### PR TITLE
chore(ci): eco benchmark compare using by commits perf data

### DIFF
--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -113,6 +113,8 @@ jobs:
       - name: Run rspack-ecosystem-benchmark
         timeout-minutes: 40
         id: run-benchmark
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RSPACK_DIR=$(pwd)
           git clone --single-branch --depth 1 https://github.com/web-infra-dev/rspack-ecosystem-benchmark.git


### PR DESCRIPTION
## Summary
Ref to https://github.com/web-infra-dev/rspack-ecosystem-benchmark/pull/86 
Rspack Benchmark repo support uses git ref to specify the base benchmark data, like in Binary size limit.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
