### PR TITLE
Fix rspack timing logger to align compiler phases with webpack

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/mod.rs
@@ -17,14 +17,10 @@ pub use self::{
   module_executor::{ExecuteModuleId, ExecutedRuntimeModule, ModuleExecutor},
 };
 pub use crate::{BuildModuleGraphArtifact, BuildModuleGraphArtifactState};
-use crate::{Compilation, ExportsInfoArtifact, logger::Logger};
+use crate::{Compilation, ExportsInfoArtifact};
 
 pub async fn build_module_graph_pass(compilation: &mut Compilation) -> Result<()> {
-  let logger = compilation.get_logger("rspack.Compiler");
-  let start = logger.time("build module graph");
-  do_build_module_graph(compilation).await?;
-  logger.time_end(start);
-  Ok(())
+  do_build_module_graph(compilation).await
 }
 
 #[instrument("Compilation:build_module_graph",target=TRACING_BENCH_TARGET, skip_all)]

--- a/crates/rspack_core/src/compilation/build_module_graph/pass.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/pass.rs
@@ -5,10 +5,8 @@ use super::build_module_graph_pass;
 use crate::{
   Compilation,
   cache::Cache,
-  compilation::{
-    finish_make::finish_make_pass, finish_module_graph::finish_module_graph_pass,
-    make::make_hook_pass, pass::PassExt,
-  },
+  compilation::{finish_make::finish_make_pass, make::make_hook_pass, pass::PassExt},
+  logger::Logger,
 };
 
 /// Composite pass for the entire Build Module Graph phase.
@@ -17,7 +15,6 @@ use crate::{
 /// - make hook
 /// - build module graph
 /// - finish make
-/// - finish module graph
 pub struct BuildModuleGraphPhasePass;
 
 #[async_trait]
@@ -41,30 +38,18 @@ impl PassExt for BuildModuleGraphPhasePass {
     _cache: &mut dyn Cache,
   ) -> Result<()> {
     let plugin_driver = compilation.plugin_driver.clone();
+    let logger = compilation.get_logger("rspack.Compiler");
 
-    // Sub-phase: make hook
+    // webpack's `make hook` timing includes building the module graph.
+    let start = logger.time("make hook");
     make_hook_pass(compilation, plugin_driver.clone()).await?;
-
-    // Sub-phase: build module graph
     build_module_graph_pass(compilation).await?;
+    logger.time_end(start);
 
-    // Sub-phase: finish make
+    let start = logger.time("finish make hook");
     finish_make_pass(compilation, plugin_driver.clone()).await?;
+    logger.time_end(start);
 
-    // Sub-phase: finish module graph
-    finish_module_graph_pass(compilation).await?;
-
-    // Add checkpoint if incremental build is enabled
-    use crate::incremental::IncrementalPasses;
-    if compilation
-      .incremental
-      .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
-    {
-      compilation
-        .build_module_graph_artifact
-        .module_graph
-        .checkpoint();
-    }
     Ok(())
   }
 

--- a/crates/rspack_core/src/compilation/finish_make/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_make/mod.rs
@@ -1,19 +1,14 @@
 use rspack_error::Result;
 
-use crate::{Compilation, SharedPluginDriver, logger::Logger};
+use crate::{Compilation, SharedPluginDriver};
 
 pub async fn finish_make_pass(
   compilation: &mut Compilation,
   plugin_driver: SharedPluginDriver,
 ) -> Result<()> {
-  let logger = compilation.get_logger("rspack.Compiler");
-  let start = logger.time("finish make hook");
   plugin_driver
     .compiler_hooks
     .finish_make
     .call(compilation)
-    .await?;
-  logger.time_end(start);
-
-  Ok(())
+    .await
 }

--- a/crates/rspack_core/src/compilation/finish_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_module_graph/mod.rs
@@ -4,18 +4,10 @@ use rspack_error::Result;
 use rspack_util::tracing_preset::TRACING_BENCH_TARGET;
 use tracing::instrument;
 
-use crate::{
-  Compilation, compilation::build_module_graph::finish_build_module_graph, logger::Logger,
-};
+use crate::{Compilation, compilation::build_module_graph::finish_build_module_graph};
 
 pub async fn finish_module_graph_pass(compilation: &mut Compilation) -> Result<()> {
-  let logger = compilation.get_logger("rspack.Compiler");
-  let start = logger.time("finish compilation");
-  finish_build_module_graph_pass(compilation).await?;
-
-  logger.time_end(start);
-
-  Ok(())
+  finish_build_module_graph_pass(compilation).await
 }
 
 #[instrument("Compilation:finish",target=TRACING_BENCH_TARGET, skip_all)]

--- a/crates/rspack_core/src/compilation/make/mod.rs
+++ b/crates/rspack_core/src/compilation/make/mod.rs
@@ -1,16 +1,10 @@
 use rspack_error::Result;
 
-use crate::{Compilation, SharedPluginDriver, logger::Logger};
+use crate::{Compilation, SharedPluginDriver};
 
 pub async fn make_hook_pass(
   compilation: &mut Compilation,
   plugin_driver: SharedPluginDriver,
 ) -> Result<()> {
-  let logger = compilation.get_logger("rspack.Compiler");
-
-  let start = logger.time("make hook");
-  plugin_driver.compiler_hooks.make.call(compilation).await?;
-  logger.time_end(start);
-
-  Ok(())
+  plugin_driver.compiler_hooks.make.call(compilation).await
 }

--- a/crates/rspack_core/src/compilation/run_passes.rs
+++ b/crates/rspack_core/src/compilation/run_passes.rs
@@ -4,14 +4,17 @@ use super::{
   build_module_graph::pass::BuildModuleGraphPhasePass, chunk_ids::ChunkIdsPass,
   code_generation::CodeGenerationPass, create_chunk_assets::CreateChunkAssetsPass,
   create_hash::CreateHashPass, create_module_assets::CreateModuleAssetsPass,
-  create_module_hashes::CreateModuleHashesPass, finish_modules::FinishModulesPhasePass,
-  module_ids::ModuleIdsPass, optimize_chunk_modules::OptimizeChunkModulesPass,
-  optimize_chunks::OptimizeChunksPass, optimize_code_generation::OptimizeCodeGenerationPass,
+  create_module_hashes::CreateModuleHashesPass, finish_module_graph::finish_module_graph_pass,
+  finish_modules::FinishModulesPhasePass, module_ids::ModuleIdsPass,
+  optimize_chunk_modules::OptimizeChunkModulesPass, optimize_chunks::OptimizeChunksPass,
+  optimize_code_generation::OptimizeCodeGenerationPass,
   optimize_dependencies::OptimizeDependenciesPass, optimize_modules::OptimizeModulesPass,
   optimize_tree::OptimizeTreePass, pass::PassExt, process_assets::ProcessAssetsPass,
   runtime_requirements::RuntimeRequirementsPass, seal::SealPass, *,
 };
-use crate::{Compilation, SharedPluginDriver, cache::Cache};
+use crate::{
+  Compilation, SharedPluginDriver, cache::Cache, incremental::IncrementalPasses, logger::Logger,
+};
 
 impl Compilation {
   pub async fn run_passes(
@@ -19,9 +22,7 @@ impl Compilation {
     _plugin_driver: SharedPluginDriver,
     cache: &mut dyn Cache,
   ) -> Result<()> {
-    let passes: Vec<Box<dyn PassExt>> = vec![
-      Box::new(BuildModuleGraphPhasePass),
-      Box::new(FinishModulesPhasePass),
+    let seal_passes: Vec<Box<dyn PassExt>> = vec![
       Box::new(SealPass),
       Box::new(OptimizeDependenciesPass),
       Box::new(BuildChunkGraphPass),
@@ -47,9 +48,29 @@ impl Compilation {
       self.module_static_cache.enable_new_cache();
     }
 
-    for pass in &passes {
+    let build_module_graph_phase = BuildModuleGraphPhasePass;
+    build_module_graph_phase.run(self, cache).await?;
+
+    let logger = self.get_logger("rspack.Compiler");
+
+    let start = logger.time("finish compilation");
+    finish_module_graph_pass(self).await?;
+    if self
+      .incremental
+      .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
+    {
+      self.build_module_graph_artifact.module_graph.checkpoint();
+    }
+    let finish_modules_phase = FinishModulesPhasePass;
+    finish_modules_phase.run(self, cache).await?;
+    logger.time_end(start);
+
+    let start = logger.time("seal compilation");
+    for pass in &seal_passes {
       pass.run(self, cache).await?;
     }
+    logger.time_end(start);
+
     if !self.options.mode.is_development() {
       self.module_static_cache.disable_cache();
     }

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -293,13 +293,10 @@ impl Compiler {
       .call(&mut self.compilation, &mut compilation_params)
       .await?;
 
-    let logger = self.compilation.get_logger("rspack.Compiler");
-    let start = logger.time("seal compilation");
     self
       .compilation
       .run_passes(self.plugin_driver.clone(), &mut *self.cache)
       .await?;
-    logger.time_end(start);
 
     // Consume plugin driver diagnostic
     let plugin_driver_diagnostics = self.plugin_driver.take_diagnostic();

--- a/tests/rspack-test/statsOutputCases/logging/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/logging/__snapshots__/stats.txt
@@ -83,7 +83,6 @@ LOG from rspack.Compilation
 
 LOG from rspack.Compiler
 <t> make hook: xx ms
-<t> build module graph: xx ms
 <t> finish make hook: xx ms
 <t> finish compilation: xx ms
 <t> seal compilation: xx ms

--- a/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
@@ -72,7 +72,6 @@ LOG from rspack.Compilation
 
 LOG from rspack.Compiler
 <t> make hook: xx ms
-<t> build module graph: xx ms
 <t> finish make hook: xx ms
 <t> finish compilation: xx ms
 <t> seal compilation: xx ms


### PR DESCRIPTION
## Summary
- move compiler timing boundaries so `make hook` includes module graph building, matching webpack
- start `finish compilation` after the make phase and start `seal compilation` only for the seal and post-seal pass sequence
- remove the extra compiler-level `build module graph` timing entry and update verbose stats snapshots accordingly

## Testing
- `cargo fmt --all --check`
- `pnpm run build:binding:dev`
- `pnpm --filter "@rspack/core" build`
- `pnpm --dir tests/rspack-test test StatsOutput.test.js Config.part2.test.js Config.part3.test.js --testNamePattern 'rspack-issue-1652|rspack-issue-5548|rspack-issue-4338|swc-js-minifier|logging|preset-verbose'`
- `cargo clippy -p rspack_core --all-targets -- -D warnings`