### PR TITLE
fix(core): implement new Map methods on Compilation.entries

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,6 @@
     "esModuleInterop": true,
     "outDir": "dist",
     "declaration": true,
-    "types": ["node"],
     "isolatedModules": true,
     "sourceMap": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

This fixes a TypeScript compatibility issue in `Compilation.entries`.

TypeScript 6 adds `Map#getOrInsert` and `Map#getOrInsertComputed`. Our `Entries` wrapper implements `Map<string, EntryData>`, but it did not expose these new methods, which caused downstream type errors when consuming `@rspack/core` with newer TypeScript versions.

```bash
> tsc --noEmit

../../node_modules/.pnpm/@rspack+core@2.0.0-beta.7_@module-federation+runtime-tools@2.2.3_@swc+helpers@0.5.19/node_modules/@rspack/core/dist/Compilation.d.ts:423:22 - error TS2420: Class 'Entries' incorrectly implements interface 'Map<string, EntryData>'.
  Type 'Entries' is missing the following properties from type 'Map<string, EntryData>': getOrInsert, getOrInsertComputed

423 export declare class Entries implements Map<string, EntryData> {
                         ~~~~~~~

Found 1 error in ../../node_modules/.pnpm/@rspack+core@2.0.0-beta.7_@module-federation+runtime-tools@2.2.3_@swc+helpers@0.5.19/node_modules/@rspack/core/dist/Compilation.d.ts:423
```

## Related links

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/getOrInsert
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/getOrInsertComputed

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
