### PR TITLE
perf(core): optimize module rule matcher

### DIFF
--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -925,8 +925,40 @@ impl DataRef<'_> {
 }
 
 impl RuleSetCondition {
+  fn try_match_sync(&self, data: DataRef<'_>) -> Option<bool> {
+    match self {
+      Self::String(s) => Some(
+        data
+          .as_str()
+          .map(|data| data.starts_with(s))
+          .unwrap_or_default(),
+      ),
+      Self::Regexp(r) => Some(data.as_str().map(|data| r.test(data)).unwrap_or_default()),
+      Self::Logical(g) => g.try_match_sync(data),
+      Self::Array(list) => {
+        for condition in list {
+          match condition.try_match_sync(data) {
+            Some(true) => return Some(true),
+            Some(false) => continue,
+            None => return None,
+          }
+        }
+        Some(false)
+      }
+      Self::Func(_) => None,
+    }
+  }
+
+  #[inline]
+  pub async fn try_match(&self, data: DataRef<'_>) -> Result<bool> {
+    if let Some(matched) = self.try_match_sync(data) {
+      return Ok(matched);
+    }
+    self.try_match_slow(data).await
+  }
+
   #[async_recursion]
-  pub async fn try_match(&self, data: DataRef<'async_recursion>) -> Result<bool> {
+  async fn try_match_slow(&self, data: DataRef<'async_recursion>) -> Result<bool> {
     match self {
       Self::String(s) => Ok(
         data
@@ -941,8 +973,26 @@ impl RuleSetCondition {
     }
   }
 
-  #[async_recursion]
+  fn match_when_empty_sync(&self) -> Option<bool> {
+    match self {
+      RuleSetCondition::String(s) => Some(s.is_empty()),
+      RuleSetCondition::Regexp(rspack_regex) => Some(rspack_regex.test("")),
+      RuleSetCondition::Logical(logical) => logical.match_when_empty_sync(),
+      RuleSetCondition::Array(_) => Some(false),
+      RuleSetCondition::Func(_) => None,
+    }
+  }
+
+  #[inline]
   async fn match_when_empty(&self) -> Result<bool> {
+    if let Some(matched) = self.match_when_empty_sync() {
+      return Ok(matched);
+    }
+    self.match_when_empty_slow().await
+  }
+
+  #[async_recursion]
+  async fn match_when_empty_slow(&self) -> Result<bool> {
     let res = match self {
       RuleSetCondition::String(s) => s.is_empty(),
       RuleSetCondition::Regexp(rspack_regex) => rspack_regex.test(""),
@@ -975,6 +1025,12 @@ impl RuleSetConditionWithEmpty {
   }
 
   pub async fn match_when_empty(&self) -> Result<bool> {
+    if let Some(matched) = self.match_when_empty.get().copied() {
+      return Ok(matched);
+    }
+    if let Some(matched) = self.condition.match_when_empty_sync() {
+      return Ok(matched);
+    }
     self
       .match_when_empty
       .get_or_try_init(|| async { self.condition.match_when_empty().await })
@@ -997,8 +1053,42 @@ pub struct RuleSetLogicalConditions {
 }
 
 impl RuleSetLogicalConditions {
+  fn try_match_sync(&self, data: DataRef<'_>) -> Option<bool> {
+    if let Some(and) = &self.and {
+      for condition in and {
+        match condition.try_match_sync(data) {
+          Some(false) => return Some(false),
+          Some(true) => continue,
+          None => return None,
+        }
+      }
+    }
+    if let Some(or) = &self.or {
+      for condition in or {
+        match condition.try_match_sync(data) {
+          Some(true) => return Some(true),
+          Some(false) => continue,
+          None => return None,
+        }
+      }
+      return Some(false);
+    }
+    if let Some(not) = &self.not {
+      return not.try_match_sync(data).map(|matched| !matched);
+    }
+    Some(true)
+  }
+
+  #[inline]
+  pub async fn try_match(&self, data: DataRef<'_>) -> Result<bool> {
+    if let Some(matched) = self.try_match_sync(data) {
+      return Ok(matched);
+    }
+    self.try_match_slow(data).await
+  }
+
   #[async_recursion]
-  pub async fn try_match(&self, data: DataRef<'async_recursion>) -> Result<bool> {
+  async fn try_match_slow(&self, data: DataRef<'async_recursion>) -> Result<bool> {
     if let Some(and) = &self.and
       && try_any(and, |i| async { i.try_match(data).await.map(|i| !i) }).await?
     {
@@ -1017,7 +1107,54 @@ impl RuleSetLogicalConditions {
     Ok(true)
   }
 
+  fn match_when_empty_sync(&self) -> Option<bool> {
+    let mut has_condition = false;
+    let mut match_when_empty = true;
+
+    if let Some(and) = &self.and {
+      has_condition = true;
+      for condition in and {
+        match condition.match_when_empty_sync() {
+          Some(false) => return Some(false),
+          Some(true) => continue,
+          None => return None,
+        }
+      }
+    }
+
+    if let Some(or) = &self.or {
+      has_condition = true;
+      let mut matched = false;
+      for condition in or {
+        match condition.match_when_empty_sync() {
+          Some(true) => {
+            matched = true;
+            break;
+          }
+          Some(false) => continue,
+          None => return None,
+        }
+      }
+      match_when_empty &= matched;
+    }
+
+    if let Some(not) = &self.not {
+      has_condition = true;
+      match_when_empty &= !not.match_when_empty_sync()?;
+    }
+
+    Some(has_condition && match_when_empty)
+  }
+
+  #[inline]
   pub async fn match_when_empty(&self) -> Result<bool> {
+    if let Some(matched) = self.match_when_empty_sync() {
+      return Ok(matched);
+    }
+    self.match_when_empty_slow().await
+  }
+
+  async fn match_when_empty_slow(&self) -> Result<bool> {
     let mut has_condition = false;
     let mut match_when_empty = true;
     if let Some(and) = &self.and {
@@ -1190,4 +1327,70 @@ pub struct ModuleOptions {
   pub parser: Option<ParserOptionsMap>,
   pub generator: Option<GeneratorOptionsMap>,
   pub no_parse: Option<ModuleNoParseRules>,
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+  };
+
+  use futures::FutureExt;
+
+  use super::RuleSetCondition;
+
+  #[tokio::test]
+  async fn short_circuits_sync_array_conditions_before_async_fallback() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let condition = RuleSetCondition::Array(vec![
+      RuleSetCondition::String("/project/src".into()),
+      RuleSetCondition::Func(Box::new({
+        let calls = Arc::clone(&calls);
+        move |_| {
+          let calls = Arc::clone(&calls);
+          async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(false)
+          }
+          .boxed()
+        }
+      })),
+    ]);
+
+    let matched = condition
+      .try_match("/project/src/index.js".into())
+      .await
+      .expect("condition should match");
+
+    assert!(matched);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+  }
+
+  #[tokio::test]
+  async fn falls_back_to_async_function_conditions_when_sync_checks_miss() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let condition = RuleSetCondition::Array(vec![
+      RuleSetCondition::String("/project/dist".into()),
+      RuleSetCondition::Func(Box::new({
+        let calls = Arc::clone(&calls);
+        move |_| {
+          let calls = Arc::clone(&calls);
+          async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(true)
+          }
+          .boxed()
+        }
+      })),
+    ]);
+
+    let matched = condition
+      .try_match("/project/src/index.js".into())
+      .await
+      .expect("condition should match through async fallback");
+
+    assert!(matched);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+  }
 }

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -1,82 +1,188 @@
 use async_recursion::async_recursion;
 use rspack_error::Result;
-use rspack_loader_runner::ResourceData;
+use rspack_loader_runner::{DescriptionData as ResourceDescriptionData, ResourceData};
 use rspack_paths::Utf8Path;
 
 use crate::{DependencyCategory, ImportAttributes, ModuleRule, ModuleRuleEffect};
 
-pub async fn module_rules_matcher<'a>(
-  rules: &'a [ModuleRule],
-  resource_data: &ResourceData,
+pub async fn module_rules_matcher<'rule, 'ctx>(
+  rules: &'rule [ModuleRule],
+  resource_data: &'ctx ResourceData,
+  issuer: Option<&'ctx str>,
+  issuer_layer: Option<&'ctx str>,
+  dependency: &'ctx DependencyCategory,
+  attributes: Option<&'ctx ImportAttributes>,
+  matched_rules: &mut Vec<&'rule ModuleRuleEffect>,
+) -> Result<()> {
+  let context =
+    ModuleRuleMatchContext::new(resource_data, issuer, issuer_layer, dependency, attributes);
+  module_rules_matcher_with_context(rules, &context, matched_rules).await
+}
+
+/// Match the `ModuleRule` against the given `ResourceData`, and return the matching `ModuleRule` if matched.
+pub async fn module_rule_matcher<'rule, 'ctx>(
+  module_rule: &'rule ModuleRule,
+  resource_data: &'ctx ResourceData,
+  issuer: Option<&'ctx str>,
+  issuer_layer: Option<&'ctx str>,
+  dependency: &'ctx DependencyCategory,
+  attributes: Option<&'ctx ImportAttributes>,
+  matched_rules: &mut Vec<&'rule ModuleRuleEffect>,
+) -> Result<bool> {
+  let context =
+    ModuleRuleMatchContext::new(resource_data, issuer, issuer_layer, dependency, attributes);
+  module_rule_matcher_with_context(module_rule, &context, matched_rules).await
+}
+
+struct ModuleRuleMatchContext<'a> {
+  resource: &'a str,
+  resource_path: &'a str,
+  resource_query: Option<&'a str>,
+  resource_fragment: Option<&'a str>,
+  mimetype: Option<&'a str>,
+  scheme: &'a str,
+  scheme_is_none: bool,
   issuer: Option<&'a str>,
   issuer_layer: Option<&'a str>,
-  dependency: &DependencyCategory,
-  attributes: Option<&ImportAttributes>,
-  matched_rules: &mut Vec<&'a ModuleRuleEffect>,
-) -> Result<()> {
-  for rule in rules {
-    module_rule_matcher(
-      rule,
-      resource_data,
+  dependency: &'a str,
+  resource_description: Option<&'a ResourceDescriptionData>,
+  attributes: Option<&'a ImportAttributes>,
+}
+
+impl<'a> ModuleRuleMatchContext<'a> {
+  fn new(
+    resource_data: &'a ResourceData,
+    issuer: Option<&'a str>,
+    issuer_layer: Option<&'a str>,
+    dependency: &'a DependencyCategory,
+    attributes: Option<&'a ImportAttributes>,
+  ) -> Self {
+    let scheme = resource_data.get_scheme();
+    Self {
+      resource: resource_data.resource(),
+      resource_path: resource_data
+        .path()
+        .unwrap_or_else(|| Utf8Path::new(""))
+        .as_str(),
+      resource_query: resource_data.query(),
+      resource_fragment: resource_data.fragment(),
+      mimetype: resource_data.mimetype(),
+      scheme: scheme.as_str(),
+      scheme_is_none: scheme.is_none(),
       issuer,
       issuer_layer,
-      dependency,
+      dependency: dependency.as_str(),
+      resource_description: resource_data.description(),
       attributes,
-      matched_rules,
-    )
-    .await?;
+    }
+  }
+}
+
+async fn module_rules_matcher_with_context<'rule, 'ctx>(
+  rules: &'rule [ModuleRule],
+  context: &ModuleRuleMatchContext<'ctx>,
+  matched_rules: &mut Vec<&'rule ModuleRuleEffect>,
+) -> Result<()> {
+  for rule in rules {
+    module_rule_matcher_with_context(rule, context, matched_rules).await?;
   }
   Ok(())
 }
 
-/// Match the `ModuleRule` against the given `ResourceData`, and return the matching `ModuleRule` if matched.
+async fn module_rule_matcher_with_context<'rule, 'ctx>(
+  module_rule: &'rule ModuleRule,
+  context: &ModuleRuleMatchContext<'ctx>,
+  matched_rules: &mut Vec<&'rule ModuleRuleEffect>,
+) -> Result<bool> {
+  if module_rule.rules.is_none() && module_rule.one_of.is_none() {
+    return module_rule_matcher_leaf(module_rule, context, matched_rules).await;
+  }
+  module_rule_matcher_recursive(module_rule, context, matched_rules).await
+}
+
+async fn module_rule_matcher_leaf<'rule, 'ctx>(
+  module_rule: &'rule ModuleRule,
+  context: &ModuleRuleMatchContext<'ctx>,
+  matched_rules: &mut Vec<&'rule ModuleRuleEffect>,
+) -> Result<bool> {
+  if !match_module_rule_conditions(module_rule, context).await? {
+    return Ok(false);
+  }
+
+  matched_rules.push(&module_rule.effect);
+  Ok(true)
+}
+
 #[async_recursion]
-pub async fn module_rule_matcher<'a>(
+async fn module_rule_matcher_recursive<'a>(
   module_rule: &'a ModuleRule,
-  resource_data: &ResourceData,
-  issuer: Option<&'a str>,
-  issuer_layer: Option<&'a str>,
-  dependency: &DependencyCategory,
-  attributes: Option<&ImportAttributes>,
+  context: &ModuleRuleMatchContext<'_>,
   matched_rules: &mut Vec<&'a ModuleRuleEffect>,
 ) -> Result<bool> {
+  if !match_module_rule_conditions(module_rule, context).await? {
+    return Ok(false);
+  }
+
+  matched_rules.push(&module_rule.effect);
+
+  if let Some(rules) = &module_rule.rules {
+    module_rules_matcher_with_context(rules, context, matched_rules).await?;
+  }
+
+  if let Some(one_of) = &module_rule.one_of {
+    let mut matched_once = false;
+    for rule in one_of {
+      if module_rule_matcher_with_context(rule, context, matched_rules).await? {
+        matched_once = true;
+        break;
+      }
+    }
+    if !matched_once {
+      return Ok(false);
+    }
+  }
+
+  Ok(true)
+}
+
+async fn match_module_rule_conditions(
+  module_rule: &ModuleRule,
+  context: &ModuleRuleMatchContext<'_>,
+) -> Result<bool> {
   if let Some(test_rule) = &module_rule.rspack_resource
-    && !test_rule.try_match(resource_data.resource().into()).await?
+    && !test_rule.try_match(context.resource.into()).await?
   {
     return Ok(false);
   }
 
   // Include all modules that pass test assertion. If you supply a Rule.test option, you cannot also supply a `Rule.resource`.
   // See: https://webpack.js.org/configuration/module/#ruletest
-  let resource_path = resource_data
-    .path()
-    .unwrap_or_else(|| Utf8Path::new(""))
-    .as_str();
-
   if let Some(test_rule) = &module_rule.test
-    && !test_rule.try_match(resource_path.into()).await?
+    && !test_rule.try_match(context.resource_path.into()).await?
   {
     return Ok(false);
   } else if let Some(resource_rule) = &module_rule.resource
-    && !resource_rule.try_match(resource_path.into()).await?
+    && !resource_rule
+      .try_match(context.resource_path.into())
+      .await?
   {
     return Ok(false);
   }
 
   if let Some(include_rule) = &module_rule.include
-    && !include_rule.try_match(resource_path.into()).await?
+    && !include_rule.try_match(context.resource_path.into()).await?
   {
     return Ok(false);
   }
 
   if let Some(exclude_rule) = &module_rule.exclude
-    && exclude_rule.try_match(resource_path.into()).await?
+    && exclude_rule.try_match(context.resource_path.into()).await?
   {
     return Ok(false);
   }
 
   if let Some(resource_query_rule) = &module_rule.resource_query {
-    if let Some(resource_query) = resource_data.query() {
+    if let Some(resource_query) = context.resource_query {
       if !resource_query_rule.try_match(resource_query.into()).await? {
         return Ok(false);
       }
@@ -86,7 +192,7 @@ pub async fn module_rule_matcher<'a>(
   }
 
   if let Some(resource_fragment_condition) = &module_rule.resource_fragment {
-    if let Some(resource_fragment) = resource_data.fragment() {
+    if let Some(resource_fragment) = context.resource_fragment {
       if !resource_fragment_condition
         .try_match(resource_fragment.into())
         .await?
@@ -99,7 +205,7 @@ pub async fn module_rule_matcher<'a>(
   }
 
   if let Some(mimetype_condition) = &module_rule.mimetype {
-    if let Some(mimetype) = resource_data.mimetype() {
+    if let Some(mimetype) = context.mimetype {
       if !mimetype_condition.try_match(mimetype.into()).await? {
         return Ok(false);
       }
@@ -109,17 +215,16 @@ pub async fn module_rule_matcher<'a>(
   }
 
   if let Some(scheme_condition) = &module_rule.scheme {
-    let scheme = resource_data.get_scheme();
-    if scheme.is_none() && !scheme_condition.match_when_empty().await? {
+    if context.scheme_is_none && !scheme_condition.match_when_empty().await? {
       return Ok(false);
     }
-    if !scheme_condition.try_match(scheme.as_str().into()).await? {
+    if !scheme_condition.try_match(context.scheme.into()).await? {
       return Ok(false);
     }
   }
 
   if let Some(issuer_rule) = &module_rule.issuer {
-    match issuer {
+    match context.issuer {
       Some(issuer) => {
         if !issuer_rule.try_match(issuer.into()).await? {
           return Ok(false);
@@ -134,7 +239,7 @@ pub async fn module_rule_matcher<'a>(
   }
 
   if let Some(issuer_layer_rule) = &module_rule.issuer_layer {
-    match issuer_layer {
+    match context.issuer_layer {
       Some(issuer_layer) => {
         if !issuer_layer_rule.try_match(issuer_layer.into()).await? {
           return Ok(false);
@@ -149,93 +254,134 @@ pub async fn module_rule_matcher<'a>(
   }
 
   if let Some(dependency_rule) = &module_rule.dependency
-    && !dependency_rule
-      .try_match(dependency.as_str().into())
-      .await?
+    && !dependency_rule.try_match(context.dependency.into()).await?
   {
     return Ok(false);
   }
 
   if let Some(description_data) = &module_rule.description_data {
-    if let Some(resource_description) = resource_data.description() {
-      for (k, matcher) in description_data {
-        if let Some(v) = k
-          .split('.')
-          .try_fold(resource_description.json(), |acc, key| acc.get(key))
-        {
-          if !matcher.try_match(v.into()).await? {
-            return Ok(false);
-          }
-        } else if !matcher.match_when_empty().await? {
-          return Ok(false);
-        }
+    if let Some(resource_description) = context.resource_description {
+      if !match_description_data(description_data, resource_description).await? {
+        return Ok(false);
       }
-    } else {
-      for matcher in description_data.values() {
-        if !matcher.match_when_empty().await? {
-          return Ok(false);
-        }
-      }
+    } else if !match_when_empty_for_all(description_data.values()).await? {
+      return Ok(false);
     }
   }
 
   if let Some(with) = &module_rule.with {
-    if let Some(attributes) = attributes {
-      for (k, matcher) in with {
-        if let Some(v) = attributes.get(k) {
-          if !matcher.try_match(v.into()).await? {
+    if let Some(attributes) = context.attributes {
+      for (key, matcher) in with {
+        if let Some(value) = attributes.get(key) {
+          if !matcher.try_match(value.into()).await? {
             return Ok(false);
           }
         } else if !matcher.match_when_empty().await? {
           return Ok(false);
         }
       }
-    } else {
-      for matcher in with.values() {
-        if !matcher.match_when_empty().await? {
-          return Ok(false);
-        }
-      }
-    }
-  }
-
-  matched_rules.push(&module_rule.effect);
-
-  if let Some(rules) = &module_rule.rules {
-    module_rules_matcher(
-      rules,
-      resource_data,
-      issuer,
-      issuer_layer,
-      dependency,
-      attributes,
-      matched_rules,
-    )
-    .await?;
-  }
-
-  if let Some(one_of) = &module_rule.one_of {
-    let mut matched_once = false;
-    for rule in one_of {
-      if module_rule_matcher(
-        rule,
-        resource_data,
-        issuer,
-        issuer_layer,
-        dependency,
-        attributes,
-        matched_rules,
-      )
-      .await?
-      {
-        matched_once = true;
-        break;
-      }
-    }
-    if !matched_once {
+    } else if !match_when_empty_for_all(with.values()).await? {
       return Ok(false);
     }
   }
 
   Ok(true)
+}
+
+async fn match_description_data<'a>(
+  description_data: impl IntoIterator<Item = (&'a String, &'a crate::RuleSetConditionWithEmpty)>,
+  resource_description: &ResourceDescriptionData,
+) -> Result<bool> {
+  let json = resource_description.json();
+  for (key, matcher) in description_data {
+    if let Some(value) = key
+      .split('.')
+      .try_fold(json, |acc, segment| acc.get(segment))
+    {
+      if !matcher.try_match(value.into()).await? {
+        return Ok(false);
+      }
+    } else if !matcher.match_when_empty().await? {
+      return Ok(false);
+    }
+  }
+  Ok(true)
+}
+
+async fn match_when_empty_for_all<'a>(
+  matchers: impl IntoIterator<Item = &'a crate::RuleSetConditionWithEmpty>,
+) -> Result<bool> {
+  for matcher in matchers {
+    if !matcher.match_when_empty().await? {
+      return Ok(false);
+    }
+  }
+  Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+  };
+
+  use futures::FutureExt;
+  use rspack_regex::RspackRegex;
+
+  use super::module_rule_matcher;
+  use crate::{DependencyCategory, ModuleRule, ResourceData, RuleSetCondition};
+
+  #[tokio::test]
+  async fn supports_one_of_rules_with_async_conditions() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let module_rule = ModuleRule {
+      one_of: Some(vec![
+        ModuleRule {
+          test: Some(RuleSetCondition::Func(Box::new({
+            let calls = Arc::clone(&calls);
+            move |_| {
+              let calls = Arc::clone(&calls);
+              async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(false)
+              }
+              .boxed()
+            }
+          }))),
+          ..Default::default()
+        },
+        ModuleRule {
+          test: Some(RuleSetCondition::Regexp(
+            RspackRegex::new("\\.js$").expect("regex should compile"),
+          )),
+          ..Default::default()
+        },
+      ]),
+      ..Default::default()
+    };
+    let resource_data = ResourceData::new_with_path(
+      "/project/src/index.js".into(),
+      "/project/src/index.js".into(),
+      None,
+      None,
+    );
+    let mut matched_rules = Vec::new();
+
+    let matched = module_rule_matcher(
+      &module_rule,
+      &resource_data,
+      None,
+      None,
+      &DependencyCategory::Esm,
+      None,
+      &mut matched_rules,
+    )
+    .await
+    .expect("module rule should match");
+
+    assert!(matched);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(matched_rules.len(), 2);
+  }
 }


### PR DESCRIPTION
## Summary

- add synchronous fast paths for common `RuleSetCondition` and logical matcher cases to avoid async recursion overhead
- reuse a precomputed module-rule match context and a leaf-rule fast path to cut repeated resource lookups during matching
- add regression coverage for sync short-circuiting and `oneOf` rules with async conditions

## Related links

- N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Verification

- `cargo fmt --all --check`
- `cargo test -p rspack_core --lib`
- `pnpm install`
- `pnpm run build:js`
- `pnpm run test:unit`