### PR TITLE
docs: update import.meta documentation for clarity

### DIFF
--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -94,7 +94,7 @@ __dirname
 
 </Columns>
 
-## import.meta (ESM)
+## import.meta (ESM) \{#import-meta}
 
 The `import.meta` exposes context-specific metadata to a JavaScript module, such as the URL of the module. It is only available in modules that support ESM ([module type](/misc/glossary#module-type) is `javascript/auto` or `javascript/esm`).
 

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -1219,16 +1219,12 @@ export default {
 
 <ApiMeta addedVersion="1.0.0-alpha.6" />
 
-<PropertyType
-  type="boolean | 'preserve-unknown'"
-  defaultValueList={[{ defaultValue: 'true' }]}
-/>
+- **Type:** `boolean | 'preserve-unknown'`
+- **Default:** When using [ESM output](/guide/features/esm), the default value is `'preserve-unknown'`; otherwise, it is `true`
 
-Enable or disable evaluating `import.meta`.
+Control whether Rspack parses and replaces `import.meta` in source code. Available values:
 
-When using [ESM output](/guide/features/esm), default value is set to `'preserve-unknown'`, otherwise `true`.
-
-- `"preserve-unknown"`: [Known `import.meta` properties](/api/runtime-api/module-variables#importmeta-esm) are statically analyzed at compile-time, other properties are preserved and evaluated at runtime.
+- `"preserve-unknown"`: [Known `import.meta` properties](/api/runtime-api/module-variables#importmetaesm) are statically analyzed at compile-time, other properties are preserved and evaluated at runtime.
 - `true`: All `import.meta` properties are statically analyzed at compile-time.
 - `false`: All `import.meta` properties are evaluated at runtime.
 

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -1224,7 +1224,7 @@ export default {
 
 Control whether Rspack parses and replaces `import.meta` in source code. Available values:
 
-- `"preserve-unknown"`: [Known `import.meta` properties](/api/runtime-api/module-variables#importmetaesm) are statically analyzed at compile-time, other properties are preserved and evaluated at runtime.
+- `"preserve-unknown"`: [Known `import.meta` properties](/api/runtime-api/module-variables#import-meta) are statically analyzed at compile-time, other properties are preserved and evaluated at runtime.
 - `true`: All `import.meta` properties are statically analyzed at compile-time.
 - `false`: All `import.meta` properties are evaluated at runtime.
 

--- a/website/docs/en/guide/optimization/tree-shaking.mdx
+++ b/website/docs/en/guide/optimization/tree-shaking.mdx
@@ -191,8 +191,8 @@ When an unused variable's initial value is marked as side-effect-free (pure), it
 
 This feature is currently experimental and needs to be enabled via following experimental feature configuration, and it depends on [optimization.sideEffects](/config/optimization#optimizationsideeffects) (`sideEffects` is enabled by default in production mode):
 
-```javascript title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   experiments: {
     pureFunctions: true,
   },
@@ -203,7 +203,7 @@ module.exports = {
 
 You can place this annotation before function declarations, function expressions, arrow functions, or export statements, check [spec](https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/no-side-effects-notation-spec.md) for details:
 
-```javascript
+```js
 /*#__NO_SIDE_EFFECTS__*/
 function foo() {
   console.log('foo');
@@ -241,8 +241,8 @@ For business source code where modification is possible, it is recommended to us
 
 This option is configured in `module.rules[i].parser`:
 
-```javascript title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   experiments: {
     pureFunctions: true,
   },

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -94,7 +94,7 @@ __dirname
 
 </Columns>
 
-## import.meta（ESM）
+## import.meta（ESM） \{#import-meta}
 
 `import.meta` 将特定上下文的元数据暴露给 JavaScript 模块，例如模块的 URL。它仅在支持 ESM（[模块类型](/misc/glossary#module-type模块类型)为 `javascript/auto` 或 `javascript/esm`）的模块中可用。
 

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -1216,18 +1216,14 @@ export default {
 
 <ApiMeta addedVersion="1.0.0-alpha.6" />
 
-<PropertyType
-  type="boolean | 'preserve-unknown'"
-  defaultValueList={[{ defaultValue: 'true' }]}
-/>
+- **类型：** `boolean | 'preserve-unknown'`
+- **默认值：** 当输出为 [ESM 格式](/guide/features/esm) 时，默认值为 `'preserve-unknown'`，其他情况默认值为 `true`
 
-是否要解析替换 `import.meta`。
+用于控制是否要解析和替换源代码中的 `import.meta`，可选值有：
 
-当输出为[ESM 格式](/guide/features/esm)时，默认值为`'preserve-unknown'`，其他情况默认值为`true`。
-
-- `"preserve-unknown"`: [已知的`import.meta`字段](/api/runtime-api/module-variables#importmeta-esm)会在编译期被替换，其他字段会被保留并在运行时被计算。
-- `true`: 所有`import.meta`字段在编译期被替换。
-- `false`: 所有`import.meta`字段都在运行时被计算。
+- `"preserve-unknown"`: [已知的 `import.meta` 字段](/api/runtime-api/module-variables#importmetaesm) 会在编译期被替换，其他字段会被保留并在运行时被计算。
+- `true`: 所有 `import.meta` 字段在编译期被替换。
+- `false`: 所有 `import.meta` 字段都在运行时被计算。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -1221,7 +1221,7 @@ export default {
 
 用于控制是否要解析和替换源代码中的 `import.meta`，可选值有：
 
-- `"preserve-unknown"`: [已知的 `import.meta` 字段](/api/runtime-api/module-variables#importmetaesm) 会在编译期被替换，其他字段会被保留并在运行时被计算。
+- `"preserve-unknown"`: [已知的 `import.meta` 字段](/api/runtime-api/module-variables#import-meta) 会在编译期被替换，其他字段会被保留并在运行时被计算。
 - `true`: 所有 `import.meta` 字段在编译期被替换。
 - `false`: 所有 `import.meta` 字段都在运行时被计算。
 

--- a/website/docs/zh/guide/optimization/tree-shaking.mdx
+++ b/website/docs/zh/guide/optimization/tree-shaking.mdx
@@ -194,8 +194,8 @@ export const foo = 42;
 
 该功能目前处于实验阶段，需要通过下面的实验性 feature 开关开启，且依赖于 [optimization.sideEffects](/config/optimization#optimizationsideeffects)（sideEffects 在生产模式下默认开启）：
 
-```javascript title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   experiments: {
     pureFunctions: true,
   },
@@ -204,7 +204,7 @@ module.exports = {
 
 你可以将该注解放在函数声明、函数表达式、箭头函数或导出语句之前，更多请参考社区[规范](https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/no-side-effects-notation-spec.md)：
 
-```javascript
+```js
 /*#__NO_SIDE_EFFECTS__*/
 function foo() {
   console.log('foo');
@@ -242,8 +242,8 @@ export function baz() {}
 
 该选项配置在 `module.rules` 的 `parser` 中：
 
-```javascript title="rspack.config.js"
-module.exports = {
+```js title="rspack.config.mjs"
+export default {
   experiments: {
     pureFunctions: true,
   },


### PR DESCRIPTION
## Summary

- Updated the description and default value for the `import.meta` option 
- Changed code examples from CommonJS to ES module syntax
