### PR TITLE
chore: limit tokio worker nums for all benchmarks

### DIFF
--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -13,6 +13,7 @@ default  = []
 
 [dependencies]
 criterion = { workspace = true }
+tokio     = { workspace = true }
 
 [dev-dependencies]
 # Make rust analyzer happy
@@ -32,7 +33,6 @@ rspack_tasks               = { workspace = true }
 rustc-hash                 = { workspace = true }
 serde_json                 = { workspace = true }
 swc_core                   = { workspace = true, features = ["__parser", "base"] }
-tokio                      = { workspace = true }
 
 [[bench]]
 harness = false

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -13,7 +13,6 @@ use rspack_core::{
 use rspack_error::Diagnostic;
 use rspack_fs::{MemoryFileSystem, WritableFileSystem};
 use rspack_tasks::{CURRENT_COMPILER_CONTEXT, within_compiler_context_for_testing_sync};
-use tokio::runtime::Builder;
 
 pub(crate) static NUM_MODULES: usize = 10000;
 
@@ -103,9 +102,7 @@ pub fn build_chunk_graph_benchmark(c: &mut Criterion) {
   })
 }
 pub fn build_chunk_graph_benchmark_inner(c: &mut Criterion) {
-  let rt = Builder::new_multi_thread()
-    .build()
-    .expect("should not fail to build tokio runtime");
+  let rt = rspack_benchmark::build_tokio_rt();
   let _guard = rt.enter();
 
   let fs = Arc::new(MemoryFileSystem::default());
@@ -227,9 +224,7 @@ pub fn build_module_graph_benchmark(c: &mut Criterion) {
 }
 
 pub fn build_module_graph_benchmark_inner(c: &mut Criterion) {
-  let rt = Builder::new_multi_thread()
-    .build()
-    .expect("should not fail to build tokio runtime");
+  let rt = rspack_benchmark::build_tokio_rt();
   let _guard = rt.enter();
 
   let fs = Arc::new(MemoryFileSystem::default());

--- a/xtask/benchmark/benches/groups/bundle.rs
+++ b/xtask/benchmark/benches/groups/bundle.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use criterion::{Criterion, criterion_group};
 use rspack_tasks::{CompilerContext, within_compiler_context, within_compiler_context_sync};
-use tokio::runtime;
 
 use crate::groups::bundle::util::{CompilerBuilderGenerator, derive_projects};
 
@@ -21,12 +20,7 @@ fn bundle_benchmark(c: &mut Criterion) {
   ];
 
   // Codspeed can only handle to up to 500 threads by default
-  let rt = runtime::Builder::new_multi_thread()
-    .worker_threads(8)
-    .max_blocking_threads(8)
-    .build()
-    .unwrap();
-
+  let rt = rspack_benchmark::build_tokio_rt();
   for (id, get_compiler) in derive_projects(projects) {
     group.bench_function(format!("bundle@{id}"), |b| {
       b.to_async(&rt).iter_batched(

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -35,7 +35,6 @@ use rspack_plugin_split_chunks::{
 };
 use rspack_tasks::within_compiler_context_for_testing_sync;
 use rustc_hash::FxHashMap;
-use tokio::runtime::Builder;
 
 use crate::groups::build_chunk_graph::prepare_large_code_splitting_case;
 
@@ -55,9 +54,7 @@ pub fn compilation_stages_benchmark(c: &mut Criterion) {
 }
 
 fn compilation_stages_benchmark_inner(c: &mut Criterion) {
-  let rt = Builder::new_multi_thread()
-    .build()
-    .expect("should not fail to build tokio runtime");
+  let rt = rspack_benchmark::build_tokio_rt();
   let _guard = rt.enter();
 
   flag_dependency_exports_benchmark(c, &rt);

--- a/xtask/benchmark/benches/groups/module_graph_api.rs
+++ b/xtask/benchmark/benches/groups/module_graph_api.rs
@@ -11,7 +11,6 @@ use rspack_core::{
 };
 use rspack_fs::{MemoryFileSystem, WritableFileSystem};
 use rspack_tasks::within_compiler_context_for_testing_sync;
-use tokio::runtime::Builder;
 
 use crate::groups::build_chunk_graph::{NUM_MODULES, prepare_large_code_splitting_case};
 
@@ -22,9 +21,7 @@ pub fn module_graph_api_benchmark(c: &mut Criterion) {
 }
 
 pub fn module_graph_api_benchmark_inner(c: &mut Criterion) {
-  let rt = Builder::new_multi_thread()
-    .build()
-    .expect("should not fail to build tokio runtime");
+  let rt = rspack_benchmark::build_tokio_rt();
   let _guard = rt.enter();
 
   let fs = Arc::new(MemoryFileSystem::default());

--- a/xtask/benchmark/benches/groups/persistent_cache.rs
+++ b/xtask/benchmark/benches/groups/persistent_cache.rs
@@ -15,7 +15,6 @@ use rspack_core::{
 };
 use rspack_fs::{MemoryFileSystem, NativeFileSystem};
 use rspack_tasks::{CompilerContext, within_compiler_context, within_compiler_context_sync};
-use tokio::runtime::Builder;
 
 use super::bundle::basic_react;
 
@@ -35,11 +34,7 @@ const UPDATED_TEXT: &str = "Hello from cache";
 // is covered by dedicated test cases elsewhere.
 pub fn persistent_cache_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("persistent_cache");
-  let rt = Builder::new_multi_thread()
-    .worker_threads(8)
-    .max_blocking_threads(8)
-    .build()
-    .unwrap();
+  let rt = rspack_benchmark::build_tokio_rt();
   let pending_cleanup = RefCell::new(Vec::new());
 
   group.bench_function(

--- a/xtask/benchmark/src/lib.rs
+++ b/xtask/benchmark/src/lib.rs
@@ -1,8 +1,12 @@
 #![allow(clippy::unwrap_used)]
 
-use std::alloc::{GlobalAlloc, Layout, System};
+use std::{
+  alloc::{GlobalAlloc, Layout, System},
+  thread,
+};
 
 pub use criterion::*;
+use tokio::runtime::{Builder, Runtime};
 
 #[global_allocator]
 static GLOBAL: NeverGrowInPlaceAllocator = NeverGrowInPlaceAllocator;
@@ -39,4 +43,15 @@ unsafe impl GlobalAlloc for NeverGrowInPlaceAllocator {
   unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
     unsafe { System.dealloc(ptr, layout) }
   }
+}
+
+pub fn build_tokio_rt() -> Runtime {
+  let cpu_num = thread::available_parallelism()
+    .expect("failed to get cpu num")
+    .get();
+  Builder::new_multi_thread()
+    .worker_threads(cpu_num.min(4))
+    .max_blocking_threads(8)
+    .build()
+    .expect("should not fail to build tokio runtime")
 }


### PR DESCRIPTION
## Summary

This may reduce the variance and speed up the benchmark CI

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
