### PR TITLE
ci: add contents:read permission for ecosystem CI commit comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,8 @@ jobs:
     name: Run ecosystem CI per commit
     needs: [check-changed, build-linux]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
       - name: Trigger Ecosystem CI


### PR DESCRIPTION
## Summary

- Add job-level `permissions: { contents: read }` to the `ecosystem_ci_per_commit` job in `ci.yml`

## Motivation

The `ecosystem_ci_per_commit` composite action uses `github.rest.repos.createCommitComment()` to post ecosystem CI results on the triggering commit. This API requires `contents: read` permission on the `GITHUB_TOKEN`.

Since `ci.yml` declares an explicit top-level `permissions` block (with only `issues: write` and `pull-requests: write`), all undeclared permissions default to `none`, causing the commit comment step to fail with 403 `Resource not accessible by integration`.

Using job-level permissions keeps the fix scoped to this single job without granting extra permissions to the rest of CI.

## Related

- Failing run: https://github.com/web-infra-dev/rspack/actions/runs/23938667456/job/69820609313
- Parent PR: #13522

🤖 Generated with [Claude Code](https://claude.com/claude-code)