### PR TITLE
fix(esm_library): extract TLA shared modules to break circular dependency

### DIFF
--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -119,13 +119,13 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
 
       // Check if target is in an ancestor chunk of origin_async_chunk → circular dep
       for &target_chunk in target_chunks {
-        if let Some(ancestor_of) = chunk_to_ancestor_of.get(&target_chunk) {
-          if ancestor_of.contains(&origin_async_chunk) {
-            modules_to_extract
-              .entry(*target)
-              .or_default()
-              .insert(target_chunk);
-          }
+        if let Some(ancestor_of) = chunk_to_ancestor_of.get(&target_chunk)
+          && ancestor_of.contains(&origin_async_chunk)
+        {
+          modules_to_extract
+            .entry(*target)
+            .or_default()
+            .insert(target_chunk);
         }
       }
 

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -23,11 +23,11 @@ use crate::EsmLibraryPlugin;
 /// chunks to break the cycle.
 ///
 /// Returns `true` if any module uses top-level await, `false` otherwise.
-/// When returning `false`, no computation was performed.
+/// When returning `false`, no chunk-graph scanning was performed.
 pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool {
   let module_graph = compilation.get_module_graph();
 
-  // Early exit: if no module uses TLA, skip all computation
+  // Early exit: if no module uses TLA, skip chunk-graph scanning
   let has_tla = module_graph
     .modules()
     .any(|(_, m)| m.build_meta().has_top_level_await);
@@ -57,8 +57,11 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
     return true;
   }
 
-  // 2. For each async chunk, find ancestor chunks and scan for cross-chunk deps
-  let mut modules_to_extract: FxHashMap<ChunkUkey, IdentifierSet> = FxHashMap::default();
+  // 2. For each async chunk, find ancestor chunks and scan for cross-chunk deps.
+  //    Collect modules to extract keyed by module id → set of source chunks they
+  //    need to be removed from. This ensures each module is only extracted once
+  //    even if it appears in multiple ancestor chunks.
+  let mut modules_to_extract: IdentifierMap<FxHashSet<ChunkUkey>> = IdentifierMap::default();
 
   for async_chunk_ukey in &async_chunks {
     // Get all ancestor chunk group ukeys
@@ -94,6 +97,16 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
       }
 
       for conn in module_graph.get_outgoing_connections(&module_id) {
+        // Skip inactive connections
+        if !conn.is_target_active(
+          module_graph,
+          None,
+          &compilation.module_graph_cache_artifact,
+          &compilation.exports_info_artifact,
+        ) {
+          continue;
+        }
+
         let Some(target) = module_graph.module_identifier_by_dependency_id(&conn.dependency_id)
         else {
           continue;
@@ -105,9 +118,9 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
         for &target_chunk in target_chunks {
           if ancestor_chunks.contains(&target_chunk) {
             modules_to_extract
-              .entry(target_chunk)
+              .entry(*target)
               .or_default()
-              .insert(*target);
+              .insert(target_chunk);
           }
         }
 
@@ -123,8 +136,21 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
     return true;
   }
 
-  // 3. Extract modules: for each source chunk, create new chunk and move modules
-  for (source_chunk_ukey, modules) in modules_to_extract {
+  // 3. Group modules by their sorted set of source chunks, so modules that share
+  //    the same source chunks are moved to the same new chunk (like RemoveDuplicateModulesPlugin).
+  let mut chunk_group_map: FxHashMap<Vec<ChunkUkey>, Vec<ModuleIdentifier>> =
+    FxHashMap::default();
+  for (module_id, source_chunks) in &modules_to_extract {
+    let mut sorted_chunks: Vec<ChunkUkey> = source_chunks.iter().copied().collect();
+    sorted_chunks.sort();
+    chunk_group_map
+      .entry(sorted_chunks)
+      .or_default()
+      .push(*module_id);
+  }
+
+  // 4. Extract modules: for each group, create one new chunk and move modules there
+  for (source_chunks, modules) in chunk_group_map {
     let new_chunk_ukey =
       Compilation::add_chunk(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
 
@@ -139,53 +165,79 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
       .chunk_graph
       .add_chunk(new_chunk_ukey);
 
-    // Collect entry modules in source chunk
-    let entry_modules: IdentifierSet = compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_chunk_entry_modules(&source_chunk_ukey)
-      .into_iter()
-      .collect();
-
-    // Move modules from source chunk to new chunk
     for module_id in &modules {
-      compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .disconnect_chunk_and_module(&source_chunk_ukey, *module_id);
+      // Disconnect module from all source chunks
+      for source_chunk_ukey in &source_chunks {
+        // Collect entry module entrypoints before disconnecting
+        let entry_entrypoint: Option<ChunkGroupUkey> = compilation
+          .build_chunk_graph_artifact
+          .chunk_graph
+          .get_chunk_entry_modules_with_chunk_group_iterable(source_chunk_ukey)
+          .get(module_id)
+          .copied();
 
-      if entry_modules.contains(module_id) {
         compilation
           .build_chunk_graph_artifact
           .chunk_graph
-          .disconnect_chunk_and_entry_module(&source_chunk_ukey, *module_id);
+          .disconnect_chunk_and_module(source_chunk_ukey, *module_id);
+
+        if entry_entrypoint.is_some() {
+          compilation
+            .build_chunk_graph_artifact
+            .chunk_graph
+            .disconnect_chunk_and_entry_module(source_chunk_ukey, *module_id);
+        }
       }
 
+      // Connect module to new chunk
       compilation
         .build_chunk_graph_artifact
         .chunk_graph
         .connect_chunk_and_module(new_chunk_ukey, *module_id);
     }
 
-    // Establish chunk group relationship via split
-    let [Some(source_chunk), Some(new_chunk)] = compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .get_many_mut([&source_chunk_ukey, &new_chunk_ukey])
-    else {
-      unreachable!("source_chunk and new_chunk should both exist")
-    };
+    // Establish chunk group relationships via split from each source chunk
+    for source_chunk_ukey in &source_chunks {
+      let [Some(source_chunk), Some(new_chunk)] = compilation
+        .build_chunk_graph_artifact
+        .chunk_by_ukey
+        .get_many_mut([source_chunk_ukey, &new_chunk_ukey])
+      else {
+        unreachable!("source_chunk and new_chunk should both exist")
+      };
 
-    source_chunk.split(
-      new_chunk,
-      &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
-    );
+      source_chunk.split(
+        new_chunk,
+        &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+      );
 
-    if let Some(mut mutations) = compilation.incremental.mutations_write() {
-      mutations.add(Mutation::ChunkSplit {
-        from: source_chunk_ukey,
-        to: new_chunk_ukey,
-      });
+      if let Some(mut mutations) = compilation.incremental.mutations_write() {
+        mutations.add(Mutation::ChunkSplit {
+          from: *source_chunk_ukey,
+          to: new_chunk_ukey,
+        });
+      }
+    }
+
+    // Reconnect entry modules to new chunk with their entrypoint metadata.
+    // This must happen after split() so the new chunk has the correct groups.
+    for module_id in &modules {
+      let new_chunk = compilation
+        .build_chunk_graph_artifact
+        .chunk_by_ukey
+        .expect_get(&new_chunk_ukey);
+      for group_ukey in new_chunk.groups().iter().copied().collect::<Vec<_>>() {
+        let group = compilation
+          .build_chunk_graph_artifact
+          .chunk_group_by_ukey
+          .expect_get(&group_ukey);
+        if group.is_initial() && group.kind.is_entrypoint() {
+          compilation
+            .build_chunk_graph_artifact
+            .chunk_graph
+            .connect_chunk_and_entry_module(new_chunk_ukey, *module_id, group_ukey);
+        }
+      }
     }
   }
 

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -15,69 +15,67 @@ use rspack_util::{
 
 use crate::EsmLibraryPlugin;
 
-/// Scan async (TLA) chunks for dependencies that reside in ancestor chunks.
-/// When an async chunk with TLA imports a module from its ancestor, a circular
-/// dependency is created (ancestor awaits the async chunk, which imports back
-/// from the ancestor). This function extracts such shared modules into separate
-/// chunks to break the cycle.
+/// Scan TLA-awaited async chunks for static dependencies that reside in ancestor
+/// chunks. When a module with top-level await dynamically imports a chunk, and
+/// that chunk has static imports back to ancestor chunks, the ancestor must
+/// already have fully executed before the child can resolve its imports — but
+/// the ancestor is paused at its top-level await, creating a deadlock.
 ///
-/// Returns `true` if shared modules were actually extracted (circular dep found),
-/// `false` otherwise (no TLA or no circular deps detected).
+/// This function extracts such shared modules into separate chunks to break
+/// the cycle. It returns `true` if modules were actually extracted.
 pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool {
   let module_graph = compilation.get_module_graph();
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
   let chunk_group_by_ukey = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
 
-  // 1. Find async chunks: non-initial chunks that are the target of a
-  //    `DynamicImport` whose source module has top-level await.
-  //    When such a chunk is loaded via `await import()` from a module currently
-  //    paused at a top-level await, and the chunk has static imports back to
-  //    ancestor chunks, a circular dependency deadlock occurs.
+  // Phase 1: Detect at-risk async chunks.
+  // Source: modules with `has_top_level_await`.
+  // Their TOP-LEVEL `AsyncDependenciesBlock`s (we only iterate `module.get_blocks()`,
+  // which returns blocks attached to the module itself, not nested function blocks)
+  // target async chunk groups loaded via `await import()`. Those chunk groups'
+  // chunks are the ones at risk of deadlocking with the parent.
   let mut async_chunks_set: FxHashSet<ChunkUkey> = FxHashSet::default();
   for (module_id, module) in module_graph.modules() {
     if !module.build_meta().has_top_level_await {
       continue;
     }
-    // Collect DynamicImport dependencies from this TLA module (including ones in blocks)
-    let mut dep_ids: Vec<_> = module.get_dependencies().to_vec();
     for block_id in module.get_blocks() {
-      if let Some(block) = module_graph.block_by_id(block_id) {
-        dep_ids.extend(block.get_dependencies().iter().copied());
-      }
-    }
-    for dep_id in dep_ids {
-      let dep = module_graph.dependency_by_id(&dep_id);
-      if dep.dependency_type() != &DependencyType::DynamicImport {
-        continue;
-      }
-      let Some(target) = module_graph.module_identifier_by_dependency_id(&dep_id) else {
+      let Some(block) = module_graph.block_by_id(block_id) else {
         continue;
       };
-      // Skip self-imports; also only care about chunks that contain the target
-      if target == module_id {
-        continue;
-      }
-      for &chunk_ukey in chunk_graph.get_module_chunks(*target) {
-        let chunk = compilation
-          .build_chunk_graph_artifact
-          .chunk_by_ukey
-          .expect_get(&chunk_ukey);
-        if !chunk.is_only_initial(chunk_group_by_ukey) {
-          async_chunks_set.insert(chunk_ukey);
+      for dep_id in block.get_dependencies() {
+        let dep = module_graph.dependency_by_id(dep_id);
+        if dep.dependency_type() != &DependencyType::DynamicImport {
+          continue;
+        }
+        let Some(target) = module_graph.module_identifier_by_dependency_id(dep_id) else {
+          continue;
+        };
+        if target == module_id {
+          continue;
+        }
+        for &chunk_ukey in chunk_graph.get_module_chunks(*target) {
+          let chunk = compilation
+            .build_chunk_graph_artifact
+            .chunk_by_ukey
+            .expect_get(&chunk_ukey);
+          if !chunk.is_only_initial(chunk_group_by_ukey) {
+            async_chunks_set.insert(chunk_ukey);
+          }
         }
       }
     }
   }
-  let async_chunks: Vec<ChunkUkey> = async_chunks_set.iter().copied().collect();
 
-  if async_chunks.is_empty() {
+  if async_chunks_set.is_empty() {
     return false;
   }
 
-  // 2. Pre-compute: for each async chunk, its ancestor chunks; also build a
-  //    reverse lookup from chunk → which async chunks consider it an ancestor.
-  //    Then do a single BFS across all async chunks sharing one visited set.
-  let mut chunk_to_ancestor_of: FxHashMap<ChunkUkey, Vec<ChunkUkey>> = FxHashMap::default();
+  // Phase 2: Reverse map `ancestor_chunk → {async_chunks that consider it an ancestor}`.
+  // This replaces per-async-chunk repeated ancestor walks with one O(1) lookup
+  // during BFS.
+  let async_chunks: Vec<ChunkUkey> = async_chunks_set.iter().copied().collect();
+  let mut chunk_to_ancestor_of: FxHashMap<ChunkUkey, FxHashSet<ChunkUkey>> = FxHashMap::default();
   let mut module_to_async_chunk: IdentifierMap<ChunkUkey> = IdentifierMap::default();
   let mut queue: VecDeque<ModuleIdentifier> = VecDeque::new();
 
@@ -86,30 +84,32 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
       .build_chunk_graph_artifact
       .chunk_by_ukey
       .expect_get(&async_chunk_ukey);
-    let mut ancestor_group_ukeys = FxHashSet::default();
+    let mut ancestor_groups = FxHashSet::default();
     for group_ukey in chunk.groups() {
       let group = chunk_group_by_ukey.expect_get(group_ukey);
-      ancestor_group_ukeys.extend(group.ancestors(chunk_group_by_ukey));
+      ancestor_groups.extend(group.ancestors(chunk_group_by_ukey));
     }
-    for g in &ancestor_group_ukeys {
+    for g in &ancestor_groups {
       for &ancestor_chunk in &chunk_group_by_ukey.expect_get(g).chunks {
         chunk_to_ancestor_of
           .entry(ancestor_chunk)
           .or_default()
-          .push(async_chunk_ukey);
+          .insert(async_chunk_ukey);
       }
     }
 
-    // Seed BFS with all modules in this async chunk
+    // Seed BFS with modules in this async chunk
     for &m in chunk_graph.get_chunk_modules_identifier(&async_chunk_ukey) {
       module_to_async_chunk.insert(m, async_chunk_ukey);
       queue.push_back(m);
     }
   }
 
-  // Single BFS across all async chunks with a shared visited set — O(N + E).
-  // Each module is visited at most once. When a target is in an ancestor chunk
-  // of the originating async chunk, we mark it for extraction.
+  // Phase 3: Single BFS with shared `visited`. For each module visited, walk all
+  // active outgoing connections (skipping `DynamicImport` — those produce
+  // promises and don't require the target chunk to be fully executed in the
+  // current evaluation frame). If the target is in an ancestor chunk of this
+  // module's owning async chunk, record it for extraction.
   let mut modules_to_extract: IdentifierMap<FxHashSet<ChunkUkey>> = IdentifierMap::default();
   let mut visited = IdentifierSet::default();
 
@@ -117,13 +117,17 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
     if !visited.insert(module_id) {
       continue;
     }
-
-    // Determine which async chunk this module belongs to
     let Some(&origin_async_chunk) = module_to_async_chunk.get(&module_id) else {
       continue;
     };
 
     for conn in module_graph.get_outgoing_connections(&module_id) {
+      // Dynamic imports don't cause sync-load deadlocks — they hand out a
+      // promise; skip.
+      let dep = module_graph.dependency_by_id(&conn.dependency_id);
+      if dep.dependency_type() == &DependencyType::DynamicImport {
+        continue;
+      }
       if !conn.is_target_active(
         module_graph,
         None,
@@ -135,15 +139,12 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
       ) {
         continue;
       }
-
       let Some(target) = module_graph.module_identifier_by_dependency_id(&conn.dependency_id)
       else {
         continue;
       };
-
       let target_chunks = chunk_graph.get_module_chunks(*target);
 
-      // Check if target is in an ancestor chunk of origin_async_chunk → circular dep
       for &target_chunk in target_chunks {
         if let Some(ancestor_of) = chunk_to_ancestor_of.get(&target_chunk)
           && ancestor_of.contains(&origin_async_chunk)
@@ -155,7 +156,7 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
         }
       }
 
-      // Continue BFS if target is in the same async chunk
+      // Continue BFS if target is inside the same async chunk boundary
       if target_chunks.contains(&origin_async_chunk) {
         module_to_async_chunk.insert(*target, origin_async_chunk);
         queue.push_back(*target);
@@ -167,106 +168,90 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
     return false;
   }
 
-  // 3. Group modules by their sorted set of source chunks, so modules that share
-  //    the same source chunks are moved to the same new chunk (like RemoveDuplicateModulesPlugin).
+  // Phase 4: Group modules by their exact source-chunk set (modules that live
+  // in the same set of chunks go into one new chunk — mirrors
+  // `RemoveDuplicateModulesPlugin`). Then create new chunks and relocate.
   let mut chunk_group_map: FxHashMap<Vec<ChunkUkey>, Vec<ModuleIdentifier>> = FxHashMap::default();
   for (module_id, source_chunks) in &modules_to_extract {
-    let mut sorted_chunks: Vec<ChunkUkey> = source_chunks.iter().copied().collect();
-    sorted_chunks.sort();
-    chunk_group_map
-      .entry(sorted_chunks)
-      .or_default()
-      .push(*module_id);
+    let mut sorted: Vec<ChunkUkey> = source_chunks.iter().copied().collect();
+    sorted.sort();
+    chunk_group_map.entry(sorted).or_default().push(*module_id);
   }
 
-  // 4. Extract modules: for each group, create one new chunk and move modules there
   for (source_chunks, modules) in chunk_group_map {
     let new_chunk_ukey =
       Compilation::add_chunk(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
-
     if let Some(mut mutations) = compilation.incremental.mutations_write() {
       mutations.add(Mutation::ChunkAdd {
         chunk: new_chunk_ukey,
       });
     }
-
+    {
+      let new_chunk = compilation
+        .build_chunk_graph_artifact
+        .chunk_by_ukey
+        .expect_get_mut(&new_chunk_ukey);
+      *new_chunk.chunk_reason_mut() = Some("extracted to break TLA circular dependency".into());
+    }
     compilation
       .build_chunk_graph_artifact
       .chunk_graph
       .add_chunk(new_chunk_ukey);
 
-    for module_id in &modules {
-      // Disconnect module from all source chunks
+    // For each module: collect which source chunks had it registered as an
+    // entry module, then disconnect from all source chunks and connect to the
+    // new chunk. Only modules that WERE entry modules get reconnected as entry.
+    for &module_id in &modules {
+      let mut entry_reconnections: Vec<ChunkGroupUkey> = Vec::new();
       for source_chunk_ukey in &source_chunks {
-        // Collect entry module entrypoints before disconnecting
-        let entry_entrypoint: Option<ChunkGroupUkey> = compilation
+        if let Some(&entrypoint) = compilation
           .build_chunk_graph_artifact
           .chunk_graph
           .get_chunk_entry_modules_with_chunk_group_iterable(source_chunk_ukey)
-          .get(module_id)
-          .copied();
-
-        compilation
-          .build_chunk_graph_artifact
-          .chunk_graph
-          .disconnect_chunk_and_module(source_chunk_ukey, *module_id);
-
-        if entry_entrypoint.is_some() {
+          .get(&module_id)
+        {
+          entry_reconnections.push(entrypoint);
           compilation
             .build_chunk_graph_artifact
             .chunk_graph
-            .disconnect_chunk_and_entry_module(source_chunk_ukey, *module_id);
+            .disconnect_chunk_and_entry_module(source_chunk_ukey, module_id);
         }
+        compilation
+          .build_chunk_graph_artifact
+          .chunk_graph
+          .disconnect_chunk_and_module(source_chunk_ukey, module_id);
       }
-
-      // Connect module to new chunk
       compilation
         .build_chunk_graph_artifact
         .chunk_graph
-        .connect_chunk_and_module(new_chunk_ukey, *module_id);
+        .connect_chunk_and_module(new_chunk_ukey, module_id);
+      for entrypoint in entry_reconnections {
+        compilation
+          .build_chunk_graph_artifact
+          .chunk_graph
+          .connect_chunk_and_entry_module(new_chunk_ukey, module_id, entrypoint);
+      }
     }
 
-    // Establish chunk group relationships via split from each source chunk
+    // Establish chunk group relationships: new_chunk joins each source chunk's
+    // groups (making it a sibling — it will be loaded alongside the source).
     for source_chunk_ukey in &source_chunks {
       let [Some(source_chunk), Some(new_chunk)] = compilation
         .build_chunk_graph_artifact
         .chunk_by_ukey
         .get_many_mut([source_chunk_ukey, &new_chunk_ukey])
       else {
-        unreachable!("source_chunk and new_chunk should both exist")
+        unreachable!("both chunks should exist")
       };
-
       source_chunk.split(
         new_chunk,
         &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
       );
-
       if let Some(mut mutations) = compilation.incremental.mutations_write() {
         mutations.add(Mutation::ChunkSplit {
           from: *source_chunk_ukey,
           to: new_chunk_ukey,
         });
-      }
-    }
-
-    // Reconnect entry modules to new chunk with their entrypoint metadata.
-    // This must happen after split() so the new chunk has the correct groups.
-    for module_id in &modules {
-      let new_chunk = compilation
-        .build_chunk_graph_artifact
-        .chunk_by_ukey
-        .expect_get(&new_chunk_ukey);
-      for group_ukey in new_chunk.groups().iter().copied().collect::<Vec<_>>() {
-        let group = compilation
-          .build_chunk_graph_artifact
-          .chunk_group_by_ukey
-          .expect_get(&group_ukey);
-        if group.is_initial() && group.kind.is_entrypoint() {
-          compilation
-            .build_chunk_graph_artifact
-            .chunk_graph
-            .connect_chunk_and_entry_module(new_chunk_ukey, *module_id, group_ukey);
-        }
       }
     }
   }

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -30,10 +30,14 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
 
   // Phase 1: Detect at-risk async chunks.
   // Source: modules with `has_top_level_await`.
-  // Their TOP-LEVEL `AsyncDependenciesBlock`s (we only iterate `module.get_blocks()`,
-  // which returns blocks attached to the module itself, not nested function blocks)
-  // target async chunk groups loaded via `await import()`. Those chunk groups'
-  // chunks are the ones at risk of deadlocking with the parent.
+  // We iterate `module.get_blocks()` (blocks attached directly to the module).
+  // This is conservative: a function-scoped `import()` also shows up here when
+  // the parser attaches its block to the module. We accept that over-inclusion
+  // — extraction only actually happens in later phases when there's a real
+  // cross-chunk static dependency back to an ancestor chunk, so function-only
+  // imports without cycles incur only a cheap BFS and no chunk mutation.
+  // Precise filtering would need AST-level "is the import() directly awaited
+  // at module top level" info which is not exposed on the block.
   let mut async_chunks_set: FxHashSet<ChunkUkey> = FxHashSet::default();
   for (module_id, module) in module_graph.modules() {
     if !module.build_meta().has_top_level_await {
@@ -71,15 +75,17 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
     return false;
   }
 
-  // Phase 2: Reverse map `ancestor_chunk → {async_chunks that consider it an ancestor}`.
-  // This replaces per-async-chunk repeated ancestor walks with one O(1) lookup
-  // during BFS.
+  // Phase 2 + 3: For each at-risk async chunk, compute its ancestor chunks and
+  // run a BFS through static outgoing edges. Each async chunk uses its OWN
+  // `visited` set so that a module reachable from multiple async chunks is
+  // analyzed once per origin — this matters when a shared module lives in
+  // DIFFERENT ancestor chunks for different async chunks (e.g. multi-entry
+  // builds where an async chunk hangs off each entry).
   let async_chunks: Vec<ChunkUkey> = async_chunks_set.iter().copied().collect();
-  let mut chunk_to_ancestor_of: FxHashMap<ChunkUkey, FxHashSet<ChunkUkey>> = FxHashMap::default();
-  let mut module_to_async_chunk: IdentifierMap<ChunkUkey> = IdentifierMap::default();
-  let mut queue: VecDeque<ModuleIdentifier> = VecDeque::new();
+  let mut modules_to_extract: IdentifierMap<FxHashSet<ChunkUkey>> = IdentifierMap::default();
 
   for &async_chunk_ukey in &async_chunks {
+    // Collect ancestor chunks via chunk group parent traversal
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
@@ -89,77 +95,68 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
       let group = chunk_group_by_ukey.expect_get(group_ukey);
       ancestor_groups.extend(group.ancestors(chunk_group_by_ukey));
     }
+    let mut ancestor_chunks: FxHashSet<ChunkUkey> = FxHashSet::default();
     for g in &ancestor_groups {
-      for &ancestor_chunk in &chunk_group_by_ukey.expect_get(g).chunks {
-        chunk_to_ancestor_of
-          .entry(ancestor_chunk)
-          .or_default()
-          .insert(async_chunk_ukey);
-      }
+      ancestor_chunks.extend(chunk_group_by_ukey.expect_get(g).chunks.iter().copied());
     }
 
-    // Seed BFS with modules in this async chunk
-    for &m in chunk_graph.get_chunk_modules_identifier(&async_chunk_ukey) {
-      module_to_async_chunk.insert(m, async_chunk_ukey);
-      queue.push_back(m);
-    }
-  }
-
-  // Phase 3: Single BFS with shared `visited`. For each module visited, walk all
-  // active outgoing connections (skipping `DynamicImport` — those produce
-  // promises and don't require the target chunk to be fully executed in the
-  // current evaluation frame). If the target is in an ancestor chunk of this
-  // module's owning async chunk, record it for extraction.
-  let mut modules_to_extract: IdentifierMap<FxHashSet<ChunkUkey>> = IdentifierMap::default();
-  let mut visited = IdentifierSet::default();
-
-  while let Some(module_id) = queue.pop_front() {
-    if !visited.insert(module_id) {
+    if ancestor_chunks.is_empty() {
       continue;
     }
-    let Some(&origin_async_chunk) = module_to_async_chunk.get(&module_id) else {
-      continue;
-    };
 
-    for conn in module_graph.get_outgoing_connections(&module_id) {
-      // Dynamic imports don't cause sync-load deadlocks — they hand out a
-      // promise; skip.
-      let dep = module_graph.dependency_by_id(&conn.dependency_id);
-      if dep.dependency_type() == &DependencyType::DynamicImport {
+    // Per-async-chunk BFS with a local `visited` set. Starts from all modules
+    // that live in this async chunk.
+    let mut visited = IdentifierSet::default();
+    let mut queue: VecDeque<ModuleIdentifier> = chunk_graph
+      .get_chunk_modules_identifier(&async_chunk_ukey)
+      .iter()
+      .copied()
+      .collect();
+
+    while let Some(module_id) = queue.pop_front() {
+      if !visited.insert(module_id) {
         continue;
       }
-      if !conn.is_target_active(
-        module_graph,
-        None,
-        &compilation.module_graph_cache_artifact,
-        &compilation
-          .build_module_graph_artifact
-          .side_effects_state_artifact,
-        &compilation.exports_info_artifact,
-      ) {
-        continue;
-      }
-      let Some(target) = module_graph.module_identifier_by_dependency_id(&conn.dependency_id)
-      else {
-        continue;
-      };
-      let target_chunks = chunk_graph.get_module_chunks(*target);
 
-      for &target_chunk in target_chunks {
-        if let Some(ancestor_of) = chunk_to_ancestor_of.get(&target_chunk)
-          && ancestor_of.contains(&origin_async_chunk)
-        {
-          modules_to_extract
-            .entry(*target)
-            .or_default()
-            .insert(target_chunk);
+      for conn in module_graph.get_outgoing_connections(&module_id) {
+        // Dynamic imports produce promises; the target is not required to have
+        // finished evaluating in the current frame, so no sync-load deadlock.
+        let dep = module_graph.dependency_by_id(&conn.dependency_id);
+        if dep.dependency_type() == &DependencyType::DynamicImport {
+          continue;
         }
-      }
+        if !conn.is_target_active(
+          module_graph,
+          None,
+          &compilation.module_graph_cache_artifact,
+          &compilation
+            .build_module_graph_artifact
+            .side_effects_state_artifact,
+          &compilation.exports_info_artifact,
+        ) {
+          continue;
+        }
+        let Some(target) = module_graph.module_identifier_by_dependency_id(&conn.dependency_id)
+        else {
+          continue;
+        };
+        let target_chunks = chunk_graph.get_module_chunks(*target);
 
-      // Continue BFS if target is inside the same async chunk boundary
-      if target_chunks.contains(&origin_async_chunk) {
-        module_to_async_chunk.insert(*target, origin_async_chunk);
-        queue.push_back(*target);
+        // If the target lives in a chunk that is an ancestor of THIS async
+        // chunk, extract it from that specific ancestor chunk.
+        for &target_chunk in target_chunks {
+          if ancestor_chunks.contains(&target_chunk) {
+            modules_to_extract
+              .entry(*target)
+              .or_default()
+              .insert(target_chunk);
+          }
+        }
+
+        // Continue BFS if target is inside THIS async chunk boundary
+        if target_chunks.contains(&async_chunk_ukey) {
+          queue.push_back(*target);
+        }
       }
     }
   }

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -102,6 +102,9 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
         module_graph,
         None,
         &compilation.module_graph_cache_artifact,
+        &compilation
+          .build_module_graph_artifact
+          .side_effects_state_artifact,
         &compilation.exports_info_artifact,
       ) {
         continue;

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -48,77 +48,88 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
     return false;
   }
 
-  // 2. For each async chunk, find ancestor chunks and scan for cross-chunk deps.
-  //    Collect modules to extract keyed by module id → set of source chunks they
-  //    need to be removed from. This ensures each module is only extracted once
-  //    even if it appears in multiple ancestor chunks.
-  let mut modules_to_extract: IdentifierMap<FxHashSet<ChunkUkey>> = IdentifierMap::default();
+  // 2. Pre-compute: for each async chunk, its ancestor chunks; also build a
+  //    reverse lookup from chunk → which async chunks consider it an ancestor.
+  //    Then do a single BFS across all async chunks sharing one visited set.
+  let mut chunk_to_ancestor_of: FxHashMap<ChunkUkey, Vec<ChunkUkey>> = FxHashMap::default();
+  let mut module_to_async_chunk: IdentifierMap<ChunkUkey> = IdentifierMap::default();
+  let mut queue: VecDeque<ModuleIdentifier> = VecDeque::new();
 
-  for async_chunk_ukey in &async_chunks {
-    // Get all ancestor chunk group ukeys
+  for &async_chunk_ukey in &async_chunks {
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
-      .expect_get(async_chunk_ukey);
+      .expect_get(&async_chunk_ukey);
     let mut ancestor_group_ukeys = FxHashSet::default();
     for group_ukey in chunk.groups() {
       let group = chunk_group_by_ukey.expect_get(group_ukey);
       ancestor_group_ukeys.extend(group.ancestors(chunk_group_by_ukey));
     }
+    for g in &ancestor_group_ukeys {
+      for &ancestor_chunk in &chunk_group_by_ukey.expect_get(g).chunks {
+        chunk_to_ancestor_of
+          .entry(ancestor_chunk)
+          .or_default()
+          .push(async_chunk_ukey);
+      }
+    }
 
-    // Collect ancestor chunk ukeys from ancestor groups
-    let ancestor_chunks: FxHashSet<ChunkUkey> = ancestor_group_ukeys
-      .iter()
-      .flat_map(|g| chunk_group_by_ukey.expect_get(g).chunks.iter().copied())
-      .collect();
+    // Seed BFS with all modules in this async chunk
+    for &m in chunk_graph.get_chunk_modules_identifier(&async_chunk_ukey) {
+      module_to_async_chunk.insert(m, async_chunk_ukey);
+      queue.push_back(m);
+    }
+  }
 
-    if ancestor_chunks.is_empty() {
+  // Single BFS across all async chunks with a shared visited set — O(N + E).
+  // Each module is visited at most once. When a target is in an ancestor chunk
+  // of the originating async chunk, we mark it for extraction.
+  let mut modules_to_extract: IdentifierMap<FxHashSet<ChunkUkey>> = IdentifierMap::default();
+  let mut visited = IdentifierSet::default();
+
+  while let Some(module_id) = queue.pop_front() {
+    if !visited.insert(module_id) {
       continue;
     }
 
-    let chunk_modules = chunk_graph.get_chunk_modules_identifier(async_chunk_ukey);
+    // Determine which async chunk this module belongs to
+    let Some(&origin_async_chunk) = module_to_async_chunk.get(&module_id) else {
+      continue;
+    };
 
-    // BFS through all outgoing dependencies of modules in async chunk
-    let mut visited = IdentifierSet::default();
-    let mut queue: VecDeque<ModuleIdentifier> = chunk_modules.iter().copied().collect();
-
-    while let Some(module_id) = queue.pop_front() {
-      if !visited.insert(module_id) {
+    for conn in module_graph.get_outgoing_connections(&module_id) {
+      if !conn.is_target_active(
+        module_graph,
+        None,
+        &compilation.module_graph_cache_artifact,
+        &compilation.exports_info_artifact,
+      ) {
         continue;
       }
 
-      for conn in module_graph.get_outgoing_connections(&module_id) {
-        // Skip inactive connections
-        if !conn.is_target_active(
-          module_graph,
-          None,
-          &compilation.module_graph_cache_artifact,
-          &compilation.exports_info_artifact,
-        ) {
-          continue;
-        }
+      let Some(target) = module_graph.module_identifier_by_dependency_id(&conn.dependency_id)
+      else {
+        continue;
+      };
 
-        let Some(target) = module_graph.module_identifier_by_dependency_id(&conn.dependency_id)
-        else {
-          continue;
-        };
+      let target_chunks = chunk_graph.get_module_chunks(*target);
 
-        let target_chunks = chunk_graph.get_module_chunks(*target);
-
-        // Check if target is in an ancestor chunk → circular dep
-        for &target_chunk in target_chunks {
-          if ancestor_chunks.contains(&target_chunk) {
+      // Check if target is in an ancestor chunk of origin_async_chunk → circular dep
+      for &target_chunk in target_chunks {
+        if let Some(ancestor_of) = chunk_to_ancestor_of.get(&target_chunk) {
+          if ancestor_of.contains(&origin_async_chunk) {
             modules_to_extract
               .entry(*target)
               .or_default()
               .insert(target_chunk);
           }
         }
+      }
 
-        // Continue BFS if target is in the same async chunk
-        if target_chunks.contains(async_chunk_ukey) {
-          queue.push_back(*target);
-        }
+      // Continue BFS if target is in the same async chunk
+      if target_chunks.contains(&origin_async_chunk) {
+        module_to_async_chunk.insert(*target, origin_async_chunk);
+        queue.push_back(*target);
       }
     }
   }

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
@@ -5,7 +6,7 @@ use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   ChunkGroupUkey, ChunkUkey, Compilation, DependenciesBlock, DependencyType, ExportProvided,
-  ModuleIdentifier, UsageState, find_new_name, get_cached_readable_identifier,
+  ModuleGraph, ModuleIdentifier, UsageState, find_new_name, get_cached_readable_identifier,
   incremental::Mutation, split_readable_identifier,
 };
 use rspack_util::{
@@ -14,6 +15,182 @@ use rspack_util::{
 };
 
 use crate::EsmLibraryPlugin;
+
+/// Scan async (TLA) chunks for dependencies that reside in ancestor chunks.
+/// When an async chunk with TLA imports a module from its ancestor, a circular
+/// dependency is created (ancestor awaits the async chunk, which imports back
+/// from the ancestor). This function extracts such shared modules into separate
+/// chunks to break the cycle.
+///
+/// Returns `true` if any module uses top-level await, `false` otherwise.
+/// When returning `false`, no computation was performed.
+pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool {
+  let module_graph = compilation.get_module_graph();
+
+  // Early exit: if no module uses TLA, skip all computation
+  let has_tla = module_graph
+    .modules()
+    .any(|(_, m)| m.build_meta().has_top_level_await);
+  if !has_tla {
+    return false;
+  }
+
+  let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+  let chunk_group_by_ukey = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
+
+  // 1. Find async chunks: non-initial chunks containing at least one async module
+  let async_chunks: Vec<ChunkUkey> = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .iter()
+    .filter(|(_, chunk)| !chunk.can_be_initial(chunk_group_by_ukey))
+    .filter(|(ukey, _)| {
+      chunk_graph
+        .get_chunk_modules_identifier(ukey)
+        .iter()
+        .any(|m| ModuleGraph::is_async(&compilation.async_modules_artifact, m))
+    })
+    .map(|(ukey, _)| *ukey)
+    .collect();
+
+  if async_chunks.is_empty() {
+    return true;
+  }
+
+  // 2. For each async chunk, find ancestor chunks and scan for cross-chunk deps
+  let mut modules_to_extract: FxHashMap<ChunkUkey, IdentifierSet> = FxHashMap::default();
+
+  for async_chunk_ukey in &async_chunks {
+    // Get all ancestor chunk group ukeys
+    let chunk = compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .expect_get(async_chunk_ukey);
+    let mut ancestor_group_ukeys = FxHashSet::default();
+    for group_ukey in chunk.groups() {
+      let group = chunk_group_by_ukey.expect_get(group_ukey);
+      ancestor_group_ukeys.extend(group.ancestors(chunk_group_by_ukey));
+    }
+
+    // Collect ancestor chunk ukeys from ancestor groups
+    let ancestor_chunks: FxHashSet<ChunkUkey> = ancestor_group_ukeys
+      .iter()
+      .flat_map(|g| chunk_group_by_ukey.expect_get(g).chunks.iter().copied())
+      .collect();
+
+    if ancestor_chunks.is_empty() {
+      continue;
+    }
+
+    let chunk_modules = chunk_graph.get_chunk_modules_identifier(async_chunk_ukey);
+
+    // BFS through all outgoing dependencies of modules in async chunk
+    let mut visited = IdentifierSet::default();
+    let mut queue: VecDeque<ModuleIdentifier> = chunk_modules.iter().copied().collect();
+
+    while let Some(module_id) = queue.pop_front() {
+      if !visited.insert(module_id) {
+        continue;
+      }
+
+      for conn in module_graph.get_outgoing_connections(&module_id) {
+        let Some(target) = module_graph.module_identifier_by_dependency_id(&conn.dependency_id)
+        else {
+          continue;
+        };
+
+        let target_chunks = chunk_graph.get_module_chunks(*target);
+
+        // Check if target is in an ancestor chunk → circular dep
+        for &target_chunk in target_chunks {
+          if ancestor_chunks.contains(&target_chunk) {
+            modules_to_extract
+              .entry(target_chunk)
+              .or_default()
+              .insert(*target);
+          }
+        }
+
+        // Continue BFS if target is in the same async chunk
+        if target_chunks.contains(async_chunk_ukey) {
+          queue.push_back(*target);
+        }
+      }
+    }
+  }
+
+  if modules_to_extract.is_empty() {
+    return true;
+  }
+
+  // 3. Extract modules: for each source chunk, create new chunk and move modules
+  for (source_chunk_ukey, modules) in modules_to_extract {
+    let new_chunk_ukey =
+      Compilation::add_chunk(&mut compilation.build_chunk_graph_artifact.chunk_by_ukey);
+
+    if let Some(mut mutations) = compilation.incremental.mutations_write() {
+      mutations.add(Mutation::ChunkAdd {
+        chunk: new_chunk_ukey,
+      });
+    }
+
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .add_chunk(new_chunk_ukey);
+
+    // Collect entry modules in source chunk
+    let entry_modules: IdentifierSet = compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_chunk_entry_modules(&source_chunk_ukey)
+      .into_iter()
+      .collect();
+
+    // Move modules from source chunk to new chunk
+    for module_id in &modules {
+      compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .disconnect_chunk_and_module(&source_chunk_ukey, *module_id);
+
+      if entry_modules.contains(module_id) {
+        compilation
+          .build_chunk_graph_artifact
+          .chunk_graph
+          .disconnect_chunk_and_entry_module(&source_chunk_ukey, *module_id);
+      }
+
+      compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .connect_chunk_and_module(new_chunk_ukey, *module_id);
+    }
+
+    // Establish chunk group relationship via split
+    let [Some(source_chunk), Some(new_chunk)] = compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .get_many_mut([&source_chunk_ukey, &new_chunk_ukey])
+    else {
+      unreachable!("source_chunk and new_chunk should both exist")
+    };
+
+    source_chunk.split(
+      new_chunk,
+      &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+    );
+
+    if let Some(mut mutations) = compilation.incremental.mutations_write() {
+      mutations.add(Mutation::ChunkSplit {
+        from: source_chunk_ukey,
+        to: new_chunk_ukey,
+      });
+    }
+  }
+
+  true
+}
 
 /// Ensure that all entry chunks only export the exports used by other chunks,
 /// this requires no other chunks depend on the entry chunk to get exports

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -1,5 +1,4 @@
-use std::collections::VecDeque;
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc};
 
 use atomic_refcell::AtomicRefCell;
 use rayon::prelude::*;
@@ -22,8 +21,8 @@ use crate::EsmLibraryPlugin;
 /// from the ancestor). This function extracts such shared modules into separate
 /// chunks to break the cycle.
 ///
-/// Returns `true` if any module uses top-level await, `false` otherwise.
-/// When returning `false`, no chunk-graph scanning was performed.
+/// Returns `true` if shared modules were actually extracted (circular dep found),
+/// `false` otherwise (no TLA or no circular deps detected).
 pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool {
   let module_graph = compilation.get_module_graph();
 
@@ -54,7 +53,7 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
     .collect();
 
   if async_chunks.is_empty() {
-    return true;
+    return false;
   }
 
   // 2. For each async chunk, find ancestor chunks and scan for cross-chunk deps.
@@ -133,13 +132,12 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
   }
 
   if modules_to_extract.is_empty() {
-    return true;
+    return false;
   }
 
   // 3. Group modules by their sorted set of source chunks, so modules that share
   //    the same source chunks are moved to the same new chunk (like RemoveDuplicateModulesPlugin).
-  let mut chunk_group_map: FxHashMap<Vec<ChunkUkey>, Vec<ModuleIdentifier>> =
-    FxHashMap::default();
+  let mut chunk_group_map: FxHashMap<Vec<ChunkUkey>, Vec<ModuleIdentifier>> = FxHashMap::default();
   for (module_id, source_chunks) in &modules_to_extract {
     let mut sorted_chunks: Vec<ChunkUkey> = source_chunks.iter().copied().collect();
     sorted_chunks.sort();

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -143,18 +143,23 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
         let target_chunks = chunk_graph.get_module_chunks(*target);
 
         // If the target lives in a chunk that is an ancestor of THIS async
-        // chunk, extract it from that specific ancestor chunk.
+        // chunk, extract it from that specific ancestor chunk. Also continue
+        // BFS into the target — its own static deps may also live in ancestor
+        // chunks (e.g. async → sharedA(ancestor) → sharedB(ancestor)).
+        let mut in_ancestor = false;
         for &target_chunk in target_chunks {
           if ancestor_chunks.contains(&target_chunk) {
             modules_to_extract
               .entry(*target)
               .or_default()
               .insert(target_chunk);
+            in_ancestor = true;
           }
         }
 
-        // Continue BFS if target is inside THIS async chunk boundary
-        if target_chunks.contains(&async_chunk_ukey) {
+        // Continue BFS if target is inside this async chunk OR in an ancestor
+        // chunk (to transitively find all ancestor-resident dependencies).
+        if in_ancestor || target_chunks.contains(&async_chunk_ukey) {
           queue.push_back(*target);
         }
       }

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   ChunkGroupUkey, ChunkUkey, Compilation, DependenciesBlock, DependencyType, ExportProvided,
-  ModuleGraph, ModuleIdentifier, UsageState, find_new_name, get_cached_readable_identifier,
+  ModuleIdentifier, UsageState, find_new_name, get_cached_readable_identifier,
   incremental::Mutation, split_readable_identifier,
 };
 use rspack_util::{
@@ -28,21 +28,47 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
   let chunk_group_by_ukey = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
 
-  // 1. Find async chunks: chunks that belong to at least one non-initial group
-  //    and contain at least one async (TLA) module
-  let async_chunks: Vec<ChunkUkey> = compilation
-    .build_chunk_graph_artifact
-    .chunk_by_ukey
-    .iter()
-    .filter(|(_, chunk)| !chunk.is_only_initial(chunk_group_by_ukey))
-    .filter(|(ukey, _)| {
-      chunk_graph
-        .get_chunk_modules_identifier(ukey)
-        .iter()
-        .any(|m| ModuleGraph::is_async(&compilation.async_modules_artifact, m))
-    })
-    .map(|(ukey, _)| *ukey)
-    .collect();
+  // 1. Find async chunks: non-initial chunks that are the target of a
+  //    `DynamicImport` whose source module has top-level await.
+  //    When such a chunk is loaded via `await import()` from a module currently
+  //    paused at a top-level await, and the chunk has static imports back to
+  //    ancestor chunks, a circular dependency deadlock occurs.
+  let mut async_chunks_set: FxHashSet<ChunkUkey> = FxHashSet::default();
+  for (module_id, module) in module_graph.modules() {
+    if !module.build_meta().has_top_level_await {
+      continue;
+    }
+    // Collect DynamicImport dependencies from this TLA module (including ones in blocks)
+    let mut dep_ids: Vec<_> = module.get_dependencies().to_vec();
+    for block_id in module.get_blocks() {
+      if let Some(block) = module_graph.block_by_id(block_id) {
+        dep_ids.extend(block.get_dependencies().iter().copied());
+      }
+    }
+    for dep_id in dep_ids {
+      let dep = module_graph.dependency_by_id(&dep_id);
+      if dep.dependency_type() != &DependencyType::DynamicImport {
+        continue;
+      }
+      let Some(target) = module_graph.module_identifier_by_dependency_id(&dep_id) else {
+        continue;
+      };
+      // Skip self-imports; also only care about chunks that contain the target
+      if target == module_id {
+        continue;
+      }
+      for &chunk_ukey in chunk_graph.get_module_chunks(*target) {
+        let chunk = compilation
+          .build_chunk_graph_artifact
+          .chunk_by_ukey
+          .expect_get(&chunk_ukey);
+        if !chunk.is_only_initial(chunk_group_by_ukey) {
+          async_chunks_set.insert(chunk_ukey);
+        }
+      }
+    }
+  }
+  let async_chunks: Vec<ChunkUkey> = async_chunks_set.iter().copied().collect();
 
   if async_chunks.is_empty() {
     return false;

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -25,24 +25,16 @@ use crate::EsmLibraryPlugin;
 /// `false` otherwise (no TLA or no circular deps detected).
 pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool {
   let module_graph = compilation.get_module_graph();
-
-  // Early exit: if no module uses TLA, skip chunk-graph scanning
-  let has_tla = module_graph
-    .modules()
-    .any(|(_, m)| m.build_meta().has_top_level_await);
-  if !has_tla {
-    return false;
-  }
-
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
   let chunk_group_by_ukey = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
 
-  // 1. Find async chunks: non-initial chunks containing at least one async module
+  // 1. Find async chunks: chunks that belong to at least one non-initial group
+  //    and contain at least one async (TLA) module
   let async_chunks: Vec<ChunkUkey> = compilation
     .build_chunk_graph_artifact
     .chunk_by_ukey
     .iter()
-    .filter(|(_, chunk)| !chunk.can_be_initial(chunk_group_by_ukey))
+    .filter(|(_, chunk)| !chunk.is_only_initial(chunk_group_by_ukey))
     .filter(|(ukey, _)| {
       chunk_graph
         .get_chunk_modules_identifier(ukey)

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -43,7 +43,7 @@ use crate::{
   esm_lib_parser_plugin::EsmLibParserPlugin,
   optimize_chunks::{
     analyze_dyn_import_targets, assign_dyn_import_chunk_short_names, ensure_entry_exports,
-    optimize_runtime_chunks,
+    extract_tla_shared_modules, optimize_runtime_chunks,
   },
   preserve_modules::preserve_modules,
   runtime::EsmRegisterModuleRuntimeModule,
@@ -695,6 +695,17 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     }
   } else if let Some(cache_groups) = &self.split_chunks {
     crate::split_chunks::split(cache_groups, compilation).await?;
+  }
+
+  let has_tla = extract_tla_shared_modules(compilation);
+  if has_tla {
+    compilation.push_diagnostic(rspack_error::Diagnostic::warn(
+      "EsmLibraryPlugin".into(),
+      "Top-level await is used with ESM library output. After bundling, the execution order \
+       of top-level await may differ from the original source, which could lead to incorrect \
+       runtime behavior."
+        .into(),
+    ));
   }
 
   ensure_entry_exports(compilation);

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -697,13 +697,14 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
     crate::split_chunks::split(cache_groups, compilation).await?;
   }
 
-  let has_tla = extract_tla_shared_modules(compilation);
-  if has_tla {
+  let extracted_tla_shared = extract_tla_shared_modules(compilation);
+  if extracted_tla_shared {
     compilation.push_diagnostic(rspack_error::Diagnostic::warn(
       "EsmLibraryPlugin".into(),
-      "Top-level await is used with ESM library output. After bundling, the execution order \
-       of top-level await may differ from the original source, which could lead to incorrect \
-       runtime behavior."
+      "Top-level await with shared modules caused a circular dependency between async and \
+       parent chunks. The shared modules have been extracted into separate chunks to break \
+       the cycle. After bundling, the execution order of top-level await may differ from the \
+       original source, which could lead to incorrect runtime behavior."
         .into(),
     ));
   }

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/__snapshots__/esm.snap.txt
@@ -1,0 +1,32 @@
+```mjs title=async.mjs
+
+// ./async.js
+
+
+
+export { value } from "./lib_js.mjs";
+
+```
+
+```mjs title=lib_js.mjs
+// ./lib.js
+const value = () => 42
+export { value };
+
+```
+
+```mjs title=main.mjs
+import { value } from "./lib_js.mjs";
+
+// ./index.js
+
+
+const {value: valueAsync} = await import("./async.mjs");
+
+it('should have correct value', () => {
+  expect(value).toBe(valueAsync);
+  expect(value()).toBe(42);
+})
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/test.filter.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "cycle caused by available modules"

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/test.filter.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "cycle caused by available modules"

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/warnings.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [/Top-level await with shared modules caused a circular dependency/];

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/warnings.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-1/warnings.js
@@ -1,1 +1,0 @@
-module.exports = [/Top-level await with shared modules caused a circular dependency/];

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/__snapshots__/esm.snap.txt
@@ -1,0 +1,34 @@
+```mjs title=async.mjs
+
+// ./async.js
+
+
+
+export { value } from "./lib_js.mjs";
+
+```
+
+```mjs title=lib_js.mjs
+// ./lib.js
+const value = () => 42
+export { value };
+
+```
+
+```mjs title=main.mjs
+import { value } from "./lib_js.mjs";
+
+// ./index2.js
+
+
+const {value: valueAsync} = await import("./async.mjs");
+
+it('should have correct value', () => {
+  expect(value).toBe(valueAsync);
+  expect(value()).toBe(42);
+})
+// ./index.js
+
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/test.filter.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "cycle caused by available modules"

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/test.filter.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "cycle caused by available modules"

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/warnings.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [/Top-level await with shared modules caused a circular dependency/];

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/warnings.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-2/warnings.js
@@ -1,1 +1,0 @@
-module.exports = [/Top-level await with shared modules caused a circular dependency/];

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/__snapshots__/esm.snap.txt
@@ -1,0 +1,47 @@
+```mjs title=async1.mjs
+
+// ./async1.js
+
+
+
+export { value } from "./lib_js.mjs";
+
+```
+
+```mjs title=async2.mjs
+
+// ./async2.js
+
+
+
+export { value } from "./lib_js.mjs";
+
+```
+
+```mjs title=lib_js.mjs
+// ./lib.js
+const value = () => 42
+export { value };
+
+```
+
+```mjs title=main.mjs
+import { value } from "./lib_js.mjs";
+
+// ./index2.js
+
+
+const {value: valueAsync1} = await import("./async1.mjs");
+
+
+it('should have correct value', async () => {
+  expect(value).toBe(valueAsync1);
+  const {value: valueAsync2} = await import("./async2.mjs");
+  expect(valueAsync1).toBe(valueAsync2);
+  expect(value()).toBe(42);
+})
+// ./index.js
+
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/test.filter.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => "cycle caused by available modules"

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/test.filter.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "cycle caused by available modules"

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/warnings.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [/Top-level await with shared modules caused a circular dependency/];

--- a/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/warnings.js
+++ b/tests/rspack-test/esmOutputCases/top-level-await/split-sync-modules-3/warnings.js
@@ -1,1 +1,0 @@
-module.exports = [/Top-level await with shared modules caused a circular dependency/];


### PR DESCRIPTION
## Summary
- When using ESM library output with top-level await (TLA), a circular dependency occurs: the main chunk `await import()`s the async chunk (because it has TLA), but the async chunk imports shared modules back from the main chunk via the "available modules" optimization.
- Adds `extract_tla_shared_modules()` in the `optimize_chunks` hook that scans async chunks' dependency graphs and extracts modules residing in ancestor chunks into separate chunks to break the cycle.
- Emits a warning when TLA is used with ESM library output, since bundled execution order may differ from the original source.

## Link

https://github.com/web-infra-dev/rslib/issues/1573

## Test plan
- [x] `cargo check -p rspack_plugin_esm_library` passes
- [x] `cargo test -p rspack_plugin_esm_library` — all 19 tests pass
- [ ] Manual verification with a TLA + shared dependency scenario