### PR TITLE
feat(rsc): collect client component css files

### DIFF
--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -40,7 +40,8 @@ pub struct RscClientPlugin {
 fn extend_required_chunks(
   chunk_group: &ChunkGroup,
   compilation: &Compilation,
-  required_chunks: &mut Vec<String>,
+  required_chunks: &mut FxIndexSet<String>,
+  required_css_chunks: &mut FxIndexSet<String>,
 ) {
   for chunk_ukey in &chunk_group.chunks {
     let Some(chunk) = compilation
@@ -53,7 +54,11 @@ fn extend_required_chunks(
     let Some(chunk_id) = chunk.id() else {
       continue;
     };
-    for file in chunk.files().iter().filter(|f| f.ends_with(".js")) {
+    for file in chunk
+      .files()
+      .iter()
+      .filter(|file| file.ends_with(".js") || file.ends_with(".css"))
+    {
       if let Some(asset) = compilation.assets().get(file) {
         let asset_info = asset.get_info();
         if asset_info.hot_module_replacement.unwrap_or(false)
@@ -62,13 +67,17 @@ fn extend_required_chunks(
           continue;
         }
       };
-      required_chunks.push(chunk_id.to_string());
-      // We encode the file as a URI because our server (and many other services such as S3)
-      // expect to receive reserved characters such as `[` and `]` as encoded. This was
-      // previously done for dynamic chunks by patching the Rspack runtime but we want
-      // these filenames to be managed by React's Flight runtime instead and so we need
-      // to implement any special handling of the file name here.
-      required_chunks.push(encode_uri_path(file));
+      if file.ends_with(".js") {
+        required_chunks.insert(chunk_id.to_string());
+        // We encode the file as a URI because our server (and many other services such as S3)
+        // expect to receive reserved characters such as `[` and `]` as encoded. This was
+        // previously done for dynamic chunks by patching the Rspack runtime but we want
+        // these filenames to be managed by React's Flight runtime instead and so we need
+        // to implement any special handling of the file name here.
+        required_chunks.insert(encode_uri_path(file));
+      } else {
+        required_css_chunks.insert(encode_uri_path(file));
+      }
     }
   }
 }
@@ -80,7 +89,8 @@ fn record_module(
   module_identifier: &ModuleIdentifier,
   chunk_ukey: &ChunkUkey,
   compilation: &Compilation,
-  required_chunks: &[String],
+  required_chunks: &FxIndexSet<String>,
+  required_css_chunks: &FxIndexSet<String>,
   entry_state: &mut EntryState,
 ) {
   let Some(module) = compilation.module_by_identifier(module_identifier) else {
@@ -139,7 +149,8 @@ fn record_module(
     ManifestExport {
       id: module_id.to_string(),
       name: "*".to_string(),
-      chunks: required_chunks.to_vec(),
+      chunks: required_chunks.iter().cloned().collect(),
+      css_files: required_css_chunks.iter().cloned().collect(),
       r#async: Some(is_async),
     },
   );
@@ -151,7 +162,8 @@ fn record_chunk_group(
   client_entry_modules: &IdentifierSet,
   chunk_group: &ChunkGroup,
   compilation: &Compilation,
-  required_chunks: &mut Vec<String>,
+  required_chunks: &mut FxIndexSet<String>,
+  required_css_chunks: &mut FxIndexSet<String>,
   checked_chunk_groups: &mut FxHashSet<ChunkGroupUkey>,
   checked_chunks: &mut FxHashSet<ChunkUkey>,
   entry_state: &mut EntryState,
@@ -201,6 +213,7 @@ fn record_chunk_group(
           chunk_ukey,
           compilation,
           required_chunks,
+          required_css_chunks,
           entry_state,
         );
       } else {
@@ -211,6 +224,7 @@ fn record_chunk_group(
           chunk_ukey,
           compilation,
           required_chunks,
+          required_css_chunks,
           entry_state,
         );
       }
@@ -227,18 +241,21 @@ fn record_chunk_group(
       continue;
     };
     let start_len = required_chunks.len();
-    extend_required_chunks(child, compilation, required_chunks);
+    let start_css_len = required_css_chunks.len();
+    extend_required_chunks(child, compilation, required_chunks, required_css_chunks);
     record_chunk_group(
       module_loading,
       client_entry_modules,
       child,
       compilation,
       required_chunks,
+      required_css_chunks,
       checked_chunk_groups,
       checked_chunks,
       entry_state,
     );
     required_chunks.truncate(start_len);
+    required_css_chunks.truncate(start_css_len);
   }
 }
 
@@ -435,7 +452,8 @@ impl RscClientPlugin {
       }
     }
 
-    let mut required_chunks: Vec<String> = Default::default();
+    let mut required_chunks: FxIndexSet<String> = Default::default();
+    let mut required_css_chunks: FxIndexSet<String> = Default::default();
     let mut checked_chunk_groups: FxHashSet<ChunkGroupUkey> = Default::default();
     let mut checked_chunks: FxHashSet<ChunkUkey> = Default::default();
 
@@ -457,6 +475,7 @@ impl RscClientPlugin {
       };
 
       required_chunks.clear();
+      required_css_chunks.clear();
       checked_chunk_groups.clear();
       checked_chunks.clear();
 
@@ -466,6 +485,7 @@ impl RscClientPlugin {
         entrypoint,
         compilation,
         &mut required_chunks,
+        &mut required_css_chunks,
         &mut checked_chunk_groups,
         &mut checked_chunks,
         entry_state,

--- a/crates/rspack_plugin_rsc/src/reference_manifest.rs
+++ b/crates/rspack_plugin_rsc/src/reference_manifest.rs
@@ -20,8 +20,12 @@ pub struct ManifestExport {
   pub id: String,
   /// Export name
   pub name: String,
-  /// Chunks for the module. JS and CSS.
+  /// JavaScript chunks for the module.
   pub chunks: Vec<String>,
+  /// CSS files required by the module.
+  #[serde(rename = "cssFiles")]
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  pub css_files: Vec<String>,
   /// If chunk contains async module
   #[serde(skip_serializing_if = "Option::is_none")]
   pub r#async: Option<bool>,
@@ -122,6 +126,7 @@ fn build_server_manifest_per_entry(
                 // Server Action modules serve as endpoints rather than code splitting points,
                 // so ensuring chunk loading at runtime is unnecessary.
                 chunks: vec![],
+                css_files: vec![],
                 r#async: Some(ModuleGraph::is_async(
                   &compilation.async_modules_artifact,
                   &module.identifier(),
@@ -212,6 +217,7 @@ pub fn build_server_consumer_module_map(
       id: module_id.to_string(),
       name: "*".to_string(),
       chunks: vec![],
+      css_files: vec![],
       r#async: Some(ModuleGraph::is_async(
         &compilation.async_modules_artifact,
         &module.identifier(),

--- a/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
@@ -8,6 +8,7 @@ export interface RscManifestExport {
   id: string;
   name: string;
   chunks: string[];
+  cssFiles?: string[];
   async?: boolean;
 }
 

--- a/tests/rspack-test/configCases/rsc-plugin/on-manifest/rspack.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/on-manifest/rspack.config.js
@@ -82,6 +82,7 @@ module.exports = [
           expect(mainEntry.moduleLoading.prefix).toBe('/');
           expect(mainEntry).toHaveProperty('serverManifest');
           expect(mainEntry).toHaveProperty('clientManifest');
+          expect(mainEntry).not.toHaveProperty('clientCssManifest');
           expect(mainEntry).toHaveProperty('serverConsumerModuleMap');
           expect(mainEntry).toHaveProperty('entryCssFiles');
           expect(mainEntry).toHaveProperty('entryJsFiles');
@@ -93,6 +94,26 @@ module.exports = [
           const clientManifestExport = mainEntry.clientManifest[clientPath];
           expect(clientManifestExport.id).toBe(clientModuleId);
           expect(clientManifestExport.name).toBe('*');
+          expect(clientManifestExport.chunks.length % 2).toBe(0);
+          expect(clientManifestExport.chunks).toEqual([
+            ...new Set(clientManifestExport.chunks),
+          ]);
+          expect(
+            clientManifestExport.chunks.every(
+              (chunk, index) => index % 2 === 0 || chunk.endsWith('.js'),
+            ),
+          ).toBe(true);
+          expect(clientManifestExport).toHaveProperty('cssFiles');
+          const clientCssFiles = clientManifestExport.cssFiles;
+          expect(clientCssFiles).toEqual([
+            expect.stringMatching(/^src_Client_js\..*\.css$/),
+          ]);
+          expect(clientCssFiles).toEqual([...new Set(clientCssFiles)]);
+          expect(
+            clientCssFiles.some((cssFile) =>
+              clientManifestExport.chunks.includes(cssFile),
+            ),
+          ).toBe(false);
 
           expect(mainEntry.serverConsumerModuleMap[clientModuleId]).toEqual({
             '*': {

--- a/tests/rspack-test/configCases/rsc-plugin/on-manifest/src/Client.css
+++ b/tests/rspack-test/configCases/rsc-plugin/on-manifest/src/Client.css
@@ -1,0 +1,3 @@
+.client-button {
+	color: green;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/on-manifest/src/Client.js
+++ b/tests/rspack-test/configCases/rsc-plugin/on-manifest/src/Client.js
@@ -1,5 +1,6 @@
 'use client';
 
+import './Client.css';
 import { add, del, get, update } from './actions';
 
 export const Client = () => {
@@ -11,7 +12,7 @@ export const Client = () => {
     }
 
     return (
-        <button type="button" onClick={onClick}>
+        <button className="client-button" type="button" onClick={onClick}>
             Run actions
         </button>
     );


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR adds CSS asset metadata for RSC client components so SSR can discover and preload the CSS required by rendered client components.

- Add `cssFiles` to each RSC `clientManifest` entry for client component CSS assets.
- Keep `clientManifest[*].chunks` JS-only, so CSS files are not treated as script chunks by React/Rspack runtime loading.
- Update the RSC manifest typing and `onManifest` test coverage to assert that client component CSS is emitted through `clientManifest[*].cssFiles`.
- Align with the React-side change that adds `onClientReference` support in `react-server-dom-rspack`, allowing SSR consumers to observe used client references and their dependencies.

Related React change: [facebook/react#35473 commit f5b6240](https://github.com/facebook/react/pull/35473/changes/f5b62403a2935362a2dbf8bd68a64757ec9b7ccf)

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
