### PR TITLE
feat(cli): add --open / --no-open to rspack dev / serve

### DIFF
--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -22,6 +22,7 @@ type ServerOptions = CommonOptionsForBuildAndServe & {
   hot?: boolean | 'only';
   port?: number | string;
   host?: string;
+  open?: boolean | string;
 };
 
 function normalizeHotOption(
@@ -47,7 +48,11 @@ export class ServeCommand implements RspackCommand {
     commonOptionsForBuildAndServe(commonOptions(command))
       .option('--hot [mode]', 'enables hot module replacement')
       .option('--port <port>', 'allows to specify a port to use')
-      .option('--host <host>', 'allows to specify a hostname to use');
+      .option('--host <host>', 'allows to specify a hostname to use')
+      .option(
+        '--open [value]',
+        'open browser on server start; pass --no-open to disable, or --open <url> to open a specific URL',
+      );
 
     command.action(
       cli.wrapAction(async (cliOptions: ServerOptions) => {
@@ -184,6 +189,9 @@ export class ServeCommand implements RspackCommand {
           cliOptions.hot ?? devServerOptions.hot ?? DEFAULT_SERVER_HOT;
         devServerOptions.host = cliOptions.host || devServerOptions.host;
         devServerOptions.port = cliOptions.port ?? devServerOptions.port;
+        if (cliOptions.open !== undefined) {
+          devServerOptions.open = cliOptions.open;
+        }
         if (devServerOptions.client !== false) {
           if (
             devServerOptions.client === true ||


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md before opening a pull request. -->

## Summary

Adds `--open` and `--no-open` CLI flags to `rspack dev` (aka `serve`), so users can override `devServer.open` at the invocation level instead of editing `rspack.config.js` per environment.

Closes #13727

## Why

- `rspack preview` already has `--open` but `rspack dev` / `serve` did not, so package-script callers had no way to flip browser opening without editing the config.
- Webpack CLI has `--open` / `--no-open`, and Vite has `--open` - aligning with webpack here matches the existing "1-to-1 recreation" goal in the issue.

## Change

`packages/rspack-cli/src/commands/serve.ts`:

- `ServerOptions` gains `open?: boolean | string` (matches `DevServer.open` at its most common shape).
- New `.option('--open [value]', ...)` on the serve command. `cac` parses this as:
  - `--open`       -> `open: true`
  - `--open <url>` -> `open: '<url>'` (string)
  - `--no-open`    -> `open: false`
- After resolving `devServerOptions`, the CLI value (if defined) takes precedence over `devServer.open` from config. When the flag is absent, config wins, which keeps existing behavior unchanged.

Verified `cac`'s `--open [value]` / `--no-open` parse matrix against a minimal program:

```
--no-open      -> { open: false }
--open http://x -> { open: 'http://x' }
--open         -> { open: true }
```

## Scope

- The richer `devServer.open` shapes (object, [string, object], repeated-flag array) are not wired in - the string/boolean path covers the webpack-docs 1-to-1 example and almost all package.json use cases. Happy to add multi-open array semantics in a follow-up if the maintainers want it.
- `preview.ts` already has `--open` (boolean only). Not touched here.

## Testing

- `git diff` is localized to `serve.ts` and adds 9 lines.
- Pre-existing `tsc --noEmit` errors (all `Cannot find module '@rspack/core'`) reflect the monorepo's expected build-first step; no new errors are introduced in `serve.ts`.
