### PR TITLE
docs: unify website description

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -14,12 +14,13 @@ import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 
 const PUBLISH_URL = 'https://rspack.rs';
+const description =
+  'Fast Rust-based bundler for the web with a modernized webpack API';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
   title: 'Rspack',
-  description:
-    'Rspack is a high performance JavaScript bundler written in Rust. It offers strong compatibility with the webpack ecosystem, and lightning fast build speeds.',
+  description,
   logo: {
     light: 'https://assets.rspack.rs/rspack/navbar-logo-light.png',
     dark: 'https://assets.rspack.rs/rspack/navbar-logo-dark.png',
@@ -120,8 +121,7 @@ export default defineConfig({
       {
         lang: 'en',
         title: 'Rspack',
-        description:
-          'Fast Rust-based bundler for the web with a modernized webpack API',
+        description,
         label: 'English',
       },
       {
@@ -155,8 +155,7 @@ export default defineConfig({
       pluginGoogleAnalytics({ id: 'G-XKKCNZZNJD' }),
       pluginOpenGraph({
         url: PUBLISH_URL,
-        description:
-          'Fast Rust-based bundler for the web with a modernized webpack API',
+        description,
         twitter: {
           site: '@rspack_dev',
           card: 'summary_large_image',


### PR DESCRIPTION
## Summary

Use a single constant for the website description to maintain consistency and reduce duplication across multiple configuration sections.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
