### PR TITLE
chore: update @rspack/dev-server to v2.0.0

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3"
+    "@rspack/dev-server": "^2.0.0"
   }
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3",
+    "@rspack/dev-server": "^2.0.0",
     "@rspack/plugin-react-refresh": "^2.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3",
+    "@rspack/dev-server": "^2.0.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/create-rspack/template-react-js/package.json
+++ b/packages/create-rspack/template-react-js/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3",
+    "@rspack/dev-server": "^2.0.0",
     "@rspack/plugin-react-refresh": "^2.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/packages/create-rspack/template-react-ts/package.json
+++ b/packages/create-rspack/template-react-ts/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3",
+    "@rspack/dev-server": "^2.0.0",
     "@rspack/plugin-react-refresh": "^2.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/packages/create-rspack/template-vanilla-js/package.json
+++ b/packages/create-rspack/template-vanilla-js/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3"
+    "@rspack/dev-server": "^2.0.0"
   }
 }

--- a/packages/create-rspack/template-vanilla-ts/package.json
+++ b/packages/create-rspack/template-vanilla-ts/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3",
+    "@rspack/dev-server": "^2.0.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/create-rspack/template-vue-js/package.json
+++ b/packages/create-rspack/template-vue-js/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3",
+    "@rspack/dev-server": "^2.0.0",
     "rspack-vue-loader": "^17.5.0"
   }
 }

--- a/packages/create-rspack/template-vue-ts/package.json
+++ b/packages/create-rspack/template-vue-ts/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3",
+    "@rspack/dev-server": "^2.0.0",
     "rspack-vue-loader": "^17.5.0",
     "typescript": "^6.0.3"
   }

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -37,7 +37,7 @@
     "@discoveryjs/json-ext": "^0.5.7",
     "@rslib/core": "0.21.2",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3",
+    "@rspack/dev-server": "^2.0.0",
     "@rspack/test-tools": "workspace:*",
     "cac": "^7.0.0",
     "concat-stream": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack
       '@rspack/dev-server':
-        specifier: 2.0.0-rc.3
-        version: 2.0.0-rc.3(@rspack/core@packages+rspack)(selfsigned@5.5.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rspack/core@packages+rspack)(selfsigned@5.5.0)
 
   examples/react:
     dependencies:
@@ -161,8 +161,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack
       '@rspack/dev-server':
-        specifier: 2.0.0-rc.3
-        version: 2.0.0-rc.3(@rspack/core@packages+rspack)(selfsigned@5.5.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rspack/core@packages+rspack)(selfsigned@5.5.0)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.0
         version: 2.0.0(@rspack/core@packages+rspack)(react-refresh@0.18.0)
@@ -188,8 +188,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack
       '@rspack/dev-server':
-        specifier: 2.0.0-rc.3
-        version: 2.0.0-rc.3(@rspack/core@packages+rspack)(selfsigned@5.5.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rspack/core@packages+rspack)(selfsigned@5.5.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -352,8 +352,8 @@ importers:
         specifier: workspace:*
         version: link:../rspack
       '@rspack/dev-server':
-        specifier: 2.0.0-rc.3
-        version: 2.0.0-rc.3(@rspack/core@packages+rspack)(selfsigned@5.5.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rspack/core@packages+rspack)(selfsigned@5.5.0)
       '@rspack/test-tools':
         specifier: workspace:*
         version: link:../rspack-test-tools
@@ -552,8 +552,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack
       '@rspack/dev-server':
-        specifier: 2.0.0-rc.3
-        version: 2.0.0-rc.3(@rspack/core@packages+rspack)(selfsigned@5.5.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rspack/core@packages+rspack)(selfsigned@5.5.0)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.0
         version: 2.0.0(@rspack/core@packages+rspack)(react-refresh@0.18.0)
@@ -3267,8 +3267,8 @@ packages:
       '@rspack/core':
         optional: true
 
-  '@rspack/dev-server@2.0.0-rc.3':
-    resolution: {integrity: sha512-05awfTvXy9ZgWsKnYR3oOoPGJ+XS0RN/mhfPfA9WmWCETG9+Wop/OkL54FgokSPG0nJInfU3byNskTdDFYY4eQ==}
+  '@rspack/dev-server@2.0.0':
+    resolution: {integrity: sha512-bSdIlt8Nq1Q2K0Gv+AMmETMKsLjEgTtL8DNlDtSe14cdtBrF0Z8kfpKUpgUKb5i0O7CZ5pmPzVwHZIEqMrCJNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rspack/core': ^2.0.0-0
@@ -10155,7 +10155,7 @@ snapshots:
     optionalDependencies:
       '@rspack/core': link:packages/rspack
 
-  '@rspack/dev-server@2.0.0-rc.3(@rspack/core@packages+rspack)(selfsigned@5.5.0)':
+  '@rspack/dev-server@2.0.0(@rspack/core@packages+rspack)(selfsigned@5.5.0)':
     dependencies:
       '@rspack/core': link:packages/rspack
       '@rspack/dev-middleware': 2.0.1(@rspack/core@packages+rspack)

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -13,7 +13,7 @@
     "@playwright/test": "1.59.1",
     "core-js": "3.49.0",
     "@rspack/core": "workspace:*",
-    "@rspack/dev-server": "2.0.0-rc.3",
+    "@rspack/dev-server": "^2.0.0",
     "@rspack/plugin-react-refresh": "^2.0.0",
     "@module-federation/runtime-tools": "2.3.3",
     "@swc/helpers": "0.5.21",

--- a/website/docs/en/guide/migration/rspack_1.x.mdx
+++ b/website/docs/en/guide/migration/rspack_1.x.mdx
@@ -31,7 +31,7 @@ After installation, let the agent guide you through the upgrade.
   "devDependencies": {
     "@rspack/core": "^2.0.0-rc.0",
     "@rspack/cli": "^2.0.0-rc.0",
-    "@rspack/dev-server": "^2.0.0-rc.0",
+    "@rspack/dev-server": "^2.0.0",
     "@rspack/plugin-react-refresh": "^2.0.0"
   }
 }

--- a/website/docs/zh/guide/migration/rspack_1.x.mdx
+++ b/website/docs/zh/guide/migration/rspack_1.x.mdx
@@ -31,7 +31,7 @@ npx skills add rstackjs/agent-skills --skill rspack-v2-upgrade
   "devDependencies": {
     "@rspack/core": "^2.0.0-rc.0",
     "@rspack/cli": "^2.0.0-rc.0",
-    "@rspack/dev-server": "^2.0.0-rc.0",
+    "@rspack/dev-server": "^2.0.0",
     "@rspack/plugin-react-refresh": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Update all `@rspack/dev-server` references from the `2.0.0-rc` builds to `^2.0.0` across examples, create-rspack templates, the CLI package, and e2e fixtures.
- Refresh the v1-to-v2 migration docs so the stable dev-server version is shown in the upgrade examples.

## Related links

- https://github.com/rstackjs/rspack-dev-server/releases/tag/v2.0.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
