### PR TITLE
refactor(core): batch runtime spec key updates

### DIFF
--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -87,13 +87,12 @@ impl RuntimeSpec {
     this
   }
 
-  pub fn from_single(runtime: Ustr) -> Self {
+  pub fn from_runtimes<'a>(runtimes: impl IntoIterator<Item = &'a RuntimeSpec>) -> Self {
     let mut inner = UstrSet::default();
-    inner.insert(runtime);
-    Self {
-      inner,
-      key: runtime.as_str().to_string(),
+    for runtime in runtimes {
+      inner.extend(runtime.inner.iter().copied());
     }
+    Self::new(inner)
   }
 
   pub fn from_entry(entry: &str, runtime: Option<&EntryRuntime>) -> Self {
@@ -101,16 +100,16 @@ impl RuntimeSpec {
       Some(EntryRuntime::String(s)) => s,
       _ => entry,
     }
-    .into();
-    Self::from_single(r)
+    .to_string();
+    Self::from_iter([r.into()])
   }
 
   pub fn from_entry_options(options: &EntryOptions) -> Option<Self> {
     let r = match &options.runtime {
-      Some(EntryRuntime::String(s)) => Some(Ustr::from(s.as_str())),
-      _ => options.name.as_deref().map(Ustr::from),
+      Some(EntryRuntime::String(s)) => Some(s.to_owned()),
+      _ => options.name.clone(),
     };
-    r.map(Self::from_single)
+    r.map(|r| Self::from_iter([r.into()]))
   }
 
   pub fn subtract(&self, b: &RuntimeSpec) -> Self {

--- a/crates/rspack_core/src/utils/runtime.rs
+++ b/crates/rspack_core/src/utils/runtime.rs
@@ -3,12 +3,11 @@ use std::borrow::Cow;
 use cow_utils::CowUtils;
 use indexmap::IndexMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use ustr::UstrSet;
 
 use super::extract_hash_pattern;
 use crate::{
-  CHUNK_HASH_PLACEHOLDER, CONTENT_HASH_PLACEHOLDER, EntryData, EntryOptions, EntryRuntime,
-  FULL_HASH_PLACEHOLDER, Filename, HASH_PLACEHOLDER, RuntimeSpec,
+  CHUNK_HASH_PLACEHOLDER, CONTENT_HASH_PLACEHOLDER, EntryData, EntryOptions, FULL_HASH_PLACEHOLDER,
+  Filename, HASH_PLACEHOLDER, RuntimeSpec,
 };
 
 pub fn get_entry_runtime(
@@ -17,7 +16,7 @@ pub fn get_entry_runtime(
   entries: &IndexMap<String, EntryData>,
 ) -> RuntimeSpec {
   if let Some(depend_on) = &options.depend_on {
-    let mut result = UstrSet::default();
+    let mut result: RuntimeSpec = Default::default();
     let mut queue = vec![];
     queue.extend(depend_on.clone());
 
@@ -37,14 +36,10 @@ pub fn get_entry_runtime(
           queue.push(depend.clone());
         }
       } else {
-        let runtime = match options.runtime.as_ref() {
-          Some(EntryRuntime::String(runtime)) => runtime.as_str(),
-          _ => name.as_str(),
-        };
-        result.insert(runtime.into());
+        result.extend(&RuntimeSpec::from_entry(&name, options.runtime.as_ref()));
       }
     }
-    RuntimeSpec::new(result)
+    result
   } else {
     RuntimeSpec::from_entry(name, options.runtime.as_ref())
   }

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -394,10 +394,9 @@ impl ModuleConcatenationPlugin {
           if let Some(origin_runtime) = module_cache.get(origin_module).map(|m| &m.runtime) {
             !runtime.is_disjoint(origin_runtime)
           } else {
-            let mut origin_runtime = RuntimeSpec::default();
-            for r in chunk_graph.get_module_runtimes_iter(*origin_module, chunk_by_ukey) {
-              origin_runtime.extend(r);
-            }
+            let origin_runtime = RuntimeSpec::from_runtimes(
+              chunk_graph.get_module_runtimes_iter(*origin_module, chunk_by_ukey),
+            );
             !runtime.is_disjoint(&origin_runtime)
           }
         } else {
@@ -1083,17 +1082,15 @@ impl ModuleConcatenationPlugin {
         let module = module_graph
           .module_by_identifier(&module_id)
           .expect("should have module");
-        let mut runtime = RuntimeSpec::default();
-        for r in compilation
-          .build_chunk_graph_artifact
-          .chunk_graph
-          .get_module_runtimes_iter(
-            module_id,
-            &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-          )
-        {
-          runtime.extend(r);
-        }
+        let runtime = RuntimeSpec::from_runtimes(
+          compilation
+            .build_chunk_graph_artifact
+            .chunk_graph
+            .get_module_runtimes_iter(
+              module_id,
+              &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+            ),
+        );
 
         let _ = get_cached_readable_identifier(
           &module_id,

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -110,17 +110,15 @@ impl ModernModuleLibraryPlugin {
       .collect::<HashSet<_>>();
 
     for module_id in unconcatenated_module_ids {
-      let chunk_runtime = compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .get_module_runtimes_iter(
-          *module_id,
-          &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-        )
-        .fold(RuntimeSpec::default(), |mut acc, r| {
-          acc.extend(r);
-          acc
-        });
+      let chunk_runtime = RuntimeSpec::from_runtimes(
+        compilation
+          .build_chunk_graph_artifact
+          .chunk_graph
+          .get_module_runtimes_iter(
+            *module_id,
+            &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+          ),
+      );
 
       let current_configuration: ConcatConfiguration =
         ConcatConfiguration::new(*module_id, Some(chunk_runtime.clone()));


### PR DESCRIPTION
## Summary

- add `RuntimeSpec::from_runtimes` to union runtime sets with a single key rebuild
- replace the hot `RuntimeSpec::default() + extend()` loops in module runtime aggregation paths with `from_runtimes(...)`
- keep the change scoped to the `from_runtimes` batching path after benchmarking the broader variants

## Related links

- None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `cargo fmt --all --check`
- `cargo check -p rspack_core -p rspack_plugin_javascript -p rspack_plugin_library`
