### PR TITLE
feat: skip building side-effect-only imports in make

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Before running tests after code changes:
 
 ### Modifying code
 
-- **Rust**: Core in `crates/rspack_core/`, plugins in `crates/rspack_plugin_*/`, rebuild with `pnpm run build:binding:dev`, test with `pnpm run test:rs`, and ensure `cargo fmt --all --check && cargo lint` passes
+- **Rust**: Core in `crates/rspack_core/`, plugins in `crates/rspack_plugin_*/`, rebuild with `pnpm run build:binding:dev`, test with `pnpm run test:rs`, avoid linting and formatting for fast local development
 - **JS/TS**: API in `packages/rspack/src/`, CLI in `packages/rspack-cli/src/`, rebuild with `pnpm run build:js`, test with `pnpm run test:unit`
 
 ### Adding tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,8 @@ Before running tests after code changes:
 
 ## Code quality
 
-- **Linting**: `pnpm run lint:js` (Rslint), `pnpm run lint:rs` (cargo check)
-- **Formatting**: `pnpm run format:rs` (cargo fmt), `pnpm run format:js` (prettier), `pnpm run format:toml` (taplo)
-- **Rust gate**: After modifying Rust code, ensure both `cargo fmt --all --check` and `cargo lint` pass before commit/PR
+- **Linting**: `pnpm run lint:js` (Rslint), `pnpm run lint:rs` (cargo check), `cargo lint` (Rust)
+- **Formatting**: `pnpm run format:rs` (cargo fmt), `pnpm run format:js` (prettier), `pnpm run format:toml` (taplo), `cargo fmt --all --check` (Rust)
 - **Style**: snake_case for Rust, camelCase for JS/TS
 
 ## Common tasks

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -5,9 +5,10 @@ use rspack_sources::BoxSource;
 
 use super::{TaskContext, add::AddTask};
 use crate::{
-  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, FactorizeInfo, ModuleFactory,
-  ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer, Resolve,
-  ResolverFactory,
+  BoxDependency, CompilationId, CompilerId, CompilerOptions, Context, FactorizeInfo, ImportPhase,
+  ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer,
+  Resolve, ResolverFactory,
+  dependency::DependencyType,
   module_graph::ModuleGraphModule,
   utils::{
     ResourceId,
@@ -199,6 +200,20 @@ impl Task<TaskContext> for FactorizeResultTask {
       return Ok(vec![]);
     };
 
+    if let Some(module) = factory_result.module.as_ref()
+      && skip_side_effect_free_esm_import_side_effect_dependencies(module, &dependencies)
+    {
+      let dep = &dependencies[0];
+      tracing::trace!("Module make-skipped as side-effect-only import: {dep:?}");
+      for dep in &mut dependencies {
+        dep.set_lazy();
+      }
+      for dep in dependencies {
+        module_graph.add_dependency(dep)
+      }
+      return Ok(vec![]);
+    }
+
     let Some(module) = factory_result.module else {
       let dep = &dependencies[0];
       tracing::trace!("Module ignored: {dep:?}");
@@ -222,4 +237,16 @@ impl Task<TaskContext> for FactorizeResultTask {
       from_unlazy,
     })])
   }
+}
+
+fn skip_side_effect_free_esm_import_side_effect_dependencies(
+  module: &crate::BoxModule,
+  dependencies: &[BoxDependency],
+) -> bool {
+  module.as_normal_module().is_some()
+    && module.factory_meta().and_then(|meta| meta.side_effect_free) == Some(true)
+    && dependencies.iter().all(|dep| {
+      dep.dependency_type() == &DependencyType::EsmImport
+        && dep.get_phase() == ImportPhase::Evaluation
+    })
 }

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -128,6 +128,8 @@ pub trait Dependency:
     None
   }
 
+  fn set_lazy(&mut self) {}
+
   fn unset_lazy(&mut self) -> bool {
     false
   }

--- a/crates/rspack_core/src/dependency/dependency_type.rs
+++ b/crates/rspack_core/src/dependency/dependency_type.rs
@@ -118,6 +118,8 @@ pub enum DependencyType {
   ProvideModuleForShared,
   /// consume shared fallback
   ConsumeSharedFallback,
+  /// federation runtime
+  FederationRuntime,
   /// is included
   IsIncluded,
   LoaderImport,
@@ -206,6 +208,7 @@ impl DependencyType {
       DependencyType::ProvideSharedModule => "provide shared module",
       DependencyType::ProvideModuleForShared => "provide module for shared",
       DependencyType::ConsumeSharedFallback => "consume shared fallback",
+      DependencyType::FederationRuntime => "federation runtime",
       DependencyType::IsIncluded => "__webpack_is_included__",
       DependencyType::LazyImport => "lazy import()",
       DependencyType::ModuleDecorator => "module decorator",

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -97,10 +97,6 @@ impl ESMExportImportedSpecifierDependency {
     }
   }
 
-  pub fn set_lazy(&mut self) {
-    self.lazy_make = true;
-  }
-
   // Because it is shared by multiply ESMExportImportedSpecifierDependency, so put it to `BuildInfo`
   pub fn active_exports<'a>(&self, module_graph: &'a ModuleGraph) -> &'a HashSet<Atom> {
     let build_info = module_graph
@@ -1484,6 +1480,10 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         LazyUntil::Fallback
       }
     })
+  }
+
+  fn set_lazy(&mut self) {
+    self.lazy_make = true;
   }
 
   fn unset_lazy(&mut self) -> bool {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -64,6 +64,7 @@ pub struct ESMImportSideEffectDependency {
   source_order: i32,
   id: DependencyId,
   range: DependencyRange,
+  dependency_type: DependencyType,
   phase: ImportPhase,
   attributes: Option<ImportAttributes>,
   resource_identifier: ResourceIdentifier,
@@ -79,6 +80,7 @@ impl ESMImportSideEffectDependency {
     request: Atom,
     source_order: i32,
     range: DependencyRange,
+    dependency_type: DependencyType,
     phase: ImportPhase,
     attributes: Option<ImportAttributes>,
     loc: Option<DependencyLocation>,
@@ -91,6 +93,7 @@ impl ESMImportSideEffectDependency {
       source_order,
       request,
       range,
+      dependency_type,
       phase,
       attributes,
       resource_identifier,
@@ -556,7 +559,7 @@ impl Dependency for ESMImportSideEffectDependency {
   }
 
   fn dependency_type(&self) -> &DependencyType {
-    &DependencyType::EsmImport
+    &self.dependency_type
   }
 
   fn get_phase(&self) -> ImportPhase {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -64,7 +64,6 @@ pub struct ESMImportSideEffectDependency {
   source_order: i32,
   id: DependencyId,
   range: DependencyRange,
-  dependency_type: DependencyType,
   phase: ImportPhase,
   attributes: Option<ImportAttributes>,
   resource_identifier: ResourceIdentifier,
@@ -80,7 +79,6 @@ impl ESMImportSideEffectDependency {
     request: Atom,
     source_order: i32,
     range: DependencyRange,
-    dependency_type: DependencyType,
     phase: ImportPhase,
     attributes: Option<ImportAttributes>,
     loc: Option<DependencyLocation>,
@@ -93,7 +91,6 @@ impl ESMImportSideEffectDependency {
       source_order,
       request,
       range,
-      dependency_type,
       phase,
       attributes,
       resource_identifier,
@@ -104,8 +101,8 @@ impl ESMImportSideEffectDependency {
     }
   }
 
-  pub fn set_lazy(&mut self) {
-    self.lazy_make = true;
+  fn missing_module_active(&self) -> bool {
+    !self.lazy_make
   }
 }
 
@@ -559,7 +556,7 @@ impl Dependency for ESMImportSideEffectDependency {
   }
 
   fn dependency_type(&self) -> &DependencyType {
-    &self.dependency_type
+    &DependencyType::EsmImport
   }
 
   fn get_phase(&self) -> ImportPhase {
@@ -590,7 +587,7 @@ impl Dependency for ESMImportSideEffectDependency {
         connection_state_cache,
       )
     } else {
-      ConnectionState::Active(true)
+      ConnectionState::Active(self.missing_module_active())
     }
   }
 
@@ -624,6 +621,10 @@ impl Dependency for ESMImportSideEffectDependency {
         LazyUntil::NoUntil
       }
     })
+  }
+
+  fn set_lazy(&mut self) {
+    self.lazy_make = true;
   }
 
   fn unset_lazy(&mut self) -> bool {
@@ -685,7 +686,11 @@ impl DependencyConditionFn for ESMImportSideEffectDependencyCondition {
         &mut IdentifierMap::default(),
       )
     } else {
-      ConnectionState::Active(true)
+      let dependency = module_graph.dependency_by_id(&conn.dependency_id);
+      let dependency = dependency
+        .downcast_ref::<ESMImportSideEffectDependency>()
+        .expect("should be ESMImportSideEffectDependency");
+      ConnectionState::Active(dependency.missing_module_active())
     }
   }
 }
@@ -726,6 +731,10 @@ impl DependencyTemplate for ESMImportSideEffectDependencyTemplate {
     let module_graph = compilation.get_module_graph();
 
     let module = module_graph.get_module_by_dependency_id(&dep.id);
+
+    if module.is_none() && !dep.missing_module_active() {
+      return;
+    }
 
     if let Some(module) = module {
       let source_types = module.source_types(module_graph);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -1,5 +1,7 @@
 use itertools::Itertools;
-use rspack_core::{BoxDependency, ConstDependency, DependencyRange, DependencyType, ImportPhase};
+use rspack_core::{
+  BoxDependency, ConstDependency, Dependency, DependencyRange, DependencyType, ImportPhase,
+};
 use rspack_util::SpanExt;
 use swc_core::{
   atoms::Atom,
@@ -58,7 +60,6 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
       source.clone(),
       parser.last_esm_import_order,
       statement.span().into(),
-      DependencyType::EsmExportImport,
       ImportPhase::Evaluation,
       statement.get_with_obj().map(get_attributes),
       loc,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -60,6 +60,7 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
       source.clone(),
       parser.last_esm_import_order,
       statement.span().into(),
+      DependencyType::EsmExportImport,
       ImportPhase::Evaluation,
       statement.get_with_obj().map(get_attributes),
       loc,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -62,6 +62,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       source.into(),
       parser.last_esm_import_order,
       import_decl.span.into(),
+      DependencyType::EsmImport,
       phase,
       attributes,
       parser.to_dependency_location(DependencyRange::from(import_decl.span)),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -62,7 +62,6 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       source.into(),
       parser.last_esm_import_order,
       import_decl.span.into(),
-      DependencyType::EsmImport,
       phase,
       attributes,
       parser.to_dependency_location(DependencyRange::from(import_decl.span)),

--- a/crates/rspack_plugin_mf/src/container/federation_runtime_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/federation_runtime_dependency.rs
@@ -4,10 +4,6 @@ use rspack_core::{
   DependencyType, FactorizeInfo, ModuleDependency,
 };
 
-//TODO: consider adding a new variant to DependencyType enum for 'federation runtime dependency'
-// For now, using a related existing type or a placeholder.
-const FEDERATION_RUNTIME_DEPENDENCY_TYPE: DependencyType = DependencyType::EsmImport;
-
 #[cacheable]
 #[derive(Debug, Clone)]
 pub struct FederationRuntimeDependency {
@@ -33,11 +29,11 @@ impl Dependency for FederationRuntimeDependency {
   }
 
   fn category(&self) -> &DependencyCategory {
-    &DependencyCategory::Esm // Or another appropriate category
+    &DependencyCategory::Esm
   }
 
   fn dependency_type(&self) -> &DependencyType {
-    &FEDERATION_RUNTIME_DEPENDENCY_TYPE
+    &DependencyType::FederationRuntime
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
@@ -6,9 +6,9 @@
 use rspack_cacheable::cacheable;
 use rspack_core::{
   AsyncModulesArtifact, BoxDependency, ChunkUkey, Compilation,
-  CompilationAdditionalTreeRuntimeRequirements, CompilationFinishModules, CompilerFinishMake,
-  EntryOptions, ExportsInfoArtifact, Plugin, RuntimeGlobals, RuntimeModule,
-  SideEffectsStateArtifact,
+  CompilationAdditionalTreeRuntimeRequirements, CompilationFinishModules, CompilationParams,
+  CompilerCompilation, CompilerFinishMake, DependencyType, EntryOptions, ExportsInfoArtifact,
+  Plugin, RuntimeGlobals, RuntimeModule, SideEffectsStateArtifact,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -47,6 +47,18 @@ impl ModuleFederationRuntimePlugin {
   pub fn new(options: ModuleFederationRuntimePluginOptions) -> Self {
     Self::new_inner(options)
   }
+}
+
+#[plugin_hook(CompilerCompilation for ModuleFederationRuntimePlugin)]
+async fn compilation(
+  &self,
+  compilation: &mut Compilation,
+  params: &mut CompilationParams,
+) -> Result<()> {
+  compilation.set_dependency_factory(
+    DependencyType::FederationRuntime,
+    params.normal_module_factory.clone(),
+  );
 }
 
 #[plugin_hook(CompilationAdditionalTreeRuntimeRequirements for ModuleFederationRuntimePlugin)]
@@ -126,6 +138,8 @@ impl Plugin for ModuleFederationRuntimePlugin {
   }
 
   fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
+
     ctx
       .compilation_hooks
       .additional_tree_runtime_requirements

--- a/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
@@ -59,6 +59,7 @@ async fn compilation(
     DependencyType::FederationRuntime,
     params.normal_module_factory.clone(),
   );
+  Ok(())
 }
 
 #[plugin_hook(CompilationAdditionalTreeRuntimeRequirements for ModuleFederationRuntimePlugin)]

--- a/tests/rspack-test/configCases/side-effects/skip-side-effect-only-import/foo.js
+++ b/tests/rspack-test/configCases/side-effects/skip-side-effect-only-import/foo.js
@@ -1,0 +1,1 @@
+export const foo = "foo";

--- a/tests/rspack-test/configCases/side-effects/skip-side-effect-only-import/index.js
+++ b/tests/rspack-test/configCases/side-effects/skip-side-effect-only-import/index.js
@@ -1,0 +1,5 @@
+import "./foo";
+
+it("should still compile", () => {
+  expect(true).toBe(true);
+});

--- a/tests/rspack-test/configCases/side-effects/skip-side-effect-only-import/rspack.config.js
+++ b/tests/rspack-test/configCases/side-effects/skip-side-effect-only-import/rspack.config.js
@@ -1,0 +1,37 @@
+const { strictEqual } = require('assert');
+
+class TestPlugin {
+  apply(compiler) {
+    let identifiers = [];
+    compiler.hooks.compilation.tap('TestPlugin', (compilation) => {
+      identifiers = [];
+      compilation.hooks.buildModule.tap('TestPlugin', (module) => {
+        identifiers.push(module.identifier());
+      });
+    });
+    compiler.hooks.done.tap('TestPlugin', () => {
+      const fooBuilds = identifiers.filter((identifier) =>
+        identifier.endsWith('foo.js'),
+      ).length;
+
+      strictEqual(fooBuilds, 0);
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  optimization: {
+    sideEffects: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /foo\.js$/,
+        sideEffects: false,
+      },
+    ],
+  },
+  plugins: [new TestPlugin()],
+};

--- a/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/0/foo.js
+++ b/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/0/foo.js
@@ -1,0 +1,1 @@
+export const value = "foo";

--- a/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/0/index.js
+++ b/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/0/index.js
@@ -1,0 +1,1 @@
+import "./foo";

--- a/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/0/package.json
+++ b/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/0/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/1/foo.js
+++ b/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/1/foo.js
@@ -1,0 +1,1 @@
+export const value = "bar";

--- a/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/2/index.js
+++ b/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/2/index.js
@@ -1,0 +1,3 @@
+import { value } from "./foo";
+
+globalThis.__foo = value;

--- a/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/rspack.config.js
+++ b/tests/rspack-test/watchCases/side-effects/skip-side-effect-only-import/rspack.config.js
@@ -1,0 +1,36 @@
+let step = 0;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  optimization: {
+    sideEffects: true,
+  },
+  plugins: [
+    function (compiler) {
+      let identifiers = [];
+      compiler.hooks.compilation.tap('TestPlugin', (compilation) => {
+        identifiers = [];
+        compilation.hooks.buildModule.tap('TestPlugin', (module) => {
+          identifiers.push(module.identifier());
+        });
+      });
+      compiler.hooks.done.tap('TestPlugin', () => {
+        const fooBuilds = identifiers.filter((identifier) =>
+          identifier.endsWith('foo.js'),
+        ).length;
+
+        if (step === 0) {
+          expect(fooBuilds).toBe(0);
+        } else if (step === 1) {
+          expect(fooBuilds).toBe(0);
+        } else if (step === 2) {
+          expect(fooBuilds).toBe(1);
+        } else {
+          throw new Error('Unexpected step');
+        }
+
+        step += 1;
+      });
+    },
+  ],
+};

--- a/website/docs/en/guide/optimization/lazy-barrel.mdx
+++ b/website/docs/en/guide/optimization/lazy-barrel.mdx
@@ -175,6 +175,20 @@ Rspack can analyze whether a module has side effects (this capability is already
 
 During the make phase, dependencies must be built before their side effects can be analyzed. Lazy barrel is specifically designed to avoid building those dependencies. Therefore, it relies on explicit markers like `"sideEffects": false` in `package.json` or `rules[].sideEffects`, which don't require dependency checking since they declare the entire package or matched modules as side-effect-free.
 
+## Related optimization: skipping side-effect-only import builds
+
+This optimization is not a part of lazy barrel, but it was inspired by lazy barrel, so it is documented here separately.
+
+For the following ESM import that is only used to trigger side effects:
+
+```js title="src/index.js"
+import './module';
+```
+
+If `./module` has already been marked as side-effect-free through `"sideEffects": false` in `package.json`, or [`rules[].sideEffects`](/config/module-rules#rulessideeffects), Rspack will directly skip building this module during the make phase.
+
+This kind of `import './module'` would be removed later by side-effects optimization anyway, so continuing to run loader, parser, and build would not affect the final output and would only add overhead to the make phase. Therefore, Rspack determines its side effects early during the make phase, and if it is side-effect-free, directly skips building it.
+
 ## Further reading
 
 - [RFC: Lazy make for reexports in side effects free barrel file](https://github.com/web-infra-dev/rspack/discussions/11273)

--- a/website/docs/zh/guide/optimization/lazy-barrel.mdx
+++ b/website/docs/zh/guide/optimization/lazy-barrel.mdx
@@ -206,6 +206,20 @@ Rspack 可以分析模块是否有副作用（这个能力已经被 [`optimizati
 
 在 make 阶段，必须先构建依赖才能分析它们的副作用。Lazy barrel 专门设计用于避免构建这些依赖。因此，它依赖于显式标记，如 `package.json` 中的 `"sideEffects": false` 或 `rules[].sideEffects`，这些标记不需要依赖检查，因为它们声明整个包或匹配的模块都是无副作用的。
 
+## 相关优化：跳过仅用于副作用的 import 构建
+
+这个优化不属于 lazy barrel，但受 lazy barrel 启发而来，因此放在这里单独说明。
+
+对于下面这种仅用于触发副作用的 ESM 导入：
+
+```js title="src/index.js"
+import './module';
+```
+
+如果 `./module` 已经通过 `package.json` 中的 `"sideEffects": false`，或 [`rules[].sideEffects`](/config/module-rules#rulessideeffects) 被标记为无副作用，Rspack 会在 make 阶段直接跳过这个模块的构建。
+
+这类 `import './module'` 在后续副作用优化中本来就会被移除，因此继续执行 loader、parser 和 build 并不能影响最终产物，只会增加 make 阶段的开销。所以 Rspack 会在 make 阶段提前判定它的副作用，如果无副作用则直接跳过它的构建。
+
 ## 延伸阅读
 
 - [RFC: Lazy make for reexports in side effects free barrel file](https://github.com/web-infra-dev/rspack/discussions/11273)


### PR DESCRIPTION
## Summary

Skip building "side effect free" side–effect-only imports in make

```js
import "./module.js"
```
Now rspack will skip building module.js if its package.json has `"sideEffects": false` or marked as side effect free in module rule
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
