### PR TITLE
chore(ci): add pre-watcher delay to prevent FSEvents stale events in native watch tests

### DIFF
--- a/packages/rspack-test-tools/src/case/watch.ts
+++ b/packages/rspack-test-tools/src/case/watch.ts
@@ -112,8 +112,8 @@ export function createWatchInitialProcessor(
       // a watcher is created. Wait briefly so the kernel event log commits all
       // copyDiff writes, ensuring kFSEventStreamEventIdSinceNow excludes them.
       // See: https://gist.github.com/stormslowly/ed758500de6f23211fd63b39eba5ed07
-      if (nativeWatcher) {
-        await new Promise((resolve) => setTimeout(resolve, 50));
+      if (nativeWatcher && process.platform === 'darwin') {
+        await new Promise((resolve) => setTimeout(resolve, 10));
       }
 
       const task = new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

Fix the flaky `nativeWatcher > watchCases/compilation/built-modules > should compile step 1` test on macOS by adding a 50ms delay between `copyDiff(step0)` and `compiler.watch()` in `createWatchInitialProcessor`.

## Root Cause

On macOS, the `notify` crate uses the FSEvents backend (`macos_fsevent`). FSEvents delivers **stale events** for files written shortly before a watcher is created — even though `kFSEventStreamEventIdSinceNow` is used.

Minimal reproduction: https://gist.github.com/stormslowly/ed758500de6f23211fd63b39eba5ed07

In the watch test framework:
1. `copyDiff(step0)` writes `index.js` + `foo.js` to tempDir
2. `compiler.watch()` creates the FSEvents watcher **immediately** after
3. FSEvents delivers stale Create/Modify events for both files to the new watcher
4. These stale events can merge with step1's `foo.js` change in the executor's 50ms aggregate window
5. `compilation.builtModules` contains both `['./foo', './index.js']` instead of just `['./foo']`

## Fix

Add a 50ms delay between `copyDiff` and `compiler.watch()` so the kernel event log fully commits all pending writes before the watcher stream is created. This ensures `kFSEventStreamEventIdSinceNow` correctly excludes pre-watcher events.

Empirical validation (using the reproduction gist):

| pre-watcher delay | stale event rate |
|------------------:|----------------:|
| 0ms | 196/200 (98%) |
| 10ms | 0/200 |
| 50ms | 0/200 |

## Test Plan

- [x] `NativeWatcher.part1.test.js` passes 10/10 sequential runs locally
- [x] `built-modules` test passes 10/10 under 2x parallel stress (previously failed at 1x parallel)