### PR TITLE
ci(workflow): add condition to only run canary release in main 

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -35,12 +35,14 @@ permissions:
 jobs:
   get-runner-labels:
     name: Get Runner Labels
+    if: ${{ github.repository == 'web-infra-dev/rspack' }}
     uses: ./.github/workflows/get-runner-labels.yml
     with:
       force-use-github-runner: true
 
   build:
     name: Build Canary
+    if: ${{ github.repository == 'web-infra-dev/rspack' }}
     needs: [get-runner-labels]
     strategy:
       fail-fast: false
@@ -76,6 +78,7 @@ jobs:
 
   release:
     name: Release Canary
+    if: ${{ github.repository == 'web-infra-dev/rspack' }}
     runs-on: ubuntu-latest
     needs: build
     environment: npm-canary


### PR DESCRIPTION
## Summary


add condition to only run canary release in main repository

Only execute the canary release process when in the web-infra-dev/rspack repository

otherwise, it is always running in my fork repository
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
