### PR TITLE
feat(create-rspack): add optional agent skills

### DIFF
--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -24,7 +24,7 @@
     "dev": "rslib build -w"
   },
   "dependencies": {
-    "create-rstack": "1.9.1"
+    "create-rstack": "2.0.0"
   },
   "devDependencies": {
     "@rslib/core": "0.21.0",

--- a/packages/create-rspack/src/index.ts
+++ b/packages/create-rspack/src/index.ts
@@ -101,4 +101,23 @@ create({
       },
     },
   ],
+  extraSkills: [
+    {
+      value: 'rspack-best-practices',
+      label: 'Rspack best practices',
+      source: 'rstackjs/agent-skills',
+    },
+    {
+      value: 'rstest-best-practices',
+      label: 'Rstest best practices',
+      source: 'rstackjs/agent-skills',
+      when: ({ tools }) => tools.includes('rstest'),
+    },
+    {
+      value: 'vercel-react-best-practices',
+      label: 'React best practices',
+      source: 'vercel-labs/agent-skills',
+      when: ({ templateName }) => templateName.startsWith('react-'),
+    },
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,8 +227,8 @@ importers:
   packages/create-rspack:
     dependencies:
       create-rstack:
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
       '@rslib/core':
         specifier: 0.21.0
@@ -4141,8 +4141,8 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  create-rstack@1.9.1:
-    resolution: {integrity: sha512-93fIyIqIrwisw7IvjwZ1NhaE58xylnpWPK1JIZaTRtNDRSwWtdAyGbP9HuACU4rZm/HohN8BU7DAmxGbPK9CBA==}
+  create-rstack@2.0.0:
+    resolution: {integrity: sha512-4VCqXXBL94CoogOFwCA1DHAg6q4MMSXqMkr7daIQLfQnvcl5UHyTzFVxXyjU2rp4eNaDGMgWZWmBE4dEDdBVnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   cross-env@10.1.0:
@@ -11016,7 +11016,7 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  create-rstack@1.9.1: {}
+  create-rstack@2.0.0: {}
 
   cross-env@10.1.0:
     dependencies:
@@ -14112,7 +14112,7 @@ snapshots:
   rsbuild-plugin-dts@0.21.0(@rsbuild/core@2.0.0-rc.1)(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.0-rc.1(@module-federation/runtime-tools@2.3.1)(core-js@3.49.0)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@module-federation/runtime-tools@2.3.1)(core-js@3.49.0)
     optionalDependencies:
       typescript: 6.0.2
 


### PR DESCRIPTION
## Summary

- upgrade `create-rstack` to `2.0.0` so `create-rspack` can use the new `extraSkills` support
- add optional Rspack, Rstest, and React best-practice skills based on the selected template and tools

## Related links

- https://github.com/rstackjs/create-rstack/releases/tag/v2.0.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
