### PR TITLE
fix(parser): avoid treating require.resolve chains as require

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -872,13 +872,14 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     member_expr: &MemberExpr,
-    _callee_members: &[Atom],
+    callee_members: &[Atom],
     call_expr: &CallExpr,
     members: &[Atom],
     _member_ranges: &[Span],
     for_name: &str,
   ) -> Option<bool> {
-    if (for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE)
+    if callee_members.is_empty()
+      && (for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE)
       && let Some(dep) = self.chain_handler(parser, member_expr, call_expr, members, false)
     {
       parser.add_dependency(Box::new(dep));
@@ -891,13 +892,14 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     call_expr: &CallExpr,
-    _callee_members: &[Atom],
+    callee_members: &[Atom],
     inner_call_expr: &CallExpr,
     members: &[Atom],
     _member_ranges: &[Span],
     for_name: &str,
   ) -> Option<bool> {
-    if (for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE)
+    if callee_members.is_empty()
+      && (for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE)
       && let Some(callee) = call_expr.callee.as_expr()
       && let Some(member) = callee.as_member()
       && let Some(dep) = self.chain_handler(parser, member, inner_call_expr, members, true)

--- a/tests/rspack-test/configCases/parsing/require-resolve/index.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve/index.js
@@ -22,3 +22,4 @@ const resolve6 = require.resolve('./a', { paths: [ cwd, path.resolve(cwd, 'node_
 // const __require = require
 // const resolve8 = __require.resolve('./other.js')
 
+const resolve9 = require.resolve('./foo').replace('', '')

--- a/tests/rspack-test/configCases/parsing/require-resolve/test.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve/test.js
@@ -9,4 +9,5 @@ it("`require.resolve` should preserve as-is when `requireResolve` is disabled", 
   expect(code).toContain("require.resolve(process.env.RANDOM ? './foo/' + dir + '.js' : './bar/' + dir + 'js')");
   expect(code).toContain("require.resolve(external_path_default().resolve(__dirname, './other.js'))");
   expect(code).toContain("require.resolve('./a', { paths: [ cwd, external_path_default().resolve(cwd, 'node_modules') ] })");
+  expect(code).toContain("require.resolve('./foo').replace('', '')");
 });


### PR DESCRIPTION
## Summary

- prevent CommonJS full-require chain handling from treating `require.resolve(...)` call chains as `require(...)`
- only create `CommonJsFullRequireDependency` when the inner callee is a direct `require(...)` call
- add a regression case to ensure `requireResolve: false` preserves `require.resolve('./foo').replace('', '')` as-is

## Related links

- None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).