### PR TITLE
feat: enable mangle exports for cjs reexport

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -197,6 +197,10 @@ impl CommonJsExportRequireDependency {
     mg.get_dep_meta_if_existing(&self.id)
       .map_or_else(|| self.ids.as_slice(), |meta| meta.ids.as_slice())
   }
+
+  fn is_all_exported_by_module_exports(&self) -> bool {
+    self.base.is_module_exports() && self.names.is_empty()
+  }
 }
 
 #[cacheable_dyn]
@@ -261,7 +265,8 @@ impl Dependency for CommonJsExportRequireDependency {
                   name: name.to_owned(),
                   from: Some(from.to_owned()),
                   export: Some(Nullable::Value(export)),
-                  can_mangle: Some(false),
+                  // `module.exports = require("./m")` can't be mangled
+                  can_mangle: Some(!self.is_all_exported_by_module_exports()),
                   ..Default::default()
                 })
               })
@@ -278,7 +283,8 @@ impl Dependency for CommonJsExportRequireDependency {
           } else {
             None
           },
-          can_mangle: Some(false),
+          // `module.exports = require("./m")` can't be mangled
+          can_mangle: Some(!self.is_all_exported_by_module_exports()),
           dependencies: Some(vec![*from.module_identifier()]),
           ..Default::default()
         })
@@ -313,7 +319,8 @@ impl Dependency for CommonJsExportRequireDependency {
       } else {
         vec![ExtendedReferencedExport::Export(ReferencedExport {
           name: ids.to_vec(),
-          can_mangle: false,
+          // `module.exports = require("./m")` can't be mangled
+          can_mangle: !self.is_all_exported_by_module_exports(),
           can_inline: false,
         })]
       }
@@ -376,7 +383,8 @@ impl Dependency for CommonJsExportRequireDependency {
       .map(|name| {
         ExtendedReferencedExport::Export(ReferencedExport {
           name: name.into_iter().map(|i| i.to_owned()).collect_vec(),
-          can_mangle: false,
+          // `module.exports = require("./m")` can't be mangled
+          can_mangle: !self.is_all_exported_by_module_exports(),
           can_inline: false,
         })
       })

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/reexport-mangle-exports/index.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/reexport-mangle-exports/index.js
@@ -1,0 +1,13 @@
+it("should allow mangling for cjs property reexports", () => {
+	expect(require("./module-exports-property").aaa).toBe("aaa");
+	expect(require("./module-exports-property").aaaCanMangle).toBe(true);
+	expect(require("./module-exports-property").aaaReexportedCanMangle).toBe(true);
+	expect(require("./module-exports-property").usedExports).toEqual(["aaa","aaaCanMangle","usedExports"]);
+});
+
+it("should not allow mangling for whole module.exports reexports", () => {
+	expect(require("./module-exports-all").aaa).toBe("aaa");
+	expect(require("./module-exports-all").aaaCanMangle).toBe(false);
+	expect(require("./module-exports-all").aaaReexportedCanMangle).toBe(false);
+	expect(require("./module-exports-all").usedExports).toEqual(["aaa","aaaCanMangle","aaaReexportedCanMangle", "usedExports"]);
+});

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/reexport-mangle-exports/module-exports-all.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/reexport-mangle-exports/module-exports-all.js
@@ -1,0 +1,2 @@
+module.exports = require("./source?whole");
+module.exports.aaaReexportedCanMangle = __webpack_exports_info__.aaa.canMangle;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/reexport-mangle-exports/module-exports-property.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/reexport-mangle-exports/module-exports-property.js
@@ -1,0 +1,4 @@
+module.exports.aaa = require("./source?property").aaa;
+module.exports.aaaCanMangle = require("./source?property").aaaCanMangle;
+module.exports.usedExports = require("./source?property").usedExports;
+module.exports.aaaReexportedCanMangle = __webpack_exports_info__.aaa.canMangle;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/reexport-mangle-exports/source.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/reexport-mangle-exports/source.js
@@ -1,0 +1,5 @@
+exports.aaa = "aaa";
+exports.bbb = "bbb";
+exports.aaaCanMangle = __webpack_exports_info__.aaa.canMangle;
+exports.bbbCanMangle = __webpack_exports_info__.bbb.canMangle;
+exports.usedExports = __webpack_exports_info__.usedExports;


### PR DESCRIPTION
## Summary

Now rspack support below cjs reexports:

- `module.exports = require("./m")`
- `[exports|module.exports|this].a.b = require("./m").a.b`

The first one is hard to support mangle exports because we have to rewrite the exports to something like this: `module.exports = { az: (temp = __webpack_require__(123)).abc, Oi: temp.def }`, but the second one is easy to support mangle exports, so for now we only mangle for the second case.
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
