### PR TITLE
perf(core): defer top-level declaration flattening

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -3740,7 +3740,7 @@ mod tests {
   }
 
   #[test]
-  fn merge_concatenated_build_partials_drops_top_level_declarations_when_any_partial_is_none() {
+  fn merge_concatenated_build_partials_drops_top_level_declarations_when_any_partial_is_unknown() {
     let mut build_info = BuildInfo {
       top_level_declarations: TopLevelDeclarations::Single(Default::default()),
       ..Default::default()

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -40,19 +40,19 @@ use crate::{
   BoxModuleDependency, BuildContext, BuildInfo, BuildMeta, BuildMetaDefaultObject,
   BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments, ChunkRenderContext,
   CodeGenerationDataTopLevelDeclarations, CodeGenerationExportsFinalNames,
-  CodeGenerationPublicPathAutoReplace, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
-  ConcatenationScope, ConditionalInitFragment, ConnectionState, Context, DEFAULT_EXPORT,
-  DEFAULT_EXPORT_ATOM, DependenciesBlock, DependencyId, DependencyType, ExportInfoHashKey,
-  ExportProvided, ExportsArgument, ExportsInfoArtifact, ExportsInfoGetter, ExportsType,
-  FactoryMeta, GetUsedNameParam, ImportedByDeferModulesArtifact, InitFragment, InitFragmentStage,
-  LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, ModuleLayer,
+  CodeGenerationPublicPathAutoReplace, CodeGenerationResult, Compilation, CompilationAsset,
+  ConcatenatedModuleIdent, ConcatenationScope, ConditionalInitFragment, ConnectionState, Context,
+  DEFAULT_EXPORT, DEFAULT_EXPORT_ATOM, DependenciesBlock, DependencyId, DependencyType,
+  ExportInfoHashKey, ExportProvided, ExportsArgument, ExportsInfoArtifact, ExportsInfoGetter,
+  ExportsType, FactoryMeta, GetUsedNameParam, ImportedByDeferModulesArtifact, InitFragment,
+  InitFragmentStage, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, ModuleLayer,
   ModuleStaticCache, ModuleType, NAMESPACE_OBJECT_EXPORT, ParserOptions, PrefetchExportsInfoMode,
   Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType,
-  URLStaticMode, UsageState, UsedName, UsedNameItem, escape_identifier, fast_set, filter_runtime,
-  find_target, get_runtime_key, impl_source_map_config, merge_runtime_condition,
-  merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
-  render_make_deferred_namespace_mode_from_exports_type,
+  TopLevelDeclarations, URLStaticMode, UsageState, UsedName, UsedNameItem, escape_identifier,
+  fast_set, filter_runtime, find_target, get_runtime_key, impl_source_map_config,
+  merge_runtime_condition, merge_runtime_condition_non_false, module_update_hash, property_access,
+  property_name, render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
@@ -643,7 +643,7 @@ impl ConcatenatedModule {
         strict: true,
         module_argument,
         exports_argument,
-        top_level_declarations: Some(Default::default()),
+        top_level_declarations: TopLevelDeclarations::Single(Default::default()),
         ..Default::default()
       },
       source_map_kind: SourceMapKind::empty(),
@@ -792,6 +792,79 @@ pub fn render_imports(source: &str, attr: Option<&str>, import_spec: &ImportSpec
   format!("{import_ns_stmt}{import_stmt}")
 }
 
+#[derive(Debug)]
+struct ConcatenatedBuildPartial {
+  dependencies: Vec<DependencyId>,
+  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  diagnostics: Vec<Diagnostic>,
+  top_level_declarations: TopLevelDeclarations,
+  need_create_require: bool,
+  cacheable: bool,
+  assets: HashMap<String, CompilationAsset>,
+}
+
+fn merge_concatenated_build_partials(
+  build_info: &mut BuildInfo,
+  dependencies: &mut Vec<DependencyId>,
+  blocks: &mut Vec<AsyncDependenciesBlockIdentifier>,
+  diagnostics: &mut Vec<Diagnostic>,
+  partials: Vec<ConcatenatedBuildPartial>,
+) {
+  for partial in partials {
+    if !partial.cacheable {
+      build_info.cacheable = false;
+    }
+
+    dependencies.extend(partial.dependencies);
+    blocks.extend(partial.blocks);
+    diagnostics.extend(partial.diagnostics);
+    build_info
+      .top_level_declarations
+      .merge(partial.top_level_declarations);
+
+    if partial.need_create_require {
+      build_info.need_create_require = true;
+    }
+
+    build_info.assets.extend(partial.assets);
+  }
+}
+
+fn collect_concatenated_build_partial(
+  module_graph: &ModuleGraph,
+  concatenated_modules: &IdentifierSet,
+  module_id: ModuleIdentifier,
+) -> ConcatenatedBuildPartial {
+  let module = module_graph
+    .module_by_identifier(&module_id)
+    .expect("should have module");
+  let module_build_info = module.build_info();
+
+  let dependencies = module
+    .get_dependencies()
+    .iter()
+    .filter(|dep_id| {
+      let dep = module_graph.dependency_by_id(dep_id);
+      let dependency_module = module_graph.module_identifier_by_dependency_id(dep_id);
+      !is_esm_dep_like(dep)
+        || dependency_module.map_or(true, |dependency_module| {
+          !concatenated_modules.contains(dependency_module)
+        })
+    })
+    .copied()
+    .collect();
+
+  ConcatenatedBuildPartial {
+    dependencies,
+    blocks: module.get_blocks().to_vec(),
+    diagnostics: module.diagnostics().into_owned(),
+    top_level_declarations: module_build_info.top_level_declarations.clone(),
+    need_create_require: module_build_info.need_create_require,
+    cacheable: module_build_info.cacheable,
+    assets: module_build_info.assets.as_ref().clone(),
+  }
+}
+
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for ConcatenatedModule {
@@ -868,11 +941,11 @@ impl Module for ConcatenatedModule {
     let compilation = compilation.expect("should pass compilation");
 
     let module_graph = compilation.get_module_graph();
-    let modules = self
+    let concatenated_modules = self
       .modules
       .iter()
-      .map(|item| Some(&item.id))
-      .collect::<HashSet<_>>();
+      .map(|item| item.id)
+      .collect::<IdentifierSet>();
 
     let root_module = module_graph
       .module_by_identifier(&self.root_module_ctxt.id)
@@ -881,53 +954,22 @@ impl Module for ConcatenatedModule {
     // populate root inline_exports
     self.build_info.inline_exports = root_module.build_info().inline_exports;
 
-    for m in self.modules.iter() {
-      let module = module_graph
-        .module_by_identifier(&m.id)
-        .expect("should have module");
-      let cur_build_info = module.build_info();
+    // Vec::par_iter() is indexed, so collecting into Vec preserves self.modules order.
+    let partials = self
+      .modules
+      .par_iter()
+      .map(|module| {
+        collect_concatenated_build_partial(module_graph, &concatenated_modules, module.id)
+      })
+      .collect::<Vec<_>>();
 
-      // populate cacheable
-      if !cur_build_info.cacheable {
-        self.build_info.cacheable = false;
-      }
-
-      // populate dependencies
-      for dep_id in module.get_dependencies().iter() {
-        let dep = module_graph.dependency_by_id(dep_id);
-        let module_id_of_dep = module_graph.module_identifier_by_dependency_id(dep_id);
-        if !is_esm_dep_like(dep) || !modules.contains(&module_id_of_dep) {
-          self.dependencies.push(*dep_id);
-        }
-      }
-
-      // populate blocks
-      for b in module.get_blocks() {
-        self.blocks.push(*b);
-      }
-      // populate diagnostic
-      self.diagnostics.extend(module.diagnostics().into_owned());
-
-      // populate topLevelDeclarations
-      let module_build_info = module.build_info();
-      if let Some(decls) = &module_build_info.top_level_declarations
-        && let Some(top_level_declarations) = &mut self.build_info.top_level_declarations
-      {
-        top_level_declarations.extend(decls.iter().cloned());
-      } else {
-        self.build_info.top_level_declarations = None;
-      }
-
-      if module_build_info.need_create_require {
-        self.build_info.need_create_require = true;
-      }
-
-      // populate assets
-      self
-        .build_info
-        .assets
-        .extend(module_build_info.assets.as_ref().clone());
-    }
+    merge_concatenated_build_partials(
+      &mut self.build_info,
+      &mut self.dependencies,
+      &mut self.blocks,
+      &mut self.diagnostics,
+      partials,
+    );
     // return a dummy result is enough, since we don't build the ConcatenatedModule in make phase
     Ok(BuildResult {
       module: BoxModule::new(self),
@@ -3568,4 +3610,173 @@ pub fn collect_ident(
   };
   collector.visit_module(root);
   collector.ids
+}
+
+#[cfg(test)]
+mod tests {
+  use rspack_sources::{RawStringSource, SourceExt};
+
+  use super::*;
+  use crate::{AssetInfo, CompilationAsset};
+
+  fn create_test_asset(content: &str) -> CompilationAsset {
+    CompilationAsset::new(
+      Some(RawStringSource::from(content).boxed()),
+      AssetInfo::default(),
+    )
+  }
+
+  fn create_test_partial(
+    dep: DependencyId,
+    block: AsyncDependenciesBlockIdentifier,
+    diagnostic_message: &str,
+    top_level_declarations: TopLevelDeclarations,
+    need_create_require: bool,
+    cacheable: bool,
+    assets: HashMap<String, CompilationAsset>,
+  ) -> ConcatenatedBuildPartial {
+    ConcatenatedBuildPartial {
+      dependencies: vec![dep],
+      blocks: vec![block],
+      diagnostics: vec![Diagnostic::warn(
+        "TEST".to_string(),
+        diagnostic_message.to_string(),
+      )],
+      top_level_declarations,
+      need_create_require,
+      cacheable,
+      assets,
+    }
+  }
+
+  #[test]
+  fn merge_concatenated_build_partials_preserves_order_and_override_semantics() {
+    let dep_a = DependencyId::from(1);
+    let dep_b = DependencyId::from(2);
+    let block_a = AsyncDependenciesBlockIdentifier::from("block-a".to_string());
+    let block_b = AsyncDependenciesBlockIdentifier::from("block-b".to_string());
+
+    let mut first_assets = HashMap::default();
+    first_assets.insert("shared.js".to_string(), create_test_asset("first"));
+    first_assets.insert("first.js".to_string(), create_test_asset("first-only"));
+
+    let mut second_assets = HashMap::default();
+    second_assets.insert("shared.js".to_string(), create_test_asset("second"));
+    second_assets.insert("second.js".to_string(), create_test_asset("second-only"));
+
+    let mut build_info = BuildInfo {
+      top_level_declarations: TopLevelDeclarations::Single(Default::default()),
+      ..Default::default()
+    };
+    let mut dependencies = vec![];
+    let mut blocks = vec![];
+    let mut diagnostics = vec![];
+
+    merge_concatenated_build_partials(
+      &mut build_info,
+      &mut dependencies,
+      &mut blocks,
+      &mut diagnostics,
+      vec![
+        create_test_partial(
+          dep_a,
+          block_a,
+          "first",
+          TopLevelDeclarations::Single(HashSet::from_iter([Atom::from("alpha")])),
+          false,
+          true,
+          first_assets,
+        ),
+        create_test_partial(
+          dep_b,
+          block_b,
+          "second",
+          TopLevelDeclarations::Single(HashSet::from_iter([Atom::from("beta")])),
+          true,
+          false,
+          second_assets,
+        ),
+      ],
+    );
+
+    assert_eq!(dependencies, vec![dep_a, dep_b]);
+    assert_eq!(blocks, vec![block_a, block_b]);
+    assert_eq!(
+      diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.message.as_str())
+        .collect::<Vec<_>>(),
+      vec!["first", "second"]
+    );
+    assert!(!build_info.cacheable);
+    assert!(build_info.need_create_require);
+
+    assert!(
+      build_info
+        .top_level_declarations
+        .contains(&Atom::from("alpha"))
+    );
+    assert!(
+      build_info
+        .top_level_declarations
+        .contains(&Atom::from("beta"))
+    );
+    assert!(matches!(
+      build_info.top_level_declarations,
+      TopLevelDeclarations::Multiple(_)
+    ));
+
+    let shared_asset = build_info
+      .assets
+      .get("shared.js")
+      .expect("shared asset should exist");
+    assert_eq!(
+      shared_asset
+        .get_source()
+        .expect("shared asset should have source")
+        .source()
+        .into_string_lossy(),
+      "second"
+    );
+  }
+
+  #[test]
+  fn merge_concatenated_build_partials_drops_top_level_declarations_when_any_partial_is_none() {
+    let mut build_info = BuildInfo {
+      top_level_declarations: TopLevelDeclarations::Single(Default::default()),
+      ..Default::default()
+    };
+    let mut dependencies = vec![];
+    let mut blocks = vec![];
+    let mut diagnostics = vec![];
+
+    merge_concatenated_build_partials(
+      &mut build_info,
+      &mut dependencies,
+      &mut blocks,
+      &mut diagnostics,
+      vec![
+        create_test_partial(
+          DependencyId::from(1),
+          AsyncDependenciesBlockIdentifier::from("block-a".to_string()),
+          "first",
+          TopLevelDeclarations::Single(HashSet::from_iter([Atom::from("alpha")])),
+          false,
+          true,
+          HashMap::default(),
+        ),
+        create_test_partial(
+          DependencyId::from(2),
+          AsyncDependenciesBlockIdentifier::from("block-b".to_string()),
+          "second",
+          TopLevelDeclarations::Unknown,
+          false,
+          true,
+          HashMap::default(),
+        ),
+      ],
+    );
+
+    assert!(build_info.top_level_declarations.is_unknown());
+  }
 }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -847,9 +847,8 @@ fn collect_concatenated_build_partial(
       let dep = module_graph.dependency_by_id(dep_id);
       let dependency_module = module_graph.module_identifier_by_dependency_id(dep_id);
       !is_esm_dep_like(dep)
-        || dependency_module.map_or(true, |dependency_module| {
-          !concatenated_modules.contains(dependency_module)
-        })
+        || dependency_module
+          .is_none_or(|dependency_module| !concatenated_modules.contains(dependency_module))
     })
     .copied()
     .collect();

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -6,7 +6,7 @@ use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_macros::impl_source_map_config;
 use rspack_util::{ext::DynHash, json_stringify_str, source_map::SourceMapKind};
-use rustc_hash::{FxHashMap as HashMap, FxHashSet};
+use rustc_hash::FxHashMap as HashMap;
 use serde::Serialize;
 
 use crate::{
@@ -17,8 +17,8 @@ use crate::{
   InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
   ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
   NAMESPACE_OBJECT_EXPORT, NormalInitFragment, PrefetchExportsInfoMode, RuntimeGlobals,
-  RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec, UsedExports,
-  extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
+  RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec, TopLevelDeclarations,
+  UsedExports, extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -275,7 +275,7 @@ impl ExternalModule {
       user_request,
       factory_meta: None,
       build_info: BuildInfo {
-        top_level_declarations: Some(FxHashSet::default()),
+        top_level_declarations: TopLevelDeclarations::Single(Default::default()),
         strict: true,
         ..Default::default()
       },

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -130,17 +130,25 @@ impl TopLevelDeclarations {
   pub fn merge(&mut self, other: Self) {
     if self.is_unknown() || other.is_unknown() {
       *self = Self::Unknown;
+      return;
     }
 
     if let Self::Single(set) = self {
-      *self = Self::Multiple(vec![std::mem::take(set)]);
+      if set.is_empty() {
+        *self = other;
+        return;
+      } else {
+        *self = Self::Multiple(vec![std::mem::take(set)]);
+      }
     }
 
     if let Self::Multiple(sets) = self {
       if let Self::Single(other_set) = other {
-        sets.push(other_set);
+        if !other_set.is_empty() {
+          sets.push(other_set);
+        }
       } else if let Self::Multiple(other_sets) = other {
-        sets.extend(other_sets);
+        sets.extend(other_sets.into_iter().filter(|set| !set.is_empty()));
       }
     }
   }
@@ -1013,5 +1021,20 @@ mod test {
     declarations.merge(TopLevelDeclarations::Unknown);
 
     assert!(declarations.is_unknown());
+  }
+
+  #[test]
+  fn top_level_declarations_merge_ignores_right_side_empty_single() {
+    let mut declarations = TopLevelDeclarations::Single(HashSet::from_iter([Atom::from("alpha")]));
+
+    declarations.merge(TopLevelDeclarations::Single(Default::default()));
+
+    match declarations {
+      TopLevelDeclarations::Multiple(sets) => {
+        assert_eq!(sets.len(), 1);
+        assert!(sets[0].contains(&Atom::from("alpha")));
+      }
+      other => panic!("expected multiple declarations, got {other:?}"),
+    }
   }
 }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -93,6 +93,10 @@ pub enum TopLevelDeclarations {
 }
 
 impl TopLevelDeclarations {
+  pub fn empty() -> Self {
+    Self::Single(HashSet::default())
+  }
+
   pub fn is_unknown(&self) -> bool {
     matches!(self, Self::Unknown)
   }
@@ -123,39 +127,22 @@ impl TopLevelDeclarations {
     }
   }
 
-  fn into_known_sets(self) -> Option<Vec<HashSet<Atom>>> {
-    match self {
-      Self::Unknown => None,
-      Self::Single(set) => Some((!set.is_empty()).then_some(set).into_iter().collect()),
-      Self::Multiple(sets) => Some(
-        sets
-          .into_iter()
-          .filter(|set| !set.is_empty())
-          .collect::<Vec<_>>(),
-      ),
-    }
-  }
-
-  fn from_known_sets(sets: Vec<HashSet<Atom>>) -> Self {
-    match sets.len() {
-      0 => Self::Single(Default::default()),
-      1 => Self::Single(sets.into_iter().next().expect("should have set")),
-      _ => Self::Multiple(sets),
-    }
-  }
-
   pub fn merge(&mut self, other: Self) {
-    let Some(mut own_sets) = std::mem::take(self).into_known_sets() else {
+    if self.is_unknown() || other.is_unknown() {
       *self = Self::Unknown;
-      return;
-    };
-    let Some(other_sets) = other.into_known_sets() else {
-      *self = Self::Unknown;
-      return;
-    };
+    }
 
-    own_sets.extend(other_sets);
-    *self = Self::from_known_sets(own_sets);
+    if let Self::Single(set) = self {
+      *self = Self::Multiple(vec![std::mem::take(set)]);
+    }
+
+    if let Self::Multiple(sets) = self {
+      if let Self::Single(other_set) = other {
+        sets.push(other_set);
+      } else if let Self::Multiple(other_sets) = other {
+        sets.extend(other_sets);
+      }
+    }
   }
 }
 
@@ -989,7 +976,7 @@ mod test {
 
   #[test]
   fn top_level_declarations_merge_upgrades_to_multiple_without_flattening() {
-    let mut declarations = TopLevelDeclarations::Single(Default::default());
+    let mut declarations = TopLevelDeclarations::empty();
 
     declarations.merge(TopLevelDeclarations::Single(HashSet::from_iter([
       Atom::from("alpha"),
@@ -1022,7 +1009,7 @@ mod test {
 
   #[test]
   fn top_level_declarations_unknown_dominates_merge() {
-    let mut declarations = TopLevelDeclarations::Single(Default::default());
+    let mut declarations = TopLevelDeclarations::empty();
     declarations.merge(TopLevelDeclarations::Unknown);
 
     assert!(declarations.is_unknown());

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -84,6 +84,82 @@ pub struct RscMeta {
 }
 
 #[cacheable]
+#[derive(Debug, Default, Clone)]
+pub enum TopLevelDeclarations {
+  #[default]
+  Unknown,
+  Single(#[cacheable(with=AsVec<AsPreset>)] HashSet<Atom>),
+  Multiple(#[cacheable(with=AsVec<AsVec<AsPreset>>)] Vec<HashSet<Atom>>),
+}
+
+impl TopLevelDeclarations {
+  pub fn is_unknown(&self) -> bool {
+    matches!(self, Self::Unknown)
+  }
+
+  pub fn contains(&self, atom: &Atom) -> bool {
+    match self {
+      Self::Unknown => false,
+      Self::Single(set) => set.contains(atom),
+      Self::Multiple(sets) => sets.iter().any(|set| set.contains(atom)),
+    }
+  }
+
+  pub fn insert(&mut self, atom: Atom) {
+    match self {
+      Self::Unknown => {
+        *self = Self::Single(HashSet::from_iter([atom]));
+      }
+      Self::Single(set) => {
+        set.insert(atom);
+      }
+      Self::Multiple(sets) => {
+        if let Some(set) = sets.last_mut() {
+          set.insert(atom);
+        } else {
+          *self = Self::Single(HashSet::from_iter([atom]));
+        }
+      }
+    }
+  }
+
+  fn into_known_sets(self) -> Option<Vec<HashSet<Atom>>> {
+    match self {
+      Self::Unknown => None,
+      Self::Single(set) => Some((!set.is_empty()).then_some(set).into_iter().collect()),
+      Self::Multiple(sets) => Some(
+        sets
+          .into_iter()
+          .filter(|set| !set.is_empty())
+          .collect::<Vec<_>>(),
+      ),
+    }
+  }
+
+  fn from_known_sets(sets: Vec<HashSet<Atom>>) -> Self {
+    match sets.len() {
+      0 => Self::Single(Default::default()),
+      1 => Self::Single(sets.into_iter().next().expect("should have set")),
+      _ => Self::Multiple(sets),
+    }
+  }
+
+  pub fn merge(&mut self, other: Self) {
+    let Some(mut own_sets) = std::mem::take(self).into_known_sets() else {
+      *self = Self::Unknown;
+      return;
+    };
+    let Some(other_sets) = other.into_known_sets() else {
+      *self = Self::Unknown;
+      return;
+    };
+
+    own_sets.extend(other_sets);
+    *self = Self::from_known_sets(own_sets);
+  }
+}
+
+#[cacheable]
 #[derive(Debug, Clone)]
 pub struct BuildInfo {
   /// Whether the result is cacheable, i.e shared between builds.
@@ -105,8 +181,7 @@ pub struct BuildInfo {
   pub json_data: Option<JsonValue>,
   #[cacheable(with=AsOption<AsVec<AsPreset>>)]
   pub side_effects_free: Option<HashSet<Atom>>,
-  #[cacheable(with=AsOption<AsVec<AsPreset>>)]
-  pub top_level_declarations: Option<HashSet<Atom>>,
+  pub top_level_declarations: TopLevelDeclarations,
   pub module_concatenation_bailout: Option<String>,
   pub assets: BindingCell<HashMap<String, CompilationAsset>>,
   pub module: bool,
@@ -139,7 +214,7 @@ impl Default for BuildInfo {
       need_create_require: false,
       json_data: None,
       side_effects_free: None,
-      top_level_declarations: None,
+      top_level_declarations: TopLevelDeclarations::Unknown,
       module_concatenation_bailout: None,
       assets: Default::default(),
       module: false,
@@ -756,9 +831,13 @@ mod test {
   use rspack_error::{Result, impl_empty_diagnosable_trait};
   use rspack_hash::RspackHashDigest;
   use rspack_sources::BoxSource;
-  use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
+  use rspack_util::{
+    atom::Atom,
+    source_map::{ModuleSourceMapConfig, SourceMapKind},
+  };
+  use rustc_hash::FxHashSet as HashSet;
 
-  use super::{BoxModule, Module};
+  use super::{BoxModule, Module, TopLevelDeclarations};
   use crate::{
     AsyncDependenciesBlockIdentifier, BuildContext, BuildResult, CodeGenerationResult, Compilation,
     Context, DependenciesBlock, DependencyId, ModuleCodeGenerationContext, ModuleExt, ModuleGraph,
@@ -906,5 +985,46 @@ mod test {
     let b = b.as_ref();
     assert!(a.downcast_ref::<ExternalModule>().is_some());
     assert!(b.downcast_ref::<RawModule>().is_some());
+  }
+
+  #[test]
+  fn top_level_declarations_merge_upgrades_to_multiple_without_flattening() {
+    let mut declarations = TopLevelDeclarations::Single(Default::default());
+
+    declarations.merge(TopLevelDeclarations::Single(HashSet::from_iter([
+      Atom::from("alpha"),
+    ])));
+    declarations.merge(TopLevelDeclarations::Single(HashSet::from_iter([
+      Atom::from("beta"),
+    ])));
+
+    match declarations {
+      TopLevelDeclarations::Multiple(sets) => {
+        assert_eq!(sets.len(), 2);
+        assert!(sets[0].contains(&Atom::from("alpha")));
+        assert!(sets[1].contains(&Atom::from("beta")));
+      }
+      other => panic!("expected multiple declarations, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn top_level_declarations_contains_checks_across_multiple_sets() {
+    let declarations = TopLevelDeclarations::Multiple(vec![
+      HashSet::from_iter([Atom::from("alpha")]),
+      HashSet::from_iter([Atom::from("beta")]),
+    ]);
+
+    assert!(declarations.contains(&Atom::from("alpha")));
+    assert!(declarations.contains(&Atom::from("beta")));
+    assert!(!declarations.contains(&Atom::from("gamma")));
+  }
+
+  #[test]
+  fn top_level_declarations_unknown_dominates_merge() {
+    let mut declarations = TopLevelDeclarations::Single(Default::default());
+    declarations.merge(TopLevelDeclarations::Unknown);
+
+    assert!(declarations.is_unknown());
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
@@ -1,5 +1,5 @@
+use rspack_core::TopLevelDeclarations;
 use rspack_util::atom::Atom;
-use rustc_hash::FxHashSet;
 
 use super::{
   JavascriptParserPlugin,
@@ -33,8 +33,8 @@ impl JavascriptParserPlugin for JavascriptMetaInfoPlugin {
   }
 
   fn finish(&self, parser: &mut JavascriptParser) -> Option<bool> {
-    if parser.build_info.top_level_declarations.is_none() {
-      parser.build_info.top_level_declarations = Some(FxHashSet::default());
+    if parser.build_info.top_level_declarations.is_unknown() {
+      parser.build_info.top_level_declarations = TopLevelDeclarations::Single(Default::default());
     }
     let variables: Vec<_> = parser
       .get_all_variables_from_current_scope()
@@ -42,12 +42,7 @@ impl JavascriptParserPlugin for JavascriptMetaInfoPlugin {
       .collect();
     for name in variables {
       if parser.is_variable_defined(&name) {
-        parser
-          .build_info
-          .top_level_declarations
-          .as_mut()
-          .expect("must have value")
-          .insert(name);
+        parser.build_info.top_level_declarations.insert(name);
       }
     }
     None

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -461,7 +461,10 @@ var {} = {{}};
                 .is_some_and(|m| !m.build_info().top_level_declarations.is_unknown());
             !has_top_level_decls
           } {
-            buf2.push("// This entry module doesn't tell about it's top-level declarations so it can't be inlined".into());
+            buf2.push(
+              "// This entry module doesn't specify its top-level declarations so it can't be inlined"
+                .into(),
+            );
             allow_inline_startup = false;
           }
           let hooks = JsPlugin::get_compilation_hooks(compilation.id());

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -452,16 +452,14 @@ var {} = {{}};
               .code_generation_results
               .get(module, Some(chunk.runtime()));
             let module_graph = compilation.get_module_graph();
-            let top_level_decls = codegen
+            let has_top_level_decls = codegen
               .data
               .get::<CodeGenerationDataTopLevelDeclarations>()
-              .map(|d| d.inner())
-              .or_else(|| {
-                module_graph
-                  .module_by_identifier(module)
-                  .and_then(|m| m.build_info().top_level_declarations.as_ref())
-              });
-            top_level_decls.is_none()
+              .is_some()
+              || module_graph
+                .module_by_identifier(module)
+                .is_some_and(|m| !m.build_info().top_level_declarations.is_unknown());
+            !has_top_level_decls
           } {
             buf2.push("// This entry module doesn't tell about it's top-level declarations so it can't be inlined".into());
             allow_inline_startup = false;

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1751,6 +1751,7 @@ fn add_concatenated_module(
 
   let module_graph = compilation.get_module_graph_mut();
 
+  let root_module_chunks = chunk_graph.get_module_chunks(root_module_id).clone();
   for m in modules_set.iter() {
     if *m == root_module_id {
       continue;
@@ -1759,18 +1760,16 @@ fn add_concatenated_module(
       .module_by_identifier(m)
       .expect("should exist module");
     // TODO: optimize asset module https://github.com/webpack/webpack/pull/15515/files
-    for chunk_ukey in chunk_graph.get_module_chunks(root_module_id).clone() {
+    for chunk_ukey in root_module_chunks.iter() {
       let source_types =
-        chunk_graph.get_chunk_module_source_types(&chunk_ukey, module, module_graph);
+        chunk_graph.get_chunk_module_source_types(chunk_ukey, module, module_graph);
 
       if source_types.len() == 1 {
-        chunk_graph.disconnect_chunk_and_module(&chunk_ukey, *m);
+        chunk_graph.disconnect_chunk_and_module(chunk_ukey, *m);
       } else {
-        let new_source_types = source_types
-          .into_iter()
-          .filter(|source_type| !matches!(source_type, SourceType::JavaScript))
-          .collect();
-        chunk_graph.set_chunk_modules_source_types(&chunk_ukey, *m, new_source_types)
+        let mut new_source_types = source_types.clone();
+        new_source_types.remove(&SourceType::JavaScript);
+        chunk_graph.set_chunk_modules_source_types(chunk_ukey, *m, new_source_types)
       }
     }
   }

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1653,30 +1653,36 @@ fn prepare_concatenated_module_connections<F>(
   filter_connection: F,
 ) -> Vec<DependencyId>
 where
-  F: Fn(&ModuleIdentifier, &ModuleGraphConnection, &BoxDependency) -> bool,
+  F: Fn(&ModuleIdentifier, &ModuleGraphConnection, &BoxDependency) -> bool + Sync,
 {
   let mg = compilation.get_module_graph();
-  let mut res = vec![];
-  for m in modules_set.iter() {
-    if m == new_module {
-      continue;
-    }
+  let batches = modules_set
+    .par_iter()
+    .filter(|m| *m != new_module)
+    .map(|m| {
+      let old_mgm_connections = mg
+        .module_graph_module_by_identifier(m)
+        .expect("should have mgm")
+        .outgoing_connections();
 
-    let old_mgm_connections = mg
-      .module_graph_module_by_identifier(m)
-      .expect("should have mgm")
-      .outgoing_connections();
-
-    // Outgoing connections
-    for dep_id in old_mgm_connections {
-      let connection = mg
-        .connection_by_dependency_id(dep_id)
-        .expect("should have connection");
-      let dep = mg.dependency_by_id(dep_id);
-      if filter_connection(m, connection, dep) {
-        res.push(*dep_id);
+      let mut module_res = vec![];
+      for dep_id in old_mgm_connections {
+        let connection = mg
+          .connection_by_dependency_id(dep_id)
+          .expect("should have connection");
+        let dep = mg.dependency_by_id(dep_id);
+        if filter_connection(m, connection, dep) {
+          module_res.push(*dep_id);
+        }
       }
-    }
+      module_res
+    })
+    .collect::<Vec<_>>();
+
+  let total_len = batches.iter().map(Vec::len).sum();
+  let mut res = Vec::with_capacity(total_len);
+  for batch in batches {
+    res.extend(batch);
   }
   res
 }

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1755,30 +1755,43 @@ fn add_concatenated_module(
   ModuleGraph::clone_module_attributes(compilation, &root_module_id, &new_module.identifier());
   // integrate
 
-  let module_graph = compilation.get_module_graph_mut();
-
   let root_module_chunks = chunk_graph.get_module_chunks(root_module_id).clone();
-  for m in modules_set.iter() {
-    if *m == root_module_id {
-      continue;
-    }
-    let module = module_graph
-      .module_by_identifier(m)
-      .expect("should exist module");
-    // TODO: optimize asset module https://github.com/webpack/webpack/pull/15515/files
-    for chunk_ukey in root_module_chunks.iter() {
-      let source_types =
-        chunk_graph.get_chunk_module_source_types(chunk_ukey, module, module_graph);
+  let module_graph = compilation.get_module_graph();
+  let chunk_graph_mutations = modules_set
+    .par_iter()
+    .filter(|m| **m != root_module_id)
+    .map(|m| {
+      let module = module_graph
+        .module_by_identifier(m)
+        .expect("should exist module");
+      let mut disconnects = vec![];
+      let mut source_type_updates = vec![];
+      // TODO: optimize asset module https://github.com/webpack/webpack/pull/15515/files
+      for chunk_ukey in root_module_chunks.iter() {
+        let mut source_types =
+          chunk_graph.get_chunk_module_source_types(chunk_ukey, module, module_graph);
 
-      if source_types.len() == 1 {
-        chunk_graph.disconnect_chunk_and_module(chunk_ukey, *m);
-      } else {
-        let mut new_source_types = source_types.clone();
-        new_source_types.remove(&SourceType::JavaScript);
-        chunk_graph.set_chunk_modules_source_types(chunk_ukey, *m, new_source_types)
+        if source_types.len() == 1 {
+          disconnects.push((*chunk_ukey, *m));
+        } else {
+          source_types.remove(&SourceType::JavaScript);
+          source_type_updates.push((*chunk_ukey, *m, source_types));
+        }
       }
+      (disconnects, source_type_updates)
+    })
+    .collect::<Vec<_>>();
+
+  for (disconnects, source_type_updates) in chunk_graph_mutations {
+    for (chunk_ukey, module_identifier) in disconnects {
+      chunk_graph.disconnect_chunk_and_module(&chunk_ukey, module_identifier);
+    }
+    for (chunk_ukey, module_identifier, new_source_types) in source_type_updates {
+      chunk_graph.set_chunk_modules_source_types(&chunk_ukey, module_identifier, new_source_types);
     }
   }
+
+  let module_graph = compilation.get_module_graph_mut();
 
   // different from webpack
   // Rspack: if entry is an asset module, outputs a js chunk and a asset chunk

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -395,12 +395,11 @@ async fn embed_in_runtime_bailout(
   let codegen = compilation
     .code_generation_results
     .get(&module.identifier(), Some(chunk.runtime()));
-  let top_level_decls = codegen
+  if let Some(top_level_decls) = codegen
     .data
     .get::<CodeGenerationDataTopLevelDeclarations>()
     .map(|d| d.inner())
-    .or_else(|| module.build_info().top_level_declarations.as_ref());
-  if let Some(top_level_decls) = top_level_decls {
+  {
     let full_name = self
       .get_resolved_full_name(&options, compilation, chunk)
       .await?;
@@ -413,9 +412,26 @@ async fn embed_in_runtime_bailout(
     }
     return Ok(None);
   }
-  Ok(Some(
-    "it doesn't tell about top level declarations.".to_string(),
-  ))
+
+  let top_level_decls = &module.build_info().top_level_declarations;
+  if top_level_decls.is_unknown() {
+    return Ok(Some(
+      "it doesn't tell about top level declarations.".to_string(),
+    ));
+  }
+
+  let full_name = self
+    .get_resolved_full_name(&options, compilation, chunk)
+    .await?;
+  if let Some(base) = full_name.first()
+    && top_level_decls.contains(&Atom::new(base.as_str()))
+  {
+    return Ok(Some(format!(
+      "it declares '{base}' on top-level, which conflicts with the current library output."
+    )));
+  }
+
+  Ok(None)
 }
 
 #[plugin_hook(JavascriptModulesStrictRuntimeBailout for AssignLibraryPlugin)]

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -416,7 +416,7 @@ async fn embed_in_runtime_bailout(
   let top_level_decls = &module.build_info().top_level_declarations;
   if top_level_decls.is_unknown() {
     return Ok(Some(
-      "it doesn't tell about top level declarations.".to_string(),
+      "it doesn't specify its top-level declarations.".to_string(),
     ));
   }
 

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -9,14 +9,13 @@ use rspack_core::{
   Compilation, Context, DependenciesBlock, Dependency, DependencyId, DependencyType,
   ExportsArgument, FactoryMeta, GroupOptions, LibIdentOptions, Module, ModuleCodeGenerationContext,
   ModuleCodeTemplate, ModuleDependency, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
-  RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec, impl_module_meta_info,
-  impl_source_map_config, module_update_hash,
+  RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec, TopLevelDeclarations,
+  impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_util::{json_stringify_str, source_map::SourceMapKind};
-use rustc_hash::FxHashSet;
 
 use super::{
   container_exposed_dependency::ContainerExposedDependency, container_plugin::ExposeOptions,
@@ -65,7 +64,7 @@ impl ContainerEntryModule {
       factory_meta: None,
       build_info: BuildInfo {
         strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
+        top_level_declarations: TopLevelDeclarations::Single(Default::default()),
         ..Default::default()
       },
       build_meta: BuildMeta {
@@ -93,7 +92,7 @@ impl ContainerEntryModule {
       factory_meta: None,
       build_info: BuildInfo {
         strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
+        top_level_declarations: TopLevelDeclarations::Single(Default::default()),
         ..Default::default()
       },
       build_meta: BuildMeta {

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -9,7 +9,8 @@ use rspack_core::{
   Context, DependenciesBlock, Dependency, DependencyId, DependencyRange, FactoryMeta, ImportPhase,
   LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleDependency, ModuleGraph,
   ModuleIdentifier, ModuleLayer, ModuleType, ReferencedSpecifier, RuntimeSpec, SourceType,
-  contextify, impl_module_meta_info, impl_source_map_config, module_update_hash,
+  TopLevelDeclarations, contextify, impl_module_meta_info, impl_source_map_config,
+  module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   to_comment,
 };
@@ -17,7 +18,6 @@ use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_plugin_javascript::dependency::ImportEagerDependency;
 use rspack_util::{fx_hash::FxIndexSet, source_map::SourceMapKind};
-use rustc_hash::FxHashSet;
 use swc_core::ecma::atoms::Atom;
 
 use crate::{
@@ -76,7 +76,7 @@ impl RscEntryModule {
       factory_meta: None,
       build_info: BuildInfo {
         strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
+        top_level_declarations: TopLevelDeclarations::Single(Default::default()),
         ..Default::default()
       },
       build_meta: BuildMeta {


### PR DESCRIPTION
## Summary
- replace eager `top_level_declarations` flattening with a delayed `TopLevelDeclarations` representation
- keep `Unknown` semantics while allowing concatenated modules to carry multiple declaration sets without merging them eagerly
- update fallback consumers to query declaration knowledge and membership without forcing a flatten step

## Why
The previous concatenated-module path eagerly merged large top-level declaration sets during build, which added noticeable cost to the hot path. This change defers flattening until it is actually needed and lets most callers operate on lightweight `contains`/`is_unknown` checks.

## Impact
- reduces eager work in `ConcatenatedModule::build`
- preserves existing fallback behavior for library/runtime checks
- keeps code generation as the source of truth for flattened top-level declarations

## Validation
- `cargo test -p rspack_core top_level_declarations --lib`
- `cargo test -p rspack_core merge_concatenated_build_partials --lib`
- `cargo check -p rspack_core -p rspack_plugin_javascript -p rspack_plugin_library -p rspack_plugin_rsc -p rspack_plugin_mf`
- `cargo fmt --all --check`
- `pnpm run build:binding:dev` is blocked in this shell by the local Node.js version (`v18.12.1`); the branch is being published per user request after local verification