### PR TITLE
fix: lightningcss with previous loader source maps

### DIFF
--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -15,7 +15,10 @@ use lightningcss::{
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
   Loader, LoaderContext, RunnerContext,
-  rspack_sources::{Mapping, OriginalLocation, SourceMap, encode_mappings},
+  rspack_sources::{
+    MapOptions, Mapping, ObjectPool, OriginalLocation, Source, SourceMap, SourceMapSource,
+    SourceMapSourceOptions, encode_mappings,
+  },
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_loader_runner::Identifier;
@@ -172,31 +175,13 @@ impl LightningCssLoader {
       })
       .to_rspack_result()?;
 
-    let mut source_map = if loader_context.context.source_map_kind.enabled() {
-      Some(
-        loader_context
-          .source_map()
-          .map(|input_source_map| -> Result<_> {
-            let mut sm = parcel_sourcemap::SourceMap::new(
-              input_source_map
-                .source_root()
-                .unwrap_or(&loader_context.context.options.context),
-            );
-            sm.add_source(&filename);
-            sm.set_source_content(0, &content_str).to_rspack_result()?;
-            Ok(sm)
-          })
-          .transpose()?
-          .unwrap_or_else(|| {
-            let mut source_map =
-              parcel_sourcemap::SourceMap::new(&loader_context.context.options.context);
-            let source_idx = source_map.add_source(&filename);
-            source_map
-              .set_source_content(source_idx as usize, &content_str)
-              .expect("should set source content");
-            source_map
-          }),
-      )
+    let module_request = loader_context.context.module.request();
+
+    let mut parcel_source_map = if loader_context.context.source_map_kind.enabled() {
+      let mut sm = parcel_sourcemap::SourceMap::new(&loader_context.context.options.context);
+      sm.add_source(module_request);
+      sm.set_source_content(0, &content_str).to_rspack_result()?;
+      Some(sm)
     } else {
       None
     };
@@ -204,7 +189,7 @@ impl LightningCssLoader {
     let content = stylesheet
       .to_css(PrinterOptions {
         minify: self.config.minify.unwrap_or(false),
-        source_map: source_map.as_mut(),
+        source_map: parcel_source_map.as_mut(),
         project_root: None,
         targets,
         analyze_dependencies: None,
@@ -222,36 +207,55 @@ impl LightningCssLoader {
       })
       .to_rspack_result_with_message(|e| format!("failed to generate css: {e}"))?;
 
-    if let Some(source_map) = source_map {
-      let mappings = encode_mappings(source_map.get_mappings().iter().map(|mapping| Mapping {
-        generated_line: mapping.generated_line,
-        generated_column: mapping.generated_column,
-        original: mapping.original.map(|original| OriginalLocation {
-          source_index: original.source,
-          original_line: original.original_line,
-          original_column: original.original_column,
-          name_index: original.name,
-        }),
+    if let Some(parcel_source_map) = parcel_source_map {
+      let mappings = encode_mappings(parcel_source_map.get_mappings().iter().map(|mapping| {
+        // Parcel source map uses 0-based line numbers, while Rspack source map uses 1-based
+        Mapping {
+          generated_line: mapping.generated_line + 1,
+          generated_column: mapping.generated_column,
+          original: mapping.original.map(|original| OriginalLocation {
+            source_index: original.source,
+            original_line: original.original_line + 1,
+            original_column: original.original_column,
+            name_index: original.name,
+          }),
+        }
       }));
       let rspack_source_map = SourceMap::new(
         mappings,
-        source_map
+        parcel_source_map
           .get_sources()
           .iter()
           .map(ToString::to_string)
           .collect::<Vec<_>>(),
-        source_map
+        parcel_source_map
           .get_sources_content()
           .iter()
           .map(|source_content| Arc::from(source_content.clone()))
           .collect::<Vec<_>>(),
-        source_map
+        parcel_source_map
           .get_names()
           .iter()
           .map(ToString::to_string)
           .collect::<Vec<_>>(),
       );
-      loader_context.finish_with((content.code, rspack_source_map));
+
+      let source_map_source = SourceMapSource::new(SourceMapSourceOptions {
+        value: content.code.clone(),
+        name: module_request.to_string(),
+        source_map: rspack_source_map,
+        original_source: None,
+        inner_source_map: loader_context.take_source_map(),
+        remove_original_source: false,
+      });
+      match source_map_source.map(&ObjectPool::default(), &MapOptions::default()) {
+        Some(source_map) => {
+          loader_context.finish_with((content.code, source_map));
+        }
+        None => {
+          loader_context.finish_with(content.code);
+        }
+      }
     } else {
       loader_context.finish_with(content.code);
     }

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/bar.scss
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/bar.scss
@@ -1,0 +1,5 @@
+.bar {
+  .child {
+    color: blue;
+  }
+}

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/foo.scss
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/foo.scss
@@ -1,0 +1,5 @@
+@use "./bar.scss";
+
+.foo {
+  color: red;
+}

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/index.js
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/index.js
@@ -1,0 +1,1 @@
+require("./foo.scss");

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/rspack.config.js
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/rspack.config.js
@@ -1,0 +1,74 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const checkMap = require("@rspack/test-tools/helper/util/checkSourceMap").default;
+
+class Plugin {
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
+	apply(compiler) {
+		compiler.hooks.done.tapAsync(
+			"Plugin",
+			(stats, callback) => {
+				(async () => {
+					const outputPath = stats.compilation.getPath(compiler.outputPath, {});
+					const source = fs.readFileSync(
+						path.resolve(outputPath, "bundle0.css.map"),
+						"utf-8"
+					);
+					const map = JSON.parse(source);
+					const fooSource = map.sources.find(source =>
+						source.endsWith("foo.scss")
+					);
+					const barSource = map.sources.find(source =>
+						source.endsWith("bar.scss")
+					);
+
+					expect(fooSource).toBeTruthy();
+					expect(barSource).toBeTruthy();
+					expect(map.file).toEqual("bundle0.css");
+					const normalizedBarSource = `webpack:///${path.basename(barSource)}`;
+
+					const css = fs.readFileSync(
+						path.resolve(outputPath, "bundle0.css"),
+						"utf-8"
+					);
+					expect(
+						await checkMap(css, source, {
+							".child {": {
+								inSource: normalizedBarSource,
+								outId: ".bar .child {"
+							}
+						})
+					).toBe(true);
+				})().then(() => callback(), callback);
+			}
+		);
+	}
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "web",
+	devtool: "source-map",
+	module: {
+		rules: [
+			{
+				test: /\.scss$/,
+				use: [
+					"builtin:lightningcss-loader",
+					{
+						loader: "sass-loader",
+						options: {
+							sassOptions: {
+								style: "expanded"
+							}
+						}
+					}
+				],
+				type: "css/auto"
+			}
+		]
+	},
+	plugins: [new Plugin()]
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Adds coverage and implementation changes to ensure LightningCSS correctly composes source maps from previous loaders.

Fix #10274

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
