### PR TITLE
fix: avoid spreading huge dependency iterables

### DIFF
--- a/packages/rspack/src/util/fake.ts
+++ b/packages/rspack/src/util/fake.ts
@@ -17,7 +17,13 @@ export function createFakeCompilationDependencies(
   };
 
   const getAllDeps = () => {
-    const deps = new Set([...getDeps(), ...addDepsCaller.pendingData()]);
+    const deps = new Set<string>();
+    for (const dep of getDeps()) {
+      deps.add(dep);
+    }
+    for (const dep of addDepsCaller.pendingData()) {
+      deps.add(dep);
+    }
     for (const deleted of deletedDeps) {
       deps.delete(deleted);
     }
@@ -39,8 +45,8 @@ export function createFakeCompilationDependencies(
     addAll: (deps: Iterable<string>) => {
       for (const dep of deps) {
         deletedDeps.delete(dep);
+        addDepsCaller.push(dep);
       }
-      addDepsCaller.push(...deps);
     },
     delete: (dep: string) => {
       const hadDep = hasDep(dep);

--- a/tests/rspack-test/configCases/dependencies/file-dependencies-huge/rspack.config.js
+++ b/tests/rspack-test/configCases/dependencies/file-dependencies-huge/rspack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 // Number large enough to exceed engine's max arguments (e.g. ~65536) when
 // spread in push(...data), which would cause "Maximum call stack size exceeded".
-const HUGE_DEPS_COUNT = 100_000;
+const HUGE_DEPS_COUNT = 1_000_000;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -13,7 +13,10 @@ module.exports = {
 					{ length: HUGE_DEPS_COUNT },
 					(_, i) => path.resolve(__dirname, `fake-dep-${i}.js`)
 				);
+				const originalDeps = Array.from(compilation.fileDependencies);
 				compilation.fileDependencies.addAll(largeDeps);
+
+				expect(Array.from(compilation.fileDependencies)).toEqual(originalDeps.concat(largeDeps));
 			});
 		}
 	]


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This fixes a RangeError: Maximum call stack size exceeded when Compilation dependency collections receive very large inputs through addAll().

The change updates the shared dependency collection path to consume iterables item by item instead of forwarding them via variadic spread, which keeps fileDependencies, contextDependencies, missingDependencies, and buildDependencies safe for huge inputs and one-shot iterables such as generators. It also avoids an unnecessary intermediate array when rebuilding the merged dependency Set, reducing transient memory overhead for large dependency sets.

Regression coverage is included for the huge dependency case and for iterable-based addAll() behavior across compilation dependency collections.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
