### PR TITLE
refactor(split-chunks): optimize get_combs lookups

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -70,6 +70,40 @@ pub(crate) struct Combinator {
 }
 
 impl Combinator {
+  fn get_non_used_exports_combs(
+    &self,
+    module: ModuleIdentifier,
+    module_chunks: &ModuleChunks,
+    chunk_index_map: &FxHashMap<ChunkUkey, u32>,
+  ) -> &[FxHashSet<ChunkUkey>] {
+    let chunks = module_chunks
+      .get(&module)
+      .expect("should have module chunks");
+    let chunks_key = get_key(chunks.iter().copied(), chunk_index_map);
+    self
+      .combinations
+      .get(&chunks_key)
+      .expect("should have combinations")
+  }
+
+  fn get_used_exports_combs(&self, module: ModuleIdentifier) -> Vec<&FxHashSet<ChunkUkey>> {
+    let mut result = vec![];
+    let chunks_by_module_used = self
+      .grouped_by_exports
+      .get(&module)
+      .expect("should have exports for module");
+
+    for chunks_key in chunks_by_module_used.iter() {
+      let combs = self
+        .used_exports_combinations
+        .get(chunks_key)
+        .expect("should have combinations");
+      result.extend(combs.iter());
+    }
+
+    result
+  }
+
   fn group_chunks_by_exports(
     module_identifier: &ModuleIdentifier,
     module_chunks: impl Iterator<Item = ChunkUkey>,
@@ -105,32 +139,15 @@ impl Combinator {
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
   ) -> Vec<FxHashSet<ChunkUkey>> {
     if used_exports {
-      let mut result = vec![];
-      let chunks_by_module_used = self
-        .grouped_by_exports
-        .get(&module)
-        .expect("should have exports for module");
-
-      for chunks_key in chunks_by_module_used.iter() {
-        let combs = self
-          .used_exports_combinations
-          .get(chunks_key)
-          .expect("should have combinations")
-          .clone();
-        result.extend(combs.into_iter());
-      }
-
-      result
-    } else {
-      let chunks = module_chunks
-        .get(&module)
-        .expect("should have module chunks");
-      let chunks_key = get_key(chunks.iter().copied(), chunk_index_map);
       self
-        .combinations
-        .get(&chunks_key)
-        .expect("should have combinations")
-        .clone()
+        .get_used_exports_combs(module)
+        .into_iter()
+        .cloned()
+        .collect()
+    } else {
+      self
+        .get_non_used_exports_combs(module, module_chunks, chunk_index_map)
+        .to_vec()
     }
   }
 


### PR DESCRIPTION
## Summary
- `Combinator::get_combs` reads from precomputed combination maps, but the previous `used_exports` path cloned an entire `Vec<FxHashSet<ChunkUkey>>` for each `chunks_key` before extending the final result
- this change reuses borrowed combination entries first and clones only once when collecting the final result, which cuts temporary `Vec` allocations, element moves, allocator pressure, and memory traffic on this split-chunks hot path
- `get_combs` is called repeatedly while preparing module groups across many modules and cache groups, so reducing this per-call overhead improves total split-chunks time without changing the algorithm or output
- keep the optimization scoped to `Combinator::get_combs` and its helpers, explicitly excluding the `BinaryHeap`-related changes from the original branch

## Validation
- `cargo fmt --all --check`
- `cargo lint`