### PR TITLE
chore(ci): move renovate schedule to saturday

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   timezone: 'Asia/Shanghai',
   extends: [':dependencyDashboard', 'helpers:pinGitHubActionDigests'],
-  schedule: ['before 8am on wednesday'],
+  schedule: ['before 8am on saturday'],
   enabledManagers: ['github-actions', 'cargo', 'npm'],
   ignorePaths: [
     '**/fixtures/**',


### PR DESCRIPTION
## Summary

- Move the Renovate schedule from Wednesday to Saturday in the `Asia/Shanghai` timezone.
- This shifts automated dependency update activity away from weekdays to reduce CI usage during the work week.

## Related links

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
