### PR TITLE
fix(rsc): tree shaking client barrel

### DIFF
--- a/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
+++ b/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
@@ -6,6 +6,7 @@ use rspack_core::{
   AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
   DependencyType, ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
   ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport, ResourceIdentifier, RuntimeSpec,
+  create_exports_object_referenced,
 };
 use rspack_util::fx_hash::FxIndexSet;
 use swc_core::atoms::Atom;
@@ -69,6 +70,18 @@ impl Dependency for ClientReferenceDependency {
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ExtendedReferencedExport> {
+    // `*` is an internal sentinel meaning this client reference needs the
+    // whole exports object, not a narrowed list of named exports.
+    if self
+      .referenced_exports
+      .iter()
+      .any(|export_name| export_name == "*")
+    {
+      return create_exports_object_referenced();
+    }
+
+    // Otherwise keep the exact export names so usage analysis can preserve
+    // tree-shaking granularity for this client reference.
     vec![ExtendedReferencedExport::Export(ReferencedExport::new(
       self.referenced_exports.iter().cloned().collect(),
       false,

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/rspack.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/rspack.config.js
@@ -1,0 +1,103 @@
+const path = require('node:path');
+const { rspack, experiments } = require('@rspack/core');
+
+const { createPlugins, Layers } = experiments.rsc;
+const { ServerPlugin, ClientPlugin } = createPlugins();
+
+const ssrEntry = path.join(__dirname, 'src/framework/entry.ssr.js');
+const rscEntry = path.join(__dirname, 'src/framework/entry.rsc.js');
+
+const swcLoaderRule = {
+    test: /\.jsx?$/,
+    use: [
+        {
+            loader: 'builtin:swc-loader',
+            options: {
+                jsc: {
+                    parser: {
+                        syntax: 'ecmascript',
+                        jsx: true,
+                    },
+                    transform: {
+                        react: {
+                            runtime: 'automatic',
+                        },
+                    },
+                },
+                rspackExperiments: {
+                    reactServerComponents: true,
+                },
+            },
+        },
+    ],
+};
+
+module.exports = [
+    {
+        name: 'server',
+        mode: 'production',
+        target: 'node',
+        entry: {
+            main: {
+                import: ssrEntry,
+            },
+        },
+        resolve: {
+            extensions: ['...', '.ts', '.tsx', '.jsx'],
+        },
+        module: {
+            rules: [
+                swcLoaderRule,
+                {
+                    resource: ssrEntry,
+                    layer: Layers.ssr,
+                },
+                {
+                    resource: rscEntry,
+                    layer: Layers.rsc,
+                    resolve: {
+                        conditionNames: ['react-server', '...'],
+                    },
+                },
+                {
+                    issuerLayer: Layers.rsc,
+                    resolve: {
+                        conditionNames: ['react-server', '...'],
+                    },
+                },
+            ],
+        },
+        plugins: [
+            new ServerPlugin(),
+            new rspack.DefinePlugin({
+                LIB_PATH: JSON.stringify(path.join(__dirname, 'src/lib.js')),
+            }),
+        ],
+        output: {
+            filename: '[name].js',
+        },
+    },
+    {
+        name: 'client',
+        mode: 'production',
+        target: 'node',
+        entry: {
+            main: {
+                import: './src/framework/entry.client.js',
+            },
+        },
+        resolve: {
+            extensions: ['...', '.ts', '.tsx', '.jsx'],
+        },
+        module: {
+            rules: [swcLoaderRule],
+        },
+        plugins: [new ClientPlugin()],
+        output: {
+            filename: 'static/[name].js',
+            library: {
+                type: 'commonjs',
+            },
+        },
+    },
+];

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/App.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/App.js
@@ -1,0 +1,8 @@
+"use server-entry";
+
+import { Client } from './lib';
+import './lib';
+
+export const App = async () => {
+    return <Client />;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/Client.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/Client.js
@@ -1,0 +1,7 @@
+export const Client = () => {
+    return <></>;
+};
+
+export const Unused = () => {
+    return <></>;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/framework/entry.client.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/framework/entry.client.js
@@ -1,0 +1,8 @@
+// In a real app this entry would consume the RSC payload and hydrate.
+// This file exists mainly to mirror the typical split of RSC/SSR/client entries.
+
+export const loadClientModule = async (chunkId, moduleId) => {
+    await __webpack_chunk_load__(chunkId);
+    const mod = __webpack_require__(moduleId);
+    return Object.keys(mod);
+}

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/framework/entry.rsc.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/framework/entry.rsc.js
@@ -1,0 +1,14 @@
+import { renderToReadableStream } from 'react-server-dom-rspack/server';
+import { App } from '../App';
+
+export const renderRscStream = () => {
+    return renderToReadableStream(<App />);
+};
+
+it('should keep all exports when a client boundary is upgraded to a whole-module reference', async () => {
+    const { loadClientModule } = __non_webpack_require__("./static/main.js");
+    const clientModule = __rspack_rsc_manifest__.clientManifest[LIB_PATH];
+    const exports = await loadClientModule(clientModule.chunks[0], clientModule.id);
+
+    expect(exports.sort()).toEqual(['Client', 'Unused']);
+});

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/framework/entry.ssr.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/framework/entry.ssr.js
@@ -1,0 +1,9 @@
+import { createFromReadableStream } from 'react-server-dom-rspack/client';
+import { renderRscStream } from './entry.rsc';
+
+export const renderHTML = async () => {
+    // In real SSR, the HTML renderer would consume the RSC stream.
+    // For this test case we just ensure the pipeline can be invoked.
+    const rscStream = await renderRscStream();
+    return createFromReadableStream(rscStream);
+};

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/lib.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/src/lib.js
@@ -1,0 +1,3 @@
+"use client";
+
+export { Client, Unused } from './Client';

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/test.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+    findBundle: function () {
+        return ['main.js'];
+    },
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR fixes export usage tracking for RSC client references when `referenced_exports` contains `*`.

In this case, `*` is an internal sentinel meaning the client reference should be treated as a whole-module reference instead of a narrowed set of named exports. Previously, this case was not handled in `client_reference_dependency`, which could cause the target client module's exports to be incorrectly tree-shaken away in real projects.

This change updates `get_referenced_exports` to return an exports-object reference when `*` is present, and keeps the existing precise export tracking for normal named-export cases. It also clarifies the related comments in English.

Additionally, this PR adds a regression test in `tests/rspack-test/configCases/rsc-plugin/tree-shaking-client-barrel` to cover a client barrel scenario where a server entry both imports a named export and side-effect imports the same client boundary. The test verifies that once the reference is upgraded to a whole-module reference, all exports from the client module are preserved.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
