### PR TITLE
chore: zigbuild for all linux targets

### DIFF
--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -63,11 +63,13 @@ jobs:
           save-if: true
 
       - name: Setup Zig
+        if: ${{ contains(inputs.target, 'linux') }}
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
         with:
           version: '0.14.1'
 
       - name: Install cargo-zigbuild
+        if: ${{ contains(inputs.target, 'linux') }}
         uses: taiki-e/install-action@dfcb1ee29051d97c8d0f2d437199570008fd5612 # v2
         with:
           tool: cargo-zigbuild


### PR DESCRIPTION
## Summary

Enable `cargo-zigbuild` for all linux targets to lock the glibc version to 2.28.
Note that the glibc version is determined by node v20, which is the oldest version that rspack supports. And zig 0.14.1 also specifies glibc 2.28, see https://github.com/ziglang/zig/blob/0.14.1/lib/std/Target.zig#L473

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
