### PR TITLE
refactor(storage): db switch to readonly mode when save failed

### DIFF
--- a/crates/rspack_storage/src/filesystem/db/bucket/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/bucket/mod.rs
@@ -121,12 +121,7 @@ impl Bucket {
     }
     let hot_pack = std::mem::take(&mut self.hot_pack);
     pack_generator.extend(hot_pack.data());
-    pack_generator.extend(
-      data
-        .into_iter()
-        .filter_map(|(k, v)| v.map(|v| (k, v)))
-        .collect(),
-    );
+    pack_generator.extend(data.into_iter().filter_map(|(k, v)| v.map(|v| (k, v))));
     let (hot_pack, new_packs) = pack_generator.finish();
 
     // Alloc id for packs

--- a/crates/rspack_storage/src/filesystem/db/bucket/pack/generator.rs
+++ b/crates/rspack_storage/src/filesystem/db/bucket/pack/generator.rs
@@ -31,7 +31,7 @@ impl PackGenerator {
   ///
   /// Large items (>80% of max size) are isolated to avoid fragmentation.
   /// Regular items are grouped until a pack reaches max size.
-  pub fn extend(&mut self, data: Vec<(Vec<u8>, Vec<u8>)>) {
+  pub fn extend<T: IntoIterator<Item = (Vec<u8>, Vec<u8>)>>(&mut self, data: T) {
     for (key, value) in data {
       let size = key.len() + value.len();
 
@@ -70,16 +70,12 @@ mod test {
   #[test]
   fn test_pack_generator() {
     let mut generator = PackGenerator::new(25);
-    generator.extend(
-      (0..9)
-        .map(|num| {
-          (
-            format!("key{num}").as_bytes().to_vec(),
-            format!("value{num}").as_bytes().to_vec(),
-          )
-        })
-        .collect(),
-    );
+    generator.extend((0..9).map(|num| {
+      (
+        format!("key{num}").as_bytes().to_vec(),
+        format!("value{num}").as_bytes().to_vec(),
+      )
+    }));
     let (hot_pack, packs) = generator.finish();
     assert_eq!(packs.len(), 4);
     assert_eq!(hot_pack.data.len(), 1);

--- a/crates/rspack_storage/src/filesystem/db/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/mod.rs
@@ -2,7 +2,13 @@ mod bucket;
 mod task_queue;
 mod transaction;
 
-use std::{collections::hash_map::Entry, sync::Arc};
+use std::{
+  collections::hash_map::Entry,
+  sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+  },
+};
 
 use rspack_parallel::TryFutureConsumer;
 use rustc_hash::FxHashMap as HashMap;
@@ -25,7 +31,8 @@ pub struct DB {
   /// Cached buckets, lazily loaded on first access
   buckets: Arc<Mutex<HashMap<String, Bucket>>>,
   /// Background task queue for asynchronous save operations
-  task_queue: TaskQueue,
+  task_queue: Arc<TaskQueue>,
+  readonly: Arc<AtomicBool>,
 }
 
 impl DB {
@@ -34,7 +41,8 @@ impl DB {
     Self {
       fs,
       buckets: Default::default(),
-      task_queue: TaskQueue::default(),
+      task_queue: Arc::new(TaskQueue::default()),
+      readonly: Arc::new(AtomicBool::new(false)),
     }
   }
 
@@ -60,13 +68,13 @@ impl DB {
   }
 
   /// Loads all key-value pairs from the specified bucket.
-  ///
-  /// If the bucket doesn't exist yet, it will be created empty.
-  /// Updates the database metadata with current access time.
   pub async fn load(&self, bucket_name: &str) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
-    self.fs.ensure_exist().await?;
-
     let mut buckets = self.buckets.lock().await;
+
+    self.fs.ensure_exist().await?;
+    // Ensure any crashed prior transaction is recovered before we read.
+    Transaction::ensure_committed(&self.fs).await?;
+
     let bucket = match buckets.entry(bucket_name.to_string()) {
       Entry::Occupied(entry) => entry.into_mut(),
       Entry::Vacant(entry) => {
@@ -85,21 +93,24 @@ impl DB {
   /// - `Some(value)`: Set or update the key
   /// - `None`: Remove the key
   ///
-  /// The write is performed asynchronously by the background [`TaskQueue`] worker.
-  /// Call [`DB::flush`] to wait until the enqueued write has completed.
+  /// No-op when the DB is in readonly mode.
   pub fn save(&self, changes: BucketChanges, max_pack_size: usize) {
     let fs = self.fs.clone();
     let buckets = self.buckets.clone();
+    let readonly = self.readonly.clone();
 
     self.task_queue.add_task(async move {
-      let task_fn = async move || -> Result<()> {
-        let transaction = Transaction::new(&fs).await?;
+      if readonly.load(Ordering::Relaxed) {
+        return;
+      }
 
-        // Acquire write lock for the entire commit operation
+      let task_fn = async move || -> Result<()> {
         let mut buckets = buckets.lock().await;
 
-        // Separate cached buckets from those that need initialization,
-        // so both Bucket::new and bucket.save can run in parallel.
+        let transaction = Transaction::new(&fs).await?;
+
+        // Split changes into cached vs. uncached buckets so Bucket::new and
+        // bucket.save can run concurrently across buckets.
         let pending_buckets: Vec<_> = changes
           .into_iter()
           .map(|(bucket_name, bucket_changes)| {
@@ -110,7 +121,8 @@ impl DB {
 
         let mut all_files_to_add = Vec::new();
         let mut all_files_to_remove = Vec::new();
-        pending_buckets
+        let mut updated_buckets = HashMap::default();
+        let save_result = pending_buckets
           .into_iter()
           .map(|(bucket_name, cached_bucket, changes)| {
             let readable_fs = transaction.readable_fs().child_fs(&bucket_name);
@@ -130,7 +142,7 @@ impl DB {
           })
           .try_fut_consume(|(bucket_name, bucket, affacted_files)| {
             let (added_pack, removed_pack) = affacted_files;
-            buckets.insert(bucket_name.clone(), bucket);
+            updated_buckets.insert(bucket_name.clone(), bucket);
             all_files_to_add.extend(
               added_pack
                 .into_iter()
@@ -142,17 +154,33 @@ impl DB {
                 .map(|file| format!("{bucket_name}/{file}")),
             );
           })
-          .await?;
+          .await;
 
-        // Atomically commit all changes
-        transaction
-          .commit(all_files_to_add, all_files_to_remove)
-          .await
+        match save_result {
+          Ok(()) => {
+            transaction
+              .commit(all_files_to_add, all_files_to_remove)
+              .await?;
+            buckets.extend(updated_buckets);
+          }
+          Err(e) => {
+            transaction.rollback().await?;
+            return Err(e);
+          }
+        }
+        Ok(())
       };
 
       if let Err(err) = task_fn().await {
-        // TODO use infrastructure logger instead of println
-        println!("persistent cache save failed. {err}");
+        // The cache may be in an indeterminate state. Switch to readonly so no
+        // further writes can make things worse. Restart the process to recover.
+        // The current build is not affected.
+        readonly.store(true, Ordering::Relaxed);
+        println!(
+          "Rspack persistent cache save failed: {err}\n  \
+           Persistent cache has been disabled for this session. \
+           Restart the process to re-enable it."
+        );
       }
     });
   }

--- a/crates/rspack_storage/src/filesystem/db/transaction/lock/commit.rs
+++ b/crates/rspack_storage/src/filesystem/db/transaction/lock/commit.rs
@@ -23,6 +23,8 @@ pub struct CommitLock {
 
 impl CommitLock {
   pub fn new(added_files: Vec<String>, removed_files: Vec<String>) -> Self {
+    // added_files and removed_files should be mutually exclusive.
+    debug_assert!(!removed_files.iter().any(|item| added_files.contains(item)));
     Self {
       added_files,
       removed_files,

--- a/crates/rspack_storage/src/filesystem/db/transaction/lock/state.rs
+++ b/crates/rspack_storage/src/filesystem/db/transaction/lock/state.rs
@@ -79,6 +79,11 @@ impl StateLock {
     Ok(())
   }
 
+  /// Remove state lock from filesystem
+  pub async fn remove(fs: &ScopeFileSystem) -> Result<()> {
+    fs.remove_file(STATE_LOCK_FILE).await
+  }
+
   /// Checks if the process recorded in this lock is currently running.
   pub fn is_running(&self) -> bool {
     let Some(actual_name) = get_process_name(self.pid) else {

--- a/crates/rspack_storage/src/filesystem/db/transaction/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/transaction/mod.rs
@@ -22,55 +22,54 @@ pub struct Transaction {
 }
 
 impl Transaction {
-  /// Creates a new transaction, performing crash recovery if needed.
+  /// Creates a new transaction.
   pub async fn new(root_fs: &ScopeFileSystem) -> Result<Self> {
+    // Replay any interrupted commit from a previous crashed process.
+    Self::ensure_committed(root_fs).await?;
+
     let root_fs = root_fs.clone();
     let temp_fs = root_fs.child_fs(".temp");
+    temp_fs.ensure_exist().await?;
 
-    let transaction = Self { root_fs, temp_fs };
-    transaction.init().await?;
+    // Create state lock for current process
+    let state_lock = StateLock::default();
+    state_lock.save(&temp_fs).await?;
 
-    Ok(transaction)
+    Ok(Self { root_fs, temp_fs })
   }
 
-  /// Initializes the transaction, checking for stale locks and recovering crashed commits.
-  async fn init(&self) -> Result<()> {
-    // Try to load existing state lock
-    let state_lock = match StateLock::load(&self.temp_fs).await {
+  /// Ensures any previously interrupted commit is fully applied before reading.
+  pub async fn ensure_committed(root_fs: &ScopeFileSystem) -> Result<()> {
+    let temp_fs = root_fs.child_fs(".temp");
+    let state_lock = match StateLock::load(&temp_fs).await {
       Ok(lock) => Some(lock),
       Err(e) if e.is_not_found() => None,
       Err(e) => return Err(e),
     };
-
-    if let Some(state_lock) = state_lock {
-      if state_lock.is_running() {
-        // Another process is actively using this transaction
-        panic!(
-          "Transaction already in progress by process {} in directory '{}'",
-          state_lock, self.temp_fs
-        );
-      } else {
-        // Process crashed - attempt to recover
-        let commit_lock = match CommitLock::load(&self.temp_fs).await {
-          Ok(lock) => Some(lock),
-          Err(e) if e.is_not_found() => None,
-          Err(e) => return Err(e),
-        };
-
-        if let Some(commit_lock) = commit_lock {
-          // Recover incomplete commit
-          self.execute_commit(&commit_lock).await?;
-        }
-      }
+    if let Some(state_lock) = state_lock
+      && state_lock.is_running()
+    {
+      // Another process is actively using this transaction
+      panic!("Transaction already in progress by process {state_lock} in directory '{temp_fs}'",);
     }
 
-    // Clean up temp directory and prepare for new transaction
-    self.temp_fs.remove().await?;
-    self.temp_fs.ensure_exist().await?;
+    // Process crashed — check for a pending commit.lock
+    let commit_lock = match CommitLock::load(&temp_fs).await {
+      Ok(lock) => Some(lock),
+      Err(e) if e.is_not_found() => None,
+      Err(e) => return Err(e),
+    };
+    if let Some(commit_lock) = commit_lock {
+      let transaction = Self {
+        root_fs: root_fs.clone(),
+        temp_fs: temp_fs.clone(),
+      };
+      transaction.execute_commit(&commit_lock).await?;
+      // Clean up temp directory
+      temp_fs.remove().await?;
+    }
 
-    // Create state lock for current process
-    let state_lock = StateLock::default();
-    state_lock.save(&self.temp_fs).await
+    Ok(())
   }
 
   /// Returns the readable filesystem (committed files).
@@ -94,27 +93,39 @@ impl Transaction {
     removed_relative_path: Vec<String>,
   ) -> Result<()> {
     // Verify this transaction still belongs to current process
-    let state_lock = StateLock::load(&self.temp_fs).await?;
-
-    if !state_lock.is_current() {
-      panic!(
+    match StateLock::load(&self.temp_fs).await {
+      Ok(state_lock) if state_lock.is_current() => {}
+      Ok(state_lock) => panic!(
         "State lock mismatch in '{}': expected current process (pid={}), found {}. \
          This indicates a race condition.",
         self.temp_fs,
         std::process::id(),
         state_lock
-      );
+      ),
+      Err(e) => {
+        // Failed to read state lock — rollback and surface the error.
+        let _ = self.temp_fs.remove().await;
+        return Err(e);
+      }
     }
 
     // Write commit lock to record operations (for crash recovery)
     let commit_lock = CommitLock::new(added_relative_path, removed_relative_path);
-    commit_lock.save(&self.temp_fs).await?;
+    if let Err(e) = commit_lock.save(&self.temp_fs).await {
+      // Failed to write commit lock - rollback and surface the error.
+      let _ = self.temp_fs.remove().await;
+      return Err(e);
+    }
 
     // Execute the commit operations
-    self.execute_commit(&commit_lock).await?;
+    if let Err(e) = self.execute_commit(&commit_lock).await {
+      // Failed to commit, remove state lock
+      let _ = StateLock::remove(&self.temp_fs).await;
+      return Err(e);
+    }
 
-    // Clean up temp directory
-    self.temp_fs.remove().await?;
+    // Clean up temp directory and ignore error
+    let _ = self.temp_fs.remove().await;
     Ok(())
   }
 
@@ -131,6 +142,11 @@ impl Transaction {
     }
 
     Ok(())
+  }
+
+  /// Rollback the transaction, discard all changes.
+  pub async fn rollback(self) -> Result<()> {
+    self.temp_fs.remove().await
   }
 }
 


### PR DESCRIPTION
## Summary

* If the database fails to save data, the data will be rollback and the database will be switched to readonly mode to protect the database data security and prevent data loss due to incremental save logic.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
