### PR TITLE
fix(cli): bundle lazy-loaded helper deps

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -31,11 +31,8 @@
     "dev": "rslib build -w",
     "test": "rstest"
   },
-  "dependencies": {
-    "@discoveryjs/json-ext": "^0.5.7",
-    "exit-hook": "^4.0.0"
-  },
   "devDependencies": {
+    "@discoveryjs/json-ext": "^0.5.7",
     "@rslib/core": "0.20.2",
     "@rspack/core": "workspace:*",
     "@rspack/dev-server": "2.0.0-beta.7",
@@ -44,6 +41,7 @@
     "concat-stream": "^2.0.0",
     "cross-env": "^10.1.0",
     "execa": "^5.1.1",
+    "exit-hook": "^4.0.0",
     "pirates": "^4.0.7",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.2"

--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -27,7 +27,9 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
   let createJsonStringifyStream: typeof import('@discoveryjs/json-ext').stringifyStream;
 
   if (options.json) {
-    const jsonExt = await import('@discoveryjs/json-ext');
+    const jsonExt = await import(
+      /* webpackChunkName: "json-ext" */ '@discoveryjs/json-ext'
+    );
     createJsonStringifyStream = jsonExt.default.stringifyStream;
   }
 

--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -14,7 +14,9 @@ export async function applyProfile(
   traceLayer: string = DEFAULT_RUST_TRACE_LAYER,
   traceOutput?: string,
 ) {
-  const { asyncExitHook } = await import('exit-hook');
+  const { asyncExitHook } = await import(
+    /* webpackChunkName: "exit-hook" */ 'exit-hook'
+  );
 
   if (traceLayer !== 'logger' && traceLayer !== 'perfetto') {
     throw new Error(`unsupported trace layer: ${traceLayer}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,14 +328,10 @@ importers:
         version: 3.3.4(patch_hash=0d62122aa5f9ac77d9ad3b4959c3c0492778a5948c0b00b45a673f3facfca327)
 
   packages/rspack-cli:
-    dependencies:
+    devDependencies:
       '@discoveryjs/json-ext':
         specifier: ^0.5.7
         version: 0.5.7
-      exit-hook:
-        specifier: ^4.0.0
-        version: 4.0.0
-    devDependencies:
       '@rslib/core':
         specifier: 0.20.2
         version: 0.20.2(@module-federation/runtime-tools@2.3.1)(core-js@3.49.0)(typescript@6.0.2)
@@ -360,6 +356,9 @@ importers:
       execa:
         specifier: ^5.1.1
         version: 5.1.1
+      exit-hook:
+        specifier: ^4.0.0
+        version: 4.0.0
       pirates:
         specifier: ^4.0.7
         version: 4.0.7


### PR DESCRIPTION
## Summary

- Make the lazily loaded `@discoveryjs/json-ext` and `exit-hook` helpers in `@rspack/cli` build into explicit chunks.
- Move both packages to `devDependencies` so the `@rspack/cli` now have 0 dependencies.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
