### PR TITLE
ci: update ecosystem CI suite

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -14,7 +14,6 @@ on:
         options:
           - '-'
           - modernjs
-          # - nx
           - rspress
           - rsbuild
           - rslib
@@ -22,7 +21,6 @@ on:
           - rsdoctor
           - examples
           - devserver
-          - nuxt
           - plugin
           - lynx-stack
           - rsbuild-rsc-plugin
@@ -116,7 +114,6 @@ jobs:
             const suiteName = `${{ github.event_name == 'workflow_dispatch' && inputs.suite || '-' }}`
             let suites = [
               "modernjs",
-              // "nx",
               "rspress",
               "rslib",
               "rstest",
@@ -124,7 +121,6 @@ jobs:
               "rsdoctor",
               "examples",
               "devserver",
-              "nuxt",
               "plugin",
               "lynx-stack",
               "rsbuild-rsc-plugin",


### PR DESCRIPTION
## Summary

Update ecosystem CI suite to reduce CI cost. The Nuxt ecosystem CI has been failing for several months. We may fix it and re-enable it in the future.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
