### PR TITLE
fix(runtime): invalidate ESM chunk cache in development SSR

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -297,12 +297,19 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
       let body = if matches!(has_js_matcher, BooleanMatcher::Condition(false)) {
         "installedChunks[chunkId] = 0;".to_string()
       } else {
+        let cache_bust = if compilation.options.mode.is_development() {
+          " + \"?t=\" + Date.now()".to_string()
+        } else {
+          String::new()
+        };
+
         runtime_template.render(
           &self.template(TemplateId::WithLoading),
           Some(serde_json::json!({
             "_js_matcher": &has_js_matcher.render("chunkId"),
             "_import_function_name":&compilation.options.output.import_function_name,
             "_output_dir": &root_output_dir,
+            "_cache_bust": &cache_bust,
             "_match_fallback":    if matches!(has_js_matcher, BooleanMatcher::Condition(true)) {
               ""
             } else {

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -337,10 +337,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
 
           let fallback_hash =
             rspack_util::json_stringify_str(compilation.get_hash().unwrap_or("dev"));
-          format!(
-            " + \"?t=\" + ({}[chunkId] || {})",
-            chunk_hash_map, fallback_hash
-          )
+          format!(" + \"?t=\" + ({chunk_hash_map}[chunkId] || {fallback_hash})")
         } else {
           String::new()
         };

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -297,7 +297,9 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
       let body = if matches!(has_js_matcher, BooleanMatcher::Condition(false)) {
         "installedChunks[chunkId] = 0;".to_string()
       } else {
-        let cache_bust = if compilation.options.mode.is_development() {
+        let cache_bust = if compilation.options.mode.is_development()
+          && compilation.platform.is_node()
+        {
           let mut chunk_hash_map = String::from("{");
           let mut first = true;
           for referenced_chunk_ukey in chunk

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -298,7 +298,49 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
         "installedChunks[chunkId] = 0;".to_string()
       } else {
         let cache_bust = if compilation.options.mode.is_development() {
-          " + \"?t=\" + Date.now()".to_string()
+          let mut chunk_hash_map = String::from("{");
+          let mut first = true;
+          for referenced_chunk_ukey in chunk
+            .get_all_referenced_chunks(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
+            .iter()
+          {
+            if !chunk_has_js(referenced_chunk_ukey, compilation) {
+              continue;
+            }
+
+            let referenced_chunk = compilation
+              .build_chunk_graph_artifact
+              .chunk_by_ukey
+              .expect_get(referenced_chunk_ukey);
+
+            let Some(chunk_id) = referenced_chunk.id() else {
+              continue;
+            };
+
+            let chunk_hash = referenced_chunk
+              .rendered_hash(
+                &compilation.chunk_hashes_artifact,
+                compilation.options.output.hash_digest_length,
+              )
+              .or_else(|| compilation.get_hash())
+              .unwrap_or("dev");
+
+            if !first {
+              chunk_hash_map.push(',');
+            }
+            first = false;
+            chunk_hash_map.push_str(&rspack_util::json_stringify_str(chunk_id.as_str()));
+            chunk_hash_map.push(':');
+            chunk_hash_map.push_str(&rspack_util::json_stringify_str(chunk_hash));
+          }
+          chunk_hash_map.push('}');
+
+          let fallback_hash =
+            rspack_util::json_stringify_str(compilation.get_hash().unwrap_or("dev"));
+          format!(
+            " + \"?t=\" + ({}[chunkId] || {})",
+            chunk_hash_map, fallback_hash
+          )
         } else {
           String::new()
         };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_loading.ejs
@@ -7,7 +7,7 @@ if (installedChunkData !== 0) { // 0 means "already installed".'
     } else {
         if (<%- _js_matcher %>) {
             // setup Promise in chunk cache
-            var promise = <%- _import_function_name %>("<%- _output_dir %>" + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId)).then(installChunk, <%- basicFunction("e") %> {
+            var promise = <%- _import_function_name %>("<%- _output_dir %>" + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId)<%- _cache_bust %>).then(installChunk, <%- basicFunction("e") %> {
                 if (installedChunks[chunkId] !== 0) installedChunks[chunkId] = undefined;
                 throw e;
             });

--- a/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/chunk.js
+++ b/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/chunk.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/index.js
+++ b/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/index.js
@@ -15,13 +15,19 @@ it("should not include development cache bust in production", () => {
 });
 
 it("should still load dynamic import", async () => {
+	const mod = await import("./chunk");
+	expect(mod.default).toBe(42);
+
 	const runtimeChunk = __STATS__.chunks.find(chunk =>
 		chunk.names.includes("runtime~main")
 	);
 	expect(runtimeChunk).toBeDefined();
 
-	const isOnlyRuntimeAndMain = __STATS__.chunks.every(chunk =>
-		chunk.names.includes("runtime~main") || chunk.names.includes("main")
-	);
-	expect(isOnlyRuntimeAndMain).toBe(true);
+	const hasAsyncChunk = __STATS__.chunks.some(chunk => {
+		if (chunk.names.includes("runtime~main") || chunk.names.includes("main")) {
+			return false;
+		}
+		return chunk.files.some(file => file.endsWith(".mjs"));
+	});
+	expect(hasAsyncChunk).toBe(true);
 });

--- a/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/index.js
+++ b/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/index.js
@@ -11,7 +11,7 @@ it("should not include development cache bust in production", () => {
 	expect(runtimeAsset).toBeDefined();
 
 	const source = fs.readFileSync(path.join(__dirname, runtimeAsset), "utf-8");
-	expect(source).not.toContain('?t=" + Date.now()');
+	expect(source).not.toContain("?t=");
 });
 
 it("should still load dynamic import", async () => {

--- a/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/index.js
+++ b/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/index.js
@@ -1,0 +1,27 @@
+it("should not include development cache bust in production", () => {
+	const fs = require("fs");
+	const path = require("path");
+	const runtimeChunk = __STATS__.chunks.find(chunk =>
+		chunk.names.includes("runtime~main")
+	);
+
+	expect(runtimeChunk).toBeDefined();
+
+	const runtimeAsset = runtimeChunk.files.find(file => file.endsWith(".js") || file.endsWith(".mjs"));
+	expect(runtimeAsset).toBeDefined();
+
+	const source = fs.readFileSync(path.join(__dirname, runtimeAsset), "utf-8");
+	expect(source).not.toContain('?t=" + Date.now()');
+});
+
+it("should still load dynamic import", async () => {
+	const runtimeChunk = __STATS__.chunks.find(chunk =>
+		chunk.names.includes("runtime~main")
+	);
+	expect(runtimeChunk).toBeDefined();
+
+	const isOnlyRuntimeAndMain = __STATS__.chunks.every(chunk =>
+		chunk.names.includes("runtime~main") || chunk.names.includes("main")
+	);
+	expect(isOnlyRuntimeAndMain).toBe(true);
+});

--- a/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/rspack.config.js
+++ b/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/rspack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		module: true,
+		library: { type: "module" },
+		chunkFormat: "module",
+		chunkLoading: "import",
+		filename: "[name].mjs",
+		chunkFilename: "[name].chunk.js"
+	},
+	optimization: {
+		runtimeChunk: true,
+		minimize: false
+	}
+};

--- a/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/test.config.js
+++ b/tests/rspack-test/configCases/module/dev-module-dynamic-import-no-cache-bust/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.mjs", "runtime~main.mjs"];
+	}
+};

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/0/dynamic.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/0/dynamic.js
@@ -1,0 +1,1 @@
+export default "Normal";

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/0/index.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/0/index.js
@@ -1,0 +1,9 @@
+it("should load dynamic chunk in development web module mode", async () => {
+	const step = WATCH_STEP;
+	const mod = await import(/* webpackChunkName: "dynamic" */ "./dynamic");
+	if (step === "0") {
+		expect(mod.default).toBe("Normal");
+	} else {
+		expect(mod.default).toBe("Changed");
+	}
+});

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/1/dynamic.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/1/dynamic.js
@@ -1,0 +1,1 @@
+export default "Changed";

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/rspack.config.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/rspack.config.js
@@ -1,18 +1,16 @@
-"use strict";
-
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	mode: "production",
+	mode: "development",
+	target: "web",
 	entry: {
 		main: "./index.js"
 	},
 	output: {
 		module: true,
-		library: { type: "module" },
-		chunkFormat: "module",
 		chunkLoading: "import",
+		chunkFormat: "module",
 		filename: "[name].mjs",
-		chunkFilename: "[name].chunk.mjs"
+		chunkFilename: "[name].chunk.js"
 	},
 	optimization: {
 		runtimeChunk: true,

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/test.config.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust-web/test.config.js
@@ -1,0 +1,16 @@
+const fs = require("fs");
+const path = require("path");
+
+let outputPath = "";
+
+module.exports = {
+	findBundle(i, config) {
+		outputPath = config.output.path;
+		return [];
+	},
+	checkStats() {
+		const source = fs.readFileSync(path.join(outputPath, "runtime~main.mjs"), "utf-8");
+		expect(source).not.toContain("?t=");
+		return true;
+	}
+};

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/0/dynamic.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/0/dynamic.js
@@ -1,0 +1,1 @@
+export default "Normal";

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/0/index.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/0/index.js
@@ -1,0 +1,9 @@
+it("should load dynamic chunk in development module mode", async () => {
+	const step = WATCH_STEP;
+	const mod = await import(/* webpackChunkName: "dynamic" */ "./dynamic");
+	if (step === "0") {
+		expect(mod.default).toBe("Normal");
+	} else {
+		expect(mod.default).toBe("Changed");
+	}
+});

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/1/dynamic.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/1/dynamic.js
@@ -1,0 +1,1 @@
+export default "Changed";

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/rspack.config.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/rspack.config.js
@@ -1,0 +1,19 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	target: "node",
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		module: true,
+		chunkLoading: "import",
+		chunkFormat: "module",
+		filename: "[name].mjs",
+		chunkFilename: "[name].chunk.js"
+	},
+	optimization: {
+		runtimeChunk: true,
+		minimize: false
+	}
+};

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/test.config.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/test.config.js
@@ -10,8 +10,9 @@ module.exports = {
 	},
 	checkStats() {
 		const source = fs.readFileSync(path.join(outputPath, "runtime~main.mjs"), "utf-8");
-		expect(source).toContain("Date.now");
 		expect(source).toContain("?t=");
+		expect(source).toContain("chunkId");
+		expect(source).not.toContain("Date.now");
 		return true;
 	}
 };

--- a/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/test.config.js
+++ b/tests/rspack-test/watchCases/runtime/module-dynamic-import-cache-bust/test.config.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const path = require("path");
+
+let outputPath = "";
+
+module.exports = {
+	findBundle(i, config) {
+		outputPath = config.output.path;
+		return [];
+	},
+	checkStats() {
+		const source = fs.readFileSync(path.join(outputPath, "runtime~main.mjs"), "utf-8");
+		expect(source).toContain("Date.now");
+		expect(source).toContain("?t=");
+		return true;
+	}
+};


### PR DESCRIPTION
## Summary
- replace coarse development cache-busting (`?t=${Date.now()}`) in ESM module chunk loading with per-chunk versioning based on `chunkId -> rendered chunk hash`
- keep cache invalidation scoped: only changed chunks get a new import URL, unchanged chunks can still hit cache
- keep production behavior unchanged (no dev cache-busting query emitted)
- update regression assertions to verify `?t=` is present in dev runtime, `Date.now` is not emitted, and no cache-busting query appears in production

## Issue
Closes #13304

## Verification
- `pnpm run build:binding:dev`
- `cd tests/rspack-test && pnpm run test -t "watchCases/runtime/module-dynamic-import-cache-bust"`
- `cd tests/rspack-test && pnpm run test -t "configCases/module/dev-module-dynamic-import-no-cache-bust"`