### PR TITLE
chore: update rust toolchain from nightly-2025-11-13 to nightly-2026-04-16

### DIFF
--- a/crates/rspack_binding_api/src/chunk.rs
+++ b/crates/rspack_binding_api/src/chunk.rs
@@ -231,7 +231,7 @@ impl Chunk {
           .get(group)
       })
       .collect::<Vec<_>>();
-    groups.sort_unstable_by(|a, b| a.index.cmp(&b.index));
+    groups.sort_unstable_by_key(|a| a.index);
     Ok(
       groups
         .iter()

--- a/crates/rspack_binding_api/src/dependency.rs
+++ b/crates/rspack_binding_api/src/dependency.rs
@@ -25,19 +25,32 @@ pub struct Dependency {
 }
 
 impl Dependency {
-  fn as_ref(&mut self) -> napi::Result<(&dyn rspack_core::Dependency, Option<&Compilation>)> {
+  fn as_ref<'a>(
+    &'a mut self,
+  ) -> napi::Result<(
+    &'a (dyn rspack_core::Dependency + 'a),
+    Option<&'a Compilation>,
+  )> {
     if let Some(compilation) = self.compilation {
       let compilation = unsafe { compilation.as_ref() };
       let module_graph = compilation.get_module_graph();
       if let Some(dependency) = internal::try_dependency_by_id(module_graph, &self.dependency_id) {
-        self.dependency = {
-          #[allow(clippy::unwrap_used)]
-          NonNull::new(
-            (&**dependency) as *const dyn rspack_core::Dependency
-              as *mut dyn rspack_core::Dependency,
-          )
-          .unwrap()
+        // SAFETY:
+        // We extend `'a` to `'static` to satisfy the `NonNull<dyn Dependency>` field type,
+        // which has an implied `'static` bound on the trait object. All actual accesses are
+        // still mediated by the JS wrapper lifecycle plus runtime dependency lookups, so the
+        // references derived from this pointer must not outlive the original allocation.
+        let dependency_ptr = unsafe {
+          std::mem::transmute::<
+            *const (dyn rspack_core::Dependency + 'a),
+            *mut (dyn rspack_core::Dependency + 'static),
+          >(dependency.as_ref())
         };
+
+        // SAFETY:
+        // `dependency` is a valid reference, so the erased raw pointer is non-null.
+        self.dependency = unsafe { NonNull::new_unchecked(dependency_ptr) };
+
         Ok((unsafe { self.dependency.as_ref() }, Some(compilation)))
       } else {
         Err(napi::Error::from_reason(format!(
@@ -189,20 +202,33 @@ pub struct DependencyWrapper {
 }
 
 impl DependencyWrapper {
-  pub fn new(
-    dependency: &dyn rspack_core::Dependency,
+  pub fn new<'a>(
+    dependency: &'a dyn rspack_core::Dependency,
     compilation_id: CompilationId,
     compilation: Option<&Compilation>,
   ) -> Self {
     let dependency_id = *dependency.id();
 
+    // SAFETY:
+    // We extend `'a` to `'static` to satisfy the `NonNull<dyn Dependency>` field type,
+    // which has an implied `'static` bound on the trait object. All actual accesses are
+    // still mediated by the JS wrapper lifecycle plus runtime dependency lookups, so the
+    // references derived from this pointer must not outlive the original allocation.
+    let dependency_ptr = unsafe {
+      std::mem::transmute::<
+        *const (dyn rspack_core::Dependency + 'a),
+        *mut (dyn rspack_core::Dependency + 'static),
+      >(dependency)
+    };
+
+    // SAFETY:
+    // `dependency` is a valid reference, so the erased raw pointer is non-null.
+    let dependency = unsafe { NonNull::new_unchecked(dependency_ptr) };
+
     #[allow(clippy::unwrap_used)]
     Self {
       dependency_id,
-      dependency: NonNull::new(
-        dependency as *const dyn rspack_core::Dependency as *mut dyn rspack_core::Dependency,
-      )
-      .unwrap(),
+      dependency,
       compilation_id,
       compilation: compilation
         .map(|c| NonNull::new(c as *const Compilation as *mut Compilation).unwrap()),

--- a/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
@@ -65,10 +65,7 @@ impl BuildDeps {
     let mut queue = VecDeque::new();
     queue.extend(std::mem::take(&mut self.pending));
     queue.extend(data);
-    loop {
-      let Some(current) = queue.pop_front() else {
-        break;
-      };
+    while let Some(current) = queue.pop_front() {
       if !self.added.insert(current.clone()) {
         continue;
       }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/fix_issuers.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/fix_issuers.rs
@@ -267,11 +267,7 @@ impl FixIssuers {
     let module_graph = &mut artifact.module_graph;
     let mut revoke_module = IdentifierSet::default();
     let mut need_check_available_modules = IdentifierMap::default();
-    loop {
-      let Some((mid, mut parents)) = queue.pop_front() else {
-        break;
-      };
-
+    while let Some((mid, mut parents)) = queue.pop_front() {
       // remove revoke_module from parents
       parents.retain(|item| {
         let Some(parent_mid) = item else {
@@ -367,10 +363,7 @@ impl FixIssuers {
           // the parent which cycle_paths contains current module can be set as issuer.
           let mut queue = VecDeque::with_capacity(1);
           queue.push_back(mid);
-          loop {
-            let Some(current_id) = queue.pop_front() else {
-              break;
-            };
+          while let Some(current_id) = queue.pop_front() {
             need_clean_cycle_modules.retain(|id, paths| {
               for (issuer, cycle_paths) in paths {
                 if cycle_paths.contains(&current_id) {
@@ -420,10 +413,7 @@ impl FixIssuers {
       let mut useless_module = IdentifierSet::default();
       let mut queue = VecDeque::new();
       queue.push_back((mid, paths));
-      loop {
-        let Some((current, current_parents)) = queue.pop_front() else {
-          break;
-        };
+      while let Some((current, current_parents)) = queue.pop_front() {
         useless_module.insert(current);
 
         for mid in current_parents {

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -530,24 +530,19 @@ impl Compiler {
     }
 
     let assets = self.compilation.assets();
-    join_all(
-      self
-        .emitted_asset_versions
-        .iter()
-        .filter_map(|(filename, _version)| {
-          if !assets.contains_key(filename) {
-            let filename = filename.to_owned();
-            Some(async {
-              if !clean_options.keep(&filename).await {
-                let filename = output_path.join(filename);
-                let _ = self.output_filesystem.remove_file(&filename).await;
-              }
-            })
-          } else {
-            None
+    join_all(self.emitted_asset_versions.keys().filter_map(|filename| {
+      if !assets.contains_key(filename) {
+        let filename = filename.to_owned();
+        Some(async {
+          if !clean_options.keep(&filename).await {
+            let filename = output_path.join(filename);
+            let _ = self.output_filesystem.remove_file(&filename).await;
           }
-        }),
-    )
+        })
+      } else {
+        None
+      }
+    }))
     .await;
 
     Ok(())

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -658,7 +658,7 @@ impl ConcatenatedModule {
     runtime: Option<RuntimeSpec>,
     compilation: &Compilation,
   ) -> Self {
-    modules.sort_unstable_by(|a, b| a.id.cmp(&b.id));
+    modules.sort_unstable_by_key(|a| a.id);
     let id = Self::create_identifier(&root_module_ctxt, &modules, hash_function);
     Self::new(id.as_str().into(), root_module_ctxt, modules, runtime)
   }

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -422,12 +422,7 @@ async fn visit_dirs(
   resolve_options: &ResolveInnerOptions<'_>,
   fs: Arc<dyn ReadableFileSystem>,
 ) -> Result<()> {
-  if !fs
-    .metadata(dir)
-    .await
-    .map(|m| m.is_directory)
-    .unwrap_or(false)
-  {
+  if !fs.metadata(dir).await.is_ok_and(|m| m.is_directory) {
     return Ok(());
   }
   let include = &options.context_options.include;
@@ -443,12 +438,7 @@ async fn visit_dirs(
       continue;
     }
 
-    if fs
-      .metadata(&path)
-      .await
-      .map(|m| m.is_directory)
-      .unwrap_or(false)
-    {
+    if fs.metadata(&path).await.is_ok_and(|m| m.is_directory) {
       if options.context_options.recursive {
         visit_dirs(
           ctx,

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -883,6 +883,8 @@ impl Module for ExternalModule {
     };
     let mut can_mangle = false;
     let mut exports_type = BuildMetaExportsType::Dynamic;
+
+    #[allow(clippy::collapsible_match)]
     match resolved_external_type {
       "this" => self.build_info.strict = false,
       "system" => {

--- a/crates/rspack_core/src/utils/extract_source_map.rs
+++ b/crates/rspack_core/src/utils/extract_source_map.rs
@@ -317,7 +317,7 @@ pub async fn extract_source_map(
   let mut futures = FuturesOrdered::new();
 
   // Use zip to consume both vectors without extra cloning
-  for (source, original_content) in sources.into_iter().zip(source_contents.into_iter()) {
+  for (source, original_content) in sources.into_iter().zip(source_contents) {
     let skip_reading = original_content.is_some();
     let source_root = source_root.clone();
     let context = context.to_path_buf();

--- a/crates/rspack_core/src/utils/find_graph_roots.rs
+++ b/crates/rspack_core/src/utils/find_graph_roots.rs
@@ -159,7 +159,7 @@ pub fn find_graph_roots<
   let mut roots = FxHashSet::with_capacity_and_hasher(db.len(), Default::default());
 
   let mut keys = db.keys().copied().collect::<Vec<_>>();
-  keys.sort_by(|a, b| expect_get(&db, a).item.cmp(&expect_get(&db, b).item));
+  keys.sort_by_key(|a| expect_get(&db, a).item);
 
   // For all non-marked nodes
   for select_node in keys {
@@ -175,7 +175,7 @@ pub fn find_graph_roots<
         node: select_node,
         open_edges: {
           let mut v: Vec<_> = expect_get(&db, &select_node).dependencies.clone();
-          v.sort_by(|a, b| expect_get(&db, a).item.cmp(&expect_get(&db, b).item));
+          v.sort_by_key(|a| expect_get(&db, a).item);
           v
         },
       }];
@@ -192,7 +192,7 @@ pub fn find_graph_roots<
             .map(|edge| expect_get(&db, edge))
             .collect::<Vec<_>>();
 
-          edges.sort_by(|a, b| a.item.cmp(&b.item));
+          edges.sort_by_key(|a| a.item);
 
           // Process one dependency
           let dependency = stack[top_of_stack_idx]

--- a/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
@@ -1300,6 +1300,7 @@ impl<'a, C: Comments> VisitMut for ServerActions<'a, C> {
     // 2. Register any remaining exports in the post-pass that weren't handled by the visitor.
     if should_track_exports {
       for stmt in stmts.iter() {
+        #[allow(clippy::collapsible_match)]
         match stmt {
           ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(export_default_expr)) => {
             if let Expr::Ident(ident) = &*export_default_expr.expr {
@@ -1447,7 +1448,7 @@ impl<'a, C: Comments> VisitMut for ServerActions<'a, C> {
     for mut stmt in stmts.take() {
       if should_track_exports {
         let mut disallowed_export_span = DUMMY_SP;
-
+        #[allow(clippy::collapsible_match)]
         match &mut stmt {
           ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl { decl, span })) => match decl {
             Decl::Var(_)
@@ -1902,10 +1903,8 @@ impl<'a, C: Comments> VisitMut for ServerActions<'a, C> {
   fn visit_mut_assign_expr(&mut self, assign_expr: &mut AssignExpr) {
     let old_arrow_or_fn_expr_ident = self.arrow_or_fn_expr_ident.clone();
 
-    if let (
-      AssignTarget::Simple(SimpleAssignTarget::Ident(ident)),
-      box (Expr::Arrow(_) | Expr::Fn(_)),
-    ) = (&assign_expr.left, &assign_expr.right)
+    if let (AssignTarget::Simple(SimpleAssignTarget::Ident(ident)), Expr::Arrow(_) | Expr::Fn(_)) =
+      (&assign_expr.left, assign_expr.right.as_ref())
     {
       self.arrow_or_fn_expr_ident = Some(ident.id.clone());
     }

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -628,7 +628,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       .deref_mut(),
   ));
 
-  copied_result.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+  copied_result.sort_unstable_by_key(|a| a.0);
 
   // Keep track of source to destination file mappings for permission copying
   let mut permission_copies = Vec::new();

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -444,9 +444,8 @@ impl ParserAndGenerator for CssParserAndGenerator {
               let convention_names = export_locals_convention(&name, convention);
               let convention_local_class = export_locals_convention(local_class, convention);
 
-              for (convention_name, local_class) in convention_names
-                .into_iter()
-                .zip(convention_local_class.into_iter())
+              for (convention_name, local_class) in
+                convention_names.into_iter().zip(convention_local_class)
               {
                 if let Some(existing) = exports.get(name.as_str())
                   && from.is_none()

--- a/crates/rspack_plugin_css_chunking/src/lib.rs
+++ b/crates/rspack_plugin_css_chunking/src/lib.rs
@@ -214,10 +214,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
 
   // Process through all modules
   let start = logger.time("process through all modules");
-  loop {
-    let Some(start_module_identifier) = remaining_modules.iter().next().copied() else {
-      break;
-    };
+  while let Some(start_module_identifier) = remaining_modules.iter().next().copied() {
     remaining_modules.shift_remove(&start_module_identifier);
 
     #[allow(clippy::unwrap_used)]

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -2793,8 +2793,8 @@ var {} = {{}};
     for chunk_link in link.values_mut() {
       let all_chunk_used_symbols = chunk_link
         .refs
-        .iter()
-        .filter_map(|(_, symbol_ref)| {
+        .values()
+        .filter_map(|symbol_ref| {
           if let Ref::Symbol(symbol_ref) = symbol_ref {
             Some(&symbol_ref.symbol)
           } else {

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -621,7 +621,7 @@ pub(crate) fn assign_dyn_import_chunk_short_names(compilation: &mut Compilation)
   }
 
   // Sort by module identifier for deterministic ordering
-  candidates.sort_by(|a, b| a.1.cmp(&b.1));
+  candidates.sort_by_key(|a| a.1);
 
   // Compute short names and track duplicates
   // name_to_chunks: maps base_name → list of (chunk_ukey, module_identifier) in sorted order

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -99,7 +99,7 @@ impl EsmLibraryPlugin {
     let mut modules_map = IdentifierIndexMap::default();
     let modules = module_graph.modules();
     let mut modules = modules.collect::<Vec<_>>();
-    modules.sort_by(|(m1, _), (m2, _)| m1.cmp(m2));
+    modules.sort_by_key(|(m1, _)| *m1);
     let logger = compilation.get_logger("rspack.EsmLibraryPlugin");
 
     for (idx, (module_identifier, module)) in modules.into_iter().enumerate() {
@@ -300,7 +300,7 @@ async fn finish_modules(
   let module_graph = compilation.get_module_graph();
   let mut modules_map = IdentifierIndexMap::default();
   let mut modules = module_graph.modules().collect::<Vec<_>>();
-  modules.sort_by(|(m1, _), (m2, _)| m1.cmp(m2));
+  modules.sort_by_key(|(m1, _)| *m1);
   let logger = compilation.get_logger("rspack.EsmLibraryPlugin");
 
   for (idx, (module_identifier, module)) in modules.into_iter().enumerate() {

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -308,7 +308,7 @@ var {} = {{}};
       .namespace_object_sources
       .iter()
       .collect::<Vec<_>>();
-    namespace_object_sources.sort_by(|(a, _), (b, _)| a.cmp(b));
+    namespace_object_sources.sort_by_key(|(a, _)| *a);
     for (_, namespace) in namespace_object_sources {
       render_source.add(RawStringSource::from(format!("{namespace}\n")));
     }

--- a/crates/rspack_plugin_extract_css/src/runtime.rs
+++ b/crates/rspack_plugin_extract_css/src/runtime.rs
@@ -165,7 +165,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
 
     let mut attr = String::default();
     let mut attributes: Vec<(&String, &String)> = self.attributes.iter().collect::<Vec<_>>();
-    attributes.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+    attributes.sort_unstable_by_key(|(k1, _)| *k1);
 
     for (attr_key, attr_value) in attributes {
       attr += &format!("linkTag.setAttribute({attr_key}, {attr_value});\n");

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -456,6 +456,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       return Some(create_error(msg));
     }
   }
+  #[allow(clippy::collapsible_match)]
   match exports_type {
     ExportsType::DefaultOnly => {
       if !ids.is_empty() && ids[0] != "default" {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
@@ -55,6 +55,7 @@ pub fn get_hoisted_declarations<'ast>(
     };
 
   while let Some(node) = stmt_stack.pop() {
+    #[allow(clippy::collapsible_match)]
     match node {
       Statement::Block(block) => {
         for s in &block.stmts {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -119,6 +119,7 @@ impl<'a> Visit for PureAnnotation<'a> {
 
   fn visit_stmt(&mut self, node: &Stmt) {
     if let Stmt::Decl(decl) = node {
+      #[allow(clippy::collapsible_match)]
       match decl {
         Decl::Fn(fn_decl) => {
           if has_no_side_effects_notation(self.parser.comments, fn_decl.span()) {
@@ -261,6 +262,7 @@ fn collect_exported_side_effects_free_refs(program: &Program) -> FxHashSet<Atom>
       continue;
     };
 
+    #[allow(clippy::collapsible_match)]
     match decl {
       ModuleDecl::ExportDecl(export_decl) => match &export_decl.decl {
         Decl::Fn(fn_decl) => {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1391,7 +1391,7 @@ impl ModuleConcatenationPlugin {
     // TODO(from webpack): Allow reusing existing configuration while trying to add dependencies.
     // This would improve performance. O(n^2) -> O(n)
     let start = logger.time("sort concat configurations");
-    concat_configurations.sort_by(|a, b| b.modules.len().cmp(&a.modules.len()));
+    concat_configurations.sort_by_key(|b| std::cmp::Reverse(b.modules.len()));
     logger.time_end(start);
 
     let mut used_modules = IdentifierSet::default();

--- a/crates/rspack_plugin_json/src/utils.rs
+++ b/crates/rspack_plugin_json/src/utils.rs
@@ -20,7 +20,7 @@ pub fn escape_json(input: &str) -> Cow<'_, str> {
     // "\u2028\u2029\u2028"
     // ```
     // The final vec would be `[(0, '\u{2028}'),(2, '\u{2028}'),(1, '\u{2029}'),]`
-    vec.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    vec.sort_unstable_by_key(|a| a.0);
     // Length of `\u2028` and `\u2029` are both 3 , and would be replaced by raw string `r#"\\u2028"#` or `r#"\\u2029"#`
     // which length is 7.That's why we need to allocate extra `vec.len() * (7 - 3)` bytes.
     let mut ret = String::with_capacity(input.len() + vec.len() * 4);

--- a/crates/rspack_plugin_mf/src/manifest/mod.rs
+++ b/crates/rspack_plugin_mf/src/manifest/mod.rs
@@ -375,7 +375,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         shared_module_targets
           .entry(pkg.clone())
           .or_default()
-          .extend(target_ids.into_iter());
+          .extend(target_ids);
         let entry = ensure_shared_entry(&mut shared_map, &container_name, &pkg);
         if entry.requiredVersion.is_none() && required.is_some() {
           entry.requiredVersion = required;

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -137,10 +137,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   let mut computed_hashes = HashSet::default();
   let mut top_task = ordered_hashes_iter.next();
 
-  loop {
-    let Some(top) = top_task else {
-      break;
-    };
+  while let Some(top) = top_task {
     let mut batch = vec![top];
     top_task = None;
 

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -211,6 +211,7 @@ async fn runtime_requirements_in_tree(
   };
 
   let runtime_template = compilation.runtime_template.create_runtime_code_template();
+  #[allow(clippy::collapsible_match)]
   for runtime_requirement in runtime_requirements.iter() {
     match runtime_requirement {
       RuntimeGlobals::ASYNC_MODULE => {

--- a/crates/rspack_tools/src/compare/mod.rs
+++ b/crates/rspack_tools/src/compare/mod.rs
@@ -16,10 +16,7 @@ pub fn find_relative_cache_path(root_path: &Utf8PathBuf) -> HashSet<String> {
   let mut relative_paths = HashSet::default();
   let mut queue = VecDeque::new();
   queue.push_back(root_path.clone());
-  loop {
-    let Some(path) = queue.pop_front() else {
-      break;
-    };
+  while let Some(path) = queue.pop_front() {
     if matches!(path.file_name(), Some("rspack")) {
       relative_paths.insert(
         path

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 profile = "default"
 components = ["rust-src"]
 # Use nightly for better access to the latest Rust features.
-channel = "nightly-2025-11-13"
+channel = "nightly-2026-04-16"


### PR DESCRIPTION
## Summary

Code updates:
1. `crates/rspack_binding_api/src/dependency.rs`: refers to https://github.com/metrics-rs/metrics/pull/564
2. Fix clippy

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
