### PR TITLE
chore: remove `-Zfmt-debug=none`

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -63,10 +63,6 @@ async function build() {
 		}
 		if (process.env.RUST_TARGET) {
 			args.push("--target", process.env.RUST_TARGET);
-			if (process.env.RUST_TARGET.includes("wasm32")) {
-				// Strip debug format to reduce wasm size of wasm artifacts
-				rustflags.push("-Zfmt-debug=none");
-			}
 		}
 		if (!process.env.DISABLE_PLUGIN) {
 			args.push("--no-default-features");


### PR DESCRIPTION
## Summary

Revert: https://github.com/web-infra-dev/rspack/pull/13527, https://github.com/web-infra-dev/rspack/pull/11439

This should fix WASM CI in some way

1. Code generations in rspack relies on the `Debug` trait
2. Error, tracing

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
