### PR TITLE
perf(core): reduce target resolution overhead

### DIFF
--- a/crates/rspack_core/src/exports/target.rs
+++ b/crates/rspack_core/src/exports/target.rs
@@ -1,4 +1,4 @@
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet as HashSet;
@@ -20,7 +20,7 @@ pub struct UnResolvedExportInfoTarget {
   pub export: Option<Vec<Atom>>,
 }
 
-pub type ResolveFilterFnTy<'a> = Rc<dyn Fn(&ResolvedExportInfoTarget) -> bool + 'a>;
+pub type ResolveFilterFnTy<'a> = dyn Fn(&ResolvedExportInfoTarget) -> bool + 'a;
 
 #[derive(Debug)]
 pub enum GetTargetResult {
@@ -68,7 +68,7 @@ pub fn get_terminal_binding(
     export_info,
     mg,
     exports_info_artifact,
-    Rc::new(|_| true),
+    &|_| true,
     &mut Default::default(),
   ) else {
     return None;
@@ -125,10 +125,9 @@ pub fn find_target(
       .get_prefetched_exports_info(&target.module, PrefetchExportsInfoMode::Default);
     let export_info = exports_info.get_export_info_without_mut_module_graph(name);
     let export_info_hash_key = export_info.as_hash_key();
-    if visited.contains(&export_info_hash_key) {
+    if !visited.insert(export_info_hash_key) {
       return FindTargetResult::NoTarget;
     }
-    visited.insert(export_info_hash_key);
     let new_target = find_target(
       &export_info,
       mg,
@@ -173,17 +172,16 @@ pub fn get_target(
   export_info: &ExportInfoData,
   mg: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
-  resolve_filter: ResolveFilterFnTy,
+  resolve_filter: &ResolveFilterFnTy<'_>,
   already_visited: &mut HashSet<ExportInfoHashKey>,
 ) -> Option<GetTargetResult> {
   if !export_info.target_is_set() || export_info.target().is_empty() {
     return None;
   }
   let hash_key = export_info.as_hash_key();
-  if already_visited.contains(&hash_key) {
+  if !already_visited.insert(hash_key) {
     return Some(GetTargetResult::Circular);
   }
-  already_visited.insert(hash_key);
 
   let max_target = export_info.get_max_target();
   let mut values = max_target.values().map(|item| UnResolvedExportInfoTarget {
@@ -193,7 +191,7 @@ pub fn get_target(
   let target = resolve_target(
     values.next()?,
     already_visited,
-    resolve_filter.clone(),
+    resolve_filter,
     mg,
     exports_info_artifact,
   );
@@ -203,7 +201,7 @@ pub fn get_target(
       let resolved_target = resolve_target(
         val,
         already_visited,
-        resolve_filter.clone(),
+        resolve_filter,
         mg,
         exports_info_artifact,
       );
@@ -222,7 +220,7 @@ pub fn get_target(
 fn resolve_target(
   input_target: UnResolvedExportInfoTarget,
   already_visited: &mut HashSet<ExportInfoHashKey>,
-  resolve_filter: ResolveFilterFnTy,
+  resolve_filter: &ResolveFilterFnTy<'_>,
   mg: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> Option<GetTargetResult> {
@@ -257,7 +255,7 @@ fn resolve_target(
       &maybe_export_info,
       mg,
       exports_info_artifact,
-      resolve_filter.clone(),
+      resolve_filter,
       already_visited,
     );
 
@@ -297,7 +295,7 @@ pub fn can_move_target(
   export_info: &ExportInfoData,
   mg: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
-  resolve_filter: ResolveFilterFnTy,
+  resolve_filter: &ResolveFilterFnTy<'_>,
 ) -> Option<ResolvedExportInfoTarget> {
   let Some(GetTargetResult::Target(target)) = get_target(
     export_info,

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -3,7 +3,6 @@ use std::{
   borrow::Cow,
   fmt::{Debug, Display, Formatter},
   hash::Hash,
-  rc::Rc,
   sync::Arc,
 };
 
@@ -492,7 +491,7 @@ fn get_exports_type_impl(
               export_info,
               mg,
               exports_info_artifact,
-              Rc::new(|_| true),
+              &|_| true,
               &mut Default::default(),
             ) else {
               return ExportsType::Dynamic;

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -1,6 +1,5 @@
 use std::{
   path::PathBuf,
-  rc::Rc,
   sync::{Arc, LazyLock},
 };
 
@@ -153,7 +152,7 @@ impl EsmLibraryPlugin {
                   export_info,
                   module_graph,
                   exports_info_artifact,
-                  Rc::new(|_| true),
+                  &|_| true,
                   &mut Default::default()
                 ),
                 Some(GetTargetResult::Target(_))
@@ -353,7 +352,7 @@ async fn finish_modules(
                 export_info,
                 module_graph,
                 exports_info_artifact,
-                Rc::new(|_| true),
+                &|_| true,
                 &mut Default::default()
               ),
               Some(GetTargetResult::Target(_))

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
@@ -742,7 +740,7 @@ fn find_target_exports_info(
     export_info,
     mg,
     exports_info_artifact,
-    Rc::new(|_| true),
+    &|_| true,
     &mut Default::default(),
   );
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::only_used_in_recursion)]
-use std::{borrow::Cow, collections::VecDeque, rc::Rc, sync::Arc};
+use std::{borrow::Cow, collections::VecDeque, sync::Arc};
 
 use rayon::prelude::*;
 use rspack_collections::{
@@ -929,7 +929,7 @@ impl ModuleConcatenationPlugin {
                   export_info,
                   module_graph,
                   &compilation.exports_info_artifact,
-                  Rc::new(|_| true),
+                  &|_| true,
                   &mut Default::default()
                 ),
                 Some(GetTargetResult::Target(_))

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Debug, rc::Rc};
+use std::{borrow::Cow, fmt::Debug};
 
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
@@ -363,13 +363,14 @@ fn can_optimize_connection(
       .get_prefetched_exports_info(&original_module, PrefetchExportsInfoMode::Default);
     let export_info = exports_info.get_export_info_without_mut_module_graph(name);
 
+    let resolve_filter = |target: &ResolvedExportInfoTarget| {
+      side_effects_state_map[&target.module] == ConnectionState::Active(false)
+    };
     let target = can_move_target(
       &export_info,
       module_graph,
       exports_info_artifact,
-      Rc::new(|target: &ResolvedExportInfoTarget| {
-        side_effects_state_map[&target.module] == ConnectionState::Active(false)
-      }),
+      &resolve_filter,
     )?;
     if !module_graph.can_update_module(&dependency_id, &target.module) {
       return None;
@@ -410,13 +411,14 @@ fn can_optimize_connection(
     );
     let export_info = exports_info.get_export_info_without_mut_module_graph(&ids[0]);
 
+    let resolve_filter = |target: &ResolvedExportInfoTarget| {
+      side_effects_state_map[&target.module] == ConnectionState::Active(false)
+    };
     let Some(GetTargetResult::Target(target)) = get_target(
       &export_info,
       module_graph,
       exports_info_artifact,
-      Rc::new(|target: &ResolvedExportInfoTarget| {
-        side_effects_state_map[&target.module] == ConnectionState::Active(false)
-      }),
+      &resolve_filter,
       &mut Default::default(),
     ) else {
       return None;

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hash, rc::Rc};
+use std::{borrow::Cow, hash::Hash};
 
 use rspack_cacheable::with::AsVecConverter;
 use rspack_core::{
@@ -74,7 +74,7 @@ fn print_exports_info_to_source<F>(
       export_info,
       module_graph,
       exports_info_artifact,
-      Rc::new(|_| true),
+      &|_| true,
       &mut Default::default(),
     ) {
       Some(GetTargetResult::Target(resolve_target)) => {
@@ -125,7 +125,7 @@ fn print_exports_info_to_source<F>(
       other_exports_info,
       module_graph,
       exports_info_artifact,
-      Rc::new(|_| true),
+      &|_| true,
       &mut Default::default(),
     );
     if matches!(target, Some(GetTargetResult::Target(_)))


### PR DESCRIPTION
## Summary
- remove `Rc` allocation and clone overhead from `get_target` / `can_move_target` by switching to borrowed resolve filters
- simplify visited-set checks in target resolution to avoid redundant hash lookups where possible
- update the target-resolution call sites in core and javascript plugins to use the lighter API

## Benchmark
- case: `rspack-bench-repo/cases/all`
- command: `node packages/rspack-cli/bin/rspack.js build -c rspack.config.js` with local profiling binding via `RSPACK_BINDING`
- before: `3.21s`, `2.09s`
- after: `3.14s`, `2.04s`, `2.06s`

## Test Plan
- cargo fmt --all --check
- pnpm run build:binding:dev
- pnpm run build:js
- cargo lint
- pnpm run test:rs
- __TESTING_RIMRAF_NODE_VERSION__=v14.13.0 pnpm run test:unit