### PR TITLE
docs(migration): add transformImport upgrade notes

### DIFF
--- a/website/docs/en/guide/migration/rspack_1.x.mdx
+++ b/website/docs/en/guide/migration/rspack_1.x.mdx
@@ -394,8 +394,6 @@ export default {
 };
 ```
 
-Validation errors for this feature now also reference `transformImport[*]` instead of `rspackExperiments.import[*]`.
-
 ### Derive loader and plugin targets from target
 
 In Rspack 2.0, the `targets` configuration for `builtin:swc-loader`, `builtin:lightningcss-loader`, and `rspack.LightningCssMinimizerRspackPlugin` now defaults to being derived from the [target](/config/target) configuration.

--- a/website/docs/zh/guide/migration/rspack_1.x.mdx
+++ b/website/docs/zh/guide/migration/rspack_1.x.mdx
@@ -394,8 +394,6 @@ export default {
 };
 ```
 
-相关的校验错误信息现在也会使用 `transformImport[*]`，不再引用 `rspackExperiments.import[*]`。
-
 ### 从 target 派生 loader 和 plugin 的 targets 配置
 
 在 Rspack 2.0 中，`builtin:swc-loader`、`builtin:lightningcss-loader` 和 `rspack.LightningCssMinimizerRspackPlugin` 的 `targets` 配置现在默认从 [target](/config/target) 配置派生。


### PR DESCRIPTION
## Summary

- add English and Chinese Rspack 1.x migration notes for the `builtin:swc-loader` `transformImport` API move
- document the config diff from `rspackExperiments.import` to `transformImport`
- note that validation errors now reference `transformImport[*]`

## Related links

- https://github.com/web-infra-dev/rspack/pull/13345

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
