### PR TITLE
chore(ci): use ci profile for binary size-limit job to speed up build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
 
   size-limit:
     name: Binary Size Limit
-    needs: [check-changed]
+    needs: [check-changed, build-linux]
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'pull_request' }}
     uses: ./.github/workflows/size-limit.yml
 

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -14,45 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Pnpm Setup
-        uses: ./.github/actions/pnpm/setup
-
-      - name: Install Binding Dependencies
-        run: |
-          cd ./crates/node_binding
-          pnpm i --ignore-workspace --no-lockfile
-          cd ../../
-
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
+      - name: Download binding artifact
+        uses: ./.github/actions/artifact/download
         with:
-          key: x86_64-unknown-linux-gnu-ci
-          # don't need use cache in self-hosted windows; benefits of build with cargo build are wasted by cache restore
-          save-if: ${{ runner.environment != 'self-hosted'  || runner.os != 'Windows' }}
-
-      # setup rust target for native runner
-      - name: Setup Rust Target
-        run: rustup target add x86_64-unknown-linux-gnu
-
-      - name: Run Cargo codegen
-        run: cargo codegen
-
-      - name: Trim paths
-        run: |
-          echo $'\n' >> .cargo/config.toml
-          echo 'trim-paths = true' >> .cargo/config.toml
-
-      # Fix: Resolve disk space error "ENOSPC: no space left on device" on GitHub Actions runners
-      - name: Free disk cache
-        if: runner.environment == 'github-hosted'
-        uses: xc2/free-disk-space@fbe203b3788f2bebe2c835a15925da303eaa5efe # v1.0.0
-        with:
-          tool-cache: fals
-
-      - name: Build x86_64-unknown-linux-gnu native
-        run: |
-          rustup target add x86_64-unknown-linux-gnu
-          RUST_TARGET=x86_64-unknown-linux-gnu pnpm build:binding:ci
+          name: bindings-x86_64-unknown-linux-gnu
+          path: crates/node_binding/
 
       - name: Binary Size-limit
         uses: ./.github/actions/binary-limit

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:
-          key: x86_64-unknown-linux-gnu-release
+          key: x86_64-unknown-linux-gnu-ci
           # don't need use cache in self-hosted windows; benefits of build with cargo build are wasted by cache restore
           save-if: ${{ runner.environment != 'self-hosted'  || runner.os != 'Windows' }}
 
@@ -52,7 +52,7 @@ jobs:
       - name: Build x86_64-unknown-linux-gnu native
         run: |
           rustup target add x86_64-unknown-linux-gnu
-          RUST_TARGET=x86_64-unknown-linux-gnu pnpm build:binding:release
+          RUST_TARGET=x86_64-unknown-linux-gnu pnpm build:binding:ci
 
       - name: Binary Size-limit
         uses: ./.github/actions/binary-limit

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -20,6 +20,10 @@ jobs:
           name: bindings-x86_64-unknown-linux-gnu
           path: crates/node_binding/
 
+      # ci profile builds with strip=false, strip here for accurate size comparison
+      - name: Strip binary
+        run: strip crates/node_binding/rspack.linux-x64-gnu.node
+
       - name: Binary Size-limit
         uses: ./.github/actions/binary-limit
         with:


### PR DESCRIPTION
## Summary

- Switch the binary size-limit CI job from `release` profile to `ci` profile
- The `ci` profile (`opt-level=2`, `lto=false`, `codegen-units=256`) builds significantly faster than `release` (`opt-level=3`, `lto=true`, `codegen-units=1`)
- Size comparison remains valid since both PR head and base will use the same profile

## Test plan

- [ ] Verify the size-limit job completes successfully with the `ci` profile
- [ ] Confirm build time is reduced compared to previous runs with `release` profile