### PR TITLE
docs: document CLI --open flags for dev server

### DIFF
--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -102,6 +102,14 @@ npx rspack s
 npx rspack serve
 ```
 
+Use `--open` or `--no-open` to override [`devServer.open`](/config/dev-server#devserveropen) from the CLI without editing your config file:
+
+```bash
+npx rspack dev --open
+npx rspack dev --open /my-page
+npx rspack dev --no-open
+```
+
 The complete flags are as follows:
 
 ```
@@ -117,6 +125,7 @@ Options:
       --hot            enables hot module replacement
       --port           allows to specify a port to use                  [number]
       --host           allows to specify a hostname to use              [string]
+      --open [value]   open browser on server start; pass --no-open to disable, or --open <url> to open a specific URL
 ```
 
 ## rspack preview

--- a/website/docs/en/config/dev-server.mdx
+++ b/website/docs/en/config/dev-server.mdx
@@ -549,6 +549,10 @@ export default {
 };
 ```
 
+:::info
+When using `rspack dev` or `rspack serve`, you can override this option from the CLI with `--open`, `--open <value>`, or `--no-open`. The CLI flag takes precedence over `devServer.open` in the configuration.
+:::
+
 To open a specified page in a browser:
 
 ```js title="rspack.config.mjs"

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -103,6 +103,14 @@ npx rspack s
 npx rspack serve
 ```
 
+你可以通过 `--open`、`--open <value>` 或 `--no-open` 在命令行中覆盖 [`devServer.open`](/config/dev-server#devserveropen)。
+
+```bash
+npx rspack dev --open
+npx rspack dev --open /my-page
+npx rspack dev --no-open
+```
+
 完整的选项如下：
 
 ```
@@ -118,6 +126,7 @@ Options:
       --hot          enables hot module replacement
       --port         allows to specify a port to use                    [number]
       --host         allows to specify a hostname to use                [string]
+      --open [value] open browser on server start; pass --no-open to disable, or --open <url> to open a specific URL
 ```
 
 ## rspack preview

--- a/website/docs/zh/config/dev-server.mdx
+++ b/website/docs/zh/config/dev-server.mdx
@@ -539,6 +539,10 @@ export default {
 };
 ```
 
+:::info 提示
+当你使用 `rspack dev` 或 `rspack serve` 时，可以通过 `--open`、`--open <value>` 或 `--no-open` 在命令行中覆盖此选项。命令行参数的优先级高于配置中的 `devServer.open`。
+:::
+
 在浏览器中打开指定页面：
 
 ```js title="rspack.config.mjs"


### PR DESCRIPTION
## Summary

This PR updates the English and Chinese docs to document `--open` / `--no-open` for `rspack dev` and `rspack serve`, and clarifies that the CLI flags override `devServer.open`.

## Related links

- Related PR: https://github.com/web-infra-dev/rspack/pull/13777

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).