### PR TITLE
fix(swc-loader): fallback detectSyntax auto for virtual modules

### DIFF
--- a/crates/rspack_loader_swc/src/options.rs
+++ b/crates/rspack_loader_swc/src/options.rs
@@ -191,6 +191,7 @@ enum KnownSyntaxKind {
   Ts,
   Tsx,
   MtsCts,
+  Unknown,
 }
 
 impl KnownSyntaxKind {
@@ -238,6 +239,12 @@ fn resolve_parser_syntax_for_kind(
         .or_insert(Value::String("typescript".into()));
       parser_map.entry("tsx").or_insert(Value::Bool(true));
     }
+    Some(KnownSyntaxKind::Unknown) => {
+      parser_map
+        .entry("syntax")
+        .or_insert(Value::String("typescript".into()));
+      parser_map.entry("tsx").or_insert(Value::Bool(true));
+    }
     None => {}
   }
 
@@ -261,6 +268,7 @@ struct ResourceSpecificJscCache {
   ts: std::sync::OnceLock<JscConfig>,
   tsx: std::sync::OnceLock<JscConfig>,
   mts_cts: std::sync::OnceLock<JscConfig>,
+  unknown: std::sync::OnceLock<JscConfig>,
 }
 
 impl ResourceSpecificJscCache {
@@ -278,6 +286,7 @@ impl ResourceSpecificJscCache {
       KnownSyntaxKind::Ts => &self.ts,
       KnownSyntaxKind::Tsx => &self.tsx,
       KnownSyntaxKind::MtsCts => &self.mts_cts,
+      KnownSyntaxKind::Unknown => &self.unknown,
     }
   }
 }
@@ -297,12 +306,11 @@ impl ResourceSpecificJscResolver {
   }
 
   fn parse_for_resource(&self, resource_path: &Utf8Path) -> Result<JscConfig, serde_json::Error> {
-    // Only cache the small set of known extension groups. Unknown extensions
-    // stay lazy so invalid parser configs still fail only when that resource is
-    // actually parsed.
-    let Some(kind) = KnownSyntaxKind::from_resource_path(resource_path) else {
-      return self.raw_jsc.parse_for_syntax_kind(None);
-    };
+    // Known extensions keep exact inference. Unknown resources fall back to a
+    // TSX-capable parser so virtual modules and scheme-based resources can
+    // still be compiled under `detectSyntax: "auto"`.
+    let kind =
+      KnownSyntaxKind::from_resource_path(resource_path).unwrap_or(KnownSyntaxKind::Unknown);
 
     if let Some(jsc) = self.cache.get(kind) {
       return Ok(jsc.clone());
@@ -641,5 +649,26 @@ mod tests {
         .to_string()
         .contains("`detectSyntax` only supports `false` or \"auto\", but received \"foo\"")
     );
+  }
+
+  #[test]
+  fn test_detect_syntax_auto_falls_back_to_typescript_tsx_for_unknown_resources() {
+    let raw_options = r#"{
+      "detectSyntax": "auto",
+      "jsc": {
+        "externalHelpers": true,
+        "parser": {
+          "decorators": true
+        }
+      }
+    }"#;
+    let options = parse_options(raw_options);
+    let jsc = resolve_resource_specific_jsc(&options, "/project/virtual-module");
+
+    assert!(matches!(
+      jsc.syntax,
+      Some(Syntax::Typescript(ts)) if ts.tsx && ts.decorators
+    ));
+    assert!(jsc.external_helpers.into_bool());
   }
 }

--- a/tests/rspack-test/configCases/builtin-swc-loader/detect-syntax-auto-mimetype/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/detect-syntax-auto-mimetype/index.js
@@ -1,0 +1,8 @@
+import dataTs from "data:text/javascript;charset=utf-8;base64,Y29uc3QgbWVzc2FnZTogc3RyaW5nID0gImRhdGEtdHMiOyBleHBvcnQgZGVmYXVsdCBtZXNzYWdlOw==";
+import dataTsx from "data:text/javascript;charset=utf-8;base64,Y29uc3QgZWxlbWVudCA9IDxkaXYgY2xhc3NOYW1lPSJkYXRhLXRzeCI+ZGF0YS10c3g8L2Rpdj47IGV4cG9ydCBkZWZhdWx0IGVsZW1lbnQ7";
+
+it("should support javascript mimetype virtual modules together with ts and tsx files", () => {
+	expect(dataTs).toBe("data-ts");
+	expect(dataTsx.type).toBe("div");
+	expect(dataTsx.props.className).toBe("data-tsx");
+});

--- a/tests/rspack-test/configCases/builtin-swc-loader/detect-syntax-auto-mimetype/rspack.config.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/detect-syntax-auto-mimetype/rspack.config.js
@@ -1,0 +1,35 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	resolve: {
+		extensions: ["...", ".ts", ".tsx"]
+	},
+	module: {
+		rules: [
+			{
+				mimetype: {
+					or: ["text/javascript", "application/javascript"]
+				},
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							detectSyntax: "auto",
+							jsc: {
+								externalHelpers: true,
+								parser: {
+									decorators: true
+								},
+								transform: {
+									react: {
+										runtime: "automatic"
+									}
+								}
+							}
+						}
+					}
+				],
+			}
+		]
+	}
+};

--- a/website/docs/en/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/features/builtin-swc-loader.mdx
@@ -249,7 +249,7 @@ Inference rules:
 - `.js`, `.jsx`, `.mjs`, `.cjs` -> `{ syntax: "ecmascript", jsx: true }`
 - `.ts`, `.mts`, `.cts` -> `{ syntax: "typescript", tsx: false }`
 - `.tsx` -> `{ syntax: "typescript", tsx: true }`
-- Other extensions -> no inference
+- Resources without a recognizable extension -> `{ syntax: "typescript", tsx: true }`
 
 > If `jsc.parser.syntax` is explicitly provided, `detectSyntax` does not infer syntax.
 

--- a/website/docs/zh/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-swc-loader.mdx
@@ -249,7 +249,7 @@ export default {
 - `.js`、`.jsx`、`.mjs`、`.cjs` -> `{ syntax: "ecmascript", jsx: true }`
 - `.ts`、`.mts`、`.cts` -> `{ syntax: "typescript", tsx: false }`
 - `.tsx` -> `{ syntax: "typescript", tsx: true }`
-- 其他扩展名 -> 不做推断
+- 无法识别扩展名的资源 -> `{ syntax: "typescript", tsx: true }`
 
 > 如果显式设置了 `jsc.parser.syntax`，`detectSyntax` 不会再推断语法。
 


### PR DESCRIPTION
## Summary

This PR makes `builtin:swc-loader` fall back to a TSX-capable parser when `detectSyntax: "auto"` cannot infer syntax from the resource path, so virtual modules such as JavaScript `data:` URIs no longer fail on a missing `syntax` field. It also documents the fallback behavior and adds a config case covering `mimetype`-matched virtual JavaScript modules.

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
