### PR TITLE
ci: disable Windows CPU hogs to speed up CI

### DIFF
--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -36,14 +36,16 @@ jobs:
           clean: ${{ runner.environment == 'github-hosted' }}
 
       - name: Disable CPU hogs (Windows)
-        if: runner.os == 'Windows' && runner.environment == 'github-hosted'
+        if: runner.os == 'Windows'
         shell: powershell
+        continue-on-error: true
         run: |
+          $ErrorActionPreference = 'SilentlyContinue'
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
           sc.exe config wuauserv start= disabled
-          Stop-Service wuauserv -ErrorAction SilentlyContinue
+          Stop-Service wuauserv
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
 

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -36,16 +36,14 @@ jobs:
           clean: ${{ runner.environment == 'github-hosted' }}
 
       - name: Disable CPU hogs (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && runner.environment == 'github-hosted'
         shell: powershell
-        continue-on-error: true
         run: |
-          $ErrorActionPreference = 'SilentlyContinue'
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
           sc config wuauserv start= disabled
-          Stop-Service wuauserv
+          Stop-Service wuauserv -ErrorAction SilentlyContinue
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
 

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -42,7 +42,7 @@ jobs:
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
-          sc config wuauserv start= disabled
+          sc.exe config wuauserv start= disabled
           Stop-Service wuauserv -ErrorAction SilentlyContinue
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -38,12 +38,14 @@ jobs:
       - name: Disable CPU hogs (Windows)
         if: runner.os == 'Windows'
         shell: powershell
+        continue-on-error: true
         run: |
+          $ErrorActionPreference = 'SilentlyContinue'
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
           sc config wuauserv start= disabled
-          Stop-Service wuauserv -ErrorAction SilentlyContinue
+          Stop-Service wuauserv
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
 

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -35,6 +35,18 @@ jobs:
           ref: ${{ inputs.ref }}
           clean: ${{ runner.environment == 'github-hosted' }}
 
+      - name: Disable CPU hogs (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true -Force
+          Add-MpPreference -ExclusionPath "C:\" -Force
+          Add-MpPreference -ExclusionPath "D:\" -Force
+          sc config wuauserv start= disabled
+          Stop-Service wuauserv -ErrorAction SilentlyContinue
+          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+
       - name: Download and install zstd
         if: ${{ runner.os == 'Windows' }}
         shell: bash # Use bash for curl and unzip commands

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -106,12 +106,14 @@ jobs:
       - name: Disable CPU hogs (Windows)
         if: runner.os == 'Windows'
         shell: powershell
+        continue-on-error: true
         run: |
+          $ErrorActionPreference = 'SilentlyContinue'
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
           sc config wuauserv start= disabled
-          Stop-Service wuauserv -ErrorAction SilentlyContinue
+          Stop-Service wuauserv
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
 

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -110,7 +110,7 @@ jobs:
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
-          sc config wuauserv start= disabled
+          sc.exe config wuauserv start= disabled
           Stop-Service wuauserv -ErrorAction SilentlyContinue
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -104,16 +104,14 @@ jobs:
           clean: ${{ runner.environment == 'github-hosted' }}
 
       - name: Disable CPU hogs (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && runner.environment == 'github-hosted'
         shell: powershell
-        continue-on-error: true
         run: |
-          $ErrorActionPreference = 'SilentlyContinue'
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
           sc config wuauserv start= disabled
-          Stop-Service wuauserv
+          Stop-Service wuauserv -ErrorAction SilentlyContinue
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
 

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -103,6 +103,18 @@ jobs:
           ref: ${{ inputs.ref }}
           clean: ${{ runner.environment == 'github-hosted' }}
 
+      - name: Disable CPU hogs (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true -Force
+          Add-MpPreference -ExclusionPath "C:\" -Force
+          Add-MpPreference -ExclusionPath "D:\" -Force
+          sc config wuauserv start= disabled
+          Stop-Service wuauserv -ErrorAction SilentlyContinue
+          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+
       - name: Download bindings
         uses: ./.github/actions/artifact/download
         with:

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -104,14 +104,16 @@ jobs:
           clean: ${{ runner.environment == 'github-hosted' }}
 
       - name: Disable CPU hogs (Windows)
-        if: runner.os == 'Windows' && runner.environment == 'github-hosted'
+        if: runner.os == 'Windows'
         shell: powershell
+        continue-on-error: true
         run: |
+          $ErrorActionPreference = 'SilentlyContinue'
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
           sc.exe config wuauserv start= disabled
-          Stop-Service wuauserv -ErrorAction SilentlyContinue
+          Stop-Service wuauserv
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
 

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -158,6 +158,18 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
+      - name: Disable CPU hogs (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true -Force
+          Add-MpPreference -ExclusionPath "C:\" -Force
+          Add-MpPreference -ExclusionPath "D:\" -Force
+          sc config wuauserv start= disabled
+          Stop-Service wuauserv -ErrorAction SilentlyContinue
+          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -165,7 +165,7 @@ jobs:
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
-          sc config wuauserv start= disabled
+          sc.exe config wuauserv start= disabled
           Stop-Service wuauserv -ErrorAction SilentlyContinue
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -159,14 +159,16 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Disable CPU hogs (Windows)
-        if: runner.os == 'Windows' && runner.environment == 'github-hosted'
+        if: runner.os == 'Windows'
         shell: powershell
+        continue-on-error: true
         run: |
+          $ErrorActionPreference = 'SilentlyContinue'
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
           sc.exe config wuauserv start= disabled
-          Stop-Service wuauserv -ErrorAction SilentlyContinue
+          Stop-Service wuauserv
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
 

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -161,12 +161,14 @@ jobs:
       - name: Disable CPU hogs (Windows)
         if: runner.os == 'Windows'
         shell: powershell
+        continue-on-error: true
         run: |
+          $ErrorActionPreference = 'SilentlyContinue'
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
           sc config wuauserv start= disabled
-          Stop-Service wuauserv -ErrorAction SilentlyContinue
+          Stop-Service wuauserv
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
 

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -159,16 +159,14 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Disable CPU hogs (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && runner.environment == 'github-hosted'
         shell: powershell
-        continue-on-error: true
         run: |
-          $ErrorActionPreference = 'SilentlyContinue'
           Set-MpPreference -DisableRealtimeMonitoring $true -Force
           Add-MpPreference -ExclusionPath "C:\" -Force
           Add-MpPreference -ExclusionPath "D:\" -Force
           sc config wuauserv start= disabled
-          Stop-Service wuauserv
+          Stop-Service wuauserv -ErrorAction SilentlyContinue
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
 


### PR DESCRIPTION
## Summary
- Disable Windows Defender realtime monitoring and add full disk exclusions on Windows CI runners
- Stop Windows Update service and block WSL/CompatTelRunner processes
- Applied to all 3 reusable workflows that run on Windows: build, test, and rust watcher test

## Test plan
- [ ] Compare Windows job durations before/after this PR
- [ ] Verify non-Windows jobs are unaffected (step is gated by `runner.os == 'Windows'`)