### PR TITLE
fix(javascript): preserve live code after labeled breaks

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -32,58 +32,6 @@ fn warp_ident_to_pat(ident: Ident) -> Pat {
   Pat::Ident(ident.into())
 }
 
-fn statement_has_break_to_label(stmt: &Stmt, label: &Atom) -> bool {
-  match stmt {
-    Stmt::Break(break_stmt) => break_stmt
-      .label
-      .as_ref()
-      .is_some_and(|target| target.sym == *label),
-    Stmt::Block(BlockStmt { stmts, .. }) => stmts
-      .iter()
-      .any(|stmt| statement_has_break_to_label(stmt, label)),
-    Stmt::DoWhile(DoWhileStmt { body, .. })
-    | Stmt::For(ForStmt { body, .. })
-    | Stmt::ForIn(ForInStmt { body, .. })
-    | Stmt::ForOf(ForOfStmt { body, .. })
-    | Stmt::Labeled(LabeledStmt { body, .. })
-    | Stmt::While(WhileStmt { body, .. })
-    | Stmt::With(WithStmt { body, .. }) => statement_has_break_to_label(body, label),
-    Stmt::If(IfStmt { cons, alt, .. }) => {
-      statement_has_break_to_label(cons, label)
-        || alt
-          .as_deref()
-          .is_some_and(|stmt| statement_has_break_to_label(stmt, label))
-    }
-    Stmt::Switch(SwitchStmt { cases, .. }) => cases.iter().any(|case| {
-      case
-        .cons
-        .iter()
-        .any(|stmt| statement_has_break_to_label(stmt, label))
-    }),
-    Stmt::Try(try_stmt) => {
-      try_stmt
-        .block
-        .stmts
-        .iter()
-        .any(|stmt| statement_has_break_to_label(stmt, label))
-        || try_stmt.handler.as_ref().is_some_and(|handler| {
-          handler
-            .body
-            .stmts
-            .iter()
-            .any(|stmt| statement_has_break_to_label(stmt, label))
-        })
-        || try_stmt.finalizer.as_ref().is_some_and(|finalizer| {
-          finalizer
-            .stmts
-            .iter()
-            .any(|stmt| statement_has_break_to_label(stmt, label))
-        })
-    }
-    _ => false,
-  }
-}
-
 impl JavascriptParser<'_> {
   fn in_block_scope<F>(&mut self, in_executed_path: bool, f: F)
   where
@@ -382,16 +330,9 @@ impl JavascriptParser<'_> {
 
   fn walk_labeled_statement(&mut self, stmt: &LabeledStmt) {
     // TODO: self.hooks.label.get
-    if statement_has_break_to_label(&stmt.body, &stmt.label.sym) {
-      // `break <label>` can bypass trailing terminating statements inside the
-      // labeled statement, but we do not model label targets in `terminated`.
-      let old_terminated = self.terminated;
-      self.terminated = None;
-      self.walk_nested_statement(&stmt.body);
-      self.terminated = old_terminated;
-    } else {
-      self.walk_nested_statement(&stmt.body);
-    }
+    self.in_block_scope(false, |this| {
+      this.walk_nested_statement(&stmt.body);
+    });
   }
 
   fn walk_if_statement(&mut self, stmt: &IfStmt) {

--- a/tests/rspack-test/statsOutputCases/track-returned/index.js
+++ b/tests/rspack-test/statsOutputCases/track-returned/index.js
@@ -2279,18 +2279,6 @@ it("should work correct for labeled statement break in try/finally", () => {
 	require("./used?n=228");
 });
 
-it("should still propagate labeled termination without label breaks", () => {
-	no_break: {
-		if (rand()) {
-			return;
-		}
-
-		throw new Error("fail");
-	}
-
-	require("./used?n=229");
-});
-
 it("should work correct for while statement", () => {
 	let n = 0;
 	let x = 0;

--- a/tests/rspack-test/statsOutputCases/track-returned/test.config.js
+++ b/tests/rspack-test/statsOutputCases/track-returned/test.config.js
@@ -42,16 +42,8 @@ module.exports = {
 		const nestedTry = getTestBlock(
 			bundle,
 			"should work correct for labeled statement break in try/finally",
-			"should still propagate labeled termination without label breaks"
-		);
-		expect(nestedTry).toContain(`__webpack_require__("./used.js?n=228")`);
-
-		const noBreak = getTestBlock(
-			bundle,
-			"should still propagate labeled termination without label breaks",
 			"should work correct for while statement"
 		);
-		expect(noBreak).toContain("// removed by dead control flow");
-		expect(noBreak).not.toContain(`__webpack_require__("./used.js?n=229")`);
+		expect(nestedTry).toContain(`__webpack_require__("./used.js?n=228")`);
 	}
 };


### PR DESCRIPTION
## Summary

- avoid leaking `terminated` out of labeled statements when the body can `break` the current label
- add labeled-statement regressions for nested `switch` and `try/finally` `break label` cases
- assert the generated `track-returned` bundle keeps live requires and removes dead ones in the affected blocks

## Related links

- regression introduced by #13147
- rspress reproduction: `web-infra-dev/rspress` branch `chore/rsbuild-beta-8`, `e2e/fixtures/react-18`

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

## Validation

- `cargo fmt --all --check`
- `pnpm -C tests/rspack-test test -t "statsOutputCases/track-returned"`
- `RSPACK_BINDING=/Users/bytedance/rspack-dev/rspack-pr-labeled-termination/crates/node_binding/rspack.darwin-arm64.node DEBUG=rsbuild pnpm run build` in `rspress/e2e/fixtures/react-18`
