### PR TITLE
fix(rstest): respect importFunctionName when importDynamic is disabled

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
 
 use rspack_core::{
-  AsyncDependenciesBlock, ChunkGroupOptions, ContextDependency, ContextNameSpaceObject,
-  ContextOptions, DependencyCategory, DependencyRange, DependencyType, DynamicImportFetchPriority,
-  DynamicImportMode, GroupOptions, ImportAttributes, ImportPhase, ReferencedSpecifier,
+  AsyncDependenciesBlock, ChunkGroupOptions, ConstDependency, ContextDependency,
+  ContextNameSpaceObject, ContextOptions, DependencyCategory, DependencyRange, DependencyType,
+  DynamicImportFetchPriority, DynamicImportMode, GroupOptions, ImportAttributes, ImportPhase,
+  ReferencedSpecifier,
 };
 use rspack_error::{Error, Severity};
 use rspack_util::{SpanExt, swc::get_swc_comments};
@@ -436,6 +437,13 @@ impl JavascriptParserPlugin for ImportParserPlugin {
       }
     } else {
       if matches!(parser.javascript_options.import_dynamic, Some(false)) {
+        let import_function_name = &parser.compiler_options.output.import_function_name;
+        if import_function_name != "import" {
+          parser.add_presentational_dependency(Box::new(ConstDependency::new(
+            node.callee.span().into(),
+            import_function_name.clone().into(),
+          )));
+        }
         return None;
       }
 

--- a/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/index.js
+++ b/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/index.js
@@ -1,0 +1,6 @@
+const dir = process.env.name
+
+import('./other.js')
+
+import('./' + dir + '/other.js')
+import(dir)

--- a/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/other.js
+++ b/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/other.js
@@ -1,0 +1,1 @@
+module.exports = 'other';

--- a/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/rspack.config.js
@@ -1,0 +1,21 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    bundle0: './index.js',
+    test: './test.js',
+  },
+  module: {
+    parser: {
+      javascript: {
+        importDynamic: false,
+      },
+    },
+  },
+  output: {
+    filename: '[name].js',
+    importFunctionName: '__import__',
+  },
+  node: {
+    __dirname: false,
+  },
+};

--- a/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/test.config.js
+++ b/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["test.js"];
+	}
+};

--- a/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/test.js
+++ b/tests/rspack-test/configCases/parsing/import-dynamic-import-function-name/test.js
@@ -1,0 +1,11 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should respect importFunctionName when `importDynamic` is disabled", () => {
+  const code = fs.readFileSync(path.join(__dirname, "./bundle0.js"), "utf-8");
+  expect(code).not.toContain("import('./other.js')");
+  expect(code).not.toContain("import('./' + dir + '/other.js')");
+  expect(code).not.toContain("import(dir)");
+  expect(code).toContain("__import__('./' + dir + '/other.js')");
+  expect(code).toContain("__import__(dir)");
+});


### PR DESCRIPTION
## Summary

This PR keeps `output.importFunctionName` effective even when `module.parser.javascript.importDynamic` is disabled. It also adds a dedicated parsing case so the existing `import-dynamic` test continues to cover the original preserve-as-is behavior separately.

## Related links

fix https://github.com/web-infra-dev/rstest/issues/358

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).