### PR TITLE
fix(watcher): flush pending events on unpause to prevent stuck files_data

### DIFF
--- a/crates/rspack_watcher/src/executor.rs
+++ b/crates/rspack_watcher/src/executor.rs
@@ -171,6 +171,15 @@ impl Executor {
     self.abort().await;
 
     self.run_execute_handler(event_aggregate_handler, event_handler);
+
+    // Flush events accumulated during the pause period.
+    // Without this, events that arrived while paused would sit in files_data
+    // indefinitely — the event loop already processed them (added to files_data)
+    // but skipped sending Execute because paused was true. No future OS event
+    // will re-deliver them, so we must kick the aggregate task ourselves.
+    if !self.files_data.lock().await.is_empty() {
+      let _ = self.exec_aggregate_tx.send(ExecAggregateEvent::Execute);
+    }
   }
 
   fn run_execute_handler(


### PR DESCRIPTION
## Summary

- Fix a race condition in `rspack_watcher::Executor` where file-change events accumulated during a pause period are never processed after unpause
- Root cause of the `watch-detection 10ms` test flaking on macOS CI ([example failure](https://github.com/web-infra-dev/rspack/actions/runs/23936216527/job/69813467360))

## Root Cause

When the watcher is paused during a rebuild:
1. OS file-change events still accumulate in `files_data` (the event loop inserts them)
2. But the event loop skips sending `Execute` because `paused = true`
3. After the rebuild, `wait_for_execute()` sets `paused = false`, aborts old tasks, and creates a new aggregate task
4. **Bug**: nobody checks `files_data` for pending events — the new aggregate task waits for an `Execute` signal that never comes (since the OS already delivered those events)
5. `files_data` is stuck forever → no rebuild → test timeout

This specifically affects macOS because FSEvents has higher latency than Linux's inotify, so `file.js` and `file2.js` change events often arrive in separate batches rather than together within the 50ms aggregate window.

## Fix

After creating new tasks in `wait_for_execute()`, check if `files_data` is non-empty and send an `Execute` signal to flush the pending events:

```rust
if !self.files_data.lock().await.is_empty() {
  let _ = self.exec_aggregate_tx.send(ExecAggregateEvent::Execute);
}
```

Duplicate `Execute` signals are harmless — the aggregate task simply drains empty `files_data` with a no-op `continue`.

## Test plan

- [x] `cargo test -p rspack_watcher` — all 11 tests pass
- [ ] CI: `watch-detection 10ms` test on macOS ARM64 should no longer flake