### PR TITLE
feat(create-rspack): add best-practice agent skills

### DIFF
--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -24,7 +24,7 @@
     "dev": "rslib build -w"
   },
   "dependencies": {
-    "create-rstack": "1.9.1"
+    "create-rstack": "1.9.2"
   },
   "devDependencies": {
     "@rslib/core": "0.21.0",

--- a/packages/create-rspack/src/index.ts
+++ b/packages/create-rspack/src/index.ts
@@ -101,4 +101,16 @@ create({
       },
     },
   ],
+  extraSkills: [
+    {
+      value: 'rspack-best-practices',
+      label: 'Rspack - best practices',
+      source: 'rstackjs/agent-skills',
+    },
+    {
+      value: 'rstest-best-practices',
+      label: 'Rstest - best practices',
+      source: 'rstackjs/agent-skills',
+    },
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,8 +226,8 @@ importers:
   packages/create-rspack:
     dependencies:
       create-rstack:
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: 1.9.2
+        version: 1.9.2
     devDependencies:
       '@rslib/core':
         specifier: 0.21.0
@@ -4095,8 +4095,8 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  create-rstack@1.9.1:
-    resolution: {integrity: sha512-93fIyIqIrwisw7IvjwZ1NhaE58xylnpWPK1JIZaTRtNDRSwWtdAyGbP9HuACU4rZm/HohN8BU7DAmxGbPK9CBA==}
+  create-rstack@1.9.2:
+    resolution: {integrity: sha512-nN4ThiyEZ/hRgafQRlLDoxJnoBa1m3SErwzxsqUg0Zr5bSQ5DREBhcEOsd7NNbfM4Z6GJAAqJvPge7cwtuFmCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   cross-env@10.1.0:
@@ -10985,7 +10985,7 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  create-rstack@1.9.1: {}
+  create-rstack@1.9.2: {}
 
   cross-env@10.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- upgrade `create-rstack` to `1.9.2` so `create-rspack` can use the latest scaffold capabilities
- add `rspack-best-practices` and `rstest-best-practices` as optional agent skills during project creation

## Related links

- https://github.com/rstackjs/create-rstack/releases/tag/v1.9.2

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
