### PR TITLE
fix(rstest): avoid async wrapper for sync mock factories

### DIFF
--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -65,16 +65,6 @@ pub struct RstestParserPlugin {
   options: RstestParserPluginOptions,
 }
 
-trait JavascriptParserExt<'a> {
-  fn handle_top_level_await(&mut self);
-}
-
-impl<'a> JavascriptParserExt<'a> for JavascriptParser<'a> {
-  fn handle_top_level_await(&mut self) {
-    self.build_meta.has_top_level_await = true;
-  }
-}
-
 impl RstestParserPlugin {
   pub fn new(options: RstestParserPluginOptions) -> Self {
     Self { options }
@@ -271,10 +261,6 @@ impl RstestParserPlugin {
         let first_arg_lit_str = self.handle_mock_first_arg(parser, call_expr);
 
         if let Some(lit_str) = first_arg_lit_str {
-          if hoist && method != MockMethod::Unmock && method != MockMethod::DoMock {
-            parser.handle_top_level_await();
-          }
-
           let dep = MockModuleIdDependency::new(
             lit_str.clone(),
             first_arg.span().into(),
@@ -329,10 +315,6 @@ impl RstestParserPlugin {
         let lit_str = self.handle_mock_first_arg(parser, call_expr);
 
         if let Some(lit_str) = lit_str {
-          if hoist {
-            parser.handle_top_level_await();
-          }
-
           let module_dep = MockModuleIdDependency::new(
             lit_str.clone(),
             first_arg.span().into(),

--- a/tests/rspack-test/configCases/rstest/mock/test.js
+++ b/tests/rspack-test/configCases/rstest/mock/test.js
@@ -1,10 +1,20 @@
 const path = require('path');
 const fs = require('fs');
 
-const file = path.resolve(__dirname, 'bundle1.js')
-const content = fs.readFileSync(file, 'utf-8');
+const file = path.resolve(__dirname, 'bundle1.js');
 
-it ('mocked modules should be hoisted', () => {
+it('mocked modules should be hoisted before user code', () => {
+	const content = fs.readFileSync(file, 'utf-8');
+	const firstMockHoist = content.indexOf('[Rstest mock hoist]');
 	const afterTopOfFile = content.indexOf('TOP_OF_FILE');
-	expect(afterTopOfFile).toBeGreaterThan(content.lastIndexOf('__webpack_require__.mock'));
-})
+
+	expect(firstMockHoist).toBeGreaterThan(-1);
+	expect(afterTopOfFile).toBeGreaterThan(firstMockHoist);
+});
+
+it('should not wrap synchronous mock factories as async modules', () => {
+	const content = fs.readFileSync(file, 'utf-8');
+
+	expect(content.includes('__rspack_async_done')).toBe(false);
+	expect(content.includes('__webpack_require__.a(')).toBe(false);
+});

--- a/tests/rspack-test/configCases/rstest/mock/test.js
+++ b/tests/rspack-test/configCases/rstest/mock/test.js
@@ -1,20 +1,21 @@
 const path = require('path');
 const fs = require('fs');
 
-const file = path.resolve(__dirname, 'bundle1.js');
+const syncMockFactoryFile = path.resolve(__dirname, 'bundle1.js');
 
 it('mocked modules should be hoisted before user code', () => {
-	const content = fs.readFileSync(file, 'utf-8');
-	const firstMockHoist = content.indexOf('[Rstest mock hoist]');
-	const afterTopOfFile = content.indexOf('TOP_OF_FILE');
+  const content = fs.readFileSync(syncMockFactoryFile, 'utf-8');
+  const firstMockHoist = content.indexOf('[Rstest mock hoist]');
+  const afterTopOfFile = content.indexOf('TOP_OF_FILE');
 
-	expect(firstMockHoist).toBeGreaterThan(-1);
-	expect(afterTopOfFile).toBeGreaterThan(firstMockHoist);
+  expect(firstMockHoist).toBeGreaterThan(-1);
+  expect(afterTopOfFile).toBeGreaterThan(-1);
+  expect(afterTopOfFile).toBeGreaterThan(firstMockHoist);
 });
 
 it('should not wrap synchronous mock factories as async modules', () => {
-	const content = fs.readFileSync(file, 'utf-8');
+  const content = fs.readFileSync(syncMockFactoryFile, 'utf-8');
 
-	expect(content.includes('__rspack_async_done')).toBe(false);
-	expect(content.includes('__webpack_require__.a(')).toBe(false);
+  expect(content.includes('__rspack_async_done')).toBe(false);
+  expect(content.includes('__webpack_require__.a(')).toBe(false);
 });


### PR DESCRIPTION
## Summary

This PR stops hoisted  `rs.mock(..., () => ({ ... }))` calls from marking rstest entries as async modules, which removed the unnecessary async wrapper from the generated bundle. It also strengthens the rstest mock case to assert the emitted `bundle1.js` is still hoisted correctly and does not contain async module runtime markers.

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
