### PR TITLE
docs: refresh README docs and benchmark links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Come chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! Rspack team and R
 | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
 | [awesome-rstack](https://github.com/rstackjs/awesome-rstack)                   | A curated list of awesome things related to Rstack                            |
 | [agent-skills](https://github.com/rstackjs/agent-skills)                       | A collection of Agent Skills for Rstack                                       |
-| [Rspack 2.x docs](https://v2.rspack.rs/)                                       | Documentation for Rspack 2.x (beta)                                           |
-| [Rspack 1.x docs](https://rspack.rs/)                                          | Documentation for Rspack 1.x (latest)                                         |
+| [Rspack 2.x docs](https://rspack.rs/)                                          | Documentation for Rspack 2.x                                                  |
+| [Rspack 1.x docs](https://v1.rspack.rs/)                                       | Documentation for Rspack 1.x                                                  |
 | [Rspack 0.x docs](https://v0.rspack.rs/)                                       | Documentation for Rspack 0.x version                                          |
 | [rspack-dev-server](https://github.com/rstackjs/rspack-dev-server)             | Dev server for Rspack                                                         |
 | [rstack-examples](https://github.com/rstackjs/rstack-examples)                 | Examples showcasing Rstack                                                    |
@@ -86,9 +86,10 @@ Come chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! Rspack team and R
 
 <a href="https://github.com/web-infra-dev/rspack/graphs/contributors"><img src="https://opencollective.com/rspack/contributors.svg?width=890&button=false" /></a>
 
-## Benchmark
+## Benchmarks
 
-See [Benchmark](https://ecosystem-benchmark.rspack.rs/).
+- See [build-tools-performance](https://github.com/rstackjs/build-tools-performance) for comparisons between Rspack and other tools
+- See [Rspack Benchmarks](https://ecosystem-benchmark.rspack.rs/) for Rspack's performance trends over time.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Come chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! Rspack team and R
 
 ## Benchmarks
 
-- See [build-tools-performance](https://github.com/rstackjs/build-tools-performance) for comparisons between Rspack and other tools
+- See [build-tools-performance](https://github.com/rstackjs/build-tools-performance) for comparisons between Rspack and other tools.
 - See [Rspack Benchmarks](https://ecosystem-benchmark.rspack.rs/) for Rspack's performance trends over time.
 
 ## Credits

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,8 +75,8 @@ Rstack 是一个以 Rspack 为核心的 JavaScript 统一工具链，具有优�
 | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
 | [awesome-rstack](https://github.com/rstackjs/awesome-rstack)                   | 与 Rspack 相关的精彩内容列表                                                 |
 | [agent-skills](https://github.com/rstackjs/agent-skills)                       | Rstack 的 Agent Skills 合集                                                  |
-| [Rspack 2.x 文档](https://v2.rspack.rs/zh/)                                    | Rspack 2.x 版本的文档（Beta）                                                |
-| [Rspack 1.x 文档](https://rspack.rs/zh/)                                       | Rspack 1.x 版本的文档（最新）                                                |
+| [Rspack 2.x 文档](https://rspack.rs/zh/)                                       | Rspack 2.x 版本的文档                                                        |
+| [Rspack 1.x 文档](https://v1.rspack.rs/zh/)                                    | Rspack 1.x 版本的文档                                                        |
 | [Rspack 0.x 文档](https://v0.rspack.rs/zh/)                                    | Rspack 0.x 版本的文档                                                        |
 | [rspack-dev-server](https://github.com/rstackjs/rspack-dev-server)             | Rspack 的开发服务器                                                          |
 | [rstack-examples](https://github.com/rstackjs/rstack-examples)                 | Rstack 的示例项目                                                            |
@@ -89,7 +89,8 @@ Rstack 是一个以 Rspack 为核心的 JavaScript 统一工具链，具有优�
 
 ## 基准测试
 
-参考 [基准测试](https://ecosystem-benchmark.rspack.rs/)。
+- 参考 [build-tools-performance](https://github.com/rstackjs/build-tools-performance) 了解 Rspack 与其他工具的对比
+- 参考 [Rspack 基准测试](https://ecosystem-benchmark.rspack.rs/) 了解 Rspack 性能的变化趋势
 
 ## 致谢
 


### PR DESCRIPTION
## Summary

- update `README.md` and `README.zh-CN.md` to point Rspack 2.x docs to `rspack.rs` / `rspack.rs/zh` and move the 1.x docs to `v1.rspack.rs`
- expand the benchmark section with links to cross-tool comparisons and Rspack's benchmark trend dashboard

## Related links

- None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).