### PR TITLE
fix(test-tools): move wast-loader to dependencies

### DIFF
--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -45,6 +45,7 @@
     "@babel/parser": "7.29.2",
     "@babel/traverse": "7.29.0",
     "@babel/types": "7.29.0",
+    "chalk": "^4.1.2",
     "cross-env": "^10.1.0",
     "filenamify": "4.3.0",
     "fs-extra": "^11.3.4",
@@ -59,10 +60,10 @@
     "rimraf": "^5.0.10",
     "source-map": "^0.7.6",
     "terser-webpack-plugin": "^5.4.0",
+    "wast-loader": "^1.14.1",
     "webpack": "5.104.1",
     "webpack-merge": "6.0.1",
-    "webpack-sources": "3.3.4",
-    "chalk": "^4.1.2"
+    "webpack-sources": "3.3.4"
   },
   "devDependencies": {
     "@rspack/core": "workspace:*",
@@ -70,8 +71,7 @@
     "@types/babel__traverse": "7.28.0",
     "@types/fs-extra": "11.0.4",
     "@types/jsdom": "^21.1.7",
-    "typescript": "^6.0.3",
-    "wast-loader": "^1.14.1"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "@rspack/core": ">=1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,6 +441,9 @@ importers:
       terser-webpack-plugin:
         specifier: ^5.4.0
         version: 5.4.0(webpack@5.104.1)
+      wast-loader:
+        specifier: ^1.14.1
+        version: 1.14.1
       webpack:
         specifier: 5.104.1
         version: 5.104.1
@@ -469,9 +472,6 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
-      wast-loader:
-        specifier: ^1.14.1
-        version: 1.14.1
 
   scripts:
     devDependencies:


### PR DESCRIPTION
## Summary
- move `wast-loader` from `devDependencies` to `dependencies` in `@rspack/test-tools`
- keep dependency ordering consistent and update `pnpm-lock.yaml` importer entries accordingly
- ensure runtime consumers of `setup-env` can resolve `wast-loader` without relying on dev-only install scope

https://github.com/web-infra-dev/rspack/blob/e7927e392dd277d1af9ad70361e90110d660c996/packages/rspack-test-tools/src/helper/setup-env.ts#L117

## Test Plan
- pnpm -C packages/rspack-test-tools build