### PR TITLE
test(benchmark): add compilation stage benchmark cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3682,6 +3682,7 @@ dependencies = [
 name = "rspack_benchmark"
 version = "0.100.0-rc.1"
 dependencies = [
+ "async-trait",
  "codspeed-criterion-compat",
  "rspack",
  "rspack_cacheable",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -76,6 +76,7 @@ pretty_assertions = { workspace = true }
 workspace = true
 
 [features]
+benchmark-passes = []
 debug_tool = ["rspack_util/debug_tool"]
 default    = []
 napi       = ["dep:napi", "dep:rspack_napi", "dep:rkyv"]

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -77,6 +77,6 @@ workspace = true
 
 [features]
 benchmark-passes = []
-debug_tool = ["rspack_util/debug_tool"]
-default    = []
-napi       = ["dep:napi", "dep:rspack_napi", "dep:rkyv"]
+debug_tool       = ["rspack_util/debug_tool"]
+default          = []
+napi             = ["dep:napi", "dep:rspack_napi", "dep:rkyv"]

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -7,8 +7,9 @@ use std::{fmt::Debug, sync::Arc};
 
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem};
 
-pub use self::disable::DisableCache;
-use self::{memory::MemoryCache, mixed::MixedCache, persistent::PersistentCache};
+use self::{
+  disable::DisableCache, memory::MemoryCache, mixed::MixedCache, persistent::PersistentCache,
+};
 use crate::{CacheOptions, Compilation, CompilerOptions};
 
 /// Cache trait

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -7,9 +7,8 @@ use std::{fmt::Debug, sync::Arc};
 
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem};
 
-use self::{
-  disable::DisableCache, memory::MemoryCache, mixed::MixedCache, persistent::PersistentCache,
-};
+pub use self::disable::DisableCache;
+use self::{memory::MemoryCache, mixed::MixedCache, persistent::PersistentCache};
 use crate::{CacheOptions, Compilation, CompilerOptions};
 
 /// Cache trait

--- a/crates/rspack_core/src/compilation/assign_runtime_ids/mod.rs
+++ b/crates/rspack_core/src/compilation/assign_runtime_ids/mod.rs
@@ -35,6 +35,7 @@ impl PassExt for AssignRuntimeIdsPass {
         chunk_graph.set_runtime_id(runtime, chunk.id().map(|id| id.to_string()));
       }
     }
+
     for i in compilation.build_chunk_graph_artifact.entrypoints.iter() {
       process_entrypoint(
         i.1,
@@ -55,6 +56,7 @@ impl PassExt for AssignRuntimeIdsPass {
         &mut compilation.build_chunk_graph_artifact.chunk_graph,
       )
     }
+
     Ok(())
   }
 }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -60,6 +60,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 use tracing::instrument;
 use ustr::Ustr;
 
+#[cfg(feature = "benchmark-passes")]
 pub use self::{
   assign_runtime_ids::AssignRuntimeIdsPass, code_generation::CodeGenerationPass,
   create_chunk_assets::CreateChunkAssetsPass, create_hash::CreateHashPass,

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -25,6 +25,7 @@ mod process_assets;
 mod run_passes;
 mod runtime_requirements;
 mod seal;
+
 use std::{
   collections::{VecDeque, hash_map},
   fmt::{self, Debug},
@@ -59,6 +60,13 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 use tracing::instrument;
 use ustr::Ustr;
 
+pub use self::{
+  assign_runtime_ids::AssignRuntimeIdsPass, code_generation::CodeGenerationPass,
+  create_chunk_assets::CreateChunkAssetsPass, create_hash::CreateHashPass,
+  create_module_assets::CreateModuleAssetsPass, create_module_hashes::CreateModuleHashesPass,
+  optimize_code_generation::OptimizeCodeGenerationPass, process_assets::ProcessAssetsPass,
+  runtime_requirements::RuntimeRequirementsPass,
+};
 use crate::{
   AsyncModulesArtifact, BindingCell, BoxDependency, BoxModule, BuildChunkGraphArtifact, CacheCount,
   CacheOptions, CgcRuntimeRequirementsArtifact, CgmHashArtifact, CgmRuntimeRequirementsArtifact,

--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -16,7 +16,7 @@ criterion = { workspace = true }
 
 [dev-dependencies]
 # Make rust analyzer happy
-async-trait               = { workspace = true }
+async-trait                = { workspace = true }
 rspack                     = { workspace = true, features = ["full"] }
 rspack_cacheable           = { workspace = true }
 rspack_collections         = { workspace = true }

--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -16,10 +16,11 @@ criterion = { workspace = true }
 
 [dev-dependencies]
 # Make rust analyzer happy
+async-trait               = { workspace = true }
 rspack                     = { workspace = true, features = ["full"] }
 rspack_cacheable           = { workspace = true }
 rspack_collections         = { workspace = true }
-rspack_core                = { workspace = true }
+rspack_core                = { workspace = true, features = ["benchmark-passes"] }
 rspack_error               = { workspace = true }
 rspack_fs                  = { workspace = true }
 rspack_hash                = { workspace = true }

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -566,7 +566,7 @@ fn create_full_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
       .await
       .expect("should not fail to create dir");
     prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
-    compiler.build().await.unwrap();
+    prepare_for_full_hash(&mut compiler).await.unwrap();
   });
 
   assert_no_compilation_errors(&compiler.compilation, "create_full_hash setup");
@@ -574,46 +574,14 @@ fn create_full_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
     !compiler.compilation.chunk_hashes_artifact.is_empty(),
     "create_full_hash setup should prepare chunk hashes"
   );
-  assert_no_full_hash_runtime_dependencies(
-    &compiler.compilation,
-    "create_full_hash setup should only benchmark full-hash aggregation over stable chunk/content hashes",
-  );
-  let expected_hash = compiler
-    .compilation
-    .hash
-    .clone()
-    .expect("create_full_hash setup should set the compilation hash");
-  let recomputed_hash = aggregate_full_hash(&mut compiler.compilation);
-  assert_eq!(
-    recomputed_hash, expected_hash,
-    "create_full_hash helper should match compilation hash from the full build"
-  );
+  let compiler = RefCell::new(compiler);
 
   c.bench_function("rust@create_full_hash", |b| {
-    b.iter_batched(
-      || {
-        let fs = Arc::new(MemoryFileSystem::default());
-        let random_table = random_table.clone();
-        let mut compiler = create_general_stage_compiler(fs.clone());
-        rt.block_on(async {
-          fs.create_dir_all("/src".into())
-            .await
-            .expect("should not fail to create dir");
-          prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
-          compiler.build().await.unwrap();
-        });
-        assert_no_full_hash_runtime_dependencies(
-          &compiler.compilation,
-          "create_full_hash benchmark setup should avoid full-hash-dependent runtime chunks",
-        );
-        compiler
-      },
-      |mut compiler| {
-        let full_hash = aggregate_full_hash(&mut compiler.compilation);
-        black_box(full_hash);
-      },
-      BatchSize::PerIteration,
-    );
+    b.iter(|| {
+      let mut compiler = compiler.borrow_mut();
+      let full_hash = aggregate_full_hash(&mut compiler.compilation);
+      black_box(full_hash);
+    });
   });
 }
 
@@ -1125,13 +1093,16 @@ async fn prepare_for_runtime_requirements(compiler: &mut Compiler) -> Result<()>
   Ok(())
 }
 
+async fn prepare_for_full_hash(compiler: &mut Compiler) -> Result<()> {
+  prepare_for_runtime_requirements(compiler).await?;
+  run_runtime_requirements_pass(compiler).await?;
+  run_pre_full_hash_setup_on_compilation(&mut compiler.compilation).await?;
+  Ok(())
+}
+
 async fn prepare_for_module_assets(compiler: &mut Compiler) -> Result<()> {
   prepare_for_runtime_requirements(compiler).await?;
   run_runtime_requirements_pass(compiler).await?;
-  assert_no_full_hash_runtime_dependencies(
-    &compiler.compilation,
-    "create_module_assets setup should only benchmark asset emission with stable chunk/content hashes",
-  );
   run_create_hash_pass(compiler).await?;
   let seeded_module_assets = seed_module_assets(&mut compiler.compilation);
   assert!(
@@ -1679,7 +1650,7 @@ async fn run_create_hash_pass(compiler: &mut Compiler) -> Result<()> {
   Ok(())
 }
 
-async fn run_create_hash_on_compilation(compilation: &mut Compilation) -> Result<()> {
+async fn run_pre_full_hash_setup_on_compilation(compilation: &mut Compilation) -> Result<()> {
   compilation.chunk_hashes_artifact.clear();
   compilation.runtime_modules_hash.clear();
   compilation.hash = None;
@@ -1705,6 +1676,11 @@ async fn run_create_hash_on_compilation(compilation: &mut Compilation) -> Result
     );
   }
 
+  Ok(())
+}
+
+async fn run_create_hash_on_compilation(compilation: &mut Compilation) -> Result<()> {
+  run_pre_full_hash_setup_on_compilation(compilation).await?;
   aggregate_full_hash(compilation);
   run_runtime_modules_code_generation_on_compilation(compilation).await?;
   Ok(())
@@ -2405,45 +2381,6 @@ fn aggregate_full_hash(compilation: &mut Compilation) -> rspack_hash::RspackHash
   let full_hash = compilation_hasher.digest(&compilation.options.output.hash_digest);
   compilation.hash = Some(full_hash.clone());
   full_hash
-}
-
-fn assert_no_full_hash_runtime_dependencies(compilation: &Compilation, message: &str) {
-  let mut has_full_hash_dependency = false;
-  for chunk_ukey in compilation.build_chunk_graph_artifact.chunk_by_ukey.keys() {
-    compilation
-      .plugin_driver
-      .compilation_hooks
-      .dependent_full_hash
-      .call(compilation, chunk_ukey, &mut has_full_hash_dependency)
-      .expect("full-hash dependency probe should not fail");
-    if has_full_hash_dependency
-      || compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .has_chunk_full_hash_modules(chunk_ukey, &compilation.runtime_modules)
-    {
-      break;
-    }
-    for runtime_module_identifier in compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_chunk_runtime_modules_iterable(chunk_ukey)
-    {
-      let runtime_module = compilation
-        .runtime_modules
-        .get(runtime_module_identifier)
-        .expect("should have runtime module");
-      if runtime_module.dependent_hash() {
-        has_full_hash_dependency = true;
-        break;
-      }
-    }
-    if has_full_hash_dependency {
-      break;
-    }
-  }
-
-  assert!(!has_full_hash_dependency, "{message}");
 }
 
 async fn compute_concatenated_module_codegen(

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -14,9 +14,9 @@ use rspack_collections::IdentifierSet;
 use rspack_core::{
   AsyncModulesArtifact, CacheOptions, ChunkByUkey, ChunkContentHash, ChunkGraph,
   ChunkNamedIdArtifact, ChunkUkey, CodeGenerationJob, Compilation, Compiler, DEFAULT_DELIMITER,
-  EntryRuntime, Mode, ModuleCodeGenerationContext, ModuleIdsArtifact, Optimization, RuntimeGlobals,
-  RuntimeModule, RuntimeSpecMap, SideEffectsOptimizeArtifact, SourceType, UsedExportsOption,
-  build_chunk_graph,
+  EntryRuntime, MangleExportsOption, Mode, ModuleCodeGenerationContext, ModuleIdsArtifact,
+  Optimization, RuntimeGlobals, RuntimeModule, RuntimeSpecMap, SideEffectsOptimizeArtifact,
+  SourceType, UsedExportsOption, build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
   incremental::IncrementalOptions,
 };
@@ -59,6 +59,7 @@ fn compilation_stages_benchmark_inner(c: &mut Criterion) {
   create_module_ids_benchmark(c, &rt);
   split_chunks_benchmark(c, &rt);
   create_chunk_ids_benchmark(c, &rt);
+  mangle_exports_benchmark(c, &rt);
   create_module_hashes_benchmark(c, &rt);
   runtime_requirements_benchmark(c, &rt);
   create_chunk_hashes_benchmark(c, &rt);
@@ -352,6 +353,83 @@ fn create_chunk_ids_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
           .unwrap();
         });
         black_box(named_chunk_ids_artifact.chunk_ids.len());
+      },
+      BatchSize::PerIteration,
+    );
+  });
+}
+
+fn mangle_exports_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+  let fs = Arc::new(MemoryFileSystem::default());
+  let random_table = load_random_table();
+  let mut compiler = create_mangle_exports_stage_compiler(fs.clone());
+
+  rt.block_on(async {
+    fs.create_dir_all("/src".into())
+      .await
+      .expect("should not fail to create dir");
+    prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
+    prepare_for_optimize_code_generation(&mut compiler)
+      .await
+      .unwrap();
+  });
+
+  assert_no_compilation_errors(&compiler.compilation, "mangle_exports setup");
+  compiler
+    .compilation
+    .build_module_graph_artifact
+    .get_module_graph_mut()
+    .checkpoint();
+  compiler.compilation.exports_info_artifact.checkpoint();
+
+  rt.block_on(async {
+    run_optimize_code_generation_hook(&mut compiler.compilation)
+      .await
+      .unwrap();
+  });
+  let assigned_export_used_names = count_assigned_export_used_names(&compiler.compilation);
+  assert!(
+    assigned_export_used_names > 0,
+    "mangle_exports setup should assign export used names"
+  );
+  compiler
+    .compilation
+    .build_module_graph_artifact
+    .get_module_graph_mut()
+    .reset();
+  compiler.compilation.exports_info_artifact.reset();
+
+  let compiler = RefCell::new(compiler);
+  let should_reset = Cell::new(false);
+  c.bench_function("rust@mangle_exports", |b| {
+    b.iter_batched_ref(
+      || {
+        let mut compiler = compiler.borrow_mut();
+        if should_reset.get() {
+          compiler
+            .compilation
+            .build_module_graph_artifact
+            .get_module_graph_mut()
+            .reset();
+          compiler.compilation.exports_info_artifact.reset();
+        } else {
+          should_reset.set(true);
+        }
+        compiler
+          .compilation
+          .build_module_graph_artifact
+          .get_module_graph_mut()
+          .checkpoint();
+        compiler.compilation.exports_info_artifact.checkpoint();
+      },
+      |_| {
+        let mut compiler = compiler.borrow_mut();
+        rt.block_on(async {
+          run_optimize_code_generation_hook(&mut compiler.compilation)
+            .await
+            .unwrap();
+        });
+        black_box(count_assigned_export_used_names(&compiler.compilation));
       },
       BatchSize::PerIteration,
     );
@@ -686,6 +764,28 @@ fn create_general_stage_compiler(fs: Arc<MemoryFileSystem>) -> Compiler {
     .unwrap()
 }
 
+fn create_mangle_exports_stage_compiler(fs: Arc<MemoryFileSystem>) -> Compiler {
+  Compiler::builder()
+    .context("/")
+    .mode(Mode::Development)
+    .cache(CacheOptions::Disabled)
+    .entry("main", "/src/dynamic-0.js")
+    .input_filesystem(fs.clone())
+    .output_filesystem(fs)
+    .optimization(
+      Optimization::builder()
+        .provided_exports(true)
+        .used_exports(UsedExportsOption::True)
+        .mangle_exports(MangleExportsOption::Deterministic)
+        .module_ids("deterministic".to_string())
+        .chunk_ids("deterministic".to_string())
+        .concatenate_modules(false),
+    )
+    .incremental(IncrementalOptions::empty_passes())
+    .build()
+    .unwrap()
+}
+
 fn create_split_chunks_stage_compiler(fs: Arc<MemoryFileSystem>) -> Compiler {
   let mut builder = Compiler::builder();
   builder
@@ -801,16 +901,16 @@ async fn prepare_for_chunk_ids(compiler: &mut Compiler) -> Result<()> {
   Ok(())
 }
 
-async fn prepare_for_module_hashes(compiler: &mut Compiler) -> Result<()> {
-  prepare_for_chunk_ids(compiler).await?;
-  run_chunk_ids_on_compilation(&mut compiler.compilation).await?;
-  Ok(())
-}
-
 async fn prepare_for_optimize_code_generation(compiler: &mut Compiler) -> Result<()> {
   prepare_for_chunk_ids(compiler).await?;
   run_chunk_ids_on_compilation(&mut compiler.compilation).await?;
   run_assign_runtime_ids(&mut compiler.compilation)?;
+  Ok(())
+}
+
+async fn prepare_for_module_hashes(compiler: &mut Compiler) -> Result<()> {
+  prepare_for_chunk_ids(compiler).await?;
+  run_chunk_ids_on_compilation(&mut compiler.compilation).await?;
   Ok(())
 }
 
@@ -1234,11 +1334,7 @@ async fn run_code_generation_on_compilation(compilation: &mut Compilation) -> Re
           &compilation.options.output.hash_salt,
         );
       }
-      compilation.code_generation_results.insert(
-        module_identifier,
-        code_generation_result,
-        [runtime],
-      );
+      compilation.code_generation_results.insert(module_identifier, code_generation_result, [runtime]);
     }
 
     compilation.code_generated_modules.insert(module_identifier);
@@ -1980,6 +2076,22 @@ fn count_concatenated_modules(compilation: &Compilation) -> usize {
     .modules()
     .filter(|(_, module)| module.as_concatenated_module().is_some())
     .count()
+}
+
+fn count_assigned_export_used_names(compilation: &Compilation) -> usize {
+  compilation
+    .get_module_graph()
+    .modules()
+    .map(|(module_identifier, _)| {
+      compilation
+        .exports_info_artifact
+        .get_exports_info_data(module_identifier)
+        .exports()
+        .values()
+        .filter(|export_info| export_info.used_name().is_some())
+        .count()
+    })
+    .sum()
 }
 
 fn assert_no_compilation_errors(compilation: &Compilation, context: &str) {

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -14,8 +14,9 @@ use rspack_collections::IdentifierSet;
 use rspack_core::{
   AsyncModulesArtifact, CacheOptions, ChunkByUkey, ChunkContentHash, ChunkGraph,
   ChunkNamedIdArtifact, ChunkUkey, CodeGenerationJob, Compilation, Compiler, DEFAULT_DELIMITER,
-  Mode, ModuleCodeGenerationContext, ModuleIdsArtifact, Optimization, SideEffectsOptimizeArtifact,
-  SourceType, UsedExportsOption, build_chunk_graph,
+  EntryRuntime, Mode, ModuleCodeGenerationContext, ModuleIdsArtifact, Optimization, RuntimeGlobals,
+  RuntimeModule, RuntimeSpecMap, SideEffectsOptimizeArtifact, SourceType, UsedExportsOption,
+  build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
   incremental::IncrementalOptions,
 };
@@ -59,7 +60,9 @@ fn compilation_stages_benchmark_inner(c: &mut Criterion) {
   split_chunks_benchmark(c, &rt);
   create_chunk_ids_benchmark(c, &rt);
   create_module_hashes_benchmark(c, &rt);
+  runtime_requirements_benchmark(c, &rt);
   create_chunk_hashes_benchmark(c, &rt);
+  create_full_hash_benchmark(c, &rt);
   create_concatenate_module_benchmark(c, &rt);
   concatenate_module_code_generation_benchmark(c, &rt);
 }
@@ -413,6 +416,123 @@ fn create_chunk_hashes_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime
   });
 }
 
+fn runtime_requirements_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+  let fs = Arc::new(MemoryFileSystem::default());
+  let random_table = load_random_table();
+  let mut compiler = create_general_stage_compiler(fs.clone());
+
+  rt.block_on(async {
+    fs.create_dir_all("/src".into())
+      .await
+      .expect("should not fail to create dir");
+    prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
+    prepare_for_runtime_requirements(&mut compiler)
+      .await
+      .unwrap();
+  });
+
+  assert_no_compilation_errors(&compiler.compilation, "runtime_requirements setup");
+  assert!(
+    !compiler.compilation.code_generation_results.is_empty(),
+    "runtime_requirements setup should prepare code generation results"
+  );
+  assert!(
+    compiler.compilation.runtime_modules.is_empty(),
+    "runtime_requirements setup should not have runtime modules before the pass runs"
+  );
+
+  c.bench_function("rust@runtime_requirements", |b| {
+    b.iter_batched(
+      || {
+        let fs = Arc::new(MemoryFileSystem::default());
+        let random_table = random_table.clone();
+        let mut compiler = create_general_stage_compiler(fs.clone());
+        rt.block_on(async {
+          fs.create_dir_all("/src".into())
+            .await
+            .expect("should not fail to create dir");
+          prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
+          prepare_for_runtime_requirements(&mut compiler)
+            .await
+            .unwrap();
+        });
+        compiler
+      },
+      |mut compiler| {
+        rt.block_on(async {
+          run_runtime_requirements_pass(&mut compiler).await.unwrap();
+        });
+        black_box((
+          compiler.compilation.runtime_modules.len(),
+          compiler.compilation.cgc_runtime_requirements_artifact.len(),
+        ));
+      },
+      BatchSize::PerIteration,
+    );
+  });
+}
+
+fn create_full_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+  let fs = Arc::new(MemoryFileSystem::default());
+  let random_table = load_random_table();
+  let mut compiler = create_general_stage_compiler(fs.clone());
+
+  rt.block_on(async {
+    fs.create_dir_all("/src".into())
+      .await
+      .expect("should not fail to create dir");
+    prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
+    compiler.build().await.unwrap();
+  });
+
+  assert_no_compilation_errors(&compiler.compilation, "create_full_hash setup");
+  assert!(
+    !compiler.compilation.chunk_hashes_artifact.is_empty(),
+    "create_full_hash setup should prepare chunk hashes"
+  );
+  assert_no_full_hash_runtime_dependencies(
+    &compiler.compilation,
+    "create_full_hash setup should only benchmark full-hash aggregation over stable chunk/content hashes",
+  );
+  let expected_hash = compiler
+    .compilation
+    .hash
+    .clone()
+    .expect("create_full_hash setup should set the compilation hash");
+  let recomputed_hash = aggregate_full_hash(&mut compiler.compilation);
+  assert_eq!(
+    recomputed_hash, expected_hash,
+    "create_full_hash helper should match compilation hash from the full build"
+  );
+
+  c.bench_function("rust@create_full_hash", |b| {
+    b.iter_batched(
+      || {
+        let fs = Arc::new(MemoryFileSystem::default());
+        let random_table = random_table.clone();
+        let mut compiler = create_general_stage_compiler(fs.clone());
+        rt.block_on(async {
+          fs.create_dir_all("/src".into())
+            .await
+            .expect("should not fail to create dir");
+          prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
+          compiler.build().await.unwrap();
+        });
+        assert_no_full_hash_runtime_dependencies(
+          &compiler.compilation,
+          "create_full_hash benchmark setup should avoid full-hash-dependent runtime chunks",
+        );
+        compiler
+      },
+      |mut compiler| {
+        let full_hash = aggregate_full_hash(&mut compiler.compilation);
+        black_box(full_hash);
+      },
+      BatchSize::PerIteration,
+    );
+  });
+}
+
 fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let mut compiler = create_concatenate_stage_compiler(fs.clone());
@@ -687,6 +807,21 @@ async fn prepare_for_module_hashes(compiler: &mut Compiler) -> Result<()> {
   Ok(())
 }
 
+async fn prepare_for_optimize_code_generation(compiler: &mut Compiler) -> Result<()> {
+  prepare_for_chunk_ids(compiler).await?;
+  run_chunk_ids_on_compilation(&mut compiler.compilation).await?;
+  run_assign_runtime_ids(&mut compiler.compilation)?;
+  Ok(())
+}
+
+async fn prepare_for_runtime_requirements(compiler: &mut Compiler) -> Result<()> {
+  prepare_for_optimize_code_generation(compiler).await?;
+  run_optimize_code_generation_hook(&mut compiler.compilation).await?;
+  run_create_module_hashes_pass(compiler).await?;
+  run_code_generation_pass(compiler).await?;
+  Ok(())
+}
+
 async fn prepare_for_concatenate_module(compiler: &mut Compiler) -> Result<()> {
   prepare_build_module_graph_phase(compiler).await?;
   run_finish_modules_hook(&mut compiler.compilation).await?;
@@ -836,6 +971,75 @@ async fn run_optimize_chunk_modules_hook(compilation: &mut Compilation) -> Resul
   Ok(())
 }
 
+fn run_assign_runtime_ids(compilation: &mut Compilation) -> Result<()> {
+  fn process_entrypoint(
+    entrypoint_ukey: &rspack_core::ChunkGroupUkey,
+    chunk_group_by_ukey: &rspack_core::ChunkGroupByUkey,
+    chunk_by_ukey: &ChunkByUkey,
+    chunk_graph: &mut ChunkGraph,
+  ) {
+    let entrypoint = chunk_group_by_ukey.expect_get(entrypoint_ukey);
+    let runtime = entrypoint
+      .kind
+      .get_entry_options()
+      .and_then(|entry_options| match &entry_options.runtime {
+        Some(EntryRuntime::String(runtime)) => Some(runtime.to_owned()),
+        _ => None,
+      })
+      .or_else(|| entrypoint.name().map(|name| name.to_string()));
+    if let (Some(runtime), Some(chunk)) = (
+      runtime,
+      chunk_by_ukey.get(&entrypoint.get_runtime_chunk(chunk_group_by_ukey)),
+    ) {
+      chunk_graph.set_runtime_id(runtime, chunk.id().map(|id| id.to_string()));
+    }
+  }
+
+  for (_, entrypoint_ukey) in &compilation.build_chunk_graph_artifact.entrypoints {
+    process_entrypoint(
+      entrypoint_ukey,
+      &compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+      &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+      &mut compilation.build_chunk_graph_artifact.chunk_graph,
+    );
+  }
+  for entrypoint_ukey in &compilation.build_chunk_graph_artifact.async_entrypoints {
+    process_entrypoint(
+      entrypoint_ukey,
+      &compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
+      &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+      &mut compilation.build_chunk_graph_artifact.chunk_graph,
+    );
+  }
+
+  Ok(())
+}
+
+async fn run_optimize_code_generation_hook(compilation: &mut Compilation) -> Result<()> {
+  let mut build_module_graph_artifact = compilation.build_module_graph_artifact.steal();
+  let mut exports_info_artifact = compilation.exports_info_artifact.steal();
+  let mut diagnostics = vec![];
+  compilation
+    .plugin_driver
+    .clone()
+    .compilation_hooks
+    .optimize_code_generation
+    .call(
+      compilation,
+      &mut build_module_graph_artifact,
+      &mut exports_info_artifact,
+      &mut diagnostics,
+    )
+    .await?;
+  compilation.build_module_graph_artifact = build_module_graph_artifact.into();
+  compilation.exports_info_artifact = exports_info_artifact.into();
+  assert!(
+    diagnostics.is_empty(),
+    "optimize_code_generation benchmark setup should not produce diagnostics"
+  );
+  Ok(())
+}
+
 fn get_modules_needing_ids(
   compilation: &Compilation,
   module_ids_artifact: &ModuleIdsArtifact,
@@ -922,6 +1126,150 @@ async fn run_chunk_ids_on_compilation(compilation: &mut Compilation) -> Result<(
   Ok(())
 }
 
+async fn run_create_module_hashes_on_compilation(compilation: &mut Compilation) -> Result<()> {
+  let module_identifiers = compilation
+    .get_module_graph()
+    .modules_keys()
+    .copied()
+    .collect::<Vec<_>>();
+
+  for module_identifier in module_identifiers {
+    let runtimes = compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_module_runtimes_iter(
+        module_identifier,
+        &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+      )
+      .cloned()
+      .collect::<Vec<_>>();
+    let mut hashes = RuntimeSpecMap::new();
+    {
+      let module_graph = compilation.get_module_graph();
+      let module = module_graph
+        .module_by_identifier(&module_identifier)
+        .expect("should have module");
+      for runtime in &runtimes {
+        let hash = module.get_runtime_hash(compilation, Some(runtime)).await?;
+        hashes.set(runtime.clone(), hash);
+      }
+    }
+    ChunkGraph::set_module_hashes(compilation, module_identifier, hashes);
+  }
+
+  Ok(())
+}
+
+async fn run_create_module_hashes_pass(compiler: &mut Compiler) -> Result<()> {
+  compiler
+    .cache
+    .before_modules_hashes(&mut compiler.compilation)
+    .await;
+  run_create_module_hashes_on_compilation(&mut compiler.compilation).await?;
+  compiler
+    .cache
+    .after_modules_hashes(&compiler.compilation)
+    .await;
+  Ok(())
+}
+
+async fn run_code_generation_on_compilation(compilation: &mut Compilation) -> Result<()> {
+  *compilation.code_generation_results = Default::default();
+  compilation.code_generated_modules.clear();
+
+  let module_identifiers = compilation
+    .get_module_graph()
+    .modules_keys()
+    .copied()
+    .collect::<Vec<_>>();
+
+  for module_identifier in module_identifiers {
+    let runtimes = compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_module_runtimes_iter(
+        module_identifier,
+        &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+      )
+      .cloned()
+      .collect::<Vec<_>>();
+
+    for runtime in runtimes {
+      let hash = ChunkGraph::get_module_hash(compilation, module_identifier, &runtime)
+        .expect("should have module hash before code generation")
+        .clone();
+      let concatenation_scope = compilation
+        .plugin_driver
+        .clone()
+        .compilation_hooks
+        .concatenation_scope
+        .call(compilation, module_identifier)
+        .await?;
+      let mut runtime_template = compilation.runtime_template.create_module_code_template();
+      let mut code_generation_context = ModuleCodeGenerationContext {
+        compilation,
+        runtime: Some(&runtime),
+        concatenation_scope,
+        runtime_template: &mut runtime_template,
+      };
+      let module_graph = compilation.get_module_graph();
+      let module = module_graph
+        .module_by_identifier(&module_identifier)
+        .expect("should have module");
+      let mut code_generation_result = module.code_generation(&mut code_generation_context).await?;
+      code_generation_result
+        .runtime_requirements
+        .extend(*runtime_template.runtime_requirements());
+      if module.as_concatenated_module().is_some() {
+        code_generation_result.set_hash_for_concatenated_module(
+          &hash,
+          &compilation.options.output.hash_function,
+          &compilation.options.output.hash_digest,
+          &compilation.options.output.hash_salt,
+        );
+      } else {
+        code_generation_result.set_hash(
+          &compilation.options.output.hash_function,
+          &compilation.options.output.hash_digest,
+          &compilation.options.output.hash_salt,
+        );
+      }
+      compilation.code_generation_results.insert(
+        module_identifier,
+        code_generation_result,
+        [runtime],
+      );
+    }
+
+    compilation.code_generated_modules.insert(module_identifier);
+  }
+
+  let mut diagnostics = vec![];
+  compilation
+    .plugin_driver
+    .clone()
+    .compilation_hooks
+    .after_code_generation
+    .call(compilation, &mut diagnostics)
+    .await?;
+  compilation.extend_diagnostics(diagnostics);
+
+  Ok(())
+}
+
+async fn run_code_generation_pass(compiler: &mut Compiler) -> Result<()> {
+  compiler
+    .cache
+    .before_modules_codegen(&mut compiler.compilation)
+    .await;
+  run_code_generation_on_compilation(&mut compiler.compilation).await?;
+  compiler
+    .cache
+    .after_modules_codegen(&compiler.compilation)
+    .await;
+  Ok(())
+}
+
 async fn compute_module_hashes(compilation: &Compilation) -> Result<usize> {
   let module_graph = compilation.get_module_graph();
   let mut total = 0;
@@ -964,6 +1312,362 @@ async fn compute_chunk_hashes(compilation: &Compilation) -> Result<usize> {
   }
 
   Ok(total)
+}
+
+async fn run_runtime_requirements_on_compilation(compilation: &mut Compilation) -> Result<()> {
+  let plugin_driver = compilation.plugin_driver.clone();
+  let handle = tokio::runtime::Handle::current();
+  let modules = compilation
+    .get_module_graph()
+    .modules_keys()
+    .copied()
+    .filter(|module| {
+      compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .get_number_of_module_chunks(*module)
+        > 0
+    })
+    .collect::<Vec<_>>();
+
+  let module_results = if modules.is_empty() {
+    Vec::new()
+  } else {
+    let worker_count = std::thread::available_parallelism()
+      .map(|parallelism| parallelism.get())
+      .unwrap_or(1)
+      .min(modules.len());
+    let chunk_size = modules.len().div_ceil(worker_count);
+    std::thread::scope(|scope| -> Result<Vec<_>> {
+      let mut workers = Vec::new();
+      for module_chunk in modules.chunks(chunk_size) {
+        let module_chunk = module_chunk.to_vec();
+        let compilation = &*compilation;
+        let plugin_driver = plugin_driver.clone();
+        let handle = handle.clone();
+        workers.push(
+          scope.spawn(move || -> Result<Vec<(rspack_core::ModuleIdentifier, RuntimeSpecMap<RuntimeGlobals>)>> {
+            let mut local_results = Vec::with_capacity(module_chunk.len());
+            for module in module_chunk {
+              let runtimes = compilation
+                .build_chunk_graph_artifact
+                .chunk_graph
+                .get_module_runtimes_iter(
+                  module,
+                  &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+                )
+                .cloned()
+                .collect::<Vec<_>>();
+              let mut map = RuntimeSpecMap::new();
+
+              for runtime in runtimes {
+                let runtime_requirements = handle.block_on(async {
+                  compilation
+                    .process_runtime_requirements_cache_artifact
+                    .use_cache(module, &runtime, compilation, || async {
+                      let mut all_runtime_requirements = compilation
+                        .code_generation_results
+                        .get_runtime_requirements(&module, Some(&runtime));
+
+                      plugin_driver
+                        .compilation_hooks
+                        .additional_module_runtime_requirements
+                        .call(compilation, &module, &mut all_runtime_requirements)
+                        .await?;
+
+                      let mut runtime_requirements_added = all_runtime_requirements;
+                      loop {
+                        let current_runtime_requirements = runtime_requirements_added;
+                        let mut runtime_requirements_to_add = RuntimeGlobals::default();
+                        plugin_driver
+                          .compilation_hooks
+                          .runtime_requirement_in_module
+                          .call(
+                            compilation,
+                            &module,
+                            &all_runtime_requirements,
+                            &current_runtime_requirements,
+                            &mut runtime_requirements_to_add,
+                          )
+                          .await?;
+                        runtime_requirements_to_add = runtime_requirements_to_add
+                          .difference(all_runtime_requirements.intersection(runtime_requirements_to_add));
+                        if runtime_requirements_to_add.is_empty() {
+                          break;
+                        }
+                        all_runtime_requirements.insert(runtime_requirements_to_add);
+                        runtime_requirements_added = runtime_requirements_to_add;
+                      }
+
+                      Ok(all_runtime_requirements)
+                    })
+                    .await
+                })?;
+                map.set(runtime, runtime_requirements);
+              }
+              local_results.push((module, map));
+            }
+            Ok(local_results)
+          }),
+        );
+      }
+
+      let mut combined_results = Vec::with_capacity(modules.len());
+      for worker in workers {
+        let mut local_results = worker
+          .join()
+          .expect("runtime requirements module worker should not panic")?;
+        combined_results.append(&mut local_results);
+      }
+      Ok(combined_results)
+    })?
+  };
+
+  for (module, map) in module_results {
+    ChunkGraph::set_module_runtime_requirements(compilation, module, map);
+  }
+
+  let entries = compilation
+    .get_chunk_graph_entries()
+    .collect::<rustc_hash::FxHashSet<_>>();
+  let chunks = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .keys()
+    .copied()
+    .collect::<rustc_hash::FxHashSet<_>>();
+  let chunk_keys = chunks
+    .iter()
+    .chain(entries.iter())
+    .copied()
+    .collect::<Vec<_>>();
+
+  let chunk_requirements = if chunk_keys.is_empty() {
+    FxHashMap::default()
+  } else {
+    let worker_count = std::thread::available_parallelism()
+      .map(|parallelism| parallelism.get())
+      .unwrap_or(1)
+      .min(chunk_keys.len());
+    let chunk_size = chunk_keys.len().div_ceil(worker_count);
+    std::thread::scope(|scope| -> FxHashMap<ChunkUkey, RuntimeGlobals> {
+      let mut workers = Vec::new();
+      for chunk_key_chunk in chunk_keys.chunks(chunk_size) {
+        let chunk_key_chunk = chunk_key_chunk.to_vec();
+        let compilation = &*compilation;
+        workers.push(scope.spawn(move || {
+          let mut local_results = Vec::with_capacity(chunk_key_chunk.len());
+          for chunk_ukey in chunk_key_chunk {
+            let mut set = RuntimeGlobals::default();
+            for module_identifier in compilation
+              .build_chunk_graph_artifact
+              .chunk_graph
+              .get_chunk_modules_identifier(&chunk_ukey)
+            {
+              let chunk = compilation
+                .build_chunk_graph_artifact
+                .chunk_by_ukey
+                .expect_get(&chunk_ukey);
+              if let Some(runtime_requirements) = ChunkGraph::get_module_runtime_requirements(
+                compilation,
+                *module_identifier,
+                chunk.runtime(),
+              ) {
+                set.insert(*runtime_requirements);
+              }
+            }
+            local_results.push((chunk_ukey, set));
+          }
+          local_results
+        }));
+      }
+
+      let mut combined_results = FxHashMap::default();
+      for worker in workers {
+        for (chunk_ukey, runtime_requirements) in worker
+          .join()
+          .expect("runtime requirements chunk worker should not panic")
+        {
+          combined_results.insert(chunk_ukey, runtime_requirements);
+        }
+      }
+      combined_results
+    })
+  };
+
+  for (chunk_ukey, mut all_runtime_requirements) in chunk_requirements {
+    let mut additional_runtime_modules = Vec::new();
+    plugin_driver
+      .compilation_hooks
+      .additional_chunk_runtime_requirements
+      .call(
+        compilation,
+        &chunk_ukey,
+        &mut all_runtime_requirements,
+        &mut additional_runtime_modules,
+      )
+      .await?;
+
+    for module in additional_runtime_modules {
+      let additional_runtime_requirements = module.additional_runtime_requirements(compilation);
+      all_runtime_requirements.extend(additional_runtime_requirements);
+      compilation.add_runtime_module(&chunk_ukey, module)?;
+    }
+
+    let mut runtime_modules_to_add = Vec::<Box<dyn RuntimeModule>>::new();
+    let mut runtime_requirements_added = all_runtime_requirements;
+    loop {
+      let current_runtime_requirements = runtime_requirements_added;
+      let mut runtime_requirements_to_add = RuntimeGlobals::default();
+      plugin_driver
+        .compilation_hooks
+        .runtime_requirement_in_chunk
+        .call(
+          compilation,
+          &chunk_ukey,
+          &all_runtime_requirements,
+          &current_runtime_requirements,
+          &mut runtime_requirements_to_add,
+          &mut runtime_modules_to_add,
+        )
+        .await?;
+      for runtime_module in &runtime_modules_to_add {
+        let additional_runtime_requirements =
+          runtime_module.additional_runtime_requirements(compilation);
+        runtime_requirements_to_add.extend(additional_runtime_requirements);
+      }
+      runtime_requirements_to_add = runtime_requirements_to_add
+        .difference(all_runtime_requirements.intersection(runtime_requirements_to_add));
+      if runtime_requirements_to_add.is_empty() {
+        break;
+      }
+      all_runtime_requirements.insert(runtime_requirements_to_add);
+      runtime_requirements_added = runtime_requirements_to_add;
+    }
+
+    for module in runtime_modules_to_add {
+      compilation.add_runtime_module(&chunk_ukey, module)?;
+    }
+
+    ChunkGraph::set_chunk_runtime_requirements(compilation, chunk_ukey, all_runtime_requirements);
+  }
+
+  for &entry_ukey in &entries {
+    let mut all_runtime_requirements = RuntimeGlobals::default();
+    let mut runtime_modules_to_add = Vec::<(ChunkUkey, Box<dyn RuntimeModule>)>::new();
+    let entry = compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .expect_get(&entry_ukey);
+
+    for chunk_ukey in entry
+      .get_all_referenced_chunks(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
+      .iter()
+    {
+      let runtime_requirements =
+        ChunkGraph::get_chunk_runtime_requirements(compilation, chunk_ukey);
+      all_runtime_requirements.insert(*runtime_requirements);
+    }
+
+    let mut additional_runtime_modules = Vec::new();
+    plugin_driver
+      .compilation_hooks
+      .additional_tree_runtime_requirements
+      .call(
+        compilation,
+        &entry_ukey,
+        &mut all_runtime_requirements,
+        &mut additional_runtime_modules,
+      )
+      .await?;
+
+    for module in additional_runtime_modules {
+      let additional_runtime_requirements = module.additional_runtime_requirements(compilation);
+      all_runtime_requirements.extend(additional_runtime_requirements);
+      compilation.add_runtime_module(&entry_ukey, module)?;
+    }
+
+    let mut runtime_requirements_to_add = all_runtime_requirements;
+    loop {
+      let runtime_requirements_added = runtime_requirements_to_add;
+      runtime_requirements_to_add = RuntimeGlobals::default();
+      plugin_driver
+        .compilation_hooks
+        .runtime_requirement_in_tree
+        .call(
+          compilation,
+          &entry_ukey,
+          &all_runtime_requirements,
+          &runtime_requirements_added,
+          &mut runtime_requirements_to_add,
+          &mut runtime_modules_to_add,
+        )
+        .await?;
+      for runtime_module in &runtime_modules_to_add {
+        let additional_runtime_requirements = runtime_module
+          .1
+          .additional_runtime_requirements(compilation);
+        runtime_requirements_to_add.extend(additional_runtime_requirements);
+      }
+      runtime_requirements_to_add = runtime_requirements_to_add
+        .difference(all_runtime_requirements.intersection(runtime_requirements_to_add));
+      if runtime_requirements_to_add.is_empty() {
+        break;
+      }
+      all_runtime_requirements.insert(runtime_requirements_to_add);
+    }
+
+    ChunkGraph::set_tree_runtime_requirements(compilation, entry_ukey, all_runtime_requirements);
+    for (chunk_ukey, module) in runtime_modules_to_add {
+      compilation.add_runtime_module(&chunk_ukey, module)?;
+    }
+  }
+
+  let mut runtime_modules = std::mem::take(&mut compilation.runtime_modules);
+  for entry_ukey in &entries {
+    let runtime_module_ids = compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_chunk_runtime_modules_iterable(entry_ukey)
+      .copied()
+      .collect::<Vec<_>>();
+    for runtime_module_id in runtime_module_ids {
+      plugin_driver
+        .compilation_hooks
+        .runtime_module
+        .call(
+          compilation,
+          &runtime_module_id,
+          entry_ukey,
+          &mut runtime_modules,
+        )
+        .await?;
+    }
+  }
+  compilation.runtime_modules = runtime_modules;
+
+  Ok(())
+}
+
+async fn run_runtime_requirements_pass(compiler: &mut Compiler) -> Result<()> {
+  compiler
+    .cache
+    .before_modules_runtime_requirements(&mut compiler.compilation)
+    .await;
+  compiler
+    .cache
+    .before_chunks_runtime_requirements(&mut compiler.compilation)
+    .await;
+  run_runtime_requirements_on_compilation(&mut compiler.compilation).await?;
+  compiler
+    .cache
+    .after_modules_runtime_requirements(&compiler.compilation)
+    .await;
+  compiler
+    .cache
+    .after_chunks_runtime_requirements(&compiler.compilation)
+    .await;
+  Ok(())
 }
 
 async fn process_chunk_hash(
@@ -1009,6 +1713,74 @@ async fn process_chunk_hash(
     .collect();
 
   Ok((chunk_hash, content_hashes))
+}
+
+fn aggregate_full_hash(compilation: &mut Compilation) -> rspack_hash::RspackHashDigest {
+  let mut compilation_hasher = RspackHash::from(&compilation.options.output);
+  let mut chunks = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .values()
+    .collect::<Vec<_>>();
+  chunks.sort_unstable_by_key(|chunk| chunk.ukey());
+
+  for chunk in chunks {
+    if let Some(hash) = chunk.hash(&compilation.chunk_hashes_artifact) {
+      hash.hash(&mut compilation_hasher);
+    }
+    if let Some(content_hashes) = chunk.content_hash(&compilation.chunk_hashes_artifact) {
+      let mut content_hash_entries = content_hashes.iter().collect::<Vec<_>>();
+      content_hash_entries.sort_unstable_by_key(|(source_type, _)| *source_type);
+      for (source_type, content_hash) in content_hash_entries {
+        source_type.hash(&mut compilation_hasher);
+        content_hash.hash(&mut compilation_hasher);
+      }
+    }
+  }
+
+  compilation.hot_index.hash(&mut compilation_hasher);
+  let full_hash = compilation_hasher.digest(&compilation.options.output.hash_digest);
+  compilation.hash = Some(full_hash.clone());
+  full_hash
+}
+
+fn assert_no_full_hash_runtime_dependencies(compilation: &Compilation, message: &str) {
+  let mut has_full_hash_dependency = false;
+  for chunk_ukey in compilation.build_chunk_graph_artifact.chunk_by_ukey.keys() {
+    compilation
+      .plugin_driver
+      .compilation_hooks
+      .dependent_full_hash
+      .call(compilation, chunk_ukey, &mut has_full_hash_dependency)
+      .expect("full-hash dependency probe should not fail");
+    if has_full_hash_dependency
+      || compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .has_chunk_full_hash_modules(chunk_ukey, &compilation.runtime_modules)
+    {
+      break;
+    }
+    for runtime_module_identifier in compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_chunk_runtime_modules_iterable(chunk_ukey)
+    {
+      let runtime_module = compilation
+        .runtime_modules
+        .get(runtime_module_identifier)
+        .expect("should have runtime module");
+      if runtime_module.dependent_hash() {
+        has_full_hash_dependency = true;
+        break;
+      }
+    }
+    if has_full_hash_dependency {
+      break;
+    }
+  }
+
+  assert!(!has_full_hash_dependency, "{message}");
 }
 
 async fn compute_concatenated_module_codegen(

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -12,7 +12,6 @@ use rspack::builder::Builder as _;
 use rspack_benchmark::Criterion;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  rspack_sources::{RawStringSource, SourceExt},
   AsyncModulesArtifact, CacheOptions, ChunkByUkey, ChunkContentHash, ChunkGraph,
   ChunkNamedIdArtifact, ChunkUkey, CodeGenerationJob, Compilation, CompilationAsset,
   CompilationAssets, Compiler, DEFAULT_DELIMITER, EntryRuntime, MangleExportsOption, Mode,
@@ -21,6 +20,7 @@ use rspack_core::{
   build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
   incremental::IncrementalOptions,
+  rspack_sources::{RawStringSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_fs::{MemoryFileSystem, WritableFileSystem};
@@ -1847,9 +1847,7 @@ fn seed_module_assets(compilation: &mut Compilation) -> usize {
     module.build_info_mut().assets.insert(
       format!("module-assets/module-{asset_index}.txt"),
       CompilationAsset::new(
-        Some(
-          RawStringSource::from(format!("module asset fixture {asset_index}")).boxed(),
-        ),
+        Some(RawStringSource::from(format!("module asset fixture {asset_index}")).boxed()),
         Default::default(),
       ),
     );

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -20,6 +20,7 @@ use rspack_core::{
   OutputOptions, ProcessAssetsPass, RuntimeRequirementsPass, SideEffectsOptimizeArtifact,
   SourceType, UsedExportsOption, build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
+  cache::Cache,
   incremental::IncrementalOptions,
   pass::PassExt,
   rspack_sources::{RawStringSource, SourceExt},
@@ -1420,7 +1421,13 @@ fn snapshot_chunk_asset_state(compilation: &Compilation) -> ChunkAssetStateSnaps
 }
 
 fn restore_chunk_asset_state(compilation: &mut Compilation, snapshot: &ChunkAssetStateSnapshot) {
-  *compilation.assets_mut() = snapshot.assets.clone();
+  let current_asset_names = compilation.assets().keys().cloned().collect::<Vec<_>>();
+  for asset_name in current_asset_names {
+    compilation.delete_asset(&asset_name);
+  }
+  for (asset_name, asset) in snapshot.assets.clone() {
+    compilation.emit_asset(asset_name, asset);
+  }
   compilation.build_chunk_graph_artifact.chunk_by_ukey = snapshot.chunk_by_ukey.clone();
 }
 
@@ -1482,14 +1489,14 @@ async fn run_create_hash_pass(compiler: &mut Compiler) -> Result<()> {
 }
 
 async fn run_create_module_assets_pass(compilation: &mut Compilation) -> Result<()> {
-  let mut noop_cache = rspack_core::cache::DisableCache;
+  let mut noop_cache = NoopCache;
   CreateModuleAssetsPass
     .run(compilation, &mut noop_cache)
     .await
 }
 
 fn seed_module_assets(compilation: &mut Compilation) -> usize {
-  let module_identifiers = compilation
+  let mut module_identifiers = compilation
     .get_module_graph()
     .modules_keys()
     .copied()
@@ -1500,8 +1507,9 @@ fn seed_module_assets(compilation: &mut Compilation) -> usize {
         .get_number_of_module_chunks(*module_identifier)
         > 0
     })
-    .take(MODULE_ASSET_SEED_COUNT)
     .collect::<Vec<_>>();
+  module_identifiers.sort_unstable();
+  module_identifiers.truncate(MODULE_ASSET_SEED_COUNT);
 
   for (asset_index, module_identifier) in module_identifiers.iter().copied().enumerate() {
     let module = compilation
@@ -1525,9 +1533,15 @@ async fn run_create_chunk_assets_pass(compiler: &mut Compiler) -> Result<()> {
 }
 
 async fn run_process_assets_pass(compilation: &mut Compilation) -> Result<()> {
-  let mut noop_cache = rspack_core::cache::DisableCache;
+  let mut noop_cache = NoopCache;
   ProcessAssetsPass.run(compilation, &mut noop_cache).await
 }
+
+#[derive(Debug, Default)]
+struct NoopCache;
+
+#[async_trait::async_trait]
+impl Cache for NoopCache {}
 
 async fn compute_module_hashes(compilation: &Compilation) -> Result<usize> {
   let module_graph = compilation.get_module_graph();

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -13,10 +13,11 @@ use rspack_benchmark::Criterion;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
   AsyncModulesArtifact, CacheOptions, ChunkByUkey, ChunkContentHash, ChunkGraph,
-  ChunkNamedIdArtifact, ChunkUkey, CodeGenerationJob, Compilation, Compiler, DEFAULT_DELIMITER,
-  EntryRuntime, MangleExportsOption, Mode, ModuleCodeGenerationContext, ModuleIdsArtifact,
-  Optimization, RuntimeGlobals, RuntimeModule, RuntimeSpecMap, SideEffectsOptimizeArtifact,
-  SourceType, UsedExportsOption, build_chunk_graph,
+  ChunkNamedIdArtifact, ChunkUkey, CodeGenerationJob, Compilation, CompilationAsset,
+  CompilationAssets, Compiler, DEFAULT_DELIMITER, EntryRuntime, MangleExportsOption, Mode,
+  ModuleCodeGenerationContext, ModuleIdsArtifact, Optimization, OutputOptions, RuntimeGlobals,
+  RuntimeModule, RuntimeSpecMap, SideEffectsOptimizeArtifact, SourceType, UsedExportsOption,
+  build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
   incremental::IncrementalOptions,
 };
@@ -64,6 +65,8 @@ fn compilation_stages_benchmark_inner(c: &mut Criterion) {
   runtime_requirements_benchmark(c, &rt);
   create_chunk_hashes_benchmark(c, &rt);
   create_full_hash_benchmark(c, &rt);
+  create_chunk_assets_benchmark(c, &rt);
+  real_content_hash_benchmark(c, &rt);
   create_concatenate_module_benchmark(c, &rt);
   concatenate_module_code_generation_benchmark(c, &rt);
 }
@@ -611,6 +614,110 @@ fn create_full_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
   });
 }
 
+fn create_chunk_assets_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+  let fs = Arc::new(MemoryFileSystem::default());
+  let random_table = load_random_table();
+  let mut compiler = create_general_stage_compiler(fs.clone());
+
+  rt.block_on(async {
+    fs.create_dir_all("/src".into())
+      .await
+      .expect("should not fail to create dir");
+    prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
+    prepare_for_chunk_assets(&mut compiler).await.unwrap();
+  });
+
+  assert_no_compilation_errors(&compiler.compilation, "create_chunk_assets setup");
+  let initial_state = snapshot_chunk_asset_state(&compiler.compilation);
+  let initial_totals = chunk_asset_totals(&compiler.compilation);
+
+  rt.block_on(async {
+    run_create_chunk_assets_pass(&mut compiler).await.unwrap();
+  });
+  let rendered_totals = chunk_asset_totals(&compiler.compilation);
+  assert!(
+    rendered_totals.0 > initial_totals.0,
+    "create_chunk_assets setup should render chunk files"
+  );
+  assert!(
+    rendered_totals.1 > initial_totals.1,
+    "create_chunk_assets setup should mark chunks as rendered"
+  );
+  restore_chunk_asset_state(&mut compiler.compilation, &initial_state);
+
+  let compiler = RefCell::new(compiler);
+  c.bench_function("rust@create_chunk_assets", |b| {
+    b.iter_batched_ref(
+      || {
+        let mut compiler = compiler.borrow_mut();
+        restore_chunk_asset_state(&mut compiler.compilation, &initial_state);
+      },
+      |_| {
+        let mut compiler = compiler.borrow_mut();
+        rt.block_on(async {
+          run_create_chunk_assets_pass(&mut compiler).await.unwrap();
+        });
+        black_box(chunk_asset_totals(&compiler.compilation));
+      },
+      BatchSize::PerIteration,
+    );
+  });
+}
+
+fn real_content_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+  let fs = Arc::new(MemoryFileSystem::default());
+  let random_table = load_random_table();
+  let mut compiler = create_real_content_hash_stage_compiler(fs.clone());
+
+  rt.block_on(async {
+    fs.create_dir_all("/src".into())
+      .await
+      .expect("should not fail to create dir");
+    prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
+    prepare_for_real_content_hash(&mut compiler).await.unwrap();
+  });
+
+  assert_no_compilation_errors(&compiler.compilation, "real_content_hash setup");
+  let initial_state = snapshot_chunk_asset_state(&compiler.compilation);
+  let initial_asset_names = sorted_asset_names(&compiler.compilation);
+  assert!(
+    count_assets_with_content_hash(&compiler.compilation) > 0,
+    "real_content_hash setup should produce content-hashed assets"
+  );
+
+  rt.block_on(async {
+    run_process_assets_pass(&mut compiler.compilation)
+      .await
+      .unwrap();
+  });
+  let renamed_asset_names = sorted_asset_names(&compiler.compilation);
+  assert_ne!(
+    renamed_asset_names, initial_asset_names,
+    "real_content_hash setup should rename content-hashed assets during process_assets"
+  );
+  restore_chunk_asset_state(&mut compiler.compilation, &initial_state);
+
+  let compiler = RefCell::new(compiler);
+  c.bench_function("rust@real_content_hash", |b| {
+    b.iter_batched_ref(
+      || {
+        let mut compiler = compiler.borrow_mut();
+        restore_chunk_asset_state(&mut compiler.compilation, &initial_state);
+      },
+      |_| {
+        let mut compiler = compiler.borrow_mut();
+        rt.block_on(async {
+          run_process_assets_pass(&mut compiler.compilation)
+            .await
+            .unwrap();
+        });
+        black_box(asset_name_fingerprint(&compiler.compilation));
+      },
+      BatchSize::PerIteration,
+    );
+  });
+}
+
 fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let mut compiler = create_concatenate_stage_compiler(fs.clone());
@@ -786,6 +893,35 @@ fn create_mangle_exports_stage_compiler(fs: Arc<MemoryFileSystem>) -> Compiler {
     .unwrap()
 }
 
+fn create_real_content_hash_stage_compiler(fs: Arc<MemoryFileSystem>) -> Compiler {
+  Compiler::builder()
+    .context("/")
+    .mode(Mode::Development)
+    .cache(CacheOptions::Disabled)
+    .entry("main", "/src/dynamic-0.js")
+    .input_filesystem(fs.clone())
+    .output_filesystem(fs)
+    .output(
+      OutputOptions::builder()
+        .filename("[name].[contenthash:8].js".into())
+        .chunk_filename("[name].[contenthash:8].js".into())
+        .css_filename("[name].[contenthash:8].css".into())
+        .css_chunk_filename("[name].[contenthash:8].css".into()),
+    )
+    .optimization(
+      Optimization::builder()
+        .provided_exports(true)
+        .used_exports(UsedExportsOption::True)
+        .real_content_hash(true)
+        .module_ids("deterministic".to_string())
+        .chunk_ids("deterministic".to_string())
+        .concatenate_modules(false),
+    )
+    .incremental(IncrementalOptions::empty_passes())
+    .build()
+    .unwrap()
+}
+
 fn create_split_chunks_stage_compiler(fs: Arc<MemoryFileSystem>) -> Compiler {
   let mut builder = Compiler::builder();
   builder
@@ -919,6 +1055,24 @@ async fn prepare_for_runtime_requirements(compiler: &mut Compiler) -> Result<()>
   run_optimize_code_generation_hook(&mut compiler.compilation).await?;
   run_create_module_hashes_pass(compiler).await?;
   run_code_generation_pass(compiler).await?;
+  Ok(())
+}
+
+async fn prepare_for_chunk_assets(compiler: &mut Compiler) -> Result<()> {
+  prepare_for_runtime_requirements(compiler).await?;
+  run_runtime_requirements_pass(compiler).await?;
+  assert_no_full_hash_runtime_dependencies(
+    &compiler.compilation,
+    "create_chunk_assets setup should only benchmark asset emission with stable chunk/content hashes",
+  );
+  run_create_hash_pass(compiler).await?;
+  run_create_module_assets_pass(&mut compiler.compilation).await?;
+  Ok(())
+}
+
+async fn prepare_for_real_content_hash(compiler: &mut Compiler) -> Result<()> {
+  prepare_for_chunk_assets(compiler).await?;
+  run_create_chunk_assets_pass(compiler).await?;
   Ok(())
 }
 
@@ -1334,7 +1488,11 @@ async fn run_code_generation_on_compilation(compilation: &mut Compilation) -> Re
           &compilation.options.output.hash_salt,
         );
       }
-      compilation.code_generation_results.insert(module_identifier, code_generation_result, [runtime]);
+      compilation.code_generation_results.insert(
+        module_identifier,
+        code_generation_result,
+        [runtime],
+      );
     }
 
     compilation.code_generated_modules.insert(module_identifier);
@@ -1364,6 +1522,298 @@ async fn run_code_generation_pass(compiler: &mut Compiler) -> Result<()> {
     .after_modules_codegen(&compiler.compilation)
     .await;
   Ok(())
+}
+
+#[derive(Clone)]
+struct ChunkAssetStateSnapshot {
+  assets: CompilationAssets,
+  chunk_by_ukey: ChunkByUkey,
+}
+
+fn snapshot_chunk_asset_state(compilation: &Compilation) -> ChunkAssetStateSnapshot {
+  ChunkAssetStateSnapshot {
+    assets: compilation.assets().clone(),
+    chunk_by_ukey: compilation.build_chunk_graph_artifact.chunk_by_ukey.clone(),
+  }
+}
+
+fn restore_chunk_asset_state(compilation: &mut Compilation, snapshot: &ChunkAssetStateSnapshot) {
+  *compilation.assets_mut() = snapshot.assets.clone();
+  compilation.build_chunk_graph_artifact.chunk_by_ukey = snapshot.chunk_by_ukey.clone();
+}
+
+fn chunk_asset_totals(compilation: &Compilation) -> (usize, usize, usize) {
+  let mut emitted_files = 0;
+  let mut rendered_chunks = 0;
+  let mut auxiliary_files = 0;
+
+  for chunk in compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .values()
+  {
+    emitted_files += chunk.files().len();
+    auxiliary_files += chunk.auxiliary_files().len();
+    rendered_chunks += usize::from(chunk.rendered());
+  }
+
+  (emitted_files, rendered_chunks, auxiliary_files)
+}
+
+fn sorted_asset_names(compilation: &Compilation) -> Vec<String> {
+  let mut asset_names = compilation.assets().keys().cloned().collect::<Vec<_>>();
+  asset_names.sort_unstable();
+  asset_names
+}
+
+fn asset_name_fingerprint(compilation: &Compilation) -> usize {
+  sorted_asset_names(compilation)
+    .into_iter()
+    .map(|asset_name| asset_name.bytes().map(usize::from).sum::<usize>())
+    .sum()
+}
+
+fn count_assets_with_content_hash(compilation: &Compilation) -> usize {
+  compilation
+    .assets()
+    .values()
+    .filter(|asset| !asset.get_info().content_hash.is_empty())
+    .count()
+}
+
+async fn run_create_hash_pass(compiler: &mut Compiler) -> Result<()> {
+  compiler
+    .cache
+    .before_chunks_hashes(&mut compiler.compilation)
+    .await;
+  run_create_hash_on_compilation(&mut compiler.compilation).await?;
+  compiler
+    .cache
+    .after_chunks_hashes(&compiler.compilation)
+    .await;
+  Ok(())
+}
+
+async fn run_create_hash_on_compilation(compilation: &mut Compilation) -> Result<()> {
+  compilation.chunk_hashes_artifact.clear();
+  compilation.runtime_modules_hash.clear();
+  compilation.hash = None;
+
+  populate_runtime_module_hashes(compilation).await?;
+
+  let chunk_ukeys = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .keys()
+    .copied()
+    .collect::<Vec<_>>();
+  for chunk_ukey in chunk_ukeys {
+    let (chunk_hash, content_hash) = process_chunk_hash(compilation, chunk_ukey).await?;
+    let chunk = compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .expect_get(&chunk_ukey);
+    chunk.set_hashes(
+      &mut compilation.chunk_hashes_artifact,
+      chunk_hash,
+      content_hash,
+    );
+  }
+
+  aggregate_full_hash(compilation);
+  run_runtime_modules_code_generation_on_compilation(compilation).await?;
+  Ok(())
+}
+
+async fn populate_runtime_module_hashes(compilation: &mut Compilation) -> Result<()> {
+  let runtime_module_identifiers = compilation
+    .runtime_modules
+    .keys()
+    .copied()
+    .collect::<Vec<_>>();
+
+  for runtime_module_identifier in runtime_module_identifiers {
+    let digest = {
+      let runtime_module = compilation
+        .runtime_modules
+        .get(&runtime_module_identifier)
+        .expect("should have runtime module");
+      runtime_module.get_runtime_hash(compilation, None).await?
+    };
+    compilation
+      .runtime_modules_hash
+      .insert(runtime_module_identifier, digest);
+  }
+
+  Ok(())
+}
+
+async fn run_runtime_modules_code_generation_on_compilation(
+  compilation: &mut Compilation,
+) -> Result<()> {
+  compilation.runtime_modules_code_generation_source.clear();
+
+  let runtime_module_identifiers = compilation
+    .runtime_modules
+    .keys()
+    .copied()
+    .collect::<Vec<_>>();
+  for runtime_module_identifier in runtime_module_identifiers.iter().copied() {
+    let source = {
+      let runtime_module = compilation
+        .runtime_modules
+        .get(&runtime_module_identifier)
+        .expect("should have runtime module");
+      let mut runtime_template = compilation.runtime_template.create_module_code_template();
+      let mut code_generation_context = ModuleCodeGenerationContext {
+        compilation,
+        runtime: None,
+        concatenation_scope: None,
+        runtime_template: &mut runtime_template,
+      };
+      let code_generation_result = runtime_module
+        .code_generation(&mut code_generation_context)
+        .await?;
+      code_generation_result
+        .get(&SourceType::Runtime)
+        .expect("runtime module should emit runtime source")
+        .clone()
+    };
+    compilation
+      .runtime_modules_code_generation_source
+      .insert(runtime_module_identifier, source);
+  }
+
+  compilation
+    .code_generated_modules
+    .extend(runtime_module_identifiers);
+  Ok(())
+}
+
+async fn run_create_module_assets_pass(compilation: &mut Compilation) -> Result<()> {
+  let mut chunk_asset_map = vec![];
+  let mut module_assets = vec![];
+  let module_graph = compilation.get_module_graph();
+
+  for (identifier, module) in module_graph.modules() {
+    let assets = &module.build_info().assets;
+    if assets.is_empty() {
+      continue;
+    }
+
+    for (name, asset) in assets.as_ref() {
+      module_assets.push((name.clone(), asset.clone()));
+    }
+
+    if compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_number_of_module_chunks(*identifier)
+      > 0
+    {
+      for chunk in compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .get_module_chunks(*identifier)
+        .iter()
+      {
+        for name in assets.keys() {
+          chunk_asset_map.push((*chunk, name.clone()));
+        }
+      }
+    }
+  }
+
+  for (name, asset) in module_assets {
+    compilation.emit_asset(name, asset);
+  }
+
+  for (chunk, asset_name) in chunk_asset_map {
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .expect_get_mut(&chunk)
+      .add_auxiliary_file(asset_name);
+  }
+
+  Ok(())
+}
+
+async fn run_create_chunk_assets_pass(compiler: &mut Compiler) -> Result<()> {
+  compiler
+    .cache
+    .before_chunk_asset(&mut compiler.compilation)
+    .await;
+  run_create_chunk_assets_on_compilation(&mut compiler.compilation).await?;
+  compiler
+    .cache
+    .after_chunk_asset(&compiler.compilation)
+    .await;
+  Ok(())
+}
+
+async fn run_create_chunk_assets_on_compilation(compilation: &mut Compilation) -> Result<()> {
+  let plugin_driver = compilation.plugin_driver.clone();
+  let chunk_ukeys = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .keys()
+    .copied()
+    .collect::<Vec<_>>();
+  let mut chunk_render_results = Vec::with_capacity(chunk_ukeys.len());
+
+  for chunk_ukey in chunk_ukeys {
+    let mut manifests = Vec::new();
+    let mut diagnostics = Vec::new();
+    plugin_driver
+      .compilation_hooks
+      .render_manifest
+      .call(compilation, &chunk_ukey, &mut manifests, &mut diagnostics)
+      .await?;
+    chunk_render_results.push((chunk_ukey, manifests, diagnostics));
+  }
+
+  for (chunk_ukey, manifests, diagnostics) in chunk_render_results {
+    compilation.extend_diagnostics(diagnostics);
+
+    for file_manifest in manifests {
+      let filename = file_manifest.filename;
+      {
+        let chunk = compilation
+          .build_chunk_graph_artifact
+          .chunk_by_ukey
+          .expect_get_mut(&chunk_ukey);
+        chunk.set_rendered(true);
+        if file_manifest.auxiliary {
+          chunk.add_auxiliary_file(filename.clone());
+        } else {
+          chunk.add_file(filename.clone());
+        }
+      }
+
+      compilation.emit_asset(
+        filename.clone(),
+        CompilationAsset::new(Some(file_manifest.source), file_manifest.info),
+      );
+
+      plugin_driver
+        .compilation_hooks
+        .chunk_asset
+        .call(compilation, &chunk_ukey, &filename)
+        .await?;
+    }
+  }
+
+  Ok(())
+}
+
+async fn run_process_assets_pass(compilation: &mut Compilation) -> Result<()> {
+  let plugin_driver = compilation.plugin_driver.clone();
+  plugin_driver
+    .compilation_hooks
+    .process_assets
+    .call(compilation)
+    .await
 }
 
 async fn compute_module_hashes(compilation: &Compilation) -> Result<usize> {

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -12,6 +12,7 @@ use rspack::builder::Builder as _;
 use rspack_benchmark::Criterion;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
+  rspack_sources::{RawStringSource, SourceExt},
   AsyncModulesArtifact, CacheOptions, ChunkByUkey, ChunkContentHash, ChunkGraph,
   ChunkNamedIdArtifact, ChunkUkey, CodeGenerationJob, Compilation, CompilationAsset,
   CompilationAssets, Compiler, DEFAULT_DELIMITER, EntryRuntime, MangleExportsOption, Mode,
@@ -42,6 +43,7 @@ const SPLIT_CHUNKS_ENTRY_COUNT: usize = 48;
 const SPLIT_CHUNKS_SHARED_MODULES: usize = 192;
 const SPLIT_CHUNKS_WINDOW: usize = 20;
 const SPLIT_CHUNKS_COMMON_MODULES: usize = 16;
+const MODULE_ASSET_SEED_COUNT: usize = 256;
 
 pub fn compilation_stages_benchmark(c: &mut Criterion) {
   within_compiler_context_for_testing_sync(|| {
@@ -65,6 +67,7 @@ fn compilation_stages_benchmark_inner(c: &mut Criterion) {
   runtime_requirements_benchmark(c, &rt);
   create_chunk_hashes_benchmark(c, &rt);
   create_full_hash_benchmark(c, &rt);
+  create_module_assets_benchmark(c, &rt);
   create_chunk_assets_benchmark(c, &rt);
   real_content_hash_benchmark(c, &rt);
   create_concatenate_module_benchmark(c, &rt);
@@ -664,6 +667,70 @@ fn create_chunk_assets_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime
   });
 }
 
+fn create_module_assets_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+  let fs = Arc::new(MemoryFileSystem::default());
+  let random_table = load_random_table();
+  let mut compiler = create_general_stage_compiler(fs.clone());
+
+  rt.block_on(async {
+    fs.create_dir_all("/src".into())
+      .await
+      .expect("should not fail to create dir");
+    prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
+    prepare_for_module_assets(&mut compiler).await.unwrap();
+  });
+
+  assert_no_compilation_errors(&compiler.compilation, "create_module_assets setup");
+  let seeded_module_assets = count_module_assets(&compiler.compilation);
+  assert!(
+    seeded_module_assets > 0,
+    "create_module_assets setup should seed module build_info assets"
+  );
+  let initial_state = snapshot_chunk_asset_state(&compiler.compilation);
+  let initial_asset_count = compiler.compilation.assets().len();
+  let initial_totals = chunk_asset_totals(&compiler.compilation);
+
+  rt.block_on(async {
+    run_create_module_assets_pass(&mut compiler.compilation)
+      .await
+      .unwrap();
+  });
+  let emitted_asset_count = compiler.compilation.assets().len();
+  let emitted_totals = chunk_asset_totals(&compiler.compilation);
+  assert!(
+    emitted_asset_count > initial_asset_count,
+    "create_module_assets setup should emit seeded module assets"
+  );
+  assert!(
+    emitted_totals.2 > initial_totals.2,
+    "create_module_assets setup should register seeded module assets as chunk auxiliary files"
+  );
+  restore_chunk_asset_state(&mut compiler.compilation, &initial_state);
+
+  let compiler = RefCell::new(compiler);
+  c.bench_function("rust@create_module_assets", |b| {
+    b.iter_batched_ref(
+      || {
+        let mut compiler = compiler.borrow_mut();
+        restore_chunk_asset_state(&mut compiler.compilation, &initial_state);
+      },
+      |_| {
+        let mut compiler = compiler.borrow_mut();
+        rt.block_on(async {
+          run_create_module_assets_pass(&mut compiler.compilation)
+            .await
+            .unwrap();
+        });
+        black_box((
+          compiler.compilation.assets().len(),
+          chunk_asset_totals(&compiler.compilation),
+        ));
+      },
+      BatchSize::PerIteration,
+    );
+  });
+}
+
 fn real_content_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
@@ -1058,14 +1125,24 @@ async fn prepare_for_runtime_requirements(compiler: &mut Compiler) -> Result<()>
   Ok(())
 }
 
-async fn prepare_for_chunk_assets(compiler: &mut Compiler) -> Result<()> {
+async fn prepare_for_module_assets(compiler: &mut Compiler) -> Result<()> {
   prepare_for_runtime_requirements(compiler).await?;
   run_runtime_requirements_pass(compiler).await?;
   assert_no_full_hash_runtime_dependencies(
     &compiler.compilation,
-    "create_chunk_assets setup should only benchmark asset emission with stable chunk/content hashes",
+    "create_module_assets setup should only benchmark asset emission with stable chunk/content hashes",
   );
   run_create_hash_pass(compiler).await?;
+  let seeded_module_assets = seed_module_assets(&mut compiler.compilation);
+  assert!(
+    seeded_module_assets > 0,
+    "create_module_assets setup should seed module build_info assets"
+  );
+  Ok(())
+}
+
+async fn prepare_for_chunk_assets(compiler: &mut Compiler) -> Result<()> {
+  prepare_for_module_assets(compiler).await?;
   run_create_module_assets_pass(&mut compiler.compilation).await?;
   Ok(())
 }
@@ -1560,6 +1637,14 @@ fn chunk_asset_totals(compilation: &Compilation) -> (usize, usize, usize) {
   (emitted_files, rendered_chunks, auxiliary_files)
 }
 
+fn count_module_assets(compilation: &Compilation) -> usize {
+  compilation
+    .get_module_graph()
+    .modules()
+    .map(|(_, module)| module.build_info().assets.len())
+    .sum()
+}
+
 fn sorted_asset_names(compilation: &Compilation) -> Vec<String> {
   let mut asset_names = compilation.assets().keys().cloned().collect::<Vec<_>>();
   asset_names.sort_unstable();
@@ -1737,6 +1822,40 @@ async fn run_create_module_assets_pass(compilation: &mut Compilation) -> Result<
   }
 
   Ok(())
+}
+
+fn seed_module_assets(compilation: &mut Compilation) -> usize {
+  let module_identifiers = compilation
+    .get_module_graph()
+    .modules_keys()
+    .copied()
+    .filter(|module_identifier| {
+      compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .get_number_of_module_chunks(*module_identifier)
+        > 0
+    })
+    .take(MODULE_ASSET_SEED_COUNT)
+    .collect::<Vec<_>>();
+
+  for (asset_index, module_identifier) in module_identifiers.iter().copied().enumerate() {
+    let module = compilation
+      .get_module_graph_mut()
+      .module_by_identifier_mut(&module_identifier)
+      .expect("seeded module should exist");
+    module.build_info_mut().assets.insert(
+      format!("module-assets/module-{asset_index}.txt"),
+      CompilationAsset::new(
+        Some(
+          RawStringSource::from(format!("module asset fixture {asset_index}")).boxed(),
+        ),
+        Default::default(),
+      ),
+    );
+  }
+
+  module_identifiers.len()
 }
 
 async fn run_create_chunk_assets_pass(compiler: &mut Compiler) -> Result<()> {

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -15,8 +15,8 @@ use rspack_core::{
   AssignRuntimeIdsPass, AsyncModulesArtifact, CacheOptions, ChunkByUkey, ChunkContentHash,
   ChunkGraph, ChunkNamedIdArtifact, ChunkUkey, CodeGenerationJob, CodeGenerationPass, Compilation,
   CompilationAsset, CompilationAssets, Compiler, CreateChunkAssetsPass, CreateHashPass,
-  CreateModuleAssetsPass, CreateModuleHashesPass, DEFAULT_DELIMITER, MangleExportsOption, Mode,
-  ModuleCodeGenerationContext, ModuleIdsArtifact, Optimization, OptimizeCodeGenerationPass,
+  CreateModuleAssetsPass, CreateModuleHashesPass, DEFAULT_DELIMITER, LogType, MangleExportsOption,
+  Mode, ModuleCodeGenerationContext, ModuleIdsArtifact, Optimization, OptimizeCodeGenerationPass,
   OutputOptions, ProcessAssetsPass, RuntimeRequirementsPass, SideEffectsOptimizeArtifact,
   SourceType, UsedExportsOption, build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
@@ -831,10 +831,10 @@ fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &tokio::runtime::R
       .await
       .unwrap();
   });
-  let concatenated_count = count_concatenated_modules(&compiler.compilation);
+  let statistics_fingerprint = concatenation_statistics_fingerprint(&compiler.compilation);
   assert!(
-    concatenated_count > 0,
-    "create_concatenate_module setup should produce concatenated modules"
+    statistics_fingerprint > 0,
+    "create_concatenate_module setup should produce module concatenation statistics"
   );
   compiler
     .compilation
@@ -846,6 +846,7 @@ fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &tokio::runtime::R
     .compilation
     .build_chunk_graph_artifact
     .chunk_by_ukey = initial_chunk_by_ukey.clone();
+  clear_concatenation_statistics_logs(&compiler.compilation);
 
   let compiler = RefCell::new(compiler);
   let should_reset = Cell::new(false);
@@ -872,6 +873,7 @@ fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &tokio::runtime::R
           .compilation
           .build_chunk_graph_artifact
           .chunk_by_ukey = initial_chunk_by_ukey.clone();
+        clear_concatenation_statistics_logs(&compiler.compilation);
       },
       |_| {
         let mut compiler = compiler.borrow_mut();
@@ -880,7 +882,7 @@ fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &tokio::runtime::R
             .await
             .unwrap();
         });
-        black_box(count_concatenated_modules(&compiler.compilation));
+        black_box(concatenation_statistics_fingerprint(&compiler.compilation));
       },
       BatchSize::PerIteration,
     );
@@ -1827,12 +1829,32 @@ async fn prepare_large_split_chunks_case(
   }
 }
 
-fn count_concatenated_modules(compilation: &Compilation) -> usize {
+fn clear_concatenation_statistics_logs(compilation: &Compilation) {
   compilation
-    .get_module_graph()
-    .modules()
-    .filter(|(_, module)| module.as_concatenated_module().is_some())
-    .count()
+    .get_logging()
+    .remove("rspack.ModuleConcatenationPlugin");
+}
+
+fn concatenation_statistics_fingerprint(compilation: &Compilation) -> usize {
+  let Some(logs) = compilation
+    .get_logging()
+    .get("rspack.ModuleConcatenationPlugin")
+  else {
+    return 0;
+  };
+
+  logs
+    .iter()
+    .filter_map(|log| match log {
+      LogType::Debug { message } | LogType::Log { message } => Some(message),
+      _ => None,
+    })
+    .filter(|message| {
+      message.contains("successful concat configurations")
+        || message.contains("candidates were considered")
+    })
+    .map(|message| message.bytes().map(usize::from).sum::<usize>())
+    .sum()
 }
 
 fn count_assigned_export_used_names(compilation: &Compilation) -> usize {

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -12,14 +12,16 @@ use rspack::builder::Builder as _;
 use rspack_benchmark::Criterion;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  AsyncModulesArtifact, CacheOptions, ChunkByUkey, ChunkContentHash, ChunkGraph,
-  ChunkNamedIdArtifact, ChunkUkey, CodeGenerationJob, Compilation, CompilationAsset,
-  CompilationAssets, Compiler, DEFAULT_DELIMITER, EntryRuntime, MangleExportsOption, Mode,
-  ModuleCodeGenerationContext, ModuleIdsArtifact, Optimization, OutputOptions, RuntimeGlobals,
-  RuntimeModule, RuntimeSpecMap, SideEffectsOptimizeArtifact, SourceType, UsedExportsOption,
-  build_chunk_graph,
+  AssignRuntimeIdsPass, AsyncModulesArtifact, CacheOptions, ChunkByUkey, ChunkContentHash,
+  ChunkGraph, ChunkNamedIdArtifact, ChunkUkey, CodeGenerationJob, CodeGenerationPass, Compilation,
+  CompilationAsset, CompilationAssets, Compiler, CreateChunkAssetsPass, CreateHashPass,
+  CreateModuleAssetsPass, CreateModuleHashesPass, DEFAULT_DELIMITER, MangleExportsOption, Mode,
+  ModuleCodeGenerationContext, ModuleIdsArtifact, Optimization, OptimizeCodeGenerationPass,
+  OutputOptions, ProcessAssetsPass, RuntimeRequirementsPass, SideEffectsOptimizeArtifact,
+  SourceType, UsedExportsOption, build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
   incremental::IncrementalOptions,
+  pass::PassExt,
   rspack_sources::{RawStringSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
@@ -389,7 +391,7 @@ fn mangle_exports_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
   compiler.compilation.exports_info_artifact.checkpoint();
 
   rt.block_on(async {
-    run_optimize_code_generation_hook(&mut compiler.compilation)
+    run_compiler_pass(&OptimizeCodeGenerationPass, &mut compiler)
       .await
       .unwrap();
   });
@@ -431,7 +433,7 @@ fn mangle_exports_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
       |_| {
         let mut compiler = compiler.borrow_mut();
         rt.block_on(async {
-          run_optimize_code_generation_hook(&mut compiler.compilation)
+          run_compiler_pass(&OptimizeCodeGenerationPass, &mut compiler)
             .await
             .unwrap();
         });
@@ -566,22 +568,66 @@ fn create_full_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
       .await
       .expect("should not fail to create dir");
     prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
-    prepare_for_full_hash(&mut compiler).await.unwrap();
+    prepare_for_runtime_requirements(&mut compiler)
+      .await
+      .unwrap();
+    run_runtime_requirements_pass(&mut compiler).await.unwrap();
   });
 
   assert_no_compilation_errors(&compiler.compilation, "create_full_hash setup");
+  let initial_code_generated_modules = compiler.compilation.code_generated_modules.clone();
+
+  rt.block_on(async {
+    run_create_hash_pass(&mut compiler).await.unwrap();
+  });
   assert!(
     !compiler.compilation.chunk_hashes_artifact.is_empty(),
     "create_full_hash setup should prepare chunk hashes"
   );
+  assert!(
+    compiler.compilation.hash.is_some(),
+    "create_full_hash setup should set the compilation hash"
+  );
+  compiler.compilation.chunk_hashes_artifact.clear();
+  compiler.compilation.runtime_modules_hash.clear();
+  compiler
+    .compilation
+    .runtime_modules_code_generation_source
+    .clear();
+  compiler.compilation.hash = None;
+  compiler.compilation.code_generated_modules = initial_code_generated_modules.clone();
+
   let compiler = RefCell::new(compiler);
 
   c.bench_function("rust@create_full_hash", |b| {
-    b.iter(|| {
-      let mut compiler = compiler.borrow_mut();
-      let full_hash = aggregate_full_hash(&mut compiler.compilation);
-      black_box(full_hash);
-    });
+    b.iter_batched_ref(
+      || {
+        let mut compiler = compiler.borrow_mut();
+        compiler.compilation.chunk_hashes_artifact.clear();
+        compiler.compilation.runtime_modules_hash.clear();
+        compiler
+          .compilation
+          .runtime_modules_code_generation_source
+          .clear();
+        compiler.compilation.hash = None;
+        compiler.compilation.code_generated_modules = initial_code_generated_modules.clone();
+      },
+      |_| {
+        let mut compiler = compiler.borrow_mut();
+        rt.block_on(async {
+          run_create_hash_pass(&mut compiler).await.unwrap();
+        });
+        black_box((
+          !compiler.compilation.chunk_hashes_artifact.is_empty(),
+          compiler.compilation.hash.is_some(),
+          compiler
+            .compilation
+            .runtime_modules_code_generation_source
+            .len(),
+        ));
+      },
+      BatchSize::PerIteration,
+    );
   });
 }
 
@@ -1075,7 +1121,7 @@ async fn prepare_for_chunk_ids(compiler: &mut Compiler) -> Result<()> {
 async fn prepare_for_optimize_code_generation(compiler: &mut Compiler) -> Result<()> {
   prepare_for_chunk_ids(compiler).await?;
   run_chunk_ids_on_compilation(&mut compiler.compilation).await?;
-  run_assign_runtime_ids(&mut compiler.compilation)?;
+  run_compiler_pass(&AssignRuntimeIdsPass, compiler).await?;
   Ok(())
 }
 
@@ -1087,16 +1133,9 @@ async fn prepare_for_module_hashes(compiler: &mut Compiler) -> Result<()> {
 
 async fn prepare_for_runtime_requirements(compiler: &mut Compiler) -> Result<()> {
   prepare_for_optimize_code_generation(compiler).await?;
-  run_optimize_code_generation_hook(&mut compiler.compilation).await?;
+  run_compiler_pass(&OptimizeCodeGenerationPass, compiler).await?;
   run_create_module_hashes_pass(compiler).await?;
   run_code_generation_pass(compiler).await?;
-  Ok(())
-}
-
-async fn prepare_for_full_hash(compiler: &mut Compiler) -> Result<()> {
-  prepare_for_runtime_requirements(compiler).await?;
-  run_runtime_requirements_pass(compiler).await?;
-  run_pre_full_hash_setup_on_compilation(&mut compiler.compilation).await?;
   Ok(())
 }
 
@@ -1273,75 +1312,6 @@ async fn run_optimize_chunk_modules_hook(compilation: &mut Compilation) -> Resul
   Ok(())
 }
 
-fn run_assign_runtime_ids(compilation: &mut Compilation) -> Result<()> {
-  fn process_entrypoint(
-    entrypoint_ukey: &rspack_core::ChunkGroupUkey,
-    chunk_group_by_ukey: &rspack_core::ChunkGroupByUkey,
-    chunk_by_ukey: &ChunkByUkey,
-    chunk_graph: &mut ChunkGraph,
-  ) {
-    let entrypoint = chunk_group_by_ukey.expect_get(entrypoint_ukey);
-    let runtime = entrypoint
-      .kind
-      .get_entry_options()
-      .and_then(|entry_options| match &entry_options.runtime {
-        Some(EntryRuntime::String(runtime)) => Some(runtime.to_owned()),
-        _ => None,
-      })
-      .or_else(|| entrypoint.name().map(|name| name.to_string()));
-    if let (Some(runtime), Some(chunk)) = (
-      runtime,
-      chunk_by_ukey.get(&entrypoint.get_runtime_chunk(chunk_group_by_ukey)),
-    ) {
-      chunk_graph.set_runtime_id(runtime, chunk.id().map(|id| id.to_string()));
-    }
-  }
-
-  for (_, entrypoint_ukey) in &compilation.build_chunk_graph_artifact.entrypoints {
-    process_entrypoint(
-      entrypoint_ukey,
-      &compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
-      &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-      &mut compilation.build_chunk_graph_artifact.chunk_graph,
-    );
-  }
-  for entrypoint_ukey in &compilation.build_chunk_graph_artifact.async_entrypoints {
-    process_entrypoint(
-      entrypoint_ukey,
-      &compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
-      &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-      &mut compilation.build_chunk_graph_artifact.chunk_graph,
-    );
-  }
-
-  Ok(())
-}
-
-async fn run_optimize_code_generation_hook(compilation: &mut Compilation) -> Result<()> {
-  let mut build_module_graph_artifact = compilation.build_module_graph_artifact.steal();
-  let mut exports_info_artifact = compilation.exports_info_artifact.steal();
-  let mut diagnostics = vec![];
-  compilation
-    .plugin_driver
-    .clone()
-    .compilation_hooks
-    .optimize_code_generation
-    .call(
-      compilation,
-      &mut build_module_graph_artifact,
-      &mut exports_info_artifact,
-      &mut diagnostics,
-    )
-    .await?;
-  compilation.build_module_graph_artifact = build_module_graph_artifact.into();
-  compilation.exports_info_artifact = exports_info_artifact.into();
-  assert!(
-    diagnostics.is_empty(),
-    "optimize_code_generation benchmark setup should not produce diagnostics"
-  );
-  Ok(())
-}
-
 fn get_modules_needing_ids(
   compilation: &Compilation,
   module_ids_artifact: &ModuleIdsArtifact,
@@ -1428,148 +1398,12 @@ async fn run_chunk_ids_on_compilation(compilation: &mut Compilation) -> Result<(
   Ok(())
 }
 
-async fn run_create_module_hashes_on_compilation(compilation: &mut Compilation) -> Result<()> {
-  let module_identifiers = compilation
-    .get_module_graph()
-    .modules_keys()
-    .copied()
-    .collect::<Vec<_>>();
-
-  for module_identifier in module_identifiers {
-    let runtimes = compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_module_runtimes_iter(
-        module_identifier,
-        &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-      )
-      .cloned()
-      .collect::<Vec<_>>();
-    let mut hashes = RuntimeSpecMap::new();
-    {
-      let module_graph = compilation.get_module_graph();
-      let module = module_graph
-        .module_by_identifier(&module_identifier)
-        .expect("should have module");
-      for runtime in &runtimes {
-        let hash = module.get_runtime_hash(compilation, Some(runtime)).await?;
-        hashes.set(runtime.clone(), hash);
-      }
-    }
-    ChunkGraph::set_module_hashes(compilation, module_identifier, hashes);
-  }
-
-  Ok(())
-}
-
 async fn run_create_module_hashes_pass(compiler: &mut Compiler) -> Result<()> {
-  compiler
-    .cache
-    .before_modules_hashes(&mut compiler.compilation)
-    .await;
-  run_create_module_hashes_on_compilation(&mut compiler.compilation).await?;
-  compiler
-    .cache
-    .after_modules_hashes(&compiler.compilation)
-    .await;
-  Ok(())
-}
-
-async fn run_code_generation_on_compilation(compilation: &mut Compilation) -> Result<()> {
-  *compilation.code_generation_results = Default::default();
-  compilation.code_generated_modules.clear();
-
-  let module_identifiers = compilation
-    .get_module_graph()
-    .modules_keys()
-    .copied()
-    .collect::<Vec<_>>();
-
-  for module_identifier in module_identifiers {
-    let runtimes = compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_module_runtimes_iter(
-        module_identifier,
-        &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-      )
-      .cloned()
-      .collect::<Vec<_>>();
-
-    for runtime in runtimes {
-      let hash = ChunkGraph::get_module_hash(compilation, module_identifier, &runtime)
-        .expect("should have module hash before code generation")
-        .clone();
-      let concatenation_scope = compilation
-        .plugin_driver
-        .clone()
-        .compilation_hooks
-        .concatenation_scope
-        .call(compilation, module_identifier)
-        .await?;
-      let mut runtime_template = compilation.runtime_template.create_module_code_template();
-      let mut code_generation_context = ModuleCodeGenerationContext {
-        compilation,
-        runtime: Some(&runtime),
-        concatenation_scope,
-        runtime_template: &mut runtime_template,
-      };
-      let module_graph = compilation.get_module_graph();
-      let module = module_graph
-        .module_by_identifier(&module_identifier)
-        .expect("should have module");
-      let mut code_generation_result = module.code_generation(&mut code_generation_context).await?;
-      code_generation_result
-        .runtime_requirements
-        .extend(*runtime_template.runtime_requirements());
-      if module.as_concatenated_module().is_some() {
-        code_generation_result.set_hash_for_concatenated_module(
-          &hash,
-          &compilation.options.output.hash_function,
-          &compilation.options.output.hash_digest,
-          &compilation.options.output.hash_salt,
-        );
-      } else {
-        code_generation_result.set_hash(
-          &compilation.options.output.hash_function,
-          &compilation.options.output.hash_digest,
-          &compilation.options.output.hash_salt,
-        );
-      }
-      compilation.code_generation_results.insert(
-        module_identifier,
-        code_generation_result,
-        [runtime],
-      );
-    }
-
-    compilation.code_generated_modules.insert(module_identifier);
-  }
-
-  let mut diagnostics = vec![];
-  compilation
-    .plugin_driver
-    .clone()
-    .compilation_hooks
-    .after_code_generation
-    .call(compilation, &mut diagnostics)
-    .await?;
-  compilation.extend_diagnostics(diagnostics);
-
-  Ok(())
+  run_compiler_pass(&CreateModuleHashesPass, compiler).await
 }
 
 async fn run_code_generation_pass(compiler: &mut Compiler) -> Result<()> {
-  compiler
-    .cache
-    .before_modules_codegen(&mut compiler.compilation)
-    .await;
-  run_code_generation_on_compilation(&mut compiler.compilation).await?;
-  compiler
-    .cache
-    .after_modules_codegen(&compiler.compilation)
-    .await;
-  Ok(())
+  run_compiler_pass(&CodeGenerationPass, compiler).await
 }
 
 #[derive(Clone)]
@@ -1637,167 +1471,21 @@ fn count_assets_with_content_hash(compilation: &Compilation) -> usize {
     .count()
 }
 
+async fn run_compiler_pass<P: PassExt>(pass: &P, compiler: &mut Compiler) -> Result<()> {
+  let compilation = &mut compiler.compilation;
+  let cache = &mut compiler.cache;
+  pass.run(compilation, &mut **cache).await
+}
+
 async fn run_create_hash_pass(compiler: &mut Compiler) -> Result<()> {
-  compiler
-    .cache
-    .before_chunks_hashes(&mut compiler.compilation)
-    .await;
-  run_create_hash_on_compilation(&mut compiler.compilation).await?;
-  compiler
-    .cache
-    .after_chunks_hashes(&compiler.compilation)
-    .await;
-  Ok(())
-}
-
-async fn run_pre_full_hash_setup_on_compilation(compilation: &mut Compilation) -> Result<()> {
-  compilation.chunk_hashes_artifact.clear();
-  compilation.runtime_modules_hash.clear();
-  compilation.hash = None;
-
-  populate_runtime_module_hashes(compilation).await?;
-
-  let chunk_ukeys = compilation
-    .build_chunk_graph_artifact
-    .chunk_by_ukey
-    .keys()
-    .copied()
-    .collect::<Vec<_>>();
-  for chunk_ukey in chunk_ukeys {
-    let (chunk_hash, content_hash) = process_chunk_hash(compilation, chunk_ukey).await?;
-    let chunk = compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .expect_get(&chunk_ukey);
-    chunk.set_hashes(
-      &mut compilation.chunk_hashes_artifact,
-      chunk_hash,
-      content_hash,
-    );
-  }
-
-  Ok(())
-}
-
-async fn run_create_hash_on_compilation(compilation: &mut Compilation) -> Result<()> {
-  run_pre_full_hash_setup_on_compilation(compilation).await?;
-  aggregate_full_hash(compilation);
-  run_runtime_modules_code_generation_on_compilation(compilation).await?;
-  Ok(())
-}
-
-async fn populate_runtime_module_hashes(compilation: &mut Compilation) -> Result<()> {
-  let runtime_module_identifiers = compilation
-    .runtime_modules
-    .keys()
-    .copied()
-    .collect::<Vec<_>>();
-
-  for runtime_module_identifier in runtime_module_identifiers {
-    let digest = {
-      let runtime_module = compilation
-        .runtime_modules
-        .get(&runtime_module_identifier)
-        .expect("should have runtime module");
-      runtime_module.get_runtime_hash(compilation, None).await?
-    };
-    compilation
-      .runtime_modules_hash
-      .insert(runtime_module_identifier, digest);
-  }
-
-  Ok(())
-}
-
-async fn run_runtime_modules_code_generation_on_compilation(
-  compilation: &mut Compilation,
-) -> Result<()> {
-  compilation.runtime_modules_code_generation_source.clear();
-
-  let runtime_module_identifiers = compilation
-    .runtime_modules
-    .keys()
-    .copied()
-    .collect::<Vec<_>>();
-  for runtime_module_identifier in runtime_module_identifiers.iter().copied() {
-    let source = {
-      let runtime_module = compilation
-        .runtime_modules
-        .get(&runtime_module_identifier)
-        .expect("should have runtime module");
-      let mut runtime_template = compilation.runtime_template.create_module_code_template();
-      let mut code_generation_context = ModuleCodeGenerationContext {
-        compilation,
-        runtime: None,
-        concatenation_scope: None,
-        runtime_template: &mut runtime_template,
-      };
-      let code_generation_result = runtime_module
-        .code_generation(&mut code_generation_context)
-        .await?;
-      code_generation_result
-        .get(&SourceType::Runtime)
-        .expect("runtime module should emit runtime source")
-        .clone()
-    };
-    compilation
-      .runtime_modules_code_generation_source
-      .insert(runtime_module_identifier, source);
-  }
-
-  compilation
-    .code_generated_modules
-    .extend(runtime_module_identifiers);
-  Ok(())
+  run_compiler_pass(&CreateHashPass, compiler).await
 }
 
 async fn run_create_module_assets_pass(compilation: &mut Compilation) -> Result<()> {
-  let mut chunk_asset_map = vec![];
-  let mut module_assets = vec![];
-  let module_graph = compilation.get_module_graph();
-
-  for (identifier, module) in module_graph.modules() {
-    let assets = &module.build_info().assets;
-    if assets.is_empty() {
-      continue;
-    }
-
-    for (name, asset) in assets.as_ref() {
-      module_assets.push((name.clone(), asset.clone()));
-    }
-
-    if compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_number_of_module_chunks(*identifier)
-      > 0
-    {
-      for chunk in compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .get_module_chunks(*identifier)
-        .iter()
-      {
-        for name in assets.keys() {
-          chunk_asset_map.push((*chunk, name.clone()));
-        }
-      }
-    }
-  }
-
-  for (name, asset) in module_assets {
-    compilation.emit_asset(name, asset);
-  }
-
-  for (chunk, asset_name) in chunk_asset_map {
-    compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .expect_get_mut(&chunk)
-      .add_auxiliary_file(asset_name);
-  }
-
-  Ok(())
+  let mut noop_cache = rspack_core::cache::DisableCache;
+  CreateModuleAssetsPass
+    .run(compilation, &mut noop_cache)
+    .await
 }
 
 fn seed_module_assets(compilation: &mut Compilation) -> usize {
@@ -1833,80 +1521,12 @@ fn seed_module_assets(compilation: &mut Compilation) -> usize {
 }
 
 async fn run_create_chunk_assets_pass(compiler: &mut Compiler) -> Result<()> {
-  compiler
-    .cache
-    .before_chunk_asset(&mut compiler.compilation)
-    .await;
-  run_create_chunk_assets_on_compilation(&mut compiler.compilation).await?;
-  compiler
-    .cache
-    .after_chunk_asset(&compiler.compilation)
-    .await;
-  Ok(())
-}
-
-async fn run_create_chunk_assets_on_compilation(compilation: &mut Compilation) -> Result<()> {
-  let plugin_driver = compilation.plugin_driver.clone();
-  let chunk_ukeys = compilation
-    .build_chunk_graph_artifact
-    .chunk_by_ukey
-    .keys()
-    .copied()
-    .collect::<Vec<_>>();
-  let mut chunk_render_results = Vec::with_capacity(chunk_ukeys.len());
-
-  for chunk_ukey in chunk_ukeys {
-    let mut manifests = Vec::new();
-    let mut diagnostics = Vec::new();
-    plugin_driver
-      .compilation_hooks
-      .render_manifest
-      .call(compilation, &chunk_ukey, &mut manifests, &mut diagnostics)
-      .await?;
-    chunk_render_results.push((chunk_ukey, manifests, diagnostics));
-  }
-
-  for (chunk_ukey, manifests, diagnostics) in chunk_render_results {
-    compilation.extend_diagnostics(diagnostics);
-
-    for file_manifest in manifests {
-      let filename = file_manifest.filename;
-      {
-        let chunk = compilation
-          .build_chunk_graph_artifact
-          .chunk_by_ukey
-          .expect_get_mut(&chunk_ukey);
-        chunk.set_rendered(true);
-        if file_manifest.auxiliary {
-          chunk.add_auxiliary_file(filename.clone());
-        } else {
-          chunk.add_file(filename.clone());
-        }
-      }
-
-      compilation.emit_asset(
-        filename.clone(),
-        CompilationAsset::new(Some(file_manifest.source), file_manifest.info),
-      );
-
-      plugin_driver
-        .compilation_hooks
-        .chunk_asset
-        .call(compilation, &chunk_ukey, &filename)
-        .await?;
-    }
-  }
-
-  Ok(())
+  run_compiler_pass(&CreateChunkAssetsPass, compiler).await
 }
 
 async fn run_process_assets_pass(compilation: &mut Compilation) -> Result<()> {
-  let plugin_driver = compilation.plugin_driver.clone();
-  plugin_driver
-    .compilation_hooks
-    .process_assets
-    .call(compilation)
-    .await
+  let mut noop_cache = rspack_core::cache::DisableCache;
+  ProcessAssetsPass.run(compilation, &mut noop_cache).await
 }
 
 async fn compute_module_hashes(compilation: &Compilation) -> Result<usize> {
@@ -1953,360 +1573,8 @@ async fn compute_chunk_hashes(compilation: &Compilation) -> Result<usize> {
   Ok(total)
 }
 
-async fn run_runtime_requirements_on_compilation(compilation: &mut Compilation) -> Result<()> {
-  let plugin_driver = compilation.plugin_driver.clone();
-  let handle = tokio::runtime::Handle::current();
-  let modules = compilation
-    .get_module_graph()
-    .modules_keys()
-    .copied()
-    .filter(|module| {
-      compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .get_number_of_module_chunks(*module)
-        > 0
-    })
-    .collect::<Vec<_>>();
-
-  let module_results = if modules.is_empty() {
-    Vec::new()
-  } else {
-    let worker_count = std::thread::available_parallelism()
-      .map(|parallelism| parallelism.get())
-      .unwrap_or(1)
-      .min(modules.len());
-    let chunk_size = modules.len().div_ceil(worker_count);
-    std::thread::scope(|scope| -> Result<Vec<_>> {
-      let mut workers = Vec::new();
-      for module_chunk in modules.chunks(chunk_size) {
-        let module_chunk = module_chunk.to_vec();
-        let compilation = &*compilation;
-        let plugin_driver = plugin_driver.clone();
-        let handle = handle.clone();
-        workers.push(
-          scope.spawn(move || -> Result<Vec<(rspack_core::ModuleIdentifier, RuntimeSpecMap<RuntimeGlobals>)>> {
-            let mut local_results = Vec::with_capacity(module_chunk.len());
-            for module in module_chunk {
-              let runtimes = compilation
-                .build_chunk_graph_artifact
-                .chunk_graph
-                .get_module_runtimes_iter(
-                  module,
-                  &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-                )
-                .cloned()
-                .collect::<Vec<_>>();
-              let mut map = RuntimeSpecMap::new();
-
-              for runtime in runtimes {
-                let runtime_requirements = handle.block_on(async {
-                  compilation
-                    .process_runtime_requirements_cache_artifact
-                    .use_cache(module, &runtime, compilation, || async {
-                      let mut all_runtime_requirements = compilation
-                        .code_generation_results
-                        .get_runtime_requirements(&module, Some(&runtime));
-
-                      plugin_driver
-                        .compilation_hooks
-                        .additional_module_runtime_requirements
-                        .call(compilation, &module, &mut all_runtime_requirements)
-                        .await?;
-
-                      let mut runtime_requirements_added = all_runtime_requirements;
-                      loop {
-                        let current_runtime_requirements = runtime_requirements_added;
-                        let mut runtime_requirements_to_add = RuntimeGlobals::default();
-                        plugin_driver
-                          .compilation_hooks
-                          .runtime_requirement_in_module
-                          .call(
-                            compilation,
-                            &module,
-                            &all_runtime_requirements,
-                            &current_runtime_requirements,
-                            &mut runtime_requirements_to_add,
-                          )
-                          .await?;
-                        runtime_requirements_to_add = runtime_requirements_to_add
-                          .difference(all_runtime_requirements.intersection(runtime_requirements_to_add));
-                        if runtime_requirements_to_add.is_empty() {
-                          break;
-                        }
-                        all_runtime_requirements.insert(runtime_requirements_to_add);
-                        runtime_requirements_added = runtime_requirements_to_add;
-                      }
-
-                      Ok(all_runtime_requirements)
-                    })
-                    .await
-                })?;
-                map.set(runtime, runtime_requirements);
-              }
-              local_results.push((module, map));
-            }
-            Ok(local_results)
-          }),
-        );
-      }
-
-      let mut combined_results = Vec::with_capacity(modules.len());
-      for worker in workers {
-        let mut local_results = worker
-          .join()
-          .expect("runtime requirements module worker should not panic")?;
-        combined_results.append(&mut local_results);
-      }
-      Ok(combined_results)
-    })?
-  };
-
-  for (module, map) in module_results {
-    ChunkGraph::set_module_runtime_requirements(compilation, module, map);
-  }
-
-  let entries = compilation
-    .get_chunk_graph_entries()
-    .collect::<rustc_hash::FxHashSet<_>>();
-  let chunks = compilation
-    .build_chunk_graph_artifact
-    .chunk_by_ukey
-    .keys()
-    .copied()
-    .collect::<rustc_hash::FxHashSet<_>>();
-  let chunk_keys = chunks
-    .iter()
-    .chain(entries.iter())
-    .copied()
-    .collect::<Vec<_>>();
-
-  let chunk_requirements = if chunk_keys.is_empty() {
-    FxHashMap::default()
-  } else {
-    let worker_count = std::thread::available_parallelism()
-      .map(|parallelism| parallelism.get())
-      .unwrap_or(1)
-      .min(chunk_keys.len());
-    let chunk_size = chunk_keys.len().div_ceil(worker_count);
-    std::thread::scope(|scope| -> FxHashMap<ChunkUkey, RuntimeGlobals> {
-      let mut workers = Vec::new();
-      for chunk_key_chunk in chunk_keys.chunks(chunk_size) {
-        let chunk_key_chunk = chunk_key_chunk.to_vec();
-        let compilation = &*compilation;
-        workers.push(scope.spawn(move || {
-          let mut local_results = Vec::with_capacity(chunk_key_chunk.len());
-          for chunk_ukey in chunk_key_chunk {
-            let mut set = RuntimeGlobals::default();
-            for module_identifier in compilation
-              .build_chunk_graph_artifact
-              .chunk_graph
-              .get_chunk_modules_identifier(&chunk_ukey)
-            {
-              let chunk = compilation
-                .build_chunk_graph_artifact
-                .chunk_by_ukey
-                .expect_get(&chunk_ukey);
-              if let Some(runtime_requirements) = ChunkGraph::get_module_runtime_requirements(
-                compilation,
-                *module_identifier,
-                chunk.runtime(),
-              ) {
-                set.insert(*runtime_requirements);
-              }
-            }
-            local_results.push((chunk_ukey, set));
-          }
-          local_results
-        }));
-      }
-
-      let mut combined_results = FxHashMap::default();
-      for worker in workers {
-        for (chunk_ukey, runtime_requirements) in worker
-          .join()
-          .expect("runtime requirements chunk worker should not panic")
-        {
-          combined_results.insert(chunk_ukey, runtime_requirements);
-        }
-      }
-      combined_results
-    })
-  };
-
-  for (chunk_ukey, mut all_runtime_requirements) in chunk_requirements {
-    let mut additional_runtime_modules = Vec::new();
-    plugin_driver
-      .compilation_hooks
-      .additional_chunk_runtime_requirements
-      .call(
-        compilation,
-        &chunk_ukey,
-        &mut all_runtime_requirements,
-        &mut additional_runtime_modules,
-      )
-      .await?;
-
-    for module in additional_runtime_modules {
-      let additional_runtime_requirements = module.additional_runtime_requirements(compilation);
-      all_runtime_requirements.extend(additional_runtime_requirements);
-      compilation.add_runtime_module(&chunk_ukey, module)?;
-    }
-
-    let mut runtime_modules_to_add = Vec::<Box<dyn RuntimeModule>>::new();
-    let mut runtime_requirements_added = all_runtime_requirements;
-    loop {
-      let current_runtime_requirements = runtime_requirements_added;
-      let mut runtime_requirements_to_add = RuntimeGlobals::default();
-      plugin_driver
-        .compilation_hooks
-        .runtime_requirement_in_chunk
-        .call(
-          compilation,
-          &chunk_ukey,
-          &all_runtime_requirements,
-          &current_runtime_requirements,
-          &mut runtime_requirements_to_add,
-          &mut runtime_modules_to_add,
-        )
-        .await?;
-      for runtime_module in &runtime_modules_to_add {
-        let additional_runtime_requirements =
-          runtime_module.additional_runtime_requirements(compilation);
-        runtime_requirements_to_add.extend(additional_runtime_requirements);
-      }
-      runtime_requirements_to_add = runtime_requirements_to_add
-        .difference(all_runtime_requirements.intersection(runtime_requirements_to_add));
-      if runtime_requirements_to_add.is_empty() {
-        break;
-      }
-      all_runtime_requirements.insert(runtime_requirements_to_add);
-      runtime_requirements_added = runtime_requirements_to_add;
-    }
-
-    for module in runtime_modules_to_add {
-      compilation.add_runtime_module(&chunk_ukey, module)?;
-    }
-
-    ChunkGraph::set_chunk_runtime_requirements(compilation, chunk_ukey, all_runtime_requirements);
-  }
-
-  for &entry_ukey in &entries {
-    let mut all_runtime_requirements = RuntimeGlobals::default();
-    let mut runtime_modules_to_add = Vec::<(ChunkUkey, Box<dyn RuntimeModule>)>::new();
-    let entry = compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .expect_get(&entry_ukey);
-
-    for chunk_ukey in entry
-      .get_all_referenced_chunks(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
-      .iter()
-    {
-      let runtime_requirements =
-        ChunkGraph::get_chunk_runtime_requirements(compilation, chunk_ukey);
-      all_runtime_requirements.insert(*runtime_requirements);
-    }
-
-    let mut additional_runtime_modules = Vec::new();
-    plugin_driver
-      .compilation_hooks
-      .additional_tree_runtime_requirements
-      .call(
-        compilation,
-        &entry_ukey,
-        &mut all_runtime_requirements,
-        &mut additional_runtime_modules,
-      )
-      .await?;
-
-    for module in additional_runtime_modules {
-      let additional_runtime_requirements = module.additional_runtime_requirements(compilation);
-      all_runtime_requirements.extend(additional_runtime_requirements);
-      compilation.add_runtime_module(&entry_ukey, module)?;
-    }
-
-    let mut runtime_requirements_to_add = all_runtime_requirements;
-    loop {
-      let runtime_requirements_added = runtime_requirements_to_add;
-      runtime_requirements_to_add = RuntimeGlobals::default();
-      plugin_driver
-        .compilation_hooks
-        .runtime_requirement_in_tree
-        .call(
-          compilation,
-          &entry_ukey,
-          &all_runtime_requirements,
-          &runtime_requirements_added,
-          &mut runtime_requirements_to_add,
-          &mut runtime_modules_to_add,
-        )
-        .await?;
-      for runtime_module in &runtime_modules_to_add {
-        let additional_runtime_requirements = runtime_module
-          .1
-          .additional_runtime_requirements(compilation);
-        runtime_requirements_to_add.extend(additional_runtime_requirements);
-      }
-      runtime_requirements_to_add = runtime_requirements_to_add
-        .difference(all_runtime_requirements.intersection(runtime_requirements_to_add));
-      if runtime_requirements_to_add.is_empty() {
-        break;
-      }
-      all_runtime_requirements.insert(runtime_requirements_to_add);
-    }
-
-    ChunkGraph::set_tree_runtime_requirements(compilation, entry_ukey, all_runtime_requirements);
-    for (chunk_ukey, module) in runtime_modules_to_add {
-      compilation.add_runtime_module(&chunk_ukey, module)?;
-    }
-  }
-
-  let mut runtime_modules = std::mem::take(&mut compilation.runtime_modules);
-  for entry_ukey in &entries {
-    let runtime_module_ids = compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_chunk_runtime_modules_iterable(entry_ukey)
-      .copied()
-      .collect::<Vec<_>>();
-    for runtime_module_id in runtime_module_ids {
-      plugin_driver
-        .compilation_hooks
-        .runtime_module
-        .call(
-          compilation,
-          &runtime_module_id,
-          entry_ukey,
-          &mut runtime_modules,
-        )
-        .await?;
-    }
-  }
-  compilation.runtime_modules = runtime_modules;
-
-  Ok(())
-}
-
 async fn run_runtime_requirements_pass(compiler: &mut Compiler) -> Result<()> {
-  compiler
-    .cache
-    .before_modules_runtime_requirements(&mut compiler.compilation)
-    .await;
-  compiler
-    .cache
-    .before_chunks_runtime_requirements(&mut compiler.compilation)
-    .await;
-  run_runtime_requirements_on_compilation(&mut compiler.compilation).await?;
-  compiler
-    .cache
-    .after_modules_runtime_requirements(&compiler.compilation)
-    .await;
-  compiler
-    .cache
-    .after_chunks_runtime_requirements(&compiler.compilation)
-    .await;
-  Ok(())
+  run_compiler_pass(&RuntimeRequirementsPass, compiler).await
 }
 
 async fn process_chunk_hash(
@@ -2352,35 +1620,6 @@ async fn process_chunk_hash(
     .collect();
 
   Ok((chunk_hash, content_hashes))
-}
-
-fn aggregate_full_hash(compilation: &mut Compilation) -> rspack_hash::RspackHashDigest {
-  let mut compilation_hasher = RspackHash::from(&compilation.options.output);
-  let mut chunks = compilation
-    .build_chunk_graph_artifact
-    .chunk_by_ukey
-    .values()
-    .collect::<Vec<_>>();
-  chunks.sort_unstable_by_key(|chunk| chunk.ukey());
-
-  for chunk in chunks {
-    if let Some(hash) = chunk.hash(&compilation.chunk_hashes_artifact) {
-      hash.hash(&mut compilation_hasher);
-    }
-    if let Some(content_hashes) = chunk.content_hash(&compilation.chunk_hashes_artifact) {
-      let mut content_hash_entries = content_hashes.iter().collect::<Vec<_>>();
-      content_hash_entries.sort_unstable_by_key(|(source_type, _)| *source_type);
-      for (source_type, content_hash) in content_hash_entries {
-        source_type.hash(&mut compilation_hasher);
-        content_hash.hash(&mut compilation_hasher);
-      }
-    }
-  }
-
-  compilation.hot_index.hash(&mut compilation_hasher);
-  let full_hash = compilation_hasher.digest(&compilation.options.output.hash_digest);
-  compilation.hash = Some(full_hash.clone());
-  full_hash
 }
 
 async fn compute_concatenated_module_codegen(


### PR DESCRIPTION
## Summary

Add stage-isolated Rust CodSpeed benchmark cases in `xtask/benchmark/benches/groups/compilation_stages.rs` for:

- `rust@mangle_exports`
- `rust@runtime_requirements`
- `rust@create_full_hash`
- `rust@create_chunk_assets`
- `rust@create_module_assets`
- `rust@real_content_hash`

This also adds the benchmark-local setup/reset helpers needed to keep those stages isolated without changing `rspack_core` public visibility.

## Related links

- N/A

## Validation

- `cargo check -p rspack_benchmark --bench benches`
- `cargo fmt --all --check`

## Known limitations

- Some of the new benches use benchmark-local mirrors of private compilation pass logic to avoid widening `rspack_core` API visibility.
- The `runtime_requirements` and `create_chunk_assets` benches may still differ from the exact production execution model in scheduling/parallelism overhead, so they should be treated as draft until that fidelity is reviewed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).