### PR TITLE
test: fix try_future_consumer test unstable

### DIFF
--- a/crates/rspack_parallel/src/iterator_consumer/try_future.rs
+++ b/crates/rspack_parallel/src/iterator_consumer/try_future.rs
@@ -82,7 +82,7 @@ mod test {
   async fn try_short_circuits_on_error() {
     let result: Result<(), &str> = (0..10)
       .map(|item| async move { if item == 5 { Err("boom") } else { Ok(item) } })
-      .try_fut_consume(|item| assert!(item < 5))
+      .try_fut_consume(|_| {})
       .await;
     assert_eq!(result, Err("boom"));
   }


### PR DESCRIPTION
## Summary

Because of tokio's scheduling strategy, we cannot assert the order in which tasks are executed in parallel.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
