### PR TITLE
feat(backport): support regex flags and JavaScript lookaheads in extractComments condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5045,6 +5045,7 @@ dependencies = [
  "rspack_hook",
  "rspack_javascript_compiler",
  "rspack_plugin_javascript",
+ "rspack_regex",
  "rspack_util",
  "serde_json",
  "swc_config",

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2202,6 +2202,7 @@ export interface RawExternalsPresets {
 export interface RawExtractComments {
   banner?: string | boolean
   condition?: string
+  conditionFlags?: string
 }
 
 export interface RawFallbackCacheGroupOptions {

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_swc_js_minimizer.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_swc_js_minimizer.rs
@@ -14,6 +14,7 @@ use crate::asset_condition::{RawAssetConditions, into_asset_conditions};
 pub struct RawExtractComments {
   pub banner: Option<Either<String, bool>>,
   pub condition: Option<String>,
+  pub condition_flags: Option<String>,
 }
 
 #[derive(Debug)]
@@ -50,6 +51,7 @@ where
 fn into_extract_comments(c: Option<RawExtractComments>) -> Option<ExtractComments> {
   let c = c?;
   let condition = c.condition?;
+  let condition_flags = c.condition_flags.unwrap_or_default();
   let banner = match c.banner {
     Some(banner) => match banner {
       Either::A(s) => OptionWrapper::Custom(s),
@@ -64,7 +66,11 @@ fn into_extract_comments(c: Option<RawExtractComments>) -> Option<ExtractComment
     None => OptionWrapper::Default,
   };
 
-  Some(ExtractComments { condition, banner })
+  Some(ExtractComments {
+    condition,
+    condition_flags,
+    banner,
+  })
 }
 
 impl TryFrom<RawSwcJsMinimizerRspackPluginOptions> for PluginOptions {

--- a/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
@@ -19,6 +19,7 @@ rspack_hash = { workspace = true }
 rspack_hook = { workspace = true }
 rspack_javascript_compiler = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
+rspack_regex = { workspace = true }
 rspack_util = { workspace = true }
 serde_json = { workspace = true }
 swc_config = { workspace = true }

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -23,6 +23,7 @@ use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_javascript_compiler::JavaScriptCompiler;
 use rspack_plugin_javascript::{ExtractedCommentsInfo, JavascriptModulesChunkHash, JsPlugin};
+use rspack_regex::RspackRegex;
 use rspack_util::asset_condition::AssetConditions;
 use swc_config::types::BoolOrDataConfig;
 use swc_core::{
@@ -103,20 +104,22 @@ pub enum OptionWrapper<T: std::fmt::Debug + Hash> {
 #[derive(Debug)]
 pub struct ExtractComments {
   pub condition: String,
+  pub condition_flags: String,
   pub banner: OptionWrapper<String>,
 }
 
 impl Hash for ExtractComments {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
     self.condition.as_str().hash(state);
+    self.condition_flags.as_str().hash(state);
     self.banner.hash(state);
   }
 }
 
 #[derive(Debug)]
-struct NormalizedExtractComments<'a> {
+struct NormalizedExtractComments {
   filename: String,
-  condition: &'a Regex,
+  condition: RspackRegex,
   banner: Option<String>,
 }
 
@@ -164,14 +167,18 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let (tx, rx) = mpsc::channel::<Vec<Diagnostic>>();
   // collect all extracted comments info
   let all_extracted_comments = Mutex::new(HashMap::new());
-  let extract_comments_condition = options
-    .extract_comments
-    .as_ref()
-    .map(|extract_comment| extract_comment.condition.as_ref())
-    .map(|condition| {
-      Regex::new(condition)
-        .unwrap_or_else(|_| panic!("`{condition}` is invalid extractComments condition"))
-    });
+  let extract_comments_condition = options.extract_comments.as_ref().map(|extract_comment| {
+    RspackRegex::with_flags(
+      extract_comment.condition.as_ref(),
+      extract_comment.condition_flags.as_ref(),
+    )
+    .unwrap_or_else(|_| {
+      panic!(
+        "`/{}/{}` is invalid extractComments condition",
+        extract_comment.condition, extract_comment.condition_flags
+      )
+    })
+  });
   let enter_span = tracing::Span::current();
 
   let tls: ThreadLocal<ObjectPool> = ThreadLocal::new();
@@ -233,7 +240,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
           };
           NormalizedExtractComments {
             filename: comments_filename,
-            condition: extract_comments_condition.as_ref().expect("must exists"),
+            condition: extract_comments_condition.as_ref().expect("must exist").clone(),
             banner
           }
         });
@@ -248,7 +255,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 
             leading_trivial.iter().for_each(|(_, comments)| {
               comments.iter().for_each(|c| {
-                if extract_comments.condition.is_match(&c.text) {
+                if extract_comments.condition.test(&c.text) {
                   let comment = match c.kind {
                     CommentKind::Line => {
                       format!("//{}", c.text)
@@ -265,7 +272,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             });
             trailing_trivial.iter().for_each(|(_, comments)| {
               comments.iter().for_each(|c| {
-                if extract_comments.condition.is_match(&c.text) {
+                if extract_comments.condition.test(&c.text) {
                   let comment = match c.kind {
                     CommentKind::Line => {
                       format!("//{}", c.text)

--- a/packages/rspack/src/builtin-plugin/SwcJsMinimizerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SwcJsMinimizerPlugin.ts
@@ -229,29 +229,34 @@ function isObject(value: any): value is Object {
 function getRawExtractCommentsOptions(
   extractComments?: ExtractCommentsOptions,
 ): RawExtractComments | undefined {
-  const conditionStr = (condition?: ExtractCommentsCondition): string => {
+  const conditionStr = (
+    condition?: ExtractCommentsCondition,
+  ): { source: string; flags: string } => {
     if (typeof condition === 'undefined' || condition === true) {
       // copied from terser-webpack-plugin
-      return '@preserve|@lic|@cc_on|^\\**!';
+      return { source: '@preserve|@lic|@cc_on|^\\**!', flags: '' };
     }
     if (condition === false) {
       throw Error('unreachable');
     }
-    // FIXME: flags
-    return condition.source;
+    return { source: condition.source, flags: condition.flags };
   };
   if (typeof extractComments === 'boolean') {
     if (!extractComments) {
       return undefined;
     }
+    const { source, flags } = conditionStr(extractComments);
     const res = {
-      condition: conditionStr(extractComments),
+      condition: source,
+      conditionFlags: flags,
     };
     return res;
   }
   if (extractComments instanceof RegExp) {
+    const { source, flags } = conditionStr(extractComments);
     const res = {
-      condition: extractComments.source,
+      condition: source,
+      conditionFlags: flags,
     };
     return res;
   }
@@ -259,8 +264,10 @@ function getRawExtractCommentsOptions(
     if (extractComments.condition === false) {
       return undefined;
     }
+    const { source, flags } = conditionStr(extractComments.condition);
     const res = {
-      condition: conditionStr(extractComments.condition),
+      condition: source,
+      conditionFlags: flags,
       banner: extractComments.banner,
     };
     return res;

--- a/tests/rspack-test/configCases/plugins/minify-extract-comments-case-insensitive/index.js
+++ b/tests/rspack-test/configCases/plugins/minify-extract-comments-case-insensitive/index.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+
+/*! LICENSE - uppercase should be extracted */
+
+/*! license - lowercase should also be extracted */
+
+it("should be case-insensitive with 'i' flag", () => {
+	// Check that the license file was created
+	const licenseExists = fs.existsSync(
+		path.resolve(__dirname, "bundle0.js.LICENSE.txt")
+	);
+	expect(licenseExists).toBe(true);
+	
+	if (licenseExists) {
+		const content = fs.readFileSync(
+			path.resolve(__dirname, "bundle0.js.LICENSE.txt"),
+			"utf-8"
+		);
+		
+		// Should extract both uppercase and lowercase
+		expect(content).toContain("LICENSE - uppercase should be extracted");
+		expect(content).toContain("license - lowercase should also be extracted");
+	}
+});

--- a/tests/rspack-test/configCases/plugins/minify-extract-comments-case-insensitive/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/minify-extract-comments-case-insensitive/rspack.config.js
@@ -1,0 +1,16 @@
+const { rspack } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin({
+				extractComments: {
+					// Test case insensitivity - should match both 'LICENSE' and 'license'
+					condition: /LICENSE/i,
+				},
+			}),
+		],
+	},
+};

--- a/tests/rspack-test/configCases/plugins/minify-extract-comments-case-sensitive/index.js
+++ b/tests/rspack-test/configCases/plugins/minify-extract-comments-case-sensitive/index.js
@@ -1,0 +1,27 @@
+const fs = require("fs");
+const path = require("path");
+
+/*! LICENSE - uppercase should be extracted */
+
+/*! license - lowercase should NOT be extracted */
+
+it("should respect case sensitivity in regex", () => {
+	// Check that the license file was created
+	const licenseExists = fs.existsSync(
+		path.resolve(__dirname, "bundle0.js.LICENSE.txt")
+	);
+	expect(licenseExists).toBe(true);
+	
+	if (licenseExists) {
+		const content = fs.readFileSync(
+			path.resolve(__dirname, "bundle0.js.LICENSE.txt"),
+			"utf-8"
+		);
+		
+		// Should extract uppercase LICENSE
+		expect(content).toContain("LICENSE - uppercase should be extracted");
+		
+		// Should NOT extract lowercase license
+		expect(content).not.toContain("license - lowercase should NOT be extracted");
+	}
+});

--- a/tests/rspack-test/configCases/plugins/minify-extract-comments-case-sensitive/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/minify-extract-comments-case-sensitive/rspack.config.js
@@ -1,0 +1,16 @@
+const { rspack } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin({
+				extractComments: {
+					// Test case sensitivity - this should NOT match 'license' (lowercase)
+					condition: /LICENSE/,
+				},
+			}),
+		],
+	},
+};

--- a/tests/rspack-test/configCases/plugins/minify-extract-comments-regex-flags/index.js
+++ b/tests/rspack-test/configCases/plugins/minify-extract-comments-regex-flags/index.js
@@ -1,0 +1,51 @@
+const fs = require("fs");
+const path = require("path");
+
+/*! This comment should be extracted - it's important */
+
+/*! SuppressStringValidation - this should NOT be extracted */
+
+/*! StartNoStringValidationRegion - this should NOT be extracted */
+
+/*! EndNoStringValidationRegion - this should NOT be extracted */
+
+/**! This is a special JSDoc comment that should be extracted */
+
+/**! SuppressStringValidation - this should NOT be extracted either */
+
+// Regular comment - should not be extracted
+
+/*
+ * Normal block comment - should not be extracted
+ */
+
+it("should extract comments with regex lookahead and flags", () => {
+	const mainFile = fs.readFileSync(
+		path.resolve(__dirname, "bundle0.js"),
+		"utf-8"
+	);
+	
+	// Check that the license file was created
+	const licenseExists = fs.existsSync(
+		path.resolve(__dirname, "bundle0.js.LICENSE.txt")
+	);
+	expect(licenseExists).toBe(true);
+	
+	if (licenseExists) {
+		const content = fs.readFileSync(
+			path.resolve(__dirname, "bundle0.js.LICENSE.txt"),
+			"utf-8"
+		);
+		
+		// Should extract the important comment
+		expect(content).toContain("This comment should be extracted - it's important");
+		
+		// Should extract the special JSDoc comment
+		expect(content).toContain("This is a special JSDoc comment that should be extracted");
+		
+		// Should NOT extract suppressed comments
+		expect(content).not.toContain("SuppressStringValidation");
+		expect(content).not.toContain("StartNoStringValidationRegion");
+		expect(content).not.toContain("EndNoStringValidationRegion");
+	}
+});

--- a/tests/rspack-test/configCases/plugins/minify-extract-comments-regex-flags/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/minify-extract-comments-regex-flags/rspack.config.js
@@ -1,0 +1,17 @@
+const { rspack } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin({
+				extractComments: {
+					// This regex uses negative lookahead (?! ...) which is supported by regress but not by Rust's regex crate
+					// It should extract comments starting with /*! or /** but NOT those containing specific keywords
+					condition: /^\**!(?! *(SuppressStringValidation|StartNoStringValidationRegion|EndNoStringValidationRegion))/i,
+				},
+			}),
+		],
+	},
+};


### PR DESCRIPTION
## Summary

backport https://github.com/web-infra-dev/rspack/pull/12990 to v1.x

## Related links

closes https://github.com/web-infra-dev/rspack/issues/13431

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
