### PR TITLE
chore(ci): remove stale miri config

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -53,8 +53,7 @@ runs:
           -c cargo \
           -c rust-std \
           -c clippy \
-          -c rustfmt \
-          -c miri
+          -c rustfmt
 
     - name: Save rustup cache
       uses: ./.github/actions/cache/save

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -23,37 +23,6 @@ jobs:
     name: Run Rust Tests
     uses: ./.github/workflows/reusable-rust-test.yml
 
-  rust_test_miri:
-    name: Rust test miri
-    # TODO: enable it after self hosted runners are ready
-    # if: needs.rust_changes.outputs.changed == 'true' && github.ref_name == 'main' && github.repository_owner == 'web-infra-dev'
-    if: false
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
-        with:
-          save-if: ${{ github.ref_name == 'main' }}
-          key: check
-
-      - name: Run Cargo codegen
-        run: cargo codegen
-
-      # Compile test without debug info for reducing the CI cache size
-      - name: Change profile.test
-        shell: bash
-        run: |
-          echo '[profile.test]' >> Cargo.toml
-          echo 'debug = false' >> Cargo.toml
-
-      - name: Run test
-        env:
-          MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-disable-isolation
-        # reason for excluding https://github.com/napi-rs/napi-rs/issues/2200
-        run: cargo miri test --workspace --exclude rspack_node -- --nocapture
-
   test_required_check:
     # this job will be used for GitHub actions to determine required job success or not;
     # When code changed, it will check if any of the test jobs failed.

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -198,18 +198,14 @@ jobs:
           pnpm --filter @rspack/binding... 	            \
                --filter @rspack/binding-darwin-arm64... \
                --filter @rspack/core...                 \
-               --filter @rspack/dev-server...           \
                --filter @rspack/test-tools...           \
-               --filter @rspack/tracing...              \
               exec sh -c 'jq ".publishConfig.provenance = false" package.json > package.json.tmp && mv package.json.tmp package.json'
 
           pnpm publish --no-git-checks --provenance=false --access public --registry=http://localhost:4873 \
                --filter @rspack/binding... 	            \
                --filter @rspack/binding-darwin-arm64... \
                --filter @rspack/core...                 \
-               --filter @rspack/dev-server...           \
-               --filter @rspack/test-tools...           \
-               --filter @rspack/tracing... 
+               --filter @rspack/test-tools...
 
           cd ../..
           pwd

--- a/crates/rspack_allocator/src/lib.rs
+++ b/crates/rspack_allocator/src/lib.rs
@@ -1,16 +1,16 @@
 #[global_allocator]
-#[cfg(not(any(miri, target_family = "wasm")))]
+#[cfg(not(target_family = "wasm"))]
 #[cfg(not(any(feature = "sftrace-setup", feature = "tracy-client")))]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[global_allocator]
-#[cfg(not(any(miri, target_family = "wasm")))]
+#[cfg(not(target_family = "wasm"))]
 #[cfg(feature = "sftrace-setup")]
 static GLOBAL: sftrace_setup::SftraceAllocator<mimalloc::MiMalloc> =
   sftrace_setup::SftraceAllocator(mimalloc::MiMalloc);
 
 #[global_allocator]
-#[cfg(not(any(miri, target_family = "wasm")))]
+#[cfg(not(target_family = "wasm"))]
 #[cfg(all(feature = "tracy-client", not(feature = "sftrace-setup")))]
 static GLOBAL: tracy_client::ProfiledAllocator<std::alloc::System> =
   tracy_client::ProfiledAllocator::new(std::alloc::System, 10); // adjust callstack_depth if needed with performance cost

--- a/crates/rspack_cacheable_test/tests/macro/cacheable_dyn.rs
+++ b/crates/rspack_cacheable_test/tests/macro/cacheable_dyn.rs
@@ -4,7 +4,6 @@ use rspack_cacheable::{
 };
 
 #[test]
-#[cfg_attr(miri, ignore)]
 fn test_cacheable_dyn_macro() {
   struct Context;
   impl CacheableContext for Context {
@@ -80,7 +79,6 @@ fn test_cacheable_dyn_macro() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)]
 fn test_cacheable_dyn_macro_with_generics() {
   struct Context;
   impl CacheableContext for Context {

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
@@ -3,7 +3,6 @@ use rspack_cacheable::{
 };
 
 #[test]
-#[cfg_attr(miri, ignore)]
 fn test_manual_cacheable_dyn_macro() {
   struct Context;
   impl CacheableContext for Context {

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
@@ -3,7 +3,6 @@ use rspack_cacheable::{
 };
 
 #[test]
-#[cfg_attr(miri, ignore)]
 fn test_manual_cacheable_dyn_macro_with_generics() {
   struct Context;
   impl CacheableContext for Context {

--- a/crates/rspack_macros_test/tests/compiletest.rs
+++ b/crates/rspack_macros_test/tests/compiletest.rs
@@ -1,5 +1,4 @@
 #[test]
-#[cfg_attr(miri, ignore)]
 fn ui() {
   let t = trybuild::TestCases::new();
   t.compile_fail("tests/ui/hook/*.rs");

--- a/crates/rspack_storage/src/filesystem/db/bucket/meta.rs
+++ b/crates/rspack_storage/src/filesystem/db/bucket/meta.rs
@@ -133,7 +133,6 @@ mod test {
   use super::{super::Pack, Meta, Result, ScopeFileSystem};
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_meta() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/bucket1".into());
     fs.ensure_exist().await?;

--- a/crates/rspack_storage/src/filesystem/db/bucket/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/bucket/mod.rs
@@ -236,7 +236,6 @@ mod test {
   use super::{Bucket, Result, ScopeFileSystem};
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_bucket() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/bucket1".into());
 

--- a/crates/rspack_storage/src/filesystem/db/bucket/pack/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/bucket/pack/mod.rs
@@ -118,7 +118,6 @@ mod test {
   use super::{Pack, PackId, Result, ScopeFileSystem};
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_pack() -> Result<()> {
     let pack_id = PackId::new(10);
     let fs = ScopeFileSystem::new_memory_fs("/bucket1".into());

--- a/crates/rspack_storage/src/filesystem/db/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/mod.rs
@@ -179,7 +179,6 @@ mod test {
   use super::{DB, HashMap, Result, ScopeFileSystem};
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_db() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/".into());
     let db = DB::new(fs);

--- a/crates/rspack_storage/src/filesystem/db/task_queue.rs
+++ b/crates/rspack_storage/src/filesystem/db/task_queue.rs
@@ -63,7 +63,6 @@ mod tests {
   use super::TaskQueue;
 
   #[test]
-  #[cfg_attr(miri, ignore)]
   fn test_add_task_to_queue() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 

--- a/crates/rspack_storage/src/filesystem/db/transaction/lock/commit.rs
+++ b/crates/rspack_storage/src/filesystem/db/transaction/lock/commit.rs
@@ -101,7 +101,6 @@ mod tests {
   use super::{CommitLock, Result, ScopeFileSystem};
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_commit_lock() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/bucket1".into());
     fs.ensure_exist().await?;

--- a/crates/rspack_storage/src/filesystem/db/transaction/lock/state.rs
+++ b/crates/rspack_storage/src/filesystem/db/transaction/lock/state.rs
@@ -156,7 +156,6 @@ mod tests {
   use super::{Result, ScopeFileSystem, StateLock};
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_state_lock() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/bucket1".into());
     fs.ensure_exist().await?;

--- a/crates/rspack_storage/src/filesystem/db/transaction/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/transaction/mod.rs
@@ -138,7 +138,6 @@ impl Transaction {
 mod test {
   use super::{Result, ScopeFileSystem, Transaction};
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_smoke() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/".into());
     fs.ensure_exist().await?;

--- a/crates/rspack_storage/src/filesystem/meta.rs
+++ b/crates/rspack_storage/src/filesystem/meta.rs
@@ -123,7 +123,6 @@ mod test {
   use super::{Meta, Result, ScopeFileSystem};
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_meta() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/test_meta".into());
     fs.ensure_exist().await?;

--- a/crates/rspack_storage/src/filesystem/scope_fs.rs
+++ b/crates/rspack_storage/src/filesystem/scope_fs.rs
@@ -167,7 +167,6 @@ mod tests {
   use super::{Result, ScopeFileSystem};
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_read_and_write() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/".into());
     assert!(fs.read("/a.txt").await.is_err());
@@ -178,7 +177,6 @@ mod tests {
   }
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_stream_read_and_write() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/".into());
     assert!(fs.read("/a.txt").await.is_err());
@@ -195,7 +193,6 @@ mod tests {
   }
 
   #[tokio::test]
-  #[cfg_attr(miri, ignore)]
   async fn test_move_to() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/".into());
     fs.write("a.txt", "1".as_bytes()).await?;


### PR DESCRIPTION
## Summary

- remove stale Miri setup from the shared rustup action and CI workflow
- run allocator and storage/cacheable/macros tests normally instead of skipping them under `miri`
- stop publishing obsolete package filters in ecosystem CI

## Related links

- N/A

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).