### PR TITLE
chore(ci): eco benchmark record ci/release binary size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name != 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,skipped,success' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success' }}
         run: echo "Tess Failed" && exit 1
 
       - name: No check to Run test
@@ -220,8 +220,7 @@ jobs:
 
   size-limit:
     name: Binary Size Limit
-    needs: [check-changed, build-linux]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'pull_request' }}
+    needs: [build-linux]
     uses: ./.github/workflows/size-limit.yml
 
   ecosystem_ci_per_commit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,13 +207,13 @@ jobs:
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name == 'pull_request'
           && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success' }}
-        run: echo "Tess Failed" && exit 1
+        run: echo "Test Failed" && exit 1
 
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name != 'pull_request'
           && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success' }}
-        run: echo "Tess Failed" && exit 1
+        run: echo "Test Failed" && exit 1
 
       - name: No check to Run test
         run: echo "Success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name != 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,skipped,success' }}
         run: echo "Test Failed" && exit 1
 
       - name: No check to Run test
@@ -220,6 +220,7 @@ jobs:
 
   size-limit:
     name: Binary Size Limit
+    if: ${{ github.event_name == 'pull_request' }}
     needs: [build-linux]
     uses: ./.github/workflows/size-limit.yml
 

--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -135,7 +135,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RSPACK_DIR=$(pwd)
-          git clone --single-branch --branch ci_profile  --depth 1 https://github.com/web-infra-dev/rspack-ecosystem-benchmark.git
+          git clone --single-branch --depth 1 https://github.com/web-infra-dev/rspack-ecosystem-benchmark.git
           cd rspack-ecosystem-benchmark
           pnpm i
           RSPACK_DIR="$RSPACK_DIR" node bin/cli.js bench

--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -37,6 +37,18 @@ jobs:
       profile: 'release'
       test: false
 
+  build-ci:
+    name: Build Linux CI Profile binding
+    if: github.repository == 'web-infra-dev/rspack'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      target: x86_64-unknown-linux-gnu
+      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS ||  '"ubuntu-22.04"' }}
+      ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/head', inputs.pr) || github.sha }}
+      profile: 'ci'
+      test: false
+      binding_postfix: '-ci'
+
   create-comment:
     if: github.repository == 'web-infra-dev/rspack'
     runs-on: ubuntu-latest
@@ -73,7 +85,7 @@ jobs:
 
   bench:
     if: github.repository == 'web-infra-dev/rspack'
-    needs: [build]
+    needs: [build, build-ci]
     runs-on: [self-hosted, benchmark]
     outputs:
       diff-result: ${{ steps.run-benchmark.outputs.diff-result }}
@@ -95,6 +107,15 @@ jobs:
           path: crates/node_binding/
           force-use-github-only: true
 
+      - name: Download CI profile bindings
+        uses: ./.github/actions/artifact/download
+        with:
+          name: bindings-x86_64-unknown-linux-gnu-ci
+          path: crates/node_binding/ci/
+          force-use-github-only: true
+      - name: strip CI binding
+        run: strip crates/node_binding/ci/rspack.linux-x64-gnu.node
+
       - name: Show restored binding
         shell: bash
         run: ls -lah crates/node_binding/*.node
@@ -114,7 +135,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RSPACK_DIR=$(pwd)
-          git clone --single-branch --depth 1 https://github.com/web-infra-dev/rspack-ecosystem-benchmark.git
+          git clone --single-branch --branch ci_profile  --depth 1 https://github.com/web-infra-dev/rspack-ecosystem-benchmark.git
           cd rspack-ecosystem-benchmark
           pnpm i
           RSPACK_DIR="$RSPACK_DIR" node bin/cli.js bench

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -16,7 +16,7 @@ on:
       ref: # Git reference to checkout
         required: false
         type: string
-      binding_postfix: # Git reference to checkout
+      binding_postfix: # specify extrat postfix for binding artifact
         required: false
         type: string
 

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -16,6 +16,10 @@ on:
       ref: # Git reference to checkout
         required: false
         type: string
+      binding_postfix: # Git reference to checkout
+        required: false
+        type: string
+
 env:
   # Since CI builds are more akin to from-scratch builds, incremental compilation adds unnecessary dependency-tracking and IO overhead, reducing caching effectiveness.
   # https://github.com/rust-lang/rust-analyzer/blob/25368d24308d6a94ffe8b99f0122bcf5a2175322/.github/workflows/ci.yaml#L11
@@ -175,13 +179,13 @@ jobs:
 
       - name: Diff artifact
         run: |
-          export EXCLUDE=":(exclude).cargo/config.toml" 
+          export EXCLUDE=":(exclude).cargo/config.toml"
           git diff --quiet -- . "$EXCLUDE" || (git diff --name-status -- . "$EXCLUDE" && exit 1)
 
       - name: Upload artifact
         uses: ./.github/actions/artifact/upload
         with:
-          name: bindings-${{ inputs.target }}
+          name: bindings-${{ inputs.target }}${{ inputs.binding_postfix}}
           path: |
             crates/node_binding/*.node
             crates/node_binding/*.d.ts

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -16,7 +16,7 @@ on:
       ref: # Git reference to checkout
         required: false
         type: string
-      binding_postfix: # specify extrat postfix for binding artifact
+      binding_postfix: # specify extra postfix for binding artifact
         required: false
         type: string
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -23,6 +23,9 @@ on:
       ref: # Git reference to checkout
         required: false
         type: string
+      binding_postfix: # specify binding with postfix for build mult profile in a workflow
+        required: false
+        type: string
 
 permissions:
   # Allow commenting on issues
@@ -36,6 +39,7 @@ jobs:
       runner: ${{ inputs.runner }}
       profile: ${{ inputs.profile }}
       ref: ${{ inputs.ref }}
+      binding_postfix: ${{ inputs.binding_postfix }}
   test:
     if: inputs.test
     needs: build

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -23,7 +23,7 @@ on:
       ref: # Git reference to checkout
         required: false
         type: string
-      binding_postfix: # specify binding with postfix for build mult profile in a workflow
+      binding_postfix: # Use when building multiple profiles in one workflow run; appends a postfix to the uploaded artifact name to distinguish each build.
         required: false
         type: string
 


### PR DESCRIPTION
## Summary

Extend the ecosystem-benchmark workflow to also build the `ci` profile binding alongside the existing `release` profile, so the benchmark job can record and compare binary sizes for both profiles.

### Changes

- **`reusable-build.yml` / `reusable-build-build.yml`**: add a new optional `binding_postfix` input. When provided, the uploaded artifact name becomes `bindings-<target><postfix>` instead of `bindings-<target>`.
- **`ecosystem-benchmark.yml`**:
  - Add a new `build-ci` job that builds the `ci` profile binding with `binding_postfix: '-ci'`.
  - The `bench` job now depends on both `build` and `build-ci`, downloads the `-ci` artifact into `crates/node_binding/ci/`, and strips the binary so its measured size reflects the shipped form.


### Why the `binding_postfix`?

GitHub Actions artifact names must be unique within a workflow run. Both build jobs target the same triple (`x86_64-unknown-linux-gnu`) and would otherwise upload to the same artifact name (`bindings-x86_64-unknown-linux-gnu`), causing an upload conflict. The `binding_postfix` input lets the caller disambiguate co-existing builds of different profiles in the same workflow without forking the reusable workflow.

## Related links

- Companion branch: [`web-infra-dev/rspack-ecosystem-benchmark@ci_profile`](https://github.com/web-infra-dev/rspack-ecosystem-benchmark/tree/ci_profile)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).