### PR TITLE
docs(migration): clarify async webassembly defaults

### DIFF
--- a/website/docs/en/guide/migration/rspack_1.x.mdx
+++ b/website/docs/en/guide/migration/rspack_1.x.mdx
@@ -79,7 +79,7 @@ Available `type` options:
 
 ### experiments.asyncWebAssembly enabled by default
 
-The default value of [experiments.asyncWebAssembly](/config/experiments#experimentsasyncwebassembly) has been changed from `false` to `true`. Async WebAssembly support is now enabled by default, and Rspack automatically injects built-in `type: 'webassembly/async'` rules for common `.wasm` files and `application/wasm` requests.
+The default value of [experiments.asyncWebAssembly](/config/experiments#experimentsasyncwebassembly) has changed from `false` to `true`. Files with the `.wasm` extension will now be handled using the built-in `webassembly/async` rule.
 
 If you don't need this feature, you can explicitly disable it:
 

--- a/website/docs/zh/guide/migration/rspack_1.x.mdx
+++ b/website/docs/zh/guide/migration/rspack_1.x.mdx
@@ -79,7 +79,7 @@ export default {
 
 ### 默认启用 experiments.asyncWebAssembly
 
-[experiments.asyncWebAssembly](/config/experiments#experimentsasyncwebassembly) 的默认值从 `false` 调整为 `true`。异步 WebAssembly 支持默认启用，Rspack 会为常见的 `.wasm` 文件和 `application/wasm` 请求自动注入内置的 `type: 'webassembly/async'` 规则。
+[experiments.asyncWebAssembly](/config/experiments#experimentsasyncwebassembly) 的默认值从 `false` 调整为 `true`。后缀为 `.wasm` 的文件将使用内置的 `webassembly/async` 规则处理。
 
 如果不需要此功能，可以显式禁用：
 


### PR DESCRIPTION
## Summary

This PR fixes the migration guide entry for `experiments.asyncWebAssembly`.

The previous wording said users still needed to add `type: 'webassembly/async'` in `module.rules` after `experiments.asyncWebAssembly` became enabled by default. That is not accurate for Rspack: the built-in rules already cover common `.wasm` files and `application/wasm` requests.

This change updates both English and Chinese migration docs to clarify that users usually do not need to add a manual `module.rules` entry.

## Related links

- N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
