### PR TITLE
perf(benchmark): scale up compilation_stages benchmark data size

### DIFF
--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -33,13 +33,13 @@ use tokio::runtime::Builder;
 
 use crate::groups::build_chunk_graph::prepare_large_code_splitting_case;
 
-const GENERAL_STAGE_NUM_MODULES: usize = 3000;
-const CONCAT_GROUPS: usize = 160;
-const CONCAT_MODULES_PER_GROUP: usize = 12;
-const SPLIT_CHUNKS_ENTRY_COUNT: usize = 48;
-const SPLIT_CHUNKS_SHARED_MODULES: usize = 192;
-const SPLIT_CHUNKS_WINDOW: usize = 20;
-const SPLIT_CHUNKS_COMMON_MODULES: usize = 16;
+const GENERAL_STAGE_NUM_MODULES: usize = 10000;
+const CONCAT_GROUPS: usize = 500;
+const CONCAT_MODULES_PER_GROUP: usize = 20;
+const SPLIT_CHUNKS_ENTRY_COUNT: usize = 200;
+const SPLIT_CHUNKS_SHARED_MODULES: usize = 1000;
+const SPLIT_CHUNKS_WINDOW: usize = 40;
+const SPLIT_CHUNKS_COMMON_MODULES: usize = 32;
 
 pub fn compilation_stages_benchmark(c: &mut Criterion) {
   within_compiler_context_for_testing_sync(|| {


### PR DESCRIPTION
## Summary
- Scale up compilation_stages benchmark input sizes to reduce CodSpeed measurement noise
- CodSpeed uses Callgrind instruction counting where absolute noise is roughly constant, so larger workloads shrink noise-to-signal ratio
- Target: reduce CV from ~1%+ down to <0.3%

| Constant | Before | After | Multiplier |
|----------|--------|-------|------------|
| `GENERAL_STAGE_NUM_MODULES` | 3,000 | 10,000 | 3.3x |
| `CONCAT_GROUPS` | 160 | 500 | 3.1x |
| `CONCAT_MODULES_PER_GROUP` | 12 | 20 | 1.7x |
| `SPLIT_CHUNKS_ENTRY_COUNT` | 48 | 200 | 4.2x |
| `SPLIT_CHUNKS_SHARED_MODULES` | 192 | 1,000 | 5.2x |
| `SPLIT_CHUNKS_WINDOW` | 20 | 40 | 2x |
| `SPLIT_CHUNKS_COMMON_MODULES` | 16 | 32 | 2x |

## Test plan
- [ ] CI bench-rust passes without timeout (30min limit)
- [ ] Compare CodSpeed variance across multiple runs on this PR vs main