### PR TITLE
chore: enable enableGlobalVirtualStore for pnpm

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,8 @@ packages:
 patchedDependencies:
   webpack-sources@3.3.4: patches/webpack-sources@3.3.4.patch
 
+enableGlobalVirtualStore: true
+
 onlyBuiltDependencies:
   - '@biomejs/biome'
   - '@parcel/watcher'


### PR DESCRIPTION
enable enableGlobalVirtualStore to speedup install for worktree, see https://pnpm.io/11.x/git-worktrees