### PR TITLE
chore: Remove stacker may_grow wrappers from SWC parsing and loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3266,15 +3266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,7 +4072,6 @@ dependencies = [
  "rspack_workspace",
  "rustc-hash",
  "serde",
- "stacker",
  "swc_config",
  "swc_core",
  "swc_ecma_minifier",
@@ -4183,7 +4173,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "stacker",
  "sugar_path",
  "swc",
  "swc_config",
@@ -5714,19 +5703,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "stacker"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "static-map-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,6 @@ simd-json           = { version = "0.17.0", default-features = false }
 slotmap             = { version = "1.1.1", default-features = false }
 smallvec            = { version = "1.15.1", default-features = false }
 smol_str            = { version = "0.3.6", default-features = false }
-stacker             = { version = "0.1.23", default-features = false }
 sugar_path          = { version = "2.0.1", default-features = false, features = ["cached_current_dir"] }
 supports-color      = { version = "3.0.2", default-features = false }
 syn                 = { version = "2.0.117", default-features = false }

--- a/crates/rspack_javascript_compiler/Cargo.toml
+++ b/crates/rspack_javascript_compiler/Cargo.toml
@@ -30,9 +30,6 @@ rspack_workspace = { workspace = true }
 [lints]
 workspace = true
 
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
-stacker = { workspace = true }
-
 [lib]
 doctest = false
 test    = false

--- a/crates/rspack_javascript_compiler/src/compiler/parse.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/parse.rs
@@ -127,60 +127,45 @@ fn parse_with_lexer(
   is_module: IsModule,
   with_tokens: bool,
 ) -> Result<(SwcProgram, Option<Vec<TokenAndSpan>>), Vec<parser::error::Error>> {
-  let inner = || {
-    // don't call capturing when with_tokens is false to avoid performance cost
-    let (tokens, program_result, mut errors) = if with_tokens {
-      // `source.len + 1` is an overestimation of the number of tokens.
-      // It's wasteful and might be optimized in the future.
-      let lexer = Capturing::new(lexer);
-      let mut parser = Parser::new_from(lexer);
-      let program_result = match is_module {
-        IsModule::Bool(true) => parser.parse_module().map(SwcProgram::Module),
-        IsModule::Bool(false) => parser.parse_script().map(SwcProgram::Script),
-        IsModule::Unknown => parser.parse_program(),
-        IsModule::CommonJS => parser.parse_commonjs().map(SwcProgram::Script),
-      };
-      (
-        Some(parser.input_mut().iter_mut().take()),
-        program_result,
-        parser.take_errors(),
-      )
-    } else {
-      let mut parser = Parser::new_from(lexer);
-      let program_result = match is_module {
-        IsModule::Bool(true) => parser.parse_module().map(SwcProgram::Module),
-        IsModule::Bool(false) => parser.parse_script().map(SwcProgram::Script),
-        IsModule::Unknown => parser.parse_program(),
-        IsModule::CommonJS => parser.parse_commonjs().map(SwcProgram::Script),
-      };
-      (None, program_result, parser.take_errors())
+  // don't call capturing when with_tokens is false to avoid performance cost
+  let (tokens, program_result, mut errors) = if with_tokens {
+    // `source.len + 1` is an overestimation of the number of tokens.
+    // It's wasteful and might be optimized in the future.
+    let lexer = Capturing::new(lexer);
+    let mut parser = Parser::new_from(lexer);
+    let program_result = match is_module {
+      IsModule::Bool(true) => parser.parse_module().map(SwcProgram::Module),
+      IsModule::Bool(false) => parser.parse_script().map(SwcProgram::Script),
+      IsModule::Unknown => parser.parse_program(),
+      IsModule::CommonJS => parser.parse_commonjs().map(SwcProgram::Script),
     };
-
-    // Using combinator will let rustc unhappy.
-    match program_result {
-      Ok(program) => {
-        if !errors.is_empty() {
-          return Err(errors);
-        }
-        Ok((program, tokens))
-      }
-      Err(err) => {
-        errors.push(err);
-        Err(errors)
-      }
-    }
+    (
+      Some(parser.input_mut().iter_mut().take()),
+      program_result,
+      parser.take_errors(),
+    )
+  } else {
+    let mut parser = Parser::new_from(lexer);
+    let program_result = match is_module {
+      IsModule::Bool(true) => parser.parse_module().map(SwcProgram::Module),
+      IsModule::Bool(false) => parser.parse_script().map(SwcProgram::Script),
+      IsModule::Unknown => parser.parse_program(),
+      IsModule::CommonJS => parser.parse_commonjs().map(SwcProgram::Script),
+    };
+    (None, program_result, parser.take_errors())
   };
 
-  // TODO: add stacker to avoid stack overflow
-  #[cfg(all(debug_assertions, not(target_family = "wasm")))]
-  {
-    // Adjust stack to avoid stack overflow.
-    stacker::maybe_grow(
-      2 * 1024 * 1024, /* 2mb */
-      4 * 1024 * 1024, /* 4mb */
-      inner,
-    )
+  // Using combinator will let rustc unhappy.
+  match program_result {
+    Ok(program) => {
+      if !errors.is_empty() {
+        return Err(errors);
+      }
+      Ok((program, tokens))
+    }
+    Err(err) => {
+      errors.push(err);
+      Err(errors)
+    }
   }
-  #[cfg(any(not(debug_assertions), target_family = "wasm"))]
-  inner()
 }

--- a/crates/rspack_loader_swc/Cargo.toml
+++ b/crates/rspack_loader_swc/Cargo.toml
@@ -44,9 +44,6 @@ swc_core                       = { workspace = true, features = ["base", "ecma_a
 tokio                          = { workspace = true }
 tracing                        = { workspace = true }
 
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
-stacker = { workspace = true }
-
 [lints]
 workspace = true
 

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -249,18 +249,6 @@ impl Loader<RunnerContext> for SwcLoader {
     resource =loader_context.resource(),
   ))]
   async fn run(&self, loader_context: &mut LoaderContext<RunnerContext>) -> Result<()> {
-    #[allow(unused_mut)]
-    let mut inner = || self.loader_impl(loader_context);
-    #[cfg(all(debug_assertions, not(target_family = "wasm")))]
-    {
-      // Adjust stack to avoid stack overflow.
-      stacker::maybe_grow(
-        2 * 1024 * 1024, /* 2mb */
-        4 * 1024 * 1024, /* 4mb */
-        inner,
-      )
-    }
-    #[cfg(any(not(debug_assertions), target_family = "wasm"))]
-    inner()
+    self.loader_impl(loader_context)
   }
 }


### PR DESCRIPTION
## Summary
- remove `stacker::maybe_grow` from JavaScript parsing and SWC loader execution paths
- simplify both call sites to invoke the existing logic directly
- drop the unused `stacker` workspace/crate dependencies and clean up `Cargo.lock`

## Testing
- Not run (not requested)