### PR TITLE
fix(types): allow partial jsc.parser config when detectSyntax is auto

### DIFF
--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -18,13 +18,8 @@ export type SwcLoaderParserConfig = ParserConfig;
 export type SwcLoaderEsParserConfig = EsParserConfig;
 export type SwcLoaderTsParserConfig = TsParserConfig;
 export type SwcLoaderTransformConfig = TransformConfig;
-export type SwcLoaderOptions = Config & {
-  /**
-   * When set to `"auto"`, `builtin:swc-loader` infers `jsc.parser` from the resource extension.
-   * This is useful when one rule needs to handle mixed module types such as `.js`, `.jsx`, `.ts`, and `.tsx`.
-   * @default false
-   */
-  detectSyntax?: false | 'auto';
+
+type SwcLoaderCommonOptions = Omit<Config, 'jsc'> & {
   isModule?: boolean | 'unknown';
   /**
    * Collects information from TypeScript's AST for consumption by subsequent Rspack processes,
@@ -51,6 +46,24 @@ export type SwcLoaderOptions = Config & {
     reactServerComponents?: boolean | ReactServerComponentsOptions;
   };
 };
+
+export type SwcLoaderOptions =
+  | (SwcLoaderCommonOptions & {
+      /**
+       * When set to `"auto"`, `builtin:swc-loader` infers `jsc.parser` from the resource extension.
+       * This is useful when one rule needs to handle mixed module types such as `.js`, `.jsx`, `.ts`, and `.tsx`.
+       * @default false
+       */
+      detectSyntax?: false;
+      jsc?: JscConfig;
+    })
+  | (SwcLoaderCommonOptions & {
+      detectSyntax: 'auto';
+      jsc?: Omit<JscConfig, 'parser'> & {
+        // `detectSyntax: 'auto'` allows partial `jsc.parser` options.
+        parser?: Partial<ParserConfig>;
+      };
+    });
 
 export interface ReactServerComponentsOptions {
   /**


### PR DESCRIPTION
## Summary

- allow `SwcLoaderOptions` with `detectSyntax: 'auto'` to accept partial `jsc.parser` options
- keep the existing `jsc.parser` typing unchanged when `detectSyntax` is `false`

## Related links

- None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
