### PR TITLE
fix: WorkerPlugin should be inherented in children compiler (#13310)

### DIFF
--- a/packages/rspack/src/builtin-plugin/WorkerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/WorkerPlugin.ts
@@ -13,6 +13,7 @@ import { EnableWasmLoadingPlugin } from './EnableWasmLoadingPlugin';
 
 export class WorkerPlugin extends RspackBuiltinPlugin {
   name = BuiltinPluginName.WorkerPlugin;
+  affectedHooks = 'compilation' as const;
 
   constructor(
     private chunkLoading: ChunkLoading,

--- a/tests/rspack-test/configCases/worker/child-compiler-worker/child-entry.js
+++ b/tests/rspack-test/configCases/worker/child-compiler-worker/child-entry.js
@@ -1,0 +1,2 @@
+const worker = new Worker(new URL('./worker.js', import.meta.url));
+module.exports = { hasWorker: !!worker };

--- a/tests/rspack-test/configCases/worker/child-compiler-worker/index.js
+++ b/tests/rspack-test/configCases/worker/child-compiler-worker/index.js
@@ -1,0 +1,7 @@
+const fs = __non_webpack_require__('fs');
+const path = __non_webpack_require__('path');
+
+it('should generate child entry when child compiler processes new Worker()', () => {
+  const childEntryPath = path.resolve(__dirname, '__child-child-entry.js');
+  expect(fs.existsSync(childEntryPath)).toBe(true);
+});

--- a/tests/rspack-test/configCases/worker/child-compiler-worker/rspack.config.js
+++ b/tests/rspack-test/configCases/worker/child-compiler-worker/rspack.config.js
@@ -1,0 +1,37 @@
+const path = require('path');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  node: {
+    __dirname: false,
+  },
+  output: {
+    filename: '[name].js',
+  },
+  plugins: [
+    (compiler) => {
+      compiler.hooks.make.tapAsync(
+        'ChildCompilerWorkerTest',
+        (compilation, callback) => {
+          const childCompiler = compilation.createChildCompiler(
+            'child-compiler-worker-test',
+            { filename: '__child-[name].js', publicPath: '' },
+            [
+              new compiler.webpack.library.EnableLibraryPlugin('commonjs'),
+              new compiler.webpack.EntryPlugin(
+                compiler.context,
+                path.join(__dirname, 'child-entry.js'),
+                {
+                  name: 'child-entry',
+                  library: { type: 'commonjs' },
+                },
+              ),
+            ],
+          );
+          childCompiler.runAsChild((err) => callback(err));
+        },
+      );
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/worker/child-compiler-worker/test.config.js
+++ b/tests/rspack-test/configCases/worker/child-compiler-worker/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  findBundle: function (i, options) {
+    return ['main.js'];
+  },
+};

--- a/tests/rspack-test/configCases/worker/child-compiler-worker/worker.js
+++ b/tests/rspack-test/configCases/worker/child-compiler-worker/worker.js
@@ -1,0 +1,3 @@
+onmessage = (event) => {
+  postMessage('ok');
+};


### PR DESCRIPTION
## Summary
backport https://github.com/web-infra-dev/rspack/pull/13310
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
