### PR TITLE
chore(watcher): log raw fs events from notify in disk watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5354,6 +5354,7 @@ dependencies = [
  "rspack_util",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/rspack_watcher/Cargo.toml
+++ b/crates/rspack_watcher/Cargo.toml
@@ -16,6 +16,7 @@ rspack_paths = { workspace = true }
 rspack_regex = { workspace = true }
 rspack_util  = { workspace = true }
 tokio        = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tracing      = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "sync", "fs"] }

--- a/crates/rspack_watcher/src/disk_watcher.rs
+++ b/crates/rspack_watcher/src/disk_watcher.rs
@@ -32,10 +32,15 @@ impl DiskWatcher {
     let inner = RecommendedWatcher::new(
       move |result: notify::Result<Event>| match result {
         Ok(event) => {
-          let paths = &event.paths;
+          tracing::debug!(
+            target: "rspack_watcher::fs_event",
+            kind = ?event.kind,
+            paths = ?event.paths,
+            "fs_event",
+          );
 
-          if paths.is_empty() {
-            return; // Ignore events with no paths
+          if event.paths.is_empty() {
+            return;
           }
 
           let kind = match event.kind {
@@ -47,16 +52,15 @@ impl DiskWatcher {
             // TODO: handle this case /path/to/index.js -> /path/to/index.js.map
             // path/to/index.js should be removed, and path/to/index.js.map should be changed
             // Now /path/to/index.js and /path/to/index.js.map will both be changed
-            _ => return, // Ignore other kinds of events
+            _ => return,
           };
-          let paths = event.paths.into_iter().map(ArcPath::from);
-          for path in paths {
+          for path in event.paths.into_iter().map(ArcPath::from) {
             trigger.on_event(&path, kind);
           }
         }
 
         Err(e) => {
-          // Handle error, e.g., log it or notify the user
+          tracing::error!(target: "rspack_watcher::fs_event", "file watcher error: {e:?}");
           eprintln!("Error in file watcher: {e:?}",);
         }
       },


### PR DESCRIPTION
## Summary

- Add a `tracing::debug!` log for each raw filesystem event received from the `notify` crate inside `DiskWatcher`, recording the event `kind` and `paths`.
- Replace the existing `eprintln!` error branch with `tracing::error!` (on the same `rspack_watcher::fs_event` target) so all watcher output flows through the same tracing pipeline.
- Add `tracing` as a dependency of `rspack_watcher`.

The log is intentionally kept minimal: emitting one line per raw event makes the flow easy to follow, and downstream behavior (ignored empty-paths events, ignored unsupported kinds, per-path dispatch to the trigger) can be inferred from the code without extra log lines.

## Motivation

When diagnosing native watcher behavior (stale events, missed changes, platform-specific fsevent quirks) there was no visibility into what the OS-level watcher actually delivered. This adds that visibility behind an opt-in env filter.

## Usage

Enable from the CLI:

```bash
RSPACK_PROFILE='rspack_watcher::fs_event=debug' RSPACK_TRACE_LAYER=logger rspack build --watch
```

Requires `experiments.nativeWatcher: true` in the config, since the logs are only emitted by the Rust-side watcher.

## Test plan

- [x] `cargo check -p rspack_watcher` passes.
- [ ] Run a project with `experiments.nativeWatcher: true` and the env above; verify `fs_event` debug lines appear on file change / create / remove.