### PR TITLE
chore: switch to github runner for bench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
       test: true
       bench: true
-      bench-runner: '"rspack-ubuntu-22.04-physical-large"'
+      bench-runner: '"ubuntu-22.04"'
       test-runner: '"ubuntu-22.04"'
 
   test-windows:


### PR DESCRIPTION
## Summary
switch bench runner to github runner since self-hosted runner is not stable enough now
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
