### PR TITLE
docs(migration): simplify v2 experimental changes

### DIFF
--- a/website/docs/en/guide/migration/rspack_1.x.mdx
+++ b/website/docs/en/guide/migration/rspack_1.x.mdx
@@ -255,15 +255,7 @@ The `output.charset` configuration has been removed. It only added a `charset` a
 
 ### Removed optimization.removeAvailableModules
 
-The `optimization.removeAvailableModules` configuration has been removed. It had no actual effect in Rspack and can be safely removed from your configuration:
-
-```diff title="rspack.config.mjs"
-export default {
-  optimization: {
--   removeAvailableModules: true,
-  },
-};
-```
+The `optimization.removeAvailableModules` configuration has been removed. It had no actual effect in Rspack and can be safely removed from your configuration.
 
 ## Stats changes
 

--- a/website/docs/zh/guide/migration/rspack_1.x.mdx
+++ b/website/docs/zh/guide/migration/rspack_1.x.mdx
@@ -255,15 +255,7 @@ export default {
 
 ### 移除 optimization.removeAvailableModules
 
-`optimization.removeAvailableModules` 配置已被移除。该选项在 Rspack 中没有实际作用，可以直接从配置中删除：
-
-```diff title="rspack.config.mjs"
-export default {
-  optimization: {
--   removeAvailableModules: true,
-  },
-};
-```
+`optimization.removeAvailableModules` 配置已被移除。该选项在 Rspack 中没有实际作用，可以直接从配置中删除。
 
 ## Stats 相关变更
 


### PR DESCRIPTION
## Summary
- simplify the Rspack 2.0 experimental migration changes into a single concise section
- move scattered experimental swc-loader and SRI items into that chapter
- keep zh/en migration docs aligned
