### PR TITLE
refactor(split-chunks): reduce module group filter overhead

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, fmt};
 
 use derive_more::Debug;
 use itertools::Itertools;
@@ -27,6 +27,39 @@ impl<'a> IndexedCacheGroup<'a> {
 
   pub fn compare_by_index(&self, other: &Self) -> Ordering {
     self.cache_group_index.cmp(&other.cache_group_index)
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum ModuleGroupKey {
+  Named {
+    cache_group_index: u32,
+    chunk_name: String,
+  },
+  Anonymous {
+    cache_group_index: u32,
+    chunks_key: u64,
+  },
+}
+
+impl fmt::Display for ModuleGroupKey {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Named {
+        cache_group_index,
+        chunk_name,
+      } => write!(
+        f,
+        "named(cache_group_index={cache_group_index}, chunk_name={chunk_name})"
+      ),
+      Self::Anonymous {
+        cache_group_index,
+        chunks_key,
+      } => write!(
+        f,
+        "anonymous(cache_group_index={cache_group_index}, chunks_key={chunks_key:x})"
+      ),
+    }
   }
 }
 
@@ -116,6 +149,16 @@ impl ModuleGroup {
     }
   }
 
+  pub fn merge(&mut self, other: Self) {
+    debug_assert_eq!(self.cache_group_index, other.cache_group_index);
+    debug_assert_eq!(self.chunk_name, other.chunk_name);
+
+    for module in other.modules {
+      self.add_module(module);
+    }
+    self.chunks.extend(other.chunks);
+  }
+
   pub fn get_cache_group<'a>(&self, cache_groups: &'a [CacheGroup]) -> &'a CacheGroup {
     &cache_groups[self.cache_group_index as usize]
   }
@@ -167,9 +210,17 @@ impl ModuleGroup {
 }
 
 pub(crate) fn compare_entries(
-  (a_key, a): (&String, &ModuleGroup),
-  (b_key, b): (&String, &ModuleGroup),
+  (a_key, a): (&ModuleGroupKey, &ModuleGroup),
+  (b_key, b): (&ModuleGroupKey, &ModuleGroup),
 ) -> f64 {
+  fn ordering_to_f64(ordering: Ordering) -> f64 {
+    match ordering {
+      Ordering::Less => -1.0,
+      Ordering::Equal => 0.0,
+      Ordering::Greater => 1.0,
+    }
+  }
+
   // 1. by priority
   // no need to compare priority anymore because we already pick all cache groups with same priority
   // let diff_priority = a.cache_group_priority - b.cache_group_priority;
@@ -221,12 +272,12 @@ pub(crate) fn compare_entries(
       (Some(a), Some(b)) => {
         let res = a.cmp(b);
         if !res.is_eq() {
-          return res as i32 as f64;
+          return ordering_to_f64(res);
         }
       }
       _ => unreachable!(),
     }
   }
 
-  a_key.cmp(b_key) as i32 as f64
+  ordering_to_f64(a_key.cmp(b_key))
 }

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -4,7 +4,9 @@ use rspack_core::{ModuleIdentifier, SourceType};
 
 use super::ModuleGroupMap;
 use crate::{
-  CacheGroup, SplitChunkSizes, SplitChunksPlugin, common::ModuleSizes, module_group::ModuleGroup,
+  CacheGroup, SplitChunkSizes, SplitChunksPlugin,
+  common::ModuleSizes,
+  module_group::{ModuleGroup, ModuleGroupKey},
 };
 
 pub trait ModulesContainer {
@@ -42,7 +44,7 @@ impl ModulesContainer for ModuleGroup {
 
 /// Return `true` if the `ModuleGroup` become empty.
 pub(crate) fn remove_min_size_violating_modules(
-  module_group_key: &str,
+  module_group_key: &ModuleGroupKey,
   module_group: &mut ModuleGroup,
   cache_group: &CacheGroup,
   module_sizes: &ModuleSizes,

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -20,10 +20,10 @@ use crate::{
   CacheGroup, SplitChunkSizes,
   common::FallbackCacheGroup,
   get_module_sizes,
-  module_group::{IndexedCacheGroup, ModuleGroup},
+  module_group::{IndexedCacheGroup, ModuleGroup, ModuleGroupKey},
 };
 
-type ModuleGroupMap = FxIndexMap<String, ModuleGroup>;
+type ModuleGroupMap = FxIndexMap<ModuleGroupKey, ModuleGroup>;
 
 #[derive(Debug)]
 pub struct PluginOptions {

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -1,6 +1,7 @@
 use std::{
   cmp::Ordering,
   hash::{Hash, Hasher},
+  sync::Arc,
 };
 
 use futures::future::join_all;
@@ -11,10 +12,7 @@ use rspack_core::{
   PrefetchExportsInfoMode, RuntimeKeyMap, UsageKey, get_runtime_key,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_util::{
-  fx_hash::{FxDashMap, FxIndexMap},
-  tracing_preset::TRACING_BENCH_TARGET,
-};
+use rspack_util::{fx_hash::FxIndexMap, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use tracing::instrument;
 
@@ -23,7 +21,7 @@ use crate::{
   SplitChunksPlugin,
   common::{ModuleChunks, ModuleSizes},
   min_size::remove_min_size_violating_modules,
-  module_group::{IndexedCacheGroup, ModuleGroup, compare_entries},
+  module_group::{IndexedCacheGroup, ModuleGroup, ModuleGroupKey, compare_entries},
   options::{
     cache_group::CacheGroup,
     cache_group_test::{CacheGroupTest, CacheGroupTestFnCtx},
@@ -32,6 +30,8 @@ use crate::{
 };
 
 type ChunksKey = u64;
+type ChunkCombination = Arc<FxHashSet<ChunkUkey>>;
+type PendingModuleGroupMap = FxHashMap<ModuleGroupKey, ModuleGroup>;
 
 /// If a module meets requirements of a `ModuleGroup`. We consider the `Module` and the `CacheGroup`
 /// to be a `MatchedItem`, which are consumed later to calculate `ModuleGroup`.
@@ -64,8 +64,8 @@ fn get_key<I: Iterator<Item = ChunkUkey>>(
 
 #[derive(Default)]
 pub(crate) struct Combinator {
-  combinations: FxHashMap<ChunksKey, Vec<FxHashSet<ChunkUkey>>>,
-  used_exports_combinations: FxHashMap<ChunksKey, Vec<FxHashSet<ChunkUkey>>>,
+  combinations: FxHashMap<ChunksKey, Vec<ChunkCombination>>,
+  used_exports_combinations: FxHashMap<ChunksKey, Vec<ChunkCombination>>,
   grouped_by_exports: IdentifierMap<Vec<ChunksKey>>,
 }
 
@@ -75,7 +75,7 @@ impl Combinator {
     module: ModuleIdentifier,
     module_chunks: &ModuleChunks,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
-  ) -> &[FxHashSet<ChunkUkey>] {
+  ) -> &[ChunkCombination] {
     let chunks = module_chunks
       .get(&module)
       .expect("should have module chunks");
@@ -86,7 +86,7 @@ impl Combinator {
       .expect("should have combinations")
   }
 
-  fn get_used_exports_combs(&self, module: ModuleIdentifier) -> Vec<&FxHashSet<ChunkUkey>> {
+  fn get_used_exports_combs(&self, module: ModuleIdentifier) -> Vec<&ChunkCombination> {
     let mut result = vec![];
     let chunks_by_module_used = self
       .grouped_by_exports
@@ -109,7 +109,7 @@ impl Combinator {
     module_chunks: impl Iterator<Item = ChunkUkey>,
     exports_info_artifact: &ExportsInfoArtifact,
     chunk_by_ukey: &ChunkByUkey,
-  ) -> Vec<FxHashSet<ChunkUkey>> {
+  ) -> Vec<ChunkCombination> {
     let exports_info = exports_info_artifact
       .get_prefetched_exports_info(module_identifier, PrefetchExportsInfoMode::Default);
     let mut grouped_by_used_exports: FxHashMap<UsageKey, FxHashSet<ChunkUkey>> = Default::default();
@@ -128,33 +128,16 @@ impl Combinator {
         .insert(chunk_ukey);
     }
 
-    grouped_by_used_exports.into_values().collect()
-  }
-
-  fn get_combs(
-    &self,
-    module: ModuleIdentifier,
-    used_exports: bool,
-    module_chunks: &ModuleChunks,
-    chunk_index_map: &FxHashMap<ChunkUkey, u32>,
-  ) -> Vec<FxHashSet<ChunkUkey>> {
-    if used_exports {
-      self
-        .get_used_exports_combs(module)
-        .into_iter()
-        .cloned()
-        .collect()
-    } else {
-      self
-        .get_non_used_exports_combs(module, module_chunks, chunk_index_map)
-        .to_vec()
-    }
+    grouped_by_used_exports
+      .into_values()
+      .map(Arc::new)
+      .collect()
   }
 
   fn get_combinations(
-    chunk_sets_in_graph: FxHashMap<ChunksKey, FxHashSet<ChunkUkey>>,
-    chunk_sets_by_count: FxIndexMap<u32, Vec<FxHashSet<ChunkUkey>>>,
-  ) -> FxHashMap<ChunksKey, Vec<FxHashSet<ChunkUkey>>> {
+    chunk_sets_in_graph: FxHashMap<ChunksKey, ChunkCombination>,
+    chunk_sets_by_count: FxIndexMap<u32, Vec<ChunkCombination>>,
+  ) -> FxHashMap<ChunksKey, Vec<ChunkCombination>> {
     chunk_sets_in_graph
       .into_par_iter()
       .map(|(chunks_key, chunks_set)| {
@@ -163,7 +146,7 @@ impl Combinator {
           if *count < chunks_set.len() as u32 {
             for set in array_of_set {
               if set.is_subset(&chunks_set) {
-                result.push(set.clone());
+                result.push(Arc::clone(set));
               }
             }
           } else {
@@ -192,18 +175,18 @@ impl Combinator {
           return None;
         }
         let chunk_key = get_key(chunks.iter().copied(), chunk_index_map);
-        Some((chunk_key, chunks.clone()))
+        Some((chunk_key, Arc::new(chunks.clone())))
       })
       .collect::<FxHashMap<_, _>>();
 
-    let mut chunk_sets_by_count = FxIndexMap::<u32, Vec<FxHashSet<ChunkUkey>>>::default();
+    let mut chunk_sets_by_count = FxIndexMap::<u32, Vec<ChunkCombination>>::default();
     for chunks in chunk_sets_in_graph.values() {
       let count = chunks.len();
 
       chunk_sets_by_count
         .entry(count as u32)
-        .and_modify(|set| set.push(chunks.clone()))
-        .or_insert(vec![chunks.clone()]);
+        .and_modify(|set| set.push(Arc::clone(chunks)))
+        .or_insert_with(|| vec![Arc::clone(chunks)]);
     }
 
     chunk_sets_by_count.sort_keys();
@@ -239,7 +222,7 @@ impl Combinator {
             continue;
           }
           let chunk_key = get_key(chunks.iter().copied(), chunk_index_map);
-          used_exports_chunks.insert(chunk_key, chunks);
+          used_exports_chunks.insert(chunk_key, Arc::clone(&chunks));
           grouped_chunks_key.push(chunk_key);
         }
         Some(((*module, grouped_chunks_key), used_exports_chunks))
@@ -249,12 +232,11 @@ impl Combinator {
     self.grouped_by_exports = module_grouped_chunks.into_iter().collect();
 
     let mut used_exports_chunk_sets_in_graph = FxHashMap::default();
-    let mut used_exports_chunk_sets_by_count =
-      FxIndexMap::<u32, Vec<FxHashSet<ChunkUkey>>>::default();
+    let mut used_exports_chunk_sets_by_count = FxIndexMap::<u32, Vec<ChunkCombination>>::default();
     for used_exports_chunks in used_exports_chunks {
       for (chunk_key, chunks) in used_exports_chunks {
         if used_exports_chunk_sets_in_graph
-          .insert(chunk_key, chunks.clone())
+          .insert(chunk_key, Arc::clone(&chunks))
           .is_some()
         {
           continue;
@@ -281,7 +263,7 @@ impl SplitChunksPlugin {
   pub(crate) fn find_best_module_group(
     &self,
     module_group_map: &mut ModuleGroupMap,
-  ) -> (String, ModuleGroup) {
+  ) -> (ModuleGroupKey, ModuleGroup) {
     debug_assert!(!module_group_map.is_empty());
 
     let best_entry_key = module_group_map
@@ -319,19 +301,18 @@ impl SplitChunksPlugin {
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
   ) -> Result<ModuleGroupMap> {
     let module_graph = compilation.get_module_graph();
-    let module_group_map: FxDashMap<String, ModuleGroup> = FxDashMap::default();
     let module_group_results = rspack_futures::scope::<_, Result<_>>(|token| {
       all_modules.iter().for_each(|mid| {
-        let s = unsafe { token.used((&cache_groups, mid, &module_graph, compilation, &module_group_map, &combinator, module_chunks, removed_module_chunks, chunk_index_map)) };
-        s.spawn(|(cache_groups, mid, module_graph, compilation, module_group_map, combinator, module_chunks, removed_module_chunks, chunk_index_map)| async move {
+        let s = unsafe { token.used((&cache_groups, mid, &module_graph, compilation, &combinator, module_chunks, removed_module_chunks, chunk_index_map)) };
+        s.spawn(|(cache_groups, mid, module_graph, compilation, combinator, module_chunks, removed_module_chunks, chunk_index_map)| async move {
           let belong_to_chunks = module_chunks.get(mid).expect("should have module chunks");
           if belong_to_chunks.is_empty() {
-            return Ok(());
+            return Ok(PendingModuleGroupMap::default());
           }
 
           let removed_chunks = removed_module_chunks.get(mid);
           if let Some(removed_chunks) = removed_chunks && belong_to_chunks.iter().all(|c| removed_chunks.contains(c)) {
-            return Ok(());
+            return Ok(PendingModuleGroupMap::default());
           }
           let module = module_graph.module_by_identifier(mid).expect("should have module").as_ref();
           let module_name_for_condition = module.name_for_condition();
@@ -376,8 +357,9 @@ impl SplitChunksPlugin {
 
             filtered.push(cache_group);
           }
-          let mut used_exports_combs = None;
-          let mut non_used_exports_combs = None;
+          let mut local_module_group_map = PendingModuleGroupMap::default();
+          let mut used_exports_combs = None::<Vec<&ChunkCombination>>;
+          let mut non_used_exports_combs = None::<Vec<&ChunkCombination>>;
 
           for cache_group in filtered {
             let IndexedCacheGroup {
@@ -386,27 +368,23 @@ impl SplitChunksPlugin {
             } = cache_group;
             let combs = if cache_group.used_exports {
               if used_exports_combs.is_none() {
-                used_exports_combs = Some(combinator.get_combs(
-                  *mid,
-                  true,
-                  module_chunks,
-                  chunk_index_map,
-                ));
+                used_exports_combs = Some(combinator.get_used_exports_combs(*mid));
               }
               used_exports_combs.as_ref().expect("should have used_exports_combs")
             } else {
               if non_used_exports_combs.is_none() {
-                non_used_exports_combs = Some(combinator.get_combs(
-                  *mid,
-                  false,
-                  module_chunks,
-                  chunk_index_map,
-                ));
+                non_used_exports_combs = Some(
+                  combinator
+                    .get_non_used_exports_combs(*mid, module_chunks, chunk_index_map)
+                    .iter()
+                    .collect(),
+                );
               }
               non_used_exports_combs.as_ref().expect("should have non_used_exports_combs")
             };
 
             for chunk_combination in combs {
+              let chunk_combination = chunk_combination.as_ref();
               if chunk_combination.is_empty() {
                 continue;
               }
@@ -473,13 +451,13 @@ impl SplitChunksPlugin {
                   cache_group_index: *cache_group_index,
                   selected_chunks,
                 },
-                module_group_map,
+                &mut local_module_group_map,
                 compilation,
                 chunk_index_map,
               ).await?;
             }
           }
-          Ok(())
+          Ok(local_module_group_map)
         });
       })
     })
@@ -487,8 +465,11 @@ impl SplitChunksPlugin {
     .into_iter().map(|r| r.to_rspack_result())
     .collect::<Result<Vec<_>>>()?;
 
+    let mut module_group_map = PendingModuleGroupMap::default();
     for result in module_group_results {
-      result?;
+      for (key, module_group) in result? {
+        merge_module_group(&mut module_group_map, key, module_group);
+      }
     }
 
     // Sort the module_group_map by key to ensure deterministic iteration order
@@ -564,7 +545,7 @@ impl SplitChunksPlugin {
         }
 
         // Validate `min_size` again
-        if remove_min_size_violating_modules(&cache_group.key, other_module_group, cache_group, module_sizes)
+        if remove_min_size_violating_modules(key, other_module_group, cache_group, module_sizes)
           || !Self::check_min_size_reduction(&other_module_group.get_sizes(module_sizes), &cache_group.min_size_reduction, other_module_group.chunks.len()) {
           tracing::trace!(
             "{key} is deleted for violating min_size {:#?}",
@@ -583,9 +564,21 @@ impl SplitChunksPlugin {
   }
 }
 
+fn merge_module_group(
+  module_group_map: &mut PendingModuleGroupMap,
+  key: ModuleGroupKey,
+  module_group: ModuleGroup,
+) {
+  if let Some(existing_module_group) = module_group_map.get_mut(&key) {
+    existing_module_group.merge(module_group);
+  } else {
+    module_group_map.insert(key, module_group);
+  }
+}
+
 async fn merge_matched_item_into_module_group_map(
   matched_item: MatchedItem<'_>,
-  module_group_map: &FxDashMap<String, ModuleGroup>,
+  module_group_map: &mut PendingModuleGroupMap,
   compilation: &Compilation,
   chunk_index_map: &FxHashMap<ChunkUkey, u32>,
 ) -> Result<()> {
@@ -611,26 +604,22 @@ async fn merge_matched_item_into_module_group_map(
       f(ctx).await?
     }
   };
-  let key: String = if let Some(cache_group_name) = &chunk_name {
-    let mut key = String::with_capacity(cache_group.key.len() + cache_group_name.len());
-    key.push_str(&cache_group.key);
-    key.push_str(cache_group_name);
-    key
+  let key = if let Some(cache_group_name) = &chunk_name {
+    ModuleGroupKey::Named {
+      cache_group_index,
+      chunk_name: cache_group_name.clone(),
+    }
   } else {
-    format!(
-      "\0\0{}{:x}",
-      &cache_group.key,
-      get_key(selected_chunks.iter().copied(), chunk_index_map)
-    )
+    ModuleGroupKey::Anonymous {
+      cache_group_index,
+      chunks_key: get_key(selected_chunks.iter().copied(), chunk_index_map),
+    }
   };
 
-  let mut module_group = {
-    module_group_map
-      .entry(key)
-      .or_insert_with(|| ModuleGroup::new(chunk_name, cache_group_index, cache_group))
-  };
+  let mut module_group = ModuleGroup::new(chunk_name, cache_group_index, cache_group);
   module_group.add_module(module.identifier());
   module_group.chunks.extend(selected_chunks.iter().copied());
+  merge_module_group(module_group_map, key, module_group);
 
   Ok(())
 }


### PR DESCRIPTION
## Summary
- reorder split chunks cache group filtering to run `type` and `test` before async `layer` checks
- cache per-module `name_for_condition`, `layer`, and `removed_chunks` lookups during module group creation
- keep the change scoped to `prepare_module_group_map` without changing later module group selection/removal logic

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run build:binding:dev`
- `cargo fmt --all --check`
- `cargo lint`
- `pnpm run test:rs`