### PR TITLE
refactor: persistent cache remove lock

### DIFF
--- a/crates/rspack_core/src/cache/mixed.rs
+++ b/crates/rspack_core/src/cache/mixed.rs
@@ -55,7 +55,7 @@ impl Cache for MixedCache {
     self.persistent.before_build_module_graph(compilation).await;
   }
 
-  async fn after_build_module_graph(&self, compilation: &Compilation) {
+  async fn after_build_module_graph(&mut self, compilation: &Compilation) {
     // Save to persistent cache
     self.persistent.after_build_module_graph(compilation).await;
   }

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -34,7 +34,7 @@ pub trait Cache: Debug + Send + Sync {
 
   // BUILD_MODULE_GRAPH hooks
   async fn before_build_module_graph(&mut self, _compilation: &mut Compilation) {}
-  async fn after_build_module_graph(&self, _compilation: &Compilation) {}
+  async fn after_build_module_graph(&mut self, _compilation: &Compilation) {}
 
   // FINISH_MODULES hooks
   async fn before_finish_modules(&mut self, _compilation: &mut Compilation) {}

--- a/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
@@ -8,7 +8,10 @@ use rspack_paths::{ArcPath, ArcPathSet, AssertUtf8};
 use rustc_hash::FxHashSet as HashSet;
 
 use self::helper::{Helper, is_node_package_path};
-use super::snapshot::{Snapshot, SnapshotScope};
+use super::{
+  snapshot::{Snapshot, SnapshotScope},
+  storage::Storage,
+};
 
 pub const SCOPE: &str = "build_dependencies";
 
@@ -47,7 +50,11 @@ impl BuildDeps {
   /// Add build dependencies
   ///
   /// For performance reasons, recursive searches will stop for build dependencies in node_modules.
-  pub async fn add(&mut self, data: impl Iterator<Item = ArcPath>) -> Vec<String> {
+  pub async fn add(
+    &mut self,
+    storage: &mut dyn Storage,
+    data: impl Iterator<Item = ArcPath>,
+  ) -> Vec<String> {
     let mut helper = Helper::new(self.fs.clone());
     let mut new_deps = HashSet::default();
     let mut queue = VecDeque::new();
@@ -72,7 +79,7 @@ impl BuildDeps {
 
     self
       .snapshot
-      .add(SnapshotScope::BUILD, new_deps.into_iter())
+      .add(storage, SnapshotScope::BUILD, new_deps.into_iter())
       .await;
     helper.into_warnings()
   }
@@ -80,10 +87,10 @@ impl BuildDeps {
   /// Validate build dependencies
   ///
   /// If any build dependencies have changed, this method will return false.
-  pub async fn validate(&mut self) -> Result<bool> {
+  pub async fn validate(&mut self, storage: &dyn Storage) -> Result<bool> {
     let (_, modified_files, removed_files, no_changed_files) = self
       .snapshot
-      .calc_modified_paths(SnapshotScope::BUILD)
+      .calc_modified_paths(storage, SnapshotScope::BUILD)
       .await?;
 
     if !modified_files.is_empty() || !removed_files.is_empty() {
@@ -102,13 +109,12 @@ mod test {
   use std::{path::PathBuf, sync::Arc};
 
   use rspack_fs::{MemoryFileSystem, WritableFileSystem};
-  use rspack_storage::Storage;
 
   use super::{
     super::{
       codec::CacheCodec,
       snapshot::{Snapshot, SnapshotOptions, SnapshotScope},
-      storage::MemoryStorage,
+      storage::{MemoryStorage, Storage},
     },
     BuildDeps,
   };
@@ -149,18 +155,13 @@ mod test {
       .unwrap();
 
     let options = vec![PathBuf::from("/index.js"), PathBuf::from("/configs")];
-    let storage = Arc::new(MemoryStorage::default());
+    let mut storage = MemoryStorage::default();
     let codec = Arc::new(CacheCodec::new(None));
-    let snapshot = Arc::new(Snapshot::new(
-      SnapshotOptions::default(),
-      fs.clone(),
-      storage.clone(),
-      codec,
-    ));
+    let snapshot = Arc::new(Snapshot::new(SnapshotOptions::default(), fs.clone(), codec));
 
     let mut build_deps = BuildDeps::new(&options, fs.clone(), snapshot.clone());
 
-    let warnings = build_deps.add(vec![].into_iter()).await;
+    let warnings = build_deps.add(&mut storage, vec![].into_iter()).await;
     assert_eq!(warnings.len(), 1);
     let data = storage.load(scope).await.expect("should load success");
     assert_eq!(data.len(), 9);
@@ -171,7 +172,7 @@ mod test {
       .await
       .unwrap();
     let validate_result = build_deps
-      .validate()
+      .validate(&storage)
       .await
       .expect("should validate success");
     assert!(!validate_result);
@@ -179,7 +180,7 @@ mod test {
 
     let data = storage.load(scope).await.expect("should load success");
     assert_eq!(data.len(), 0);
-    let warnings = build_deps.add(vec![].into_iter()).await;
+    let warnings = build_deps.add(&mut storage, vec![].into_iter()).await;
     assert_eq!(warnings.len(), 0);
     let data = storage.load(scope).await.expect("should load success");
     assert_eq!(data.len(), 10);

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -23,7 +23,7 @@ use self::{
   codec::CacheCodec,
   occasion::{MakeOccasion, MetaOccasion},
   snapshot::{Snapshot, SnapshotOptions, SnapshotScope},
-  storage::{Storage, StorageOptions, create_storage},
+  storage::{BoxStorage, StorageOptions, create_storage},
 };
 use super::Cache;
 use crate::{BuildModuleGraphArtifactState, Compilation, CompilerOptions, Logger};
@@ -51,7 +51,7 @@ pub struct PersistentCache {
   snapshot: Arc<Snapshot>,
   make_occasion: MakeOccasion,
   meta_occasion: MetaOccasion,
-  storage: Arc<dyn Storage>,
+  storage: BoxStorage,
   // TODO replace to logger and output warnings directly.
   warnings: Vec<String>,
 }
@@ -88,7 +88,6 @@ impl PersistentCache {
     let snapshot = Arc::new(Snapshot::new(
       option.snapshot.clone(),
       input_filesystem.clone(),
-      storage.clone(),
       codec.clone(),
     ));
 
@@ -102,8 +101,8 @@ impl PersistentCache {
         snapshot.clone(),
       ),
       snapshot,
-      make_occasion: MakeOccasion::new(storage.clone(), codec.clone()),
-      meta_occasion: MetaOccasion::new(storage.clone(), codec),
+      make_occasion: MakeOccasion::new(codec.clone()),
+      meta_occasion: MetaOccasion::new(codec),
       warnings: Default::default(),
       storage,
     }
@@ -115,7 +114,7 @@ impl PersistentCache {
     }
     self.initialized = true;
 
-    match self.build_deps.validate().await {
+    match self.build_deps.validate(&*self.storage).await {
       Ok(success) => {
         self.valid = success;
       }
@@ -124,7 +123,7 @@ impl PersistentCache {
         self.warnings.push(err.to_string());
       }
     }
-    if let Err(err) = self.meta_occasion.recovery().await {
+    if let Err(err) = self.meta_occasion.recovery(&*self.storage).await {
       self.warnings.push(err.to_string());
     }
   }
@@ -148,14 +147,17 @@ impl Cache for PersistentCache {
       let mut modified_paths = ArcPathSet::default();
       let mut removed_paths = ArcPathSet::default();
       let data = vec![
-        self.snapshot.calc_modified_paths(SnapshotScope::FILE).await,
         self
           .snapshot
-          .calc_modified_paths(SnapshotScope::CONTEXT)
+          .calc_modified_paths(&*self.storage, SnapshotScope::FILE)
           .await,
         self
           .snapshot
-          .calc_modified_paths(SnapshotScope::MISSING)
+          .calc_modified_paths(&*self.storage, SnapshotScope::CONTEXT)
+          .await,
+        self
+          .snapshot
+          .calc_modified_paths(&*self.storage, SnapshotScope::MISSING)
           .await,
       ];
       for item in data {
@@ -189,7 +191,7 @@ impl Cache for PersistentCache {
         self.valid = true;
       }
       // save meta
-      self.meta_occasion.save();
+      self.meta_occasion.save(&mut *self.storage);
 
       // save snapshot
       // TODO add a all_dependencies to collect dependencies
@@ -197,22 +199,33 @@ impl Cache for PersistentCache {
       let (_, context_added, context_updated, context_removed) = compilation.context_dependencies();
       let (_, missing_added, missing_updated, missing_removed) = compilation.missing_dependencies();
       let (_, build_added, build_updated, _) = compilation.build_dependencies();
+      self.snapshot.remove(
+        &mut *self.storage,
+        SnapshotScope::FILE,
+        file_removed.cloned(),
+      );
+      self.snapshot.remove(
+        &mut *self.storage,
+        SnapshotScope::CONTEXT,
+        context_removed.cloned(),
+      );
+      self.snapshot.remove(
+        &mut *self.storage,
+        SnapshotScope::MISSING,
+        missing_removed.cloned(),
+      );
       self
         .snapshot
-        .remove(SnapshotScope::FILE, file_removed.cloned());
-      self
-        .snapshot
-        .remove(SnapshotScope::CONTEXT, context_removed.cloned());
-      self
-        .snapshot
-        .remove(SnapshotScope::MISSING, missing_removed.cloned());
-      self
-        .snapshot
-        .add(SnapshotScope::FILE, file_added.chain(file_updated).cloned())
+        .add(
+          &mut *self.storage,
+          SnapshotScope::FILE,
+          file_added.chain(file_updated).cloned(),
+        )
         .await;
       self
         .snapshot
         .add(
+          &mut *self.storage,
           SnapshotScope::CONTEXT,
           context_added.chain(context_updated).cloned(),
         )
@@ -220,6 +233,7 @@ impl Cache for PersistentCache {
       self
         .snapshot
         .add(
+          &mut *self.storage,
           SnapshotScope::MISSING,
           missing_added.chain(missing_updated).cloned(),
         )
@@ -227,7 +241,10 @@ impl Cache for PersistentCache {
       self.warnings.extend(
         self
           .build_deps
-          .add(build_added.chain(build_updated).cloned())
+          .add(
+            &mut *self.storage,
+            build_added.chain(build_updated).cloned(),
+          )
           .await,
       );
 
@@ -248,7 +265,7 @@ impl Cache for PersistentCache {
         BuildModuleGraphArtifactState::Uninitialized
       )
     {
-      match self.make_occasion.recovery().await {
+      match self.make_occasion.recovery(&*self.storage).await {
         Ok(artifact) => {
           *compilation.build_module_graph_artifact = artifact;
           for (module, _) in compilation
@@ -264,11 +281,11 @@ impl Cache for PersistentCache {
     }
   }
 
-  async fn after_build_module_graph(&self, compilation: &Compilation) {
+  async fn after_build_module_graph(&mut self, compilation: &Compilation) {
     if !self.readonly {
       self
         .make_occasion
-        .save(&compilation.build_module_graph_artifact);
+        .save(&mut *self.storage, &compilation.build_module_graph_artifact);
     }
   }
 

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -8,7 +8,7 @@ use rspack_collections::IdentifierSet;
 use rspack_error::Result;
 use rustc_hash::FxHashSet;
 
-use super::super::{Storage, codec::CacheCodec};
+use super::super::{codec::CacheCodec, storage::Storage};
 use crate::{
   FactorizeInfo,
   compilation::build_module_graph::{BuildModuleGraphArtifact, BuildModuleGraphArtifactState},
@@ -19,16 +19,15 @@ use crate::{
 #[derive(Debug)]
 pub struct MakeOccasion {
   codec: Arc<CacheCodec>,
-  storage: Arc<dyn Storage>,
 }
 
 impl MakeOccasion {
-  pub fn new(storage: Arc<dyn Storage>, codec: Arc<CacheCodec>) -> Self {
-    Self { storage, codec }
+  pub fn new(codec: Arc<CacheCodec>) -> Self {
+    Self { codec }
   }
 
   #[tracing::instrument(name = "Cache::Occasion::Make::save", skip_all)]
-  pub fn save(&self, artifact: &BuildModuleGraphArtifact) {
+  pub fn save(&self, storage: &mut dyn Storage, artifact: &BuildModuleGraphArtifact) {
     let BuildModuleGraphArtifact {
       // write all of field here to avoid forget to update occasion when add new fields
       // for module graph
@@ -64,15 +63,15 @@ impl MakeOccasion {
       module_to_lazy_make,
       affected_modules.removed(),
       &need_update_modules,
-      &self.storage,
+      storage,
       &self.codec,
     );
   }
 
   #[tracing::instrument(name = "Cache::Occasion::Make::recovery", skip_all)]
-  pub async fn recovery(&self) -> Result<BuildModuleGraphArtifact> {
+  pub async fn recovery(&self, storage: &dyn Storage) -> Result<BuildModuleGraphArtifact> {
     let (mg, module_to_lazy_make, entry_dependencies) =
-      module_graph::recovery_module_graph(&self.storage, &self.codec).await?;
+      module_graph::recovery_module_graph(storage, &self.codec).await?;
 
     // regenerate statistical data
     // recovery make_failed_module

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -1,7 +1,4 @@
-use std::sync::{
-  Arc,
-  atomic::{AtomicUsize, Ordering},
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rayon::prelude::*;
 use rspack_cacheable::{cacheable, utils::OwnedOrRef};
@@ -9,15 +6,12 @@ use rspack_collections::IdentifierSet;
 use rspack_error::Result;
 use rustc_hash::FxHashSet;
 
-use super::{
-  Storage,
-  alternatives::{TempDependency, TempModule},
-};
+use super::alternatives::{TempDependency, TempModule};
 use crate::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, Dependency,
   DependencyId, DependencyParents, ModuleGraph, ModuleGraphConnection, ModuleGraphModule,
   ModuleIdentifier, RayonConsumer,
-  cache::persistent::codec::CacheCodec,
+  cache::persistent::{codec::CacheCodec, storage::Storage},
   compilation::build_module_graph::{LazyDependencies, ModuleToLazyMake},
 };
 
@@ -43,7 +37,7 @@ pub fn save_module_graph(
   module_to_lazy_make: &ModuleToLazyMake,
   removed_modules: &IdentifierSet,
   need_update_modules: &IdentifierSet,
-  storage: &Arc<dyn Storage>,
+  storage: &mut dyn Storage,
   codec: &CacheCodec,
 ) {
   for identifier in removed_modules {
@@ -129,7 +123,7 @@ pub fn save_module_graph(
 
 #[tracing::instrument("Cache::Occasion::Make::ModuleGraph::recovery", skip_all)]
 pub async fn recovery_module_graph(
-  storage: &Arc<dyn Storage>,
+  storage: &dyn Storage,
   codec: &CacheCodec,
 ) -> Result<(ModuleGraph, ModuleToLazyMake, FxHashSet<DependencyId>)> {
   let mut need_check_dep = vec![];

--- a/crates/rspack_core/src/cache/persistent/occasion/meta/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/meta/mod.rs
@@ -4,7 +4,7 @@ use rspack_cacheable::cacheable;
 use rspack_error::Result;
 use rspack_tasks::{get_current_dependency_id, set_current_dependency_id};
 
-use super::super::{Storage, codec::CacheCodec};
+use super::super::{codec::CacheCodec, storage::Storage};
 
 pub const SCOPE: &str = "meta";
 
@@ -17,21 +17,20 @@ struct Meta {
 /// Meta Occasion is used to save compiler state.
 #[derive(Debug)]
 pub struct MetaOccasion {
-  storage: Arc<dyn Storage>,
   codec: Arc<CacheCodec>,
 }
 
 impl MetaOccasion {
-  pub fn new(storage: Arc<dyn Storage>, codec: Arc<CacheCodec>) -> Self {
-    Self { storage, codec }
+  pub fn new(codec: Arc<CacheCodec>) -> Self {
+    Self { codec }
   }
 
   #[tracing::instrument("Cache::Occasion::Meta::save", skip_all)]
-  pub fn save(&self) {
+  pub fn save(&self, storage: &mut dyn Storage) {
     let meta = Meta {
       max_dependencies_id: get_current_dependency_id(),
     };
-    self.storage.set(
+    storage.set(
       SCOPE,
       "default".as_bytes().to_vec(),
       self.codec.encode(&meta).expect("should encode success"),
@@ -39,8 +38,8 @@ impl MetaOccasion {
   }
 
   #[tracing::instrument("Cache::Occasion::Meta::recovery", skip_all)]
-  pub async fn recovery(&self) -> Result<()> {
-    let Some((_, value)) = self.storage.load(SCOPE).await?.pop() else {
+  pub async fn recovery(&self, storage: &dyn Storage) -> Result<()> {
+    let Some((_, value)) = storage.load(SCOPE).await?.pop() else {
       return Ok(());
     };
 

--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -25,7 +25,6 @@ use crate::FutureConsumer;
 pub struct Snapshot {
   options: Arc<SnapshotOptions>,
   fs: Arc<dyn ReadableFileSystem>,
-  storage: Arc<dyn Storage>,
   codec: Arc<CacheCodec>,
 }
 
@@ -33,13 +32,11 @@ impl Snapshot {
   pub fn new(
     options: SnapshotOptions,
     fs: Arc<dyn ReadableFileSystem>,
-    storage: Arc<dyn Storage>,
     codec: Arc<CacheCodec>,
   ) -> Self {
     Self {
       options: Arc::new(options),
       fs,
-      storage,
       codec,
     }
   }
@@ -67,7 +64,12 @@ impl Snapshot {
   }
 
   #[tracing::instrument("Cache::Snapshot::add", skip_all)]
-  pub async fn add(&self, scope: SnapshotScope, paths: impl Iterator<Item = ArcPath>) {
+  pub async fn add(
+    &self,
+    storage: &mut dyn Storage,
+    scope: SnapshotScope,
+    paths: impl Iterator<Item = ArcPath>,
+  ) {
     let helper = Arc::new(StrategyHelper::new(self.fs.clone(), self.options.clone()));
     let codec = self.codec.clone();
     // TODO merge package version file
@@ -86,17 +88,20 @@ impl Snapshot {
       })
       .fut_consume(|data| {
         if let Some((key, value)) = data {
-          self.storage.set(scope.name(), key, value);
+          storage.set(scope.name(), key, value);
         }
       })
       .await;
   }
 
-  pub fn remove(&self, scope: SnapshotScope, paths: impl Iterator<Item = ArcPath>) {
+  pub fn remove(
+    &self,
+    storage: &mut dyn Storage,
+    scope: SnapshotScope,
+    paths: impl Iterator<Item = ArcPath>,
+  ) {
     for item in paths {
-      self
-        .storage
-        .remove(scope.name(), item.as_os_str().as_encoded_bytes())
+      storage.remove(scope.name(), item.as_os_str().as_encoded_bytes())
     }
   }
 
@@ -104,6 +109,7 @@ impl Snapshot {
   #[tracing::instrument("Cache::Snapshot::calc_modified_path", skip_all)]
   pub async fn calc_modified_paths(
     &self,
+    storage: &dyn Storage,
     scope: SnapshotScope,
   ) -> Result<(bool, ArcPathSet, ArcPathSet, ArcPathSet)> {
     let mut modified_path = ArcPathSet::default();
@@ -112,7 +118,7 @@ impl Snapshot {
     let helper = Arc::new(StrategyHelper::new(self.fs.clone(), self.options.clone()));
     let codec = self.codec.clone();
 
-    let data = self.storage.load(scope.name()).await?;
+    let data = storage.load(scope.name()).await?;
     let is_hot_start = !data.is_empty();
     data
       .into_iter()
@@ -164,7 +170,7 @@ mod tests {
   #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
   async fn should_snapshot_work() {
     let fs = Arc::new(MemoryFileSystem::default());
-    let storage = Arc::new(MemoryStorage::default());
+    let mut storage = MemoryStorage::default();
     let codec = Arc::new(CacheCodec::new(None));
     let options = SnapshotOptions::new(
       vec![PathMatcher::String("constant".into())],
@@ -199,10 +205,11 @@ mod tests {
       .await
       .unwrap();
 
-    let snapshot = Snapshot::new(options, fs.clone(), storage, codec);
+    let snapshot = Snapshot::new(options, fs.clone(), codec);
 
     snapshot
       .add(
+        &mut storage,
         SnapshotScope::FILE,
         [
           p!("/file1"),
@@ -226,7 +233,7 @@ mod tests {
       .unwrap();
 
     let (is_hot_start, modified_paths, deleted_paths, no_change_paths) = snapshot
-      .calc_modified_paths(SnapshotScope::FILE)
+      .calc_modified_paths(&storage, SnapshotScope::FILE)
       .await
       .unwrap();
     assert!(is_hot_start);
@@ -244,10 +251,14 @@ mod tests {
     .await
     .unwrap();
     snapshot
-      .add(SnapshotScope::FILE, [p!("/file1")].into_iter())
+      .add(
+        &mut storage,
+        SnapshotScope::FILE,
+        [p!("/file1")].into_iter(),
+      )
       .await;
     let (is_hot_start, modified_paths, deleted_paths, no_change_paths) = snapshot
-      .calc_modified_paths(SnapshotScope::FILE)
+      .calc_modified_paths(&storage, SnapshotScope::FILE)
       .await
       .unwrap();
     assert!(is_hot_start);

--- a/crates/rspack_core/src/cache/persistent/storage/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/storage/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use rspack_cacheable::{cacheable, utils::PortablePath, with::As};
 use rspack_fs::IntermediateFileSystem;
 use rspack_paths::Utf8PathBuf;
+pub use rspack_storage::{BoxStorage, MemoryStorage, Storage};
 use rspack_storage::{FileSystemOptions, FileSystemStorage};
-pub use rspack_storage::{MemoryStorage, Storage};
 
 /// Storage Options
 ///
@@ -22,7 +22,7 @@ pub fn create_storage(
   options: StorageOptions,
   version: String,
   fs: Arc<dyn IntermediateFileSystem>,
-) -> Arc<dyn Storage> {
+) -> BoxStorage {
   match options {
     StorageOptions::FileSystem { directory } => {
       let option = FileSystemOptions {
@@ -32,7 +32,7 @@ pub fn create_storage(
         expire: 7 * 24 * 60 * 60,
         fs,
       };
-      Arc::new(FileSystemStorage::new(option))
+      Box::new(FileSystemStorage::new(option))
     }
   }
 }

--- a/crates/rspack_storage/src/filesystem/mod.rs
+++ b/crates/rspack_storage/src/filesystem/mod.rs
@@ -23,7 +23,7 @@ pub struct FileSystemStorage {
   db: DB,
   /// In-memory staged update operations, grouped by scope
   /// Value of Some(value) indicates write, None indicates deletion
-  updates: Mutex<HashMap<String, BucketChangesMap>>,
+  updates: HashMap<String, BucketChangesMap>,
   /// Storage options
   options: FileSystemOptions,
   /// Next scheduled time for metadata refresh (cleanup + access time update)
@@ -52,21 +52,19 @@ impl Storage for FileSystemStorage {
     Ok(data)
   }
 
-  fn set(&self, scope: &'static str, key: Vec<u8>, value: Vec<u8>) {
-    let mut updates = self.updates.lock().expect("should get lock");
-    let scope_update = updates.entry(scope.to_string()).or_default();
+  fn set(&mut self, scope: &'static str, key: Vec<u8>, value: Vec<u8>) {
+    let scope_update = self.updates.entry(scope.to_string()).or_default();
     scope_update.insert(key, Some(value));
   }
 
-  fn remove(&self, scope: &'static str, key: &[u8]) {
-    let mut updates = self.updates.lock().expect("should get lock");
-    let scope_update = updates.entry(scope.to_string()).or_default();
+  fn remove(&mut self, scope: &'static str, key: &[u8]) {
+    let scope_update = self.updates.entry(scope.to_string()).or_default();
     scope_update.insert(key.to_vec(), None);
   }
 
-  async fn save(&self) -> Result<()> {
+  async fn save(&mut self) -> Result<()> {
     // Take all pending updates and clear the memory buffer
-    let updates = std::mem::take(&mut *self.updates.lock().expect("should get lock"));
+    let updates = std::mem::take(&mut self.updates);
 
     // Enqueue the write to the background task queue; errors are reported internally.
     // Call flush() to wait until the write has fully completed.
@@ -120,7 +118,7 @@ impl Storage for FileSystemStorage {
     Ok(())
   }
 
-  async fn reset(&self) {
+  async fn reset(&mut self) {
     let _ = self.db.reset().await;
   }
 

--- a/crates/rspack_storage/src/lib.rs
+++ b/crates/rspack_storage/src/lib.rs
@@ -8,8 +8,6 @@ mod error;
 mod filesystem;
 mod memory;
 
-use std::sync::Arc;
-
 pub use self::{
   error::{Error, Result},
   filesystem::{FileSystemOptions, FileSystemStorage},
@@ -25,16 +23,16 @@ pub trait Storage: std::fmt::Debug + Sync + Send {
   async fn load(&self, scope: &'static str) -> Result<Vec<(Vec<u8>, Vec<u8>)>>;
 
   /// Sets a key-value pair in the specified scope (staged in memory)
-  fn set(&self, scope: &'static str, key: Vec<u8>, value: Vec<u8>);
+  fn set(&mut self, scope: &'static str, key: Vec<u8>, value: Vec<u8>);
 
   /// Removes a key from the specified scope (staged in memory)
-  fn remove(&self, scope: &'static str, key: &[u8]);
+  fn remove(&mut self, scope: &'static str, key: &[u8]);
 
   /// Enqueues a persistence operation, writing all staged memory changes to storage.
   ///
   /// The write is performed asynchronously in the background. Call [`Storage::flush`]
   /// to wait until all enqueued writes have completed.
-  async fn save(&self) -> Result<()>;
+  async fn save(&mut self) -> Result<()>;
 
   /// Waits until all previously enqueued [`Storage::save`] operations have completed.
   ///
@@ -42,11 +40,11 @@ pub trait Storage: std::fmt::Debug + Sync + Send {
   async fn flush(&self);
 
   /// Resets the storage, clearing all data
-  async fn reset(&self);
+  async fn reset(&mut self);
 
   /// Gets a list of all available scopes in the storage
   async fn scopes(&self) -> Result<Vec<String>>;
 }
 
-/// Arc-wrapped Storage trait object
-pub type ArcStorage = Arc<dyn Storage>;
+/// Box-wrapped Storage trait object
+pub type BoxStorage = Box<dyn Storage>;

--- a/crates/rspack_storage/src/memory/mod.rs
+++ b/crates/rspack_storage/src/memory/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Mutex;
-
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{Result, Storage};
@@ -13,31 +11,29 @@ use crate::{Result, Storage};
 pub struct MemoryStorage {
   /// Internal storage structure: scope -> (key -> value)
   #[allow(clippy::type_complexity)]
-  inner: Mutex<HashMap<String, HashMap<Vec<u8>, Vec<u8>>>>,
+  inner: HashMap<String, HashMap<Vec<u8>, Vec<u8>>>,
 }
 
 #[async_trait::async_trait]
 impl Storage for MemoryStorage {
   async fn load(&self, scope: &'static str) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
-    if let Some(value) = self.inner.lock().expect("should get lock").get(scope) {
+    if let Some(value) = self.inner.get(scope) {
       Ok(value.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
     } else {
       Ok(vec![])
     }
   }
 
-  fn set(&self, scope: &str, key: Vec<u8>, value: Vec<u8>) {
-    let mut map = self.inner.lock().expect("should get lock");
-    let inner = map.entry(String::from(scope)).or_default();
+  fn set(&mut self, scope: &'static str, key: Vec<u8>, value: Vec<u8>) {
+    let inner = self.inner.entry(String::from(scope)).or_default();
     inner.insert(key, value);
   }
 
-  fn remove(&self, scope: &str, key: &[u8]) {
-    let mut map = self.inner.lock().expect("should get lock");
-    map.get_mut(scope).map(|map| map.remove(key));
+  fn remove(&mut self, scope: &'static str, key: &[u8]) {
+    self.inner.get_mut(scope).map(|map| map.remove(key));
   }
 
-  async fn save(&self) -> Result<()> {
+  async fn save(&mut self) -> Result<()> {
     // MemoryStorage holds all data in memory; nothing to persist
     Ok(())
   }
@@ -46,20 +42,12 @@ impl Storage for MemoryStorage {
     // MemoryStorage has no background tasks; nothing to flush
   }
 
-  async fn reset(&self) {
-    self.inner.lock().expect("should get lock").clear();
+  async fn reset(&mut self) {
+    self.inner.clear();
   }
 
   async fn scopes(&self) -> Result<Vec<String>> {
-    Ok(
-      self
-        .inner
-        .lock()
-        .expect("should get lock")
-        .keys()
-        .cloned()
-        .collect(),
-    )
+    Ok(self.inner.keys().cloned().collect())
   }
 }
 
@@ -70,7 +58,7 @@ mod tests {
   #[tokio::test]
   async fn should_memory_storage_works() {
     let scope = "test";
-    let storage = MemoryStorage::default();
+    let mut storage = MemoryStorage::default();
     storage.set(scope, "a".as_bytes().to_vec(), "abc".as_bytes().to_vec());
     storage.set(scope, "b".as_bytes().to_vec(), "bcd".as_bytes().to_vec());
 

--- a/crates/rspack_tools/src/compare/mod.rs
+++ b/crates/rspack_tools/src/compare/mod.rs
@@ -3,7 +3,7 @@ mod snapshot;
 
 use std::{collections::VecDeque, sync::Arc};
 
-use rspack_core::cache::persistent::storage::{Storage, StorageOptions, create_storage};
+use rspack_core::cache::persistent::storage::{BoxStorage, StorageOptions, create_storage};
 use rspack_error::{Result, error};
 use rspack_fs::{NativeFileSystem, ReadableFileSystem};
 use rspack_paths::Utf8PathBuf;
@@ -41,8 +41,8 @@ pub fn find_relative_cache_path(root_path: &Utf8PathBuf) -> HashSet<String> {
 }
 
 /// Load all version storages from a directory path
-/// Returns a HashMap where key is version name and value is Storage
-pub fn load_storages_from_path(path: &Utf8PathBuf) -> HashMap<String, Arc<dyn Storage>> {
+/// Returns a HashMap where key is version name and value is BoxStorage
+pub fn load_storages_from_path(path: &Utf8PathBuf) -> HashMap<String, BoxStorage> {
   let fs = Arc::new(NativeFileSystem::new(false));
   let mut storages = HashMap::default();
 
@@ -123,8 +123,8 @@ pub async fn compare_cache_dir(path1: Utf8PathBuf, path2: Utf8PathBuf) -> Result
 
 /// Compare two storages and return whether they are equal
 async fn compare_storage(
-  storage1: Arc<dyn Storage>,
-  storage2: Arc<dyn Storage>,
+  storage1: BoxStorage,
+  storage2: BoxStorage,
   debug_info: DebugInfo,
 ) -> Result<()> {
   // Get scopes from both storages
@@ -140,10 +140,10 @@ async fn compare_storage(
 
     match scope.as_str() {
       occasion::meta::SCOPE => {
-        occasion::meta::compare(storage1.clone(), storage2.clone(), cur_debug_info).await?;
+        occasion::meta::compare(&*storage1, &*storage2, cur_debug_info).await?;
       }
       occasion::make::SCOPE => {
-        occasion::make::compare(storage1.clone(), storage2.clone(), cur_debug_info).await?;
+        occasion::make::compare(&*storage1, &*storage2, cur_debug_info).await?;
       }
       _ => {
         // TODO compare snapshot

--- a/crates/rspack_tools/src/compare/occasion/make.rs
+++ b/crates/rspack_tools/src/compare/occasion/make.rs
@@ -14,8 +14,8 @@ use crate::{debug_info::DebugInfo, utils::ensure_iter_equal};
 
 /// Compare make scope data between two storages
 pub async fn compare(
-  storage1: Arc<dyn Storage>,
-  storage2: Arc<dyn Storage>,
+  storage1: &dyn Storage,
+  storage2: &dyn Storage,
   debug_info: DebugInfo,
 ) -> Result<()> {
   // Load make data from both storages
@@ -32,11 +32,11 @@ pub async fn compare(
   // Convert stored data to BuildModuleGraphArtifact using MakeOccasion's recovery ability
   // Use a dummy path for codec since we're only deserializing
   let codec = Arc::new(CacheCodec::new(Some(Utf8PathBuf::from("/"))));
-  let occasion1 = MakeOccasion::new(storage1.clone(), codec.clone());
-  let occasion2 = MakeOccasion::new(storage2.clone(), codec.clone());
+  let occasion1 = MakeOccasion::new(codec.clone());
+  let occasion2 = MakeOccasion::new(codec.clone());
 
-  let artifact1 = occasion1.recovery().await?;
-  let artifact2 = occasion2.recovery().await?;
+  let artifact1 = occasion1.recovery(storage1).await?;
+  let artifact2 = occasion2.recovery(storage2).await?;
 
   let comparator = ArtifactComparator::new(&artifact1, &artifact2);
   comparator.compare(&debug_info)?;

--- a/crates/rspack_tools/src/compare/occasion/meta.rs
+++ b/crates/rspack_tools/src/compare/occasion/meta.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use rspack_cacheable::{cacheable, from_bytes};
 pub use rspack_core::cache::persistent::occasion::meta::SCOPE;
 use rspack_core::cache::persistent::storage::Storage;
@@ -16,8 +14,8 @@ struct Meta {
 
 /// Compare meta scope data between two storages
 pub async fn compare(
-  storage1: Arc<dyn Storage>,
-  storage2: Arc<dyn Storage>,
+  storage1: &dyn Storage,
+  storage2: &dyn Storage,
   debug_info: DebugInfo,
 ) -> Result<()> {
   // Load meta data from both storages

--- a/crates/rspack_tools/src/compare/snapshot.rs
+++ b/crates/rspack_tools/src/compare/snapshot.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use rspack_cacheable::from_bytes;
 use rspack_core::cache::persistent::{
   snapshot::{SnapshotScope, Strategy},
@@ -14,8 +12,8 @@ use crate::{debug_info::DebugInfo, utils::ensure_iter_equal};
 #[allow(dead_code)]
 pub async fn compare(
   scope: SnapshotScope,
-  storage1: Arc<dyn Storage>,
-  storage2: Arc<dyn Storage>,
+  storage1: &dyn Storage,
+  storage2: &dyn Storage,
   debug_info: DebugInfo,
 ) -> Result<()> {
   // Load snapshot data from both storages


### PR DESCRIPTION
## Summary

* Persistent cache uses storage to save data in a certain order, so there is no need to use locks on storage.

``` diff
trait Storage {
-  fn set(&self, scope: &'static str, key: Vec<u8>, value: Vec<u8>);
+  fn set(&mut self, scope: &'static str, key: Vec<u8>, value: Vec<u8>);
-  fn remove(&self, scope: &'static str, key: &[u8]);
+  fn remove(&mut self, scope: &'static str, key: &[u8]);
...
}
```

* The persistent cache replace Arc<dyn Storage> with Box<dyn Storage> and remove the storage field from the Occassion struct.

``` diff
struct MakeOccassion {
-  storage: ArcStorage
...
}
impl MakeOccassion {
-  fn save(...) {}
+  fn save(storage: &mut dyn Storage, ...) {}
...
}
```

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
