### PR TITLE
fix(rstest): no longer mark rs.mock module as async

### DIFF
--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -65,16 +65,6 @@ pub struct RstestParserPlugin {
   options: RstestParserPluginOptions,
 }
 
-trait JavascriptParserExt<'a> {
-  fn handle_top_level_await(&mut self);
-}
-
-impl<'a> JavascriptParserExt<'a> for JavascriptParser<'a> {
-  fn handle_top_level_await(&mut self) {
-    self.build_meta.has_top_level_await = true;
-  }
-}
-
 impl RstestParserPlugin {
   pub fn new(options: RstestParserPluginOptions) -> Self {
     Self { options }
@@ -271,10 +261,6 @@ impl RstestParserPlugin {
         let first_arg_lit_str = self.handle_mock_first_arg(parser, call_expr);
 
         if let Some(lit_str) = first_arg_lit_str {
-          if hoist && method != MockMethod::Unmock && method != MockMethod::DoMock {
-            parser.handle_top_level_await();
-          }
-
           let dep = MockModuleIdDependency::new(
             lit_str.clone(),
             first_arg.span().into(),
@@ -329,10 +315,6 @@ impl RstestParserPlugin {
         let lit_str = self.handle_mock_first_arg(parser, call_expr);
 
         if let Some(lit_str) = lit_str {
-          if hoist {
-            parser.handle_top_level_await();
-          }
-
           let module_dep = MockModuleIdDependency::new(
             lit_str.clone(),
             first_arg.span().into(),

--- a/tests/rspack-test/configCases/rstest/mock/test.js
+++ b/tests/rspack-test/configCases/rstest/mock/test.js
@@ -8,3 +8,13 @@ it ('mocked modules should be hoisted', () => {
 	const afterTopOfFile = content.indexOf('TOP_OF_FILE');
 	expect(afterTopOfFile).toBeGreaterThan(content.lastIndexOf('__webpack_require__.mock'));
 })
+
+it ('rs.mock(id, factory) should not turn the module into an async module', () => {
+	// `__rspack_async_done` only appears inside `__webpack_require__.a(...)` async wrapper.
+	expect(content).not.toContain('__rspack_async_done');
+})
+
+it ('rs.mock(id) should not turn the module into an async module', () => {
+	const manualMockContent = fs.readFileSync(path.resolve(__dirname, 'bundle2.js'), 'utf-8');
+	expect(manualMockContent).not.toContain('__rspack_async_done');
+})


### PR DESCRIPTION
## Summary

- Remove the `JavascriptParserExt::handle_top_level_await` extension trait and its two call sites in `process_mock` (1-arg and 2-arg branches).
- They were introduced in #11050 to support async mock factories, but after the mock runtime was simplified in #11521 to plain synchronous `__webpack_require__.rstest_mock(...)` calls, there is no `await` in the emitted code — so `build_meta.has_top_level_await = true` only serves to pointlessly wrap the module in an async module wrapper and propagate the async requirement to every importer.
- Since async mock factories are no longer supported, drop this legacy plumbing.

## Test plan

- [x] Add two regression assertions in `tests/rspack-test/configCases/rstest/mock/test.js` that read the `mockFactory.js` (2-arg `rs.mock(id, factory)`) and `manualMock.js` (1-arg `rs.mock(id)`) bundle outputs and assert they do not contain `__rspack_async_done` — the identifier that only appears inside the `__webpack_require__.a(...)` async wrapper.
- [x] `cargo check -p rspack_plugin_rstest` passes.
- [x] `configCases/rstest/mock` passes locally.