### PR TITLE
chore(ci): migrate ecosystem CI to central rstack-ecosystem-ci repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,21 @@ jobs:
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'pull_request' }}
     uses: ./.github/workflows/size-limit.yml
 
+  ecosystem_ci_per_commit:
+    name: Run ecosystem CI per commit
+    needs: [check-changed, build-linux]
+    runs-on: ubuntu-latest
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
+    steps:
+      - name: Trigger Ecosystem CI
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@v0.3.0
+        with:
+          github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
+          ecosystem-owner: web-infra-dev
+          ecosystem-repo: rspack
+          workflow-file: rspack-ecosystem-ci-from-commit.yml
+          client-payload: '{"commitSHA":"${{ github.sha }}","updateComment":true,"repo":"web-infra-dev/rspack","suite":"-","suiteRefType":"precoded","suiteRef":"precoded","sourceRunId":"${{ github.run_id }}","sourceRepo":"web-infra-dev/rspack"}'
+
   # TODO: enable it after self hosted runners are ready
   # pkg-preview:
   #   name: Pkg Preview

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -1,16 +1,6 @@
 name: Ecosystem CI
 
 on:
-  push:
-    branches:
-      - main
-      - v1.x
-    paths-ignore:
-      - '**/*.md'
-      - 'website/**'
-    tags-ignore:
-      - '**'
-
   workflow_dispatch:
     inputs:
       pr:
@@ -56,30 +46,10 @@ permissions:
   pull-requests: write
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    if: github.repository == 'web-infra-dev/rspack' && github.event_name != 'workflow_dispatch'
-    outputs:
-      changed: ${{ steps.changes.outputs.changed }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          fetch-depth: 1
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: changes
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!website/**"
-
   ecosystem_ci_dispatch:
     name: Dispatch ecosystem CI
     runs-on: ubuntu-latest
-    if: github.repository == 'web-infra-dev/rspack' && github.event_name == 'workflow_dispatch'
+    if: github.repository == 'web-infra-dev/rspack'
     steps:
       - name: Get PR info
         id: pr-info
@@ -104,18 +74,3 @@ jobs:
           pr-number: ${{ github.event.inputs.pr }}
           client-payload: '{"prNumber":"${{ github.event.inputs.pr }}","branchName":"${{ steps.pr-info.outputs.branch }}","repo":"${{ steps.pr-info.outputs.repo }}","suite":"${{ github.event.inputs.suite || ''-'' }}","suiteRefType":"${{ github.event.inputs.suiteRefType }}","suiteRef":"${{ github.event.inputs.suiteRef }}"}'
           branch: ${{ steps.pr-info.outputs.branch }}
-
-  ecosystem_ci_per_commit:
-    name: Run ecosystem CI per commit
-    needs: changes
-    runs-on: ubuntu-latest
-    if: github.repository == 'web-infra-dev/rspack' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.changed == 'true'
-    steps:
-      - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@v0.3.0
-        with:
-          github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
-          ecosystem-owner: web-infra-dev
-          ecosystem-repo: rspack
-          workflow-file: rspack-ecosystem-ci-from-commit.yml
-          client-payload: '{"commitSHA":"${{ github.sha }}","updateComment":true,"repo":"web-infra-dev/rspack","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'


### PR DESCRIPTION
## Summary

Migrate rspack ecosystem CI from the local repository to the central [rstackjs/rstack-ecosystem-ci](https://github.com/rstackjs/rstack-ecosystem-ci) repository.

The rspack repo now only dispatches lightweight downstream runs, while the central repo handles binding preparation, Verdaccio publishing, suite execution, result summarization, and ecosystem history updates.

## Motivation

The previous local workflow duplicated a large amount of shared ecosystem CI infrastructure in rspack itself. Moving the heavy work to `rstack-ecosystem-ci` gives us:
- shared maintenance across rstack projects
- one common implementation for suite execution and result reporting
- easier follow-up fixes in one place instead of per-repo workflow copies
- lower rspack-side GitHub Actions cost for ecosystem CI

## Changes

### This PR (`web-infra-dev/rspack`)
- `push` events dispatch `rspack-ecosystem-ci-from-commit` in the central repo
- `workflow_dispatch` dispatches `rspack-ecosystem-ci-from-pr` in the central repo for the selected suite(s)
- add `suiteRefType` input for explicit suite ref type selection (`precoded` / `branch` / `tag` / `commit`)
- keep `dorny/paths-filter` so doc-only pushes still skip ecosystem CI
- move per-commit ecosystem CI dispatch to `ci.yml` so it can reuse the upstream rspack CI binding artifact after `build-linux`
- pass `sourceRunId` / `sourceRepo` to central repo for push-to-main style runs

### Central repo (`rstackjs/rstack-ecosystem-ci`) — already merged
- add rspack-specific `rspack-ecosystem-ci-from-pr` and `rspack-ecosystem-ci-from-commit` workflows
- support two binding preparation paths:
  - PR/manual path builds binding from the requested rspack ref
  - push-to-main path downloads the pre-built binding artifact from rspack CI and republishes it as `binding-linux-x64-gnu`
- keep Verdaccio publishing inside the central workflow so rspack suites run against the locally published packages
- handle PR comment creation, result summarization, and ecosystem history publishing in shared composite actions
- restore manual rspack ecosystem CI summary output and suite ref passthrough in central repo follow-up fixes

## Resource Savings

- rspack no longer runs the full ecosystem CI matrix locally on every relevant push / manual dispatch
- push-to-main style ecosystem CI can now reuse the upstream rspack CI binding artifact instead of rebuilding it again in the downstream workflow
- the remaining rspack-side cost is a lightweight dispatch/poll job rather than the full ecosystem execution

## Verification

- [x] PR manual dispatch path validated
  - rspack trigger run: https://github.com/web-infra-dev/rspack/actions/runs/23845949520
  - downstream central run: https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/23845961026
  - verified that PR mode builds binding from the PR branch ref in central repo
  - verified that the PR comment summary is populated correctly (not the previously empty table)
  - verified that failing suites fail at their own business/test stage (`rstest`, `examples`, `rsbuild`, `lynx-stack`) rather than early in workflow wiring
- [x] Push-to-main style path validated
  - downstream central run: https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/23846078915
  - dispatched with real parameters from rspack CI run `23843229894`
  - verified that `prepare-binding` downloads `bindings-x86_64-unknown-linux-gnu` from rspack CI and republishes it as `binding-linux-x64-gnu`
  - verified that the workflow behavior matches the intended push-to-main path and does not rebuild binding from scratch
  - verified that the only failing suite is `lynx-stack`, and it fails inside the suite build itself rather than in migration plumbing

## Prerequisites

- `REPO_RSTACK_ECO_CI_GITHUB_TOKEN` secret is already configured in this repo
