### PR TITLE
chore(backport): use OIDC to publish crates

### DIFF
--- a/.github/workflows/reusable-release-crates.yml
+++ b/.github/workflows/reusable-release-crates.yml
@@ -27,6 +27,7 @@ jobs:
     name: Release Crates
     permissions:
       contents: write
+      id-token: write
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS ||  '"ubuntu-22.04"') }}
     needs: [rust_tests]
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -56,8 +57,11 @@ jobs:
       - name: Run Cargo codegen
         run: cargo codegen
 
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+        id: auth
+
       - name: Publish Crates
         run: |
           ./x crate-publish --token $CARGO_REGISTRY_TOKEN ${{ inputs.dry_run && '--dry-run' || '' }} ${{ inputs.push_tags && '--push-tags' || '' }}
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary

Backport of #13543 to v1.x branch.

- Add `id-token: write` permission for OIDC authentication
- Use `rust-lang/crates-io-auth-action` to get auth token
- Replace static `CARGO_REGISTRY_TOKEN` secret with OIDC-based token