### PR TITLE
chore: change CodSpeed baseline branch from main to v1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ on:
     types: [opened, synchronize]
   push:
     branches:
-      - main
-      - v2
+      - v1.x
     paths-ignore:
       - '**/*.md'
       - 'website/**'
@@ -24,7 +23,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'v2' }}
+  cancel-in-progress: ${{ github.ref_name != 'v1.x' }}
 
 permissions:
   # Allow commenting on issues for `reusable-build.yml`


### PR DESCRIPTION
## Summary
- Change CI push trigger branches from `main`/`v2` to `v1.x`
- Update concurrency cancel-in-progress to protect `v1.x` branch

## Why
The `v1.x` branch is the active development branch for v1, but CodSpeed was still comparing PR benchmarks against `main`. This caused misleading performance regression detection since the baseline data came from a different branch. Switching the baseline to `v1.x` ensures CodSpeed compares against the correct reference point.

## Test plan
- [ ] Verify CodSpeed benchmark runs on push to `v1.x`
- [ ] Verify PR benchmark comparisons use `v1.x` as baseline