### PR TITLE
refactor: replace expect("TODO") with descriptive error messages

### DIFF
--- a/crates/rspack_binding_api/src/codegen_result.rs
+++ b/crates/rspack_binding_api/src/codegen_result.rs
@@ -47,8 +47,12 @@ impl From<&CodeGenerationResults> for JsCodegenerationResults {
               runtime_map.insert(
                 get_runtime_key(runtime_result_map.single_runtime.as_ref().expect("exist")).clone(),
                 id_result_map
-                  .get(&runtime_result_map.single_value.expect("TODO"))
-                  .expect("TODO")
+                  .get(
+                    &runtime_result_map
+                      .single_value
+                      .expect("should have single value in SingleEntry mode"),
+                  )
+                  .expect("should have codegen result for single value")
                   .as_ref()
                   .into(),
               );
@@ -57,7 +61,11 @@ impl From<&CodeGenerationResults> for JsCodegenerationResults {
               runtime_result_map.map.iter().for_each(|(k, v)| {
                 runtime_map.insert(
                   k.clone(),
-                  id_result_map.get(v).expect("TODO").as_ref().into(),
+                  id_result_map
+                    .get(v)
+                    .expect("should have codegen result for runtime value")
+                    .as_ref()
+                    .into(),
                 );
               });
             }

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -417,7 +417,7 @@ impl PublicPath {
 
 impl Default for PublicPath {
   fn default() -> Self {
-    Self::from_str("/").expect("TODO:")
+    Self::from_str("/").expect("'/' should be a valid public path")
   }
 }
 

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -52,7 +52,9 @@ impl PluginDriver {
       compiler_options: &options,
     };
     for plugin in &plugins {
-      plugin.apply(&mut apply_context).expect("TODO:");
+      plugin
+        .apply(&mut apply_context)
+        .expect("should apply plugin successfully");
     }
 
     Arc::new(Self {
@@ -71,7 +73,10 @@ impl PluginDriver {
   }
 
   pub fn take_diagnostic(&self) -> Vec<Diagnostic> {
-    let mut diagnostic = self.diagnostics.lock().expect("TODO:");
+    let mut diagnostic = self
+      .diagnostics
+      .lock()
+      .expect("should be able to lock diagnostics");
     std::mem::take(&mut diagnostic)
   }
 

--- a/crates/rspack_javascript_compiler/src/compiler/minify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/minify.rs
@@ -78,7 +78,7 @@ impl JavaScriptCompiler {
               _ => SourceMapsConfig::Bool(false),
             })
           })
-          .expect("TODO:");
+          .expect("should have source map config");
 
         let mut min_opts = MinifyOptions {
           compress: opts

--- a/crates/rspack_plugin_css/src/plugin/mod.rs
+++ b/crates/rspack_plugin_css/src/plugin/mod.rs
@@ -126,14 +126,14 @@ impl CssPlugin {
         // done, everything empty
         break;
       }
-      let mut selected_module = *list.last().expect("TODO:");
+      let mut selected_module = *list.last().expect("list should not be empty");
       let mut has_failed = None;
       'outer: loop {
         for SortedModules { set, list } in &modules_by_chunk_group {
           if list.is_empty() {
             continue;
           }
-          let last_module = *list.last().expect("TODO:");
+          let last_module = *list.last().expect("list should not be empty");
           if last_module.identifier() == selected_module.identifier() {
             continue;
           }

--- a/crates/rspack_plugin_html/src/asset.rs
+++ b/crates/rspack_plugin_html/src/asset.rs
@@ -85,7 +85,10 @@ impl HtmlPluginAssets {
       .map(|entry_name| compilation.entrypoint_by_name(entry_name))
       .flat_map(|entry| entry.get_files(&compilation.build_chunk_graph_artifact.chunk_by_ukey))
       .filter_map(|asset_name| {
-        let asset = compilation.assets().get(&asset_name).expect("TODO:");
+        let asset = compilation
+          .assets()
+          .get(&asset_name)
+          .expect("should have asset for entrypoint file");
         if asset.info.hot_module_replacement.unwrap_or(false)
           || asset.info.development.unwrap_or(false)
         {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -553,7 +553,7 @@ impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
       };
       source.replace(dep.range.start, dep.range.end, expr, None)
     } else if dep.base.is_define_property() {
-      panic!("TODO")
+      todo!("CommonJsExportRequireDependency define_property base type")
     } else {
       panic!("Unexpected type");
     }

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -101,7 +101,7 @@ impl ProgressPlugin {
         let progress_bar = MULTI_PROGRESS.add(ProgressBar::new(100));
 
         let mut progress_bar_style = ProgressStyle::with_template(&options.template)
-          .expect("TODO:")
+          .expect("should be a valid progress bar template")
           .progress_chars(&options.progress_chars);
         if let Some(tick_strings) = &options.tick_strings {
           progress_bar_style = progress_bar_style.tick_strings(

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -10,9 +10,9 @@ use regex::Regex;
 use sugar_path::SugarPath;
 
 static SEGMENTS_SPLIT_REGEXP: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"([|!])").expect("TODO:"));
+  LazyLock::new(|| Regex::new(r"([|!])").expect("should be a valid regex"));
 static WINDOWS_ABS_PATH_REGEXP: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"^[a-zA-Z]:[/\\]").expect("TODO:"));
+  LazyLock::new(|| Regex::new(r"^[a-zA-Z]:[/\\]").expect("should be a valid regex"));
 static WINDOWS_PATH_SEPARATOR: &[char] = &['/', '\\'];
 
 /// # Example


### PR DESCRIPTION
## Summary
Replace all `expect("TODO")` / `expect("TODO:")` / `panic!("TODO")` with descriptive error messages across the codebae

These placeholder messages provide no useful context when a panic occurs. Replaced them with meaningful messages following the project's `expect("should ...")` convention:

- `rspack_util`: `expect("should be a valid regex")`
- `rspack_core/output.rs`: `expect("'/' should be a valid public path")`
- `rspack_core/plugin_driver.rs`: `expect("should apply plugin successfully")`, `expect("should be able to lock diagnostics")`
- `rspack_binding_api`: descriptive messages for codegen result lookups
- `rspack_plugin_progress`: `expect("should be a valid progress bar template")`
- `rspack_plugin_html`: `expect("should have asset for entrypoint file")`
- `rspack_plugin_css`: `expect("list should not be empty")`
- `rspack_javascript_compiler`: `expect("should have source map config")`
- `rspack_plugin_javascript`: `panic!("TODO")` → `todo!("CommonJsExportRequireDependency define_property base type")`

## Related links
N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
