### PR TITLE
docs(config): replace generic webpack references with Rspack

### DIFF
--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -334,7 +334,7 @@ export type WorkerPublicPath = string;
 /** Controls [Trusted Types](https://web.dev/articles/trusted-types) compatibility. */
 export type TrustedTypes = {
   /**
-   * The name of the Trusted Types policy created by webpack to serve bundle chunks.
+   * The name of the Trusted Types policy created by Rspack to serve bundle chunks.
    */
   policyName?: string;
   /**
@@ -438,7 +438,7 @@ export type Environment = {
 
   /**
    * Determines if the node: prefix is generated for core module imports in environments that support it.
-   * This is only applicable to Webpack runtime code.
+   * This is only applicable to Rspack runtime code.
    * */
   nodePrefixForCoreModules?: boolean;
 
@@ -2949,14 +2949,14 @@ export type Watch = boolean;
 export type WatchOptions = {
   /**
    * Add a delay before rebuilding once the first file changed.
-   * This allows webpack to aggregate any other changes made during this time period into one rebuild.
+   * This allows Rspack to aggregate any other changes made during this time period into one rebuild.
    * @default 5
    */
   aggregateTimeout?: number;
 
   /**
    * Follow symlinks while looking for files.
-   * This is usually not needed as webpack already resolves symlinks ('resolve.symlinks' and 'resolve.alias').
+   * This is usually not needed as Rspack already resolves symlinks ('resolve.symlinks' and 'resolve.alias').
    */
   followSymlinks?: boolean;
 
@@ -3053,7 +3053,7 @@ export type Performance =
        */
       hints?: false | 'warning' | 'error';
       /**
-       * File size limit (in bytes) when exceeded, that webpack will provide performance hints.
+       * File size limit (in bytes) when exceeded, that Rspack will provide performance hints.
        * @default 307200 (300 KiB)
        */
       maxAssetSize?: number;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3053,7 +3053,7 @@ export type Performance =
        */
       hints?: false | 'warning' | 'error';
       /**
-       * File size limit (in bytes) when exceeded, that Rspack will provide performance hints.
+       * File size limit (in bytes) when exceeded, Rspack will provide performance hints.
        * @default 307200 (300 KiB)
        */
       maxAssetSize?: number;

--- a/packages/rspack/src/container/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/container/ModuleFederationPlugin.ts
@@ -42,7 +42,7 @@ export class ModuleFederationPlugin {
   constructor(private _options: ModuleFederationPluginOptions) {}
 
   apply(compiler: Compiler) {
-    const { webpack } = compiler;
+    const { rspack } = compiler;
     const paths = getPaths(this._options, compiler);
     compiler.options.resolve.alias = {
       '@module-federation/runtime-tools': paths.runtimeTools,
@@ -124,7 +124,7 @@ export class ModuleFederationPlugin {
       shared: this._options.shared,
       enhanced: true,
     };
-    new webpack.container.ModuleFederationPluginV1(v1Options).apply(compiler);
+    new rspack.container.ModuleFederationPluginV1(v1Options).apply(compiler);
 
     if (this._options.manifest) {
       new ModuleFederationManifestPlugin(this._options).apply(compiler);

--- a/website/docs/en/config/entry.mdx
+++ b/website/docs/en/config/entry.mdx
@@ -263,7 +263,7 @@ export default {
 
 If a function is passed then it will be invoked on every [make](/api/plugin-api/compiler-hooks#make) event.
 
-> Note that the `make` event triggers when webpack starts and for every invalidation when [watching for file changes](/config/watch).
+> Note that the `make` event triggers when Rspack starts and for every invalidation when [watching for file changes](/config/watch).
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -466,7 +466,7 @@ var __webpack_modules__ = {
   },
 };
 
-// webpack runtime...
+// Rspack runtime...
 
 async function foo() {
   const jq = await Promise.resolve(/* import() */).then(
@@ -515,7 +515,7 @@ var __webpack_modules__ = {
   },
 };
 
-// webpack runtime...
+// Rspack runtime...
 
 async function foo() {
   const jq = await Promise.resolve(/* import() */).then(

--- a/website/docs/en/config/other-options.mdx
+++ b/website/docs/en/config/other-options.mdx
@@ -181,5 +181,5 @@ export default function (source) {
 ```
 
 :::tip
-You can override properties in the loader context as webpack copies all properties that are defined in the loader to the loader context.
+You can override properties in the loader context because Rspack copies all properties defined on the loader to the loader context.
 :::

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -461,7 +461,7 @@ type Environment = {
   module?: boolean;
   /**
    * Determines if the node: prefix is generated for core module imports in environments that support it.
-   * This is only applicable to Webpack runtime code.
+   * This is only applicable to Rspack runtime code.
    * */
   nodePrefixForCoreModules?: boolean;
   /** The environment supports optional chaining ('obj?.a' or 'obj?.()'). */

--- a/website/docs/zh/config/entry.mdx
+++ b/website/docs/zh/config/entry.mdx
@@ -263,7 +263,7 @@ export default {
 
 如果传入一个函数，那么它将会在每次 [make](/api/plugin-api/compiler-hooks#make) 事件中被调用。
 
-> 要注意的是，`make` 事件在 webpack 启动和每当[监听文件变化](/config/watch)时都会触发。
+> 要注意的是，`make` 事件在 Rspack 启动和每当[监听文件变化](/config/watch)时都会触发。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -466,7 +466,7 @@ var __webpack_modules__ = {
   },
 };
 
-// webpack runtime...
+// Rspack runtime...
 
 async function foo() {
   const jq = await Promise.resolve(/* import() */).then(
@@ -514,7 +514,7 @@ var __webpack_modules__ = {
   },
 };
 
-// webpack runtime...
+// Rspack runtime...
 
 async function foo() {
   const jq = await Promise.resolve(/* import() */).then(

--- a/website/docs/zh/config/other-options.mdx
+++ b/website/docs/zh/config/other-options.mdx
@@ -180,5 +180,5 @@ export default function (source) {
 ```
 
 :::tip
-你可以覆盖 Loader 上下文中的属性，因为 Rspack 会将所有定义在 Loader 中的属性负责到 Loader 上下文中。
+你可以覆盖 Loader 上下文中的属性，因为 Rspack 会将所有定义在 Loader 上的属性复制到 Loader 上下文中。
 :::

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -457,7 +457,7 @@ type Environment = {
   module?: boolean;
   /**
    * Determines if the node: prefix is generated for core module imports in environments that support it.
-   * This is only applicable to Webpack runtime code.
+   * This is only applicable to Rspack runtime code.
    * */
   nodePrefixForCoreModules?: boolean;
   /** The environment supports optional chaining ('obj?.a' or 'obj?.()'). */


### PR DESCRIPTION
## Summary

Replace generic `webpack` wording with `Rspack` in config JSDoc and config docs when the text describes Rspack behavior rather than webpack-specific compatibility.