### PR TITLE
fix(esm-library): deconflict module external helper names

### DIFF
--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -387,6 +387,10 @@ impl ExternalModule {
               InitFragmentKey::ModuleExternal("node-commonjs".to_string()),
               None,
             )
+            .with_top_level_decl_symbols(vec![
+              "__rspack_createRequire".into(),
+              "__rspack_createRequire_require".into(),
+            ])
             .boxed(),
           );
           let (request, specifiers) = if let Some(request) = request {

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -171,6 +171,10 @@ pub trait InitFragment<C>: IntoAny + DynHash + DynClone + Debug + Sync + Send {
   fn position(&self) -> i32;
 
   fn key(&self) -> &InitFragmentKey;
+
+  fn top_level_decl_symbols(&self) -> &[Atom] {
+    &[]
+  }
 }
 
 clone_trait_object!(InitFragment<GenerateContext<'_>>);
@@ -292,6 +296,7 @@ pub struct NormalInitFragment {
   position: i32,
   key: InitFragmentKey,
   end_content: Option<String>,
+  top_level_decl_symbols: Vec<Atom>,
 }
 
 impl NormalInitFragment {
@@ -308,7 +313,13 @@ impl NormalInitFragment {
       position,
       key,
       end_content,
+      top_level_decl_symbols: Vec::new(),
     }
+  }
+
+  pub fn with_top_level_decl_symbols(mut self, top_level_decl_symbols: Vec<Atom>) -> Self {
+    self.top_level_decl_symbols = top_level_decl_symbols;
+    self
   }
 }
 
@@ -330,6 +341,10 @@ impl<C> InitFragment<C> for NormalInitFragment {
 
   fn key(&self) -> &InitFragmentKey {
     &self.key
+  }
+
+  fn top_level_decl_symbols(&self) -> &[Atom] {
+    &self.top_level_decl_symbols
   }
 }
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -74,6 +74,72 @@ enum ExternalImportBinding {
 }
 
 impl EsmLibraryPlugin {
+  fn module_external_fragment_content(
+    init_fragment: &Box<dyn rspack_core::InitFragment<ChunkRenderContext>>,
+  ) -> Option<String> {
+    if !matches!(init_fragment.key(), InitFragmentKey::ModuleExternal(_)) {
+      return None;
+    }
+
+    if let Ok(fragment) = init_fragment
+      .clone()
+      .into_any()
+      .downcast::<ConditionalInitFragment>()
+    {
+      Some(fragment.content().to_owned())
+    } else {
+      init_fragment
+        .clone()
+        .contents(&mut ChunkRenderContext {})
+        .ok()
+        .map(|contents| contents.start)
+    }
+  }
+
+  fn collect_module_external_fragments_in_render_order<'a>(
+    init_fragment_groups: impl IntoIterator<Item = &'a ChunkInitFragments>,
+  ) -> Vec<String> {
+    let mut ordered_fragments = Vec::new();
+
+    for init_fragments in init_fragment_groups {
+      for init_fragment in init_fragments {
+        let Some(content) = Self::module_external_fragment_content(init_fragment) else {
+          continue;
+        };
+
+        ordered_fragments.push((
+          init_fragment.stage(),
+          init_fragment.position(),
+          ordered_fragments.len(),
+          init_fragment.key().clone(),
+          content,
+        ));
+      }
+    }
+
+    ordered_fragments.sort_by(|a, b| {
+      let stage = a.0.cmp(&b.0);
+      if !stage.is_eq() {
+        return stage;
+      }
+      let position = a.1.cmp(&b.1);
+      if !position.is_eq() {
+        return position;
+      }
+      a.2.cmp(&b.2)
+    });
+
+    let mut rendered_keys = FxHashSet::default();
+    let mut rendered_fragments = Vec::with_capacity(ordered_fragments.len());
+    for (_, _, _, key, content) in ordered_fragments {
+      if rendered_keys.insert(key) {
+        rendered_fragments.push(content);
+      }
+    }
+
+    rendered_fragments
+  }
+
   fn parse_module_external_namespace_import(content: &str) -> Option<(RawImportSource, Atom)> {
     let content = content.trim_start();
     let content = content.strip_prefix("import * as ")?;
@@ -119,54 +185,9 @@ impl EsmLibraryPlugin {
   fn collect_module_external_namespace_imports_in_render_order<'a>(
     init_fragment_groups: impl IntoIterator<Item = &'a ChunkInitFragments>,
   ) -> Vec<(RawImportSource, Atom)> {
-    let mut ordered_imports = Vec::new();
-
-    for init_fragments in init_fragment_groups {
-      for init_fragment in init_fragments {
-        if !matches!(init_fragment.key(), InitFragmentKey::ModuleExternal(_)) {
-          continue;
-        }
-
-        let content = if let Ok(fragment) = init_fragment
-          .clone()
-          .into_any()
-          .downcast::<ConditionalInitFragment>()
-        {
-          fragment.content().to_owned()
-        } else {
-          let Ok(contents) = init_fragment.clone().contents(&mut ChunkRenderContext {}) else {
-            continue;
-          };
-          contents.start
-        };
-
-        if let Some((source, local_name)) = Self::parse_module_external_namespace_import(&content) {
-          ordered_imports.push((
-            init_fragment.stage(),
-            init_fragment.position(),
-            ordered_imports.len(),
-            source,
-            local_name,
-          ));
-        }
-      }
-    }
-
-    ordered_imports.sort_by(|a, b| {
-      let stage = a.0.cmp(&b.0);
-      if !stage.is_eq() {
-        return stage;
-      }
-      let position = a.1.cmp(&b.1);
-      if !position.is_eq() {
-        return position;
-      }
-      a.2.cmp(&b.2)
-    });
-
-    ordered_imports
+    Self::collect_module_external_fragments_in_render_order(init_fragment_groups)
       .into_iter()
-      .map(|(_, _, _, source, local_name)| (source, local_name))
+      .filter_map(|content| Self::parse_module_external_namespace_import(&content))
       .collect()
   }
 
@@ -188,6 +209,163 @@ impl EsmLibraryPlugin {
       } else {
         used_names.insert(local_name);
       }
+    }
+  }
+
+  fn strip_leading_comments(mut line: &str) -> &str {
+    loop {
+      line = line.trim_start();
+
+      if line.is_empty() {
+        return line;
+      }
+
+      if let Some(rest) = line.strip_prefix("//") {
+        let _ = rest;
+        return "";
+      }
+
+      if let Some(rest) = line.strip_prefix("/*")
+        && let Some(comment_end) = rest.find("*/")
+      {
+        line = &rest[comment_end + 2..];
+        continue;
+      }
+
+      return line;
+    }
+  }
+
+  fn parse_identifier(input: &str) -> Option<(&str, &str)> {
+    let input = input.trim_start();
+    let mut chars = input.char_indices();
+    let (_, first) = chars.next()?;
+    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+      return None;
+    }
+
+    let mut end = first.len_utf8();
+    for (idx, ch) in chars {
+      if ch == '_' || ch == '$' || ch.is_ascii_alphanumeric() {
+        end = idx + ch.len_utf8();
+      } else {
+        break;
+      }
+    }
+
+    Some((&input[..end], &input[end..]))
+  }
+
+  fn parse_named_import_locals(clause: &str) -> Vec<Atom> {
+    let Some(clause) = clause.strip_prefix('{') else {
+      return vec![];
+    };
+    let Some((named_part, _)) = clause.split_once('}') else {
+      return vec![];
+    };
+
+    named_part
+      .split(',')
+      .filter_map(|specifier| {
+        let specifier = specifier.trim();
+        if specifier.is_empty() {
+          return None;
+        }
+
+        let local = specifier
+          .rsplit_once(" as ")
+          .map(|(_, local)| local)
+          .unwrap_or(specifier)
+          .trim();
+
+        if local.is_empty() {
+          None
+        } else {
+          Some(local.into())
+        }
+      })
+      .collect()
+  }
+
+  fn parse_module_external_top_level_decls(content: &str) -> Vec<Atom> {
+    let mut decls = Vec::new();
+
+    for line in content.lines() {
+      let line = Self::strip_leading_comments(line);
+      if line.is_empty() {
+        continue;
+      }
+
+      if let Some(import_clause) = line.strip_prefix("import ")
+        && let Some((binding_clause, _)) = import_clause.rsplit_once(" from ")
+      {
+        let binding_clause = binding_clause.trim();
+        if binding_clause.starts_with('"') || binding_clause.starts_with('\'') {
+          continue;
+        }
+
+        if let Some(namespace_clause) = binding_clause.strip_prefix("* as ") {
+          if let Some((local, _)) = Self::parse_identifier(namespace_clause) {
+            decls.push(local.into());
+          }
+          continue;
+        }
+
+        if let Some((default_clause, rest)) = binding_clause.split_once(',') {
+          if let Some((local, _)) = Self::parse_identifier(default_clause) {
+            decls.push(local.into());
+          }
+
+          let rest = rest.trim();
+          if let Some(namespace_clause) = rest.strip_prefix("* as ") {
+            if let Some((local, _)) = Self::parse_identifier(namespace_clause) {
+              decls.push(local.into());
+            }
+          } else {
+            decls.extend(Self::parse_named_import_locals(rest));
+          }
+          continue;
+        }
+
+        if binding_clause.starts_with('{') {
+          decls.extend(Self::parse_named_import_locals(binding_clause));
+          continue;
+        }
+
+        if let Some((local, _)) = Self::parse_identifier(binding_clause) {
+          decls.push(local.into());
+        }
+
+        continue;
+      }
+
+      for keyword in ["const ", "let ", "var "] {
+        if let Some(rest) = line.strip_prefix(keyword) {
+          if let Some((local, _)) = Self::parse_identifier(rest) {
+            decls.push(local.into());
+          }
+          break;
+        }
+      }
+    }
+
+    decls
+  }
+
+  #[cfg(test)]
+  fn reserve_module_external_top_level_decls(
+    init_fragments: &ChunkInitFragments,
+    used_names: &mut FxHashSet<Atom>,
+  ) {
+    Self::reserve_module_external_top_level_decls_in_render_order([init_fragments], used_names);
+  }
+
+  fn reserve_module_external_top_level_decls_in_render_order<'a>(
+    init_fragment_groups: impl IntoIterator<Item = &'a ChunkInitFragments>,
+    used_names: &mut FxHashSet<Atom>,
+  ) {
+    for content in Self::collect_module_external_fragments_in_render_order(init_fragment_groups) {
+      used_names.extend(Self::parse_module_external_top_level_decls(&content));
     }
   }
 
@@ -971,9 +1149,13 @@ var {} = {{}};
       }
     }
     Self::reserve_module_external_namespace_import_locals_in_render_order(
-      module_external_init_fragment_groups,
+      module_external_init_fragment_groups.iter().copied(),
       &mut all_used_names,
       Some(&mut chunk_link.module_external_namespace_imports),
+    );
+    Self::reserve_module_external_top_level_decls_in_render_order(
+      module_external_init_fragment_groups.iter().copied(),
+      &mut all_used_names,
     );
 
     // deconflict top level symbols
@@ -3570,6 +3752,80 @@ mod tests {
     );
 
     assert!(chunk_used_names.is_empty());
+  }
+
+  #[test]
+  fn module_external_non_namespace_init_fragment_claims_top_level_decls() {
+    let init_fragments: ChunkInitFragments = vec![Box::new(rspack_core::NormalInitFragment::new(
+      "import { createRequire as __rspack_createRequire } from \"node:module\";\nconst __rspack_createRequire_require = __rspack_createRequire(import.meta.url);\n"
+        .into(),
+      rspack_core::InitFragmentStage::StageESMImports,
+      0,
+      InitFragmentKey::ModuleExternal("node-commonjs".into()),
+      None,
+    ))];
+    let mut chunk_used_names = FxHashSet::default();
+
+    EsmLibraryPlugin::reserve_module_external_top_level_decls(
+      &init_fragments,
+      &mut chunk_used_names,
+    );
+
+    assert!(chunk_used_names.contains(&Atom::from("__rspack_createRequire")));
+    assert!(chunk_used_names.contains(&Atom::from("__rspack_createRequire_require")));
+  }
+
+  #[test]
+  fn module_external_top_level_decls_keep_first_rendered_fragment() {
+    let init_fragments: ChunkInitFragments = vec![
+      Box::new(rspack_core::NormalInitFragment::new(
+        "import { createRequire as __rspack_createRequire_1 } from \"node:module\";\nconst __rspack_createRequire_require_1 = __rspack_createRequire_1(import.meta.url);\n"
+          .into(),
+        rspack_core::InitFragmentStage::StageESMImports,
+        1,
+        InitFragmentKey::ModuleExternal("node-commonjs".into()),
+        None,
+      )),
+      Box::new(rspack_core::NormalInitFragment::new(
+        "import { createRequire as __rspack_createRequire_0 } from \"node:module\";\nconst __rspack_createRequire_require_0 = __rspack_createRequire_0(import.meta.url);\n"
+          .into(),
+        rspack_core::InitFragmentStage::StageESMImports,
+        0,
+        InitFragmentKey::ModuleExternal("node-commonjs".into()),
+        None,
+      )),
+    ];
+    let mut chunk_used_names = FxHashSet::default();
+
+    EsmLibraryPlugin::reserve_module_external_top_level_decls(
+      &init_fragments,
+      &mut chunk_used_names,
+    );
+
+    assert!(chunk_used_names.contains(&Atom::from("__rspack_createRequire_0")));
+    assert!(chunk_used_names.contains(&Atom::from("__rspack_createRequire_require_0")));
+    assert!(!chunk_used_names.contains(&Atom::from("__rspack_createRequire_1")));
+    assert!(!chunk_used_names.contains(&Atom::from("__rspack_createRequire_require_1")));
+  }
+
+  #[test]
+  fn module_external_var_init_fragment_claims_top_level_decl() {
+    let init_fragments: ChunkInitFragments = vec![Box::new(rspack_core::NormalInitFragment::new(
+      "/* provided dependency */ var provided_identifier = __webpack_require__(\"./dep\");\n"
+        .into(),
+      rspack_core::InitFragmentStage::StageProvides,
+      1,
+      InitFragmentKey::ModuleExternal("provided provided_identifier".into()),
+      None,
+    ))];
+    let mut chunk_used_names = FxHashSet::default();
+
+    EsmLibraryPlugin::reserve_module_external_top_level_decls(
+      &init_fragments,
+      &mut chunk_used_names,
+    );
+
+    assert!(chunk_used_names.contains(&Atom::from("provided_identifier")));
   }
 
   #[test]

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -4,7 +4,6 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use dyn_clone::clone_box;
 use rayon::{iter::Either, prelude::*};
 use rspack_collections::{IdentifierIndexMap, IdentifierIndexSet, IdentifierMap};
 use rspack_core::{
@@ -76,13 +75,11 @@ enum ExternalImportBinding {
 
 impl EsmLibraryPlugin {
   fn module_external_fragment_content(
-    init_fragment: &(dyn rspack_core::InitFragment<ChunkRenderContext> + '_),
+    init_fragment: Box<dyn rspack_core::InitFragment<ChunkRenderContext>>,
   ) -> Option<String> {
     if !matches!(init_fragment.key(), InitFragmentKey::ModuleExternal(_)) {
       return None;
     }
-
-    let init_fragment = clone_box(init_fragment);
 
     if let Ok(fragment) = init_fragment
       .clone()
@@ -106,7 +103,7 @@ impl EsmLibraryPlugin {
 
     for init_fragments in init_fragment_groups {
       for init_fragment in init_fragments {
-        let Some(content) = Self::module_external_fragment_content(init_fragment.as_ref()) else {
+        let Some(content) = Self::module_external_fragment_content(init_fragment.clone()) else {
           continue;
         };
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -4,6 +4,7 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
+use dyn_clone::clone_box;
 use rayon::{iter::Either, prelude::*};
 use rspack_collections::{IdentifierIndexMap, IdentifierIndexSet, IdentifierMap};
 use rspack_core::{
@@ -75,11 +76,13 @@ enum ExternalImportBinding {
 
 impl EsmLibraryPlugin {
   fn module_external_fragment_content(
-    init_fragment: &Box<dyn rspack_core::InitFragment<ChunkRenderContext>>,
+    init_fragment: &(dyn rspack_core::InitFragment<ChunkRenderContext> + '_),
   ) -> Option<String> {
     if !matches!(init_fragment.key(), InitFragmentKey::ModuleExternal(_)) {
       return None;
     }
+
+    let init_fragment = clone_box(init_fragment);
 
     if let Ok(fragment) = init_fragment
       .clone()
@@ -103,7 +106,7 @@ impl EsmLibraryPlugin {
 
     for init_fragments in init_fragment_groups {
       for init_fragment in init_fragments {
-        let Some(content) = Self::module_external_fragment_content(init_fragment) else {
+        let Some(content) = Self::module_external_fragment_content(init_fragment.as_ref()) else {
           continue;
         };
 
@@ -274,8 +277,7 @@ impl EsmLibraryPlugin {
 
         let local = specifier
           .rsplit_once(" as ")
-          .map(|(_, local)| local)
-          .unwrap_or(specifier)
+          .map_or(specifier, |(_, local)| local)
           .trim();
 
         if local.is_empty() {

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -98,21 +98,21 @@ impl EsmLibraryPlugin {
 
   fn collect_module_external_fragments_in_render_order<'a>(
     init_fragment_groups: impl IntoIterator<Item = &'a ChunkInitFragments>,
-  ) -> Vec<String> {
+  ) -> Vec<Box<dyn rspack_core::InitFragment<ChunkRenderContext>>> {
     let mut ordered_fragments = Vec::new();
 
     for init_fragments in init_fragment_groups {
       for init_fragment in init_fragments {
-        let Some(content) = Self::module_external_fragment_content(init_fragment.clone()) else {
+        if !matches!(init_fragment.key(), InitFragmentKey::ModuleExternal(_)) {
           continue;
-        };
+        }
 
         ordered_fragments.push((
           init_fragment.stage(),
           init_fragment.position(),
           ordered_fragments.len(),
           init_fragment.key().clone(),
-          content,
+          init_fragment.clone(),
         ));
       }
     }
@@ -131,9 +131,9 @@ impl EsmLibraryPlugin {
 
     let mut rendered_keys = FxHashSet::default();
     let mut rendered_fragments = Vec::with_capacity(ordered_fragments.len());
-    for (_, _, _, key, content) in ordered_fragments {
+    for (_, _, _, key, init_fragment) in ordered_fragments {
       if rendered_keys.insert(key) {
-        rendered_fragments.push(content);
+        rendered_fragments.push(init_fragment);
       }
     }
 
@@ -187,6 +187,7 @@ impl EsmLibraryPlugin {
   ) -> Vec<(RawImportSource, Atom)> {
     Self::collect_module_external_fragments_in_render_order(init_fragment_groups)
       .into_iter()
+      .filter_map(Self::module_external_fragment_content)
       .filter_map(|content| Self::parse_module_external_namespace_import(&content))
       .collect()
   }
@@ -212,145 +213,6 @@ impl EsmLibraryPlugin {
     }
   }
 
-  fn strip_leading_comments(mut line: &str) -> &str {
-    loop {
-      line = line.trim_start();
-
-      if line.is_empty() {
-        return line;
-      }
-
-      if let Some(rest) = line.strip_prefix("//") {
-        let _ = rest;
-        return "";
-      }
-
-      if let Some(rest) = line.strip_prefix("/*")
-        && let Some(comment_end) = rest.find("*/")
-      {
-        line = &rest[comment_end + 2..];
-        continue;
-      }
-
-      return line;
-    }
-  }
-
-  fn parse_identifier(input: &str) -> Option<(&str, &str)> {
-    let input = input.trim_start();
-    let mut chars = input.char_indices();
-    let (_, first) = chars.next()?;
-    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
-      return None;
-    }
-
-    let mut end = first.len_utf8();
-    for (idx, ch) in chars {
-      if ch == '_' || ch == '$' || ch.is_ascii_alphanumeric() {
-        end = idx + ch.len_utf8();
-      } else {
-        break;
-      }
-    }
-
-    Some((&input[..end], &input[end..]))
-  }
-
-  fn parse_named_import_locals(clause: &str) -> Vec<Atom> {
-    let Some(clause) = clause.strip_prefix('{') else {
-      return vec![];
-    };
-    let Some((named_part, _)) = clause.split_once('}') else {
-      return vec![];
-    };
-
-    named_part
-      .split(',')
-      .filter_map(|specifier| {
-        let specifier = specifier.trim();
-        if specifier.is_empty() {
-          return None;
-        }
-
-        let local = specifier
-          .rsplit_once(" as ")
-          .map_or(specifier, |(_, local)| local)
-          .trim();
-
-        if local.is_empty() {
-          None
-        } else {
-          Some(local.into())
-        }
-      })
-      .collect()
-  }
-
-  fn parse_module_external_top_level_decls(content: &str) -> Vec<Atom> {
-    let mut decls = Vec::new();
-
-    for line in content.lines() {
-      let line = Self::strip_leading_comments(line);
-      if line.is_empty() {
-        continue;
-      }
-
-      if let Some(import_clause) = line.strip_prefix("import ")
-        && let Some((binding_clause, _)) = import_clause.rsplit_once(" from ")
-      {
-        let binding_clause = binding_clause.trim();
-        if binding_clause.starts_with('"') || binding_clause.starts_with('\'') {
-          continue;
-        }
-
-        if let Some(namespace_clause) = binding_clause.strip_prefix("* as ") {
-          if let Some((local, _)) = Self::parse_identifier(namespace_clause) {
-            decls.push(local.into());
-          }
-          continue;
-        }
-
-        if let Some((default_clause, rest)) = binding_clause.split_once(',') {
-          if let Some((local, _)) = Self::parse_identifier(default_clause) {
-            decls.push(local.into());
-          }
-
-          let rest = rest.trim();
-          if let Some(namespace_clause) = rest.strip_prefix("* as ") {
-            if let Some((local, _)) = Self::parse_identifier(namespace_clause) {
-              decls.push(local.into());
-            }
-          } else {
-            decls.extend(Self::parse_named_import_locals(rest));
-          }
-          continue;
-        }
-
-        if binding_clause.starts_with('{') {
-          decls.extend(Self::parse_named_import_locals(binding_clause));
-          continue;
-        }
-
-        if let Some((local, _)) = Self::parse_identifier(binding_clause) {
-          decls.push(local.into());
-        }
-
-        continue;
-      }
-
-      for keyword in ["const ", "let ", "var "] {
-        if let Some(rest) = line.strip_prefix(keyword) {
-          if let Some((local, _)) = Self::parse_identifier(rest) {
-            decls.push(local.into());
-          }
-          break;
-        }
-      }
-    }
-
-    decls
-  }
-
   #[cfg(test)]
   fn reserve_module_external_top_level_decls(
     init_fragments: &ChunkInitFragments,
@@ -363,8 +225,10 @@ impl EsmLibraryPlugin {
     init_fragment_groups: impl IntoIterator<Item = &'a ChunkInitFragments>,
     used_names: &mut FxHashSet<Atom>,
   ) {
-    for content in Self::collect_module_external_fragments_in_render_order(init_fragment_groups) {
-      used_names.extend(Self::parse_module_external_top_level_decls(&content));
+    for init_fragment in
+      Self::collect_module_external_fragments_in_render_order(init_fragment_groups)
+    {
+      used_names.extend(init_fragment.top_level_decl_symbols().iter().cloned());
     }
   }
 
@@ -3762,7 +3626,11 @@ mod tests {
       0,
       InitFragmentKey::ModuleExternal("node-commonjs".into()),
       None,
-    ))];
+    )
+    .with_top_level_decl_symbols(vec![
+      "__rspack_createRequire".into(),
+      "__rspack_createRequire_require".into(),
+    ]))];
     let mut chunk_used_names = FxHashSet::default();
 
     EsmLibraryPlugin::reserve_module_external_top_level_decls(
@@ -3784,7 +3652,11 @@ mod tests {
         1,
         InitFragmentKey::ModuleExternal("node-commonjs".into()),
         None,
-      )),
+      )
+      .with_top_level_decl_symbols(vec![
+        "__rspack_createRequire_1".into(),
+        "__rspack_createRequire_require_1".into(),
+      ])),
       Box::new(rspack_core::NormalInitFragment::new(
         "import { createRequire as __rspack_createRequire_0 } from \"node:module\";\nconst __rspack_createRequire_require_0 = __rspack_createRequire_0(import.meta.url);\n"
           .into(),
@@ -3792,7 +3664,11 @@ mod tests {
         0,
         InitFragmentKey::ModuleExternal("node-commonjs".into()),
         None,
-      )),
+      )
+      .with_top_level_decl_symbols(vec![
+        "__rspack_createRequire_0".into(),
+        "__rspack_createRequire_require_0".into(),
+      ])),
     ];
     let mut chunk_used_names = FxHashSet::default();
 
@@ -3809,14 +3685,17 @@ mod tests {
 
   #[test]
   fn module_external_var_init_fragment_claims_top_level_decl() {
-    let init_fragments: ChunkInitFragments = vec![Box::new(rspack_core::NormalInitFragment::new(
-      "/* provided dependency */ var provided_identifier = __webpack_require__(\"./dep\");\n"
-        .into(),
-      rspack_core::InitFragmentStage::StageProvides,
-      1,
-      InitFragmentKey::ModuleExternal("provided provided_identifier".into()),
-      None,
-    ))];
+    let init_fragments: ChunkInitFragments = vec![Box::new(
+      rspack_core::NormalInitFragment::new(
+        "/* provided dependency */ var provided_identifier = __webpack_require__(\"./dep\");\n"
+          .into(),
+        rspack_core::InitFragmentStage::StageProvides,
+        1,
+        InitFragmentKey::ModuleExternal("provided provided_identifier".into()),
+        None,
+      )
+      .with_top_level_decl_symbols(vec!["provided_identifier".into()]),
+    )];
     let mut chunk_used_names = FxHashSet::default();
 
     EsmLibraryPlugin::reserve_module_external_top_level_decls(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -194,18 +194,21 @@ impl DependencyTemplate for ProvideDependencyTemplate {
       )
     };
 
-    init_fragments.push(Box::new(NormalInitFragment::new(
-      format!(
-        "/* provided dependency */ var {} = {}{};\n",
-        dep.identifier,
-        runtime_template.module_raw(compilation, dep.id(), dep.request(), dep.weak()),
-        path_to_string(used_name.as_ref())
-      ),
-      InitFragmentStage::StageProvides,
-      1,
-      InitFragmentKey::ModuleExternal(format!("provided {}", dep.identifier)),
-      None,
-    )));
+    init_fragments.push(Box::new(
+      NormalInitFragment::new(
+        format!(
+          "/* provided dependency */ var {} = {}{};\n",
+          dep.identifier,
+          runtime_template.module_raw(compilation, dep.id(), dep.request(), dep.weak()),
+          path_to_string(used_name.as_ref())
+        ),
+        InitFragmentStage::StageProvides,
+        1,
+        InitFragmentKey::ModuleExternal(format!("provided {}", dep.identifier)),
+        None,
+      )
+      .with_top_level_decl_symbols(vec![dep.identifier.clone().into()]),
+    ));
     source.replace(dep.range.start, dep.range.end, dep.identifier.clone(), None);
   }
 }

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -61,6 +61,10 @@ async fn render_module_content(
         InitFragmentKey::ModuleExternal("node-commonjs".to_string()),
         None,
       )
+      .with_top_level_decl_symbols(vec![
+        "__rspack_createRequire".into(),
+        "__rspack_createRequire_require".into(),
+      ])
       .boxed(),
     );
   }

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/__snapshots__/esm.snap.txt
@@ -1,37 +1,88 @@
 ```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
 import {fileURLToPath as __rspack_fileURLToPath} from "node:url";
 import {dirname as __rspack_dirname} from "node:path";
 import { createRequire as __rspack_createRequire } from "node:module";
 const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
-// fs
-const external_fs_namespaceObject = __rspack_createRequire_require("fs");
+__webpack_require__.add({
+"fs"
+/*!*********************!*\
+  !*** external "fs" ***!
+  \*********************/
+(module) {
+module.exports = __rspack_createRequire_require("fs");
+
+},
+});
+// node:module
+const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
 // ./index.js
 var index_dirname = __rspack_dirname(__rspack_fileURLToPath(import.meta.url));
-const index_rspack_createRequire_require = "user-defined";
-
-const userCreateRequireRequire = index_rspack_createRequire_require;
 
 
-it("should rename user bindings that collide with the node-commonjs helper", async () => {
+const index_rspack_createRequire_require = (0,external_node_module_namespaceObject.createRequire)('<ROOT>/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/index.js');
+// fs
+const external_fs_namespaceObject = index_rspack_createRequire_require("fs");
+
+const sourceCreateRequireRequire = index_rspack_createRequire_require;
+const sourceReadFile = external_fs_namespaceObject.readFile;
+const sourceRequireReadFile = (__webpack_require__(/*! fs */ "fs")/* .readFile */.readFile);
+
+it("should deconflict source bindings that already use the node-commonjs helper names", async () => {
   const mod = await import(/* webpackIgnore: true */ "./main.mjs");
   const { createRequire } = await import(/* webpackIgnore: true */ "node:module");
   const require = createRequire('<ROOT>/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/index.js');
   const fs = require("fs");
-  const outputPath = require("path");
-  const code = fs.readFileSync(outputPath.join(index_dirname, "main.mjs"), "utf-8");
+  const path = require("path");
+  const code = fs.readFileSync(path.join(index_dirname, "main.mjs"), "utf-8");
 
-  expect(mod.userCreateRequireRequire).toBe("user-defined");
-  expect(mod.readFile).toBe(fs.readFile);
+  expect(mod.sourceReadFile).toBe(fs.readFile);
+  expect(mod.sourceRequireReadFile).toBe(fs.readFile);
+  expect(mod.sourceCreateRequireRequire("fs").readFile).toBe(fs.readFile);
   expect(code).toContain(
     'const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);'
   );
   expect(code).toMatch(
-    /^const [A-Za-z0-9_$]*rspack_createRequire_require = "user-defined";$/m
+    /^const (?!__rspack_createRequire_require\b)[A-Za-z0-9_$]*rspack_createRequire_require = .*createRequire.*;$/m
   );
-  expect(code).not.toMatch(/^const __rspack_createRequire_require = "user-defined";$/m);
 });
 
-var readFile = external_fs_namespaceObject.readFile;
-export { readFile, userCreateRequireRequire };
+export { sourceCreateRequireRequire, sourceReadFile, sourceRequireReadFile };
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+
+export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/__snapshots__/esm.snap.txt
@@ -1,0 +1,37 @@
+```mjs title=main.mjs
+import {fileURLToPath as __rspack_fileURLToPath} from "node:url";
+import {dirname as __rspack_dirname} from "node:path";
+import { createRequire as __rspack_createRequire } from "node:module";
+const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
+// fs
+const external_fs_namespaceObject = __rspack_createRequire_require("fs");
+// ./index.js
+var index_dirname = __rspack_dirname(__rspack_fileURLToPath(import.meta.url));
+const index_rspack_createRequire_require = "user-defined";
+
+const userCreateRequireRequire = index_rspack_createRequire_require;
+
+
+it("should rename user bindings that collide with the node-commonjs helper", async () => {
+  const mod = await import(/* webpackIgnore: true */ "./main.mjs");
+  const { createRequire } = await import(/* webpackIgnore: true */ "node:module");
+  const require = createRequire('<ROOT>/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/index.js');
+  const fs = require("fs");
+  const outputPath = require("path");
+  const code = fs.readFileSync(outputPath.join(index_dirname, "main.mjs"), "utf-8");
+
+  expect(mod.userCreateRequireRequire).toBe("user-defined");
+  expect(mod.readFile).toBe(fs.readFile);
+  expect(code).toContain(
+    'const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);'
+  );
+  expect(code).toMatch(
+    /^const [A-Za-z0-9_$]*rspack_createRequire_require = "user-defined";$/m
+  );
+  expect(code).not.toMatch(/^const __rspack_createRequire_require = "user-defined";$/m);
+});
+
+var readFile = external_fs_namespaceObject.readFile;
+export { readFile, userCreateRequireRequire };
+
+```

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/index.js
@@ -1,0 +1,23 @@
+const __rspack_createRequire_require = "user-defined";
+
+export const userCreateRequireRequire = __rspack_createRequire_require;
+export { readFile } from "fs";
+
+it("should rename user bindings that collide with the node-commonjs helper", async () => {
+  const mod = await import(/* webpackIgnore: true */ "./main.mjs");
+  const { createRequire } = await import(/* webpackIgnore: true */ "node:module");
+  const require = createRequire(import.meta.url);
+  const fs = require("fs");
+  const outputPath = require("path");
+  const code = fs.readFileSync(outputPath.join(__dirname, "main.mjs"), "utf-8");
+
+  expect(mod.userCreateRequireRequire).toBe("user-defined");
+  expect(mod.readFile).toBe(fs.readFile);
+  expect(code).toContain(
+    'const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);'
+  );
+  expect(code).toMatch(
+    /^const [A-Za-z0-9_$]*rspack_createRequire_require = "user-defined";$/m
+  );
+  expect(code).not.toMatch(/^const __rspack_createRequire_require = "user-defined";$/m);
+});

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/index.js
@@ -1,23 +1,28 @@
-const __rspack_createRequire_require = "user-defined";
+import { createRequire as __rspack_createRequire } from "node:module";
 
-export const userCreateRequireRequire = __rspack_createRequire_require;
-export { readFile } from "fs";
+const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
+// fs
+const external_fs_namespaceObject = __rspack_createRequire_require("fs");
 
-it("should rename user bindings that collide with the node-commonjs helper", async () => {
+export const sourceCreateRequireRequire = __rspack_createRequire_require;
+export const sourceReadFile = external_fs_namespaceObject.readFile;
+export const sourceRequireReadFile = require("fs").readFile;
+
+it("should deconflict source bindings that already use the node-commonjs helper names", async () => {
   const mod = await import(/* webpackIgnore: true */ "./main.mjs");
   const { createRequire } = await import(/* webpackIgnore: true */ "node:module");
   const require = createRequire(import.meta.url);
   const fs = require("fs");
-  const outputPath = require("path");
-  const code = fs.readFileSync(outputPath.join(__dirname, "main.mjs"), "utf-8");
+  const path = require("path");
+  const code = fs.readFileSync(path.join(__dirname, "main.mjs"), "utf-8");
 
-  expect(mod.userCreateRequireRequire).toBe("user-defined");
-  expect(mod.readFile).toBe(fs.readFile);
+  expect(mod.sourceReadFile).toBe(fs.readFile);
+  expect(mod.sourceRequireReadFile).toBe(fs.readFile);
+  expect(mod.sourceCreateRequireRequire("fs").readFile).toBe(fs.readFile);
   expect(code).toContain(
     'const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);'
   );
   expect(code).toMatch(
-    /^const [A-Za-z0-9_$]*rspack_createRequire_require = "user-defined";$/m
+    /^const (?!__rspack_createRequire_require\b)[A-Za-z0-9_$]*rspack_createRequire_require = .*createRequire.*;$/m
   );
-  expect(code).not.toMatch(/^const __rspack_createRequire_require = "user-defined";$/m);
 });

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  externals: {
+    fs: 'node-commonjs fs',
+  },
+};


### PR DESCRIPTION
## Summary

This PR fixes modern-module ESM rendering when a `ModuleExternal` init fragment introduces top-level bindings that collide with source bindings during deconfliction.

It also adds an externals case that covers helper-shaped source code directly in `index.js`, including a literal `require("fs")`, while the project external for `fs` is also configured as `node-commonjs`.

## Root Cause

`rspack_plugin_esm_library` previously reserved namespace-import locals from `ModuleExternal` init fragments, but it did not reserve other top-level declarations introduced by those fragments. That allowed generated helpers like `__rspack_createRequire` and `__rspack_createRequire_require` to collide with user/source bindings in ESM library rendering.

## What Changed

- reserve top-level declarations from `ModuleExternal` init fragments before top-level symbol deconfliction
- keep the reservation order aligned with init-fragment render order and key deduplication semantics
- add unit coverage for helper/provided-dependency declarations in `link.rs`
- add an ESM output case where the source already contains helper-shaped bindings and `require("fs")`, while `fs` is also a `node-commonjs` external

## Validation

- `cargo test -p rspack_plugin_esm_library link --lib`
- `cargo fmt --all --check`
- `cd tests/rspack-test && PATH="/tmp/codex-bin:$HOME/.nvm/versions/node/v20.19.0/bin:$PATH" pnpm testu EsmOutput.test.js -t "externals/node-commonjs-helper-name-collision"`
- `cd tests/rspack-test && PATH="/tmp/codex-bin:$HOME/.nvm/versions/node/v20.19.0/bin:$PATH" pnpm test EsmOutput.test.js -t "externals/node-commonjs-helper-name-collision"`
