### PR TITLE
fix(css): update fullhash on CSS-only changes

### DIFF
--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -9,11 +9,11 @@ use std::{
 use atomic_refcell::AtomicRefCell;
 use rspack_core::{
   AssetInfo, Chunk, ChunkGraph, ChunkKind, ChunkLoading, ChunkLoadingType, ChunkUkey, Compilation,
-  CompilationContentHash, CompilationId, CompilationParams, CompilationRenderManifest,
-  CompilationRuntimeRequirementInTree, CompilerCompilation, DependencyType, ManifestAssetType,
-  Module, ModuleGraph, ModuleType, ParserAndGenerator, PathData, Plugin, PublicPath,
-  RenderManifestEntry, RuntimeGlobals, RuntimeModule, RuntimeModuleExt, SelfModuleFactory,
-  SourceType, get_css_chunk_filename_template,
+  CompilationChunkHash, CompilationContentHash, CompilationId, CompilationParams,
+  CompilationRenderManifest, CompilationRuntimeRequirementInTree, CompilerCompilation,
+  DependencyType, ManifestAssetType, Module, ModuleGraph, ModuleType, ParserAndGenerator, PathData,
+  Plugin, PublicPath, RenderManifestEntry, RuntimeGlobals, RuntimeModule, RuntimeModuleExt,
+  SelfModuleFactory, SourceType, get_css_chunk_filename_template,
   rspack_sources::{
     BoxSource, CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
   },
@@ -365,6 +365,49 @@ async fn runtime_requirements_in_tree(
   Ok(None)
 }
 
+#[plugin_hook(CompilationChunkHash for CssPlugin)]
+async fn chunk_hash(
+  &self,
+  compilation: &Compilation,
+  chunk_ukey: &ChunkUkey,
+  hasher: &mut RspackHash,
+) -> Result<()> {
+  let chunk = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .expect_get(chunk_ukey);
+  let module_graph = compilation.get_module_graph();
+  let css_import_modules = compilation
+    .build_chunk_graph_artifact
+    .chunk_graph
+    .get_chunk_modules_by_source_type(chunk_ukey, SourceType::CssImport, module_graph);
+  let css_modules = compilation
+    .build_chunk_graph_artifact
+    .chunk_graph
+    .get_chunk_modules_by_source_type(chunk_ukey, SourceType::Css, module_graph);
+  let (ordered_modules, _) =
+    Self::get_ordered_chunk_css_modules(chunk, compilation, css_import_modules, css_modules);
+
+  ordered_modules
+    .iter()
+    .map(|m| {
+      (
+        compilation
+          .code_generation_results
+          .get_hash(&m.identifier(), Some(chunk.runtime())),
+        ChunkGraph::get_module_id(&compilation.module_ids_artifact, m.identifier()),
+      )
+    })
+    .for_each(|(current, id)| {
+      if let Some(current) = current {
+        current.hash(hasher);
+        id.hash(hasher);
+      }
+    });
+
+  Ok(())
+}
+
 #[plugin_hook(CompilationContentHash for CssPlugin)]
 async fn content_hash(
   &self,
@@ -507,6 +550,7 @@ impl Plugin for CssPlugin {
       .compilation_hooks
       .runtime_requirement_in_tree
       .tap(runtime_requirements_in_tree::new(self));
+    ctx.compilation_hooks.chunk_hash.tap(chunk_hash::new(self));
     ctx
       .compilation_hooks
       .content_hash

--- a/tests/rspack-test/hashCases/issue-12866/rspack.config.js
+++ b/tests/rspack-test/hashCases/issue-12866/rspack.config.js
@@ -1,0 +1,19 @@
+const path = require("path");
+
+function config(subpath) {
+	return {
+		mode: "production",
+		context: path.resolve(__dirname, subpath),
+		entry: "./index.js",
+		experiments: { css: true },
+		module: { rules: [{ test: /\.css$/, type: "css/auto" }] },
+		output: {
+			path: path.resolve(__dirname, `dist/`),
+			filename: "main.[fullhash].js",
+			cssFilename: "main.[contenthash].css"
+		},
+		optimization: { realContentHash: true, minimize: false }
+	};
+}
+
+module.exports = [config("version0"), config("version1")];

--- a/tests/rspack-test/hashCases/issue-12866/test.config.js
+++ b/tests/rspack-test/hashCases/issue-12866/test.config.js
@@ -1,0 +1,15 @@
+/** @type {import('@rspack/test-tools').THashCaseConfig} */
+module.exports = {
+	validate(stats) {
+		const v0 = stats.stats[0].toJson({ assets: true, hash: true });
+		const v1 = stats.stats[1].toJson({ assets: true, hash: true });
+
+		const v0Css = v0.assets.find(a => a.name.endsWith(".css"))?.name;
+		const v1Css = v1.assets.find(a => a.name.endsWith(".css"))?.name;
+
+		expect(v0Css).toBeDefined();
+		expect(v1Css).toBeDefined();
+		expect(v0Css).not.toBe(v1Css);
+		expect(v0.hash).not.toBe(v1.hash);
+	}
+};

--- a/tests/rspack-test/hashCases/issue-12866/version0/index.css
+++ b/tests/rspack-test/hashCases/issue-12866/version0/index.css
@@ -1,0 +1,3 @@
+body {
+	color: red;
+}

--- a/tests/rspack-test/hashCases/issue-12866/version0/index.js
+++ b/tests/rspack-test/hashCases/issue-12866/version0/index.js
@@ -1,0 +1,1 @@
+import "./index.css";

--- a/tests/rspack-test/hashCases/issue-12866/version1/index.css
+++ b/tests/rspack-test/hashCases/issue-12866/version1/index.css
@@ -1,0 +1,3 @@
+body {
+	color: green;
+}

--- a/tests/rspack-test/hashCases/issue-12866/version1/index.js
+++ b/tests/rspack-test/hashCases/issue-12866/version1/index.js
@@ -1,0 +1,1 @@
+import "./index.css";


### PR DESCRIPTION
## Summary

- Fix CSS-only updates not affecting `[fullhash]` by adding a `CompilationChunkHash` hook in `CssPlugin`.
- Include ordered CSS module codegen hash + module id in chunk hash calculation so JS `[fullhash]` changes when CSS content changes.
- Add regression case `tests/rspack-test/hashCases/issue-12866` to verify CSS-only changes update both CSS `[contenthash]` and build `[fullhash]`.

## Related links

Closes #12866

## Checklist

- [x] Tests updated (hash case added)
- [x] Documentation updated (not required)