### PR TITLE
chore(ci): revert run size limit on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name != 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,skipped,success' }}
         run: echo "Test Failed" && exit 1
 
       - name: No check to Run test
@@ -220,7 +220,8 @@ jobs:
 
   size-limit:
     name: Binary Size Limit
-    needs: [build-linux]
+    needs: [check-changed, build-linux]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'pull_request' }}
     uses: ./.github/workflows/size-limit.yml
 
   ecosystem_ci_per_commit:


### PR DESCRIPTION
## Summary
We don't need it to run on main. It's expected to run on PR only.

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
