### PR TITLE
feat: persistent cache for swc js minimizer plugin

### DIFF
--- a/crates/rspack_core/src/cache/mixed.rs
+++ b/crates/rspack_core/src/cache/mixed.rs
@@ -213,6 +213,15 @@ impl Cache for MixedCache {
     self.persistent.after_chunk_asset(compilation).await;
   }
 
+  // PROCESS_ASSETS hooks
+  async fn before_process_assets(&mut self, compilation: &mut Compilation) {
+    self.persistent.before_process_assets(compilation).await;
+  }
+
+  async fn after_process_assets(&mut self, compilation: &Compilation) {
+    self.persistent.after_process_assets(compilation).await;
+  }
+
   // EMIT_ASSETS hooks
   async fn before_emit_assets(&mut self, compilation: &mut Compilation) {
     self.memory.before_emit_assets(compilation).await;

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -84,6 +84,10 @@ pub trait Cache: Debug + Send + Sync {
   async fn before_chunk_asset(&mut self, _compilation: &mut Compilation) {}
   async fn after_chunk_asset(&self, _compilation: &Compilation) {}
 
+  // PROCESS_ASSETS hooks
+  async fn before_process_assets(&mut self, _compilation: &mut Compilation) {}
+  async fn after_process_assets(&mut self, _compilation: &Compilation) {}
+
   // EMIT_ASSETS hooks
   async fn before_emit_assets(&mut self, _compilation: &mut Compilation) {}
   async fn after_emit_assets(&self, _compilation: &Compilation) {}

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -22,7 +22,7 @@ use self::{
   build_dependencies::{BuildDeps, BuildDepsOptions},
   codec::CacheCodec,
   context::CacheContext,
-  occasion::{MakeOccasion, MetaOccasion, MinimizeOccasion},
+  occasion::{MakeOccasion, MetaOccasion, MinimizeCacheArtifact, MinimizeOccasion},
   snapshot::{Snapshot, SnapshotOptions},
   storage::{StorageOptions, create_storage},
 };
@@ -213,19 +213,24 @@ impl Cache for PersistentCache {
 
   async fn before_process_assets(&mut self, compilation: &mut Compilation) {
     if compilation.is_rebuild {
+      // During rebuild (HMR), start with a fresh empty cache.
+      // The persistent storage is not loaded; cache entries from the
+      // previous compilation are not reused across in-memory rebuilds.
+      compilation.minimize_cache_artifact = Some(MinimizeCacheArtifact::default());
       return;
     }
 
-    if let Some(artifact) = self.ctx.load_occasion(&self.minimize_occasion).await {
-      compilation.minimize_cache_artifact = artifact;
-    }
+    let artifact = match self.ctx.load_occasion(&self.minimize_occasion).await {
+      Some(artifact) => artifact,
+      None => MinimizeCacheArtifact::default(),
+    };
+    compilation.minimize_cache_artifact = Some(artifact);
   }
 
   async fn after_process_assets(&mut self, compilation: &Compilation) {
-    self.ctx.save_occasion(
-      &self.minimize_occasion,
-      &compilation.minimize_cache_artifact,
-    );
+    if let Some(artifact) = &compilation.minimize_cache_artifact {
+      self.ctx.save_occasion(&self.minimize_occasion, artifact);
+    }
   }
 
   async fn close(&self) {

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -22,7 +22,7 @@ use self::{
   build_dependencies::{BuildDeps, BuildDepsOptions},
   codec::CacheCodec,
   context::CacheContext,
-  occasion::{MakeOccasion, MetaOccasion},
+  occasion::{MakeOccasion, MetaOccasion, MinimizeOccasion},
   snapshot::{Snapshot, SnapshotOptions},
   storage::{StorageOptions, create_storage},
 };
@@ -53,6 +53,7 @@ pub struct PersistentCache {
   snapshot: Arc<Snapshot>,
   make_occasion: MakeOccasion,
   meta_occasion: MetaOccasion,
+  minimize_occasion: MinimizeOccasion,
 }
 
 impl PersistentCache {
@@ -100,7 +101,8 @@ impl PersistentCache {
       ),
       snapshot,
       make_occasion: MakeOccasion::new(codec.clone()),
-      meta_occasion: MetaOccasion::new(codec),
+      meta_occasion: MetaOccasion::new(codec.clone()),
+      minimize_occasion: MinimizeOccasion::new(codec),
     }
   }
 
@@ -206,6 +208,23 @@ impl Cache for PersistentCache {
     self.ctx.save_occasion(
       &self.make_occasion,
       &compilation.build_module_graph_artifact,
+    );
+  }
+
+  async fn before_process_assets(&mut self, compilation: &mut Compilation) {
+    if compilation.is_rebuild {
+      return;
+    }
+
+    if let Some(artifact) = self.ctx.load_occasion(&self.minimize_occasion).await {
+      compilation.minimize_cache_artifact = artifact;
+    }
+  }
+
+  async fn after_process_assets(&mut self, compilation: &Compilation) {
+    self.ctx.save_occasion(
+      &self.minimize_occasion,
+      &compilation.minimize_cache_artifact,
     );
   }
 

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -22,7 +22,7 @@ use self::{
   build_dependencies::{BuildDeps, BuildDepsOptions},
   codec::CacheCodec,
   context::CacheContext,
-  occasion::{MakeOccasion, MetaOccasion, MinimizeCacheArtifact, MinimizeOccasion},
+  occasion::{MakeOccasion, MetaOccasion, MinimizeOccasion},
   snapshot::{Snapshot, SnapshotOptions},
   storage::{StorageOptions, create_storage},
 };
@@ -213,22 +213,19 @@ impl Cache for PersistentCache {
 
   async fn before_process_assets(&mut self, compilation: &mut Compilation) {
     if compilation.is_rebuild {
-      // During rebuild (HMR), start with a fresh empty cache.
-      // The persistent storage is not loaded; cache entries from the
-      // previous compilation are not reused across in-memory rebuilds.
-      compilation.minimize_cache_artifact = Some(MinimizeCacheArtifact::default());
       return;
     }
 
-    let artifact = match self.ctx.load_occasion(&self.minimize_occasion).await {
-      Some(artifact) => artifact,
-      None => MinimizeCacheArtifact::default(),
-    };
-    compilation.minimize_cache_artifact = Some(artifact);
+    let artifact = self
+      .ctx
+      .load_occasion(&self.minimize_occasion)
+      .await
+      .unwrap_or_default();
+    compilation.minimize_persistent_cache_artifact = Some(artifact);
   }
 
   async fn after_process_assets(&mut self, compilation: &Compilation) {
-    if let Some(artifact) = &compilation.minimize_cache_artifact {
+    if let Some(artifact) = &compilation.minimize_persistent_cache_artifact {
       self.ctx.save_occasion(&self.minimize_occasion, artifact);
     }
   }

--- a/crates/rspack_core/src/cache/persistent/occasion/minimize/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/minimize/mod.rs
@@ -14,7 +14,6 @@ use crate::RayonConsumer;
 
 pub const SCOPE: &str = "occasion_minimize";
 
-/// The value struct of current storage scope
 #[cacheable]
 struct Entry {
   #[cacheable(with=AsPreset)]
@@ -29,7 +28,6 @@ struct ExtractedCommentsEntry {
   pub comments_file_name: String,
 }
 
-/// A content hash key for the minimize cache.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MinimizeCacheKey(u64);
 
@@ -49,45 +47,36 @@ impl MinimizeCacheKey {
   }
 }
 
-/// In-memory representation of cached minimize results.
-///
-/// Keys are content hashes (computed from source content + plugin options).
-/// Values are the minimized source and optional extracted comments.
 #[derive(Debug, Default)]
-pub struct MinimizeCacheArtifact {
+pub struct MinimizePersistentCacheArtifact {
   entries: FxHashMap<MinimizeCacheKey, CachedMinimizeEntry>,
   /// Keys of entries that were added during this build and need to be persisted.
   dirty_keys: Vec<MinimizeCacheKey>,
 }
 
-/// A single cached minimize result.
 #[derive(Debug, Clone)]
 pub struct CachedMinimizeEntry {
   pub source: BoxSource,
   pub extracted_comments: Option<CachedExtractedComments>,
 }
 
-/// Cached extracted comments data.
 #[derive(Debug, Clone)]
 pub struct CachedExtractedComments {
   pub source: BoxSource,
   pub comments_file_name: String,
 }
 
-impl MinimizeCacheArtifact {
-  /// Look up a cached minimize result by content hash key.
+impl MinimizePersistentCacheArtifact {
   pub fn get(&self, key: MinimizeCacheKey) -> Option<&CachedMinimizeEntry> {
     self.entries.get(&key)
   }
 
-  /// Insert a new minimize result. Marks the key as dirty for persistence.
   pub fn insert(&mut self, key: MinimizeCacheKey, entry: CachedMinimizeEntry) {
     self.dirty_keys.push(key);
     self.entries.insert(key, entry);
   }
 }
 
-/// Minimize Occasion is used to save minimized asset results.
 #[derive(Debug)]
 pub struct MinimizeOccasion {
   codec: Arc<CacheCodec>,
@@ -101,7 +90,7 @@ impl MinimizeOccasion {
 
 #[async_trait::async_trait]
 impl Occasion for MinimizeOccasion {
-  type Artifact = MinimizeCacheArtifact;
+  type Artifact = MinimizePersistentCacheArtifact;
 
   #[tracing::instrument(name = "Cache::Occasion::Minimize::reset", skip_all)]
   fn reset(&self, storage: &mut dyn Storage) {
@@ -109,7 +98,7 @@ impl Occasion for MinimizeOccasion {
   }
 
   #[tracing::instrument(name = "Cache::Occasion::Minimize::save", skip_all)]
-  fn save(&self, storage: &mut dyn Storage, artifact: &MinimizeCacheArtifact) {
+  fn save(&self, storage: &mut dyn Storage, artifact: &MinimizePersistentCacheArtifact) {
     // Only persist entries that were added during this build.
     artifact
       .dirty_keys
@@ -129,7 +118,7 @@ impl Occasion for MinimizeOccasion {
         match self.codec.encode(&storage_entry) {
           Ok(bytes) => Some((key.to_bytes(), bytes)),
           Err(err) => {
-            tracing::warn!("minimize cache encode failed: {:?}", err);
+            tracing::warn!("minimize persistent cache encode failed: {:?}", err);
             None
           }
         }
@@ -138,18 +127,21 @@ impl Occasion for MinimizeOccasion {
         storage.set(SCOPE, key, bytes);
       });
 
-    tracing::debug!("saved {} minimize cache entries", artifact.dirty_keys.len());
+    tracing::debug!(
+      "saved {} minimize persistent cache entries",
+      artifact.dirty_keys.len()
+    );
   }
 
   #[tracing::instrument(name = "Cache::Occasion::Minimize::recovery", skip_all)]
-  async fn recovery(&self, storage: &dyn Storage) -> Result<MinimizeCacheArtifact> {
+  async fn recovery(&self, storage: &dyn Storage) -> Result<MinimizePersistentCacheArtifact> {
     let items = storage.load(SCOPE).await?;
     let mut entries = FxHashMap::default();
     entries.reserve(items.len());
 
     for (key, value) in items {
       let Some(key) = MinimizeCacheKey::from_bytes(&key) else {
-        tracing::warn!("minimize cache key has invalid length");
+        tracing::warn!("minimize persistent cache key has invalid length");
         continue;
       };
       match self.codec.decode::<Entry>(&value) {
@@ -166,13 +158,16 @@ impl Occasion for MinimizeOccasion {
           );
         }
         Err(err) => {
-          tracing::warn!("minimize cache decode failed: {:?}", err);
+          tracing::warn!("minimize persistent cache decode failed: {:?}", err);
         }
       }
     }
 
-    tracing::debug!("recovered {} minimize cache entries", entries.len());
-    Ok(MinimizeCacheArtifact {
+    tracing::debug!(
+      "recovered {} minimize persistent cache entries",
+      entries.len()
+    );
+    Ok(MinimizePersistentCacheArtifact {
       entries,
       dirty_keys: Vec::new(),
     })

--- a/crates/rspack_core/src/cache/persistent/occasion/minimize/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/minimize/mod.rs
@@ -29,15 +29,35 @@ struct ExtractedCommentsEntry {
   pub comments_file_name: String,
 }
 
+/// A content hash key for the minimize cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MinimizeCacheKey(u64);
+
+impl MinimizeCacheKey {
+  pub fn new(hash: u64) -> Self {
+    Self(hash)
+  }
+
+  fn to_bytes(self) -> Vec<u8> {
+    self.0.to_ne_bytes().to_vec()
+  }
+
+  fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    <[u8; 8]>::try_from(bytes)
+      .ok()
+      .map(|b| Self(u64::from_ne_bytes(b)))
+  }
+}
+
 /// In-memory representation of cached minimize results.
 ///
 /// Keys are content hashes (computed from source content + plugin options).
 /// Values are the minimized source and optional extracted comments.
 #[derive(Debug, Default)]
 pub struct MinimizeCacheArtifact {
-  entries: FxHashMap<Vec<u8>, CachedMinimizeEntry>,
+  entries: FxHashMap<MinimizeCacheKey, CachedMinimizeEntry>,
   /// Keys of entries that were added during this build and need to be persisted.
-  dirty_keys: Vec<Vec<u8>>,
+  dirty_keys: Vec<MinimizeCacheKey>,
 }
 
 /// A single cached minimize result.
@@ -56,13 +76,13 @@ pub struct CachedExtractedComments {
 
 impl MinimizeCacheArtifact {
   /// Look up a cached minimize result by content hash key.
-  pub fn get(&self, key: &[u8]) -> Option<&CachedMinimizeEntry> {
-    self.entries.get(key)
+  pub fn get(&self, key: MinimizeCacheKey) -> Option<&CachedMinimizeEntry> {
+    self.entries.get(&key)
   }
 
   /// Insert a new minimize result. Marks the key as dirty for persistence.
-  pub fn insert(&mut self, key: Vec<u8>, entry: CachedMinimizeEntry) {
-    self.dirty_keys.push(key.clone());
+  pub fn insert(&mut self, key: MinimizeCacheKey, entry: CachedMinimizeEntry) {
+    self.dirty_keys.push(key);
     self.entries.insert(key, entry);
   }
 }
@@ -107,7 +127,7 @@ impl Occasion for MinimizeOccasion {
             }),
         };
         match self.codec.encode(&storage_entry) {
-          Ok(bytes) => Some((key.clone(), bytes)),
+          Ok(bytes) => Some((key.to_bytes(), bytes)),
           Err(err) => {
             tracing::warn!("minimize cache encode failed: {:?}", err);
             None
@@ -128,6 +148,10 @@ impl Occasion for MinimizeOccasion {
     entries.reserve(items.len());
 
     for (key, value) in items {
+      let Some(key) = MinimizeCacheKey::from_bytes(&key) else {
+        tracing::warn!("minimize cache key has invalid length");
+        continue;
+      };
       match self.codec.decode::<Entry>(&value) {
         Ok(entry) => {
           entries.insert(

--- a/crates/rspack_core/src/cache/persistent/occasion/minimize/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/minimize/mod.rs
@@ -1,0 +1,156 @@
+use std::sync::Arc;
+
+use rayon::prelude::*;
+use rspack_cacheable::{cacheable, with::AsPreset};
+use rspack_error::Result;
+use rspack_sources::BoxSource;
+use rustc_hash::FxHashMap;
+
+use super::{
+  super::{codec::CacheCodec, storage::Storage},
+  Occasion,
+};
+use crate::RayonConsumer;
+
+pub const SCOPE: &str = "occasion_minimize";
+
+/// The value struct of current storage scope
+#[cacheable]
+struct Entry {
+  #[cacheable(with=AsPreset)]
+  pub source: BoxSource,
+  pub extracted_comments: Option<ExtractedCommentsEntry>,
+}
+
+#[cacheable]
+struct ExtractedCommentsEntry {
+  #[cacheable(with=AsPreset)]
+  pub source: BoxSource,
+  pub comments_file_name: String,
+}
+
+/// In-memory representation of cached minimize results.
+///
+/// Keys are content hashes (computed from source content + plugin options).
+/// Values are the minimized source and optional extracted comments.
+#[derive(Debug, Default)]
+pub struct MinimizeCacheArtifact {
+  entries: FxHashMap<Vec<u8>, CachedMinimizeEntry>,
+  /// Keys of entries that were added during this build and need to be persisted.
+  dirty_keys: Vec<Vec<u8>>,
+}
+
+/// A single cached minimize result.
+#[derive(Debug, Clone)]
+pub struct CachedMinimizeEntry {
+  pub source: BoxSource,
+  pub extracted_comments: Option<CachedExtractedComments>,
+}
+
+/// Cached extracted comments data.
+#[derive(Debug, Clone)]
+pub struct CachedExtractedComments {
+  pub source: BoxSource,
+  pub comments_file_name: String,
+}
+
+impl MinimizeCacheArtifact {
+  /// Look up a cached minimize result by content hash key.
+  pub fn get(&self, key: &[u8]) -> Option<&CachedMinimizeEntry> {
+    self.entries.get(key)
+  }
+
+  /// Insert a new minimize result. Marks the key as dirty for persistence.
+  pub fn insert(&mut self, key: Vec<u8>, entry: CachedMinimizeEntry) {
+    self.dirty_keys.push(key.clone());
+    self.entries.insert(key, entry);
+  }
+}
+
+/// Minimize Occasion is used to save minimized asset results.
+#[derive(Debug)]
+pub struct MinimizeOccasion {
+  codec: Arc<CacheCodec>,
+}
+
+impl MinimizeOccasion {
+  pub fn new(codec: Arc<CacheCodec>) -> Self {
+    Self { codec }
+  }
+}
+
+#[async_trait::async_trait]
+impl Occasion for MinimizeOccasion {
+  type Artifact = MinimizeCacheArtifact;
+
+  #[tracing::instrument(name = "Cache::Occasion::Minimize::reset", skip_all)]
+  fn reset(&self, storage: &mut dyn Storage) {
+    storage.reset(SCOPE);
+  }
+
+  #[tracing::instrument(name = "Cache::Occasion::Minimize::save", skip_all)]
+  fn save(&self, storage: &mut dyn Storage, artifact: &MinimizeCacheArtifact) {
+    // Only persist entries that were added during this build.
+    artifact
+      .dirty_keys
+      .par_iter()
+      .filter_map(|key| {
+        let entry = artifact.entries.get(key)?;
+        let storage_entry = Entry {
+          source: entry.source.clone(),
+          extracted_comments: entry
+            .extracted_comments
+            .as_ref()
+            .map(|ec| ExtractedCommentsEntry {
+              source: ec.source.clone(),
+              comments_file_name: ec.comments_file_name.clone(),
+            }),
+        };
+        match self.codec.encode(&storage_entry) {
+          Ok(bytes) => Some((key.clone(), bytes)),
+          Err(err) => {
+            tracing::warn!("minimize cache encode failed: {:?}", err);
+            None
+          }
+        }
+      })
+      .consume(|(key, bytes)| {
+        storage.set(SCOPE, key, bytes);
+      });
+
+    tracing::debug!("saved {} minimize cache entries", artifact.dirty_keys.len());
+  }
+
+  #[tracing::instrument(name = "Cache::Occasion::Minimize::recovery", skip_all)]
+  async fn recovery(&self, storage: &dyn Storage) -> Result<MinimizeCacheArtifact> {
+    let items = storage.load(SCOPE).await?;
+    let mut entries = FxHashMap::default();
+    entries.reserve(items.len());
+
+    for (key, value) in items {
+      match self.codec.decode::<Entry>(&value) {
+        Ok(entry) => {
+          entries.insert(
+            key,
+            CachedMinimizeEntry {
+              source: entry.source,
+              extracted_comments: entry.extracted_comments.map(|ec| CachedExtractedComments {
+                source: ec.source,
+                comments_file_name: ec.comments_file_name,
+              }),
+            },
+          );
+        }
+        Err(err) => {
+          tracing::warn!("minimize cache decode failed: {:?}", err);
+        }
+      }
+    }
+
+    tracing::debug!("recovered {} minimize cache entries", entries.len());
+    Ok(MinimizeCacheArtifact {
+      entries,
+      dirty_keys: Vec::new(),
+    })
+  }
+}

--- a/crates/rspack_core/src/cache/persistent/occasion/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/mod.rs
@@ -1,8 +1,12 @@
 pub mod make;
 pub mod meta;
+pub mod minimize;
 
 pub use make::MakeOccasion;
 pub use meta::MetaOccasion;
+pub use minimize::{
+  CachedExtractedComments, CachedMinimizeEntry, MinimizeCacheArtifact, MinimizeOccasion,
+};
 use rspack_error::Result;
 
 use super::storage::Storage;

--- a/crates/rspack_core/src/cache/persistent/occasion/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/mod.rs
@@ -5,7 +5,7 @@ pub mod minimize;
 pub use make::MakeOccasion;
 pub use meta::MetaOccasion;
 pub use minimize::{
-  CachedExtractedComments, CachedMinimizeEntry, MinimizeCacheArtifact, MinimizeOccasion,
+  CachedExtractedComments, CachedMinimizeEntry, MinimizeOccasion, MinimizePersistentCacheArtifact,
 };
 use rspack_error::Result;
 

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -261,7 +261,7 @@ pub struct Compilation {
     StealCell<ProcessRuntimeRequirementsCacheArtifact>,
   pub imported_by_defer_modules_artifact: StealCell<ImportedByDeferModulesArtifact>,
 
-  pub minimize_cache_artifact: MinimizeCacheArtifact,
+  pub minimize_cache_artifact: Option<MinimizeCacheArtifact>,
 
   pub code_generated_modules: IdentifierSet,
   pub build_time_executed_modules: IdentifierSet,
@@ -392,7 +392,7 @@ impl Compilation {
       process_runtime_requirements_cache_artifact: StealCell::new(
         ProcessRuntimeRequirementsCacheArtifact::new(&options),
       ),
-      minimize_cache_artifact: MinimizeCacheArtifact::default(),
+      minimize_cache_artifact: None,
       build_time_executed_modules: Default::default(),
       incremental,
       build_chunk_graph_artifact: Default::default(),

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -76,6 +76,7 @@ use crate::{
   RuntimeMode, RuntimeModule, RuntimeSpec, RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver,
   SideEffectsOptimizeArtifact, SideEffectsStateArtifact, SourceType, Stats, StatsContext,
   StealCell, ValueCacheVersions,
+  cache::persistent::occasion::minimize::MinimizeCacheArtifact,
   compilation::build_module_graph::{
     BuildModuleGraphArtifact, ModuleExecutor, UpdateParam, update_module_graph,
   },
@@ -260,6 +261,8 @@ pub struct Compilation {
     StealCell<ProcessRuntimeRequirementsCacheArtifact>,
   pub imported_by_defer_modules_artifact: StealCell<ImportedByDeferModulesArtifact>,
 
+  pub minimize_cache_artifact: MinimizeCacheArtifact,
+
   pub code_generated_modules: IdentifierSet,
   pub build_time_executed_modules: IdentifierSet,
   pub build_chunk_graph_artifact: BuildChunkGraphArtifact,
@@ -389,6 +392,7 @@ impl Compilation {
       process_runtime_requirements_cache_artifact: StealCell::new(
         ProcessRuntimeRequirementsCacheArtifact::new(&options),
       ),
+      minimize_cache_artifact: MinimizeCacheArtifact::default(),
       build_time_executed_modules: Default::default(),
       incremental,
       build_chunk_graph_artifact: Default::default(),

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -76,7 +76,7 @@ use crate::{
   RuntimeMode, RuntimeModule, RuntimeSpec, RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver,
   SideEffectsOptimizeArtifact, SideEffectsStateArtifact, SourceType, Stats, StatsContext,
   StealCell, ValueCacheVersions,
-  cache::persistent::occasion::minimize::MinimizeCacheArtifact,
+  cache::persistent::occasion::minimize::MinimizePersistentCacheArtifact,
   compilation::build_module_graph::{
     BuildModuleGraphArtifact, ModuleExecutor, UpdateParam, update_module_graph,
   },
@@ -261,7 +261,7 @@ pub struct Compilation {
     StealCell<ProcessRuntimeRequirementsCacheArtifact>,
   pub imported_by_defer_modules_artifact: StealCell<ImportedByDeferModulesArtifact>,
 
-  pub minimize_cache_artifact: Option<MinimizeCacheArtifact>,
+  pub minimize_persistent_cache_artifact: Option<MinimizePersistentCacheArtifact>,
 
   pub code_generated_modules: IdentifierSet,
   pub build_time_executed_modules: IdentifierSet,
@@ -392,7 +392,7 @@ impl Compilation {
       process_runtime_requirements_cache_artifact: StealCell::new(
         ProcessRuntimeRequirementsCacheArtifact::new(&options),
       ),
-      minimize_cache_artifact: None,
+      minimize_persistent_cache_artifact: None,
       build_time_executed_modules: Default::default(),
       incremental,
       build_chunk_graph_artifact: Default::default(),

--- a/crates/rspack_core/src/compilation/process_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/process_assets/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
 use super::*;
-use crate::compilation::pass::PassExt;
+use crate::{cache::Cache, compilation::pass::PassExt};
 
 pub struct ProcessAssetsPass;
 
@@ -11,9 +11,17 @@ impl PassExt for ProcessAssetsPass {
     "process assets"
   }
 
+  async fn before_pass(&self, compilation: &mut Compilation, cache: &mut dyn Cache) {
+    cache.before_process_assets(compilation).await;
+  }
+
   async fn run_pass(&self, compilation: &mut Compilation) -> Result<()> {
     let plugin_driver = compilation.plugin_driver.clone();
     process_assets(compilation, plugin_driver).await
+  }
+
+  async fn after_pass(&self, compilation: &mut Compilation, cache: &mut dyn Cache) {
+    cache.after_process_assets(compilation).await;
   }
 }
 

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -15,7 +15,9 @@ use regex::Regex;
 use rspack_core::{
   AssetInfo, ChunkUkey, Compilation, CompilationAsset, CompilationParams, CompilationProcessAssets,
   CompilerCompilation, Logger, Plugin,
-  cache::persistent::occasion::minimize::{CachedExtractedComments, CachedMinimizeEntry},
+  cache::persistent::occasion::minimize::{
+    CachedExtractedComments, CachedMinimizeEntry, MinimizeCacheKey,
+  },
   diagnostics::MinifyError,
   rspack_sources::{
     ConcatSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMapSource,
@@ -134,11 +136,16 @@ struct NormalizedExtractComments {
 #[derive(Debug)]
 pub struct SwcJsMinimizerRspackPlugin {
   options: PluginOptions,
+  options_hash: u64,
 }
 
 impl SwcJsMinimizerRspackPlugin {
   pub fn new(options: PluginOptions) -> Self {
-    Self::new_inner(options)
+    let mut hasher = FxHasher::default();
+    PLUGIN_NAME.hash(&mut hasher);
+    options.hash(&mut hasher);
+    let options_hash = hasher.finish();
+    Self::new_inner(options, options_hash)
   }
 }
 
@@ -161,8 +168,7 @@ async fn js_chunk_hash(
   _chunk_ukey: &ChunkUkey,
   hasher: &mut RspackHash,
 ) -> Result<()> {
-  PLUGIN_NAME.hash(hasher);
-  self.options.hash(hasher);
+  self.options_hash.hash(hasher);
   Ok(())
 }
 
@@ -171,18 +177,11 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let options = &self.options;
   let minimizer_options = &self.options.minimizer_options;
 
-  // Compute options hash once for cache key computation
-  let options_hash = {
-    let mut hasher = FxHasher::default();
-    self.options.hash(&mut hasher);
-    hasher.finish()
-  };
-
-  // Take the cache out temporarily for concurrent read access
-  let minimize_cache = std::mem::take(&mut compilation.minimize_cache_artifact);
-  // Collect new cache entries from cache misses
-  let new_cache_entries: Mutex<Vec<(Vec<u8>, CachedMinimizeEntry)>> = Mutex::new(Vec::new());
-  // Track cache hit/miss counts for logging
+  // Take persistent cache out if enabled. When Some, we compute cache keys and
+  // do lookups; when None, we skip all cache overhead entirely.
+  let minimize_cache = compilation.minimize_cache_artifact.take();
+  let new_cache_entries: Mutex<Vec<(MinimizeCacheKey, CachedMinimizeEntry)>> =
+    Mutex::new(Vec::new());
   let cache_hits = AtomicU32::new(0);
   let cache_misses = AtomicU32::new(0);
 
@@ -233,39 +232,43 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
           None
         };
 
-        // Compute cache key from source content + filename + options + is_module
-        let cache_key = {
-          let source_buffer = original_source.buffer();
-          let mut hasher = std::hash::DefaultHasher::new();
-          source_buffer.hash(&mut hasher);
-          filename.hash(&mut hasher);
-          options_hash.hash(&mut hasher);
-          is_module.hash(&mut hasher);
-          std::hash::Hasher::finish(&hasher).to_ne_bytes().to_vec()
-        };
+        // Compute cache key and check persistent cache (only when enabled)
+        let cache_key = if let Some(minimize_cache) = &minimize_cache {
+          let key = {
+            let source_buffer = original_source.buffer();
+            let mut hasher = FxHasher::default();
+            source_buffer.hash(&mut hasher);
+            filename.hash(&mut hasher);
+            self.options_hash.hash(&mut hasher);
+            is_module.hash(&mut hasher);
+            MinimizeCacheKey::new(hasher.finish())
+          };
 
-        // Check persistent cache
-        if let Some(cached) = minimize_cache.get(&cache_key) {
-          cache_hits.fetch_add(1, Ordering::Relaxed);
-          original.set_source(Some(cached.source.clone()));
-          original.get_info_mut().minimized.replace(true);
-          if let Some(ec) = &cached.extracted_comments {
-            all_extracted_comments
-              .lock()
-              .expect("all_extract_comments lock failed")
-              .insert(
-                filename.to_string(),
-                ExtractedCommentsInfo {
-                  source: ec.source.clone(),
-                  comments_file_name: ec.comments_file_name.clone(),
-                },
-              );
+          // Check persistent cache
+          if let Some(cached) = minimize_cache.get(key) {
+            cache_hits.fetch_add(1, Ordering::Relaxed);
+            original.set_source(Some(cached.source.clone()));
+            original.get_info_mut().minimized.replace(true);
+            if let Some(ec) = &cached.extracted_comments {
+              all_extracted_comments
+                .lock()
+                .expect("all_extract_comments lock failed")
+                .insert(
+                  filename.to_string(),
+                  ExtractedCommentsInfo {
+                    source: ec.source.clone(),
+                    comments_file_name: ec.comments_file_name.clone(),
+                  },
+                );
+            }
+            return Ok(());
           }
-          return Ok(());
-        }
 
-        // Cache miss - proceed with minification
-        cache_misses.fetch_add(1, Ordering::Relaxed);
+          cache_misses.fetch_add(1, Ordering::Relaxed);
+          Some(key)
+        } else {
+          None
+        };
         let input = original_source.source().into_string_lossy().into_owned();
         let object_pool = tls.get_or(ObjectPool::default);
         let input_source_map = original_source.map(object_pool, &MapOptions::default());
@@ -452,26 +455,28 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             },
         };
 
-        // Store result in cache
-        let extracted_comments_for_cache = all_extracted_comments
-          .lock()
-          .expect("all_extract_comments lock failed")
-          .get(filename)
-          .map(|ec| CachedExtractedComments {
-            source: ec.source.clone(),
-            comments_file_name: ec.comments_file_name.clone(),
-          });
+        // Store result in persistent cache (only when enabled)
+        if let Some(cache_key) = cache_key {
+          let extracted_comments_for_cache = all_extracted_comments
+            .lock()
+            .expect("all_extract_comments lock failed")
+            .get(filename)
+            .map(|ec| CachedExtractedComments {
+              source: ec.source.clone(),
+              comments_file_name: ec.comments_file_name.clone(),
+            });
 
-        new_cache_entries
-          .lock()
-          .expect("new_cache_entries lock failed")
-          .push((
-            cache_key,
-            CachedMinimizeEntry {
-              source: source.clone(),
-              extracted_comments: extracted_comments_for_cache,
-            },
-          ));
+          new_cache_entries
+            .lock()
+            .expect("new_cache_entries lock failed")
+            .push((
+              cache_key,
+              CachedMinimizeEntry {
+                source: source.clone(),
+                extracted_comments: extracted_comments_for_cache,
+              },
+            ));
+        }
 
         original.set_source(Some(source));
         original.get_info_mut().minimized.replace(true);
@@ -480,21 +485,22 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       Ok(())
   })?;
 
-  // Restore cache and insert new entries
-  let mut minimize_cache = minimize_cache;
-  for (key, entry) in new_cache_entries
-    .into_inner()
-    .expect("new_cache_entries lock failed")
-  {
-    minimize_cache.insert(key, entry);
-  }
-  compilation.minimize_cache_artifact = minimize_cache;
+  // Restore persistent cache with new entries (only when enabled)
+  if let Some(mut minimize_cache) = minimize_cache {
+    for (key, entry) in new_cache_entries
+      .into_inner()
+      .expect("new_cache_entries lock failed")
+    {
+      minimize_cache.insert(key, entry);
+    }
+    compilation.minimize_cache_artifact = Some(minimize_cache);
 
-  // Log cache statistics
-  let hits = cache_hits.load(Ordering::Relaxed);
-  let misses = cache_misses.load(Ordering::Relaxed);
-  let logger = compilation.get_logger(PLUGIN_NAME);
-  logger.log(format!("minimize cache: {hits} hit, {misses} miss"));
+    // Log cache statistics
+    let hits = cache_hits.load(Ordering::Relaxed);
+    let misses = cache_misses.load(Ordering::Relaxed);
+    let logger = compilation.get_logger(PLUGIN_NAME);
+    logger.log(format!("minimize cache: {hits} hit, {misses} miss"));
+  }
 
   compilation.extend_diagnostics(rx.into_iter().flatten().collect::<Vec<_>>());
 

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -179,8 +179,8 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 
   // Take persistent cache out if enabled. When Some, we compute cache keys and
   // do lookups; when None, we skip all cache overhead entirely.
-  let minimize_cache = compilation.minimize_cache_artifact.take();
-  let new_cache_entries: Mutex<Vec<(MinimizeCacheKey, CachedMinimizeEntry)>> =
+  let minimize_persistent_cache = compilation.minimize_persistent_cache_artifact.take();
+  let new_persistent_cache_entries: Mutex<Vec<(MinimizeCacheKey, CachedMinimizeEntry)>> =
     Mutex::new(Vec::new());
   let cache_hits = AtomicU32::new(0);
   let cache_misses = AtomicU32::new(0);
@@ -233,19 +233,18 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         };
 
         // Compute cache key and check persistent cache (only when enabled)
-        let cache_key = if let Some(minimize_cache) = &minimize_cache {
+        let cache_key = if let Some(cache) = &minimize_persistent_cache {
           let key = {
-            let source_buffer = original_source.buffer();
             let mut hasher = FxHasher::default();
-            source_buffer.hash(&mut hasher);
-            filename.hash(&mut hasher);
+            original_source.buffer().hash(&mut hasher);
             self.options_hash.hash(&mut hasher);
+            filename.hash(&mut hasher);
             is_module.hash(&mut hasher);
             MinimizeCacheKey::new(hasher.finish())
           };
 
           // Check persistent cache
-          if let Some(cached) = minimize_cache.get(key) {
+          if let Some(cached) = cache.get(key) {
             cache_hits.fetch_add(1, Ordering::Relaxed);
             original.set_source(Some(cached.source.clone()));
             original.get_info_mut().minimized.replace(true);
@@ -466,7 +465,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
               comments_file_name: ec.comments_file_name.clone(),
             });
 
-          new_cache_entries
+          new_persistent_cache_entries
             .lock()
             .expect("new_cache_entries lock failed")
             .push((
@@ -486,20 +485,22 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   })?;
 
   // Restore persistent cache with new entries (only when enabled)
-  if let Some(mut minimize_cache) = minimize_cache {
-    for (key, entry) in new_cache_entries
+  if let Some(mut cache) = minimize_persistent_cache {
+    for (key, entry) in new_persistent_cache_entries
       .into_inner()
-      .expect("new_cache_entries lock failed")
+      .expect("new_persistent_cache_entries lock failed")
     {
-      minimize_cache.insert(key, entry);
+      cache.insert(key, entry);
     }
-    compilation.minimize_cache_artifact = Some(minimize_cache);
+    compilation.minimize_persistent_cache_artifact = Some(cache);
 
     // Log cache statistics
     let hits = cache_hits.load(Ordering::Relaxed);
     let misses = cache_misses.load(Ordering::Relaxed);
     let logger = compilation.get_logger(PLUGIN_NAME);
-    logger.log(format!("minimize cache: {hits} hit, {misses} miss"));
+    logger.log(format!(
+      "minimize persistent cache: {hits} hit, {misses} miss"
+    ));
   }
 
   compilation.extend_diagnostics(rx.into_iter().flatten().collect::<Vec<_>>());

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -11,6 +11,7 @@ use regex::Regex;
 use rspack_core::{
   AssetInfo, ChunkUkey, Compilation, CompilationAsset, CompilationParams, CompilationProcessAssets,
   CompilerCompilation, Plugin,
+  cache::persistent::occasion::minimize::{CachedExtractedComments, CachedMinimizeEntry},
   diagnostics::MinifyError,
   rspack_sources::{
     ConcatSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMapSource,
@@ -163,6 +164,18 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let options = &self.options;
   let minimizer_options = &self.options.minimizer_options;
 
+  // Compute options hash once for cache key computation
+  let options_hash = {
+    let mut hasher = std::hash::DefaultHasher::new();
+    self.options.hash(&mut hasher);
+    std::hash::Hasher::finish(&hasher)
+  };
+
+  // Take the cache out temporarily for concurrent read access
+  let minimize_cache = std::mem::take(&mut compilation.minimize_cache_artifact);
+  // Collect new cache entries from cache misses
+  let new_cache_entries: Mutex<Vec<(Vec<u8>, CachedMinimizeEntry)>> = Mutex::new(Vec::new());
+
   let (tx, rx) = mpsc::channel::<Vec<Diagnostic>>();
   // collect all extracted comments info
   let all_extracted_comments = Mutex::new(FxHashMap::default());
@@ -198,10 +211,6 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       let _guard = enter_span.enter();
       let filename = filename.split('?').next().expect("Should have filename");
       if let Some(original_source) = original.get_source() {
-        let input = original_source.source().into_string_lossy().into_owned();
-        let object_pool = tls.get_or(ObjectPool::default);
-        let input_source_map = original_source.map(object_pool, &MapOptions::default());
-
         let is_module = if let Some(module) = minimizer_options.module {
           Some(module)
         } else if let Some(module) = original.info.javascript_module {
@@ -213,6 +222,41 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         } else {
           None
         };
+
+        // Compute cache key from source content + filename + options + is_module
+        let cache_key = {
+          let source_buffer = original_source.buffer();
+          let mut hasher = std::hash::DefaultHasher::new();
+          source_buffer.hash(&mut hasher);
+          filename.hash(&mut hasher);
+          options_hash.hash(&mut hasher);
+          is_module.hash(&mut hasher);
+          std::hash::Hasher::finish(&hasher).to_ne_bytes().to_vec()
+        };
+
+        // Check persistent cache
+        if let Some(cached) = minimize_cache.get(&cache_key) {
+          original.set_source(Some(cached.source.clone()));
+          original.get_info_mut().minimized.replace(true);
+          if let Some(ec) = &cached.extracted_comments {
+            all_extracted_comments
+              .lock()
+              .expect("all_extract_comments lock failed")
+              .insert(
+                filename.to_string(),
+                ExtractedCommentsInfo {
+                  source: ec.source.clone(),
+                  comments_file_name: ec.comments_file_name.clone(),
+                },
+              );
+          }
+          return Ok(());
+        }
+
+        // Cache miss - proceed with minification
+        let input = original_source.source().into_string_lossy().into_owned();
+        let object_pool = tls.get_or(ObjectPool::default);
+        let input_source_map = original_source.map(object_pool, &MapOptions::default());
 
         let js_minify_options = rspack_javascript_compiler::minify::JsMinifyOptions {
           minify: minimizer_options.minify.unwrap_or(true),
@@ -396,12 +440,44 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             },
         };
 
+        // Store result in cache
+        let extracted_comments_for_cache = all_extracted_comments
+          .lock()
+          .expect("all_extract_comments lock failed")
+          .get(filename)
+          .map(|ec| CachedExtractedComments {
+            source: ec.source.clone(),
+            comments_file_name: ec.comments_file_name.clone(),
+          });
+
+        new_cache_entries
+          .lock()
+          .expect("new_cache_entries lock failed")
+          .push((
+            cache_key,
+            CachedMinimizeEntry {
+              source: source.clone(),
+              extracted_comments: extracted_comments_for_cache,
+            },
+          ));
+
         original.set_source(Some(source));
         original.get_info_mut().minimized.replace(true);
       }
 
       Ok(())
   })?;
+
+  // Restore cache and insert new entries
+  let mut minimize_cache = minimize_cache;
+  for (key, entry) in new_cache_entries
+    .into_inner()
+    .expect("new_cache_entries lock failed")
+  {
+    minimize_cache.insert(key, entry);
+  }
+  compilation.minimize_cache_artifact = minimize_cache;
+
   compilation.extend_diagnostics(rx.into_iter().flatten().collect::<Vec<_>>());
 
   // write all extracted comments to assets

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -1,7 +1,11 @@
 use std::{
-  hash::Hash,
+  hash::{Hash, Hasher},
   path::Path,
-  sync::{LazyLock, Mutex, mpsc},
+  sync::{
+    LazyLock, Mutex,
+    atomic::{AtomicU32, Ordering},
+    mpsc,
+  },
 };
 
 use cow_utils::CowUtils;
@@ -10,7 +14,7 @@ use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
   AssetInfo, ChunkUkey, Compilation, CompilationAsset, CompilationParams, CompilationProcessAssets,
-  CompilerCompilation, Plugin,
+  CompilerCompilation, Logger, Plugin,
   cache::persistent::occasion::minimize::{CachedExtractedComments, CachedMinimizeEntry},
   diagnostics::MinifyError,
   rspack_sources::{
@@ -24,7 +28,10 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_javascript_compiler::JavaScriptCompiler;
 use rspack_plugin_javascript::{ExtractedCommentsInfo, JavascriptModulesChunkHash, JsPlugin};
 use rspack_regex::RspackRegex;
-use rspack_util::{asset_condition::AssetConditions, fx_hash::FxHashMap};
+use rspack_util::{
+  asset_condition::AssetConditions,
+  fx_hash::{FxHashMap, FxHasher},
+};
 use swc_config::types::BoolOrDataConfig;
 use swc_core::{
   base::config::JsMinifyFormatOptions,
@@ -166,15 +173,18 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 
   // Compute options hash once for cache key computation
   let options_hash = {
-    let mut hasher = std::hash::DefaultHasher::new();
+    let mut hasher = FxHasher::default();
     self.options.hash(&mut hasher);
-    std::hash::Hasher::finish(&hasher)
+    hasher.finish()
   };
 
   // Take the cache out temporarily for concurrent read access
   let minimize_cache = std::mem::take(&mut compilation.minimize_cache_artifact);
   // Collect new cache entries from cache misses
   let new_cache_entries: Mutex<Vec<(Vec<u8>, CachedMinimizeEntry)>> = Mutex::new(Vec::new());
+  // Track cache hit/miss counts for logging
+  let cache_hits = AtomicU32::new(0);
+  let cache_misses = AtomicU32::new(0);
 
   let (tx, rx) = mpsc::channel::<Vec<Diagnostic>>();
   // collect all extracted comments info
@@ -236,6 +246,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 
         // Check persistent cache
         if let Some(cached) = minimize_cache.get(&cache_key) {
+          cache_hits.fetch_add(1, Ordering::Relaxed);
           original.set_source(Some(cached.source.clone()));
           original.get_info_mut().minimized.replace(true);
           if let Some(ec) = &cached.extracted_comments {
@@ -254,6 +265,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         }
 
         // Cache miss - proceed with minification
+        cache_misses.fetch_add(1, Ordering::Relaxed);
         let input = original_source.source().into_string_lossy().into_owned();
         let object_pool = tls.get_or(ObjectPool::default);
         let input_source_map = original_source.map(object_pool, &MapOptions::default());
@@ -268,7 +280,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
           inline_sources_content: true, /* Using true so original_source can be None in SourceMapSource */
           module: is_module,
           ..Default::default()
-          };
+        };
         let extract_comments_option = options.extract_comments.as_ref().map(|extract_comments| {
           let comments_filename = format!("{filename}.LICENSE.txt");
           let banner = match &extract_comments.banner {
@@ -477,6 +489,12 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     minimize_cache.insert(key, entry);
   }
   compilation.minimize_cache_artifact = minimize_cache;
+
+  // Log cache statistics
+  let hits = cache_hits.load(Ordering::Relaxed);
+  let misses = cache_misses.load(Ordering::Relaxed);
+  let logger = compilation.get_logger(PLUGIN_NAME);
+  logger.log(format!("minimize cache: {hits} hit, {misses} miss"));
 
   compilation.extend_diagnostics(rx.into_iter().flatten().collect::<Vec<_>>());
 

--- a/crates/rspack_util/src/fx_hash.rs
+++ b/crates/rspack_util/src/fx_hash.rs
@@ -4,7 +4,7 @@ use dashmap::{DashMap, DashSet};
 use hashlink::{LinkedHashMap, LinkedHashSet};
 pub use indexmap;
 use indexmap::{IndexMap, IndexSet};
-use rustc_hash::FxHasher;
+pub use rustc_hash::FxHasher;
 pub type BuildFxHasher = BuildHasherDefault<FxHasher>;
 pub use rustc_hash::{FxHashMap, FxHashSet};
 pub type FxDashMap<K, V> = DashMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/tests/rspack-test/cacheCases/common/minimize-cache/async-module.js
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/async-module.js
@@ -1,0 +1,11 @@
+export const value = 42;
+---
+export const value = 42;
+---
+export const value = 42;
+---
+export const value = 42;
+---
+export const value = 42;
+---
+export const value = 42;

--- a/tests/rspack-test/cacheCases/common/minimize-cache/file.js
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/file.js
@@ -1,0 +1,11 @@
+export default 1;
+---
+export default 1;
+---
+export default 1;
+---
+export default 2;
+---
+export default 3;
+---
+export default 4;

--- a/tests/rspack-test/cacheCases/common/minimize-cache/index.js
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/index.js
@@ -1,0 +1,30 @@
+import value from "./file";
+
+it("should hit minimize cache on cold restart and across HMR", async () => {
+	const asyncMod = await import("./async-module");
+	expect(asyncMod.value).toBe(42);
+
+	if (COMPILER_INDEX == 0) {
+		expect(value).toBe(1);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(value).toBe(1);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 2) {
+		expect(value).toBe(1);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 3) {
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 4) {
+		expect(value).toBe(3);
+		await NEXT_HMR();
+		expect(value).toBe(4);
+	}
+});
+
+module.hot.accept("./file");

--- a/tests/rspack-test/cacheCases/common/minimize-cache/index.js
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/index.js
@@ -1,6 +1,6 @@
 import value from "./file";
 
-it("should hit minimize cache on cold restart and across HMR", async () => {
+it("should hit minimize persistent cache on cold restart and across HMR", async () => {
 	const asyncMod = await import("./async-module");
 	expect(asyncMod.value).toBe(42);
 

--- a/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
@@ -1,3 +1,5 @@
+const rspack = require('@rspack/core');
+
 const PLUGIN_NAME = 'rspack.SwcJsMinimizerRspackPlugin';
 
 let updateIndex = 0;
@@ -11,6 +13,7 @@ module.exports = {
   },
   optimization: {
     minimize: true,
+    minimizer: [new rspack.SwcJsMinimizerRspackPlugin()],
   },
   cache: {
     type: 'persistent',

--- a/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
@@ -1,0 +1,85 @@
+const PLUGIN_NAME = 'rspack.SwcJsMinimizerRspackPlugin';
+
+let updateIndex = 0;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  mode: 'production',
+  output: {
+    chunkFilename: '[id].chunk.js',
+  },
+  optimization: {
+    minimize: true,
+  },
+  cache: {
+    type: 'persistent',
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.done.tap('MinimizeCacheTest', (stats) => {
+          const s = stats.toJson({
+            all: false,
+            assets: true,
+            logging: 'log',
+          });
+
+          const jsAssets = s.assets.filter((a) => a.name?.endsWith('.js'));
+          for (const asset of jsAssets) {
+            expect(asset.info.minimized).toBe(true);
+          }
+
+          const logEntries = s.logging[PLUGIN_NAME]?.entries ?? [];
+          const cacheLogEntry = logEntries.find(
+            (e) => e.message && e.message.includes('minimize cache:'),
+          );
+          expect(cacheLogEntry).toBeTruthy();
+
+          const match = cacheLogEntry.message.match(
+            /minimize cache: (\d+) hit, (\d+) miss/,
+          );
+          expect(match).toBeTruthy();
+
+          const hits = parseInt(match[1], 10);
+          const misses = parseInt(match[2], 10);
+
+          if (updateIndex === 0) {
+            // Cold build, cache is empty → all misses
+            expect(hits).toBe(0);
+            expect(misses).toBe(2);
+          }
+          if (updateIndex === 1) {
+            // First hot build with same source content, module is recovered from cache.
+            expect(hits).toBe(1);
+            expect(misses).toBe(1);
+          }
+          if (updateIndex === 2) {
+            // Hot build with same source content.
+            expect(hits).toBe(2);
+            expect(misses).toBe(0);
+          }
+          if (updateIndex === 3) {
+            // Third cold build with changed file content.
+            // Async chunk unchanged → hit; entry chunk changed → miss.
+            expect(hits).toBe(1);
+            expect(misses).toBe(1);
+          }
+          if (updateIndex === 4) {
+            // Cold restart. Async chunk still unchanged → hit.
+            expect(hits).toBe(1);
+            expect(misses).toBe(1);
+          }
+          if (updateIndex === 5) {
+            // HMR update with changed file content
+            // Minimize cache is not shared across in-memory rebuilds, so both assets are processed as new → all misses.
+            expect(hits).toBe(0);
+            expect(misses).toBe(3); // hot-update.js
+          }
+
+          updateIndex++;
+        });
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
@@ -21,7 +21,7 @@ module.exports = {
   plugins: [
     {
       apply(compiler) {
-        compiler.hooks.done.tap('MinimizeCacheTest', (stats) => {
+        compiler.hooks.done.tap('MinimizePersistentCacheTest', (stats) => {
           const s = stats.toJson({
             all: false,
             assets: true,
@@ -35,12 +35,21 @@ module.exports = {
 
           const logEntries = s.logging[PLUGIN_NAME]?.entries ?? [];
           const cacheLogEntry = logEntries.find(
-            (e) => e.message && e.message.includes('minimize cache:'),
+            (e) =>
+              e.message && e.message.includes('minimize persistent cache:'),
           );
+
+          if (updateIndex === 5) {
+            // HMR update with changed file content
+            // Minimize persistent cache is not shared across in-memory rebuilds, so both assets are processed as new → all misses.
+            expect(cacheLogEntry).toBeUndefined();
+            return;
+          }
+
           expect(cacheLogEntry).toBeTruthy();
 
           const match = cacheLogEntry.message.match(
-            /minimize cache: (\d+) hit, (\d+) miss/,
+            /minimize persistent cache: (\d+) hit, (\d+) miss/,
           );
           expect(match).toBeTruthy();
 
@@ -72,12 +81,6 @@ module.exports = {
             // Cold restart. Async chunk still unchanged → hit.
             expect(hits).toBe(1);
             expect(misses).toBe(1);
-          }
-          if (updateIndex === 5) {
-            // HMR update with changed file content
-            // Minimize cache is not shared across in-memory rebuilds, so both assets are processed as new → all misses.
-            expect(hits).toBe(0);
-            expect(misses).toBe(3); // hot-update.js
           }
 
           updateIndex++;

--- a/tests/rspack-test/statsAPICases/basic.js
+++ b/tests/rspack-test/statsAPICases/basic.js
@@ -69,7 +69,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 785a0c9dd1c007e6,
+			      hash: cb00f6f863f5faec,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -199,7 +199,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 2ab382c6c7cc3d80,
+			  hash: ec79eb103428f92c,
 			  modules: Array [
 			    Object {
 			      assets: Array [],
@@ -319,7 +319,7 @@ module.exports = {
 			  entry ./fixtures/a
 			  cjs self exports reference self [195] ./fixtures/a.js
 			  
-			Rspack compiled successfully (2ab382c6c7cc3d80)
+			Rspack compiled successfully (ec79eb103428f92c)
 		`);
 	}
 };

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: f85e8d7b16f4685f,
+			      hash: 0e8b742a551be43a,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: ab09081e1ca7cdd4,
+			  hash: adc8a01990ef52f1,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsAPICases/ids.js
+++ b/tests/rspack-test/statsAPICases/ids.js
@@ -58,7 +58,7 @@ module.exports = {
 			      files: Array [
 			        main.js,
 			      ],
-			      hash: 785a0c9dd1c007e6,
+			      hash: cb00f6f863f5faec,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,

--- a/tests/rspack-test/statsAPICases/with-query.js
+++ b/tests/rspack-test/statsAPICases/with-query.js
@@ -63,7 +63,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: cad16422e0bb8638,
+			      hash: c27ad289237261c4,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -432,7 +432,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: c006b8309b3bcbd2,
+			  hash: e525b5e2aca9a71e,
 			  modules: Array [
 			    Object {
 			      assets: Array [],


### PR DESCRIPTION
## Summary

Add persistent cache for SwcJsMinimizerPlugin

For our internal project:

before:

- cold build: 23.55s
- first hot build: 14.94s
- second hot build: 13.70s

after:

- cold build: 23.66s
- first hot build: 9.01s
- second hot build: 7.92s

(For now we have a bug that causes the first hot build can't fully use the cache, fix is coming in [next PR](https://github.com/web-infra-dev/rspack/pull/13731))

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
