### PR TITLE
docs: clarify compiler target documentation

### DIFF
--- a/website/docs/en/api/javascript-api/compiler.mdx
+++ b/website/docs/en/api/javascript-api/compiler.mdx
@@ -358,8 +358,11 @@ Or access `compiler.target` in a custom loader:
 ```js title="my-loader.js"
 export default function myLoader(source) {
   const options = this.getOptions();
+  const compilerTarget = this._compiler.target ?? {};
   // Use user-specified targets, or fall back to Rspack's derived targets
-  const targets = options.targets ?? this._compiler.target.targets;
+  const targets = options.targets ?? compilerTarget.targets;
+  // Fall back to Rspack's derived ECMAScript version when needed
+  const ecmaVersion = options.ecmaVersion ?? compilerTarget.esVersion;
   // Use targets for transformation...
   return transform(source, { targets, ecmaVersion });
 }

--- a/website/docs/en/api/javascript-api/compiler.mdx
+++ b/website/docs/en/api/javascript-api/compiler.mdx
@@ -324,14 +324,36 @@ Get the full options used by this compiler.
 
 ### target
 
-- **Type:** `{ targets?: Record<string, string>; esVersion?: number }`
+- **Type:**
+
+```ts
+type CompilerTarget = {
+  // ECMAScript version
+  esVersion?: number | null;
+  // Platform names with versions
+  targets?: Record<string, string> | null;
+};
+```
 
 Get the target information derived from the [`target`](/config/target) configuration. This is useful for plugin and loader authors who need to access the target environment information.
 
 - `targets`: An object of platform names and their versions (e.g., `{ 'chrome': '87', 'firefox': '78', 'node': '18' }`).
 - `esVersion`: The ECMAScript version number (e.g., `5`, `2015`, `2022`).
 
-Example of using `compiler.target` in a custom loader to set default targets:
+For example, access `compiler.target` in a plugin:
+
+```js
+class ExamplePlugin {
+  apply(compiler) {
+    compiler.hooks.initialize.tap('ExamplePlugin', () => {
+      const { targets, esVersion } = compiler.target ?? {};
+      console.log(targets, esVersion);
+    });
+  }
+}
+```
+
+Or access `compiler.target` in a custom loader:
 
 ```js title="my-loader.js"
 export default function myLoader(source) {

--- a/website/docs/en/config/target.mdx
+++ b/website/docs/en/config/target.mdx
@@ -107,20 +107,26 @@ export default {
 
 When Rspack generates runtime code, this helps determine which ES features can be used (all chunks and modules are wrapped by runtime code).
 
-## Default targets for builtin loaders and plugins
+## Target inheritance
 
-Rspack derives default targets from the `target` configuration and provides them to built-in loaders and plugins. If you don't specify targets in the loader/plugin options, the derived targets will be used:
+When you use Rspack built-in loaders or minimizer plugins, Rspack automatically derives and applies default target settings for them from the [target](/config/target) option.
 
-- `builtin:swc-loader` uses the derived targets as default `env.targets` or `jsc.target`
-- `builtin:lightningcss-loader` uses the derived targets as default `targets` (only for browserslist-related targets, since Lightning CSS only supports browser targets)
-- `SwcJsMinimizerRspackPlugin` uses the derived targets as default `ecma` version
-- `LightningCssMinimizerRspackPlugin` uses the derived targets as default `targets` (only for browserslist-related targets)
+For example, if you configure `target: 'node22'`, Rspack's `builtin:swc-loader` will automatically use target settings compatible with Node.js 22.
 
-This means you no longer need to manually configure the same targets in multiple places. For example, if you set `target: 'node18'`, the loaders and plugins will automatically use Node.js 18 compatible settings.
+In practice, this means you usually only need to configure the `target` option once, and JavaScript transforms, CSS transforms, and code minimization will all use a consistent target. If needed, you can still override the default target in a specific loader or minimizer plugin configuration.
 
-Third-party loaders and plugins can also access `compiler.target` to derive default targets based on Rspack's target configuration. The `compiler.target` object contains `targets` (platform names with versions) and `esVersion` (the ECMAScript version number).
+The following loaders and plugins inherit this default:
 
-## target: false
+- [builtin:swc-loader](/guide/features/builtin-swc-loader): automatically sets the `env.targets` or `jsc.target` option
+- [builtin:lightningcss-loader](/guide/features/builtin-lightningcss-loader): automatically sets the `targets` option. This only applies to browserslist-related `target` values, because Lightning CSS only supports browser targets
+- [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin): automatically sets the `ecma` version
+- [LightningCssMinimizerRspackPlugin](/plugins/rspack/lightning-css-minimizer-rspack-plugin): automatically sets the `targets` option. This only applies to browserslist-related `target` values
+
+:::tip
+If you are developing a third-party loader or plugin, you can also use [compiler.target](/api/javascript-api/compiler#target) to access Rspack's resolved target information and adjust behavior based on the target.
+:::
+
+## Disable target
 
 If none of the predefined targets in the above list meet your needs, you can set `target` to `false`, which will instruct Rspack not to use any plugins.
 

--- a/website/docs/en/config/target.mdx
+++ b/website/docs/en/config/target.mdx
@@ -128,7 +128,7 @@ If you are developing a third-party loader or plugin, you can also use [compiler
 
 ## Disable target
 
-If none of the predefined targets in the above list meet your needs, you can set `target` to `false`, which will instruct Rspack not to use any plugins.
+If none of the predefined targets in the above list meet your needs, you can set `target` to `false`, which disables target inference and target-derived defaults.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/types/compiler.mdx
+++ b/website/docs/en/types/compiler.mdx
@@ -9,10 +9,9 @@ type Compiler = {
   options: RspackOptionsNormalized;
   watching: Watching;
   target: {
-    targets?: Record<string, string>;
-    esVersion?: number;
+    esVersion?: number | null;
+    targets?: Record<string, string> | null;
   };
-
   getInfrastructureLogger(name: string | (() => string)): Logger;
   getCache(name: string): CacheFacade;
   watch(

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -337,8 +337,8 @@ type CompilerTarget = {
 
 从 [target](/config/target) 配置中推断出。这对需要访问目标环境信息的插件和 loader 作者非常有用。
 
-- `targets`: 包含平台名称及其版本的对象 (例如：`{ 'chrome': '87', 'firefox': '78', 'node': '18' }`)。
-- `esVersion`: ECMAScript 版本号 (例如：`5`, `2015`, `2022`)。
+- `targets`: 包含平台名称及其版本的对象（例如：`{ 'chrome': '87', 'firefox': '78', 'node': '18' }`）。
+- `esVersion`: ECMAScript 版本号（例如：`5`, `2015`, `2022`）。
 
 例如，在插件中访问 `compiler.target`：
 

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -337,7 +337,7 @@ type CompilerTarget = {
 
 从 [target](/config/target) 配置中推断出。这对需要访问目标环境信息的插件和 loader 作者非常有用。
 
-- `targets`: 带有版本的平台字符串数组 (例如：`{ 'chrome': '87', 'firefox': '78', 'node': '18' }`)。
+- `targets`: 包含平台名称及其版本的对象 (例如：`{ 'chrome': '87', 'firefox': '78', 'node': '18' }`)。
 - `esVersion`: ECMAScript 版本号 (例如：`5`, `2015`, `2022`)。
 
 例如，在插件中访问 `compiler.target`：

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -358,8 +358,11 @@ class ExamplePlugin {
 ```js title="my-loader.js"
 export default function myLoader(source) {
   const options = this.getOptions();
+  const compilerTarget = this._compiler.target ?? {};
   // 使用用户指定的 targets，或者回退到 Rspack 推断出的 targets
-  const targets = options.targets ?? this._compiler.target.targets;
+  const targets = options.targets ?? compilerTarget.targets;
+  // 需要时回退到 Rspack 推断出的 ECMAScript 版本
+  const ecmaVersion = options.ecmaVersion ?? compilerTarget.esVersion;
   // 使用 targets 进行转换...
   return transform(source, { targets, ecmaVersion });
 }

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -324,14 +324,36 @@ console.log(compiler.webpack === compiler.rspack); // true
 
 ### target
 
-- **类型：** `{ targets: Record<string, string>, esVersion: number }`
+- **类型：**
 
-从 [`target`](/config/target) 配置中推断出。这对需要访问目标环境信息的插件和 loader 作者非常有用。
+```ts
+type CompilerTarget = {
+  // ECMAScript 版本
+  esVersion?: number | null;
+  // 包含版本号的平台名称
+  targets?: Record<string, string> | null;
+};
+```
+
+从 [target](/config/target) 配置中推断出。这对需要访问目标环境信息的插件和 loader 作者非常有用。
 
 - `targets`: 带有版本的平台字符串数组 (例如：`{ 'chrome': '87', 'firefox': '78', 'node': '18' }`)。
 - `esVersion`: ECMAScript 版本号 (例如：`5`, `2015`, `2022`)。
 
-在自定义 loader 中使用 `compiler.target` 设置默认 targets 的示例：
+例如，在插件中访问 `compiler.target`：
+
+```js
+class ExamplePlugin {
+  apply(compiler) {
+    compiler.hooks.initialize.tap('ExamplePlugin', () => {
+      const { targets, esVersion } = compiler.target ?? {};
+      console.log(targets, esVersion);
+    });
+  }
+}
+```
+
+或是在自定义 loader 中访问 `compiler.target`：
 
 ```js title="my-loader.js"
 export default function myLoader(source) {

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -128,7 +128,7 @@ export default {
 
 ## 禁用 target
 
-如果上述列表中的预设 target 都不符合你的需求，你可以将 `target` 设置为 `false`，这将告诉 Rspack 不使用任何插件。
+如果上述列表中的预设 target 都不符合你的需求，你可以将 `target` 设置为 `false`，这会禁用基于 `target` 的默认推断和相关的默认行为。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -107,20 +107,26 @@ export default {
 
 当 Rspack 生成运行时代码时，这有助于确定所能使用的 ES 特性（所有的代码块和模块都被运行时代码包裹）。
 
-## 内置 loader 和插件的默认 target
+## 目标环境继承
 
-Rspack 从 `target` 配置中推断出默认 targets，并将其提供给内置 loader 和插件。如果你没有在 loader 和 plugin 的选项中指定 targets，将使用由 `target` 配置推断出的 targets：
+当你使用 Rspack 内置的 loaders 或压缩插件时，Rspack 会基于 [target](/config/target) 选项自动为它们设置默认的目标环境。
 
-- `builtin:swc-loader` 使用推断出的 targets 作为默认的 `env.targets` 或 `jsc.target`
-- `builtin:lightningcss-loader` 使用推断出的 targets 作为默认的 `targets`（仅适用于与 browserslist 相关的 targets，因为 Lightning CSS 仅支持浏览器 targets）
-- `SwcJsMinimizerRspackPlugin` 使用推断出的 targets 作为默认的 `ecma` 版本
-- `LightningCssMinimizerRspackPlugin` 使用推断出的 targets 作为默认的 `targets`（仅适用于与 browserslist 相关的 targets）
+例如，配置 `target: 'node22'` 后，Rspack 的 `builtin:swc-loader` 会默认使用与 Node.js 22 对应的目标设置。
 
-这意味着你不再需要在多个地方手动配置相同的 targets。例如，如果你设置 `target: 'node18'`，loader 和插件将自动使用与 Node.js 18 兼容的设置。
+这意味着，通常你只需要配置 `target` 选项，JavaScript 转换、CSS 转换和代码压缩就会自动使用一致的目标环境；当你需要为某个 loader 或压缩插件指定不同的目标时，依然可以在它们的配置中覆盖默认值。
 
-第三方 loader 和插件也可以访问 `compiler.target`，根据 Rspack 的 target 配置推断默认 targets。`compiler.target` 对象包含 `targets`（带有版本的平台名称）和 `esVersion`（ECMAScript 版本号）。
+以下 loaders 和插件会继承这个默认值：
 
-## target: false
+- [builtin:swc-loader](/guide/features/builtin-swc-loader)：自动设置 `env.targets` 或 `jsc.target` 选项
+- [builtin:lightningcss-loader](/guide/features/builtin-lightningcss-loader)：自动设置 `targets` 选项。仅对 browserslist 相关的 `target` 生效，因为 Lightning CSS 只支持浏览器目标
+- [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin)：自动设置 `ecma` 版本
+- [LightningCssMinimizerRspackPlugin](/plugins/rspack/lightning-css-minimizer-rspack-plugin)：自动设置 `targets` 选项。仅对 browserslist 相关的 `target` 生效
+
+:::tip
+如果你开发了一个第三方 loader 或插件，你也可以通过 [compiler.target](/api/javascript-api/compiler#target) 访问 Rspack 解析后的目标环境信息，以便根据目标环境调整你的 loader 或插件的行为。
+:::
+
+## 禁用 target
 
 如果上述列表中的预设 target 都不符合你的需求，你可以将 `target` 设置为 `false`，这将告诉 Rspack 不使用任何插件。
 

--- a/website/docs/zh/types/compiler.mdx
+++ b/website/docs/zh/types/compiler.mdx
@@ -9,10 +9,9 @@ type Compiler = {
   options: RspackOptionsNormalized;
   watching: Watching;
   target: {
-    targets?: string[];
-    esVersion?: number;
+    esVersion?: number | null;
+    targets?: Record<string, string> | null;
   };
-
   getInfrastructureLogger(name: string | (() => string)): Logger;
   getCache(name: string): CacheFacade;
   watch(


### PR DESCRIPTION
## Summary

- clarify the `compiler.target` type in docs, including nullable fields and plugin access examples
- explain how built-in loaders and minimizer plugins inherit resolved `target` defaults
- align the compiler type docs with the actual `targets` shape
