### PR TITLE
perf: reduce string churn across identifiers, ids, and runtime helpers

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -11,6 +11,7 @@ use crate::{
   ArtifactExt, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation,
   Logger, ModuleIdentifier,
   build_chunk_graph::code_splitter::{CodeSplitter, DependenciesBlockIdentifier},
+  fast_set,
   incremental::{IncrementalPasses, Mutation},
 };
 
@@ -28,6 +29,10 @@ pub struct BuildChunkGraphArtifact {
 }
 
 impl BuildChunkGraphArtifact {
+  pub(crate) fn set_code_splitter(&mut self, code_splitter: CodeSplitter) {
+    fast_set(&mut self.code_splitter, code_splitter);
+  }
+
   // we can skip rebuilding chunk graph if none of modules
   // has changed its outgoings
   // we don't need to check if module has changed its incomings
@@ -193,7 +198,7 @@ impl BuildChunkGraphArtifact {
     self.async_entrypoints.clear();
     self.named_chunk_groups.clear();
     self.named_chunks.clear();
-    self.code_splitter = Default::default();
+    self.set_code_splitter(Default::default());
     self.module_idx.clear();
   }
 }

--- a/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
@@ -50,7 +50,9 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
       .add_module(module_identifier)
   }
 
-  compilation.build_chunk_graph_artifact.code_splitter = splitter;
+  compilation
+    .build_chunk_graph_artifact
+    .set_code_splitter(splitter);
 
   Ok(())
 }

--- a/crates/rspack_core/src/utils/identifier.rs
+++ b/crates/rspack_core/src/utils/identifier.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use rspack_paths::Utf8Path;
-use rspack_util::identifier::absolute_to_request;
+use rspack_util::identifier::push_absolute_to_request;
 use swc_core::ecma::utils::is_valid_prop_ident;
 
 use crate::BoxLoader;
@@ -15,12 +15,20 @@ pub fn to_module_export_name(name: &str) -> String {
 }
 
 pub fn contextify(context: impl AsRef<Utf8Path>, request: &str) -> String {
-  let context = context.as_ref();
-  request
-    .split('!')
-    .map(|r| absolute_to_request(context.as_str(), r))
-    .collect::<Vec<Cow<str>>>()
-    .join("!")
+  let context = context.as_ref().as_str();
+  let mut result = String::with_capacity(request.len());
+  let mut last = 0;
+
+  for (index, byte) in request.bytes().enumerate() {
+    if byte == b'!' {
+      push_absolute_to_request(context, &request[last..index], &mut result);
+      result.push('!');
+      last = index + 1;
+    }
+  }
+
+  push_absolute_to_request(context, &request[last..], &mut result);
+  result
 }
 
 macro_rules! ident_table {
@@ -217,4 +225,23 @@ fn test_to_identifier_with_escaped() {
     "with_space"
   );
   assert_eq!(to_identifier_with_escaped("a.b".into()), "a_b");
+}
+
+#[test]
+fn test_contextify_preserves_loader_segments_and_queries() {
+  assert_eq!(
+    contextify(
+      "/workspace/app",
+      "/workspace/app/loaders/a.js!/workspace/app/src/index.js?foo=1"
+    ),
+    "./loaders/a.js!./src/index.js?foo=1"
+  );
+}
+
+#[test]
+fn test_contextify_preserves_empty_segments_and_regex_segments() {
+  assert_eq!(
+    contextify("/workspace/app", "!!/regexp/!/workspace/app/src/index.js"),
+    "!!/regexp/!./src/index.js"
+  );
 }

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -9,7 +9,8 @@ use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::id_helpers::{
-  assign_deterministic_ids, compare_chunks_natural, get_full_chunk_name, get_used_chunk_ids,
+  NaturalChunkCompareCache, assign_deterministic_ids, compare_chunks_natural, get_full_chunk_name,
+  get_used_chunk_ids,
 };
 
 #[plugin]
@@ -84,7 +85,7 @@ async fn chunk_ids(
     })
     .collect::<FxHashMap<_, _>>();
 
-  let mut ordered_chunk_modules_cache = Default::default();
+  let mut chunk_compare_cache = NaturalChunkCompareCache::default();
 
   assign_deterministic_ids(
     chunks,
@@ -103,7 +104,7 @@ async fn chunk_ids(
         &compilation.module_ids_artifact,
         a,
         b,
-        &mut ordered_chunk_modules_cache,
+        &mut chunk_compare_cache,
       )
     },
     |chunk, id| {

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use rayon::prelude::*;
 use rspack_core::{
   ChunkByUkey, ChunkNamedIdArtifact, CompilationChunkIds, Plugin, incremental::IncrementalPasses,
@@ -87,10 +89,12 @@ async fn chunk_ids(
   assign_deterministic_ids(
     chunks,
     |chunk| {
-      chunk_names
-        .get(&chunk.ukey())
-        .expect("should have generated full chunk name")
-        .clone()
+      Cow::Borrowed(
+        chunk_names
+          .get(&chunk.ukey())
+          .expect("should have generated full chunk name")
+          .as_str(),
+      )
     },
     |a, b| {
       compare_chunks_natural(

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
@@ -60,10 +62,12 @@ async fn module_ids(
   assign_deterministic_ids(
     modules,
     |m| {
-      module_names
-        .get(&m.identifier())
-        .expect("should have generated full module name")
-        .clone()
+      Cow::Borrowed(
+        module_names
+          .get(&m.identifier())
+          .expect("should have generated full module name")
+          .as_str(),
+      )
     },
     |a, b| {
       compare_modules_by_pre_order_index_or_identifier(

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -17,8 +17,7 @@ use rspack_core::{
 use rspack_util::{
   comparators::{compare_ids, compare_numbers},
   identifier::make_paths_relative,
-  itoa,
-  number_hash::get_number_hash,
+  number_hash::get_number_hash_combined,
 };
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 
@@ -159,12 +158,10 @@ pub fn assign_deterministic_ids<T>(
   for item in items {
     let ident = get_name(&item);
     let mut i = salt;
-    let mut i_buffer = itoa::Buffer::new();
-    let mut id = get_number_hash(&format!("{ident}{}", i_buffer.format(i)), range);
+    let mut id = get_number_hash_combined(&ident, i, range);
     while !assign_id(&item, id) {
       i += 1;
-      let mut i_buffer = itoa::Buffer::new();
-      id = get_number_hash(&format!("{ident}{}", i_buffer.format(i)), range);
+      id = get_number_hash_combined(&ident, i, range);
     }
   }
 }

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -128,9 +128,9 @@ pub fn get_hash(s: impl Hash, length: usize) -> String {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn assign_deterministic_ids<T>(
+pub fn assign_deterministic_ids<'a, T>(
   mut items: Vec<T>,
-  get_name: impl Fn(&T) -> String,
+  get_name: impl Fn(&T) -> Cow<'a, str>,
   comparator: impl FnMut(&T, &T) -> Ordering,
   mut assign_id: impl FnMut(&T, usize) -> bool,
   ranges: &[usize],
@@ -158,10 +158,10 @@ pub fn assign_deterministic_ids<T>(
   for item in items {
     let ident = get_name(&item);
     let mut i = salt;
-    let mut id = get_number_hash_combined(&ident, i, range);
+    let mut id = get_number_hash_combined(ident.as_ref(), i, range);
     while !assign_id(&item, id) {
       i += 1;
-      id = get_number_hash_combined(&ident, i, range);
+      id = get_number_hash_combined(ident.as_ref(), i, range);
     }
   }
 }
@@ -197,6 +197,40 @@ pub fn compare_modules_by_pre_order_index_or_identifier(
     compare_numbers(a, b)
   } else {
     compare_ids(a, b)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rustc_hash::FxHashMap;
+
+  use super::assign_deterministic_ids;
+
+  #[test]
+  fn assign_deterministic_ids_accepts_borrowed_names() {
+    let items = vec![1usize, 2usize, 3usize];
+    let names = FxHashMap::from_iter([
+      (1usize, "module-a".to_string()),
+      (2usize, "module-b".to_string()),
+      (3usize, "module-c".to_string()),
+    ]);
+    let mut assigned = FxHashMap::default();
+
+    assign_deterministic_ids(
+      items,
+      |item| std::borrow::Cow::Borrowed(names.get(item).expect("should have name").as_str()),
+      |a, b| a.cmp(b),
+      |item, id| {
+        assigned.insert(*item, id);
+        true
+      },
+      &[1000],
+      10,
+      0,
+      0,
+    );
+
+    assert_eq!(assigned.len(), 3);
   }
 }
 

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -10,9 +10,10 @@ use itertools::{
 };
 use rspack_collections::Identifier;
 use rspack_core::{
-  BoxModule, Chunk, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkNamedIdArtifact, ChunkUkey,
-  Compilation, ExportsInfoArtifact, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
-  ModuleIdsArtifact, SideEffectsStateArtifact, compare_runtime,
+  BoxModule, Chunk, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey,
+  ChunkNamedIdArtifact, ChunkUkey, Compilation, ExportsInfoArtifact, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact, SideEffectsStateArtifact,
+  compare_runtime,
 };
 use rspack_util::{
   comparators::{compare_ids, compare_numbers},
@@ -202,9 +203,14 @@ pub fn compare_modules_by_pre_order_index_or_identifier(
 
 #[cfg(test)]
 mod tests {
+  use std::cmp::Ordering;
+
+  use rspack_core::{
+    Chunk, ChunkGraph, ChunkGroup, ChunkGroupByUkey, ChunkKind, ModuleIdentifier, ModuleIdsArtifact,
+  };
   use rustc_hash::FxHashMap;
 
-  use super::assign_deterministic_ids;
+  use super::{NaturalChunkCompareCache, assign_deterministic_ids, compare_chunks_natural};
 
   #[test]
   fn assign_deterministic_ids_accepts_borrowed_names() {
@@ -231,6 +237,63 @@ mod tests {
     );
 
     assert_eq!(assigned.len(), 3);
+  }
+
+  #[test]
+  fn compare_chunks_natural_orders_by_modules_then_groups() {
+    let mut chunk_graph = ChunkGraph::default();
+    let mut module_ids = ModuleIdsArtifact::default();
+    let mut chunk_group_by_ukey = ChunkGroupByUkey::default();
+    let mut cache = NaturalChunkCompareCache::default();
+
+    let chunk_a = Chunk::new(None, ChunkKind::Normal);
+    let chunk_b = Chunk::new(None, ChunkKind::Normal);
+    let module_a: ModuleIdentifier = "module-a".into();
+    let module_b: ModuleIdentifier = "module-b".into();
+
+    chunk_graph.connect_chunk_and_module(chunk_a.ukey(), module_a);
+    chunk_graph.connect_chunk_and_module(chunk_b.ukey(), module_b);
+    ChunkGraph::set_module_id(&mut module_ids, module_a, "a".into());
+    ChunkGraph::set_module_id(&mut module_ids, module_b, "b".into());
+
+    assert_eq!(
+      compare_chunks_natural(
+        &chunk_graph,
+        &chunk_group_by_ukey,
+        &module_ids,
+        &chunk_a,
+        &chunk_b,
+        &mut cache,
+      ),
+      Ordering::Less
+    );
+
+    let mut chunk_c = Chunk::new(None, ChunkKind::Normal);
+    let mut chunk_d = Chunk::new(None, ChunkKind::Normal);
+    let shared_module: ModuleIdentifier = "shared-module".into();
+    ChunkGraph::set_module_id(&mut module_ids, shared_module, "shared".into());
+    chunk_graph.connect_chunk_and_module(chunk_c.ukey(), shared_module);
+    chunk_graph.connect_chunk_and_module(chunk_d.ukey(), shared_module);
+
+    let mut group = ChunkGroup::default();
+    group.index = Some(1);
+    group.chunks = vec![chunk_c.ukey(), chunk_d.ukey()];
+    chunk_c.add_group(group.ukey());
+    chunk_d.add_group(group.ukey());
+    chunk_group_by_ukey.add(group);
+
+    let mut cache = NaturalChunkCompareCache::default();
+    assert_eq!(
+      compare_chunks_natural(
+        &chunk_graph,
+        &chunk_group_by_ukey,
+        &module_ids,
+        &chunk_c,
+        &chunk_d,
+        &mut cache,
+      ),
+      Ordering::Less
+    );
   }
 }
 
@@ -421,16 +484,23 @@ pub fn assign_ascending_chunk_ids(chunks: &[ChunkUkey], chunk_by_ukey: &mut Chun
   }
 }
 
+#[derive(Default)]
+pub struct NaturalChunkCompareCache<'a> {
+  ordered_chunk_modules: FxHashMap<ChunkUkey, Vec<Option<&'a str>>>,
+  sorted_chunk_groups: FxHashMap<ChunkUkey, Vec<ChunkGroupUkey>>,
+}
+
 fn compare_chunks_by_modules<'a>(
   chunk_graph: &ChunkGraph,
   module_ids: &'a ModuleIdsArtifact,
   a: &Chunk,
   b: &Chunk,
-  ordered_chunk_modules_cache: &mut FxHashMap<ChunkUkey, Vec<Option<&'a str>>>,
+  cache: &mut NaturalChunkCompareCache<'a>,
 ) -> Ordering {
   let a_ukey = a.ukey();
   let b_ukey = b.ukey();
-  let a_modules = ordered_chunk_modules_cache
+  cache
+    .ordered_chunk_modules
     .entry(a_ukey)
     .or_insert_with(|| {
       chunk_graph
@@ -438,9 +508,9 @@ fn compare_chunks_by_modules<'a>(
         .into_iter()
         .map(|m| ChunkGraph::get_module_id(module_ids, m).map(|s| s.as_str()))
         .collect_vec()
-    })
-    .clone();
-  let b_modules = ordered_chunk_modules_cache
+    });
+  cache
+    .ordered_chunk_modules
     .entry(b_ukey)
     .or_insert_with(|| {
       chunk_graph
@@ -448,12 +518,20 @@ fn compare_chunks_by_modules<'a>(
         .into_iter()
         .map(|m| ChunkGraph::get_module_id(module_ids, m).map(|s| s.as_str()))
         .collect_vec()
-    })
-    .clone();
+    });
+
+  let a_modules = cache
+    .ordered_chunk_modules
+    .get(&a_ukey)
+    .expect("should cache ordered chunk modules");
+  let b_modules = cache
+    .ordered_chunk_modules
+    .get(&b_ukey)
+    .expect("should cache ordered chunk modules");
 
   a_modules
-    .into_iter()
-    .zip_longest(b_modules)
+    .iter()
+    .zip_longest(b_modules.iter())
     .find_map(|pair| match pair {
       Both(a_module_id, b_module_id) => {
         let ordering = compare_ids(
@@ -475,20 +553,51 @@ fn compare_chunks_by_groups(
   chunk_group_by_ukey: &ChunkGroupByUkey,
   a: &Chunk,
   b: &Chunk,
+  cache: &mut NaturalChunkCompareCache<'_>,
 ) -> Ordering {
-  let a_groups: Vec<_> = a
-    .get_sorted_groups_iter(chunk_group_by_ukey)
-    .map(|group| chunk_group_by_ukey.expect_get(group))
-    .collect();
-  let a_groups_index = a_groups.iter().map(|group| group.index).collect_vec();
+  let a_ukey = a.ukey();
+  let b_ukey = b.ukey();
+  cache.sorted_chunk_groups.entry(a_ukey).or_insert_with(|| {
+    a.get_sorted_groups_iter(chunk_group_by_ukey)
+      .copied()
+      .collect_vec()
+  });
+  cache.sorted_chunk_groups.entry(b_ukey).or_insert_with(|| {
+    b.get_sorted_groups_iter(chunk_group_by_ukey)
+      .copied()
+      .collect_vec()
+  });
 
-  let b_groups: Vec<_> = b
-    .get_sorted_groups_iter(chunk_group_by_ukey)
-    .map(|group| chunk_group_by_ukey.expect_get(group))
-    .collect();
-  let b_groups_index = b_groups.iter().map(|group| group.index).collect_vec();
+  let a_groups = cache
+    .sorted_chunk_groups
+    .get(&a_ukey)
+    .expect("should cache sorted chunk groups");
+  let b_groups = cache
+    .sorted_chunk_groups
+    .get(&b_ukey)
+    .expect("should cache sorted chunk groups");
 
-  let groups_ordering = a_groups_index.cmp(&b_groups_index);
+  let groups_ordering = a_groups
+    .iter()
+    .map(|group| chunk_group_by_ukey.expect_get(group).index)
+    .zip_longest(
+      b_groups
+        .iter()
+        .map(|group| chunk_group_by_ukey.expect_get(group).index),
+    )
+    .find_map(|pair| match pair {
+      Both(a_group_index, b_group_index) => {
+        let ordering = a_group_index.cmp(&b_group_index);
+        if ordering != Ordering::Equal {
+          Some(ordering)
+        } else {
+          None
+        }
+      }
+      Left(_) => Some(Ordering::Greater),
+      Right(_) => Some(Ordering::Less),
+    })
+    .unwrap_or(Ordering::Equal);
 
   if groups_ordering != Ordering::Equal {
     return groups_ordering;
@@ -497,6 +606,7 @@ fn compare_chunks_by_groups(
   let Some(group) = a_groups.first() else {
     return Ordering::Equal;
   };
+  let group = chunk_group_by_ukey.expect_get(group);
 
   let a_in_children = group
     .chunks
@@ -516,7 +626,7 @@ pub fn compare_chunks_natural<'a>(
   module_ids: &'a ModuleIdsArtifact,
   a: &Chunk,
   b: &Chunk,
-  ordered_chunk_modules_cache: &mut FxHashMap<ChunkUkey, Vec<Option<&'a str>>>,
+  cache: &mut NaturalChunkCompareCache<'a>,
 ) -> Ordering {
   let name_ordering = compare_ids(a.name().unwrap_or_default(), b.name().unwrap_or_default());
   if name_ordering != Ordering::Equal {
@@ -528,11 +638,10 @@ pub fn compare_chunks_natural<'a>(
     return runtime_ordering;
   }
 
-  let modules_ordering =
-    compare_chunks_by_modules(chunk_graph, module_ids, a, b, ordered_chunk_modules_cache);
+  let modules_ordering = compare_chunks_by_modules(chunk_graph, module_ids, a, b, cache);
   if modules_ordering != Ordering::Equal {
     return modules_ordering;
   }
 
-  compare_chunks_by_groups(chunk_group_by_ukey, a, b)
+  compare_chunks_by_groups(chunk_group_by_ukey, a, b, cache)
 }

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -10,7 +10,9 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_util::{fx_hash::FxIndexSet, itoa};
 use rustc_hash::FxHashSet;
 
-use crate::id_helpers::{compare_chunks_natural, get_long_chunk_name, get_short_chunk_name};
+use crate::id_helpers::{
+  NaturalChunkCompareCache, compare_chunks_natural, get_long_chunk_name, get_short_chunk_name,
+};
 
 #[tracing::instrument(skip_all)]
 #[allow(clippy::too_many_arguments)]
@@ -118,7 +120,7 @@ fn assign_named_chunk_ids(
   let name_to_items_keys = name_to_items.keys().cloned().collect::<ChunkIdSet>();
   let mut unnamed_items = vec![];
 
-  let mut ordered_chunk_modules_cache = Default::default();
+  let mut chunk_compare_cache = NaturalChunkCompareCache::default();
 
   // Sort by name to ensure deterministic processing order
   let mut name_to_items_sorted: Vec<_> = name_to_items.into_iter().collect();
@@ -148,7 +150,7 @@ fn assign_named_chunk_ids(
           module_ids_artifact,
           a,
           b,
-          &mut ordered_chunk_modules_cache,
+          &mut chunk_compare_cache,
         )
       });
       let mut i = 0;
@@ -181,7 +183,7 @@ fn assign_named_chunk_ids(
       module_ids_artifact,
       a,
       b,
-      &mut ordered_chunk_modules_cache,
+      &mut chunk_compare_cache,
     )
   });
   unnamed_items

--- a/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
@@ -6,7 +6,9 @@ use rspack_core::{
 use rspack_error::Diagnostic;
 use rspack_hook::{plugin, plugin_hook};
 
-use crate::id_helpers::{assign_ascending_chunk_ids, compare_chunks_natural};
+use crate::id_helpers::{
+  NaturalChunkCompareCache, assign_ascending_chunk_ids, compare_chunks_natural,
+};
 
 #[plugin]
 #[derive(Debug, Default)]
@@ -31,7 +33,7 @@ async fn chunk_ids(
 
   let module_ids = &compilation.module_ids_artifact;
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
-  let mut ordered_chunk_modules_cache = Default::default();
+  let mut chunk_compare_cache = NaturalChunkCompareCache::default();
 
   let chunks = chunk_by_ukey
     .values()
@@ -43,7 +45,7 @@ async fn chunk_ids(
         module_ids,
         a,
         b,
-        &mut ordered_chunk_modules_cache,
+        &mut chunk_compare_cache,
       )
     })
     .map(|chunk| chunk.ukey())

--- a/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
@@ -7,7 +7,9 @@ use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::id_helpers::{assign_ascending_chunk_ids, compare_chunks_natural};
+use crate::id_helpers::{
+  NaturalChunkCompareCache, assign_ascending_chunk_ids, compare_chunks_natural,
+};
 
 #[derive(Debug)]
 pub struct OccurrenceChunkIdsPluginOptions {
@@ -63,7 +65,7 @@ async fn chunk_ids(
     occurs_in_initial_chunks_map.insert(chunk.ukey(), occurs);
   }
 
-  let mut ordered_chunk_modules_cache = Default::default();
+  let mut chunk_compare_cache = NaturalChunkCompareCache::default();
   let chunks = chunk_by_ukey
     .values()
     .map(|chunk| chunk as &Chunk)
@@ -88,7 +90,7 @@ async fn chunk_ids(
         &compilation.module_ids_artifact,
         a,
         b,
-        &mut ordered_chunk_modules_cache,
+        &mut chunk_compare_cache,
       )
     })
     .map(|chunk| chunk.ukey())

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use std::{borrow::Cow, sync::LazyLock};
 
 use itertools::Itertools;
 use rayon::prelude::*;
@@ -273,10 +273,12 @@ fn mangle_exports_info(
     assign_deterministic_ids(
       mangleable_exports,
       |e| {
-        mangleable_export_names
-          .get(e)
-          .expect("should have name")
-          .to_string()
+        Cow::Borrowed(
+          mangleable_export_names
+            .get(e)
+            .expect("should have name")
+            .as_str(),
+        )
       },
       |a, b| {
         compare_strings_numeric(

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -59,6 +59,50 @@ struct ExportInfoCache {
   can_mangle: Manglable,
 }
 
+struct PreparedMangleableExports<'a> {
+  changes: Vec<(ExportInfo, UsedNameItem)>,
+  nested_exports: Vec<ExportsInfo>,
+  used_names: FxHashSet<Cow<'a, str>>,
+  mangleable_exports: Vec<ExportInfo>,
+  mangleable_export_names: FxHashMap<ExportInfo, &'a Atom>,
+}
+
+fn prepare_mangleable_exports<'a>(
+  export_list: &'a [ExportInfoCache],
+) -> PreparedMangleableExports<'a> {
+  let mut changes = vec![];
+  let mut nested_exports = vec![];
+  let mut used_names = FxHashSet::default();
+  let mut mangleable_exports = Vec::new();
+  let mut mangleable_export_names = FxHashMap::default();
+
+  for export_info in export_list {
+    match &export_info.can_mangle {
+      Manglable::CanNotMangle(name) => {
+        changes.push((export_info.id.clone(), UsedNameItem::Str(name.clone())));
+        used_names.insert(Cow::Borrowed(name.as_str()));
+      }
+      Manglable::CanMangle(name) => {
+        mangleable_export_names.insert(export_info.id.clone(), name);
+        mangleable_exports.push(export_info.id.clone());
+      }
+      Manglable::Mangled => {}
+    }
+
+    if let Some(nested_exports_info) = export_info.exports_info {
+      nested_exports.push(nested_exports_info);
+    }
+  }
+
+  PreparedMangleableExports {
+    changes,
+    nested_exports,
+    used_names,
+    mangleable_exports,
+    mangleable_export_names,
+  }
+}
+
 #[plugin_hook(CompilationOptimizeCodeGeneration for MangleExportsPlugin)]
 async fn optimize_code_generation(
   &self,
@@ -239,33 +283,17 @@ fn mangle_exports_info(
   exports_info: ExportsInfo,
   exports_info_cache: &FxHashMap<ExportsInfo, Vec<ExportInfoCache>>,
 ) -> (Vec<(ExportInfo, UsedNameItem)>, Vec<ExportsInfo>) {
-  let mut changes = vec![];
-  let mut nested_exports = vec![];
-  let mut used_names = FxHashSet::default();
-  let mut mangleable_exports = Vec::new();
   let Some(export_list) = exports_info_cache.get(&exports_info) else {
-    return (changes, nested_exports);
+    return (vec![], vec![]);
   };
 
-  let mut mangleable_export_names = FxHashMap::default();
-
-  for export_info in export_list {
-    match &export_info.can_mangle {
-      Manglable::CanNotMangle(name) => {
-        changes.push((export_info.id.clone(), UsedNameItem::Str(name.clone())));
-        used_names.insert(name.to_string());
-      }
-      Manglable::CanMangle(name) => {
-        mangleable_export_names.insert(export_info.id.clone(), name.clone());
-        mangleable_exports.push(export_info.id.clone());
-      }
-      Manglable::Mangled => {}
-    }
-
-    if let Some(nested_exports_info) = export_info.exports_info {
-      nested_exports.push(nested_exports_info);
-    }
-  }
+  let PreparedMangleableExports {
+    mut changes,
+    nested_exports,
+    mut used_names,
+    mangleable_exports,
+    mangleable_export_names,
+  } = prepare_mangleable_exports(export_list);
 
   if deterministic {
     let used_names_len = used_names.len();
@@ -282,14 +310,14 @@ fn mangle_exports_info(
       },
       |a, b| {
         compare_strings_numeric(
-          Some(mangleable_export_names.get(a).expect("should have name")),
-          Some(mangleable_export_names.get(b).expect("should have name")),
+          mangleable_export_names.get(a).copied(),
+          mangleable_export_names.get(b).copied(),
         )
       },
       |e, id| {
         let name = number_to_identifier(id as u32);
         let size = used_names.len();
-        used_names.insert(name.clone());
+        used_names.insert(Cow::Owned(name.clone()));
         if size == used_names.len() {
           false
         } else {
@@ -323,14 +351,14 @@ fn mangle_exports_info(
 
     used_exports.sort_by(|a, b| {
       compare_strings_numeric(
-        Some(mangleable_export_names.get(a).expect("should have name")),
-        Some(mangleable_export_names.get(b).expect("should have name")),
+        mangleable_export_names.get(a).copied(),
+        mangleable_export_names.get(b).copied(),
       )
     });
     unused_exports.sort_by(|a, b| {
       compare_strings_numeric(
-        Some(mangleable_export_names.get(a).expect("should have name")),
-        Some(mangleable_export_names.get(b).expect("should have name")),
+        mangleable_export_names.get(a).copied(),
+        mangleable_export_names.get(b).copied(),
       )
     });
 
@@ -341,7 +369,7 @@ fn mangle_exports_info(
         loop {
           name = number_to_identifier(i);
           i += 1;
-          if !used_names.contains(&name) {
+          if !used_names.contains(name.as_str()) {
             break;
           }
         }

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -1,6 +1,5 @@
 use std::fmt::Write as _;
 
-use itertools::Itertools;
 use rspack_core::{
   Chunk, ChunkLoading, ChunkUkey, Compilation, PathData, RuntimeCodeTemplate, SourceType,
   chunk_graph_chunk::{ChunkId, ChunkIdSet},
@@ -180,21 +179,38 @@ where
   format!("\" + {content} + \"")
 }
 
-pub fn stringify_static_chunk_map(filename: &String, chunk_ids: &[&ChunkId]) -> String {
+pub fn stringify_static_chunk_map(filename: &str, chunk_ids: &[&ChunkId]) -> String {
   let condition = if chunk_ids.len() == 1 {
-    format!(
-      "chunkId === {}",
-      serde_json::to_string(&chunk_ids.first()).expect("invalid json to_string")
-    )
+    let mut condition = String::from("chunkId === ");
+    let chunk_id = chunk_ids.first().expect("should have one chunk id");
+    condition.push_str(&rspack_util::json_stringify(*chunk_id));
+    condition
   } else {
-    let content = chunk_ids
-      .iter()
-      .sorted_unstable()
-      .map(|chunk_id| format!("{}:1", rspack_util::json_stringify(*chunk_id)))
-      .join(",");
-    format!("{{ {content} }}[chunkId]")
+    let mut sorted_chunk_ids = chunk_ids.to_vec();
+    sorted_chunk_ids.sort_unstable();
+
+    let mut condition = String::with_capacity(sorted_chunk_ids.len() * 8 + 14);
+    condition.push('{');
+    condition.push(' ');
+    for (idx, chunk_id) in sorted_chunk_ids.iter().enumerate() {
+      if idx != 0 {
+        condition.push(',');
+      }
+      let key = rspack_util::json_stringify(*chunk_id);
+      condition.reserve(key.len() + 2);
+      condition.push_str(&key);
+      condition.push_str(":1");
+    }
+    condition.push_str(" }[chunkId]");
+    condition
   };
-  format!("if ({condition}) return {filename};")
+  let mut result = String::with_capacity(condition.len() + filename.len() + 14);
+  result.push_str("if (");
+  result.push_str(&condition);
+  result.push_str(") return ");
+  result.push_str(filename);
+  result.push(';');
+  result
 }
 
 fn stringify_map<T: std::fmt::Display>(entries: &mut [(&ChunkId, T)]) -> String {
@@ -231,7 +247,7 @@ pub fn generate_javascript_hmr_runtime(
 mod tests {
   use rspack_core::chunk_graph_chunk::{ChunkId, ChunkIdSet};
 
-  use super::{stringify_chunks, stringify_map};
+  use super::{stringify_chunks, stringify_map, stringify_static_chunk_map};
 
   #[test]
   fn stringify_chunks_keeps_sorted_numeric_ids() {
@@ -254,6 +270,29 @@ mod tests {
     assert_eq!(
       stringify_map(&mut entries),
       r#"{"a": "alpha","b": "beta",}"#
+    );
+  }
+
+  #[test]
+  fn stringify_static_chunk_map_single_chunk_keeps_condition_shape() {
+    let filename = "\"style.css\"".to_string();
+    let chunk_id = ChunkId::from("main");
+
+    assert_eq!(
+      stringify_static_chunk_map(&filename, &[&chunk_id]),
+      r#"if (chunkId === "main") return "style.css";"#
+    );
+  }
+
+  #[test]
+  fn stringify_static_chunk_map_multiple_chunks_keeps_sorted_object_shape() {
+    let filename = "\"style.css\"".to_string();
+    let chunk_a = ChunkId::from("b");
+    let chunk_b = ChunkId::from("a");
+
+    assert_eq!(
+      stringify_static_chunk_map(&filename, &[&chunk_a, &chunk_b]),
+      r#"if ({ "a":1,"b":1 }[chunkId]) return "style.css";"#
     );
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -198,7 +198,7 @@ pub fn stringify_static_chunk_map(filename: &String, chunk_ids: &[&ChunkId]) -> 
 }
 
 fn stringify_map<T: std::fmt::Display>(entries: &mut [(&ChunkId, T)]) -> String {
-  entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+  entries.sort_unstable_by_key(|(left, _)| *left);
 
   let mut result = String::with_capacity(entries.len() * 8 + 2);
   result.push('{');

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use itertools::Itertools;
 use rspack_core::{
   Chunk, ChunkLoading, ChunkUkey, Compilation, PathData, RuntimeCodeTemplate, SourceType,
@@ -9,7 +11,6 @@ use rspack_util::{
   fx_hash::{FxIndexMap, FxIndexSet},
   test::is_hot_test,
 };
-use rustc_hash::FxHashMap as HashMap;
 
 pub fn get_initial_chunk_ids(
   chunk: Option<ChunkUkey>,
@@ -48,12 +49,17 @@ pub fn stringify_chunks(chunks: &ChunkIdSet, value: u8) -> String {
   let mut v = chunks.iter().collect::<Vec<_>>();
   v.sort_unstable();
 
-  format!(
-    r#"{{{}}}"#,
-    v.iter().fold(String::new(), |prev, cur| {
-      prev + format!(r#"{}: {value},"#, rspack_util::json_stringify(cur)).as_str()
-    })
-  )
+  let mut result = String::with_capacity(v.len() * 8 + 2);
+  result.push('{');
+  for chunk_id in v {
+    let key = rspack_util::json_stringify(chunk_id);
+    result.reserve(key.len() + 4);
+    result.push_str(&key);
+    result.push_str(": ");
+    write!(result, "{value},").expect("infallible write to String");
+  }
+  result.push('}');
+  result
 }
 
 pub fn chunk_has_css(chunk: &ChunkUkey, compilation: &Compilation) -> bool {
@@ -133,10 +139,8 @@ pub fn stringify_dynamic_chunk_map<F>(
 where
   F: Fn(&Chunk) -> Option<String>,
 {
-  let mut result = HashMap::default();
+  let mut entries = Vec::with_capacity(chunks.len());
   let mut use_id = false;
-  let mut last_key = None;
-  let mut entries = 0;
 
   for chunk_ukey in chunks.iter() {
     if let Some(chunk) = chunk_map.get(chunk_ukey)
@@ -146,33 +150,32 @@ where
       if value.as_str() == chunk_id.as_str() {
         use_id = true;
       } else {
-        result.insert(chunk_id, rspack_util::json_stringify_str(&value));
-        last_key = Some(chunk_id);
-        entries += 1;
+        entries.push((chunk_id, rspack_util::json_stringify_str(&value)));
       }
     }
   }
 
-  let content = if entries == 0 {
-    "chunkId".to_string()
-  } else if entries == 1 {
-    if let Some(last_key) = last_key {
+  let content = match entries.as_mut_slice() {
+    [] => "chunkId".to_string(),
+    [(chunk_id, value)] => {
       if use_id {
         format!(
           "(chunkId === {} ? {} : chunkId)",
-          rspack_util::json_stringify(last_key),
-          result.get(last_key).expect("cannot find last key")
+          rspack_util::json_stringify(*chunk_id),
+          value
         )
       } else {
-        result.get(last_key).expect("cannot find last key").clone()
+        value.clone()
       }
-    } else {
-      unreachable!();
     }
-  } else if use_id {
-    format!("({}[chunkId] || chunkId)", stringify_map(&result))
-  } else {
-    format!("{}[chunkId]", stringify_map(&result))
+    entries => {
+      let map = stringify_map(entries);
+      if use_id {
+        format!("({map}[chunkId] || chunkId)")
+      } else {
+        format!("{map}[chunkId]")
+      }
+    }
   };
   format!("\" + {content} + \"")
 }
@@ -194,22 +197,20 @@ pub fn stringify_static_chunk_map(filename: &String, chunk_ids: &[&ChunkId]) -> 
   format!("if ({condition}) return {filename};")
 }
 
-fn stringify_map<T: std::fmt::Display>(map: &HashMap<&ChunkId, T>) -> String {
-  format!(
-    r#"{{{}}}"#,
-    map
-      .keys()
-      .sorted_unstable()
-      .fold(String::new(), |prev, cur| {
-        prev
-          + format!(
-            r#"{}: {},"#,
-            rspack_util::json_stringify(*cur),
-            map.get(cur).expect("get key from map")
-          )
-          .as_str()
-      })
-  )
+fn stringify_map<T: std::fmt::Display>(entries: &mut [(&ChunkId, T)]) -> String {
+  entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+
+  let mut result = String::with_capacity(entries.len() * 8 + 2);
+  result.push('{');
+  for (chunk_id, value) in entries.iter() {
+    let key = rspack_util::json_stringify(*chunk_id);
+    result.reserve(key.len() + 4);
+    result.push_str(&key);
+    result.push_str(": ");
+    write!(result, "{value},").expect("infallible write to String");
+  }
+  result.push('}');
+  result
 }
 
 pub fn generate_javascript_hmr_runtime(
@@ -224,4 +225,35 @@ pub fn generate_javascript_hmr_runtime(
       "_is_hot_test": is_hot_test(),
     })),
   )
+}
+
+#[cfg(test)]
+mod tests {
+  use rspack_core::chunk_graph_chunk::{ChunkId, ChunkIdSet};
+
+  use super::{stringify_chunks, stringify_map};
+
+  #[test]
+  fn stringify_chunks_keeps_sorted_numeric_ids() {
+    let mut chunks = ChunkIdSet::default();
+    chunks.insert(ChunkId::from("2"));
+    chunks.insert(ChunkId::from("10"));
+
+    assert_eq!(stringify_chunks(&chunks, 1), "{10: 1,2: 1,}");
+  }
+
+  #[test]
+  fn stringify_map_keeps_sorted_and_quoted_values() {
+    let chunk_a = ChunkId::from("a");
+    let chunk_b = ChunkId::from("b");
+    let mut entries = vec![
+      (&chunk_b, rspack_util::json_stringify_str("beta")),
+      (&chunk_a, rspack_util::json_stringify_str("alpha")),
+    ];
+
+    assert_eq!(
+      stringify_map(&mut entries),
+      r#"{"a": "alpha","b": "beta",}"#
+    );
+  }
 }

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -153,11 +153,24 @@ pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
     .collect()
 }
 
+fn push_make_paths_relative(context: &str, identifier: &str, out: &mut String) {
+  let mut last = 0;
+
+  for (index, byte) in identifier.bytes().enumerate() {
+    if matches!(byte, b'|' | b'!') {
+      push_absolute_to_request(context, &identifier[last..index], out);
+      out.push(byte as char);
+      last = index + 1;
+    }
+  }
+
+  push_absolute_to_request(context, &identifier[last..], out);
+}
+
 pub fn make_paths_relative(context: &str, identifier: &str) -> String {
-  split_keep(&SEGMENTS_SPLIT_REGEXP, identifier)
-    .into_iter()
-    .map(|str| absolute_to_request(context, str))
-    .collect()
+  let mut result = String::with_capacity(identifier.len());
+  push_make_paths_relative(context, identifier, &mut result);
+  result
 }
 
 pub fn strip_zero_width_space_for_fragment(s: &str) -> Cow<'_, str> {
@@ -215,4 +228,15 @@ fn test_push_absolute_to_request() {
   let mut out = String::new();
   push_absolute_to_request("/workspace/app", "loader", &mut out);
   assert_eq!(out, "loader");
+}
+
+#[test]
+fn test_push_make_paths_relative_preserves_segments_and_delimiters() {
+  let mut out = String::new();
+  push_make_paths_relative(
+    "/workspace/app",
+    "/workspace/app/a.js|/workspace/app/b.js!/workspace/app/c.js?x=1",
+    &mut out,
+  );
+  assert_eq!(out, "./a.js|./b.js!./c.js?x=1");
 }

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -85,6 +85,16 @@ fn push_relative_path_to_request(rel: &str, out: &mut String) {
   }
 }
 
+/// Appends a request-form path for `maybe_absolute_path` into `out`.
+///
+/// This function appends to the provided output buffer and does not clear or
+/// overwrite existing contents in `out`.
+///
+/// Accepted inputs:
+/// - Absolute POSIX paths are converted to a request relative to `context`.
+/// - Absolute Windows paths are converted similarly when possible.
+/// - Query parts (for example `?foo`) are preserved and appended.
+/// - Non-absolute inputs are accepted and appended unchanged.
 pub fn push_absolute_to_request(context: &str, maybe_absolute_path: &str, out: &mut String) {
   if maybe_absolute_path.starts_with('/')
     && maybe_absolute_path.len() > 1

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -229,14 +229,3 @@ fn test_push_absolute_to_request() {
   push_absolute_to_request("/workspace/app", "loader", &mut out);
   assert_eq!(out, "loader");
 }
-
-#[test]
-fn test_push_make_paths_relative_preserves_segments_and_delimiters() {
-  let mut out = String::new();
-  push_make_paths_relative(
-    "/workspace/app",
-    "/workspace/app/a.js|/workspace/app/b.js!/workspace/app/c.js?x=1",
-    &mut out,
-  );
-  assert_eq!(out, "./a.js|./b.js!./c.js?x=1");
-}

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -11,8 +11,6 @@ use sugar_path::SugarPath;
 
 static SEGMENTS_SPLIT_REGEXP: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"([|!])").expect("should be a valid regex"));
-static WINDOWS_ABS_PATH_REGEXP: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"^[a-zA-Z]:[/\\]").expect("should be a valid regex"));
 static WINDOWS_PATH_SEPARATOR: &[char] = &['/', '\\'];
 
 /// # Example
@@ -38,36 +36,14 @@ pub fn absolute_to_request<'b>(context: &str, maybe_absolute_path: &'b str) -> C
     return Cow::Borrowed(maybe_absolute_path);
   }
 
-  let (maybe_absolute_resource, query_part) = split_at_query_mark(maybe_absolute_path);
-
-  let relative_resource = if maybe_absolute_path.starts_with('/') {
-    let tmp = Path::new(maybe_absolute_resource).relative(context);
-    let tmp_path = tmp.to_string_lossy();
-    relative_path_to_request(&tmp_path).into_owned()
-  } else if WINDOWS_ABS_PATH_REGEXP.is_match(maybe_absolute_path) {
-    let mut resource = maybe_absolute_resource
-      .as_path()
-      .relative(context)
-      .to_string_lossy()
-      .into_owned();
-
-    // In windows, A path that relative to a another path could still be absolute.
-    // ("d:/aaaa/cccc").relative("c:/aaaaa/") would get "d:/aaaa/cccc".
-    if !WINDOWS_ABS_PATH_REGEXP.is_match(&resource) {
-      resource =
-        relative_path_to_request(&resource.cow_replace(WINDOWS_PATH_SEPARATOR, "/")).into_owned();
-    }
-    resource
-  } else {
+  if !maybe_absolute_path.starts_with('/') && !is_windows_absolute_path(maybe_absolute_path) {
     // not an absolute path
     return Cow::Borrowed(maybe_absolute_path);
-  };
-
-  if let Some(query_part) = query_part {
-    Cow::Owned(concat_string!(relative_resource, query_part))
-  } else {
-    Cow::Owned(relative_resource)
   }
+
+  let mut result = String::with_capacity(maybe_absolute_path.len());
+  push_absolute_to_request(context, maybe_absolute_path, &mut result);
+  Cow::Owned(result)
 }
 
 /// # Context
@@ -84,6 +60,72 @@ pub fn relative_path_to_request(rel: &str) -> Cow<'_, str> {
   } else {
     Cow::Owned(concat_string!("./", rel))
   }
+}
+
+#[inline]
+fn is_windows_absolute_path(path: &str) -> bool {
+  let bytes = path.as_bytes();
+  bytes.len() >= 3
+    && bytes[0].is_ascii_alphabetic()
+    && bytes[1] == b':'
+    && matches!(bytes[2], b'/' | b'\\')
+}
+
+#[inline]
+fn push_relative_path_to_request(rel: &str, out: &mut String) {
+  if rel.is_empty() {
+    out.push_str("./.");
+  } else if rel == ".." {
+    out.push_str("../.");
+  } else if rel.starts_with("../") {
+    out.push_str(rel);
+  } else {
+    out.push_str("./");
+    out.push_str(rel);
+  }
+}
+
+pub fn push_absolute_to_request(context: &str, maybe_absolute_path: &str, out: &mut String) {
+  if maybe_absolute_path.starts_with('/')
+    && maybe_absolute_path.len() > 1
+    && maybe_absolute_path.ends_with('/')
+  {
+    out.push_str(maybe_absolute_path);
+    return;
+  }
+
+  if maybe_absolute_path.starts_with('/') {
+    let (maybe_absolute_resource, query_part) = split_at_query_mark(maybe_absolute_path);
+    let tmp = Path::new(maybe_absolute_resource).relative(context);
+    let tmp_path = tmp.to_string_lossy();
+    push_relative_path_to_request(&tmp_path, out);
+    if let Some(query_part) = query_part {
+      out.push_str(query_part);
+    }
+    return;
+  }
+
+  if is_windows_absolute_path(maybe_absolute_path) {
+    let (maybe_absolute_resource, query_part) = split_at_query_mark(maybe_absolute_path);
+    let relative_resource = maybe_absolute_resource.as_path().relative(context);
+    let resource = relative_resource.to_string_lossy();
+
+    // In windows, A path that relative to a another path could still be absolute.
+    // ("d:/aaaa/cccc").relative("c:/aaaaa/") would get "d:/aaaa/cccc".
+    if is_windows_absolute_path(resource.as_ref()) {
+      out.push_str(resource.as_ref());
+    } else {
+      let resource = resource.cow_replace(WINDOWS_PATH_SEPARATOR, "/");
+      push_relative_path_to_request(resource.as_ref(), out);
+    }
+
+    if let Some(query_part) = query_part {
+      out.push_str(query_part);
+    }
+    return;
+  }
+
+  out.push_str(maybe_absolute_path);
 }
 
 fn request_to_absolute(context: &str, relative_path: &str) -> String {
@@ -154,4 +196,23 @@ pub fn request_to_id(request: &str) -> String {
   REQUEST_TO_ID_REGEX2
     .replace_all(&REQUEST_TO_ID_REGEX1.replace(request, ""), "_")
     .to_string()
+}
+
+#[test]
+fn test_push_absolute_to_request() {
+  let mut out = String::new();
+  push_absolute_to_request(
+    "/workspace/app",
+    "/workspace/app/src/index.js?foo=1",
+    &mut out,
+  );
+  assert_eq!(out, "./src/index.js?foo=1");
+
+  let mut out = String::new();
+  push_absolute_to_request("/workspace/app", "/regexp/", &mut out);
+  assert_eq!(out, "/regexp/");
+
+  let mut out = String::new();
+  push_absolute_to_request("/workspace/app", "loader", &mut out);
+  assert_eq!(out, "loader");
 }

--- a/crates/rspack_util/src/number_hash.rs
+++ b/crates/rspack_util/src/number_hash.rs
@@ -130,7 +130,7 @@ fn test_number_hash_combined_matches_concatenated_input() {
     ("chunk~main", 9usize, 167_772_160_usize),
     (
       "君が笑ってると、僕もうれしくなるんだ。",
-      314159usize,
+      314_159_usize,
       167_772_160_usize,
     ),
   ];

--- a/crates/rspack_util/src/number_hash.rs
+++ b/crates/rspack_util/src/number_hash.rs
@@ -1,3 +1,5 @@
+use crate::itoa;
+
 /*
   MIT License http://www.opensource.org/licenses/mit-license.php
   Author Tobias Koppers @sokra
@@ -18,14 +20,16 @@ const FNV_OFFSET_64: u64 = 0xCBF2_9CE4_8422_2325;
 const FNV_PRIME_64: u64 = 0x0100_0000_01B3;
 
 fn fnv1a32(s: &str) -> u32 {
-  let mut hash = FNV_OFFSET_32;
+  fnv1a32_update(FNV_OFFSET_32, s) & MASK_31
+}
 
+fn fnv1a32_update(mut hash: u32, s: &str) -> u32 {
   for code_unit in s.encode_utf16() {
     hash ^= code_unit as u32;
     hash = hash.wrapping_mul(FNV_PRIME_32);
   }
 
-  hash & MASK_31
+  hash
 }
 
 fn fnv1a64(s: &str) -> u64 {
@@ -39,11 +43,31 @@ fn fnv1a64(s: &str) -> u64 {
   hash
 }
 
+fn fnv1a64_update(mut hash: u64, s: &str) -> u64 {
+  for code_unit in s.encode_utf16() {
+    hash ^= code_unit as u64;
+    hash = hash.wrapping_mul(FNV_PRIME_64);
+  }
+
+  hash
+}
+
 pub fn get_number_hash(s: &str, range: usize) -> usize {
   if range < FNV_64_THRESHOLD {
     (fnv1a32(s) as usize) % range
   } else {
     (fnv1a64(s) % (range as u64)) as usize
+  }
+}
+
+pub fn get_number_hash_combined(prefix: &str, suffix: usize, range: usize) -> usize {
+  let mut suffix_buffer = itoa::Buffer::new();
+  let suffix = suffix_buffer.format(suffix);
+
+  if range < FNV_64_THRESHOLD {
+    ((fnv1a32_update(fnv1a32_update(FNV_OFFSET_32, prefix), suffix) & MASK_31) as usize) % range
+  } else {
+    (fnv1a64_update(fnv1a64_update(FNV_OFFSET_64, prefix), suffix) % (range as u64)) as usize
   }
 }
 
@@ -93,5 +117,28 @@ fn test_number_hash() {
 
   for (s, range, hash) in test_cases.iter() {
     assert_eq!(get_number_hash(s, *range), *hash);
+  }
+}
+
+#[test]
+fn test_number_hash_combined_matches_concatenated_input() {
+  let test_cases = [
+    ("module/a.js", 0usize, 100usize),
+    ("module/a.js", 7usize, 100usize),
+    ("我能吞下玻璃而不伤身体", 42usize, 100usize),
+    ("vendor/react/index.js", 12345usize, 100usize),
+    ("chunk~main", 9usize, 167_772_160_usize),
+    (
+      "君が笑ってると、僕もうれしくなるんだ。",
+      314159usize,
+      167_772_160_usize,
+    ),
+  ];
+
+  for (prefix, suffix, range) in test_cases {
+    assert_eq!(
+      get_number_hash_combined(prefix, suffix, range),
+      get_number_hash(&format!("{prefix}{suffix}"), range)
+    );
   }
 }


### PR DESCRIPTION
## Summary
- optimize the identifier/contextify path by rewriting `contextify` and `make_paths_relative` around write-through string building and documenting the `push_absolute_to_request` contract
- reduce runtime and id-generation overhead by avoiding temporary strings in deterministic id hashing, borrowing cached names in id assignment, caching chunk-comparison inputs, and rewriting runtime chunk-map stringifiers to build output in place
- trim supporting overhead in adjacent hot paths by borrowing mangle-export names and deferring `code_splitter` destruction with `fast_set`

## Why
Several hot paths in this area were spending measurable time on temporary `String` allocation, repeated concatenation, and repeated sort/comparison setup. The goal of this PR is to keep behavior the same while lowering churn in:
- identifier/contextify helpers
- deterministic and natural chunk/module id generation
- runtime chunk map rendering
- export-name mangling bookkeeping
