### PR TITLE
docs: remove useless placeholder comments

### DIFF
--- a/website/docs/en/config/other-options.mdx
+++ b/website/docs/en/config/other-options.mdx
@@ -79,7 +79,6 @@ export default [
   {
     name: 'client',
     target: 'web',
-    // …
   },
   {
     name: 'server',

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -762,7 +762,6 @@ Let's take a look at an example.
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   entry: './src/index.js',
   output: {
     library: 'MyLibrary',
@@ -793,7 +792,6 @@ In the above example, we're passing a single entry file to `entry`, however, Rsp
 
    ```js title="rspack.config.mjs"
    export default {
-     // …
      entry: ['./src/a.js', './src/b.js'], // only exports in b.js will be exposed
      output: {
        library: 'MyLibrary',
@@ -805,7 +803,6 @@ In the above example, we're passing a single entry file to `entry`, however, Rsp
 
    ```js title="rspack.config.mjs"
    export default {
-     // …
      entry: {
        a: './src/a.js',
        b: './src/b.js',
@@ -840,7 +837,6 @@ Note that the value of `amdContainer` **must be** set as a global variable.
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       amdContainer: 'window["clientContainer"]',
@@ -864,7 +860,6 @@ Specify a name for the library.
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -891,7 +886,6 @@ These options assign the return value of the entry point (e.g. whatever the entr
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -914,7 +908,6 @@ MyLibrary.doSomething();
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -936,7 +929,6 @@ Be aware that if `MyLibrary` isn't defined earlier your library will be set in g
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -972,7 +964,6 @@ These options assign the return value of the entry point (e.g. whatever the entr
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -996,7 +987,6 @@ MyLibrary.doSomething(); // if `this` is window
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -1018,7 +1008,6 @@ window.MyLibrary.doSomething();
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -1040,7 +1029,6 @@ global.MyLibrary.doSomething();
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -1070,7 +1058,6 @@ These options will result in a bundle that comes with a complete header to ensur
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       // do not specify a `name` here
@@ -1086,7 +1073,6 @@ Output ES modules.
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       // do not specify a `name` here
@@ -1102,7 +1088,6 @@ This configuration generates tree-shakable and code-splitting available output f
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       // note there's no `name` here
@@ -1130,7 +1115,6 @@ Wondering the difference between CommonJS and CommonJS2 is? While they are simil
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       // note there's no `name` here
@@ -1152,8 +1136,6 @@ Output:
 
 ```js
 function doSomething() {}
-
-// …
 
 exports.doSomething = __webpack_exports__.doSomething;
 ```
@@ -1364,7 +1346,6 @@ System.register(
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -1441,7 +1422,6 @@ To insert the same comment for each `umd` type, set `auxiliaryComment` to a stri
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   mode: 'development',
   output: {
     library: {
@@ -1475,7 +1455,6 @@ For fine-grained control, pass an object:
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   mode: 'development',
   output: {
     library: {

--- a/website/docs/zh/config/other-options.mdx
+++ b/website/docs/zh/config/other-options.mdx
@@ -78,7 +78,6 @@ export default [
   {
     name: 'client',
     target: 'web',
-    // …
   },
   {
     name: 'server',

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -753,7 +753,6 @@ export default {
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   entry: './src/index.js',
   output: {
     library: 'MyLibrary',
@@ -784,7 +783,6 @@ export function hello(name) {
 
    ```js title="rspack.config.mjs"
    export default {
-     // …
      entry: ['./src/a.js', './src/b.js'], // 只有在 b.js 中导出的内容才会被暴露
      output: {
        library: 'MyLibrary',
@@ -796,7 +794,6 @@ export function hello(name) {
 
    ```js title="rspack.config.mjs"
    export default {
-     // …
      entry: {
        a: './src/a.js',
        b: './src/b.js',
@@ -831,7 +828,6 @@ export function hello(name) {
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       amdContainer: 'window["clientContainer"]',
@@ -855,7 +851,6 @@ window['clientContainer'].define(/*define args*/); // or 'amd-require' window['c
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -882,7 +877,6 @@ export default {
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -905,7 +899,6 @@ MyLibrary.doSomething();
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -927,7 +920,6 @@ MyLibrary = _entry_return_;
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -963,7 +955,6 @@ MyLibrary.hello('World');
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -987,7 +978,6 @@ MyLibrary.doSomething(); // 如果 `this` 为 window 对象
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -1009,7 +999,6 @@ window.MyLibrary.doSomething();
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -1031,7 +1020,6 @@ global.MyLibrary.doSomething();
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -1061,7 +1049,6 @@ require('MyLibrary').doSomething();
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       // 不要指定 `name`
@@ -1077,7 +1064,6 @@ export default {
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       // 不要指定 `name`
@@ -1093,7 +1079,6 @@ export default {
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       // note there's no `name` here
@@ -1121,7 +1106,6 @@ require('MyLibrary').doSomething();
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       // note there's no `name` here
@@ -1143,8 +1127,6 @@ export function doSomething() {}
 
 ```js
 function doSomething() {}
-
-// …
 
 exports.doSomething = __webpack_exports__.doSomething;
 ```
@@ -1355,7 +1337,6 @@ System.register(
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   output: {
     library: {
       name: 'MyLibrary',
@@ -1432,7 +1413,6 @@ var MyLibrary = _entry_return_.default.subModule;
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   mode: 'development',
   output: {
     library: {
@@ -1466,7 +1446,6 @@ export default {
 
 ```js title="rspack.config.mjs"
 export default {
-  // …
   mode: 'development',
   output: {
     library: {


### PR DESCRIPTION
## Summary

Remove useless placeholder comments to reduce token cost.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
