### PR TITLE
fix: correct app type constraint in DevServerOptions

### DIFF
--- a/packages/rspack/src/config/devServer.ts
+++ b/packages/rspack/src/config/devServer.ts
@@ -248,7 +248,7 @@ export type DevServerClient = {
 };
 
 export type DevServerOptions<
-  A extends BasicApplication = ConnectApplication,
+  A extends BasicApplication = BasicApplication,
   S extends BasicServer = BasicServer,
 > = {
   ipc?: string | boolean;

--- a/packages/rspack/src/config/devServer.ts
+++ b/packages/rspack/src/config/devServer.ts
@@ -10,7 +10,7 @@
 import type { ReadStream } from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { ServerOptions } from 'node:https';
-import type { Server as ConnectApplication, NextFunction } from 'connect-next';
+import type { NextFunction } from 'connect-next';
 import type {
   Filter as ProxyFilter,
   Options as ProxyOptions,


### PR DESCRIPTION
## Summary

Changing the default type parameter for `App` from `ConnectApplication` to `BasicApplication` to support Express.

## Related links

resolve https://github.com/web-infra-dev/rspack/issues/13708

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
