### PR TITLE
perf(javascript): reduce parser hook name overhead

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/call_hooks_name.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/call_hooks_name.rs
@@ -1,6 +1,6 @@
 use swc_core::{
   atoms::Atom,
-  ecma::ast::{Expr, MemberExpr, OptChainExpr},
+  ecma::ast::{MemberExpr, OptChainExpr},
 };
 
 use super::{AllowedMemberTypes, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo};
@@ -45,7 +45,11 @@ impl CallHooksName for String {
   where
     F: Fn(&mut JavascriptParser, &str) -> Option<T>,
   {
-    self.as_str().call_hooks_name(parser, hook_call)
+    if self.contains('.') {
+      hook_call(parser, self)
+    } else {
+      self.as_str().call_hooks_name(parser, hook_call)
+    }
   }
 }
 #[allow(unused_lifetimes)]
@@ -90,11 +94,8 @@ impl CallHooksName for OptChainExpr {
   where
     F: Fn(&mut JavascriptParser, &str) -> Option<T>,
   {
-    let Some(MemberExpressionInfo::Expression(expr_name)) = parser
-      .get_member_expression_info_from_expr(
-        &Expr::OptChain(self.to_owned()),
-        AllowedMemberTypes::Expression,
-      )
+    let Some(MemberExpressionInfo::Expression(expr_name)) =
+      parser.get_member_expression_info(ExprRef::OptChain(self), AllowedMemberTypes::Expression)
     else {
       return None;
     };


### PR DESCRIPTION
## Summary
- avoid the `Atom` round-trip for parser hook names when the resolved name is already a dotted member chain
- resolve optional-chain hook names through `ExprRef::OptChain` instead of cloning the whole `OptChainExpr`
- keep identifier semantics unchanged by falling back to the existing variable-info path for non-dotted names

## Testing
- `PATH="$HOME/.nvm/versions/node/v22.18.0/bin:$PATH" pnpm run setup`
- `PATH="$HOME/.nvm/versions/node/v22.18.0/bin:$PATH" pnpm run build:cli:dev`
- `PATH="$HOME/.nvm/versions/node/v22.18.0/bin:$PATH" pnpm run build:binding:dev`
- `PATH="$HOME/.nvm/versions/node/v22.18.0/bin:$PATH" pnpm run test:rs`
- `PATH="$HOME/.nvm/versions/node/v22.18.0/bin:$PATH" __TESTING_RIMRAF_NODE_VERSION__=v14.13.0 pnpm run test:unit`
- `cargo fmt --all --check`
- `cargo lint`
- `PATH="$HOME/.nvm/versions/node/v22.18.0/bin:$PATH" pnpm run lint:js`
