### PR TITLE
fix(esm-library): align external namespace dedupe

### DIFF
--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -288,6 +288,11 @@ pub struct ChunkLinkContext {
   pub raw_import_stmts: FxIndexMap<RawImportSource, ImportSpec>,
 
   /**
+  namespace imports already provided by module init fragments
+   */
+  pub module_external_namespace_imports: FxHashMap<RawImportSource, Atom>,
+
+  /**
   `const symbol = __webpack_require__(module_id)`
   */
   pub required: IdentifierIndexMap<ExternalInterop>,
@@ -350,6 +355,7 @@ impl ChunkLinkContext {
       used_names: Default::default(),
       exported_symbols: Default::default(),
       raw_import_stmts: Default::default(),
+      module_external_namespace_imports: Default::default(),
       raw_star_exports: Default::default(),
     }
   }

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -7,16 +7,17 @@ use std::{
 use rayon::{iter::Either, prelude::*};
 use rspack_collections::{IdentifierIndexMap, IdentifierIndexSet, IdentifierMap};
 use rspack_core::{
-  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkUkey,
-  CodeGenerationPublicPathAutoReplace, Compilation, ConcatenatedModuleIdent, DependencyType,
-  ExportInfoHashKey, ExportMode, ExportProvided, ExportsInfoArtifact, ExportsInfoGetter,
-  ExportsType, FindTargetResult, GetUsedNameParam, ImportSpec, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT, PathData,
-  PrefetchExportsInfoMode, RuntimeGlobals, SourceType, URLStaticMode, UsageState, UsedName,
-  UsedNameItem, collect_ident, escape_name_atom_ref, find_new_name, find_target,
-  get_cached_readable_identifier, get_js_chunk_filename_template, get_module_directives,
-  get_module_hashbang, property_access, property_name, reserved_names::RESERVED_NAMES,
-  rspack_sources::ReplaceSource, split_readable_identifier, to_normal_comment,
+  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkRenderContext,
+  ChunkUkey, CodeGenerationPublicPathAutoReplace, Compilation, ConcatenatedModuleIdent,
+  ConditionalInitFragment, DependencyType, ExportInfoHashKey, ExportMode, ExportProvided,
+  ExportsInfoArtifact, ExportsInfoGetter, ExportsType, ExternalModuleInfo, FindTargetResult,
+  GetUsedNameParam, ImportSpec, InitFragmentKey, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT, PathData, PrefetchExportsInfoMode,
+  RuntimeGlobals, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem, collect_ident,
+  escape_name_atom_ref, find_new_name, find_target, get_cached_readable_identifier,
+  get_js_chunk_filename_template, get_module_directives, get_module_hashbang, property_access,
+  property_name, reserved_names::RESERVED_NAMES, rspack_sources::ReplaceSource,
+  split_readable_identifier, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Result};
 use rspack_plugin_javascript::{
@@ -58,7 +59,6 @@ impl<V> GetMut<ModuleIdentifier, V> for IdentifierIndexMap<V> {
 }
 
 static START_EXPORTS: LazyLock<Atom> = LazyLock::new(|| "*".into());
-static DEFAULT_EXPORT: LazyLock<Atom> = LazyLock::new(|| "default".into());
 
 #[derive(Default, Debug)]
 pub(crate) struct ExportsContext {
@@ -74,6 +74,112 @@ enum ExternalImportBinding {
 }
 
 impl EsmLibraryPlugin {
+  fn assign_external_candidate_name(
+    info: &mut ExternalModuleInfo,
+    candidate_names: &mut FxHashSet<Atom>,
+    extra_info: &[Atom],
+  ) {
+    if let Some(name) = &info.name {
+      candidate_names.insert(name.clone());
+      return;
+    }
+
+    let name = find_new_name("", candidate_names, extra_info);
+    candidate_names.insert(name.clone());
+    info.name = Some(name);
+  }
+
+  fn reserve_raw_import_locals(import_spec: &ImportSpec, used_names: &mut FxHashSet<Atom>) {
+    used_names.extend(import_spec.atoms.values().cloned());
+    if let Some(default_import) = &import_spec.default_import {
+      used_names.insert(default_import.clone());
+    }
+    if let Some(ns_import) = &import_spec.ns_import {
+      used_names.insert(ns_import.clone());
+    }
+  }
+
+  fn parse_module_external_namespace_import(content: &str) -> Option<(RawImportSource, Atom)> {
+    let content = content.trim_start();
+    let content = content.strip_prefix("import * as ")?;
+    let (local_name, source_clause) = content.split_once(" from ")?;
+    if local_name.is_empty() {
+      return None;
+    }
+
+    let source_clause = source_clause
+      .lines()
+      .next()
+      .map(str::trim)
+      .map(|line| line.trim_end_matches(';'))?;
+    let (source_literal, attr) =
+      if let Some((source_literal, attr)) = source_clause.split_once(" with ") {
+        (source_literal, Some(format!(" with {attr}")))
+      } else {
+        (source_clause, None)
+      };
+    let source = serde_json::from_str::<String>(source_literal).ok()?;
+    Some((RawImportSource::Source((source, attr)), local_name.into()))
+  }
+
+  fn collect_module_external_namespace_imports(
+    init_fragments: &ChunkInitFragments,
+  ) -> Vec<(RawImportSource, Atom)> {
+    let mut ordered_fragments = init_fragments.clone();
+    ordered_fragments.sort_by(|a, b| {
+      let stage = a.stage().cmp(&b.stage());
+      if !stage.is_eq() {
+        return stage;
+      }
+      a.position().cmp(&b.position())
+    });
+
+    let mut imports = Vec::new();
+    for init_fragment in ordered_fragments {
+      if !matches!(init_fragment.key(), InitFragmentKey::ModuleExternal(_)) {
+        continue;
+      }
+
+      let content = if let Ok(fragment) = init_fragment
+        .clone()
+        .into_any()
+        .downcast::<ConditionalInitFragment>()
+      {
+        fragment.content().to_owned()
+      } else {
+        let Ok(contents) = init_fragment.contents(&mut ChunkRenderContext {}) else {
+          continue;
+        };
+        contents.start
+      };
+
+      if let Some(import) = Self::parse_module_external_namespace_import(&content) {
+        imports.push(import);
+      }
+    }
+
+    imports
+  }
+
+  fn reserve_module_external_namespace_import_locals(
+    init_fragments: &ChunkInitFragments,
+    used_names: &mut FxHashSet<Atom>,
+    namespace_imports: Option<&mut FxHashMap<RawImportSource, Atom>>,
+  ) {
+    let mut namespace_imports = namespace_imports;
+    for (source, local_name) in Self::collect_module_external_namespace_imports(init_fragments) {
+      if let Some(namespace_imports) = namespace_imports.as_mut() {
+        if namespace_imports.contains_key(&source) {
+          continue;
+        }
+        used_names.insert(local_name.clone());
+        namespace_imports.insert(source, local_name);
+      } else {
+        used_names.insert(local_name);
+      }
+    }
+  }
+
   fn strict_export_chunk(&self, chunk: ChunkUkey) -> bool {
     self.strict_export_chunks.borrow().contains(&chunk)
   }
@@ -192,36 +298,51 @@ impl EsmLibraryPlugin {
       .insert(export_name);
   }
 
-  fn get_external_import_binding(
+  fn get_external_import_source_and_binding(
     info: &rspack_core::ConcatenatedModuleInfo,
     local_name: &Atom,
-  ) -> Option<ExternalImportBinding> {
-    info.import_map.as_ref().and_then(|import_map| {
-      import_map.values().find_map(|imported_atoms| {
+  ) -> Option<(RawImportSource, ExternalImportBinding)> {
+    if let Some(import_map) = info.import_map.as_ref() {
+      for ((source, attr), imported_atoms) in import_map {
+        let raw_import_source = RawImportSource::Source((source.clone(), attr.clone()));
+
         if imported_atoms
           .namespace
           .as_ref()
           .is_some_and(|namespace| namespace == local_name)
+          || info.namespace_object_name.as_ref() == Some(local_name)
         {
-          return Some(ExternalImportBinding::Namespace);
+          return Some((raw_import_source, ExternalImportBinding::Namespace));
         }
 
-        imported_atoms.specifiers.iter().find_map(|imported_name| {
+        for imported_name in &imported_atoms.specifiers {
           let internal_name = info
             .get_internal_name(imported_name)
             .unwrap_or(imported_name);
           if internal_name != local_name {
-            return None;
+            continue;
           }
 
-          Some(if imported_name == "default" {
-            ExternalImportBinding::Default
-          } else {
-            ExternalImportBinding::Named(imported_name.clone())
-          })
-        })
-      })
-    })
+          return Some((
+            raw_import_source,
+            if imported_name == "default" {
+              ExternalImportBinding::Default
+            } else {
+              ExternalImportBinding::Named(imported_name.clone())
+            },
+          ));
+        }
+      }
+    }
+
+    if info.namespace_object_name.as_ref() == Some(local_name) {
+      return Self::collect_module_external_namespace_imports(&info.chunk_init_fragments)
+        .into_iter()
+        .next()
+        .map(|(source, _)| (source, ExternalImportBinding::Namespace));
+    }
+
+    None
   }
 
   pub(crate) async fn link(
@@ -234,10 +355,15 @@ impl EsmLibraryPlugin {
     // codegen uses self.concatenated_modules_map_for_codegen which has hold another Arc, so
     // it's safe to access concate_modules_map lock
     let mut concate_modules_map = self.concatenated_modules_map.write().await;
+    let mut external_module_init_fragments = IdentifierMap::default();
 
     // analyze every modules and collect identifiers to concate_modules_map
     self
-      .analyze_module(compilation, &mut concate_modules_map)
+      .analyze_module(
+        compilation,
+        &mut concate_modules_map,
+        &mut external_module_init_fragments,
+      )
       .await?;
 
     // initialize data for link chunks
@@ -382,6 +508,7 @@ impl EsmLibraryPlugin {
       self.deconflict_symbols(
         compilation,
         &mut concate_modules_map,
+        &external_module_init_fragments,
         chunk_link,
         &escaped_names,
         &escaped_identifiers,
@@ -494,45 +621,35 @@ impl EsmLibraryPlugin {
                   if let Some(ext) = module_graph
                     .module_by_identifier(&symbol_binding.module)
                     .and_then(|m| m.as_external_module())
+                    && ext.get_external_type().as_str().starts_with("module")
                   {
-                    let request = ext.get_request().primary().to_string();
-                    let import_binding = concate_modules_map
+                    let Some((raw_import_source, import_binding)) = concate_modules_map
                       .get(&symbol_binding.module)
                       .and_then(|target_info| match target_info {
                         ModuleInfo::Concatenated(target_info) => {
-                          Self::get_external_import_binding(target_info, &symbol_binding.symbol)
-                            .or_else(|| {
-                              let namespace_object_name =
-                                target_info.namespace_object_name.as_ref();
-                              let default_import_name =
-                                target_info.get_internal_name(&DEFAULT_EXPORT);
-
-                              if namespace_object_name == Some(&symbol_binding.symbol) {
-                                Some(ExternalImportBinding::Namespace)
-                              } else if default_import_name == Some(&symbol_binding.symbol) {
-                                Some(ExternalImportBinding::Default)
-                              } else {
-                                None
-                              }
-                            })
+                          Self::get_external_import_source_and_binding(
+                            target_info,
+                            &symbol_binding.symbol,
+                          )
                         }
                         ModuleInfo::External(_) => None,
                       })
-                      .unwrap_or_else(|| {
-                        export_info.name().map_or_else(
-                          || ExternalImportBinding::Named(symbol_binding.symbol.clone()),
-                          |imported_name| {
-                            if imported_name == "default" {
-                              ExternalImportBinding::Default
-                            } else {
-                              ExternalImportBinding::Named(imported_name.clone())
-                            }
-                          },
-                        )
-                      });
+                    else {
+                      continue;
+                    };
+
+                    if matches!(import_binding, ExternalImportBinding::Namespace)
+                      && let Some(existing_local) = chunk_link
+                        .module_external_namespace_imports
+                        .get(&raw_import_source)
+                    {
+                      symbol_binding.symbol = existing_local.clone();
+                      continue;
+                    }
+
                     let import_spec = chunk_link
                       .raw_import_stmts
-                      .entry(RawImportSource::Source((request, None)))
+                      .entry(raw_import_source)
                       .or_default();
 
                     let existing_local = match &import_binding {
@@ -546,20 +663,7 @@ impl EsmLibraryPlugin {
                     if let Some(existing_local) = existing_local {
                       symbol_binding.symbol = existing_local.clone();
                     } else {
-                      let already_bound = import_spec
-                        .default_import
-                        .as_ref()
-                        .is_some_and(|atom| atom == &symbol_binding.symbol)
-                        || import_spec
-                          .ns_import
-                          .as_ref()
-                          .is_some_and(|atom| atom == &symbol_binding.symbol)
-                        || import_spec
-                          .atoms
-                          .values()
-                          .any(|atom| atom == &symbol_binding.symbol);
-
-                      let local_name = if already_bound {
+                      let local_name = if chunk_link.used_names.contains(&symbol_binding.symbol) {
                         let new_name = find_new_name(
                           symbol_binding.symbol.as_str(),
                           &chunk_link.used_names,
@@ -568,7 +672,9 @@ impl EsmLibraryPlugin {
                         chunk_link.used_names.insert(new_name.clone());
                         new_name
                       } else {
-                        symbol_binding.symbol.clone()
+                        let local_name = symbol_binding.symbol.clone();
+                        chunk_link.used_names.insert(local_name.clone());
+                        local_name
                       };
 
                       match import_binding {
@@ -753,6 +859,7 @@ var {} = {{}};
     &self,
     compilation: &Compilation,
     concate_modules_map: &mut IdentifierIndexMap<ModuleInfo>,
+    external_module_init_fragments: &IdentifierMap<ChunkInitFragments>,
     chunk_link: &mut ChunkLinkContext,
     escaped_names: &FxHashMap<Atom, Atom>,
     escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
@@ -795,6 +902,31 @@ var {} = {{}};
       }
     }
 
+    for id in chunk_link
+      .hoisted_modules
+      .iter()
+      .chain(chunk_link.decl_modules.iter())
+    {
+      match &concate_modules_map[id] {
+        ModuleInfo::Concatenated(info) => {
+          Self::reserve_module_external_namespace_import_locals(
+            &info.chunk_init_fragments,
+            &mut all_used_names,
+            Some(&mut chunk_link.module_external_namespace_imports),
+          );
+        }
+        ModuleInfo::External(info) => {
+          if let Some(init_fragments) = external_module_init_fragments.get(&info.module) {
+            Self::reserve_module_external_namespace_import_locals(
+              init_fragments,
+              &mut all_used_names,
+              Some(&mut chunk_link.module_external_namespace_imports),
+            );
+          }
+        }
+      }
+    }
+
     // deconflict top level symbols
     for id in chunk_link
       .hoisted_modules
@@ -817,16 +949,56 @@ var {} = {{}};
         // registered import map
         if let Some(import_map) = &concate_info.import_map {
           for ((source, attr), imported_atoms) in import_map.iter() {
-            let total_imported_atoms = chunk_link
-              .raw_import_stmts
-              .entry(RawImportSource::Source((source.clone(), attr.clone())))
-              .or_default();
+            let raw_import_source = RawImportSource::Source((source.clone(), attr.clone()));
+            let existing_namespace_import = chunk_link
+              .module_external_namespace_imports
+              .get(&raw_import_source)
+              .cloned();
+            let mut total_imported_atoms = None;
+
+            if imported_atoms.namespace.is_none()
+              && imported_atoms.specifiers.is_empty()
+              && existing_namespace_import.is_none()
+            {
+              total_imported_atoms = Some(
+                chunk_link
+                  .raw_import_stmts
+                  .entry(raw_import_source.clone())
+                  .or_default(),
+              );
+            }
 
             if let Some(ns_import) = &imported_atoms.namespace {
-              total_imported_atoms.ns_import = Some(ns_import.clone());
+              if let Some(existing_local) = existing_namespace_import.as_ref() {
+                if existing_local != ns_import {
+                  internal_names.insert(ns_import.clone(), existing_local.clone());
+                }
+              } else {
+                total_imported_atoms = Some(
+                  chunk_link
+                    .raw_import_stmts
+                    .entry(raw_import_source.clone())
+                    .or_default(),
+                );
+                total_imported_atoms
+                  .as_mut()
+                  .expect("should have import spec")
+                  .ns_import = Some(ns_import.clone());
+              }
             }
 
             for atom in &imported_atoms.specifiers {
+              if total_imported_atoms.is_none() {
+                total_imported_atoms = Some(
+                  chunk_link
+                    .raw_import_stmts
+                    .entry(raw_import_source.clone())
+                    .or_default(),
+                );
+              }
+              let total_imported_atoms = total_imported_atoms
+                .as_mut()
+                .expect("should have import spec");
               // already import this symbol
               if let Some(internal_atom) = total_imported_atoms.atoms.get(atom).or_else(|| {
                 if atom == "default"
@@ -994,45 +1166,30 @@ var {} = {{}};
       }
     }
 
-    // Build a targeted set for external module name deconfliction:
-    // Start from chunk_link.used_names (cross-chunk accumulated names) and add
-    // import binding names from raw_import_stmts. We do NOT use all_used_names here
-    // because it contains binding_to_ref keys (e.g., `cjs`, `foo`) that will be
-    // replaced during rendering and should not block external module names.
-    let mut external_used_names = chunk_link.used_names.clone();
-    for import_spec in chunk_link.raw_import_stmts.values() {
-      if let Some(ns) = &import_spec.ns_import {
-        external_used_names.insert(ns.clone());
-      }
-      for atom in import_spec.atoms.values() {
-        external_used_names.insert(atom.clone());
-      }
-      if let Some(default_import) = &import_spec.default_import {
-        external_used_names.insert(default_import.clone());
-      }
-    }
-
+    // External module names are only candidates here. The final emitted top-level
+    // symbol is resolved later by `add_require`, when the symbol actually lands in
+    // the chunk top-level emitted scope.
+    let mut external_candidate_names = FxHashSet::default();
     for external_module in chunk_link.decl_modules.iter() {
       let ModuleInfo::External(info) = &mut concate_modules_map[external_module] else {
         unreachable!("should be un-scope-hoisted module");
       };
 
-      if info.name.is_none() {
-        let readable_identifier = get_cached_readable_identifier(
-          external_module,
-          module_graph,
-          &compilation.module_static_cache,
-          context,
-        );
+      let readable_identifier = get_cached_readable_identifier(
+        external_module,
+        module_graph,
+        &compilation.module_static_cache,
+        context,
+      );
+      Self::assign_external_candidate_name(
+        info,
+        &mut external_candidate_names,
+        &escaped_identifiers[&readable_identifier],
+      );
+    }
 
-        let name = find_new_name(
-          "",
-          &external_used_names,
-          &escaped_identifiers[&readable_identifier],
-        );
-        external_used_names.insert(name.clone());
-        info.name = Some(name);
-      }
+    for import_spec in chunk_link.raw_import_stmts.values() {
+      Self::reserve_raw_import_locals(import_spec, &mut all_used_names);
     }
 
     chunk_link.used_names = all_used_names;
@@ -1042,6 +1199,7 @@ var {} = {{}};
     &self,
     compilation: &Compilation,
     orig_concate_modules_map: &mut IdentifierIndexMap<ModuleInfo>,
+    external_module_init_fragments: &mut IdentifierMap<ChunkInitFragments>,
   ) -> Result<()> {
     let runtime_template = compilation.runtime_template.create_runtime_code_template();
     let mut outputs = FxHashMap::<ChunkUkey, String>::default();
@@ -1097,7 +1255,10 @@ var {} = {{}};
         // SAFETY: caller will poll the futures
         let s = unsafe { token.used((compilation, m, info, &runtime_template)) };
         s.spawn(
-          async move |(compilation, id, info, runtime_template)| -> Result<ModuleInfo> {
+          async move |(compilation, id, info, runtime_template)| -> Result<(
+            ModuleInfo,
+            Option<(ModuleIdentifier, ChunkInitFragments)>,
+          )> {
             if compilation
               .build_chunk_graph_artifact
               .chunk_graph
@@ -1105,7 +1266,7 @@ var {} = {{}};
               .is_empty()
             {
               // orphan module
-              return Ok(info);
+              return Ok((info, None));
             }
 
             let chunk_ukey = Self::get_module_chunk(m, compilation)?;
@@ -1114,6 +1275,7 @@ var {} = {{}};
 
             match info {
               rspack_core::ModuleInfo::External(mut external_module_info) => {
+                let codegen_res = compilation.code_generation_results.get(&id, None);
                 let has_javascript_source = compilation
                   .code_generation_results
                   .get(&id, None)
@@ -1130,7 +1292,20 @@ var {} = {{}};
                     .runtime_requirements
                     .insert(RuntimeGlobals::REQUIRE | RuntimeGlobals::MODULE_FACTORIES);
                 }
-                Ok(ModuleInfo::External(external_module_info))
+                let mut chunk_init_fragments = codegen_res
+                  .data
+                  .get::<ChunkInitFragments>()
+                  .cloned()
+                  .unwrap_or_default();
+                chunk_init_fragments.extend(codegen_res.chunk_init_fragments.clone());
+                Ok((
+                  ModuleInfo::External(external_module_info),
+                  if chunk_init_fragments.is_empty() {
+                    None
+                  } else {
+                    Some((id, chunk_init_fragments))
+                  },
+                ))
               }
               rspack_core::ModuleInfo::Concatenated(mut concate_info) => {
                 let hooks = JsPlugin::get_compilation_hooks(compilation.id());
@@ -1138,7 +1313,7 @@ var {} = {{}};
 
                 let codegen_res = compilation.code_generation_results.get(&id, None);
                 let Some(js_source) = codegen_res.get(&SourceType::JavaScript) else {
-                  return Ok(ModuleInfo::Concatenated(concate_info));
+                  return Ok((ModuleInfo::Concatenated(concate_info), None));
                 };
 
                 let mut render_source = RenderSource {
@@ -1281,7 +1456,7 @@ var {} = {{}};
                 if codegen_res.data.contains::<URLStaticMode>() {
                   concate_info.static_url_replacement = true;
                 }
-                Ok(ModuleInfo::Concatenated(concate_info))
+                Ok((ModuleInfo::Concatenated(concate_info), None))
               }
             }
           },
@@ -1292,7 +1467,10 @@ var {} = {{}};
 
     for m in map {
       let m = m.map_err(|e| rspack_error::error!(e.to_string()))?;
-      let m = m.map_err(|e| rspack_error::error!(e.to_string()))?;
+      let (m, external_fragments) = m.map_err(|e| rspack_error::error!(e.to_string()))?;
+      if let Some((id, init_fragments)) = external_fragments {
+        external_module_init_fragments.insert(id, init_fragments);
+      }
       orig_concate_modules_map.insert(m.id(), m);
     }
 
@@ -2993,10 +3171,16 @@ fn normal_render(
 
 #[cfg(test)]
 mod tests {
-  use rspack_core::{ChunkUkey, ModuleIdentifier};
-  use rspack_util::fx_hash::FxHashSet;
+  use rspack_core::{
+    ChunkInitFragments, ChunkUkey, ConcatenatedImportMapItem, ConcatenatedModuleInfo,
+    ExternalModuleInfo, ImportSpec, InitFragmentKey, ModuleIdentifier,
+  };
+  use rspack_util::{
+    atom::Atom,
+    fx_hash::{FxHashMap, FxHashSet, FxIndexMap},
+  };
 
-  use crate::EsmLibraryPlugin;
+  use crate::{EsmLibraryPlugin, chunk_link::RawImportSource};
 
   #[test]
   fn get_module_chunk_empty_chunks_returns_error() {
@@ -3035,5 +3219,262 @@ mod tests {
     let result = EsmLibraryPlugin::validate_single_chunk(m, &chunks);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), expected_chunk);
+  }
+
+  #[test]
+  fn external_candidate_name_does_not_claim_chunk_top_level_name() {
+    let candidate = Atom::from("index_js_namespaceObject");
+    let mut info = ExternalModuleInfo::new(0, ModuleIdentifier::from("test_module"));
+    let mut candidate_names = FxHashSet::default();
+    let mut chunk_used_names = FxHashSet::default();
+    chunk_used_names.insert(candidate.clone());
+
+    EsmLibraryPlugin::assign_external_candidate_name(
+      &mut info,
+      &mut candidate_names,
+      std::slice::from_ref(&candidate),
+    );
+
+    assert_eq!(info.name.as_ref(), Some(&candidate));
+    assert_eq!(candidate_names.len(), 1);
+    assert!(candidate_names.contains(&candidate));
+    assert_eq!(chunk_used_names.len(), 1);
+    assert!(chunk_used_names.contains(&candidate));
+  }
+
+  #[test]
+  fn add_require_renames_external_candidate_against_chunk_top_level_name() {
+    let module = ModuleIdentifier::from("test_module");
+    let candidate = Atom::from("index_js_namespaceObject");
+    let mut info = ExternalModuleInfo::new(0, module);
+    let mut candidate_names = FxHashSet::default();
+    let mut chunk_used_names = FxHashSet::default();
+    let mut required = Default::default();
+    chunk_used_names.insert(candidate.clone());
+
+    EsmLibraryPlugin::assign_external_candidate_name(
+      &mut info,
+      &mut candidate_names,
+      std::slice::from_ref(&candidate),
+    );
+
+    let required_info = EsmLibraryPlugin::add_require(
+      module,
+      None,
+      info.name.clone(),
+      &mut chunk_used_names,
+      &mut required,
+    );
+    let required_symbol = required_info
+      .required_symbol
+      .as_ref()
+      .expect("should allocate required symbol");
+
+    assert_eq!(required_symbol.as_ref(), "index_js_namespaceObject_0");
+    assert!(chunk_used_names.contains(&candidate));
+    assert!(chunk_used_names.contains(required_symbol));
+  }
+
+  #[test]
+  fn raw_import_namespace_claims_chunk_top_level_name_for_add_require() {
+    let module = ModuleIdentifier::from("test_module");
+    let namespace_import = Atom::from("index_js_namespaceObject");
+    let import_spec = ImportSpec {
+      atoms: Default::default(),
+      default_import: None,
+      ns_import: Some(namespace_import.clone()),
+    };
+    let mut chunk_used_names = FxHashSet::default();
+    let mut required = Default::default();
+
+    EsmLibraryPlugin::reserve_raw_import_locals(&import_spec, &mut chunk_used_names);
+
+    let required_info = EsmLibraryPlugin::add_require(
+      module,
+      None,
+      Some(namespace_import.clone()),
+      &mut chunk_used_names,
+      &mut required,
+    );
+    let required_symbol = required_info
+      .required_symbol
+      .as_ref()
+      .expect("should allocate required symbol");
+
+    assert_eq!(required_symbol.as_ref(), "index_js_namespaceObject_0");
+    assert!(chunk_used_names.contains(&namespace_import));
+    assert!(chunk_used_names.contains(required_symbol));
+  }
+
+  #[test]
+  fn raw_import_renames_against_existing_required_symbol() {
+    let module = ModuleIdentifier::from("test_module");
+    let local_name = Atom::from("index_js_namespaceObject");
+    let mut chunk_used_names = FxHashSet::default();
+    let mut required = Default::default();
+
+    let required_info = EsmLibraryPlugin::add_require(
+      module,
+      None,
+      Some(local_name.clone()),
+      &mut chunk_used_names,
+      &mut required,
+    );
+    assert_eq!(required_info.required_symbol.as_ref(), Some(&local_name));
+
+    let raw_import_local = if chunk_used_names.contains(&local_name) {
+      let new_name = rspack_core::find_new_name(local_name.as_str(), &chunk_used_names, &[]);
+      chunk_used_names.insert(new_name.clone());
+      new_name
+    } else {
+      let raw_import_local = local_name.clone();
+      chunk_used_names.insert(raw_import_local.clone());
+      raw_import_local
+    };
+
+    let required_symbol = required
+      .get(&module)
+      .and_then(|info| info.required_symbol.as_ref())
+      .expect("should keep required symbol");
+
+    assert_eq!(required_symbol, &local_name);
+    assert_eq!(raw_import_local.as_ref(), "index_js_namespaceObject_0");
+    assert!(chunk_used_names.contains(&local_name));
+    assert!(chunk_used_names.contains(&raw_import_local));
+  }
+
+  #[test]
+  fn module_external_namespace_init_fragment_keeps_first_rendered_local() {
+    let first_namespace_import = Atom::from("__rspack_external_0");
+    let second_namespace_import = Atom::from("__rspack_external_1");
+    let init_fragments: ChunkInitFragments = vec![
+      Box::new(rspack_core::NormalInitFragment::new(
+        "import * as __rspack_external_1 from \"../compiled/webpack-sources/index.js\";\n".into(),
+        rspack_core::InitFragmentStage::StageESMImports,
+        1,
+        InitFragmentKey::ModuleExternal("../compiled/webpack-sources/index.js".into()),
+        None,
+      )),
+      Box::new(rspack_core::NormalInitFragment::new(
+        "import * as __rspack_external_0 from \"../compiled/webpack-sources/index.js\";\n".into(),
+        rspack_core::InitFragmentStage::StageESMImports,
+        0,
+        InitFragmentKey::ModuleExternal("../compiled/webpack-sources/index.js".into()),
+        None,
+      )),
+    ];
+    let mut chunk_used_names = FxHashSet::default();
+    let mut namespace_imports = FxHashMap::default();
+
+    EsmLibraryPlugin::reserve_module_external_namespace_import_locals(
+      &init_fragments,
+      &mut chunk_used_names,
+      Some(&mut namespace_imports),
+    );
+
+    assert_eq!(chunk_used_names.len(), 1);
+    assert!(chunk_used_names.contains(&first_namespace_import));
+    assert!(!chunk_used_names.contains(&second_namespace_import));
+    assert_eq!(
+      namespace_imports.get(&RawImportSource::Source((
+        "../compiled/webpack-sources/index.js".into(),
+        None,
+      ))),
+      Some(&first_namespace_import)
+    );
+  }
+
+  #[test]
+  fn module_external_namespace_init_fragment_claims_chunk_top_level_name() {
+    let module = ModuleIdentifier::from("test_module");
+    let namespace_import = Atom::from("index_js_namespaceObject");
+    let init_fragments: ChunkInitFragments = vec![Box::new(rspack_core::NormalInitFragment::new(
+      "import * as index_js_namespaceObject from \"../compiled/webpack-sources/index.js\";\n"
+        .into(),
+      rspack_core::InitFragmentStage::StageESMImports,
+      0,
+      InitFragmentKey::ModuleExternal("../compiled/webpack-sources/index.js".into()),
+      None,
+    ))];
+    let mut chunk_used_names = FxHashSet::default();
+    let mut namespace_imports = FxHashMap::default();
+    let mut required = Default::default();
+
+    EsmLibraryPlugin::reserve_module_external_namespace_import_locals(
+      &init_fragments,
+      &mut chunk_used_names,
+      Some(&mut namespace_imports),
+    );
+
+    let required_info = EsmLibraryPlugin::add_require(
+      module,
+      None,
+      Some(namespace_import.clone()),
+      &mut chunk_used_names,
+      &mut required,
+    );
+    let required_symbol = required_info
+      .required_symbol
+      .as_ref()
+      .expect("should allocate required symbol");
+
+    assert_eq!(required_symbol.as_ref(), "index_js_namespaceObject_0");
+    assert!(chunk_used_names.contains(&namespace_import));
+    assert!(chunk_used_names.contains(required_symbol));
+    assert_eq!(
+      namespace_imports.get(&RawImportSource::Source((
+        "../compiled/webpack-sources/index.js".into(),
+        None,
+      ))),
+      Some(&namespace_import)
+    );
+  }
+
+  #[test]
+  fn module_external_non_namespace_init_fragment_does_not_claim_chunk_top_level_name() {
+    let init_fragments: ChunkInitFragments = vec![Box::new(rspack_core::NormalInitFragment::new(
+      "import { createRequire as __rspack_createRequire } from \"node:module\";\nconst __rspack_createRequire_require = __rspack_createRequire(import.meta.url);\n"
+        .into(),
+      rspack_core::InitFragmentStage::StageESMImports,
+      0,
+      InitFragmentKey::ModuleExternal("node-commonjs".into()),
+      None,
+    ))];
+    let mut chunk_used_names = FxHashSet::default();
+
+    EsmLibraryPlugin::reserve_module_external_namespace_import_locals(
+      &init_fragments,
+      &mut chunk_used_names,
+      None,
+    );
+
+    assert!(chunk_used_names.is_empty());
+  }
+
+  #[test]
+  fn external_import_source_and_binding_preserves_attributes() {
+    let local_name = Atom::from("json_default");
+    let attr = Some(" with {\"type\":\"json\"}".to_string());
+    let mut import_map = FxIndexMap::default();
+    let mut import_spec = ConcatenatedImportMapItem::default();
+    import_spec.specifiers.insert("default".into());
+    import_map.insert(("./foo.json".into(), attr.clone()), import_spec);
+
+    let mut info = ConcatenatedModuleInfo {
+      import_map: Some(import_map),
+      ..Default::default()
+    };
+    info
+      .internal_names
+      .insert("default".into(), local_name.clone());
+
+    let binding = EsmLibraryPlugin::get_external_import_source_and_binding(&info, &local_name)
+      .expect("should resolve raw import source and binding");
+
+    assert_eq!(
+      binding.0,
+      RawImportSource::Source(("./foo.json".into(), attr))
+    );
+    assert!(matches!(binding.1, super::ExternalImportBinding::Default));
   }
 }

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -4,9 +4,9 @@ use rspack_collections::IdentifierIndexSet;
 use rspack_core::{
   AssetInfo, Chunk, ChunkGraph, ChunkGroup, ChunkRenderContext, ChunkUkey,
   CodeGenerationDataFilename, Compilation, ConcatenatedModuleInfo, DependencyId, InitFragment,
-  InitFragmentKey, ModuleIdentifier, PathData, PathInfo, RuntimeCodeTemplate, RuntimeGlobals,
-  RuntimeVariable, SourceType, export_name, get_js_chunk_filename_template, get_undo_path,
-  render_imports, render_init_fragments,
+  ModuleIdentifier, PathData, PathInfo, RuntimeCodeTemplate, RuntimeGlobals, RuntimeVariable,
+  SourceType, export_name, get_js_chunk_filename_template, get_undo_path, render_imports,
+  render_init_fragments,
   rspack_sources::{ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
 };
 use rspack_error::Result;
@@ -562,49 +562,6 @@ var {} = {{}};
 
     if !imported_chunks.is_empty() || !chunk_link.raw_import_stmts.is_empty() {
       import_source.add(RawStringSource::from_static("\n"));
-    }
-
-    // Deduplicate: remove init fragments for external modules whose namespace
-    // import is already provided by raw_import_stmts.
-    // This prevents duplicate `import * as X from "source"` when the same external
-    // module is referenced by both scope-hoisted and non-scope-hoisted modules.
-    // We only drop the fragment when raw_import_stmts already includes a namespace
-    // import (`ns_import`) for the same source+attributes, because a namespace
-    // binding (`__rspack_external_<id>`) is what the non-scope-hoisted module body
-    // references. Named-only imports would not provide that binding.
-    {
-      let ns_import_sources: FxHashSet<String> = chunk_link
-        .raw_import_stmts
-        .iter()
-        .filter_map(|(source, spec)| {
-          spec.ns_import.as_ref()?;
-          match source {
-            RawImportSource::Source((s, attr)) => {
-              // Reconstruct the key format used by module_external_fragment_key:
-              // "source" or "source|json_attrs"
-              let key = if let Some(attr_str) = attr {
-                // attr_str has format " with {json}" - strip the " with " prefix
-                let json_part = attr_str.strip_prefix(" with ").unwrap_or(attr_str);
-                format!("{s}|{json_part}")
-              } else {
-                s.clone()
-              };
-              Some(key)
-            }
-            _ => None,
-          }
-        })
-        .collect();
-
-      if !ns_import_sources.is_empty() {
-        chunk_init_fragments.retain(|frag| {
-          if let InitFragmentKey::ModuleExternal(key) = frag.key() {
-            !ns_import_sources.contains(key)
-          } else {
-            true
-          }
-        });
-      }
     }
 
     // render init fragments

--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -160,13 +160,7 @@ const codmodPlugin: RsbuildPlugin = {
         require.resolve(path.resolve(import.meta.dirname, 'dist/index.js')),
         'utf-8',
       );
-      // Remove the redundant `import * as index_js_namespaceObject from "../compiled/webpack-sources/index.js";`
-      // TODO: Remove this hack after we fix this bug
-      const normalizedDist = dist.replace(
-        'import * as index_js_namespaceObject from "../compiled/webpack-sources/index.js";\n',
-        '',
-      );
-      const root = parse(Lang.JavaScript, normalizedDist).root();
+      const root = parse(Lang.JavaScript, dist).root();
       const edits = [...replaceBinding(root)];
 
       fs.writeFileSync(

--- a/tests/rspack-test/esmOutputCases/externals/dedup-external-imports-mixed/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/dedup-external-imports-mixed/__snapshots__/esm.snap.txt
@@ -1,7 +1,7 @@
 ```mjs title=main.mjs
-import * as __rspack_external_fs from "fs";
 import { __webpack_require__ } from "./runtime.mjs";
 
+import * as __rspack_external_fs from "fs";
 __webpack_require__.add({
 "fs?94de"
 /*!*********************!*\


### PR DESCRIPTION
## Summary
- align ModuleExternal namespace reservation with final init fragment render order
- preserve import attributes when reusing module-style external raw imports
- keep external namespace dedupe in link phase and remove render-side workaround

## Testing
- cargo test -p rspack_plugin_esm_library -- --nocapture
- cargo fmt --all --check
- pnpm --filter @rspack/binding run build:dev
- cd tests/rspack-test && npx rstest esm