### PR TITLE
fix(rstest): preserve mock hoist positions in cache

### DIFF
--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -11,6 +11,8 @@ use rspack_core::{
 pub struct MockMethodDependency {
   call_expr_range: DependencyRange,
   callee_range: DependencyRange,
+  // Intentionally stored as `DependencyRange` so hoist insertion positions
+  // remain cacheable and survive persistent cache restore.
   statement_range: Option<DependencyRange>,
   request: String,
   hoist: bool,
@@ -48,7 +50,7 @@ impl MockMethodDependency {
     }
   }
 
-  pub fn new_with_statement_span(
+  pub fn new_with_statement_range(
     call_expr_range: DependencyRange,
     callee_range: DependencyRange,
     statement_range: DependencyRange,

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -1,22 +1,17 @@
-use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
+use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, AsModuleDependency, ConditionalInitFragment, DependencyCodeGeneration,
   DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, InitFragmentExt,
   InitFragmentKey, InitFragmentStage, NormalInitFragment, RuntimeCondition, RuntimeGlobals,
   TemplateContext, TemplateReplaceSource,
 };
-use rspack_util::SpanExt;
-use swc_core::common::Span;
 
 #[cacheable]
 #[derive(Debug, Clone)]
 pub struct MockMethodDependency {
-  #[cacheable(with=Skip)]
-  call_expr_span: Span,
-  #[cacheable(with=Skip)]
-  callee_span: Span,
-  #[cacheable(with=Skip)]
-  statement_span: Option<Span>,
+  call_expr_range: DependencyRange,
+  callee_range: DependencyRange,
+  statement_range: Option<DependencyRange>,
   request: String,
   hoist: bool,
   method: MockMethod,
@@ -37,16 +32,16 @@ pub enum MockMethod {
 
 impl MockMethodDependency {
   pub fn new(
-    call_expr_span: Span,
-    callee_span: Span,
+    call_expr_range: DependencyRange,
+    callee_range: DependencyRange,
     request: String,
     hoist: bool,
     method: MockMethod,
   ) -> Self {
     Self {
-      call_expr_span,
-      callee_span,
-      statement_span: None,
+      call_expr_range,
+      callee_range,
+      statement_range: None,
       request,
       hoist,
       method,
@@ -54,17 +49,17 @@ impl MockMethodDependency {
   }
 
   pub fn new_with_statement_span(
-    call_expr_span: Span,
-    callee_span: Span,
-    statement_span: Span,
+    call_expr_range: DependencyRange,
+    callee_range: DependencyRange,
+    statement_range: DependencyRange,
     request: String,
     hoist: bool,
     method: MockMethod,
   ) -> Self {
     Self {
-      call_expr_span,
-      callee_span,
-      statement_span: Some(statement_span),
+      call_expr_range,
+      callee_range,
+      statement_range: Some(statement_range),
       request,
       hoist,
       method,
@@ -141,8 +136,7 @@ impl MockMethodDependency {
   fn hoist_id(&self) -> String {
     format!(
       "{}-{}",
-      self.call_expr_span.real_lo(),
-      self.call_expr_span.real_hi()
+      self.call_expr_range.start, self.call_expr_range.end
     )
   }
 }
@@ -239,11 +233,10 @@ impl MockMethodDependencyTemplate {
     hoist_id: &str,
     request: &str,
   ) {
-    let callee_range: DependencyRange = dep.callee_span.into();
     let should_hoist = hoist_flag.is_some() && dep.hoist;
     let hoist_marker = hoist_flag.map(|flag| format!("{flag}:{hoist_id}:{request}"));
 
-    if should_hoist && dep.statement_span.is_some() {
+    if should_hoist && dep.statement_range.is_some() {
       // Case 1: Variable declaration with hoisting (e.g., `const mocks = rs.hoisted(...)`)
       // Wrap the entire statement with hoist markers
       Self::transform_with_statement_hoist(
@@ -254,7 +247,7 @@ impl MockMethodDependencyTemplate {
         hoist_marker
           .as_deref()
           .expect("hoist marker should exist when should_hoist is true"),
-        &callee_range,
+        &dep.callee_range,
       );
     } else if should_hoist {
       // Case 2: Standalone call with hoisting (e.g., `rs.hoisted(...)` or `rs.mock(...)`)
@@ -267,12 +260,12 @@ impl MockMethodDependencyTemplate {
         hoist_marker
           .as_deref()
           .expect("hoist marker should exist when should_hoist is true"),
-        &callee_range,
+        &dep.callee_range,
       );
     } else {
       // Case 3: No hoisting needed (e.g., `rs.doMock(...)`)
       // Just replace the callee
-      Self::transform_without_hoist(source, require_name, mock_method, &callee_range);
+      Self::transform_without_hoist(source, require_name, mock_method, &dep.callee_range);
     }
   }
 
@@ -287,10 +280,9 @@ impl MockMethodDependencyTemplate {
     hoist_marker: &str,
     callee_range: &DependencyRange,
   ) {
-    let stmt_range: DependencyRange = dep
-      .statement_span
-      .expect("statement_span should be Some when transform_with_statement_hoist is called")
-      .into();
+    let stmt_range = dep
+      .statement_range
+      .expect("statement_range should be Some when transform_with_statement_hoist is called");
 
     // Insert HOIST_START before the statement
     source.replace(
@@ -340,10 +332,9 @@ impl MockMethodDependencyTemplate {
     );
 
     // Insert HOIST_END after the call expression
-    let call_range: DependencyRange = dep.call_expr_span.into();
     source.replace(
-      call_range.end,
-      call_range.end,
+      dep.call_expr_range.end,
+      dep.call_expr_range.end,
       format!("\n/* RSTEST:{hoist_marker}:HOIST_END */"),
       None,
     );

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -371,7 +371,7 @@ impl RstestParserPlugin {
     match call_expr.args.len() {
       1 => {
         let dep = if let Some(stmt_span) = statement_span {
-          MockMethodDependency::new_with_statement_span(
+          MockMethodDependency::new_with_statement_range(
             call_expr.span().into(),
             call_expr.callee.span().into(),
             stmt_span.into(),

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -276,8 +276,8 @@ impl RstestParserPlugin {
           parser.add_dependency(Box::new(dep));
 
           parser.add_presentational_dependency(Box::new(MockMethodDependency::new(
-            call_expr.span(),
-            call_expr.callee.span(),
+            call_expr.span().into(),
+            call_expr.callee.span().into(),
             lit_str.clone(),
             hoist,
             method,
@@ -329,8 +329,8 @@ impl RstestParserPlugin {
           );
 
           parser.add_presentational_dependency(Box::new(MockMethodDependency::new(
-            call_expr.span(),
-            call_expr.callee.span(),
+            call_expr.span().into(),
+            call_expr.callee.span().into(),
             lit_str,
             hoist,
             method,
@@ -372,17 +372,17 @@ impl RstestParserPlugin {
       1 => {
         let dep = if let Some(stmt_span) = statement_span {
           MockMethodDependency::new_with_statement_span(
-            call_expr.span(),
-            call_expr.callee.span(),
-            stmt_span,
+            call_expr.span().into(),
+            call_expr.callee.span().into(),
+            stmt_span.into(),
             call_expr.span().real_lo().to_string(),
             true,
             MockMethod::Hoisted,
           )
         } else {
           MockMethodDependency::new(
-            call_expr.span(),
-            call_expr.callee.span(),
+            call_expr.span().into(),
+            call_expr.callee.span().into(),
             call_expr.span().real_lo().to_string(),
             true,
             MockMethod::Hoisted,

--- a/tests/rspack-test/cacheCases/common/rstest-virtual-module-mock-build-cache/index.js
+++ b/tests/rspack-test/cacheCases/common/rstest-virtual-module-mock-build-cache/index.js
@@ -1,0 +1,35 @@
+import value from "virtual-module";
+
+rs.mock("virtual-module", () => ({
+	default: "mocked-virtual-module",
+}));
+
+it("should keep virtual module mock hoists working with persistent cache", async () => {
+	expect(value).toBe("mocked-virtual-module");
+
+	if (COMPILER_INDEX === 0) {
+		await NEXT_START();
+	}
+
+	if (COMPILER_INDEX === 1) {
+		expect(value).toBe("mocked-virtual-module");
+	}
+});
+---
+import value from "virtual-module";
+
+rs.mock("virtual-module", () => ({
+	default: "mocked-virtual-module",
+}));
+
+it("should keep virtual module mock hoists working with persistent cache", async () => {
+	expect(value).toBe("mocked-virtual-module");
+
+	if (COMPILER_INDEX === 0) {
+		await NEXT_START();
+	}
+
+	if (COMPILER_INDEX === 1) {
+		expect(value).toBe("mocked-virtual-module");
+	}
+});

--- a/tests/rspack-test/cacheCases/common/rstest-virtual-module-mock-build-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/rstest-virtual-module-mock-build-cache/rspack.config.js
@@ -1,0 +1,123 @@
+const path = require('path');
+const {
+  experiments: { RstestPlugin },
+} = require('@rspack/core');
+
+class RstestSimpleRuntimePlugin {
+  apply(compiler) {
+    const { RuntimeModule } = compiler.rspack;
+
+    class RstestRuntimeModule extends RuntimeModule {
+      constructor() {
+        super('rstest runtime');
+      }
+
+      generate() {
+        return `
+if (typeof __webpack_require__ === 'undefined') {
+  return;
+}
+
+const originalRequire = __webpack_require__;
+__webpack_require__ = function(...args) {
+  try {
+    return originalRequire(...args);
+  } catch (e) {
+    const errMsg = e.message ?? e.toString();
+    if (errMsg.includes('__webpack_modules__[moduleId] is not a function')) {
+      throw new Error(\`Cannot find module '\${args[0]}'\`);
+    }
+    throw e;
+  }
+};
+
+Object.keys(originalRequire).forEach(key => {
+  __webpack_require__[key] = originalRequire[key];
+});
+
+__webpack_require__.rstest_original_modules = {};
+
+__webpack_require__.rstest_mock = (id, modFactory) => {
+  let requiredModule = undefined;
+  try {
+    requiredModule = __webpack_require__(id);
+  } catch {}
+  finally {
+    __webpack_require__.rstest_original_modules[id] = requiredModule;
+  }
+
+  if (typeof modFactory === 'string' || typeof modFactory === 'number') {
+    __webpack_module_cache__[id] = { exports: __webpack_require__(modFactory) };
+  } else if (typeof modFactory === 'function') {
+    const finalModFactory = function(
+      __unused_webpack_module,
+      __webpack_exports__,
+      __webpack_require__,
+    ) {
+      __webpack_require__.r(__webpack_exports__);
+      const res = modFactory();
+      for (const key in res) {
+        __webpack_require__.d(__webpack_exports__, {
+          [key]: () => res[key],
+        });
+      }
+    };
+
+    __webpack_modules__[id] = finalModFactory;
+    delete __webpack_module_cache__[id];
+  }
+};
+
+__webpack_require__.rstest_hoisted = fn => fn();
+`;
+      }
+    }
+
+    compiler.hooks.thisCompilation.tap(
+      'RstestSimpleRuntimePlugin',
+      (compilation) => {
+        compilation.hooks.additionalTreeRuntimeRequirements.tap(
+          'RstestSimpleRuntimePlugin',
+          (chunk) => {
+            compilation.addRuntimeModule(chunk, new RstestRuntimeModule());
+          },
+        );
+      },
+    );
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  target: 'node',
+  node: {
+    __filename: false,
+    __dirname: false,
+  },
+  cache: {
+    type: 'persistent',
+  },
+  optimization: {
+    usedExports: false,
+    mangleExports: false,
+    concatenateModules: false,
+    moduleIds: 'named',
+  },
+  output: {
+    library: { type: 'commonjs2' },
+  },
+  externals: {
+    'virtual-module': 'node-commonjs virtual-module1',
+  },
+  plugins: [
+    new RstestSimpleRuntimePlugin(),
+    new RstestPlugin({
+      injectModulePathName: true,
+      hoistMockModule: true,
+      importMetaPathName: true,
+      manualMockRoot: path.resolve(__dirname, '__mocks__'),
+      globals: true,
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary

This PR fixes a persistent cache regression in `RstestPlugin` where `rs.mock()` hoists could lose their insertion positions after a cache restore. The hoist metadata now uses cacheable `DependencyRange` values instead of skipped `Span` fields, and this PR adds a `cacheCases` regression test covering an externalized virtual module mock that passed on the first build and failed after `NEXT_START()`.

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
