### PR TITLE
fix: rspack sources cache save and recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5208,10 +5208,10 @@ dependencies = [
 [[package]]
 name = "rspack_sources"
 version = "0.4.20"
-source = "git+https://github.com/rstackjs/rspack-sources?branch=expose-inner#8d30ea97045aa5c519573e7426fb163a3104c698"
 dependencies = [
  "dyn-clone",
  "memchr",
+ "rkyv 0.8.8",
  "rustc-hash",
  "serde",
  "simd-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5207,7 +5207,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.4.20"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58a15922f723c63a408f81a7813cfe5133578057c6b9d94e94b29b3e29f51dd"
 dependencies = [
  "dyn-clone",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5207,9 +5207,8 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97367a339185ad36f3666f843a3cdaa4daec911e6cdc0274355876b7145ba69c"
+version = "0.4.20"
+source = "git+https://github.com/rstackjs/rspack-sources?branch=expose-inner#8d30ea97045aa5c519573e7426fb163a3104c698"
 dependencies = [
  "dyn-clone",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ regex               = { version = "1.12.3", default-features = false, features =
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.8.0", default-features = false }
-rspack_sources      = { version = "=0.4.21", default-features = false }
+rspack_sources      = { git = "https://github.com/rstackjs/rspack-sources", branch = "expose-inner", default-features = false }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ regex               = { version = "1.12.3", default-features = false, features =
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.8.0", default-features = false }
-rspack_sources      = { path = "/Users/bytedance/GitHub/rspack-sources", default-features = false, features = ["rspack_cacheable"] }
+rspack_sources      = { version = "=0.4.22", default-features = false, features = ["rspack_cacheable"] }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ regex               = { version = "1.12.3", default-features = false, features =
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.8.0", default-features = false }
-rspack_sources      = { git = "https://github.com/rstackjs/rspack-sources", branch = "expose-inner", default-features = false }
+rspack_sources      = { path = "/Users/bytedance/GitHub/rspack-sources", default-features = false, features = ["rspack_cacheable"] }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }

--- a/crates/rspack_cacheable/src/with/as_preset/rspack_sources/mod.rs
+++ b/crates/rspack_cacheable/src/with/as_preset/rspack_sources/mod.rs
@@ -1,5 +1,3 @@
-use std::panic;
-
 use rkyv::{
   Archive, Archived, Deserialize, Place, Resolver, Serialize,
   rancor::Fallible,
@@ -27,17 +25,17 @@ pub struct CacheableReplacement {
 
 #[cacheable(crate=crate)]
 pub enum CacheableSource {
-  RawBufferSource {
+  RawBuffer {
     buffer: Vec<u8>,
   },
-  RawStringSource {
+  RawString {
     value: String,
   },
-  OriginalSource {
+  Original {
     value: String,
     name: String,
   },
-  SourceMapSource {
+  SourceMap {
     value: String,
     name: String,
     source_map: String,
@@ -45,16 +43,16 @@ pub enum CacheableSource {
     inner_source_map: Option<String>,
     remove_original_source: bool,
   },
-  ConcatSource {
+  Concat {
     #[cacheable(omit_bounds)]
     children: Vec<CacheableSource>,
   },
-  ReplaceSource {
+  Replace {
     #[cacheable(omit_bounds)]
     inner: Box<CacheableSource>,
     replacements: Vec<CacheableReplacement>,
   },
-  CachedSource {
+  Cached {
     #[cacheable(omit_bounds)]
     inner: Box<CacheableSource>,
   },
@@ -78,32 +76,32 @@ impl ArchiveWith<BoxSource> for AsPreset {
 
 fn to_cacheable(source: &dyn Source) -> CacheableSource {
   if let Some(s) = source.as_any().downcast_ref::<CachedSource>() {
-    return CacheableSource::CachedSource {
+    return CacheableSource::Cached {
       inner: Box::new(to_cacheable(s.inner().as_ref())),
     };
   }
 
   if let Some(s) = source.as_any().downcast_ref::<OriginalSource>() {
-    return CacheableSource::OriginalSource {
+    return CacheableSource::Original {
       value: s.value().to_string(),
       name: s.name().to_string(),
     };
   }
 
   if let Some(s) = source.as_any().downcast_ref::<RawStringSource>() {
-    return CacheableSource::RawStringSource {
+    return CacheableSource::RawString {
       value: s.source().into_string_lossy().into_owned(),
     };
   }
 
   if let Some(s) = source.as_any().downcast_ref::<RawBufferSource>() {
-    return CacheableSource::RawBufferSource {
+    return CacheableSource::RawBuffer {
       buffer: s.buffer().into_owned(),
     };
   }
 
   if let Some(s) = source.as_any().downcast_ref::<SourceMapSource>() {
-    return CacheableSource::SourceMapSource {
+    return CacheableSource::SourceMap {
       value: s.value().to_string(),
       name: s.name().to_string(),
       source_map: s.source_map().to_json(),
@@ -114,7 +112,7 @@ fn to_cacheable(source: &dyn Source) -> CacheableSource {
   }
 
   if let Some(s) = source.as_any().downcast_ref::<ConcatSource>() {
-    return CacheableSource::ConcatSource {
+    return CacheableSource::Concat {
       children: s
         .children()
         .iter()
@@ -139,7 +137,7 @@ fn to_cacheable(source: &dyn Source) -> CacheableSource {
         },
       })
       .collect();
-    return CacheableSource::ReplaceSource {
+    return CacheableSource::Replace {
       inner: Box::new(to_cacheable(s.inner().as_ref())),
       replacements,
     };
@@ -178,10 +176,10 @@ where
 
 fn from_cacheable(cacheable: CacheableSource) -> BoxSource {
   match cacheable {
-    CacheableSource::RawBufferSource { buffer } => RawBufferSource::from(buffer).boxed(),
-    CacheableSource::RawStringSource { value } => RawStringSource::from(value).boxed(),
-    CacheableSource::OriginalSource { value, name } => OriginalSource::new(value, name).boxed(),
-    CacheableSource::SourceMapSource {
+    CacheableSource::RawBuffer { buffer } => RawBufferSource::from(buffer).boxed(),
+    CacheableSource::RawString { value } => RawStringSource::from(value).boxed(),
+    CacheableSource::Original { value, name } => OriginalSource::new(value, name).boxed(),
+    CacheableSource::SourceMap {
       value,
       name,
       source_map,
@@ -189,7 +187,7 @@ fn from_cacheable(cacheable: CacheableSource) -> BoxSource {
       inner_source_map,
       remove_original_source,
     } => {
-      let source_map = SourceMap::from_json(&source_map).expect("invalid cached source map JSON");
+      let source_map = SourceMap::from_json(&source_map).expect("invalid source map JSON");
       let inner_source_map = inner_source_map.and_then(|json| SourceMap::from_json(&json).ok());
       SourceMapSource::new(SourceMapSourceOptions {
         value,
@@ -201,11 +199,11 @@ fn from_cacheable(cacheable: CacheableSource) -> BoxSource {
       })
       .boxed()
     }
-    CacheableSource::ConcatSource { children } => {
+    CacheableSource::Concat { children } => {
       let children: Vec<BoxSource> = children.into_iter().map(from_cacheable).collect();
       ConcatSource::new(children).boxed()
     }
-    CacheableSource::ReplaceSource {
+    CacheableSource::Replace {
       inner,
       replacements,
     } => {
@@ -222,6 +220,6 @@ fn from_cacheable(cacheable: CacheableSource) -> BoxSource {
       }
       source.boxed()
     }
-    CacheableSource::CachedSource { inner } => CachedSource::new(from_cacheable(*inner)).boxed(),
+    CacheableSource::Cached { inner } => CachedSource::new(from_cacheable(*inner)).boxed(),
   }
 }

--- a/crates/rspack_cacheable/src/with/as_preset/rspack_sources/mod.rs
+++ b/crates/rspack_cacheable/src/with/as_preset/rspack_sources/mod.rs
@@ -4,59 +4,13 @@ use rkyv::{
   ser::{Allocator, Writer},
   with::{ArchiveWith, DeserializeWith, SerializeWith},
 };
-use rspack_cacheable_macros::enable_cacheable as cacheable;
 use rspack_sources::{
-  BoxSource, CachedSource, ConcatSource, OriginalSource, RawBufferSource, RawStringSource,
-  ReplaceSource, ReplacementEnforce, Source, SourceExt, SourceMap, SourceMapSource,
-  SourceMapSourceOptions,
+  BoxSource,
+  cacheable::{CacheableSource, from_cacheable, to_cacheable},
 };
 
 use super::AsPreset;
 use crate::{Error, Result};
-
-#[cacheable(crate=crate)]
-pub struct CacheableReplacement {
-  start: u32,
-  end: u32,
-  content: String,
-  name: Option<String>,
-  enforce: u8, // 0 = Pre, 1 = Normal, 2 = Post
-}
-
-#[cacheable(crate=crate)]
-pub enum CacheableSource {
-  RawBuffer {
-    buffer: Vec<u8>,
-  },
-  RawString {
-    value: String,
-  },
-  Original {
-    value: String,
-    name: String,
-  },
-  SourceMap {
-    value: String,
-    name: String,
-    source_map: String,
-    original_source: Option<String>,
-    inner_source_map: Option<String>,
-    remove_original_source: bool,
-  },
-  Concat {
-    #[cacheable(omit_bounds)]
-    children: Vec<CacheableSource>,
-  },
-  Replace {
-    #[cacheable(omit_bounds)]
-    inner: Box<CacheableSource>,
-    replacements: Vec<CacheableReplacement>,
-  },
-  Cached {
-    #[cacheable(omit_bounds)]
-    inner: Box<CacheableSource>,
-  },
-}
 
 pub struct InnerResolver {
   source: CacheableSource,
@@ -72,80 +26,6 @@ impl ArchiveWith<BoxSource> for AsPreset {
     let InnerResolver { source, resolver } = resolver;
     source.resolve(resolver, out)
   }
-}
-
-fn to_cacheable(source: &dyn Source) -> CacheableSource {
-  if let Some(s) = source.as_any().downcast_ref::<CachedSource>() {
-    return CacheableSource::Cached {
-      inner: Box::new(to_cacheable(s.inner().as_ref())),
-    };
-  }
-
-  if let Some(s) = source.as_any().downcast_ref::<OriginalSource>() {
-    return CacheableSource::Original {
-      value: s.value().to_string(),
-      name: s.name().to_string(),
-    };
-  }
-
-  if let Some(s) = source.as_any().downcast_ref::<RawStringSource>() {
-    return CacheableSource::RawString {
-      value: s.source().into_string_lossy().into_owned(),
-    };
-  }
-
-  if let Some(s) = source.as_any().downcast_ref::<RawBufferSource>() {
-    return CacheableSource::RawBuffer {
-      buffer: s.buffer().into_owned(),
-    };
-  }
-
-  if let Some(s) = source.as_any().downcast_ref::<SourceMapSource>() {
-    return CacheableSource::SourceMap {
-      value: s.value().to_string(),
-      name: s.name().to_string(),
-      source_map: s.source_map().to_json(),
-      original_source: s.original_source().map(|v| v.to_string()),
-      inner_source_map: s.inner_source_map().map(|m| m.to_json()),
-      remove_original_source: s.remove_original_source(),
-    };
-  }
-
-  if let Some(s) = source.as_any().downcast_ref::<ConcatSource>() {
-    return CacheableSource::Concat {
-      children: s
-        .children()
-        .iter()
-        .map(|c| to_cacheable(c.as_ref()))
-        .collect(),
-    };
-  }
-
-  if let Some(s) = source.as_any().downcast_ref::<ReplaceSource>() {
-    let replacements = s
-      .replacements()
-      .iter()
-      .map(|r| CacheableReplacement {
-        start: r.start(),
-        end: r.end(),
-        content: r.content().to_string(),
-        name: r.name().map(|n| n.to_string()),
-        enforce: match r.enforce() {
-          ReplacementEnforce::Pre => 0,
-          ReplacementEnforce::Normal => 1,
-          ReplacementEnforce::Post => 2,
-        },
-      })
-      .collect();
-    return CacheableSource::Replace {
-      inner: Box::new(to_cacheable(s.inner().as_ref())),
-      replacements,
-    };
-  }
-
-  panic!(
-    "Unexpected source type in persistent cache serialization. All BoxSource instances should be one of the known rspack_sources types."
-  )
 }
 
 impl<S> SerializeWith<BoxSource, S> for AsPreset
@@ -171,55 +51,5 @@ where
   ) -> Result<BoxSource> {
     let cacheable: CacheableSource = field.deserialize(deserializer)?;
     Ok(from_cacheable(cacheable))
-  }
-}
-
-fn from_cacheable(cacheable: CacheableSource) -> BoxSource {
-  match cacheable {
-    CacheableSource::RawBuffer { buffer } => RawBufferSource::from(buffer).boxed(),
-    CacheableSource::RawString { value } => RawStringSource::from(value).boxed(),
-    CacheableSource::Original { value, name } => OriginalSource::new(value, name).boxed(),
-    CacheableSource::SourceMap {
-      value,
-      name,
-      source_map,
-      original_source,
-      inner_source_map,
-      remove_original_source,
-    } => {
-      let source_map = SourceMap::from_json(&source_map).expect("invalid source map JSON");
-      let inner_source_map = inner_source_map.and_then(|json| SourceMap::from_json(&json).ok());
-      SourceMapSource::new(SourceMapSourceOptions {
-        value,
-        name,
-        source_map,
-        original_source: original_source.map(|s| s.into()),
-        inner_source_map,
-        remove_original_source,
-      })
-      .boxed()
-    }
-    CacheableSource::Concat { children } => {
-      let children: Vec<BoxSource> = children.into_iter().map(from_cacheable).collect();
-      ConcatSource::new(children).boxed()
-    }
-    CacheableSource::Replace {
-      inner,
-      replacements,
-    } => {
-      let inner = from_cacheable(*inner);
-      let mut source = ReplaceSource::new(inner);
-      for r in replacements {
-        let enforce = match r.enforce {
-          0 => ReplacementEnforce::Pre,
-          1 => ReplacementEnforce::Normal,
-          2 => ReplacementEnforce::Post,
-          _ => panic!("Invalid enforce value in cached replacement: {}", r.enforce),
-        };
-        source.replace_with_enforce(r.start, r.end, r.content, r.name, enforce);
-      }
-      source.boxed()
-    }
-    CacheableSource::Cached { inner } => CachedSource::new(from_cacheable(*inner)).boxed(),
   }
 }

--- a/crates/rspack_cacheable/src/with/as_preset/rspack_sources/mod.rs
+++ b/crates/rspack_cacheable/src/with/as_preset/rspack_sources/mod.rs
@@ -1,3 +1,5 @@
+use std::panic;
+
 use rkyv::{
   Archive, Archived, Deserialize, Place, Resolver, Serialize,
   rancor::Fallible,
@@ -6,17 +8,56 @@ use rkyv::{
 };
 use rspack_cacheable_macros::enable_cacheable as cacheable;
 use rspack_sources::{
-  BoxSource, ObjectPool, RawBufferSource, Source, SourceExt, SourceMap, SourceMapSource,
-  WithoutOriginalOptions,
+  BoxSource, CachedSource, ConcatSource, OriginalSource, RawBufferSource, RawStringSource,
+  ReplaceSource, ReplacementEnforce, Source, SourceExt, SourceMap, SourceMapSource,
+  SourceMapSourceOptions,
 };
 
 use super::AsPreset;
 use crate::{Error, Result};
 
 #[cacheable(crate=crate)]
-pub struct CacheableSource {
-  buffer: Vec<u8>,
-  map: Option<String>,
+pub struct CacheableReplacement {
+  start: u32,
+  end: u32,
+  content: String,
+  name: Option<String>,
+  enforce: u8, // 0 = Pre, 1 = Normal, 2 = Post
+}
+
+#[cacheable(crate=crate)]
+pub enum CacheableSource {
+  RawBufferSource {
+    buffer: Vec<u8>,
+  },
+  RawStringSource {
+    value: String,
+  },
+  OriginalSource {
+    value: String,
+    name: String,
+  },
+  SourceMapSource {
+    value: String,
+    name: String,
+    source_map: String,
+    original_source: Option<String>,
+    inner_source_map: Option<String>,
+    remove_original_source: bool,
+  },
+  ConcatSource {
+    #[cacheable(omit_bounds)]
+    children: Vec<CacheableSource>,
+  },
+  ReplaceSource {
+    #[cacheable(omit_bounds)]
+    inner: Box<CacheableSource>,
+    replacements: Vec<CacheableReplacement>,
+  },
+  CachedSource {
+    #[cacheable(omit_bounds)]
+    inner: Box<CacheableSource>,
+  },
 }
 
 pub struct InnerResolver {
@@ -35,18 +76,86 @@ impl ArchiveWith<BoxSource> for AsPreset {
   }
 }
 
+fn to_cacheable(source: &dyn Source) -> CacheableSource {
+  if let Some(s) = source.as_any().downcast_ref::<CachedSource>() {
+    return CacheableSource::CachedSource {
+      inner: Box::new(to_cacheable(s.inner().as_ref())),
+    };
+  }
+
+  if let Some(s) = source.as_any().downcast_ref::<OriginalSource>() {
+    return CacheableSource::OriginalSource {
+      value: s.value().to_string(),
+      name: s.name().to_string(),
+    };
+  }
+
+  if let Some(s) = source.as_any().downcast_ref::<RawStringSource>() {
+    return CacheableSource::RawStringSource {
+      value: s.source().into_string_lossy().into_owned(),
+    };
+  }
+
+  if let Some(s) = source.as_any().downcast_ref::<RawBufferSource>() {
+    return CacheableSource::RawBufferSource {
+      buffer: s.buffer().into_owned(),
+    };
+  }
+
+  if let Some(s) = source.as_any().downcast_ref::<SourceMapSource>() {
+    return CacheableSource::SourceMapSource {
+      value: s.value().to_string(),
+      name: s.name().to_string(),
+      source_map: s.source_map().to_json(),
+      original_source: s.original_source().map(|v| v.to_string()),
+      inner_source_map: s.inner_source_map().map(|m| m.to_json()),
+      remove_original_source: s.remove_original_source(),
+    };
+  }
+
+  if let Some(s) = source.as_any().downcast_ref::<ConcatSource>() {
+    return CacheableSource::ConcatSource {
+      children: s
+        .children()
+        .iter()
+        .map(|c| to_cacheable(c.as_ref()))
+        .collect(),
+    };
+  }
+
+  if let Some(s) = source.as_any().downcast_ref::<ReplaceSource>() {
+    let replacements = s
+      .replacements()
+      .iter()
+      .map(|r| CacheableReplacement {
+        start: r.start(),
+        end: r.end(),
+        content: r.content().to_string(),
+        name: r.name().map(|n| n.to_string()),
+        enforce: match r.enforce() {
+          ReplacementEnforce::Pre => 0,
+          ReplacementEnforce::Normal => 1,
+          ReplacementEnforce::Post => 2,
+        },
+      })
+      .collect();
+    return CacheableSource::ReplaceSource {
+      inner: Box::new(to_cacheable(s.inner().as_ref())),
+      replacements,
+    };
+  }
+
+  panic!(
+    "Unexpected source type in persistent cache serialization. All BoxSource instances should be one of the known rspack_sources types."
+  )
+}
+
 impl<S> SerializeWith<BoxSource, S> for AsPreset
 where
   S: Fallible<Error = Error> + Allocator + Writer,
 {
   fn serialize_with(field: &BoxSource, serializer: &mut S) -> Result<Self::Resolver> {
-    let map = field
-      .map(&ObjectPool::default(), &Default::default())
-      .map(|m| m.to_json());
-    let source = CacheableSource {
-      buffer: field.buffer().to_vec(),
-      map,
-    };
+    let source = to_cacheable(field.as_ref());
     Ok(InnerResolver {
       resolver: source.serialize(serializer)?,
       source,
@@ -62,19 +171,57 @@ where
     field: &Archived<CacheableSource>,
     deserializer: &mut D,
   ) -> Result<BoxSource> {
-    let CacheableSource { buffer, map } = field.deserialize(deserializer)?;
-    if let Some(map) = &map
-      && let Ok(source_map) = SourceMap::from_json(map)
-    {
-      return Ok(
-        SourceMapSource::new(WithoutOriginalOptions {
-          value: String::from_utf8_lossy(&buffer),
-          name: "persistent-cache",
-          source_map,
-        })
-        .boxed(),
-      );
+    let cacheable: CacheableSource = field.deserialize(deserializer)?;
+    Ok(from_cacheable(cacheable))
+  }
+}
+
+fn from_cacheable(cacheable: CacheableSource) -> BoxSource {
+  match cacheable {
+    CacheableSource::RawBufferSource { buffer } => RawBufferSource::from(buffer).boxed(),
+    CacheableSource::RawStringSource { value } => RawStringSource::from(value).boxed(),
+    CacheableSource::OriginalSource { value, name } => OriginalSource::new(value, name).boxed(),
+    CacheableSource::SourceMapSource {
+      value,
+      name,
+      source_map,
+      original_source,
+      inner_source_map,
+      remove_original_source,
+    } => {
+      let source_map = SourceMap::from_json(&source_map).expect("invalid cached source map JSON");
+      let inner_source_map = inner_source_map.and_then(|json| SourceMap::from_json(&json).ok());
+      SourceMapSource::new(SourceMapSourceOptions {
+        value,
+        name,
+        source_map,
+        original_source: original_source.map(|s| s.into()),
+        inner_source_map,
+        remove_original_source,
+      })
+      .boxed()
     }
-    Ok(RawBufferSource::from(buffer).boxed())
+    CacheableSource::ConcatSource { children } => {
+      let children: Vec<BoxSource> = children.into_iter().map(from_cacheable).collect();
+      ConcatSource::new(children).boxed()
+    }
+    CacheableSource::ReplaceSource {
+      inner,
+      replacements,
+    } => {
+      let inner = from_cacheable(*inner);
+      let mut source = ReplaceSource::new(inner);
+      for r in replacements {
+        let enforce = match r.enforce {
+          0 => ReplacementEnforce::Pre,
+          1 => ReplacementEnforce::Normal,
+          2 => ReplacementEnforce::Post,
+          _ => panic!("Invalid enforce value in cached replacement: {}", r.enforce),
+        };
+        source.replace_with_enforce(r.start, r.end, r.content, r.name, enforce);
+      }
+      source.boxed()
+    }
+    CacheableSource::CachedSource { inner } => CachedSource::new(from_cacheable(*inner)).boxed(),
   }
 }

--- a/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
@@ -62,9 +62,9 @@ module.exports = {
             expect(misses).toBe(2);
           }
           if (updateIndex === 1) {
-            // First hot build with same source content, module is recovered from cache.
-            expect(hits).toBe(1);
-            expect(misses).toBe(1);
+            // First hot build with same source content, all recovered from cache.
+            expect(hits).toBe(2);
+            expect(misses).toBe(0);
           }
           if (updateIndex === 2) {
             // Hot build with same source content.


### PR DESCRIPTION
## Summary

Follow up bugfix for https://github.com/web-infra-dev/rspack/pull/13706

Detailed bug:

Inconsistencies after restoring the persistent cache during the `make` phase lead to a massive cache miss when the minimize persistent cache processes the chunks. Modules restored from the persistent cache differ from those freshly built without a persistent cache.

For example, during the first build (a cold build without persistent cache), the module hash is `xxx`, but during the second build (a hot build with persistent cache), the module hash becomes `yyy`. This difference in module hashes alters the chunk content (such as the `fullhash`), which causes the minimize cache to miss. However, during the third build (a hot build with persistent cache), the module hash remains `yyy` (as expected).

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
