### PR TITLE
feat(config): update default performance budgets

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -990,8 +990,8 @@ const applyPerformanceDefaults = (
   { production }: { production: boolean },
 ) => {
   if (performance === false) return;
-  D(performance, 'maxAssetSize', 250000);
-  D(performance, 'maxEntrypointSize', 250000);
+  D(performance, 'maxAssetSize', 300 * 1024);
+  D(performance, 'maxEntrypointSize', 500 * 1024);
   F(performance, 'hints', () => (production ? 'warning' : false));
 };
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3054,12 +3054,12 @@ export type Performance =
       hints?: false | 'warning' | 'error';
       /**
        * File size limit (in bytes) when exceeded, that webpack will provide performance hints.
-       * @default 307200
+       * @default 307200 (300 KiB)
        */
       maxAssetSize?: number;
       /**
        * Total size of an entry point (in bytes).
-       * @default 512000
+       * @default 512000 (500 KiB)
        */
       maxEntrypointSize?: number;
     };

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3054,12 +3054,12 @@ export type Performance =
       hints?: false | 'warning' | 'error';
       /**
        * File size limit (in bytes) when exceeded, that webpack will provide performance hints.
-       * @default 300 * 1024
+       * @default 307200
        */
       maxAssetSize?: number;
       /**
        * Total size of an entry point (in bytes).
-       * @default 500 * 1024
+       * @default 512000
        */
       maxEntrypointSize?: number;
     };

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3054,12 +3054,12 @@ export type Performance =
       hints?: false | 'warning' | 'error';
       /**
        * File size limit (in bytes) when exceeded, that webpack will provide performance hints.
-       * @default 250000
+       * @default 300 * 1024
        */
       maxAssetSize?: number;
       /**
        * Total size of an entry point (in bytes).
-       * @default 250000
+       * @default 500 * 1024
        */
       maxEntrypointSize?: number;
     };

--- a/tests/rspack-test/defaultsCases/mode/production.js
+++ b/tests/rspack-test/defaultsCases/mode/production.js
@@ -58,8 +58,8 @@ module.exports = {
 			-   "performance": false,
 			+   "performance": Object {
 			+     "hints": "warning",
-			+     "maxAssetSize": 250000,
-			+     "maxEntrypointSize": 250000,
+			+     "maxAssetSize": 307200,
+			+     "maxEntrypointSize": 512000,
 			+   },
 		`)
 };

--- a/tests/rspack-test/defaultsCases/mode/undefined.js
+++ b/tests/rspack-test/defaultsCases/mode/undefined.js
@@ -58,8 +58,8 @@ module.exports = {
 			-   "performance": false,
 			+   "performance": Object {
 			+     "hints": "warning",
-			+     "maxAssetSize": 250000,
-			+     "maxEntrypointSize": 250000,
+			+     "maxAssetSize": 307200,
+			+     "maxEntrypointSize": 512000,
 			+   },
 		`)
 };

--- a/tests/rspack-test/statsOutputCases/performance-different-mode-and-target/rspack.config.js
+++ b/tests/rspack-test/statsOutputCases/performance-different-mode-and-target/rspack.config.js
@@ -4,6 +4,10 @@ module.exports = [
     entry: './index',
     mode: 'production',
     target: 'web',
+    performance: {
+      maxAssetSize: 200 * 1024,
+      maxEntrypointSize: 200 * 1024,
+    },
     output: {
       filename: 'warning.pro-web.js',
     },
@@ -16,6 +20,10 @@ module.exports = [
     entry: './index',
     mode: 'production',
     target: 'webworker',
+    performance: {
+      maxAssetSize: 200 * 1024,
+      maxEntrypointSize: 200 * 1024,
+    },
     output: {
       filename: 'warning.pro-webworker.js',
     },
@@ -84,6 +92,8 @@ module.exports = [
     target: 'node',
     performance: {
       hints: 'warning',
+      maxAssetSize: 200 * 1024,
+      maxEntrypointSize: 200 * 1024,
     },
     output: {
       filename: 'warning.pro-node-with-hints-set.js',

--- a/tests/rspack-test/statsOutputCases/performance-error/rspack.config.js
+++ b/tests/rspack-test/statsOutputCases/performance-error/rspack.config.js
@@ -11,5 +11,7 @@ module.exports = {
   },
   performance: {
     hints: 'error',
+    maxAssetSize: 200 * 1024,
+    maxEntrypointSize: 200 * 1024,
   },
 };

--- a/tests/rspack-test/statsOutputCases/performance-no-async-chunks-shown/rspack.config.js
+++ b/tests/rspack-test/statsOutputCases/performance-no-async-chunks-shown/rspack.config.js
@@ -7,6 +7,8 @@ module.exports = {
   },
   performance: {
     hints: 'warning',
+    maxAssetSize: 200 * 1024,
+    maxEntrypointSize: 200 * 1024,
   },
   stats: {
     assets: true,

--- a/tests/rspack-test/statsOutputCases/performance-no-hints/rspack.config.js
+++ b/tests/rspack-test/statsOutputCases/performance-no-hints/rspack.config.js
@@ -11,5 +11,7 @@ module.exports = {
   },
   performance: {
     hints: false,
+    maxAssetSize: 200 * 1024,
+    maxEntrypointSize: 200 * 1024,
   },
 };

--- a/tests/rspack-test/statsOutputCases/performance-oversize-limit-error/rspack.config.js
+++ b/tests/rspack-test/statsOutputCases/performance-oversize-limit-error/rspack.config.js
@@ -14,5 +14,7 @@ module.exports = {
   },
   performance: {
     hints: 'error',
+    maxAssetSize: 200 * 1024,
+    maxEntrypointSize: 200 * 1024,
   },
 };

--- a/tests/rspack-test/statsOutputCases/preset-normal-performance-ensure-filter-sourcemaps/rspack.config.js
+++ b/tests/rspack-test/statsOutputCases/preset-normal-performance-ensure-filter-sourcemaps/rspack.config.js
@@ -4,6 +4,8 @@ module.exports = {
   devtool: 'source-map',
   performance: {
     hints: 'warning',
+    maxAssetSize: 200 * 1024,
+    maxEntrypointSize: 200 * 1024,
   },
   entry: './index',
   stats: {

--- a/tests/rspack-test/statsOutputCases/preset-normal-performance/rspack.config.js
+++ b/tests/rspack-test/statsOutputCases/preset-normal-performance/rspack.config.js
@@ -4,6 +4,8 @@ module.exports = {
   entry: './index',
   performance: {
     hints: 'warning',
+    maxAssetSize: 200 * 1024,
+    maxEntrypointSize: 200 * 1024,
   },
   stats: {
     assets: true,

--- a/website/docs/en/config/performance.mdx
+++ b/website/docs/en/config/performance.mdx
@@ -71,7 +71,7 @@ export default {
 
 ## performance.maxAssetSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '300 * 1024' }]} />
+<PropertyType type="number" defaultValueList={[{ defaultValue: '307200' }]} />
 
 Sets the size threshold for a single asset (in bytes). Rspack emits a performance hint when an asset exceeds this value.
 
@@ -87,7 +87,7 @@ export default {
 
 ## performance.maxEntrypointSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '500 * 1024' }]} />
+<PropertyType type="number" defaultValueList={[{ defaultValue: '512000' }]} />
 
 Sets the total size threshold for an entrypoint (in bytes). Entrypoint total size means the total size needed for the initial load of that entry. Rspack emits a performance hint when the entrypoint total size exceeds this value.
 

--- a/website/docs/en/config/performance.mdx
+++ b/website/docs/en/config/performance.mdx
@@ -71,7 +71,8 @@ export default {
 
 ## performance.maxAssetSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '307200' }]} />
+- **Type:**: `number`
+- **Default:**: `307200` (`300 KiB`)
 
 Sets the size threshold for a single asset (in bytes). Rspack emits a performance hint when an asset exceeds this value.
 
@@ -87,7 +88,8 @@ export default {
 
 ## performance.maxEntrypointSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '512000' }]} />
+- **Type:**: `number`
+- **Default:**: `512000` (`500 KiB`)
 
 Sets the total size threshold for an entrypoint (in bytes). Entrypoint total size means the total size needed for the initial load of that entry. Rspack emits a performance hint when the entrypoint total size exceeds this value.
 

--- a/website/docs/en/config/performance.mdx
+++ b/website/docs/en/config/performance.mdx
@@ -71,7 +71,7 @@ export default {
 
 ## performance.maxAssetSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '250000' }]} />
+<PropertyType type="number" defaultValueList={[{ defaultValue: '300 * 1024' }]} />
 
 Sets the size threshold for a single asset (in bytes). Rspack emits a performance hint when an asset exceeds this value.
 
@@ -87,7 +87,7 @@ export default {
 
 ## performance.maxEntrypointSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '250000' }]} />
+<PropertyType type="number" defaultValueList={[{ defaultValue: '500 * 1024' }]} />
 
 Sets the total size threshold for an entrypoint (in bytes). Entrypoint total size means the total size needed for the initial load of that entry. Rspack emits a performance hint when the entrypoint total size exceeds this value.
 

--- a/website/docs/zh/config/performance.mdx
+++ b/website/docs/zh/config/performance.mdx
@@ -71,7 +71,7 @@ export default {
 
 ## performance.maxAssetSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '250000' }]} />
+<PropertyType type="number" defaultValueList={[{ defaultValue: '300 * 1024' }]} />
 
 设置单个资源体积阈值（单位：bytes）。当某个资源超过该值时，Rspack 会触发性能提示。
 
@@ -87,7 +87,7 @@ export default {
 
 ## performance.maxEntrypointSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '250000' }]} />
+<PropertyType type="number" defaultValueList={[{ defaultValue: '500 * 1024' }]} />
 
 设置入口总体积阈值（单位：bytes）。这里的入口总体积指初始加载该入口时需要的所有资源总体积，当入口总体积超过该值时，Rspack 会触发性能提示。
 

--- a/website/docs/zh/config/performance.mdx
+++ b/website/docs/zh/config/performance.mdx
@@ -71,7 +71,7 @@ export default {
 
 ## performance.maxAssetSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '300 * 1024' }]} />
+<PropertyType type="number" defaultValueList={[{ defaultValue: '307200' }]} />
 
 设置单个资源体积阈值（单位：bytes）。当某个资源超过该值时，Rspack 会触发性能提示。
 
@@ -87,7 +87,7 @@ export default {
 
 ## performance.maxEntrypointSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '500 * 1024' }]} />
+<PropertyType type="number" defaultValueList={[{ defaultValue: '512000' }]} />
 
 设置入口总体积阈值（单位：bytes）。这里的入口总体积指初始加载该入口时需要的所有资源总体积，当入口总体积超过该值时，Rspack 会触发性能提示。
 

--- a/website/docs/zh/config/performance.mdx
+++ b/website/docs/zh/config/performance.mdx
@@ -71,7 +71,8 @@ export default {
 
 ## performance.maxAssetSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '307200' }]} />
+- **类型：**: `number`
+- **默认值：**: `307200` (`300 KiB`)
 
 设置单个资源体积阈值（单位：bytes）。当某个资源超过该值时，Rspack 会触发性能提示。
 
@@ -87,7 +88,8 @@ export default {
 
 ## performance.maxEntrypointSize
 
-<PropertyType type="number" defaultValueList={[{ defaultValue: '512000' }]} />
+- **类型：**: `number`
+- **默认值：**: `512000` (`500 KiB`)
 
 设置入口总体积阈值（单位：bytes）。这里的入口总体积指初始加载该入口时需要的所有资源总体积，当入口总体积超过该值时，Rspack 会触发性能提示。
 


### PR DESCRIPTION
## Summary

Update the default performance budgets to `300 * 1024` for `maxAssetSize` and `500 * 1024` for `maxEntrypointSize` so the defaults better fit modern applications and distinguish asset vs entrypoint limits.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
