### PR TITLE
chore: pin rspack_resolver version to exact =0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,106 +20,108 @@ ignored = ["swc", "rspack"]
 libraries = [{ path = "linting/*" }]
 
 [workspace.dependencies]
-aho-corasick = { version = "1.1.4", default-features = false }
-anyhow = { version = "1.0.102", default-features = false, features = ["backtrace", "std"] }
-anymap = { package = "anymap3", version = "1.0.1", default-features = false, features = ["std"] }
+aho-corasick    = { version = "1.1.4", default-features = false }
+anyhow          = { version = "1.0.102", default-features = false, features = ["backtrace", "std"] }
+anymap          = { package = "anymap3", version = "1.0.1", default-features = false, features = ["std"] }
 async-recursion = { version = "1.1.1", default-features = false }
-async-trait = { version = "0.1.89", default-features = false }
-atomic_refcell = { version = "0.1.13", default-features = false }
-base64 = { version = "0.22.1", default-features = false }
-base64-simd = { version = "0.8.0", default-features = false, features = ["alloc"] }
-bitflags = { version = "2.11.0", default-features = false }
+async-trait     = { version = "0.1.89", default-features = false }
+atomic_refcell  = { version = "0.1.13", default-features = false }
+base64          = { version = "0.22.1", default-features = false }
+base64-simd     = { version = "0.8.0", default-features = false, features = ["alloc"] }
+bitflags        = { version = "2.11.0", default-features = false }
 browserslist-rs = { version = "0.19.0", default-features = false }
-bytes = { version = "1.11.1", default-features = false }
-camino = { version = "1.2.2", default-features = false }
-cargo_toml = { version = "0.22.3", default-features = false }
-cfg-if = { version = "1.0.4", default-features = false }
-chrono = { version = "0.4.44", default-features = false }
-clap = { version = "4.5.60", default-features = false }
-concat-string = { version = "1.0.1", default-features = false }
-cow-utils = { version = "0.1.3", default-features = false }
+bytes           = { version = "1.11.1", default-features = false }
+camino          = { version = "1.2.2", default-features = false }
+cargo_toml      = { version = "0.22.3", default-features = false }
+cfg-if          = { version = "1.0.4", default-features = false }
+chrono          = { version = "0.4.44", default-features = false }
+clap            = { version = "4.5.60", default-features = false }
+concat-string   = { version = "1.0.1", default-features = false }
+cow-utils       = { version = "0.1.3", default-features = false }
+
 criterion = { package = "codspeed-criterion-compat", default-features = false, version = "4.4.1", features = [
   "async_tokio",
 ] }
-css-module-lexer = { version = "0.0.15", default-features = false }
-dashmap = { version = "6.1.0", default-features = false }
-derive_more = { version = "2.0.1", default-features = false }
-dunce = { version = "1.0.5", default-features = false }
-dyn-clone = { version = "1.0.20", default-features = false }
-either = { version = "1.15.0", default-features = false }
-enum-tag = { version = "0.3.0", default-features = false }
-fast-glob = { version = "1.0.1", default-features = false }
-form_urlencoded = { version = "1.2.2", default-features = false }
-futures = { version = "0.3.32", default-features = false, features = ["std"] }
-glob = { version = "0.3.3", default-features = false }
-hashlink = { version = "0.10.0", default-features = false }
-heck = { version = "0.5.0", default-features = false }
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
-indexmap = { version = "2.12.1", default-features = false }
-indicatif = { version = "0.18.4", default-features = false }
-indoc = { version = "2.0.7", default-features = false }
-insta = { version = "1.42.0", default-features = false }
-itertools = { version = "0.14.0", default-features = false, features = ["use_std"] }
-itoa = { version = "1.0.17", default-features = false }
-json = { version = "0.12.4", default-features = false }
-json-escape-simd = { version = "3.0.1", default-features = false }
-lightningcss = { version = "1.0.0-alpha.71", default-features = false, features = ["serde"] }
-md4 = { version = "0.10.2", default-features = false }
-memchr = { version = "2.7.6", default-features = false }
+
+css-module-lexer    = { version = "0.0.15", default-features = false }
+dashmap             = { version = "6.1.0", default-features = false }
+derive_more         = { version = "2.0.1", default-features = false }
+dunce               = { version = "1.0.5", default-features = false }
+dyn-clone           = { version = "1.0.20", default-features = false }
+either              = { version = "1.15.0", default-features = false }
+enum-tag            = { version = "0.3.0", default-features = false }
+fast-glob           = { version = "1.0.1", default-features = false }
+form_urlencoded     = { version = "1.2.2", default-features = false }
+futures             = { version = "0.3.32", default-features = false, features = ["std"] }
+glob                = { version = "0.3.3", default-features = false }
+hashlink            = { version = "0.10.0", default-features = false }
+heck                = { version = "0.5.0", default-features = false }
+hex                 = { version = "0.4.3", default-features = false, features = ["std"] }
+indexmap            = { version = "2.12.1", default-features = false }
+indicatif           = { version = "0.18.4", default-features = false }
+indoc               = { version = "2.0.7", default-features = false }
+insta               = { version = "1.42.0", default-features = false }
+itertools           = { version = "0.14.0", default-features = false, features = ["use_std"] }
+itoa                = { version = "1.0.17", default-features = false }
+json                = { version = "0.12.4", default-features = false }
+json-escape-simd    = { version = "3.0.1", default-features = false }
+lightningcss        = { version = "1.0.0-alpha.71", default-features = false, features = ["serde"] }
+md4                 = { version = "0.10.2", default-features = false }
+memchr              = { version = "2.7.6", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
-miette = { version = "7.6.0", default-features = false }
-mimalloc = { version = "0.1.48", default-features = false }
-mime_guess = { version = "2.0.5", default-features = false, features = ["rev-mappings"] }
-notify = { version = "8.2.0", default-features = false }
-num-bigint = { version = "0.4.6", default-features = false }
-once_cell = { version = "1.21.4", default-features = false }
-oneshot = { version = "0.1.11", default-features = false, features = ["std", "async"] }
-owo-colors = { version = "4.0.0", default-features = false, features = ["supports-colors"] }
-parcel_sourcemap = { version = "2.1.1", default-features = false }
-paste = { version = "1.0.15", default-features = false }
-path-clean = { version = "1.0.1", default-features = false }
-pathdiff = { version = "0.2.3", default-features = false }
-pretty_assertions = { version = "1.4.1", default-features = false, features = ["std"] }
-proc-macro2 = { version = "1.0.106", default-features = false }
-prost = { version = "0.13", default-features = false }
-quote = { version = "1.0.45", default-features = false }
-rayon = { version = "1.11.0", default-features = false }
-regex = { version = "1.12.3", default-features = false, features = ["perf"] }
-regex-syntax = { version = "0.8.10", default-features = false, features = ["std"] }
-regress = { version = "0.10.5", default-features = false, features = ["pattern"] }
-rspack_resolver = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.7.0", default-features = false }
-rspack_sources = { version = "=0.4.20", default-features = false }
-rustc-hash = { version = "2.1.1", default-features = false }
-ryu-js = { version = "1.0.2", default-features = false }
-scopeguard = { version = "1.2.0", default-features = false }
-serde = { version = "1.0.228", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.149", default-features = false, features = ["std"] }
-sftrace-setup = { version = "0.1.2", default-features = false }
-sha2 = { version = "0.10.9", default-features = false }
-signal-hook = { version = "0.3.18", default-features = false, features = ["iterator"] }
-simd-json = { version = "0.17.0", default-features = false }
-slotmap = { version = "1.1.1", default-features = false }
-smallvec = { version = "1.15.1", default-features = false }
-smol_str = { version = "0.3.6", default-features = false }
-stacker = { version = "0.1.23", default-features = false }
-sugar_path = { version = "2.0.1", default-features = false, features = ["cached_current_dir"] }
-supports-color = { version = "3.0.2", default-features = false }
-syn = { version = "2.0.117", default-features = false }
-termcolor = { version = "1.4.1", default-features = false }
-textwrap = { version = "0.16.1", default-features = false }
-thread_local = { version = "1.1.9", default-features = false }
-tokio = { version = "1.48.0", default-features = false, features = ["rt", "rt-multi-thread"] }
-tracing = { version = "0.1.44", default-features = false, features = ["max_level_trace", "release_max_level_trace"] }
-tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "registry"] }
-trybuild = { version = "1.0.116", default-features = false, features = ["diff"] }
-unicase = { version = "2.8.1", default-features = false }
-unicode-width = { version = "0.2.2", default-features = false }
-url = { version = "2.5.8", default-features = false }
-urlencoding = { version = "2.1.3", default-features = false }
-ustr = { package = "ustr-fxhash", version = "1.0.1", default-features = false }
-wasmparser = { version = "0.222.0", default-features = false }
-winnow = { version = "0.7.15", default-features = false, features = ["std", "simd"] }
-xxhash-rust = { version = "0.8.15", default-features = false }
+miette              = { version = "7.6.0", default-features = false }
+mimalloc            = { version = "0.1.48", default-features = false }
+mime_guess          = { version = "2.0.5", default-features = false, features = ["rev-mappings"] }
+notify              = { version = "8.2.0", default-features = false }
+num-bigint          = { version = "0.4.6", default-features = false }
+once_cell           = { version = "1.21.4", default-features = false }
+oneshot             = { version = "0.1.11", default-features = false, features = ["std", "async"] }
+owo-colors          = { version = "4.0.0", default-features = false, features = ["supports-colors"] }
+parcel_sourcemap    = { version = "2.1.1", default-features = false }
+paste               = { version = "1.0.15", default-features = false }
+path-clean          = { version = "1.0.1", default-features = false }
+pathdiff            = { version = "0.2.3", default-features = false }
+pretty_assertions   = { version = "1.4.1", default-features = false, features = ["std"] }
+proc-macro2         = { version = "1.0.106", default-features = false }
+prost               = { version = "0.13", default-features = false }
+quote               = { version = "1.0.45", default-features = false }
+rayon               = { version = "1.11.0", default-features = false }
+regex               = { version = "1.12.3", default-features = false, features = ["perf"] }
+regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
+regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
+rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.7.0", default-features = false }
+rspack_sources      = { version = "=0.4.20", default-features = false }
+rustc-hash          = { version = "2.1.1", default-features = false }
+ryu-js              = { version = "1.0.2", default-features = false }
+scopeguard          = { version = "1.2.0", default-features = false }
+serde               = { version = "1.0.228", default-features = false, features = ["derive"] }
+serde_json          = { version = "1.0.149", default-features = false, features = ["std"] }
+sftrace-setup       = { version = "0.1.2", default-features = false }
+sha2                = { version = "0.10.9", default-features = false }
+signal-hook         = { version = "0.3.18", default-features = false, features = ["iterator"] }
+simd-json           = { version = "0.17.0", default-features = false }
+slotmap             = { version = "1.1.1", default-features = false }
+smallvec            = { version = "1.15.1", default-features = false }
+smol_str            = { version = "0.3.6", default-features = false }
+stacker             = { version = "0.1.23", default-features = false }
+sugar_path          = { version = "2.0.1", default-features = false, features = ["cached_current_dir"] }
+supports-color      = { version = "3.0.2", default-features = false }
+syn                 = { version = "2.0.117", default-features = false }
+termcolor           = { version = "1.4.1", default-features = false }
+textwrap            = { version = "0.16.1", default-features = false }
+thread_local        = { version = "1.1.9", default-features = false }
+tokio               = { version = "1.48.0", default-features = false, features = ["rt", "rt-multi-thread"] }
+tracing             = { version = "0.1.44", default-features = false, features = ["max_level_trace", "release_max_level_trace"] }
+tracing-subscriber  = { version = "0.3.23", default-features = false, features = ["fmt", "registry"] }
+trybuild            = { version = "1.0.116", default-features = false, features = ["diff"] }
+unicase             = { version = "2.8.1", default-features = false }
+unicode-width       = { version = "0.2.2", default-features = false }
+url                 = { version = "2.5.8", default-features = false }
+urlencoding         = { version = "2.1.3", default-features = false }
+ustr                = { package = "ustr-fxhash", version = "1.0.1", default-features = false }
+wasmparser          = { version = "0.222.0", default-features = false }
+winnow              = { version = "0.7.15", default-features = false, features = ["std", "simd"] }
+xxhash-rust         = { version = "0.8.15", default-features = false }
 
 allocative = { package = "rspack-allocative", version = "0.3.5", default-features = false, features = [
   "camino",


### PR DESCRIPTION
## Summary

- Pin `rspack_resolver` dependency from `0.7.0` (semver-compatible range `>=0.7.0, <0.8.0`) to `=0.7.0` (exact version)
- This prevents users from getting a different patch/minor version of `rspack_resolver` than what was tested with the current rspack release
- Consistent with how `rspack_sources` is already pinned (`=0.4.20`)

## Test plan

- No functional change, only version constraint tightened
- CI should pass as the resolved version remains `0.7.0`

close: https://github.com/web-infra-dev/rspack/issues/13427