### PR TITLE
Refactor allocator to use snmalloc on native targets

### DIFF
--- a/.agents/ARCHITECTURE.md
+++ b/.agents/ARCHITECTURE.md
@@ -276,7 +276,7 @@ Unified error system.
 
 ### Memory Management
 
-- Uses mimalloc for optimized allocation (Linux/macOS)
+- Uses snmalloc for optimized allocation on native targets
 - Efficient data structures (custom HashMap, HashSet)
 - Minimizes allocations in hot paths
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,16 +2348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libz-rs-sys"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,15 +2555,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3612,8 +3602,8 @@ dependencies = [
 name = "rspack_allocator"
 version = "0.100.0-beta.7"
 dependencies = [
- "mimalloc",
  "sftrace-setup",
+ "snmalloc-rs",
  "tracy-client",
 ]
 
@@ -5630,6 +5620,24 @@ name = "smol_str"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+
+[[package]]
+name = "snmalloc-rs"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb317153089fdfa4d8a2eec059d40a5a23c3bde43995ea23b19121c3f621e74a"
+dependencies = [
+ "snmalloc-sys",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065fea53d32bb77bc36cca466cb191f2e5216ebfd0ed360b1d64889ee6e559ea"
+dependencies = [
+ "cmake",
+]
 
 [[package]]
 name = "st-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.7.6", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
 miette              = { version = "7.6.0", default-features = false }
-mimalloc            = { version = "0.1.48", default-features = false }
 mime_guess          = { version = "2.0.5", default-features = false, features = ["rev-mappings"] }
 notify              = { version = "8.2.0", default-features = false }
 num-bigint          = { version = "0.4.6", default-features = false }
@@ -99,6 +98,7 @@ simd-json           = { version = "0.17.0", default-features = false }
 slotmap             = { version = "1.1.1", default-features = false }
 smallvec            = { version = "1.15.1", default-features = false }
 smol_str            = { version = "0.3.6", default-features = false }
+snmalloc-rs         = { version = "0.3.8" }
 stacker             = { version = "0.1.23", default-features = false }
 sugar_path          = { version = "2.0.1", default-features = false, features = ["cached_current_dir"] }
 supports-color      = { version = "3.0.2", default-features = false }

--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -13,14 +13,14 @@ sftrace-setup = { workspace = true, optional = true }
 tracy-client  = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-# Turned on `local_dynamic_tls` to avoid issue: https://github.com/microsoft/mimalloc/issues/147
-mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
+# Avoid static TLS allocation failures when loading the allocator dynamically.
+snmalloc-rs = { workspace = true, features = ["local_dynamic_tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+snmalloc-rs = { workspace = true }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+snmalloc-rs = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracy-client-sys"]

--- a/crates/rspack_allocator/src/lib.rs
+++ b/crates/rspack_allocator/src/lib.rs
@@ -1,13 +1,13 @@
 #[global_allocator]
 #[cfg(not(any(miri, target_family = "wasm")))]
 #[cfg(not(any(feature = "sftrace-setup", feature = "tracy-client")))]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 #[global_allocator]
 #[cfg(not(any(miri, target_family = "wasm")))]
 #[cfg(feature = "sftrace-setup")]
-static GLOBAL: sftrace_setup::SftraceAllocator<mimalloc::MiMalloc> =
-  sftrace_setup::SftraceAllocator(mimalloc::MiMalloc);
+static GLOBAL: sftrace_setup::SftraceAllocator<snmalloc_rs::SnMalloc> =
+  sftrace_setup::SftraceAllocator(snmalloc_rs::SnMalloc);
 
 #[global_allocator]
 #[cfg(not(any(miri, target_family = "wasm")))]

--- a/website/docs/en/contribute/development/project.md
+++ b/website/docs/en/contribute/development/project.md
@@ -15,7 +15,7 @@ This is a **monorepo** containing both Rust crates and JavaScript packages:
 - **`rspack_binding_api`**: Node.js binding API that bridges Rust core functionality to JavaScript/TypeScript interfaces
 - **`node_binding`**: Node.js binding implementation that generates Node.js native modules
 - **`rspack_napi`**: NAPI (Node-API) support layer for interoperability between Rust and Node.js
-- **`rspack_allocator`**: Memory allocator using mimalloc to optimize memory allocation performance (Linux/macOS)
+- **`rspack_allocator`**: Memory allocator using snmalloc to optimize memory allocation performance on native targets
 
 ### Build & binding crates
 

--- a/website/docs/zh/contribute/development/project.md
+++ b/website/docs/zh/contribute/development/project.md
@@ -15,7 +15,7 @@ description: 'Rspack 项目结构指南，介绍 monorepo 中的 Rust crates、J
 - **`rspack_binding_api`**: Node.js 绑定 API，将 Rust 核心功能桥接到 JavaScript/TypeScript 接口
 - **`node_binding`**: Node.js 绑定实现，用于生成 Node.js 原生模块
 - **`rspack_napi`**: NAPI (Node-API) 支持层，用于 Rust 和 Node.js 之间的互操作性
-- **`rspack_allocator`**: 使用 mimalloc 的内存分配器，用于优化内存分配性能（Linux/macOS）
+- **`rspack_allocator`**: 使用 snmalloc 的内存分配器，用于优化原生目标上的内存分配性能
 
 ### 构建与绑定 Crates
 

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -90,6 +90,7 @@ Llms
 magic-akari
 memfs
 mimalloc
+snmalloc
 minifiers
 miro
 modulegeneratorassetdataurl


### PR DESCRIPTION
## Summary
- Replace `mimalloc` with `snmalloc-rs` in `rspack_allocator`
- Update target-specific allocator dependency configuration and global allocator wiring
- Refresh lockfile entries and allocator-related documentation references

## Testing
- `cargo check -p rspack_allocator`
- `pnpm run build:binding:dev`
- `cargo fmt --all --check`
- `cargo lint`