### PR TITLE
refactor: future consumer drop static lifecycle requirement

### DIFF
--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -67,7 +67,7 @@ impl Snapshot {
   }
 
   #[tracing::instrument("Cache::Snapshot::add", skip_all)]
-  pub async fn add(&self, scope: SnapshotScope, paths: impl Iterator<Item = ArcPath>) {
+  pub async fn add(&self, scope: SnapshotScope, paths: impl Iterator<Item = ArcPath> + Send) {
     let helper = Arc::new(StrategyHelper::new(self.fs.clone(), self.options.clone()));
     let codec = self.codec.clone();
     // TODO merge package version file

--- a/crates/rspack_core/src/utils/iterator_consumer/bound_future.rs
+++ b/crates/rspack_core/src/utils/iterator_consumer/bound_future.rs
@@ -1,0 +1,49 @@
+use std::{
+  future::Future,
+  pin::Pin,
+  task::{Context, Poll},
+};
+
+/// A future bound to lifetime `'a` that panics if dropped before completion,
+/// guaranteeing every spawned task finishes before `'a`-borrowed data is freed.
+pub struct BoundFuture<'a, T> {
+  inner: Pin<Box<dyn Future<Output = T> + Send + 'a>>,
+  /// Set to `true` once `poll` returns `Ready`, used by `Drop` to detect early drops.
+  completed: bool,
+}
+
+impl<'a, T> BoundFuture<'a, T> {
+  /// Wraps `fut` and binds it to lifetime `'a`.
+  pub fn new<F>(fut: F) -> Self
+  where
+    F: Future<Output = T> + Send + 'a,
+  {
+    Self {
+      inner: Box::pin(fut),
+      completed: false,
+    }
+  }
+}
+
+impl<T> Future for BoundFuture<'_, T> {
+  type Output = T;
+
+  fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+    let result = self.inner.as_mut().poll(cx);
+    if result.is_ready() {
+      self.completed = true;
+    }
+    result
+  }
+}
+
+impl<T> Drop for BoundFuture<'_, T> {
+  fn drop(&mut self) {
+    if !self.completed {
+      panic!(
+        "BoundFuture dropped without being awaited to completion; \
+         this would cause use-after-free in the spawned tasks"
+      );
+    }
+  }
+}

--- a/crates/rspack_core/src/utils/iterator_consumer/future.rs
+++ b/crates/rspack_core/src/utils/iterator_consumer/future.rs
@@ -1,45 +1,61 @@
-use std::{future::Future, sync::Arc};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use tokio::sync::mpsc::unbounded_channel;
 
+use super::bound_future::BoundFuture;
+
 /// Tools for consume iterator which return future.
-#[async_trait::async_trait]
-pub trait FutureConsumer {
+pub trait FutureConsumer<'a> {
   type Item;
-  /// Use to immediately consume the data produced by the future in the iterator
-  /// without waiting for all the data to be processed.
-  /// The closures runs in the current thread.
-  fn fut_consume(self, func: impl FnMut(Self::Item) + Send) -> impl Future<Output = ()>;
+  /// Drives every future in the iterator concurrently via `tokio::spawn` and
+  /// calls `func` with each output on the current thread as results arrive.
+  /// The returned [`BoundFuture`] must be awaited to completion.
+  fn fut_consume(self, func: impl FnMut(Self::Item) + Send + 'a) -> BoundFuture<'a, ()>;
 }
 
-#[async_trait::async_trait]
-impl<I, Fut> FutureConsumer for I
+impl<'a, I, Fut> FutureConsumer<'a> for I
 where
-  I: Iterator<Item = Fut>,
-  Fut: Future + Send + 'static,
-  Fut::Output: Send,
+  I: Iterator<Item = Fut> + Send + 'a,
+  Fut: Future + Send + 'a,
+  Fut::Output: Send + 'a,
 {
   type Item = Fut::Output;
-  fn fut_consume(self, mut func: impl FnMut(Self::Item) + Send) -> impl Future<Output = ()> {
-    let mut rx = {
-      // Create the channel in the closure to ensure all sender are dropped when iterator completes
-      // This ensures that the receiver does not get stuck in an infinite loop.
-      let (tx, rx) = unbounded_channel::<Self::Item>();
+
+  fn fut_consume(self, mut func: impl FnMut(Self::Item) + Send + 'a) -> BoundFuture<'a, ()> {
+    BoundFuture::new(async move {
+      let (tx, mut rx) = unbounded_channel::<Fut::Output>();
       let tx = Arc::new(tx);
+
       self.for_each(|fut| {
         let tx = tx.clone();
-        tokio::spawn(async move {
-          let data = fut.await;
-          tx.send(data).expect("should send success");
+
+        let task: Pin<Box<dyn Future<Output = ()> + Send + 'a>> = Box::pin(async move {
+          tx.send(fut.await).expect("should send success");
         });
+
+        // SAFETY: We transmute the task from `'a` to `'static` to satisfy
+        // `tokio::spawn`. This is sound because:
+        // 1. Spawning only occurs while this async block is being polled, so
+        //    no task is spawned if `BoundFuture` is dropped before first poll.
+        // 2. `BoundFuture::drop` panics unless `completed` is true, which
+        //    requires polling to `Ready`. The future is `Ready` only after
+        //    `rx` is drained, which happens only after every task has sent
+        //    its result and exited — so no task outlives `'a`.
+        // 3. `Fut::Output` may borrow from `'a`; the task sends it into the
+        //    channel immediately and exits, and the channel buffer is dropped
+        //    within `'a`, so no `'a` data escapes.
+        let static_task: Pin<Box<dyn Future<Output = ()> + Send + 'static>> =
+          unsafe { std::mem::transmute(task) };
+        tokio::spawn(static_task);
       });
-      rx
-    };
-    async move {
+
+      // Drop the last sender so the channel closes after the iterator is exhausted.
+      drop(tx);
+
       while let Some(data) = rx.recv().await {
         func(data);
       }
-    }
+    })
   }
 }
 

--- a/crates/rspack_core/src/utils/iterator_consumer/mod.rs
+++ b/crates/rspack_core/src/utils/iterator_consumer/mod.rs
@@ -1,3 +1,4 @@
+mod bound_future;
 mod future;
 mod rayon;
 mod rayon_fut;

--- a/crates/rspack_core/src/utils/iterator_consumer/rayon_fut.rs
+++ b/crates/rspack_core/src/utils/iterator_consumer/rayon_fut.rs
@@ -1,47 +1,55 @@
-use std::{future::Future, sync::Arc};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use rayon::iter::ParallelIterator;
 use tokio::sync::mpsc::unbounded_channel;
 
-use super::RayonConsumer;
+use super::{RayonConsumer, bound_future::BoundFuture};
 
 /// Tools for consume rayon iterator which return feature.
-#[async_trait::async_trait]
-pub trait RayonFutureConsumer {
+pub trait RayonFutureConsumer<'a> {
   type Item;
-  /// Use to immediately consume the data produced by the future in the rayon iterator
-  /// without waiting for all the data to be processed.
-  /// The closures runs in the current thread.
-  async fn fut_consume(self, func: impl FnMut(Self::Item) + Send);
+  /// Drives every future in the parallel iterator concurrently via `tokio::spawn`
+  /// and calls `func` with each output on the current thread as results arrive.
+  /// The returned [`BoundFuture`] must be awaited to completion.
+  fn fut_consume(self, func: impl FnMut(Self::Item) + Send + 'a) -> BoundFuture<'a, ()>;
 }
 
-#[async_trait::async_trait]
-impl<I, Fut> RayonFutureConsumer for I
+impl<'a, I, Fut> RayonFutureConsumer<'a> for I
 where
-  I: ParallelIterator<Item = Fut> + Send,
-  Fut: Future + Send + 'static,
-  Fut::Output: Send + 'static,
+  I: ParallelIterator<Item = Fut> + Send + 'a,
+  Fut: Future + Send + 'a,
+  Fut::Output: Send + 'a,
 {
   type Item = Fut::Output;
-  async fn fut_consume(self, mut func: impl FnMut(Self::Item) + Send) {
-    let mut rx = {
-      // Create the channel in the closure to ensure all sender are dropped when iterator completes
-      // This ensures that the receiver does not get stuck in an infinite loop.
-      let (tx, rx) = unbounded_channel::<Self::Item>();
+
+  fn fut_consume(self, mut func: impl FnMut(Self::Item) + Send + 'a) -> BoundFuture<'a, ()> {
+    BoundFuture::new(async move {
+      let (tx, mut rx) = unbounded_channel::<Fut::Output>();
       let tx = Arc::new(tx);
+
+      // `consume` drives the parallel iterator on the rayon thread pool and
+      // delivers futures to the closure on the calling thread (blocking).
       self.consume(|fut| {
         let tx = tx.clone();
-        tokio::spawn(async move {
-          let data = fut.await;
-          tx.send(data).expect("should send success");
-        });
-      });
-      rx
-    };
 
-    while let Some(data) = rx.recv().await {
-      func(data);
-    }
+        let task: Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> =
+          Box::pin(async move {
+            tx.send(fut.await).expect("should send success");
+          });
+
+        // SAFETY: same argument as in `FutureConsumer::fut_consume`.
+        let static_task: Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>> =
+          unsafe { std::mem::transmute(task) };
+        tokio::spawn(static_task);
+      });
+
+      // Drop the last sender so the channel closes after the iterator is exhausted.
+      drop(tx);
+
+      while let Some(data) = rx.recv().await {
+        func(data);
+      }
+    })
   }
 }
 


### PR DESCRIPTION
## Summary

`fut_consume` drop static lifecycle requirement

``` diff
impl<I, Fut> FutureConsumer for I
where
  I: Iterator<Item = Fut>,
-  Fut: Future + Send + 'static,
-  Fut::Output: Send,
+  Fut: Future + Send + 'a,
+  Fut::Output: Send + 'a,
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
