### PR TITLE
feat: add TryFutureConsumer with short-circuit cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5240,6 +5240,7 @@ dependencies = [
  "itertools 0.14.0",
  "rspack_error",
  "rspack_fs",
+ "rspack_parallel",
  "rspack_paths",
  "rustc-hash",
  "tokio",

--- a/crates/rspack_parallel/src/iterator_consumer/mod.rs
+++ b/crates/rspack_parallel/src/iterator_consumer/mod.rs
@@ -1,5 +1,7 @@
 mod future;
 mod rayon;
+mod try_future;
 
 pub use future::FutureConsumer;
 pub use rayon::RayonConsumer;
+pub use try_future::TryFutureConsumer;

--- a/crates/rspack_parallel/src/iterator_consumer/try_future.rs
+++ b/crates/rspack_parallel/src/iterator_consumer/try_future.rs
@@ -1,0 +1,89 @@
+use std::{future::Future, sync::Arc};
+
+use rspack_tasks::spawn_in_context;
+use tokio::{sync::mpsc::unbounded_channel, task::JoinHandle};
+
+/// Like [`FutureConsumer`](super::future::FutureConsumer), but for fallible futures.
+///
+/// Spawns all futures concurrently. Calls `func` for each `Ok` value as it
+/// arrives. On the first `Err`, cancels remaining tasks and returns that error.
+pub trait TryFutureConsumer {
+  type Ok;
+  type Err;
+  fn try_fut_consume(
+    self,
+    func: impl FnMut(Self::Ok) + Send,
+  ) -> impl Future<Output = Result<(), Self::Err>>;
+}
+
+impl<I, Fut, T, E> TryFutureConsumer for I
+where
+  I: Iterator<Item = Fut>,
+  Fut: Future<Output = Result<T, E>> + Send + 'static,
+  T: Send + 'static,
+  E: Send + 'static,
+{
+  type Ok = T;
+  type Err = E;
+
+  fn try_fut_consume(
+    self,
+    mut func: impl FnMut(Self::Ok) + Send,
+  ) -> impl Future<Output = Result<(), Self::Err>> {
+    let (tx, rx) = unbounded_channel::<Result<T, E>>();
+    let tx = Arc::new(tx);
+    let handles: Vec<JoinHandle<()>> = self
+      .map(|fut| {
+        let tx = tx.clone();
+        spawn_in_context(async move {
+          let data = fut.await;
+          // Ignore send errors: the channel may already be closed.
+          tx.send(data).ok();
+        })
+      })
+      .collect();
+    // Drop our copy so the channel closes once all tasks finish.
+    drop(tx);
+
+    async move {
+      let mut rx = rx;
+      while let Some(result) = rx.recv().await {
+        match result {
+          Ok(v) => func(v),
+          Err(e) => {
+            rx.close();
+            // Best-effort: abort tasks still waiting at an .await point.
+            for handle in &handles {
+              handle.abort();
+            }
+            return Err(e);
+          }
+        }
+      }
+      Ok(())
+    }
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::TryFutureConsumer;
+
+  #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+  async fn try_available() {
+    let result: Result<(), &str> = (0..10)
+      .map(|item| async move { Ok::<_, &str>(item * 2) })
+      .try_fut_consume(|item| assert_eq!(item % 2, 0))
+      .await;
+    assert!(result.is_ok());
+  }
+
+  #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+  async fn try_short_circuits_on_error() {
+    let result: Result<(), &str> = (0..10)
+      .map(|item| async move { if item == 5 { Err("boom") } else { Ok(item) } })
+      .try_fut_consume(|item| assert!(item < 5))
+      .await;
+    assert_eq!(result, Err("boom"));
+  }
+}

--- a/crates/rspack_parallel/src/lib.rs
+++ b/crates/rspack_parallel/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
   mem::{ManuallyDrop, MaybeUninit},
 };
 
-pub use iterator_consumer::{FutureConsumer, RayonConsumer};
+pub use iterator_consumer::{FutureConsumer, RayonConsumer, TryFutureConsumer};
 pub use scope::scope;
 
 /// par_iter then collect into vec

--- a/crates/rspack_storage/Cargo.toml
+++ b/crates/rspack_storage/Cargo.toml
@@ -9,15 +9,16 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait  = { workspace = true }
-cow-utils    = { workspace = true }
-futures      = { workspace = true }
-itertools    = { workspace = true }
-rspack_error = { workspace = true }
-rspack_fs    = { workspace = true }
-rspack_paths = { workspace = true }
-rustc-hash   = { workspace = true }
-tokio        = { workspace = true, features = ["time"] }
+async-trait     = { workspace = true }
+cow-utils       = { workspace = true }
+futures         = { workspace = true }
+itertools       = { workspace = true }
+rspack_error    = { workspace = true }
+rspack_fs       = { workspace = true }
+rspack_parallel = { workspace = true }
+rspack_paths    = { workspace = true }
+rustc-hash      = { workspace = true }
+tokio           = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/crates/rspack_storage/src/filesystem/db/bucket/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/bucket/mod.rs
@@ -2,8 +2,8 @@ mod index;
 mod meta;
 mod pack;
 
-use futures::future::try_join_all;
 use pack::{PackGenerator, PackId, PackIdAlloc};
+use rspack_parallel::TryFutureConsumer;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use self::{meta::Meta, pack::Pack};
@@ -58,7 +58,7 @@ impl Bucket {
     let mut result = self.hot_pack.clone().data();
 
     // Load and verify all cold packs
-    let tasks = self
+    self
       .meta
       .cold_pack_indexes()
       .iter()
@@ -66,7 +66,7 @@ impl Bucket {
         let fs = self.fs.clone();
         let pack_id = *pack_id;
         let expected_hash = index.content_hash();
-        tokio::spawn(async move {
+        async move {
           let (pack, hash) = Pack::load(&fs, pack_id).await?;
           if hash != expected_hash {
             return Err(Error::CorruptedData(format!(
@@ -77,15 +77,11 @@ impl Bucket {
             )));
           }
           Ok(pack)
-        })
-      });
-    let results = try_join_all(tasks)
-      .await?
-      .into_iter()
-      .collect::<Result<Vec<_>>>()?;
-    for pack in results {
-      result.extend(pack.data());
-    }
+        }
+      })
+      .try_fut_consume(|pack| result.extend(pack.data()))
+      .await?;
+
     Ok(result)
   }
 
@@ -142,28 +138,26 @@ impl Bucket {
     }
 
     // Perform parallel writes on multiple threads
-    let results = try_join_all(pending_packs.into_iter().map(|(pack_id, pack)| {
-      let fs = writable_fs.clone();
-      tokio::spawn(async move {
-        let index = pack.save(&fs, pack_id).await?;
-        Ok::<_, Error>((pack_id, pack, index))
+    let mut added_files = Vec::with_capacity(pending_packs.len());
+    pending_packs
+      .into_iter()
+      .map(|(pack_id, pack)| {
+        let fs = writable_fs.clone();
+        async move {
+          let index = pack.save(&fs, pack_id).await?;
+          Ok::<_, Error>((pack_id, pack, index))
+        }
       })
-    }))
-    .await?
-    .into_iter()
-    .collect::<Result<Vec<_>>>()?;
-
-    // Update metadata with results
-    let mut added_files = Vec::with_capacity(results.len());
-    for (pack_id, pack, index) in results {
-      if pack_id == PackIdAlloc::HOT_PACK_ID {
-        self.hot_pack = pack;
-      }
-      self.meta.update_pack_index(pack_id, Some(index));
-      // Remove reused pack id
-      removed_pack_ids.remove(&pack_id);
-      added_files.push(pack_id.pack_name());
-    }
+      .try_fut_consume(|(pack_id, pack, index)| {
+        if pack_id == PackIdAlloc::HOT_PACK_ID {
+          self.hot_pack = pack;
+        }
+        self.meta.update_pack_index(pack_id, Some(index));
+        // Remove reused pack id
+        removed_pack_ids.remove(&pack_id);
+        added_files.push(pack_id.pack_name());
+      })
+      .await?;
 
     // Collect removed pack files
     let removed_files = removed_pack_ids

--- a/crates/rspack_storage/src/filesystem/db/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/mod.rs
@@ -4,7 +4,7 @@ mod transaction;
 
 use std::{collections::hash_map::Entry, sync::Arc};
 
-use futures::future::try_join_all;
+use rspack_parallel::TryFutureConsumer;
 use rustc_hash::FxHashMap as HashMap;
 use tokio::sync::Mutex;
 
@@ -108,11 +108,14 @@ impl DB {
           })
           .collect();
 
-        let results = try_join_all(pending_buckets.into_iter().map(
-          |(bucket_name, cached_bucket, changes)| {
+        let mut all_files_to_add = Vec::new();
+        let mut all_files_to_remove = Vec::new();
+        pending_buckets
+          .into_iter()
+          .map(|(bucket_name, cached_bucket, changes)| {
             let readable_fs = transaction.readable_fs().child_fs(&bucket_name);
             let writable_fs = transaction.writable_fs().child_fs(&bucket_name);
-            tokio::spawn(async move {
+            async move {
               // Initialize bucket if not already cached (runs in parallel across buckets)
               let mut bucket = if let Some(bucket) = cached_bucket {
                 bucket
@@ -123,29 +126,23 @@ impl DB {
                 .save(Some(writable_fs), changes, max_pack_size)
                 .await?;
               Ok::<_, Error>((bucket_name, bucket, affacted_files))
-            })
-          },
-        ))
-        .await?
-        .into_iter()
-        .collect::<Result<Vec<_>>>()?;
-
-        let mut all_files_to_add = Vec::new();
-        let mut all_files_to_remove = Vec::new();
-        for (bucket_name, bucket, affacted_files) in results {
-          let (added_pack, removed_pack) = affacted_files;
-          buckets.insert(bucket_name.clone(), bucket);
-          all_files_to_add.extend(
-            added_pack
-              .into_iter()
-              .map(|file| format!("{bucket_name}/{file}")),
-          );
-          all_files_to_remove.extend(
-            removed_pack
-              .into_iter()
-              .map(|file| format!("{bucket_name}/{file}")),
-          );
-        }
+            }
+          })
+          .try_fut_consume(|(bucket_name, bucket, affacted_files)| {
+            let (added_pack, removed_pack) = affacted_files;
+            buckets.insert(bucket_name.clone(), bucket);
+            all_files_to_add.extend(
+              added_pack
+                .into_iter()
+                .map(|file| format!("{bucket_name}/{file}")),
+            );
+            all_files_to_remove.extend(
+              removed_pack
+                .into_iter()
+                .map(|file| format!("{bucket_name}/{file}")),
+            );
+          })
+          .await?;
 
         // Atomically commit all changes
         transaction


### PR DESCRIPTION
## Summary

* add TryFutureConsumer with short-circuit cancellation
``` rust
let result: Result<(), &str> = (0..10)
      .map(|item| async move { if item == 5 { Err("boom") } else { Ok(item) } })
      .try_fut_consume(|item| { assert!(item < 5); } )
      .await;
assert_eq!(result, Err("boom"));
```
* rspack_storage crate use TryFutureConsumer

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
