### PR TITLE
ci: use contents:write permission for ecosystem CI commit comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
     needs: [check-changed, build-linux]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
       - name: Trigger Ecosystem CI


### PR DESCRIPTION
## Summary

fix the wrong config in https://github.com/web-infra-dev/rspack/pull/13605. the doc lied to us, AI was right.

- `createCommitComment` is a POST (write) operation, so it requires `contents: write` permission, not `contents: read`
- Fixes the `403 Resource not accessible by integration` error in ecosystem CI per commit job

## Test plan
- [ ] Verify the ecosystem CI per commit job can successfully post commit comments after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>